### PR TITLE
register cluster command when cli processor creates

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,7 @@ OS version           thinkpad 20.04 (kernel 5.10.0-1038-oem)
 version              Databend CLI version
 comment              # your comments
 package              Package command
+cluster              Cluster life cycle management
 
 [test] > package -h
 package 

--- a/cli/src/cmds/processor.rs
+++ b/cli/src/cmds/processor.rs
@@ -53,6 +53,7 @@ impl Processor {
             Box::new(VersionCommand::create()),
             Box::new(CommentCommand::create()),
             Box::new(PackageCommand::create(conf.clone())),
+            Box::new(ClusterCommand::create(conf.clone())),
         ];
 
         let mut commands: Vec<Box<dyn Command>> = sub_commands.clone();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Summary about this PR

## Changelog

- Bug Fix
register cluster command when cli processor creates


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

