### PR TITLE
ISSUE-2039: rm param "database" from get_table_by_id

### DIFF
--- a/common/meta/raft-store/src/state_machine/applied_state.rs
+++ b/common/meta/raft-store/src/state_machine/applied_state.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 
 /// The state of an applied raft log.
 /// Normally it includes two fields: the state before applying and the state after applying the log.
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum AppliedState {
     String {

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -471,6 +471,9 @@ impl StateMachine {
                 } else {
                     let table = Table {
                         table_id: self.incr_seq(SEQ_TABLE_ID).await?,
+                        table_name: table_name.to_string(),
+                        database_id: db.database_id,
+                        db_name: db_name.to_string(),
                         schema: table.schema.clone(),
                         table_engine: table.table_engine.clone(),
                         table_options: table.table_options.clone(),

--- a/common/meta/types/src/table_info.rs
+++ b/common/meta/types/src/table_info.rs
@@ -25,6 +25,15 @@ use crate::MetaVersion;
 pub struct Table {
     pub table_id: u64,
 
+    /// name of this table
+    pub table_name: String,
+
+    /// identity of the database which this table belongs to
+    pub database_id: u64,
+
+    /// snapshot of the database name which this table is being created
+    pub db_name: String,
+
     /// serialized schema
     pub schema: Vec<u8>,
 

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -175,6 +175,9 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
 
         let table = Table {
             table_id: 0,
+            table_name: table_name.to_string(),
+            database_id: 0, // this field is unused during the creation of table
+            db_name: db_name.to_string(),
             schema: flight_data.data_header,
             table_engine: plan.engine.clone(),
             table_options: plan.options.clone(),
@@ -286,9 +289,9 @@ impl RequestHandler<GetTableAction> for ActionHandler {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
                 let rst = TableInfo {
-                    database_id: 0,
+                    database_id: db.database_id,
                     table_id: table.table_id,
-                    version: 0,
+                    version: 0, // placeholder, not yet implemented in meta service
                     db: db_name.clone(),
                     name: table_name.clone(),
                     schema: Arc::new(arrow_schema.into()),
@@ -318,12 +321,11 @@ impl RequestHandler<GetTableExtReq> for ActionHandler {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
                 let rst = TableInfo {
-                    database_id: 0,
+                    database_id: table.database_id,
                     table_id: table.table_id,
+                    db: table.db_name,
+                    name: table.table_name,
                     version: 0,
-                    // TODO rm these filed
-                    db: "".to_owned(),
-                    name: "".to_owned(), // TODO for each version of table, we duplicates the name at present
                     schema: Arc::new(arrow_schema.into()),
                     engine: table.table_engine.clone(),
                     options: table.table_options,
@@ -376,7 +378,7 @@ impl RequestHandler<GetTablesAction> for ActionHandler {
                 })?;
 
                 let tbl_info = TableInfo {
-                    database_id: 0,
+                    database_id: tbl.database_id,
                     db: req.db.to_string(),
                     table_id: *id,
                     version: 0,

--- a/query/src/catalogs/backends/backend.rs
+++ b/query/src/catalogs/backends/backend.rs
@@ -48,7 +48,6 @@ pub trait CatalogBackend: Send + Sync {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableInfo>>;

--- a/query/src/catalogs/backends/impls/remote_backend.rs
+++ b/query/src/catalogs/backends/impls/remote_backend.rs
@@ -192,7 +192,6 @@ impl CatalogBackend for RemoteCatalogBackend {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableInfo>> {
@@ -213,8 +212,8 @@ impl CatalogBackend for RemoteCatalogBackend {
         )??;
 
         let res = TableInfo {
+            db: reply.db.clone(),
             database_id: 0,
-            db: db_name.to_owned(),
             table_id: reply.table_id,
             version: 0,
             name: reply.name.clone(),

--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -51,7 +51,6 @@ pub trait Catalog {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableMeta>>;

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -163,11 +163,14 @@ impl Catalog for MetaStoreCatalog {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableMeta>> {
-        let db = self.get_database(db_name)?;
+        let tbl_info = self
+            .catalog_backend
+            .get_table_by_id(table_id, table_version)?;
+        // table factories are insides Database, tobe optimized latter
+        let db = self.get_database(&tbl_info.db)?;
         db.get_table_by_id(table_id, table_version)
     }
 

--- a/query/src/catalogs/impls/catalog/overlaid_catalog.rs
+++ b/query/src/catalogs/impls/catalog/overlaid_catalog.rs
@@ -110,16 +110,12 @@ impl Catalog for OverlaidCatalog {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> common_exception::Result<Arc<TableMeta>> {
         self.read_only
-            .get_table_by_id(db_name, table_id, table_version)
-            .or_else(|_e| {
-                self.bottom
-                    .get_table_by_id(db_name, table_id, table_version)
-            })
+            .get_table_by_id(table_id, table_version)
+            .or_else(|_e| self.bottom.get_table_by_id(table_id, table_version))
     }
 
     fn get_table_function(

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -83,12 +83,20 @@ impl Catalog for SystemCatalog {
 
     fn get_table_by_id(
         &self,
-        db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<TableMeta>> {
-        let db = self.get_database(db_name)?;
-        db.get_table_by_id(table_id, table_version)
+        for db in self.dbs.values() {
+            let tbl = db.get_table_by_id(table_id, table_version);
+            match tbl {
+                Ok(tbl) => return Ok(tbl),
+                Err(_) => continue,
+            }
+        }
+        Err(ErrorCode::UnknownTable(format!(
+            "unknown table of id {}",
+            table_id
+        )))
     }
 
     fn create_database(&self, _plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {

--- a/query/src/datasources/database/default/default_database.rs
+++ b/query/src/datasources/database/default/default_database.rs
@@ -114,9 +114,9 @@ impl Database for DefaultDatabase {
             }
         }
 
-        let tbl_info =
-            self.catalog_backend
-                .get_table_by_id(self.name(), table_id, table_version)?;
+        let tbl_info = self
+            .catalog_backend
+            .get_table_by_id(table_id, table_version)?;
 
         self.build_table_instance(tbl_info.as_ref())
     }

--- a/query/src/pipelines/transforms/transform_source.rs
+++ b/query/src/pipelines/transforms/transform_source.rs
@@ -39,14 +39,11 @@ impl SourceTransform {
         Ok(SourceTransform { ctx, source_plan })
     }
 
-    async fn read_table(&self, db: &str) -> Result<SendableDataBlockStream> {
+    async fn read_table(&self, _db: &str) -> Result<SendableDataBlockStream> {
         let table_id = self.source_plan.table_id;
         let table_ver = self.source_plan.table_version;
         let table = if self.source_plan.tbl_args.is_none() {
-            self.ctx
-                .get_table_by_id(db, table_id, table_ver)?
-                .raw()
-                .clone()
+            self.ctx.get_table_by_id(table_id, table_ver)?.raw().clone()
         } else {
             let func_meta = self
                 .ctx

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -152,12 +152,10 @@ impl DatabendQueryContext {
 
     pub fn get_table_by_id(
         &self,
-        database: &str,
         table_id: MetaId,
         table_ver: Option<MetaVersion>,
     ) -> Result<Arc<TableMeta>> {
-        self.get_catalog()
-            .get_table_by_id(database, table_id, table_ver)
+        self.get_catalog().get_table_by_id(table_id, table_ver)
     }
 
     pub fn get_table_function(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- signature of Catalog::get_table_by_id changed to

```
    fn get_table_by_id(
        &self,
        table_id: MetaId,
        table_version: Option<MetaVersion>,
    ) -> Result<Arc<TableMeta>>;
```
the "database_name" parameter has been removed.

NOTE:
 1. add `database_name` and `table_name` to struct `common/meta/types/Table` 
 2. added annotation `#[allow(clippy::large_enum_variant)]` to `pub enum AppliedState`
     to disable the warning `variant is 400 bytes`

## Changelog


- Improvement
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2039

## Test Plan

Unit Tests

Stateless Tests

