### PR TITLE
[common/metatypes] refactor: move NodeInfo from common/management to common/metatypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,11 @@ name = "common-metatypes"
 version = "0.1.0"
 dependencies = [
  "async-raft",
+ "common-exception",
  "common-sled-store",
  "pretty_assertions",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/common/management/src/lib.rs
+++ b/common/management/src/lib.rs
@@ -18,7 +18,6 @@ mod user;
 
 pub use namespace::NamespaceApi;
 pub use namespace::NamespaceMgr;
-pub use namespace::NodeInfo;
 pub use user::user_api::AuthType;
 pub use user::user_api::UserInfo;
 pub use user::user_api::UserMgrApi;

--- a/common/management/src/namespace/mod.rs
+++ b/common/management/src/namespace/mod.rs
@@ -20,5 +20,4 @@ mod namespace_api;
 mod namespace_mgr;
 
 pub use namespace_api::NamespaceApi;
-pub use namespace_api::NodeInfo;
 pub use namespace_mgr::NamespaceMgr;

--- a/common/management/src/namespace/namespace_api.rs
+++ b/common/management/src/namespace/namespace_api.rs
@@ -13,47 +13,8 @@
 // limitations under the License.
 //
 
-use std::convert::TryFrom;
-
-use common_exception::ErrorCode;
 use common_exception::Result;
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct NodeInfo {
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub cpu_nums: u64,
-    #[serde(default)]
-    pub version: u32,
-    #[serde(default)]
-    pub flight_address: String,
-}
-
-impl TryFrom<Vec<u8>> for NodeInfo {
-    type Error = ErrorCode;
-
-    fn try_from(value: Vec<u8>) -> Result<Self> {
-        match serde_json::from_slice(&value) {
-            Ok(user_info) => Ok(user_info),
-            Err(serialize_error) => Err(ErrorCode::IllegalUserInfoFormat(format!(
-                "Cannot deserialize namespace from bytes. cause {}",
-                serialize_error
-            ))),
-        }
-    }
-}
-
-impl NodeInfo {
-    pub fn create(id: String, cpu_nums: u64, flight_address: String) -> NodeInfo {
-        NodeInfo {
-            id,
-            cpu_nums,
-            version: 0,
-            flight_address,
-        }
-    }
-}
+use common_metatypes::NodeInfo;
 
 #[async_trait::async_trait]
 pub trait NamespaceApi: Sync + Send {

--- a/common/management/src/namespace/namespace_mgr.rs
+++ b/common/management/src/namespace/namespace_mgr.rs
@@ -24,9 +24,9 @@ use common_kv_api::KVApi;
 use common_kv_api_vo::UpsertKVActionResult;
 use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
+use common_metatypes::NodeInfo;
 
 use crate::namespace::NamespaceApi;
-use crate::namespace::NodeInfo;
 
 #[allow(dead_code)]
 pub static NAMESPACE_API_KEY_PREFIX: &str = "__fd_namespaces";

--- a/common/management/src/namespace/namespace_mgr_test.rs
+++ b/common/management/src/namespace/namespace_mgr_test.rs
@@ -22,6 +22,7 @@ use common_exception::Result;
 use common_kv::KV;
 use common_kv_api::KVApi;
 use common_kv_api_vo::GetKVActionResult;
+use common_metatypes::NodeInfo;
 
 use super::*;
 use crate::namespace::namespace_mgr::NamespaceMgr;

--- a/common/metatypes/Cargo.toml
+++ b/common/metatypes/Cargo.toml
@@ -7,9 +7,11 @@ publish = false
 edition = "2021"
 
 [dependencies]
+common-exception = {path = "../exception"}
 common-sled-store = {path = "../sled-store"}
 
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.14" }
 
 [dev-dependencies]

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -21,6 +21,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 pub use cluster::Node;
+pub use cluster::NodeInfo;
 pub use cluster::Slot;
 pub use cmd::Cmd;
 pub use common_sled_store::KVMeta;

--- a/query/src/api/http/v1/cluster_test.rs
+++ b/query/src/api/http/v1/cluster_test.rs
@@ -21,7 +21,7 @@ use axum::AddExtensionLayer;
 use axum::Router;
 use common_base::tokio;
 use common_exception::Result;
-use common_management::NodeInfo;
+use common_metatypes::NodeInfo;
 use pretty_assertions::assert_eq;
 use tower::ServiceExt;
 

--- a/query/src/clusters/cluster.rs
+++ b/query/src/clusters/cluster.rs
@@ -25,7 +25,7 @@ use common_flight_rpc::ConnectionFactory;
 use common_kv_api::KVApi;
 use common_management::NamespaceApi;
 use common_management::NamespaceMgr;
-use common_management::NodeInfo;
+use common_metatypes::NodeInfo;
 use rand::thread_rng;
 use rand::Rng;
 

--- a/query/src/interpreters/interpreter_select.rs
+++ b/query/src/interpreters/interpreter_select.rs
@@ -23,7 +23,7 @@ use common_base::tokio::macros::support::Poll;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
-use common_management::NodeInfo;
+use common_metatypes::NodeInfo;
 use common_planners::SelectPlan;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use common_catalog::IOContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_management::NodeInfo;
+use common_metatypes::NodeInfo;
 use common_planners::AggregatorFinalPlan;
 use common_planners::AggregatorPartialPlan;
 use common_planners::BroadcastPlan;

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_management::NodeInfo;
+use common_metatypes::NodeInfo;
 
 use crate::clusters::Cluster;
 use crate::configs::Config;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/metatypes] refactor: move NodeInfo from common/management to common/metatypes

## Changelog




- Improvement


## Related Issues

- #2046
- #2059