### PR TITLE
[common/meta/raft-store] refactor: use KeySpace::NAME as seq-number generator key

### DIFF
--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -63,9 +63,8 @@ use crate::state_machine::StateMachineMetaKey::LastApplied;
 use crate::state_machine::StateMachineMetaKey::LastMembership;
 use crate::state_machine::StateMachineMetaValue;
 
-/// seq number key to generate seq for the value of a `generic_kv` record.
-const SEQ_GENERIC_KV: &str = "generic_kv";
 /// seq number key to generate database id
+/// TODO(xp): remove these const and replace with SledKeySpace::NAME
 const SEQ_DATABASE_ID: &str = "database_id";
 /// seq number key to generate table id
 const SEQ_TABLE_ID: &str = "table_id";
@@ -563,7 +562,7 @@ impl StateMachine {
 
         // insert the updated record.
 
-        let new_seq = self.incr_seq(SEQ_GENERIC_KV).await?;
+        let new_seq = self.incr_seq(KS::NAME).await?;
         let seq_kv_value = (new_seq, new_kv_value);
 
         sub_tree.insert(key, &seq_kv_value).await?;

--- a/common/meta/raft-store/src/state_machine/testing.rs
+++ b/common/meta/raft-store/src/state_machine/testing.rs
@@ -99,7 +99,7 @@ pub fn snapshot_logs() -> (Vec<Entry<LogEntry>>, Vec<String>) {
         "[3, 3]:{\"Membership\":{\"members\":[4,5,6],\"members_after_consensus\":null}}", // membership
         "[6, 97]:[1,{\"meta\":null,\"value\":[65]}]", // generic kv
         "[7, 99]:1",                                  // sequence: c
-        "[7, 103, 101, 110, 101, 114, 105, 99, 95, 107, 118]:1", // sequence: by upsertkv
+        "[7, 103, 101, 110, 101, 114, 105, 99, 45, 107, 118]:1", // sequence: by upsertkv
     ]
     .iter()
     .map(|x| x.to_string())

--- a/metasrv/src/meta_service/meta_store_test.rs
+++ b/metasrv/src/meta_service/meta_store_test.rs
@@ -289,7 +289,7 @@ async fn test_metasrv_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()>
             "[3, 2]:{\"Bool\":true}",                      // sm meta: init
             "[3, 3]:{\"Membership\":{\"members\":[1,2,3],\"members_after_consensus\":null}}", // membership
             "[6, 97]:[1,{\"meta\":null,\"value\":[65]}]", // generic kv
-            "[7, 103, 101, 110, 101, 114, 105, 99, 95, 107, 118]:1", // sequence: by upsertkv
+            "[7, 103, 101, 110, 101, 114, 105, 99, 45, 107, 118]:1", // sequence: by upsertkv
         ]
         .iter()
         .map(|x| x.to_string())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/raft-store] refactor: use KeySpace::NAME as seq-number generator key

## Changelog




- Improvement


## Related Issues

- #2030
- #2213