### PR TITLE
[query]: refactor:  rename CatalogBackend to MetaApiSync, since CataalogBackend is just a sync version of MetaApi

### DIFF
--- a/query/src/catalogs/backends/backend.rs
+++ b/query/src/catalogs/backends/backend.rs
@@ -27,7 +27,7 @@ use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 
-pub trait CatalogBackend: Send + Sync {
+pub trait MetaApiSync: Send + Sync {
     // database
 
     fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply>;

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -29,7 +29,7 @@ use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 
-use crate::catalogs::backends::CatalogBackend;
+use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::table_id_ranges::LOCAL_TBL_ID_BEGIN;
 
 /// This catalog backend used for test only.
@@ -56,12 +56,12 @@ impl InMemoryTableInfo {
 
 type Databases = Arc<RwLock<HashMap<String, (Arc<DatabaseInfo>, InMemoryTableInfo)>>>;
 
-pub struct EmbeddedCatalogBackend {
+pub struct MetaEmbeddedSync {
     databases: Databases,
     tbl_id_seq: Arc<RwLock<u64>>,
 }
 
-impl EmbeddedCatalogBackend {
+impl MetaEmbeddedSync {
     pub fn create() -> Self {
         let tbl_id_seq = Arc::new(RwLock::new(LOCAL_TBL_ID_BEGIN));
         Self {
@@ -77,7 +77,7 @@ impl EmbeddedCatalogBackend {
     }
 }
 
-impl CatalogBackend for EmbeddedCatalogBackend {
+impl MetaApiSync for MetaEmbeddedSync {
     fn create_database(
         &self,
         plan: CreateDatabasePlan,

--- a/query/src/catalogs/backends/impls/mod.rs
+++ b/query/src/catalogs/backends/impls/mod.rs
@@ -16,5 +16,5 @@
 mod embedded_backend;
 mod remote_backend;
 
-pub use embedded_backend::EmbeddedCatalogBackend;
-pub use remote_backend::RemoteCatalogBackend;
+pub use embedded_backend::MetaEmbeddedSync;
+pub use remote_backend::MetaRemoteSync;

--- a/query/src/catalogs/backends/mod.rs
+++ b/query/src/catalogs/backends/mod.rs
@@ -15,6 +15,6 @@
 mod backend;
 mod impls;
 
-pub use backend::CatalogBackend;
-pub use impls::EmbeddedCatalogBackend;
-pub use impls::RemoteCatalogBackend;
+pub use backend::MetaApiSync;
+pub use impls::MetaEmbeddedSync;
+pub use impls::MetaRemoteSync;

--- a/query/src/datasources/database/default/default_database_factory.rs
+++ b/query/src/datasources/database/default/default_database_factory.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_meta_types::DatabaseInfo;
 
-use crate::catalogs::backends::CatalogBackend;
+use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::Database;
 use crate::catalogs::DatabaseEngine;
 use crate::common::MetaClientProvider;
@@ -30,17 +30,17 @@ use crate::datasources::table_engine_registry::TableEngineRegistry;
 /// - creates tables by using TableFactory
 /// - keeps metadata in the given meta_backend
 pub struct DefaultDatabaseFactory {
-    catalog_backend: Arc<dyn CatalogBackend>,
+    meta: Arc<dyn MetaApiSync>,
     table_factory_registry: Arc<TableEngineRegistry>,
 }
 
 impl DefaultDatabaseFactory {
     pub fn new(
-        catalog_backend: Arc<dyn CatalogBackend>,
+        catalog_backend: Arc<dyn MetaApiSync>,
         table_factory_registry: Arc<TableEngineRegistry>,
     ) -> Self {
         Self {
-            catalog_backend,
+            meta: catalog_backend,
             table_factory_registry,
         }
     }
@@ -52,7 +52,7 @@ impl DatabaseEngine for DefaultDatabaseFactory {
         let db = DefaultDatabase::new(
             &db_info.db,
             &db_info.engine,
-            self.catalog_backend.clone(),
+            self.meta.clone(),
             self.table_factory_registry.clone(),
             client_provider,
         );
@@ -60,9 +60,6 @@ impl DatabaseEngine for DefaultDatabaseFactory {
     }
 
     fn description(&self) -> String {
-        format!(
-            "default database engine, with {}",
-            self.catalog_backend.name()
-        )
+        format!("default database engine, with {}", self.meta.name())
     }
 }

--- a/query/src/datasources/database/example/example_databases.rs
+++ b/query/src/datasources/database/example/example_databases.rs
@@ -17,27 +17,27 @@ use std::sync::Arc;
 use common_exception::Result;
 use common_meta_types::DatabaseInfo;
 
-use crate::catalogs::backends::CatalogBackend;
-use crate::catalogs::backends::EmbeddedCatalogBackend;
+use crate::catalogs::backends::MetaApiSync;
+use crate::catalogs::backends::MetaEmbeddedSync;
 use crate::catalogs::Database;
 use crate::catalogs::DatabaseEngine;
 use crate::configs::Config;
 use crate::datasources::database::example::ExampleDatabase;
 
 pub struct ExampleDatabaseEngine {
-    catalog_backend: Arc<dyn CatalogBackend>,
+    meta: Arc<dyn MetaApiSync>,
 }
 
 impl ExampleDatabaseEngine {
     pub fn create() -> Self {
-        let catalog_backend = Arc::new(EmbeddedCatalogBackend::create());
-        ExampleDatabaseEngine { catalog_backend }
+        let meta = Arc::new(MetaEmbeddedSync::create());
+        ExampleDatabaseEngine { meta }
     }
 }
 
 impl DatabaseEngine for ExampleDatabaseEngine {
     fn create(&self, _conf: &Config, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
-        let db = ExampleDatabase::new(&db_info.db, &db_info.engine, self.catalog_backend.clone());
+        let db = ExampleDatabase::new(&db_info.db, &db_info.engine, self.meta.clone());
         Ok(Arc::new(db))
     }
 

--- a/query/src/datasources/database/prelude.rs
+++ b/query/src/datasources/database/prelude.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use common_exception::Result;
 
-use crate::catalogs::backends::CatalogBackend;
+use crate::catalogs::backends::MetaApiSync;
 use crate::datasources::database::default::default_database_factory::DefaultDatabaseFactory;
 use crate::datasources::database_engine_registry::DatabaseEngineRegistry;
 use crate::datasources::table_engine_registry::TableEngineRegistry;
@@ -26,10 +26,10 @@ pub const DB_ENGINE_DEFAULT: &str = "Default";
 
 pub fn register_prelude_db_engines(
     registry: &DatabaseEngineRegistry,
-    catalog_backend: Arc<dyn CatalogBackend>,
+    meta: Arc<dyn MetaApiSync>,
     table_factory_registry: Arc<TableEngineRegistry>,
 ) -> Result<()> {
-    let default = DefaultDatabaseFactory::new(catalog_backend, table_factory_registry);
+    let default = DefaultDatabaseFactory::new(meta, table_factory_registry);
     registry.register(DB_ENGINE_DEFAULT, Arc::new(default))?;
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query]: refactor:  rename CatalogBackend to MetaApiSync, since CataalogBackend is just a sync version of MetaApi
- fix: #2278

## Changelog




- Improvement


## Related Issues

- #2030