### PR TITLE
[common/metatypes] feature: add NodeInfo::ip_port() to extract ip and port from node.flight_address

### DIFF
--- a/common/metatypes/src/cluster.rs
+++ b/common/metatypes/src/cluster.rs
@@ -14,6 +14,8 @@
 
 use std::convert::TryFrom;
 use std::fmt;
+use std::net::SocketAddr;
+use std::str::FromStr;
 
 use async_raft::NodeId;
 use common_exception::exception::ErrorCode;
@@ -80,5 +82,11 @@ impl NodeInfo {
             version: 0,
             flight_address,
         }
+    }
+
+    pub fn ip_port(&self) -> Result<(String, u16)> {
+        let addr = SocketAddr::from_str(&self.flight_address)?;
+
+        Ok((addr.ip().to_string(), addr.port()))
     }
 }

--- a/common/metatypes/src/cluster_test.rs
+++ b/common/metatypes/src/cluster_test.rs
@@ -1,0 +1,33 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_exception::exception::Result;
+
+use crate::NodeInfo;
+
+#[test]
+fn test_node_info_ip_port() -> Result<()> {
+    let n = NodeInfo {
+        id: "".to_string(),
+        cpu_nums: 1,
+        version: 1,
+        flight_address: "1.2.3.4:123".to_string(),
+    };
+
+    let (ip, port) = n.ip_port()?;
+    assert_eq!("1.2.3.4".to_string(), ip);
+    assert_eq!(123, port);
+
+    Ok(())
+}

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -49,6 +49,8 @@ mod raft_txid;
 mod raft_types;
 
 #[cfg(test)]
+mod cluster_test;
+#[cfg(test)]
 mod match_seq_test;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/metatypes] feature: add NodeInfo::ip_port() to extract ip and port from node.flight_address

## Changelog

- New Feature





## Related Issues

- #2046
- #2059