### PR TITLE
[common/catalog] feature: TableIOContext holds a list of all query-nodes. Table::read() needs the complete cluster info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "common-dal",
  "common-datavalues",
  "common-exception",
+ "common-metatypes",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/common/catalog/Cargo.toml
+++ b/common/catalog/Cargo.toml
@@ -12,6 +12,7 @@ common-base = {path = "../base"}
 common-dal = {path = "../dal"}
 common-datavalues = {path = "../datavalues"}
 common-exception = {path = "../exception"}
+common-metatypes = {path = "../metatypes"}
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/common/catalog/src/table_io_context.rs
+++ b/common/catalog/src/table_io_context.rs
@@ -19,6 +19,7 @@ use common_dal::DataAccessor;
 use common_dal::DataAccessorBuilder;
 use common_dal::StorageScheme;
 use common_exception::ErrorCode;
+use common_metatypes::NodeInfo;
 
 /// Methods for a table to get resource handles it needs to read/write.
 ///
@@ -36,14 +37,17 @@ pub trait IOContext {
     fn get_max_threads(&self) -> usize;
 
     /// Get a vec of `query` nodes.
-    fn get_query_nodes(&self) -> Vec<String>;
+    fn get_query_nodes(&self) -> Vec<Arc<NodeInfo>>;
+
+    /// Get a vec of `query` node ids.
+    fn get_query_node_ids(&self) -> Vec<String>;
 }
 
 pub struct TableIOContext {
     runtime: Arc<Runtime>,
     data_accessor_builder: Arc<dyn DataAccessorBuilder>,
     max_threads: usize,
-    query_nodes: Vec<String>,
+    query_nodes: Vec<Arc<NodeInfo>>,
 }
 
 impl TableIOContext {
@@ -51,7 +55,7 @@ impl TableIOContext {
         rt: Arc<Runtime>,
         dab: Arc<dyn DataAccessorBuilder>,
         max_threads: usize,
-        query_nodes: Vec<String>,
+        query_nodes: Vec<Arc<NodeInfo>>,
     ) -> TableIOContext {
         TableIOContext {
             runtime: rt,
@@ -78,7 +82,11 @@ impl IOContext for TableIOContext {
         self.max_threads
     }
 
-    fn get_query_nodes(&self) -> Vec<String> {
+    fn get_query_nodes(&self) -> Vec<Arc<NodeInfo>> {
         self.query_nodes.clone()
+    }
+
+    fn get_query_node_ids(&self) -> Vec<String> {
+        self.query_nodes.iter().map(|x| x.id.clone()).collect()
     }
 }

--- a/common/metatypes/src/cluster.rs
+++ b/common/metatypes/src/cluster.rs
@@ -48,7 +48,9 @@ impl fmt::Display for Node {
 impl SledSerde for Node {}
 
 /// Query node
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(
+    serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Default,
+)]
 pub struct NodeInfo {
     #[serde(default)]
     pub id: String,

--- a/query/src/clusters/cluster.rs
+++ b/query/src/clusters/cluster.rs
@@ -129,6 +129,10 @@ impl Cluster {
         node.id == self.local_id
     }
 
+    pub fn local_id(&self) -> String {
+        self.local_id.clone()
+    }
+
     pub async fn create_node_conn(&self, name: &str, config: &Config) -> Result<FlightClient> {
         for node in &self.nodes {
             if node.id == name {

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -856,7 +856,7 @@ impl PlanScheduler {
         table.read_plan(
             io_ctx.clone(),
             Some(node.push_downs.clone()),
-            Some(io_ctx.get_max_threads() * io_ctx.get_query_nodes().len()),
+            Some(io_ctx.get_max_threads() * io_ctx.get_query_node_ids().len()),
         )
     }
 

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -30,6 +30,7 @@ use common_exception::Result;
 use common_infallible::RwLock;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
+use common_metatypes::NodeInfo;
 use common_planners::Part;
 use common_planners::Partitions;
 use common_planners::PlanNode;
@@ -231,7 +232,11 @@ impl DatabendQueryContext {
 
     /// Build a TableIOContext for single node service.
     pub fn get_single_node_table_io_context(&self) -> Result<TableIOContext> {
-        let nodes = vec!["".to_string()];
+        let nodes = vec![Arc::new(NodeInfo {
+            id: self.get_cluster().local_id(),
+            ..Default::default()
+        })];
+
         let settings = self.get_settings();
         let max_threads = settings.get_max_threads()? as usize;
 
@@ -246,11 +251,7 @@ impl DatabendQueryContext {
     /// Build a TableIOContext that contains cluster information so that one using it could distributed data evenly in the cluster.
     pub fn get_cluster_table_io_context(&self) -> Result<TableIOContext> {
         let cluster = self.get_cluster();
-        let cluster_nodes = cluster.get_nodes();
-        let nodes = cluster_nodes
-            .iter()
-            .map(|x| x.id.clone())
-            .collect::<Vec<_>>();
+        let nodes = cluster.get_nodes();
         let settings = self.get_settings();
         let max_threads = settings.get_max_threads()? as usize;
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/catalog] feature: TableIOContext holds a list of all query-nodes. Table::read() needs the complete cluster info

## Changelog

- New Feature





## Related Issues

- #2046
- #2059