### PR TITLE
[common/base] feature: BlockingWait turns async func to sync: `async_fn().wait()` instead of `async_fn().await`

### DIFF
--- a/common/base/src/lib.rs
+++ b/common/base/src/lib.rs
@@ -24,22 +24,21 @@ mod stoppable_test;
 mod profiling;
 mod progress;
 mod runtime;
+mod stop_handle;
+mod stoppable;
+mod uniq_id;
 
 pub use profiling::Profiling;
 pub use progress::Progress;
 pub use progress::ProgressCallback;
 pub use progress::ProgressValues;
+pub use runtime::BlockingWait;
 pub use runtime::Dropper;
 pub use runtime::Runtime;
 pub use runtime::TrySpawn;
-pub use tokio;
-pub use uuid;
-
-mod stop_handle;
-mod stoppable;
-mod uniq_id;
-
 pub use stop_handle::StopHandle;
 pub use stoppable::Stoppable;
+pub use tokio;
 pub use uniq_id::GlobalSequence;
 pub use uniq_id::GlobalUniqName;
+pub use uuid;

--- a/common/base/src/runtime_test.rs
+++ b/common/base/src/runtime_test.rs
@@ -20,6 +20,7 @@ use tokio::time::sleep_until;
 use tokio::time::Duration;
 use tokio::time::Instant;
 
+use crate::runtime::BlockingWait;
 use crate::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -102,6 +103,25 @@ fn test_block_on() -> Result<()> {
             assert_eq!(expect, actual);
         }
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_blocking_wait() -> Result<()> {
+    async fn five() -> Result<u8> {
+        Ok(5)
+    }
+
+    let res = five().wait();
+    assert!(res.is_ok());
+    assert_eq!(5, res.unwrap());
+
+    let rt = Runtime::with_default_worker_threads().unwrap();
+
+    let res = five().wait_in(&rt)?;
+    assert!(res.is_ok());
+    assert_eq!(5, res.unwrap());
 
     Ok(())
 }

--- a/common/dal/src/lib.rs
+++ b/common/dal/src/lib.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use data_accessor::read_obj;
 pub use data_accessor::AsyncSeekableReader;
 pub use data_accessor::Bytes;
 pub use data_accessor::DataAccessor;
 pub use data_accessor::DataAccessorBuilder;
 pub use data_accessor::InputStream;
-pub use data_accessor::ObjectAccessor;
 pub use data_accessor::SeekableReader;
 pub use impls::aws_s3::S3InputStream;
 pub use impls::aws_s3::S3;

--- a/query/src/datasources/table/fuse/io/segment_reader.rs
+++ b/query/src/datasources/table/fuse/io/segment_reader.rs
@@ -16,11 +16,11 @@
 use std::sync::Arc;
 
 use common_catalog::SegmentInfo;
+use common_dal::read_obj;
 use common_dal::DataAccessor;
-use common_dal::ObjectAccessor;
 use common_exception::Result;
 
 #[allow(dead_code)]
 pub async fn read_segment_async(da: Arc<dyn DataAccessor>, loc: &str) -> Result<SegmentInfo> {
-    ObjectAccessor::new(da).read_obj(loc).await
+    read_obj(da, loc.to_string()).await
 }

--- a/query/src/datasources/table/fuse/meta/meta_info_reader.rs
+++ b/query/src/datasources/table/fuse/meta/meta_info_reader.rs
@@ -16,11 +16,12 @@
 use std::sync::Arc;
 
 use common_arrow::parquet::read::read_metadata;
+use common_base::BlockingWait;
 use common_base::Runtime;
 use common_catalog::RawBlockStats;
 use common_catalog::SegmentInfo;
+use common_dal::read_obj;
 use common_dal::DataAccessor;
-use common_dal::ObjectAccessor;
 use common_exception::ErrorCode;
 use common_exception::Result;
 
@@ -55,6 +56,6 @@ impl MetaInfoReader {
     }
     #[allow(dead_code)]
     pub fn read_segment_info(&self, location: &str) -> Result<SegmentInfo> {
-        ObjectAccessor::new(self.da.clone()).blocking_read_obj(&self.ctx, location)
+        read_obj(self.da.clone(), location.to_string()).wait_in(&self.ctx)?
     }
 }

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -16,11 +16,12 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use common_base::BlockingWait;
 use common_catalog::BlockLocation;
 use common_catalog::IOContext;
 use common_catalog::TableIOContext;
 use common_catalog::TableSnapshot;
-use common_dal::ObjectAccessor;
+use common_dal::read_obj;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCode;
 use common_exception::Result;
@@ -249,7 +250,7 @@ impl FuseTable {
         let schema = &self.tbl_info.schema;
         if let Some(loc) = schema.meta().get("META_SNAPSHOT_LOCATION") {
             let da = io_ctx.get_data_accessor()?;
-            let r = ObjectAccessor::new(da).blocking_read_obj(&io_ctx.get_runtime(), loc)?;
+            let r = read_obj(da, loc.to_string()).wait_in(&io_ctx.get_runtime())??;
             Ok(Some(r))
         } else {
             Ok(None)


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/base] feature: BlockingWait turns async func to sync: `async_fn().wait()` instead of `async_fn().await`
Trait `BlockingWait` turns an `async` function into `sync`.

It is meant to provide convenience for building a proof-of-concept demo or else.
Always avoid using it in a real world production,
unless **you KNOW what you are doing**:

- `wait()` runs the future in current thread and **blocks** current thread until the future is finished.
- `wait_in(rt)` runs the future in the specified runtime, and **blocks** current thread until the future is finished.

```rust
use runtime::BlockingWait;
fn main() {
    async fn five() -> u8 { 5 }
    assert_eq!(5, five().wait());
}
```

## Changelog

- New Feature





## Related Issues

- #2030