### PR TITLE
[common/planner] refactor: remove unused field: ReadDataSourcePlan::remote; If a table is "remote" can be detected by its type

### DIFF
--- a/common/planners/src/plan_read_datasource.rs
+++ b/common/planners/src/plan_read_datasource.rs
@@ -39,7 +39,6 @@ pub struct ReadDataSourcePlan {
     pub statistics: Statistics,
     pub description: String,
     pub scan_plan: Arc<ScanPlan>,
-    pub remote: bool,
 
     pub tbl_args: Option<Vec<Expression>>,
     pub push_downs: Option<Extras>,
@@ -57,7 +56,6 @@ impl ReadDataSourcePlan {
             statistics: Statistics::default(),
             description: "".to_string(),
             scan_plan: Arc::new(ScanPlan::with_table_id(table_id, table_version)),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         }

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -56,7 +56,6 @@ impl Test {
                 statistics.read_rows, statistics.read_bytes
             ),
             scan_plan: Arc::new(ScanPlan::empty()),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         }))

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -105,7 +105,6 @@ impl Table for ExampleTable {
                 self.db, self.name
             ),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -92,7 +92,6 @@ impl Table for ClustersTable {
             statistics: Statistics::default(),
             description: "(Read from system.clusters table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -115,7 +115,6 @@ impl Table for ConfigsTable {
             statistics: Statistics::default(),
             description: "(Read from system.configs table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -87,7 +87,6 @@ impl Table for ContributorsTable {
             statistics: Statistics::default(),
             description: "(Read from system.contributors table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -91,7 +91,6 @@ impl Table for CreditsTable {
             statistics: Statistics::default(),
             description: "(Read from system.credits table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -90,7 +90,6 @@ impl Table for DatabasesTable {
             statistics: Statistics::default(),
             description: "(Read from system.databases table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/engines_table.rs
+++ b/query/src/datasources/database/system/engines_table.rs
@@ -93,7 +93,6 @@ impl Table for EnginesTable {
             statistics: Statistics::default(),
             description: "(Read from system.engines table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -92,7 +92,6 @@ impl Table for FunctionsTable {
             statistics: Statistics::default(),
             description: "(Read from system.functions table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -87,7 +87,6 @@ impl Table for OneTable {
             statistics: Statistics::new_exact(1, std::mem::size_of::<u8>()),
             description: "(Read from system.one table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -114,7 +114,6 @@ impl Table for ProcessesTable {
             statistics: Statistics::default(),
             description: "(Read from system.processes table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -94,7 +94,6 @@ impl Table for SettingsTable {
             statistics: Statistics::default(),
             description: "(Read from system.settings table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -94,7 +94,6 @@ impl Table for TablesTable {
             statistics: Statistics::default(),
             description: "(Read from system.functions table)".to_string(),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -103,7 +103,6 @@ impl Table for TracingTable {
             statistics: Statistics::default(),
             description: "(Read from system.tracing table)".to_string(),
             scan_plan: Default::default(),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -114,7 +114,6 @@ impl Table for CsvTable {
             statistics: Statistics::default(),
             description: format!("(Read from CSV Engine table  {}.{})", db, name),
             scan_plan: Arc::new(ScanPlan::empty()),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -130,7 +130,6 @@ impl Table for FuseTable {
                 statistics,
                 description: "".to_string(),
                 scan_plan: Default::default(),
-                remote: true,
                 tbl_args: None,
                 push_downs,
             };
@@ -296,7 +295,6 @@ impl FuseTable {
             statistics: Statistics::default(),
             description: "".to_string(),
             scan_plan: Default::default(),
-            remote: true,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -104,7 +104,6 @@ impl Table for MemoryTable {
             statistics: Statistics::new_exact(rows, bytes),
             description: format!("(Read from Memory Engine table  {}.{})", db, self.name()),
             scan_plan: Default::default(),
-            remote: false,
             tbl_args: None,
             push_downs,
         })

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -91,7 +91,6 @@ impl Table for NullTable {
             statistics: Statistics::new_exact(0, 0),
             description: format!("(Read from Null Engine table  {}.{})", db, self.name()),
             scan_plan: Default::default(),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         })

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -137,7 +137,6 @@ impl Table for ParquetTable {
             statistics: Statistics::default(),
             description: format!("(Read from Parquet Engine table  {}.{})", db, self.name()),
             scan_plan: Default::default(),
-            remote: false,
             tbl_args: None,
             push_downs,
         })

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -150,7 +150,6 @@ impl Table for NumbersTable {
                 &self.table_name, statistics.read_rows, statistics.read_bytes
             ),
             scan_plan: Default::default(), // scan_plan will be removed form ReadSourcePlan soon
-            remote: false,
             tbl_args: tbl_arg,
             push_downs,
         })

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -130,7 +130,6 @@ impl PlanRewriter for ProjectionPushDownImpl {
                     statistics: plan.statistics.clone(),
                     description: plan.description.to_string(),
                     scan_plan: plan.scan_plan.clone(),
-                    remote: plan.remote,
                     tbl_args: plan.tbl_args.clone(),
                     push_downs: plan.push_downs.clone(),
                 })

--- a/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -109,7 +109,6 @@ fn test_projection_push_down_optimizer_2() -> Result<()> {
             statistics.read_bytes
         ),
         scan_plan: Arc::new(ScanPlan::empty()),
-        remote: false,
         tbl_args: None,
         push_downs: None,
     });
@@ -168,7 +167,6 @@ fn test_projection_push_down_optimizer_3() -> Result<()> {
             statistics.read_bytes
         ),
         scan_plan: Arc::new(ScanPlan::empty()),
-        remote: false,
         tbl_args: None,
         push_downs: None,
     });

--- a/query/src/optimizers/optimizer_statistics_exact_test.rs
+++ b/query/src/optimizers/optimizer_statistics_exact_test.rs
@@ -52,7 +52,6 @@ mod tests {
                 statistics.read_bytes
             ),
             scan_plan: Arc::new(ScanPlan::empty()),
-            remote: false,
             tbl_args: None,
             push_downs: None,
         });

--- a/query/src/tests/sessions.rs
+++ b/query/src/tests/sessions.rs
@@ -17,7 +17,6 @@ use std::env;
 use common_base::tokio::runtime::Runtime;
 use common_exception::Result;
 
-use crate::clusters::ClusterDiscovery;
 use crate::configs::Config;
 use crate::sessions::SessionManager;
 use crate::sessions::SessionManagerRef;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/planner] refactor: remove unused field: ReadDataSourcePlan::remote; If a table is "remote" can be detected by its type
- fix: #2113

## Changelog




- Improvement


## Related Issues

- #2046
- #2059