### PR TITLE
[common-io]:  Rename `BufReadExt` method: `util` ==> `until`

### DIFF
--- a/common/io/src/buf_read.rs
+++ b/common/io/src/buf_read.rs
@@ -22,7 +22,7 @@ pub trait BufReadExt {
     fn ignore_byte(&mut self, b: u8) -> Result<bool>;
     fn ignore_bytes(&mut self, bs: &[u8]) -> Result<bool>;
     fn ignore_spaces(&mut self) -> Result<bool>;
-    fn util(&mut self, delim: u8, buf: &mut Vec<u8>) -> Result<usize>;
+    fn until(&mut self, delim: u8, buf: &mut Vec<u8>) -> Result<usize>;
 }
 
 impl<R> BufReadExt for BufReader<R>
@@ -69,7 +69,7 @@ where R: std::io::Read
         Ok(cnt > 0)
     }
 
-    fn util(&mut self, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {
+    fn until(&mut self, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {
         Ok(self.read_until(delim, buf)?)
     }
 }

--- a/common/io/src/buf_read_test.rs
+++ b/common/io/src/buf_read_test.rs
@@ -25,7 +25,7 @@ fn test_buf_read() {
     assert_eq!(String::from_utf8_lossy(bs), "bytes   helloworld");
 
     let mut vec = vec![];
-    buffer.util(b's', &mut vec).unwrap();
+    buffer.until(b's', &mut vec).unwrap();
     assert_eq!(String::from_utf8_lossy(buffer.buffer()), "   helloworld");
     assert_eq!(String::from_utf8_lossy(&vec), "bytes".to_string());
 

--- a/common/streams/src/sources/source_values.rs
+++ b/common/streams/src/sources/source_values.rs
@@ -69,7 +69,7 @@ where R: io::Read
             }
             // not the first row
             if rows + self.rows != 0 {
-                reader.util(b',', &mut buf)?;
+                reader.until(b',', &mut buf)?;
             }
             let _ = reader.ignore_spaces()?;
             let _ = reader.ignore_byte(b'(')?;
@@ -80,30 +80,30 @@ where R: io::Read
 
                 let bs: Result<&[u8]> = {
                     if reader.ignore_byte(b'\'')? {
-                        reader.util(b'\'', &mut buf)?;
+                        reader.until(b'\'', &mut buf)?;
 
                         let res = &buf.as_slice()[0..buf.len() - 1];
                         if col != col_size - 1 {
-                            reader.util(b',', &mut temp)?;
+                            reader.until(b',', &mut temp)?;
                         } else {
-                            reader.util(b')', &mut temp)?;
+                            reader.until(b')', &mut temp)?;
                         }
                         Ok(res)
                     } else if reader.ignore_byte(b'"')? {
-                        reader.util(b'"', &mut buf)?;
+                        reader.until(b'"', &mut buf)?;
 
                         let res = &buf.as_slice()[0..buf.len() - 1];
                         if col != col_size - 1 {
-                            reader.util(b',', &mut temp)?;
+                            reader.until(b',', &mut temp)?;
                         } else {
-                            reader.util(b')', &mut temp)?;
+                            reader.until(b')', &mut temp)?;
                         }
                         Ok(res)
                     } else if col != col_size - 1 {
-                        reader.util(b',', &mut buf)?;
+                        reader.until(b',', &mut buf)?;
                         Ok(&buf.as_slice()[0..buf.len() - 1])
                     } else {
-                        reader.util(b')', &mut buf)?;
+                        reader.until(b')', &mut buf)?;
                         Ok(&buf.as_slice()[0..buf.len() - 1])
                     }
                 };


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Rename `BufReadExt` method: `util` ==> `until`

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

None

## Test Plan

Unit Tests

Stateless Tests

