### PR TITLE
ISSUE-2176: support remove constant conditions

### DIFF
--- a/query/src/optimizers/optimizer_constant_folding_test.rs
+++ b/query/src/optimizers/optimizer_constant_folding_test.rs
@@ -108,6 +108,70 @@ mod tests {
                 \n  Expression: String:String (Before Projection)\
                 \n    ReadDataSource: scan partitions: [1], scan schema: [dummy:UInt8], statistics: [read_rows: 1, read_bytes: 1]",
             },
+            Test {
+                name: "Filter true and cond",
+                query: "SELECT number from numbers(10) where true AND number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter cond and true",
+                query: "SELECT number from numbers(10) where number > 1 AND true",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter false and cond",
+                query: "SELECT number from numbers(10) where false AND number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: false\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter cond and false",
+                query: "SELECT number from numbers(10) where number > 1 AND false",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: false\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter false or cond",
+                query: "SELECT number from numbers(10) where false OR number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter cond or false",
+                query: "SELECT number from numbers(10) where number > 1 OR false",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: (number > 1)\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter true or cond",
+                query: "SELECT number from numbers(10) where true OR number > 1",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: true\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
+            Test {
+                name: "Filter cond or true",
+                query: "SELECT number from numbers(10) where number > 1 OR true",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: true\
+                \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
+            },
         ];
 
         for test in tests {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

If an AND condition has `cond AND FALSE`, then the entire condition is collapsed and replaced with `ALWAYS FALSE`. 

Similarly, if an OR condition has `cond OR TRUE`, then the entire condition is replaced with `ALWAYS TRUE`. 

Else only the constant condition is removed.

## Changelog

- Improvement

## Related Issues

Fixes #2176 

## Test Plan

Unit Tests

