### PR TITLE
ISSUE-2233: Add timeout to meta config for meta client

### DIFF
--- a/common/meta/flight/src/flight_client_conf.rs
+++ b/common/meta/flight/src/flight_client_conf.rs
@@ -19,4 +19,5 @@ use common_flight_rpc::FlightClientConf;
 pub struct MetaFlightClientConf {
     pub meta_service_config: FlightClientConf,
     pub kv_service_config: FlightClientConf,
+    pub client_timeout_in_second: u64,
 }

--- a/query/src/common/meta/config_converter.rs
+++ b/query/src/common/meta/config_converter.rs
@@ -44,6 +44,7 @@ impl From<&Config> for MetaFlightClientConf {
             kv_service_config: meta_config.clone(),
             // copy meta config from query config
             meta_service_config: meta_config,
+            client_timeout_in_second: conf.meta.meta_client_timeout_in_second,
         }
     }
 }

--- a/query/src/common/meta/meta_client.rs
+++ b/query/src/common/meta/meta_client.rs
@@ -14,6 +14,7 @@
 //
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_exception::Result;
 use common_meta_api::KVApi;
@@ -40,7 +41,8 @@ impl MetaClientProvider {
 
     /// Get meta async client, trait is defined in MetaApi.
     pub async fn try_get_meta_client(&self) -> Result<Arc<dyn MetaApi>> {
-        let client = MetaFlightClient::try_new(&self.conf).await?;
+        let mut client = MetaFlightClient::try_new(&self.conf).await?;
+        client.set_timeout(Duration::from_secs(self.conf.client_timeout_in_second));
         Ok(Arc::new(client))
     }
 
@@ -51,7 +53,8 @@ impl MetaClientProvider {
             let client = common_meta_local_store::KV::new_temp().await?;
             Ok(Arc::new(client))
         } else {
-            let client = MetaFlightClient::try_new(&self.conf).await?;
+            let mut client = MetaFlightClient::try_new(&self.conf).await?;
+            client.set_timeout(Duration::from_secs(self.conf.client_timeout_in_second));
             Ok(Arc::new(client))
         }
     }

--- a/query/src/configs/config_meta.rs
+++ b/query/src/configs/config_meta.rs
@@ -44,6 +44,14 @@ pub struct MetaConfig {
 
     #[structopt(
         long,
+        default_value = "10",
+        help = "Timeout for each client request, in seconds"
+    )]
+    #[serde(default)]
+    pub meta_client_timeout_in_second: u64,
+
+    #[structopt(
+        long,
         env = "META_RPC_TLS_SERVER_ROOT_CA_CERT",
         default_value = "",
         help = "Certificate for client to identify meta rpc server"
@@ -66,6 +74,7 @@ impl MetaConfig {
             meta_address: "".to_string(),
             meta_username: "root".to_string(),
             meta_password: "".to_string(),
+            meta_client_timeout_in_second: 10,
             rpc_tls_meta_server_root_ca_cert: "".to_string(),
             rpc_tls_meta_service_domain_name: "localhost".to_string(),
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Add `client_timeout_in_second` for meta client.

## Changelog

- Improvement


## Related Issues

Fixes #2233 

## Test Plan

Unit Tests

Stateless Tests

