### PR TITLE
[query] refactor: Table::read() does not need ReadDataSourcePlan, only `push_downs`

### DIFF
--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -81,5 +81,7 @@ async fn execute_query(context: DatabendQueryContextRef) -> Result<SendableDataB
         Some(context.get_settings().get_max_threads()? as usize),
     )?;
 
-    tracing_table.read(io_ctx, &tracing_table_read_plan).await
+    tracing_table
+        .read(io_ctx, &tracing_table_read_plan.push_downs)
+        .await
 }

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -53,7 +53,7 @@ pub trait Table: Sync + Send {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream>;
 
     // temporary added, pls feel free to rm it

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -113,7 +113,7 @@ impl Table for ExampleTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.schema.clone());
 

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -100,7 +100,7 @@ impl Table for ClustersTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let cluster_nodes = io_ctx.get_query_nodes();
 

--- a/query/src/datasources/database/system/clusters_table_test.rs
+++ b/query/src/datasources/database/system/clusters_table_test.rs
@@ -34,7 +34,7 @@ async fn test_clusters_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -123,7 +123,7 @@ impl Table for ConfigsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/configs_table_test.rs
+++ b/query/src/datasources/database/system/configs_table_test.rs
@@ -39,7 +39,7 @@ async fn test_configs_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -95,7 +95,7 @@ impl Table for ContributorsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let contributors: Vec<&[u8]> = env!("DATABEND_COMMIT_AUTHORS")
             .split_terminator(',')

--- a/query/src/datasources/database/system/contributors_table_test.rs
+++ b/query/src/datasources/database/system/contributors_table_test.rs
@@ -33,7 +33,7 @@ async fn test_contributors_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -99,7 +99,7 @@ impl Table for CreditsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let metadata_command = cargo_metadata::MetadataCommand::new();
 

--- a/query/src/datasources/database/system/credits_table_test.rs
+++ b/query/src/datasources/database/system/credits_table_test.rs
@@ -34,7 +34,7 @@ async fn test_credits_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -98,7 +98,7 @@ impl Table for DatabasesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/databases_table_test.rs
+++ b/query/src/datasources/database/system/databases_table_test.rs
@@ -33,7 +33,7 @@ async fn test_tables_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/database/system/engines_table.rs
+++ b/query/src/datasources/database/system/engines_table.rs
@@ -101,7 +101,7 @@ impl Table for EnginesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/engines_table_test.rs
+++ b/query/src/datasources/database/system/engines_table_test.rs
@@ -36,7 +36,7 @@ async fn test_engines_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 2);

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -100,7 +100,7 @@ impl Table for FunctionsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let function_factory = FunctionFactory::instance();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/query/src/datasources/database/system/functions_table_test.rs
+++ b/query/src/datasources/database/system/functions_table_test.rs
@@ -33,7 +33,7 @@ async fn test_functions_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 2);

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -95,7 +95,7 @@ impl Table for OneTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::create_by_array(self.schema.clone(), vec![Series::new(vec![1u8])]);
         Ok(Box::pin(DataBlockStream::create(

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -122,7 +122,7 @@ impl Table for ProcessesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -102,7 +102,7 @@ impl Table for SettingsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/settings_table_test.rs
+++ b/query/src/datasources/database/system/settings_table_test.rs
@@ -36,7 +36,7 @@ async fn test_settings_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -102,7 +102,7 @@ impl Table for TablesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/tables_table_test.rs
+++ b/query/src/datasources/database/system/tables_table_test.rs
@@ -33,7 +33,7 @@ async fn test_tables_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -111,7 +111,7 @@ impl Table for TracingTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        source_plan: &ReadDataSourcePlan,
+        push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let mut log_files = vec![];
 
@@ -130,7 +130,6 @@ impl Table for TracingTable {
 
         // Default limit.
         let mut limit = 100000000_usize;
-        let push_downs = &source_plan.push_downs;
         tracing::debug!("read push_down:{:?}", push_downs);
 
         if let Some(extras) = push_downs {

--- a/query/src/datasources/database/system/tracing_table_test.rs
+++ b/query/src/datasources/database/system/tracing_table_test.rs
@@ -33,7 +33,7 @@ async fn test_tracing_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 7);

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -122,7 +122,7 @@ impl Table for CsvTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -72,7 +72,7 @@ async fn test_csv_table() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);
@@ -146,7 +146,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await;
     // integer parse error will result to Null value
     assert_eq!(false, result.is_err());

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -142,7 +142,7 @@ impl Table for FuseTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        source_plan: &ReadDataSourcePlan,
+        push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?
@@ -154,7 +154,7 @@ impl Table for FuseTable {
                 .collect::<Vec<usize>>()
         };
 
-        let projection = if let Some(push_down) = &source_plan.push_downs {
+        let projection = if let Some(push_down) = push_downs {
             if let Some(prj) = &push_down.projection {
                 prj.clone()
             } else {

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -112,7 +112,7 @@ impl Table for MemoryTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -82,7 +82,7 @@ async fn test_memorytable() -> Result<()> {
         ctx.try_set_partitions(source_plan.parts.clone())?;
         assert_eq!(table.engine(), "Memory");
 
-        let stream = table.read(io_ctx.clone(), &source_plan).await?;
+        let stream = table.read(io_ctx.clone(), &source_plan.push_downs).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(
             vec![
@@ -114,7 +114,7 @@ async fn test_memorytable() -> Result<()> {
             None,
             Some(ctx.get_settings().get_max_threads()? as usize),
         )?;
-        let stream = table.read(io_ctx, &source_plan).await?;
+        let stream = table.read(io_ctx, &source_plan.push_downs).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(vec!["++", "++"], &result);
     }

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -99,7 +99,7 @@ impl Table for NullTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.tbl_info.schema.clone());
 

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -77,7 +77,7 @@ async fn test_null_table() -> Result<()> {
         )?;
         assert_eq!(table.engine(), "Null");
 
-        let stream = table.read(io_ctx.clone(), &source_plan).await?;
+        let stream = table.read(io_ctx.clone(), &source_plan.push_downs).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let block = &result[0];
         assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -145,7 +145,7 @@ impl Table for ParquetTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         type BlockSender = Sender<Option<Result<DataBlock>>>;
         type BlockReceiver = Receiver<Option<Result<DataBlock>>>;

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -57,7 +57,7 @@ async fn test_parquet_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let blocks = stream.try_collect::<Vec<_>>().await?;
     let rows: usize = blocks.iter().map(|block| block.num_rows()).sum();
 

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -158,7 +158,7 @@ impl Table for NumbersTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _source_plan: &ReadDataSourcePlan,
+        _push_downs: &Option<Extras>,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table_func/numbers_table_test.rs
+++ b/query/src/datasources/table_func/numbers_table_test.rs
@@ -52,7 +52,7 @@ async fn test_number_table() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan).await?;
+    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/pipelines/transforms/transform_source.rs
+++ b/query/src/pipelines/transforms/transform_source.rs
@@ -56,7 +56,7 @@ impl SourceTransform {
         // TODO(xp): get_single_node_table_io_context() or
         //           get_cluster_table_io_context()?
         let io_ctx = Arc::new(self.ctx.get_cluster_table_io_context()?);
-        let table_stream = table.read(io_ctx, &self.source_plan);
+        let table_stream = table.read(io_ctx, &self.source_plan.push_downs);
         Ok(Box::pin(
             self.ctx.try_create_abortable(table_stream.await?)?,
         ))


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: Table::read() does not need ReadDataSourcePlan, only `push_downs`
`push_downs` contains projection, filter and limit, which may be used
when reading data.

The table partitions a `read()` operation requires are fed into
`DatabendQueryContext::partition_queue`.

- fix: #2107

## Changelog




- Improvement


## Related Issues

- #2046
- #2059