### PR TITLE
BUILD-2239: Add cargo clippy --test

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args:  -- -D warnings
+          args:  --tests -- -D warnings
         env:
           CARGO_INCREMENTAL: '0'
 
@@ -43,13 +43,5 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-        env:
-          CARGO_INCREMENTAL: '0'
-
-      - name: Run clippy for tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests -- -D warnings
         env:
           CARGO_INCREMENTAL: '0'

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ fmt:
 
 lint:
 	cargo fmt
-	cargo clippy -- -D warnings
+	cargo clippy --tests -- -D warnings
 
 miri:
 	cargo miri setup

--- a/cli/src/cmds/clusters/view_test.rs
+++ b/cli/src/cmds/clusters/view_test.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use std::cell::RefCell;
-use std::fs;
 
 use comfy_table::Cell;
 use comfy_table::Color;
-use comfy_table::Row;
 use comfy_table::Table;
 use databend_query::configs::Config as QueryConfig;
 use httpmock::Method::GET;
@@ -25,13 +23,11 @@ use httpmock::MockServer;
 use metasrv::configs::Config as MetaConfig;
 use tempfile::tempdir;
 
-use crate::cmds::clusters::create::LocalBinaryPaths;
 use crate::cmds::clusters::view::HealthStatus;
 use crate::cmds::clusters::view::ViewCommand;
 use crate::cmds::status::LocalMetaConfig;
 use crate::cmds::status::LocalQueryConfig;
 use crate::cmds::Config;
-use crate::cmds::CreateCommand;
 use crate::cmds::Status;
 use crate::error::Result;
 
@@ -56,7 +52,7 @@ fn test_build_table() -> Result<()> {
             .body("health");
     });
     {
-        let mut status = Status::read(conf.clone())?;
+        let mut status = Status::read(conf)?;
         let mut meta_config = LocalMetaConfig {
             config: MetaConfig::default(),
             pid: Some(123),
@@ -108,14 +104,14 @@ fn test_build_table() -> Result<()> {
             Cell::new("local"),
             Cell::new(format!("{}", HealthStatus::Ready)).fg(Color::Green),
             Cell::new("disabled"),
-            Cell::new(format!("{}", meta_file)),
+            Cell::new(meta_file),
         ]);
         expected.add_row(vec![
             Cell::new("query_1"),
             Cell::new("local"),
             Cell::new(format!("{}", HealthStatus::Ready)).fg(Color::Green),
             Cell::new("disabled"),
-            Cell::new(format!("{}", query_configs.get(0).unwrap().0.clone())),
+            Cell::new(query_configs.get(0).unwrap().0.clone()),
         ]);
         assert_eq!(table.to_string(), expected.to_string())
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add cargo clippy --test

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #2239 

## Test Plan

Unit Tests

Stateless Tests

