### PR TITLE
[query] refactor catalog: remove unused MetaClientProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "msql-srv"
 version = "0.9.6"
-source = "git+https://github.com/datafuse-extras/msql-srv?rev=3d52211#3d52211ba1ae014c8e58b741f01d46f3f3f79574"
+source = "git+https://github.com/datafuse-extras/msql-srv?rev=e4c8f3d#e4c8f3dd4211f017027ce8ac89f871ac5ff082e1"
 dependencies = [
  "byteorder",
  "chrono",

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -49,7 +49,6 @@ pub const DEFAULT_DB_ENGINE: &str = "Default";
 /// - Instances of `Database` are created by using database factories according to the engine
 /// - Database engines are free to save table meta in metastore or not
 pub struct MetaStoreCatalog {
-    conf: Config,
     db_engine_registry: Arc<DatabaseEngineRegistry>,
     meta: Arc<dyn MetaApiSync>,
 
@@ -85,7 +84,6 @@ impl MetaStoreCatalog {
         register_prelude_db_engines(&db_engine_registry, meta.clone(), table_engine_registry)?;
 
         let cat = MetaStoreCatalog {
-            conf,
             db_engine_registry,
             meta,
             db_instances: RwLock::new(HashMap::new()),
@@ -118,7 +116,7 @@ impl MetaStoreCatalog {
             })?;
 
         let name = db_info.db.clone();
-        let db = provider.create(&self.conf, db_info)?;
+        let db = provider.create(db_info)?;
         self.db_instances.write().insert(name, db.clone());
         Ok(db)
     }

--- a/query/src/datasources/database/default/default_database_factory.rs
+++ b/query/src/datasources/database/default/default_database_factory.rs
@@ -21,8 +21,6 @@ use common_meta_types::DatabaseInfo;
 use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::Database;
 use crate::catalogs::DatabaseEngine;
-use crate::common::MetaClientProvider;
-use crate::configs::Config;
 use crate::datasources::database::default::default_database::DefaultDatabase;
 use crate::datasources::table_engine_registry::TableEngineRegistry;
 
@@ -47,14 +45,12 @@ impl DefaultDatabaseFactory {
 }
 
 impl DatabaseEngine for DefaultDatabaseFactory {
-    fn create(&self, conf: &Config, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
-        let client_provider = MetaClientProvider::new(conf);
+    fn create(&self, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
         let db = DefaultDatabase::new(
             &db_info.db,
             &db_info.engine,
             self.meta.clone(),
             self.table_factory_registry.clone(),
-            client_provider,
         );
         Ok(Arc::new(db))
     }

--- a/query/src/datasources/database/example/example_databases.rs
+++ b/query/src/datasources/database/example/example_databases.rs
@@ -21,7 +21,6 @@ use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::backends::MetaEmbeddedSync;
 use crate::catalogs::Database;
 use crate::catalogs::DatabaseEngine;
-use crate::configs::Config;
 use crate::datasources::database::example::ExampleDatabase;
 
 pub struct ExampleDatabaseEngine {
@@ -36,7 +35,7 @@ impl ExampleDatabaseEngine {
 }
 
 impl DatabaseEngine for ExampleDatabaseEngine {
-    fn create(&self, _conf: &Config, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
+    fn create(&self, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
         let db = ExampleDatabase::new(&db_info.db, &db_info.engine, self.meta.clone());
         Ok(Arc::new(db))
     }

--- a/query/src/datasources/database_engine.rs
+++ b/query/src/datasources/database_engine.rs
@@ -19,9 +19,8 @@ use common_exception::Result;
 use common_meta_types::DatabaseInfo;
 
 use crate::catalogs::Database;
-use crate::configs::Config;
 
 pub trait DatabaseEngine: Send + Sync {
-    fn create(&self, conf: &Config, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>>;
+    fn create(&self, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>>;
     fn description(&self) -> String;
 }

--- a/query/src/datasources/table_engine.rs
+++ b/query/src/datasources/table_engine.rs
@@ -16,18 +16,13 @@
 use common_meta_types::TableInfo;
 
 use crate::catalogs::Table;
-use crate::common::MetaClientProvider;
 
 // TODO maybe we should introduce a
 // `Session::store_provider(...) -> Result<StoreApiProvider>`
 // such that, we no longer need to pass store_provider to Table's constructor
 // instead, table could access apis on demand in method read_plan  and read
 pub trait TableEngine: Send + Sync {
-    fn try_create(
-        &self,
-        table_info: TableInfo,
-        store_provider: MetaClientProvider,
-    ) -> common_exception::Result<Box<dyn Table>>;
+    fn try_create(&self, table_info: TableInfo) -> common_exception::Result<Box<dyn Table>>;
 }
 
 impl<T> TableEngine for T
@@ -35,11 +30,7 @@ where
     T: Fn(TableInfo) -> common_exception::Result<Box<dyn Table>>,
     T: Send + Sync,
 {
-    fn try_create(
-        &self,
-        table_info: TableInfo,
-        _store_provider: MetaClientProvider,
-    ) -> common_exception::Result<Box<dyn Table>> {
+    fn try_create(&self, table_info: TableInfo) -> common_exception::Result<Box<dyn Table>> {
         self(table_info)
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor catalog: remove unused MetaClientProvider
Since meta access should all be done through a member of type `MetaApiSync`,
there is no need to keep a `MetaClientProvider` for `DefaultDatabase`, `DatabaseEngine` and `TableEngine`.

PS. `TableEngine` may need a `StoreClientProvider`. It could be added as needed.

## Changelog







## Related Issues

- #2030