### PR TITLE
[common/meta/raft-store] feature: store Database in sled.

### DIFF
--- a/common/meta/raft-store/src/state_machine/applied_state.rs
+++ b/common/meta/raft-store/src/state_machine/applied_state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_raft::AppDataResponse;
-use common_meta_types::Database;
+use common_meta_types::DatabaseInfo;
 use common_meta_types::KVValue;
 use common_meta_types::Node;
 use common_meta_types::SeqValue;
@@ -43,8 +43,8 @@ pub enum AppliedState {
     },
 
     DataBase {
-        prev: Option<Database>,
-        result: Option<Database>,
+        prev: Option<SeqValue<KVValue<DatabaseInfo>>>,
+        result: Option<SeqValue<KVValue<DatabaseInfo>>>,
     },
 
     Table {
@@ -102,8 +102,10 @@ impl From<(Option<Node>, Option<Node>)> for AppliedState {
     }
 }
 
-impl From<(Option<Database>, Option<Database>)> for AppliedState {
-    fn from(v: (Option<Database>, Option<Database>)) -> Self {
+type SeqDBInfo = SeqValue<KVValue<DatabaseInfo>>;
+
+impl From<(Option<SeqDBInfo>, Option<SeqDBInfo>)> for AppliedState {
+    fn from(v: (Option<SeqDBInfo>, Option<SeqDBInfo>)) -> Self {
         AppliedState::DataBase {
             prev: v.0,
             result: v.1,

--- a/common/meta/types/src/cmd.rs
+++ b/common/meta/types/src/cmd.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::table_info::Table;
-use crate::Database;
+use crate::DatabaseInfo;
 use crate::KVMeta;
 use crate::MatchSeq;
 use crate::Node;
@@ -40,8 +40,7 @@ pub enum Cmd {
         // TODO(ariesdevil): add `seq` for distinguish between the results of the execution of
         // the two commands (failed `add` and successful `delete`)
         name: String,
-        if_not_exists: bool,
-        db: Database,
+        db: DatabaseInfo,
     },
 
     /// Drop a database if absent
@@ -97,16 +96,8 @@ impl fmt::Display for Cmd {
             Cmd::AddNode { node_id, node } => {
                 write!(f, "add_node:{}={}", node_id, node)
             }
-            Cmd::CreateDatabase {
-                name,
-                if_not_exists,
-                db,
-            } => {
-                write!(
-                    f,
-                    "create_db:{}={}, if_not_exists:{}, engine:{}",
-                    name, db, if_not_exists, db.database_engine
-                )
+            Cmd::CreateDatabase { name, db } => {
+                write!(f, "create_db:{}={:?}, engine:{}", name, db, db.engine)
             }
             Cmd::DropDatabase { name } => {
                 write!(f, "drop_db:{}", name)

--- a/common/meta/types/src/database_info.rs
+++ b/common/meta/types/src/database_info.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Database {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct DatabaseInfo {
     pub database_id: u64,
     pub db: String,

--- a/metasrv/src/meta_service/meta_service_impl_test.rs
+++ b/metasrv/src/meta_service/meta_service_impl_test.rs
@@ -170,3 +170,5 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// TODO revert meta tests from git history

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -14,16 +14,28 @@
 
 //! Test arrow-flight API of metasrv
 
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use common_base::tokio;
+use common_datavalues::DataField;
+use common_datavalues::DataSchema;
+use common_datavalues::DataType;
+use common_exception::ErrorCode;
 use common_meta_api::KVApi;
+use common_meta_api::MetaApi;
 use common_meta_flight::MetaFlightClient;
+use common_meta_types::CreateDatabaseReply;
 use common_meta_types::KVMeta;
 use common_meta_types::KVValue;
 use common_meta_types::MatchSeq;
+use common_meta_types::TableInfo;
 use common_meta_types::UpsertKVActionReply;
+use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 use common_tracing::tracing;
 use metasrv::init_meta_ut;
 use pretty_assertions::assert_eq;
@@ -684,3 +696,563 @@ async fn test_generic_kv() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_database_create_get_drop() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    tracing::info!("--- create db1");
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: "db1".to_string(),
+            engine: "Local".to_string(),
+            options: Default::default(),
+        };
+
+        let res = client.create_database(plan.clone()).await;
+        tracing::info!("create database res: {:?}", res);
+        let res = res.unwrap();
+        assert_eq!(1, res.database_id, "first database id is 1");
+    }
+
+    tracing::info!("--- create db1 again with if_not_exists=false");
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: "db1".to_string(),
+            engine: "another-engine".to_string(),
+            options: Default::default(),
+        };
+
+        let res = client.create_database(plan.clone()).await;
+        tracing::info!("create database res: {:?}", res);
+        let err = res.unwrap_err();
+        assert_eq!(ErrorCode::DatabaseAlreadyExists("").code(), err.code());
+    }
+
+    tracing::info!("--- create db1 again with if_not_exists=true");
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: "db1".to_string(),
+            engine: "another-engine".to_string(),
+            options: Default::default(),
+        };
+
+        let res = client.create_database(plan.clone()).await;
+        tracing::info!("create database res: {:?}", res);
+        let err = res.unwrap_err();
+        assert_eq!(ErrorCode::DatabaseAlreadyExists("").code(), err.code());
+    }
+
+    tracing::info!("--- get db1");
+    {
+        let res = client.get_database("db1").await;
+        tracing::debug!("get present database res: {:?}", res);
+        let res = res?;
+        assert_eq!(1, res.database_id, "db1 id is 1");
+        assert_eq!("db1".to_string(), res.db, "db1.db is db1");
+        assert_eq!("Local".to_string(), res.engine,);
+    }
+
+    tracing::info!("--- create db2");
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: "db2".to_string(),
+            engine: "engine2".to_string(),
+            options: Default::default(),
+        };
+
+        let res = client.create_database(plan.clone()).await;
+        tracing::info!("create database res: {:?}", res);
+        let res = res.unwrap();
+        assert_eq!(
+            4, res.database_id,
+            "second database id is 4: seq increment but no used"
+        );
+    }
+
+    tracing::info!("--- get db2");
+    {
+        let res = client.get_database("db2").await?;
+        assert_eq!("db2".to_string(), res.db, "db1.db is db1");
+        assert_eq!("engine2".to_string(), res.engine,);
+    }
+
+    tracing::info!("--- get absent db");
+    {
+        let res = client.get_database("absent").await;
+        tracing::debug!("=== get absent database res: {:?}", res);
+        assert!(res.is_err());
+        let res = res.unwrap_err();
+        assert_eq!(3, res.code());
+        assert_eq!("absent".to_string(), res.message());
+    }
+
+    tracing::info!("--- drop db2");
+    {
+        client
+            .drop_database(DropDatabasePlan {
+                if_exists: false,
+                db: "db2".to_string(),
+            })
+            .await?;
+    }
+
+    tracing::info!("--- get db2 should not found");
+    {
+        let res = client.get_database("db2").await;
+        let err = res.unwrap_err();
+        assert_eq!(ErrorCode::UnknownDatabase("").code(), err.code());
+    }
+
+    tracing::info!("--- drop db2 with if_exists=true returns no error");
+    {
+        client
+            .drop_database(DropDatabasePlan {
+                if_exists: true,
+                db: "db2".to_string(),
+            })
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_database_list() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    tracing::info!("--- prepare db1 and db2");
+    {
+        let res = create_database(&client, "db1").await?;
+        assert_eq!(1, res.database_id);
+
+        let res = create_database(&client, "db2").await?;
+        assert_eq!(2, res.database_id);
+    }
+
+    tracing::info!("--- get_databases");
+    {
+        let dbs = client.get_databases().await?;
+        let want: Vec<u64> = vec![1, 2];
+        let got = dbs.iter().map(|x| x.database_id).collect::<Vec<_>>();
+        assert_eq!(want, got)
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_table_create_get_drop() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    let db_name = "db1";
+    let tbl_name = "tb2";
+
+    tracing::info!("--- prepare db");
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: db_name.to_string(),
+            engine: "Local".to_string(),
+            options: Default::default(),
+        };
+
+        let res = client.create_database(plan.clone()).await?;
+        tracing::info!("create database res: {:?}", res);
+
+        assert_eq!(1, res.database_id, "first database id is 1");
+    }
+
+    tracing::info!("--- create and get table");
+    {
+        // Table schema with metadata(due to serde issue).
+        let schema = Arc::new(DataSchema::new(vec![DataField::new(
+            "number",
+            DataType::UInt64,
+            false,
+        )]));
+
+        let options = maplit::hashmap! {"opt‐1".into() => "val-1".into()};
+
+        let mut plan = CreateTablePlan {
+            if_not_exists: false,
+            db: db_name.to_string(),
+            table: tbl_name.to_string(),
+            schema: schema.clone(),
+            options: options.clone(),
+            engine: "JSON".to_string(),
+        };
+
+        {
+            let res = client.create_table(plan.clone()).await?;
+            assert_eq!(1, res.table_id, "table id is 1");
+
+            let got = client.get_table(db_name, tbl_name).await?;
+
+            let want = TableInfo {
+                database_id: 1,
+                table_id: 1,
+                version: 0,
+                db: db_name.into(),
+                name: tbl_name.into(),
+                schema: schema.clone(),
+                engine: "JSON".to_owned(),
+                options: options.clone(),
+            };
+            assert_eq!(want, got.as_ref().clone(), "get created table");
+        }
+
+        tracing::info!("--- create table again with if_not_exists = true");
+        {
+            plan.if_not_exists = true;
+            let res = client.create_table(plan.clone()).await?;
+            assert_eq!(1, res.table_id, "new table id");
+
+            let got = client.get_table(db_name, tbl_name).await?;
+            let want = TableInfo {
+                database_id: 1,
+                table_id: 1,
+                version: 0,
+                db: db_name.into(),
+                name: tbl_name.into(),
+                schema: schema.clone(),
+                engine: "JSON".to_owned(),
+                options: options.clone(),
+            };
+            assert_eq!(want, got.as_ref().clone(), "get created table");
+        }
+
+        tracing::info!("--- create table again with if_not_exists = false");
+        {
+            plan.if_not_exists = false;
+
+            let res = client.create_table(plan.clone()).await;
+            tracing::info!("create table res: {:?}", res);
+
+            let status = res.err().unwrap();
+            assert_eq!(
+                format!("Code: 4003, displayText = table exists: {}.", tbl_name),
+                status.to_string()
+            );
+
+            // get_table returns the old table
+
+            let got = client.get_table("db1", "tb2").await.unwrap();
+            let want = TableInfo {
+                database_id: 1,
+                table_id: 1,
+                version: 0,
+                db: db_name.into(),
+                name: tbl_name.into(),
+                schema: schema.clone(),
+                engine: "JSON".to_owned(),
+                options: options.clone(),
+            };
+            assert_eq!(want, got.as_ref().clone(), "get old table");
+        }
+
+        tracing::info!("--- drop table with if_exists = false");
+        {
+            let plan = DropTablePlan {
+                if_exists: false,
+                db: db_name.to_string(),
+                table: tbl_name.to_string(),
+            };
+            client.drop_table(plan.clone()).await?;
+
+            tracing::info!("--- get table after drop");
+            {
+                let res = client.get_table(db_name, tbl_name).await;
+                let status = res.err().unwrap();
+                assert_eq!(
+                    format!("Code: 25, displayText = table not found: {}.", tbl_name),
+                    status.to_string(),
+                    "get dropped table {}",
+                    tbl_name
+                );
+            }
+        }
+
+        tracing::info!("--- drop table with if_exists = false again, error");
+        {
+            let plan = DropTablePlan {
+                if_exists: false,
+                db: db_name.to_string(),
+                table: tbl_name.to_string(),
+            };
+            let res = client.drop_table(plan.clone()).await;
+            let err = res.unwrap_err();
+            assert_eq!(
+                ErrorCode::UnknownTable("").code(),
+                err.code(),
+                "drop table {} with if_exists=false again",
+                tbl_name
+            );
+        }
+
+        tracing::info!("--- drop table with if_exists = true again, ok");
+        {
+            let plan = DropTablePlan {
+                if_exists: true,
+                db: db_name.to_string(),
+                table: tbl_name.to_string(),
+            };
+            client.drop_table(plan.clone()).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_table_list() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    let db_name = "db1";
+
+    tracing::info!("--- prepare db");
+    {
+        let res = create_database(&client, db_name).await?;
+        assert_eq!(1, res.database_id, "first database id is 1");
+    }
+
+    tracing::info!("--- create 2 tables: tb1 tb2");
+    {
+        // Table schema with metadata(due to serde issue).
+        let schema = Arc::new(DataSchema::new(vec![DataField::new(
+            "number",
+            DataType::UInt64,
+            false,
+        )]));
+
+        let options = maplit::hashmap! {"opt‐1".into() => "val-1".into()};
+
+        let mut plan = CreateTablePlan {
+            if_not_exists: false,
+            db: db_name.to_string(),
+            table: "tb1".to_string(),
+            schema: schema.clone(),
+            options: options.clone(),
+            engine: "JSON".to_string(),
+        };
+
+        {
+            let res = client.create_table(plan.clone()).await?;
+            assert_eq!(1, res.table_id, "table id is 1");
+
+            plan.table = "tb2".to_string();
+            let res = client.create_table(plan.clone()).await?;
+            assert_eq!(2, res.table_id, "table id is 2");
+        }
+
+        tracing::info!("--- get_tables");
+        {
+            let res = client.get_tables(db_name).await?;
+            assert_eq!(1, res[0].table_id);
+            assert_eq!(2, res[1].table_id);
+        }
+    }
+
+    Ok(())
+}
+
+async fn create_database(
+    client: &MetaFlightClient,
+    db_name: &str,
+) -> anyhow::Result<CreateDatabaseReply> {
+    tracing::info!("--- create database {}", db_name);
+
+    let plan = CreateDatabasePlan {
+        if_not_exists: false,
+        db: db_name.to_string(),
+        engine: "Local".to_string(),
+        options: Default::default(),
+    };
+
+    let res = client.create_database(plan.clone()).await?;
+    tracing::info!("create database res: {:?}", res);
+    Ok(res)
+}
+
+// TODO(xp): uncomment following tests when the function is ready
+// ------------------------------------------------------------
+
+/*
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_ddl_table() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    let test_db = "db1";
+    let plan = CreateDatabasePlan {
+        if_not_exists: false,
+        db: test_db.to_string(),
+        engine: "Local".to_string(),
+        options: Default::default(),
+    };
+    client.create_database(plan).await?;
+
+    // After `create db`, meta_ver will be increased to 1
+
+    let schema = Arc::new(DataSchema::new(vec![DataField::new(
+        "number",
+        DataType::UInt64,
+        false,
+    )]));
+
+    // create-tbl operation will increases meta_version
+    let plan = CreateTablePlan {
+        if_not_exists: true,
+        db: test_db.to_string(),
+        table: "tbl1".to_string(),
+        schema: schema.clone(),
+        options: Default::default(),
+        engine: "JSON".to_string(),
+    };
+
+    client.create_table(plan.clone()).await?;
+
+    let res = client.get_database_meta(None).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+    assert_eq!(2, snapshot.meta_ver);
+    assert_eq!(1, snapshot.db_metas.len());
+    assert_eq!(1, snapshot.tbl_metas.len());
+
+    // if lower_bound < current meta version, returns database meta
+    let res = client.get_database_meta(Some(0)).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+    assert_eq!(2, snapshot.meta_ver);
+    assert_eq!(1, snapshot.db_metas.len());
+
+    // if lower_bound equals current meta version, returns None
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_none());
+
+    // failed ddl do not effect meta version
+    //  recall: plan.if_not_exist == true
+    let _r = client.create_table(plan).await?;
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_none());
+
+    // drop-table will increase meta version
+    let plan = DropTablePlan {
+        if_exists: true,
+        db: test_db.to_string(),
+        table: "tbl1".to_string(),
+    };
+
+    client.drop_table(plan).await?;
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+    assert_eq!(3, snapshot.meta_ver);
+    assert_eq!(1, snapshot.db_metas.len());
+    assert_eq!(0, snapshot.tbl_metas.len());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    // Empty Database
+    let res = client.get_database_meta(None).await?;
+    assert!(res.is_none());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
+    let (_log_guards, ut_span) = init_meta_ut!();
+    let _ent = ut_span.enter();
+    let (_tc, addr) = metasrv::tests::start_metasrv().await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    // create-db operation will increases meta_version
+    let plan = CreateDatabasePlan {
+        if_not_exists: false,
+        db: "db1".to_string(),
+        engine: "Local".to_string(),
+        options: Default::default(),
+    };
+    client.create_database(plan).await?;
+
+    let res = client.get_database_meta(None).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+    assert_eq!(1, snapshot.meta_ver);
+    assert_eq!(1, snapshot.db_metas.len());
+
+    // if lower_bound < current meta version, returns database meta
+    let res = client.get_database_meta(Some(0)).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+    assert_eq!(1, snapshot.meta_ver);
+    assert_eq!(1, snapshot.db_metas.len());
+
+    // if lower_bound equals current meta version, returns None
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_none());
+
+    // failed ddl do not effect meta version
+    let plan = CreateDatabasePlan {
+        if_not_exists: true, // <<--
+        db: "db1".to_string(),
+        engine: "Local".to_string(),
+        options: Default::default(),
+    };
+
+    client.create_database(plan).await?;
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_none());
+
+    // drop-db will increase meta version
+    let plan = DropDatabasePlan {
+        if_exists: true,
+        db: "db1".to_string(),
+    };
+
+    client.drop_database(plan).await?;
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_some());
+    let snapshot = res.unwrap();
+
+    assert_eq!(2, snapshot.meta_ver);
+    assert_eq!(0, snapshot.db_metas.len());
+
+    Ok(())
+}
+*/


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/raft-store] feature: store Database in sled.
- Introduce a new sled tree key space `Databases` to store databases.
  Impl create/drop with the same mechanism as general-kv:
  a record is stored with 2 additional info:
  - a seq num to indicate version of a change.
  - a meta for user to store additional info.

- Store `DatabaseInfo` in sled, instead of `Database`.

- Create a in-memory map to store map of `(db_id, table_name)` to
  `table_id`.

  This will be replaced with sled too.

  The storage layout now is:
  ```
  db_name -> DatabaseInfo
  (db_id, table_name) -> table_id
  table_id -> TableInfo
  ```

- Revert deleted test of database API. Thanks to git-history :DDD

- fix: #2212
- fix: #2236

## Changelog

- New Feature





## Related Issues

- #2030