### PR TITLE
[common/meta/types] feature: add database_id and version to TableInfo; not used yet.

### DIFF
--- a/common/meta/types/src/table_info.rs
+++ b/common/meta/types/src/table_info.rs
@@ -16,11 +16,26 @@ use std::collections::HashMap;
 
 use common_datavalues::DataSchemaRef;
 
+use crate::MetaVersion;
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TableInfo {
+    pub database_id: u64,
     pub table_id: u64,
+
+    /// version of this table snapshot.
+    ///
+    /// Any change to a table causes the version to increment, e.g. insert or delete rows, update schema etc.
+    /// But renaming a table should not affect the version, since the table itself does not change.
+    /// The tuple (database_id, table_id, version) identifies a unique and consistent table snapshot.
+    ///
+    /// A version is not guaranteed to be consecutive.
+    ///
+    pub version: MetaVersion,
+
     pub db: String,
     pub name: String,
+
     pub schema: DataSchemaRef,
     pub engine: String,
     pub options: HashMap<String, String>,

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -286,7 +286,9 @@ impl RequestHandler<GetTableAction> for ActionHandler {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
                 let rst = TableInfo {
+                    database_id: 0,
                     table_id: table.table_id,
+                    version: 0,
                     db: db_name.clone(),
                     name: table_name.clone(),
                     schema: Arc::new(arrow_schema.into()),
@@ -316,7 +318,9 @@ impl RequestHandler<GetTableExtReq> for ActionHandler {
                     ErrorCode::IllegalSchema(format!("invalid schema: {:}", e.to_string()))
                 })?;
                 let rst = TableInfo {
+                    database_id: 0,
                     table_id: table.table_id,
+                    version: 0,
                     // TODO rm these filed
                     db: "".to_owned(),
                     name: "".to_owned(), // TODO for each version of table, we duplicates the name at present
@@ -372,8 +376,10 @@ impl RequestHandler<GetTablesAction> for ActionHandler {
                 })?;
 
                 let tbl_info = TableInfo {
+                    database_id: 0,
                     db: req.db.to_string(),
                     table_id: *id,
+                    version: 0,
                     name: name.to_string(),
                     schema: Arc::new(arrow_schema.into()),
                     engine: tbl.table_engine.to_string(),

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -166,8 +166,10 @@ impl CatalogBackend for EmbeddedCatalogBackend {
         let table_name = clone.table.as_str();
 
         let table_info = TableInfo {
+            database_id: 0,
             db: plan.db,
             table_id: self.next_db_id(),
+            version: 0,
             name: plan.table,
             schema: plan.schema,
             options: plan.options,

--- a/query/src/catalogs/backends/impls/remote_backend.rs
+++ b/query/src/catalogs/backends/impls/remote_backend.rs
@@ -165,8 +165,10 @@ impl CatalogBackend for RemoteCatalogBackend {
         };
 
         let table_info = TableInfo {
+            database_id: 0,
             db: reply.db,
             table_id: reply.table_id,
+            version: 0,
             name: reply.name.clone(),
             schema: reply.schema,
             engine: reply.engine,
@@ -211,8 +213,10 @@ impl CatalogBackend for RemoteCatalogBackend {
         )??;
 
         let res = TableInfo {
+            database_id: 0,
             db: db_name.to_owned(),
             table_id: reply.table_id,
+            version: 0,
             name: reply.name.clone(),
             schema: reply.schema.clone(),
             engine: reply.engine.clone(),

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -41,12 +41,14 @@ async fn test_csv_table() -> Result<()> {
 
     let ctx = crate::tests::try_create_context()?;
     let table = CsvTable::try_create(TableInfo {
+        database_id: 0,
         db: "default".into(),
         name: "test_csv".into(),
         schema: DataSchemaRefExt::create(vec![DataField::new("column1", DataType::UInt64, false)]),
         engine: "Csv".to_string(),
         options: options,
         table_id: 0,
+        version: 0,
     })?;
 
     let scan_plan = &ScanPlan {
@@ -110,6 +112,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
 
     let table = CsvTable::try_create(TableInfo {
+        database_id: 0,
         db: "default".into(),
         name: "test_csv".into(),
         schema: DataSchemaRefExt::create(vec![
@@ -121,6 +124,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
         engine: "Csv".to_string(),
         options: options,
         table_id: 0,
+        version: 0,
     })?;
 
     let scan_plan = &ScanPlan {

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -35,12 +35,14 @@ async fn test_memorytable() -> Result<()> {
         DataField::new("b", DataType::UInt64, false),
     ]);
     let table = MemoryTable::try_create(TableInfo {
+        database_id: 0,
         db: "default".into(),
         name: "a".into(),
         schema: schema.clone(),
         engine: "Memory".to_string(),
         options: TableOptions::default(),
         table_id: 0,
+        version: 0,
     })?;
 
     let io_ctx = ctx.get_single_node_table_io_context()?;

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -35,12 +35,14 @@ async fn test_null_table() -> Result<()> {
         DataField::new("b", DataType::UInt64, false),
     ]);
     let table = NullTable::try_create(TableInfo {
+        database_id: 0,
         db: "default".into(),
         name: "a".into(),
         schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::UInt64, false)]),
         engine: "Null".to_string(),
         options: TableOptions::default(),
         table_id: 0,
+        version: 0,
     })?;
 
     let io_ctx = ctx.get_single_node_table_io_context()?;

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -40,8 +40,10 @@ async fn test_parquet_table() -> Result<()> {
 
     let ctx = crate::tests::try_create_context()?;
     let tbl_info = TableInfo {
+        database_id: 0,
         db: "default".to_string(),
         table_id: 0,
+        version: 0,
         name: "test_parquet".to_string(),
         schema: DataSchemaRefExt::create(vec![DataField::new("id", DataType::Int32, false)]),
         engine: "test_parquet".into(),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] feature: add database_id and version to TableMeta; not used yet.
To re-fetch a table(e.g. from meta-service), `database_id` is required.
To re-fetch a consistent snapshot of table, `version` is required.

With these two additional field, a table can be refetched from catalog
or meta service without consistency issue.

- fix: #2152

## Changelog

- New Feature





## Related Issues

- #2046
- #2059