### PR TITLE
DAL: make DataAccessor::get_input_stream sync

### DIFF
--- a/common/dal/src/data_accessor.rs
+++ b/common/dal/src/data_accessor.rs
@@ -49,7 +49,7 @@ pub trait DataAccessor: Send + Sync {
 
     fn get_writer(&self, path: &str) -> Result<Box<dyn Write>>;
 
-    async fn get_input_stream(&self, path: &str, stream_len: Option<u64>) -> Result<InputStream>;
+    fn get_input_stream(&self, path: &str, stream_len: Option<u64>) -> Result<InputStream>;
 
     async fn get(&self, path: &str) -> Result<Bytes>;
 
@@ -65,7 +65,7 @@ pub trait DataAccessor: Send + Sync {
     ) -> Result<()>;
 
     async fn read(&self, location: &str) -> Result<Vec<u8>> {
-        let mut input_stream = self.get_input_stream(location, None).await?;
+        let mut input_stream = self.get_input_stream(location, None)?;
         let mut buffer = vec![];
         input_stream.read_to_end(&mut buffer).await?;
         Ok(buffer)

--- a/common/dal/src/impls/aws_s3/s3.rs
+++ b/common/dal/src/impls/aws_s3/s3.rs
@@ -111,7 +111,7 @@ impl DataAccessor for S3 {
         todo!()
     }
 
-    async fn get_input_stream(
+    fn get_input_stream(
         &self,
         path: &str,
         stream_len: Option<u64>,

--- a/common/dal/src/impls/aws_s3/s3_input_stream_test.rs
+++ b/common/dal/src/impls/aws_s3/s3_input_stream_test.rs
@@ -71,7 +71,7 @@ async fn test_s3_input_stream_api() -> common_exception::Result<()> {
     fixture.gen_test_obj().await?;
 
     let s3 = S3::new(fixture.region.clone(), fixture.bucket_name.clone());
-    let mut input = s3.get_input_stream(&test_key, None).await?;
+    let mut input = s3.get_input_stream(&test_key, None)?;
     let mut buffer = vec![];
     input.read_to_end(&mut buffer).await?;
     assert_eq!(fixture.content, buffer);
@@ -94,7 +94,7 @@ async fn test_s3_cli_with_credentials() -> common_exception::Result<()> {
         secret,
     )?;
     let mut buffer = vec![];
-    let mut input = s3.get_input_stream(&test_key, None).await?;
+    let mut input = s3.get_input_stream(&test_key, None)?;
     input.read_to_end(&mut buffer).await?;
     assert_eq!(fixture.content, buffer);
     Ok(())
@@ -108,7 +108,7 @@ async fn test_s3_input_stream_seek_api() -> common_exception::Result<()> {
     fixture.gen_test_obj().await?;
 
     let s3 = S3::new(fixture.region.clone(), fixture.bucket_name.clone());
-    let mut input = s3.get_input_stream(&test_key, None).await?;
+    let mut input = s3.get_input_stream(&test_key, None)?;
     let mut buffer = vec![];
     input.seek(SeekFrom::Current(1)).await?;
     input.read_to_end(&mut buffer).await?;

--- a/common/dal/src/impls/local.rs
+++ b/common/dal/src/impls/local.rs
@@ -69,9 +69,11 @@ impl DataAccessor for Local {
         Ok(Box::new(std::fs::File::create(path)?))
     }
 
-    async fn get_input_stream(&self, path: &str, _stream_len: Option<u64>) -> Result<InputStream> {
+    fn get_input_stream(&self, path: &str, _stream_len: Option<u64>) -> Result<InputStream> {
         let path = self.prefix_with_root(path)?;
-        Ok(Box::new(tokio::fs::File::open(path).await?.compat()))
+        let std_file = std::fs::File::open(path)?;
+        let tokio_file = tokio::fs::File::from_std(std_file);
+        Ok(Box::new(tokio_file.compat()))
     }
 
     async fn get(&self, path: &str) -> Result<Bytes> {

--- a/query/src/datasources/table/fuse/io/block_reader.rs
+++ b/query/src/datasources/table/fuse/io/block_reader.rs
@@ -79,7 +79,7 @@ pub(crate) async fn read_part(
 ) -> Result<()> {
     let loc = block_location(&part.name);
     // TODO pass in parquet file len
-    let mut reader = data_accessor.get_input_stream(&loc, None).await?;
+    let mut reader = data_accessor.get_input_stream(&loc, None)?;
     let metadata = read_metadata_async(&mut reader)
         .await
         .map_err(|e| ErrorCode::ParquetError(e.to_string()))?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

make DataAccessor::get_input_stream sync.
 

## Changelog


- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

