### PR TITLE
[common/catalog] feature: trait IOContext adds method get_user_data<T>() to fetch user data of any type. Table::read() on special tables need to access DatabendQueryContext

### DIFF
--- a/common/catalog/src/lib.rs
+++ b/common/catalog/src/lib.rs
@@ -17,6 +17,9 @@
 mod table_io_context;
 mod table_snapshot;
 
+#[cfg(test)]
+mod table_io_context_test;
+
 pub use table_io_context::IOContext;
 pub use table_io_context::TableIOContext;
 pub use table_snapshot::BlockLocation;

--- a/common/catalog/src/table_io_context_test.rs
+++ b/common/catalog/src/table_io_context_test.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::Runtime;
+use common_dal::DefaultDataAccessorBuilder;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::IOContext;
+use crate::TableIOContext;
+
+#[test]
+fn test_table_io_context() -> Result<()> {
+    let c = TableIOContext::new(
+        Arc::new(Runtime::with_default_worker_threads()?),
+        Arc::new(DefaultDataAccessorBuilder {}),
+        3,
+        vec![],
+        Some(Arc::new("foo".to_string())),
+    );
+
+    let s: Arc<String> = c.get_user_data()?.unwrap();
+    assert_eq!(Arc::new("foo".to_string()), s);
+
+    let s: Result<Option<Arc<u32>>> = c.get_user_data();
+    let e = s.unwrap_err();
+    assert_eq!(ErrorCode::InvalidCast("").code(), e.code());
+
+    Ok(())
+}

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -284,6 +284,8 @@ build_exceptions! {
     // A task that already started and can not start twice.
     AlreadyStopped(7102),
 
+    // Trying to cast to a invalid type
+    InvalidCast(7201),
 }
 
 pub type Result<T> = std::result::Result<T, ErrorCode>;

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -231,7 +231,7 @@ impl DatabendQueryContext {
     }
 
     /// Build a TableIOContext for single node service.
-    pub fn get_single_node_table_io_context(&self) -> Result<TableIOContext> {
+    pub fn get_single_node_table_io_context(self: &Arc<Self>) -> Result<TableIOContext> {
         let nodes = vec![Arc::new(NodeInfo {
             id: self.get_cluster().local_id(),
             ..Default::default()
@@ -245,11 +245,12 @@ impl DatabendQueryContext {
             Arc::new(DefaultDataAccessorBuilder {}),
             max_threads,
             nodes,
+            Some(Arc::new(self.clone())),
         ))
     }
 
     /// Build a TableIOContext that contains cluster information so that one using it could distributed data evenly in the cluster.
-    pub fn get_cluster_table_io_context(&self) -> Result<TableIOContext> {
+    pub fn get_cluster_table_io_context(self: &Arc<Self>) -> Result<TableIOContext> {
         let cluster = self.get_cluster();
         let nodes = cluster.get_nodes();
         let settings = self.get_settings();
@@ -260,6 +261,7 @@ impl DatabendQueryContext {
             Arc::new(DefaultDataAccessorBuilder {}),
             max_threads,
             nodes,
+            Some(Arc::new(self.clone())),
         ))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/catalog] feature: trait IOContext adds method get_user_data<T>() to fetch user data of any type. Table::read() on special tables need to access DatabendQueryContext

## Changelog

- New Feature





## Related Issues

- #2046
- #2059
- Prepare for #2091 