### PR TITLE
[common/meta/sled-store]: refactor: generalized `upsert`

### DIFF
--- a/common/meta/raft-store/src/sled_key_spaces.rs
+++ b/common/meta/raft-store/src/sled_key_spaces.rs
@@ -15,6 +15,7 @@
 use async_raft::raft::Entry;
 use common_meta_sled_store::SeqNum;
 use common_meta_sled_store::SledKeySpace;
+use common_meta_types::DatabaseInfo;
 use common_meta_types::KVValue;
 use common_meta_types::LogEntry;
 use common_meta_types::LogIndex;
@@ -92,4 +93,13 @@ impl SledKeySpace for Sequences {
     const NAME: &'static str = "sequences";
     type K = String;
     type V = SeqNum;
+}
+
+/// Key-Value Types for storing general purpose kv in sled::Tree:
+pub struct Databases {}
+impl SledKeySpace for Databases {
+    const PREFIX: u8 = 8;
+    const NAME: &'static str = "databases";
+    type K = String;
+    type V = SeqValue<KVValue<DatabaseInfo>>;
 }

--- a/common/meta/sled-store/src/kv.rs
+++ b/common/meta/sled-store/src/kv.rs
@@ -31,8 +31,20 @@ pub struct KVValue<T = Vec<u8>> {
     pub value: T,
 }
 
+impl<T> KVValue<T> {
+    pub fn set_meta(mut self, m: Option<KVMeta>) -> KVValue<T> {
+        self.meta = m;
+        self
+    }
+
+    pub fn set_value(mut self, v: T) -> KVValue<T> {
+        self.value = v;
+        self
+    }
+}
+
 /// Compare with a timestamp to check if it is expired.
-impl PartialEq<u64> for KVValue {
+impl<T> PartialEq<u64> for KVValue<T> {
     fn eq(&self, other: &u64) -> bool {
         match self.meta {
             None => false,
@@ -45,7 +57,7 @@ impl PartialEq<u64> for KVValue {
 }
 
 /// Compare with a timestamp to check if it is expired.
-impl PartialOrd<u64> for KVValue {
+impl<T> PartialOrd<u64> for KVValue<T> {
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
         match self.meta {
             None => None,

--- a/common/meta/sled-store/src/seq_value.rs
+++ b/common/meta/sled-store/src/seq_value.rs
@@ -18,4 +18,4 @@ use crate::SledSerde;
 /// Value with a corresponding sequence number
 pub type SeqValue<T = Vec<u8>> = (u64, T);
 
-impl SledSerde for SeqValue<KVValue> {}
+impl<T: serde::Serialize + serde::de::DeserializeOwned> SledSerde for SeqValue<KVValue<T>> {}

--- a/common/meta/sled-store/src/sled_key_space.rs
+++ b/common/meta/sled-store/src/sled_key_space.rs
@@ -38,7 +38,7 @@ pub trait SledKeySpace {
     type K: SledOrderedSerde + Display + Debug;
 
     /// Type for value.
-    type V: SledSerde;
+    type V: SledSerde + Debug;
 
     fn serialize_key(k: &Self::K) -> Result<sled::IVec, ErrorCode> {
         let b = k.ser()?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/sled-store]: refactor: generalized `upsert`
- Make `upsert` operation in state machine a generalized operation:
  It works on any `(seq, KVValue<T>)` now.
  Previously it only support `T=Vec<u8>`.

  This way this suite of operations can also be applied to `Database` and `Table`.

- Add sled sub tree key space: Databases;

## Changelog




- Improvement


## Related Issues

- #2030
- fix: #2211