### PR TITLE
ISSUE-1984: add socket address to authenticate api

### DIFF
--- a/common/clickhouse-srv/src/cmd.rs
+++ b/common/clickhouse-srv/src/cmd.rs
@@ -42,10 +42,11 @@ impl Cmd {
             // todo cancel
             Packet::Cancel => {}
             Packet::Hello(hello) => {
-                if !connection
-                    .session
-                    .authenticate(&hello.user, &hello.password)
-                {
+                if !connection.session.authenticate(
+                    &hello.user,
+                    &hello.password,
+                    &connection.client_addr,
+                ) {
                     let err = Error::Server(ServerError {
                         code: WRONG_PASSWORD,
                         name: "AuthenticateException".to_owned(),

--- a/common/clickhouse-srv/src/connection.rs
+++ b/common/clickhouse-srv/src/connection.rs
@@ -60,6 +60,8 @@ pub struct Connection {
     tz: Tz,
     with_stack_trace: bool,
     compress: bool,
+
+    pub client_addr: String,
 }
 
 impl Connection {
@@ -71,6 +73,7 @@ impl Connection {
         timezone: String,
     ) -> Result<Connection> {
         let tz: Tz = timezone.parse()?;
+        let client_addr = stream.peer_addr()?.to_string();
         Ok(Connection {
             stream: BufWriter::new(stream),
             buffer: BytesMut::with_capacity(4 * 1024),
@@ -78,6 +81,7 @@ impl Connection {
             tz,
             with_stack_trace: false,
             compress: true,
+            client_addr,
         })
     }
 

--- a/common/clickhouse-srv/src/lib.rs
+++ b/common/clickhouse-srv/src/lib.rs
@@ -76,7 +76,7 @@ pub trait ClickHouseSession: Send + Sync {
         Progress::default()
     }
 
-    fn authenticate(&self, _username: &str, _password: &[u8]) -> bool {
+    fn authenticate(&self, _username: &str, _password: &[u8], _client_addr: &str) -> bool {
         true
     }
 }

--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -96,11 +96,16 @@ impl ClickHouseSession for InteractiveWorker {
         54405
     }
 
-    fn authenticate(&self, user: &str, password: &[u8]) -> bool {
+    fn authenticate(&self, user: &str, password: &[u8], client_addr: &str) -> bool {
         let user_mgr = self.session.get_user_manager();
-        if let Ok(res) = user_mgr.auth_user(user, password) {
+        if let Ok(res) = user_mgr.auth_user(user, password, client_addr) {
             return res;
         }
+        log::error!(
+            "clickhouse authenticate failed, client_addr: {} user: {}",
+            client_addr,
+            user
+        );
         false
     }
 

--- a/query/src/servers/mysql/mysql_session.rs
+++ b/query/src/servers/mysql/mysql_session.rs
@@ -38,7 +38,8 @@ impl MySQLConnection {
     }
 
     fn session_executor(session: SessionRef, blocking_stream: std::net::TcpStream) {
-        let interactive_worker = InteractiveWorker::create(session);
+        let client_addr = blocking_stream.peer_addr().unwrap().to_string();
+        let interactive_worker = InteractiveWorker::create(session, client_addr);
         if let Err(error) = MysqlIntermediary::run_on_tcp(interactive_worker, blocking_stream) {
             if error.code() != ABORT_SESSION {
                 log::error!(

--- a/query/src/users/user_mgr.rs
+++ b/query/src/users/user_mgr.rs
@@ -64,7 +64,12 @@ impl UserManager {
     }
 
     // Auth the user and password for different Auth type.
-    pub fn auth_user(&self, user: &str, password: impl AsRef<[u8]>) -> Result<bool> {
+    pub fn auth_user(
+        &self,
+        user: &str,
+        password: impl AsRef<[u8]>,
+        _client_addr: &str,
+    ) -> Result<bool> {
         let user = self.get_user(user)?;
 
         match user.auth_type {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

## Changelog
- Improvement
for mysql/clickhouse auth, now we log the address if auth failed and check the auth is from remote or local in the server side.


## Related Issues
Related [#1984](https://github.com/datafuselabs/databend/issues/1984)

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

