### PR TITLE
[common/meta/api] refactor: move kv test to crate "meta/api" so that meta-embedded and meta-srv reuse the test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "common-base",
  "common-datavalues",
  "common-exception",
  "common-meta-types",

--- a/common/meta/api/Cargo.toml
+++ b/common/meta/api/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+common-base = {path = "../../base" }
 common-datavalues = {path = "../../datavalues" }
 common-exception = {path = "../../exception" }
 common-meta-types = {path= "../types" }

--- a/common/meta/api/src/kv_api_test_suite.rs
+++ b/common/meta/api/src/kv_api_test_suite.rs
@@ -1,0 +1,509 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use common_base::tokio;
+use common_meta_types::KVMeta;
+use common_meta_types::KVValue;
+use common_meta_types::MatchSeq;
+use common_tracing::tracing;
+
+use crate::KVApi;
+
+pub struct KVApiTestSuite {}
+impl KVApiTestSuite {
+    pub async fn kv_write_read<KV: KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
+        {
+            // write
+            let res = kv
+                .upsert_kv("foo", MatchSeq::Any, Some(b"bar".to_vec()), None)
+                .await?;
+            assert_eq!(None, res.prev);
+            assert_eq!(
+                Some((1, KVValue {
+                    meta: None,
+                    value: b"bar".to_vec()
+                })),
+                res.result
+            );
+        }
+
+        {
+            // write fails with unmatched seq
+            let res = kv
+                .upsert_kv("foo", MatchSeq::Exact(2), Some(b"bar".to_vec()), None)
+                .await?;
+            assert_eq!(
+                (
+                    Some((1, KVValue {
+                        meta: None,
+                        value: b"bar".to_vec()
+                    })),
+                    Some((1, KVValue {
+                        meta: None,
+                        value: b"bar".to_vec(),
+                    })),
+                ),
+                (res.prev, res.result),
+                "nothing changed"
+            );
+        }
+
+        {
+            // write done with matching seq
+            let res = kv
+                .upsert_kv("foo", MatchSeq::Exact(1), Some(b"wow".to_vec()), None)
+                .await?;
+            assert_eq!(
+                Some((1, KVValue {
+                    meta: None,
+                    value: b"bar".to_vec()
+                })),
+                res.prev,
+                "old value"
+            );
+            assert_eq!(
+                Some((2, KVValue {
+                    meta: None,
+                    value: b"wow".to_vec()
+                })),
+                res.result,
+                "new value"
+            );
+        }
+
+        Ok(())
+    }
+
+    pub async fn kv_delete<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        let test_key = "test_key";
+        client
+            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
+            .await?;
+
+        let current = client.get_kv(test_key).await?;
+        if let Some((seq, _val)) = current.result {
+            // seq mismatch
+            let wrong_seq = Some(seq + 1);
+            let res = client
+                .upsert_kv(test_key, wrong_seq.into(), None, None)
+                .await?;
+            assert_eq!(res.prev, res.result);
+
+            // seq match
+            let res = client
+                .upsert_kv(test_key, MatchSeq::Exact(seq), None, None)
+                .await?;
+            assert!(res.result.is_none());
+
+            // read nothing
+            let r = client.get_kv(test_key).await?;
+            assert!(r.result.is_none());
+        } else {
+            panic!("expecting a value, but got nothing");
+        }
+
+        // key not exist
+        let res = client
+            .upsert_kv("not exists", MatchSeq::Any, None, None)
+            .await?;
+        assert_eq!(None, res.prev);
+        assert_eq!(None, res.result);
+
+        // do not care seq
+        client
+            .upsert_kv(test_key, MatchSeq::Any, Some(b"v2".to_vec()), None)
+            .await?;
+
+        let res = client
+            .upsert_kv(test_key, MatchSeq::Any, None, None)
+            .await?;
+        assert_eq!(
+            (
+                Some((2, KVValue {
+                    meta: None,
+                    value: b"v2".to_vec()
+                })),
+                None
+            ),
+            (res.prev, res.result)
+        );
+
+        Ok(())
+    }
+
+    pub async fn kv_update<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        let test_key = "test_key_for_update";
+
+        let r = client
+            .upsert_kv(test_key, MatchSeq::GE(1), Some(b"v1".to_vec()), None)
+            .await?;
+        assert_eq!((None, None), (r.prev, r.result), "not changed");
+
+        let r = client
+            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.result
+        );
+        let seq = r.result.unwrap().0;
+
+        // unmatched seq
+        let r = client
+            .upsert_kv(
+                test_key,
+                MatchSeq::Exact(seq + 1),
+                Some(b"v2".to_vec()),
+                None,
+            )
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.prev
+        );
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.result
+        );
+
+        // matched seq
+        let r = client
+            .upsert_kv(test_key, MatchSeq::Exact(seq), Some(b"v2".to_vec()), None)
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.prev
+        );
+        assert_eq!(
+            Some((2, KVValue {
+                meta: None,
+                value: b"v2".to_vec()
+            })),
+            r.result
+        );
+
+        // blind update
+        let r = client
+            .upsert_kv(test_key, MatchSeq::GE(1), Some(b"v3".to_vec()), None)
+            .await?;
+        assert_eq!(
+            Some((2, KVValue {
+                meta: None,
+                value: b"v2".to_vec()
+            })),
+            r.prev
+        );
+        assert_eq!(
+            Some((3, KVValue {
+                meta: None,
+                value: b"v3".to_vec()
+            })),
+            r.result
+        );
+
+        // value updated
+        let kv = client.get_kv(test_key).await?;
+        assert!(kv.result.is_some());
+        assert_eq!(kv.result.unwrap().1, KVValue {
+            meta: None,
+            value: b"v3".to_vec()
+        });
+        Ok(())
+    }
+
+    pub async fn kv_timeout<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        // - Test get  expired and non-expired.
+        // - Test mget expired and non-expired.
+        // - Test list expired and non-expired.
+        // - Test update with a new expire value.
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        client
+            .upsert_kv(
+                "k1",
+                MatchSeq::Any,
+                Some(b"v1".to_vec()),
+                Some(KVMeta {
+                    expire_at: Some(now + 1),
+                }),
+            )
+            .await?;
+
+        tracing::info!("---get unexpired");
+        {
+            let res = client.get_kv(&"k1".to_string()).await?;
+            assert!(res.result.is_some(), "got unexpired");
+        }
+
+        tracing::info!("---get expired");
+        {
+            tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
+            let res = client.get_kv(&"k1".to_string()).await?;
+            tracing::debug!("got k1:{:?}", res);
+            assert!(res.result.is_none(), "got expired");
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        tracing::info!("--- expired entry act as if it does not exist, an ADD op should apply");
+        {
+            client
+                .upsert_kv(
+                    "k1",
+                    MatchSeq::Exact(0),
+                    Some(b"v1".to_vec()),
+                    Some(KVMeta {
+                        expire_at: Some(now - 1),
+                    }),
+                )
+                .await?;
+            client
+                .upsert_kv(
+                    "k2",
+                    MatchSeq::Exact(0),
+                    Some(b"v2".to_vec()),
+                    Some(KVMeta {
+                        expire_at: Some(now + 2),
+                    }),
+                )
+                .await?;
+
+            tracing::info!("--- mget should not return expired");
+            let res = client
+                .mget_kv(&["k1".to_string(), "k2".to_string()])
+                .await?;
+            assert_eq!(res.result, vec![
+                None,
+                Some((3, KVValue {
+                    meta: Some(KVMeta {
+                        expire_at: Some(now + 2)
+                    }),
+                    value: b"v2".to_vec()
+                })),
+            ]);
+        }
+
+        tracing::info!("--- list should not return expired");
+        {
+            let res = client.prefix_list_kv("k").await?;
+            let res_vec = res.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
+
+            assert_eq!(res_vec, vec!["k2".to_string(),]);
+        }
+
+        tracing::info!("--- update expire");
+        {
+            client
+                .upsert_kv(
+                    "k2",
+                    MatchSeq::Exact(3),
+                    Some(b"v2".to_vec()),
+                    Some(KVMeta {
+                        expire_at: Some(now - 1),
+                    }),
+                )
+                .await?;
+
+            let res = client.get_kv(&"k2".to_string()).await?;
+            assert!(res.result.is_none(), "k2 expired");
+        }
+
+        Ok(())
+    }
+
+    pub async fn kv_meta<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        let test_key = "test_key_for_update_meta";
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let r = client
+            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.result
+        );
+        let seq = r.result.unwrap().0;
+
+        tracing::info!("--- mismatching seq does nothing");
+
+        let r = client
+            .update_kv_meta(
+                test_key,
+                MatchSeq::Exact(seq + 1),
+                Some(KVMeta {
+                    expire_at: Some(now + 20),
+                }),
+            )
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.prev
+        );
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.result
+        );
+
+        tracing::info!("--- matching seq only update meta");
+
+        let r = client
+            .update_kv_meta(
+                test_key,
+                MatchSeq::Exact(seq),
+                Some(KVMeta {
+                    expire_at: Some(now + 20),
+                }),
+            )
+            .await?;
+        assert_eq!(
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            r.prev
+        );
+        assert_eq!(
+            Some((2, KVValue {
+                meta: Some(KVMeta {
+                    expire_at: Some(now + 20)
+                }),
+                value: b"v1".to_vec()
+            })),
+            r.result
+        );
+
+        tracing::info!("--- get returns the value with meta and seq updated");
+        let kv = client.get_kv(test_key).await?;
+        assert!(kv.result.is_some());
+        assert_eq!(
+            (seq + 1, KVValue {
+                meta: Some(KVMeta {
+                    expire_at: Some(now + 20)
+                }),
+                value: b"v1".to_vec()
+            }),
+            kv.result.unwrap(),
+        );
+
+        Ok(())
+    }
+
+    pub async fn kv_list<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        let mut values = vec![];
+        {
+            client
+                .upsert_kv("t", MatchSeq::Any, Some("".as_bytes().to_vec()), None)
+                .await?;
+
+            for i in 0..9 {
+                let key = format!("__users/{}", i);
+                let val = format!("val_{}", i);
+                values.push(val.clone());
+                client
+                    .upsert_kv(&key, MatchSeq::Any, Some(val.as_bytes().to_vec()), None)
+                    .await?;
+            }
+            client
+                .upsert_kv("v", MatchSeq::Any, Some(b"".to_vec()), None)
+                .await?;
+        }
+
+        let res = client.prefix_list_kv("__users/").await?;
+        assert_eq!(
+            res.iter()
+                .map(|(_key, (_s, val))| val.clone())
+                .collect::<Vec<_>>(),
+            values
+                .iter()
+                .map(|v| KVValue {
+                    meta: None,
+                    value: v.as_bytes().to_vec()
+                })
+                .collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    pub async fn kv_mget<KV: KVApi>(&self, client: &KV) -> anyhow::Result<()> {
+        client
+            .upsert_kv("k1", MatchSeq::Any, Some(b"v1".to_vec()), None)
+            .await?;
+        client
+            .upsert_kv("k2", MatchSeq::Any, Some(b"v2".to_vec()), None)
+            .await?;
+
+        let res = client
+            .mget_kv(&["k1".to_string(), "k2".to_string()])
+            .await?;
+        assert_eq!(res.result, vec![
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            // NOTE, the sequence number is increased globally (inside the namespace of generic kv)
+            Some((2, KVValue {
+                meta: None,
+                value: b"v2".to_vec()
+            })),
+        ]);
+
+        let res = client
+            .mget_kv(&["k1".to_string(), "key_no exist".to_string()])
+            .await?;
+        assert_eq!(res.result, vec![
+            Some((1, KVValue {
+                meta: None,
+                value: b"v1".to_vec()
+            })),
+            None
+        ]);
+
+        Ok(())
+    }
+}

--- a/common/meta/api/src/lib.rs
+++ b/common/meta/api/src/lib.rs
@@ -14,9 +14,11 @@
 //
 
 mod kv_api;
+mod kv_api_test_suite;
 mod meta_api;
 mod meta_api_test_suite;
 
 pub use kv_api::KVApi;
+pub use kv_api_test_suite::KVApiTestSuite;
 pub use meta_api::MetaApi;
 pub use meta_api_test_suite::MetaApiTestSuite;

--- a/common/meta/embedded/src/kv_api_impl_test.rs
+++ b/common/meta/embedded/src/kv_api_impl_test.rs
@@ -12,182 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
-
 use common_base::tokio;
-use common_exception::Result;
-use common_meta_api::KVApi;
-use common_meta_sled_store::init_temp_sled_db;
-use common_meta_types::GetKVActionReply;
-use common_meta_types::KVMeta;
-use common_meta_types::KVValue;
-use common_meta_types::MGetKVActionReply;
-use common_meta_types::MatchSeq;
-use common_meta_types::UpsertKVActionReply;
-use common_tracing::tracing;
+use common_meta_api::KVApiTestSuite;
 
 use crate::meta_embedded::MetaEmbedded;
 
 #[tokio::test]
-async fn test_kv_async_api() -> Result<()> {
-    init_testing_sled_db();
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
-    let api = MetaEmbedded::new_temp().await?;
-
-    tracing::info!("--- upsert");
-
-    let res = api
-        .upsert_kv(
-            "upsert-key",
-            MatchSeq::Any,
-            Some(b"upsert-value".to_vec()),
-            None,
-        )
-        .await?;
-
-    assert_eq!(
-        UpsertKVActionReply {
-            prev: None,
-            result: Some((1, KVValue {
-                meta: None,
-                value: b"upsert-value".to_vec(),
-            }))
-        },
-        res
-    );
-
-    tracing::info!("--- update meta with mismatching seq");
-
-    let res = api
-        .update_kv_meta(
-            "upsert-key",
-            MatchSeq::Exact(10),
-            Some(KVMeta {
-                expire_at: Some(now + 20),
-            }),
-        )
-        .await?;
-
-    assert_eq!(
-        UpsertKVActionReply {
-            prev: Some((1, KVValue {
-                meta: None,
-                value: b"upsert-value".to_vec(),
-            })),
-            result: Some((1, KVValue {
-                meta: None,
-                value: b"upsert-value".to_vec(),
-            }))
-        },
-        res,
-        "unchanged with mismatching seq"
-    );
-
-    tracing::info!("--- update meta with matching seq");
-
-    let res = api
-        .update_kv_meta(
-            "upsert-key",
-            MatchSeq::Exact(1),
-            Some(KVMeta {
-                expire_at: Some(now + 20),
-            }),
-        )
-        .await?;
-
-    assert_eq!(
-        UpsertKVActionReply {
-            prev: Some((1, KVValue {
-                meta: None,
-                value: b"upsert-value".to_vec(),
-            })),
-            result: Some((2, KVValue {
-                meta: Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
-                value: b"upsert-value".to_vec(),
-            })),
-        },
-        res
-    );
-
-    tracing::info!("--- get_kv");
-
-    let res = api.get_kv("upsert-key").await?;
-    assert_eq!(
-        GetKVActionReply {
-            result: Some((2, KVValue {
-                meta: Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
-                value: b"upsert-value".to_vec(),
-            })),
-        },
-        res
-    );
-
-    tracing::info!("--- mget_kv");
-
-    let _res = api
-        .upsert_kv(
-            "upsert-key-2",
-            MatchSeq::Any,
-            Some(b"upsert-value-2".to_vec()),
-            None,
-        )
-        .await?;
-
-    let res = api
-        .mget_kv(&[
-            "upsert-key".to_string(),
-            "upsert-key-2".to_string(),
-            "nonexistent".to_string(),
-        ])
-        .await?;
-
-    assert_eq!(
-        MGetKVActionReply {
-            result: vec![
-                Some((2, KVValue {
-                    meta: Some(KVMeta {
-                        expire_at: Some(now + 20)
-                    }),
-                    value: b"upsert-value".to_vec(),
-                })),
-                Some((3, KVValue {
-                    meta: None,
-                    value: b"upsert-value-2".to_vec(),
-                })),
-                None
-            ]
-        },
-        res
-    );
-
-    tracing::info!("--- prefix_list_kv");
-
-    let res = api.prefix_list_kv("upsert-key-").await?;
-    assert_eq!(
-        vec![(
-            "upsert-key-2".to_string(),
-            (3, KVValue {
-                meta: None,
-                value: b"upsert-value-2".to_vec(),
-            })
-        )],
-        res
-    );
-
-    Ok(())
+async fn test_kv_write_read() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_write_read(&kv).await
 }
 
-fn init_testing_sled_db() {
-    let t = tempfile::tempdir().expect("create temp dir to sled db");
-    init_temp_sled_db(t);
+#[tokio::test]
+async fn test_kv_delete() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_delete(&kv).await
+}
+
+#[tokio::test]
+async fn test_kv_update() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_update(&kv).await
+}
+
+#[tokio::test]
+async fn test_kv_timeout() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_timeout(&kv).await
+}
+
+#[tokio::test]
+async fn test_kv_meta() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_meta(&kv).await
+}
+
+#[tokio::test]
+async fn test_kv_list() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_list(&kv).await
+}
+
+#[tokio::test]
+async fn test_kv_mget() -> anyhow::Result<()> {
+    let kv = MetaEmbedded::new_temp().await?;
+    KVApiTestSuite {}.kv_mget(&kv).await
 }

--- a/metasrv/tests/flight/metasrv_flight_api.rs
+++ b/metasrv/tests/flight/metasrv_flight_api.rs
@@ -14,14 +14,11 @@
 
 //! Test arrow-flight API of metasrv
 
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
-
 use common_base::tokio;
 use common_meta_api::KVApi;
+use common_meta_api::KVApiTestSuite;
 use common_meta_api::MetaApiTestSuite;
 use common_meta_flight::MetaFlightClient;
-use common_meta_types::KVMeta;
 use common_meta_types::KVValue;
 use common_meta_types::MatchSeq;
 use common_meta_types::UpsertKVActionReply;
@@ -125,268 +122,48 @@ async fn test_restart() -> anyhow::Result<()> {
 async fn test_generic_kv_mget() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        client
-            .upsert_kv("k1", MatchSeq::Any, Some(b"v1".to_vec()), None)
-            .await?;
-        client
-            .upsert_kv("k2", MatchSeq::Any, Some(b"v2".to_vec()), None)
-            .await?;
-
-        let res = client
-            .mget_kv(&["k1".to_string(), "k2".to_string()])
-            .await?;
-        assert_eq!(res.result, vec![
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            // NOTE, the sequence number is increased globally (inside the namespace of generic kv)
-            Some((2, KVValue {
-                meta: None,
-                value: b"v2".to_vec()
-            })),
-        ]);
-
-        let res = client
-            .mget_kv(&["k1".to_string(), "key_no exist".to_string()])
-            .await?;
-        assert_eq!(res.result, vec![
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            None
-        ]);
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_mget(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_generic_kv_list() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let mut values = vec![];
-        {
-            client
-                .upsert_kv("t", MatchSeq::Any, Some("".as_bytes().to_vec()), None)
-                .await?;
-
-            for i in 0..9 {
-                let key = format!("__users/{}", i);
-                let val = format!("val_{}", i);
-                values.push(val.clone());
-                client
-                    .upsert_kv(&key, MatchSeq::Any, Some(val.as_bytes().to_vec()), None)
-                    .await?;
-            }
-            client
-                .upsert_kv("v", MatchSeq::Any, Some(b"".to_vec()), None)
-                .await?;
-        }
-
-        let res = client.prefix_list_kv("__users/").await?;
-        assert_eq!(
-            res.iter()
-                .map(|(_key, (_s, val))| val.clone())
-                .collect::<Vec<_>>(),
-            values
-                .iter()
-                .map(|v| KVValue {
-                    meta: None,
-                    value: v.as_bytes().to_vec()
-                })
-                .collect::<Vec<_>>()
-        );
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_list(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_generic_kv_delete() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let test_key = "test_key";
-        client
-            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
-            .await?;
-
-        let current = client.get_kv(test_key).await?;
-        if let Some((seq, _val)) = current.result {
-            // seq mismatch
-            let wrong_seq = Some(seq + 1);
-            let res = client
-                .upsert_kv(test_key, wrong_seq.into(), None, None)
-                .await?;
-            assert_eq!(res.prev, res.result);
-
-            // seq match
-            let res = client
-                .upsert_kv(test_key, MatchSeq::Exact(seq), None, None)
-                .await?;
-            assert!(res.result.is_none());
-
-            // read nothing
-            let r = client.get_kv(test_key).await?;
-            assert!(r.result.is_none());
-        } else {
-            panic!("expecting a value, but got nothing");
-        }
-
-        // key not exist
-        let res = client
-            .upsert_kv("not exists", MatchSeq::Any, None, None)
-            .await?;
-        assert_eq!(None, res.prev);
-        assert_eq!(None, res.result);
-
-        // do not care seq
-        client
-            .upsert_kv(test_key, MatchSeq::Any, Some(b"v2".to_vec()), None)
-            .await?;
-
-        let res = client
-            .upsert_kv(test_key, MatchSeq::Any, None, None)
-            .await?;
-        assert_eq!(
-            (
-                Some((2, KVValue {
-                    meta: None,
-                    value: b"v2".to_vec()
-                })),
-                None
-            ),
-            (res.prev, res.result)
-        );
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_delete(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_generic_kv_update() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_list");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let test_key = "test_key_for_update";
-
-        let r = client
-            .upsert_kv(test_key, MatchSeq::GE(1), Some(b"v1".to_vec()), None)
-            .await?;
-        assert_eq!((None, None), (r.prev, r.result), "not changed");
-
-        let r = client
-            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.result
-        );
-        let seq = r.result.unwrap().0;
-
-        // unmatched seq
-        let r = client
-            .upsert_kv(
-                test_key,
-                MatchSeq::Exact(seq + 1),
-                Some(b"v2".to_vec()),
-                None,
-            )
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.prev
-        );
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.result
-        );
-
-        // matched seq
-        let r = client
-            .upsert_kv(test_key, MatchSeq::Exact(seq), Some(b"v2".to_vec()), None)
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.prev
-        );
-        assert_eq!(
-            Some((2, KVValue {
-                meta: None,
-                value: b"v2".to_vec()
-            })),
-            r.result
-        );
-
-        // blind update
-        let r = client
-            .upsert_kv(test_key, MatchSeq::GE(1), Some(b"v3".to_vec()), None)
-            .await?;
-        assert_eq!(
-            Some((2, KVValue {
-                meta: None,
-                value: b"v2".to_vec()
-            })),
-            r.prev
-        );
-        assert_eq!(
-            Some((3, KVValue {
-                meta: None,
-                value: b"v3".to_vec()
-            })),
-            r.result
-        );
-
-        // value updated
-        let kv = client.get_kv(test_key).await?;
-        assert!(kv.result.is_some());
-        assert_eq!(kv.result.unwrap().1, KVValue {
-            meta: None,
-            value: b"v3".to_vec()
-        });
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_update(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -395,219 +172,24 @@ async fn test_generic_kv_update_meta() -> anyhow::Result<()> {
 
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_update_meta");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let test_key = "test_key_for_update_meta";
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        let r = client
-            .upsert_kv(test_key, MatchSeq::Any, Some(b"v1".to_vec()), None)
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.result
-        );
-        let seq = r.result.unwrap().0;
-
-        tracing::info!("--- mismatching seq does nothing");
-
-        let r = client
-            .update_kv_meta(
-                test_key,
-                MatchSeq::Exact(seq + 1),
-                Some(KVMeta {
-                    expire_at: Some(now + 20),
-                }),
-            )
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.prev
-        );
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.result
-        );
-
-        tracing::info!("--- matching seq only update meta");
-
-        let r = client
-            .update_kv_meta(
-                test_key,
-                MatchSeq::Exact(seq),
-                Some(KVMeta {
-                    expire_at: Some(now + 20),
-                }),
-            )
-            .await?;
-        assert_eq!(
-            Some((1, KVValue {
-                meta: None,
-                value: b"v1".to_vec()
-            })),
-            r.prev
-        );
-        assert_eq!(
-            Some((2, KVValue {
-                meta: Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
-                value: b"v1".to_vec()
-            })),
-            r.result
-        );
-
-        tracing::info!("--- get returns the value with meta and seq updated");
-        let kv = client.get_kv(test_key).await?;
-        assert!(kv.result.is_some());
-        assert_eq!(
-            (seq + 1, KVValue {
-                meta: Some(KVMeta {
-                    expire_at: Some(now + 20)
-                }),
-                value: b"v1".to_vec()
-            }),
-            kv.result.unwrap(),
-        );
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_meta(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_generic_kv_timeout() -> anyhow::Result<()> {
-    // - Test get  expired and non-expired.
-    // - Test mget expired and non-expired.
-    // - Test list expired and non-expired.
-    // - Test update with a new expire value.
-
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv_timeout");
-        let _ent = span.enter();
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        client
-            .upsert_kv(
-                "k1",
-                MatchSeq::Any,
-                Some(b"v1".to_vec()),
-                Some(KVMeta {
-                    expire_at: Some(now + 1),
-                }),
-            )
-            .await?;
-
-        tracing::info!("---get unexpired");
-        {
-            let res = client.get_kv(&"k1".to_string()).await?;
-            assert!(res.result.is_some(), "got unexpired");
-        }
-
-        tracing::info!("---get expired");
-        {
-            tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
-            let res = client.get_kv(&"k1".to_string()).await?;
-            tracing::debug!("got k1:{:?}", res);
-            assert!(res.result.is_none(), "got expired");
-        }
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        tracing::info!("--- expired entry act as if it does not exist, an ADD op should apply");
-        {
-            client
-                .upsert_kv(
-                    "k1",
-                    MatchSeq::Exact(0),
-                    Some(b"v1".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now - 1),
-                    }),
-                )
-                .await?;
-            client
-                .upsert_kv(
-                    "k2",
-                    MatchSeq::Exact(0),
-                    Some(b"v2".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now + 2),
-                    }),
-                )
-                .await?;
-
-            tracing::info!("--- mget should not return expired");
-            let res = client
-                .mget_kv(&["k1".to_string(), "k2".to_string()])
-                .await?;
-            assert_eq!(res.result, vec![
-                None,
-                Some((3, KVValue {
-                    meta: Some(KVMeta {
-                        expire_at: Some(now + 2)
-                    }),
-                    value: b"v2".to_vec()
-                })),
-            ]);
-        }
-
-        tracing::info!("--- list should not return expired");
-        {
-            let res = client.prefix_list_kv("k").await?;
-            let res_vec = res.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
-
-            assert_eq!(res_vec, vec!["k2".to_string(),]);
-        }
-
-        tracing::info!("--- update expire");
-        {
-            client
-                .upsert_kv(
-                    "k2",
-                    MatchSeq::Exact(3),
-                    Some(b"v2".to_vec()),
-                    Some(KVMeta {
-                        expire_at: Some(now - 1),
-                    }),
-                )
-                .await?;
-
-            let res = client.get_kv(&"k2".to_string()).await?;
-            assert!(res.result.is_none(), "k2 expired");
-        }
-    }
-    Ok(())
+    KVApiTestSuite {}.kv_timeout(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -615,75 +197,11 @@ async fn test_generic_kv() -> anyhow::Result<()> {
     let (_log_guards, ut_span) = init_meta_ut!();
     let _ent = ut_span.enter();
 
-    {
-        let span = tracing::span!(tracing::Level::INFO, "test_generic_kv");
-        let _ent = span.enter();
+    let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
 
-        let (_tc, addr) = databend_meta::tests::start_metasrv().await?;
+    let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
 
-        let client = MetaFlightClient::try_create(addr.as_str(), "root", "xxx").await?;
-
-        {
-            // write
-            let res = client
-                .upsert_kv("foo", MatchSeq::Any, Some(b"bar".to_vec()), None)
-                .await?;
-            assert_eq!(None, res.prev);
-            assert_eq!(
-                Some((1, KVValue {
-                    meta: None,
-                    value: b"bar".to_vec()
-                })),
-                res.result
-            );
-        }
-
-        {
-            // write fails with unmatched seq
-            let res = client
-                .upsert_kv("foo", MatchSeq::Exact(2), Some(b"bar".to_vec()), None)
-                .await?;
-            assert_eq!(
-                (
-                    Some((1, KVValue {
-                        meta: None,
-                        value: b"bar".to_vec()
-                    })),
-                    Some((1, KVValue {
-                        meta: None,
-                        value: b"bar".to_vec(),
-                    })),
-                ),
-                (res.prev, res.result),
-                "nothing changed"
-            );
-        }
-
-        {
-            // write done with matching seq
-            let res = client
-                .upsert_kv("foo", MatchSeq::Exact(1), Some(b"wow".to_vec()), None)
-                .await?;
-            assert_eq!(
-                Some((1, KVValue {
-                    meta: None,
-                    value: b"bar".to_vec()
-                })),
-                res.prev,
-                "old value"
-            );
-            assert_eq!(
-                Some((2, KVValue {
-                    meta: None,
-                    value: b"wow".to_vec()
-                })),
-                res.result,
-                "new value"
-            );
-        }
-    }
-
-    Ok(())
+    KVApiTestSuite {}.kv_write_read(&client).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/api] refactor: move kv test to crate "meta/api" so that meta-embedded and meta-srv reuse the test suite

## Changelog




- Improvement


## Related Issues

- #2030