### PR TITLE
[metasrv] Move client_last_resp.rs to raft-store

### DIFF
--- a/common/meta/raft-store/src/sled_key_spaces.rs
+++ b/common/meta/raft-store/src/sled_key_spaces.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use async_raft::raft::Entry;
-use common_meta_sled_store::ClientLastRespValue;
 use common_meta_sled_store::SeqNum;
 use common_meta_sled_store::SledKeySpace;
 use common_meta_types::DatabaseInfo;
@@ -26,6 +25,7 @@ use common_meta_types::SeqValue;
 
 use crate::state::RaftStateKey;
 use crate::state::RaftStateValue;
+use crate::state_machine::ClientLastRespValue;
 use crate::state_machine::StateMachineMetaKey;
 use crate::state_machine::StateMachineMetaValue;
 

--- a/common/meta/raft-store/src/state_machine/client_last_resp.rs
+++ b/common/meta/raft-store/src/state_machine/client_last_resp.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_meta_sled_store::SledSerde;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::SledSerde;
+use crate::state_machine::AppliedState;
 
 /// Client last response that is stored in SledTree
 /// raft state: A mapping of client serial IDs to their state info:
@@ -24,7 +25,7 @@ use crate::SledSerde;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ClientLastRespValue {
     pub req_serial_num: u64,
-    pub res: Vec<u8>,
+    pub res: AppliedState,
 }
 
 impl SledSerde for ClientLastRespValue {}

--- a/common/meta/raft-store/src/state_machine/mod.rs
+++ b/common/meta/raft-store/src/state_machine/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub use applied_state::AppliedState;
+pub use client_last_resp::ClientLastRespValue;
 pub use placement::Placement;
 pub use sm::Replication;
 pub use sm::SerializableSnapshot;
@@ -23,6 +24,7 @@ pub use state_machine_meta::StateMachineMetaKey;
 pub use state_machine_meta::StateMachineMetaValue;
 
 pub mod applied_state;
+pub mod client_last_resp;
 pub mod sm;
 pub mod snapshot;
 pub mod state_machine_meta;

--- a/common/meta/sled-store/src/lib.rs
+++ b/common/meta/sled-store/src/lib.rs
@@ -15,7 +15,6 @@
 //! sled_store implement a key-value like store backed by sled::Tree.
 //!
 //! It is used by raft for log and state machine storage.
-pub use client_last_resp::ClientLastRespValue;
 pub use db::get_sled_db;
 pub use db::init_sled_db;
 pub use db::init_temp_sled_db;
@@ -40,7 +39,6 @@ mod sled_key_space;
 mod sled_serde;
 mod sled_tree;
 
-mod client_last_resp;
 #[cfg(test)]
 mod sled_tree_test;
 #[cfg(test)]

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -18,7 +18,6 @@ pub use cluster::Node;
 pub use cluster::NodeInfo;
 pub use cluster::Slot;
 pub use cmd::Cmd;
-pub use common_meta_sled_store::ClientLastRespValue;
 pub use common_meta_sled_store::KVMeta;
 pub use common_meta_sled_store::KVValue;
 pub use common_meta_sled_store::SeqValue;
@@ -45,22 +44,21 @@ pub use table_info::Table;
 pub use table_info::TableInfo;
 pub use table_reply::CreateTableReply;
 
-#[cfg(test)]
-mod cluster_test;
-#[cfg(test)]
-mod match_seq_test;
-
-mod errors;
-mod match_seq;
-
 mod cluster;
 mod cmd;
 mod database_info;
 mod database_reply;
+mod errors;
 mod kv_reply;
 mod log_entry;
+mod match_seq;
 mod operation;
 mod raft_txid;
 mod raft_types;
 mod table_info;
 mod table_reply;
+
+#[cfg(test)]
+mod cluster_test;
+#[cfg(test)]
+mod match_seq_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Move `client_last_resp.rs` to raft-store since it is only used in `meta/raft-store`
This PR also fix some code style problems that appeared in the previous PR. cc @BohuTANG 

## Changelog

- Improvement


## Related Issues

#1919 

## Test Plan

Unit Tests

Stateless Tests

