### PR TITLE
ISSUE-1919: Store StateMachine::client_last_resp in sled::Tree

### DIFF
--- a/common/meta/raft-store/src/sled_key_spaces.rs
+++ b/common/meta/raft-store/src/sled_key_spaces.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use async_raft::raft::Entry;
+use common_meta_sled_store::ClientLastRespValue;
 use common_meta_sled_store::SeqNum;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_types::DatabaseInfo;
@@ -102,4 +103,12 @@ impl SledKeySpace for Databases {
     const NAME: &'static str = "databases";
     type K = String;
     type V = SeqValue<KVValue<DatabaseInfo>>;
+}
+
+pub struct ClientLastResps {}
+impl SledKeySpace for ClientLastResps {
+    const PREFIX: u8 = 9;
+    const NAME: &'static str = "client-last-resp";
+    type K = String;
+    type V = ClientLastRespValue;
 }

--- a/common/meta/sled-store/src/client_last_resp.rs
+++ b/common/meta/sled-store/src/client_last_resp.rs
@@ -1,0 +1,30 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::SledSerde;
+
+/// Client last response that is stored in SledTree
+/// raft state: A mapping of client serial IDs to their state info:
+/// (serial, RaftResponse)
+/// This is used to de-dup client request, to impl idempotent operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClientLastRespValue {
+    pub req_serial_num: u64,
+    pub res: Vec<u8>,
+}
+
+impl SledSerde for ClientLastRespValue {}

--- a/common/meta/sled-store/src/lib.rs
+++ b/common/meta/sled-store/src/lib.rs
@@ -15,6 +15,7 @@
 //! sled_store implement a key-value like store backed by sled::Tree.
 //!
 //! It is used by raft for log and state machine storage.
+pub use client_last_resp::ClientLastRespValue;
 pub use db::get_sled_db;
 pub use db::init_sled_db;
 pub use db::init_temp_sled_db;
@@ -39,6 +40,7 @@ mod sled_key_space;
 mod sled_serde;
 mod sled_tree;
 
+mod client_last_resp;
 #[cfg(test)]
 mod sled_tree_test;
 #[cfg(test)]

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -14,30 +14,11 @@
 
 //! This crate defines data types used in meta data storage service.
 
-#[cfg(test)]
-mod cluster_test;
-#[cfg(test)]
-mod match_seq_test;
-
-mod errors;
-mod match_seq;
-
-mod cluster;
-mod cmd;
-mod database_info;
-mod database_reply;
-mod kv_reply;
-mod log_entry;
-mod operation;
-mod raft_txid;
-mod raft_types;
-mod table_info;
-mod table_reply;
-
 pub use cluster::Node;
 pub use cluster::NodeInfo;
 pub use cluster::Slot;
 pub use cmd::Cmd;
+pub use common_meta_sled_store::ClientLastRespValue;
 pub use common_meta_sled_store::KVMeta;
 pub use common_meta_sled_store::KVValue;
 pub use common_meta_sled_store::SeqValue;
@@ -63,3 +44,23 @@ pub use raft_types::Term;
 pub use table_info::Table;
 pub use table_info::TableInfo;
 pub use table_reply::CreateTableReply;
+
+#[cfg(test)]
+mod cluster_test;
+#[cfg(test)]
+mod match_seq_test;
+
+mod errors;
+mod match_seq;
+
+mod cluster;
+mod cmd;
+mod database_info;
+mod database_reply;
+mod kv_reply;
+mod log_entry;
+mod operation;
+mod raft_txid;
+mod raft_types;
+mod table_info;
+mod table_reply;

--- a/common/meta/types/src/raft_txid.rs
+++ b/common/meta/types/src/raft_txid.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -33,5 +36,11 @@ impl RaftTxId {
             client: client.to_string(),
             serial,
         }
+    }
+}
+
+impl Display for RaftTxId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "txid-{}-{}", &self.client, self.serial)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Store `StateMachine::client_last_resp` in sled subtree.

## Changelog

- Improvement


## Related Issues

Fix: #1919 

## Test Plan

Unit Tests

Stateless Tests

