### PR TITLE
[query] refactor: decouple `MetaRemoteSync` into 3 componennt: remote meta access, caching, and async-to-sync conversion.

### DIFF
--- a/query/src/catalogs/backends/impls/meta_cached.rs
+++ b/query/src/catalogs/backends/impls/meta_cached.rs
@@ -1,0 +1,109 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_base::tokio::sync::RwLock;
+use common_cache::Cache;
+use common_cache::LruCache;
+use common_exception::Result;
+use common_meta_api::MetaApi;
+use common_meta_types::CreateDatabaseReply;
+use common_meta_types::CreateTableReply;
+use common_meta_types::DatabaseInfo;
+use common_meta_types::MetaId;
+use common_meta_types::MetaVersion;
+use common_meta_types::TableInfo;
+use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
+
+type TableInfoCache = LruCache<(MetaId, MetaVersion), Arc<TableInfo>>;
+
+/// A `MetaApi` impl with table cached in memory, backed with another `MetaApi`.
+#[derive(Clone)]
+pub struct MetaCached {
+    table_meta_cache: Arc<RwLock<TableInfoCache>>,
+    pub inner: Arc<dyn MetaApi>,
+}
+
+impl MetaCached {
+    pub fn create(inner: Arc<dyn MetaApi>) -> MetaCached {
+        MetaCached {
+            table_meta_cache: Arc::new(RwLock::new(LruCache::new(100))),
+            inner,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MetaApi for MetaCached {
+    async fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {
+        self.inner.create_database(plan).await
+    }
+
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
+        self.inner.drop_database(plan).await
+    }
+
+    async fn get_database(&self, db_name: &str) -> Result<Arc<DatabaseInfo>> {
+        self.inner.get_database(db_name).await
+    }
+
+    async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
+        self.inner.get_databases().await
+    }
+
+    async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableReply> {
+        // TODO validate plan by table engine first
+        self.inner.create_table(plan).await
+    }
+
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<()> {
+        self.inner.drop_table(plan).await
+    }
+
+    async fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableInfo>> {
+        self.inner.get_table(db_name, table_name).await
+    }
+
+    async fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>> {
+        self.inner.get_tables(db_name).await
+    }
+
+    async fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+        version: Option<MetaVersion>,
+    ) -> Result<Arc<TableInfo>> {
+        if let Some(ver) = version {
+            let mut cached = self.table_meta_cache.write().await;
+            if let Some(meta) = cached.get(&(table_id, ver)) {
+                return Ok(meta.clone());
+            }
+        }
+
+        let reply = self.inner.get_table_by_id(table_id, version).await?;
+
+        let mut cache = self.table_meta_cache.write().await;
+        // TODO version
+        cache.put((reply.table_id, 0), reply.clone());
+        Ok(reply)
+    }
+
+    fn name(&self) -> String {
+        format!("meta-cached({})", self.inner.name())
+    }
+}

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -1,0 +1,128 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_exception::Result;
+use common_meta_api::MetaApi;
+use common_meta_types::CreateDatabaseReply;
+use common_meta_types::CreateTableReply;
+use common_meta_types::DatabaseInfo;
+use common_meta_types::MetaId;
+use common_meta_types::MetaVersion;
+use common_meta_types::TableInfo;
+use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
+
+use crate::common::MetaClientProvider;
+
+/// A `MetaApi` impl with MetaApi RPC.
+#[derive(Clone)]
+pub struct MetaRemote {
+    rpc_time_out: Option<Duration>,
+    meta_api_provider: Arc<MetaClientProvider>,
+}
+
+impl MetaRemote {
+    pub fn create(apis_provider: Arc<MetaClientProvider>) -> MetaRemote {
+        Self::with_timeout_setting(apis_provider, Some(Duration::from_secs(5)))
+    }
+
+    pub fn with_timeout_setting(
+        apis_provider: Arc<MetaClientProvider>,
+        timeout: Option<Duration>,
+    ) -> MetaRemote {
+        MetaRemote {
+            rpc_time_out: timeout,
+            meta_api_provider: apis_provider,
+        }
+    }
+
+    async fn query_backend<F, T, ResFut>(&self, f: F) -> Result<T>
+    where
+        ResFut: Future<Output = Result<T>> + Send + 'static,
+        F: FnOnce(Arc<dyn MetaApi>) -> ResFut,
+        F: Send + Sync + 'static,
+        T: Send + Sync + 'static,
+    {
+        let cli = self.meta_api_provider.try_get_meta_client().await?;
+        f(cli).await
+    }
+}
+
+#[async_trait::async_trait]
+impl MetaApi for MetaRemote {
+    async fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {
+        self.query_backend(move |cli| async move { cli.create_database(plan).await })
+            .await
+    }
+
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
+        self.query_backend(move |cli| async move { cli.drop_database(plan).await })
+            .await
+    }
+
+    async fn get_database(&self, db_name: &str) -> Result<Arc<DatabaseInfo>> {
+        let db_name = db_name.to_owned();
+        self.query_backend(move |cli| async move { cli.get_database(&db_name).await })
+            .await
+    }
+
+    async fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
+        self.query_backend(move |cli| async move { cli.get_databases().await })
+            .await
+    }
+
+    async fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableReply> {
+        // TODO validate plan by table engine first
+        self.query_backend(move |cli| async move { cli.create_table(plan).await })
+            .await
+    }
+
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<()> {
+        self.query_backend(move |cli| async move { cli.drop_table(plan).await })
+            .await
+    }
+
+    async fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableInfo>> {
+        let table_name = table_name.to_string();
+        let db_name = db_name.to_string();
+        self.query_backend(move |cli| async move { cli.get_table(&db_name, &table_name).await })
+            .await
+    }
+
+    async fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>> {
+        let db_name = db_name.to_owned();
+        self.query_backend(move |cli| async move { cli.get_tables(&db_name).await })
+            .await
+    }
+
+    async fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+        version: Option<MetaVersion>,
+    ) -> Result<Arc<TableInfo>> {
+        // TODO(xp): version
+        self.query_backend(move |cli| async move { cli.get_table_by_id(table_id, version).await })
+            .await
+    }
+
+    fn name(&self) -> String {
+        "meta-remote".to_owned()
+    }
+}

--- a/query/src/catalogs/backends/impls/meta_sync.rs
+++ b/query/src/catalogs/backends/impls/meta_sync.rs
@@ -1,0 +1,113 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_base::BlockingWait;
+use common_base::Runtime;
+use common_exception::Result;
+use common_meta_api::MetaApi;
+use common_meta_types::CreateDatabaseReply;
+use common_meta_types::CreateTableReply;
+use common_meta_types::DatabaseInfo;
+use common_meta_types::MetaId;
+use common_meta_types::MetaVersion;
+use common_meta_types::TableInfo;
+use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
+
+use crate::catalogs::backends::MetaApiSync;
+
+/// A `MetaApiSync` impl, backed with another `MetaApi`.
+#[derive(Clone)]
+pub struct MetaSync {
+    rt: Arc<Runtime>,
+    timeout: Option<Duration>,
+    pub inner: Arc<dyn MetaApi>,
+}
+
+impl MetaSync {
+    pub fn create(inner: Arc<dyn MetaApi>, timeout: Option<Duration>) -> MetaSync {
+        let rt = Runtime::with_worker_threads(1).expect("remote catalogs initialization failure");
+        MetaSync {
+            rt: Arc::new(rt),
+            timeout,
+            inner,
+        }
+    }
+}
+
+impl MetaApiSync for MetaSync {
+    fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {
+        let x = self.inner.clone();
+        (async move { x.create_database(plan).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
+        let x = self.inner.clone();
+        (async move { x.drop_database(plan).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn get_database(&self, db_name: &str) -> Result<Arc<DatabaseInfo>> {
+        let x = self.inner.clone();
+        let db_name = db_name.to_owned();
+        (async move { x.get_database(&db_name).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn get_databases(&self) -> Result<Vec<Arc<DatabaseInfo>>> {
+        let x = self.inner.clone();
+        (async move { x.get_databases().await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn create_table(&self, plan: CreateTablePlan) -> Result<CreateTableReply> {
+        // TODO validate plan by table engine first
+        let x = self.inner.clone();
+        (async move { x.create_table(plan).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn drop_table(&self, plan: DropTablePlan) -> Result<()> {
+        let x = self.inner.clone();
+        (async move { x.drop_table(plan).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableInfo>> {
+        let x = self.inner.clone();
+        let table_name = table_name.to_string();
+        let db_name = db_name.to_string();
+        (async move { x.get_table(&db_name, &table_name).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>> {
+        let x = self.inner.clone();
+        let db_name = db_name.to_owned();
+        (async move { x.get_tables(&db_name).await }).wait_in(&self.rt, self.timeout)?
+    }
+
+    fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+        version: Option<MetaVersion>,
+    ) -> Result<Arc<TableInfo>> {
+        let x = self.inner.clone();
+        (async move { x.get_table_by_id(table_id, version).await })
+            .wait_in(&self.rt, self.timeout)?
+    }
+
+    fn name(&self) -> String {
+        format!("meta-sync({})", self.inner.name())
+    }
+}

--- a/query/src/catalogs/backends/impls/mod.rs
+++ b/query/src/catalogs/backends/impls/mod.rs
@@ -14,7 +14,13 @@
 //
 
 mod embedded_backend;
+mod meta_cached;
+mod meta_remote;
+mod meta_sync;
 mod remote_backend;
 
 pub use embedded_backend::MetaEmbeddedSync;
+pub use meta_cached::MetaCached;
+pub use meta_remote::MetaRemote;
+pub use meta_sync::MetaSync;
 pub use remote_backend::MetaRemoteSync;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: decouple `MetaRemoteSync` into 3 componennt: remote meta access, caching, and async-to-sync conversion.
- MetaRemote impl MetaApi and provides remote access to a meta server.
- MetaCached impl MetaApi and provides caching, which is backed with another inner `Arc<dyn MetaApi>`.
- MetaSync provides converion from `MetaApi` to `MetaApiSync`, backed with another inner `Arc<dyn MetaApi>`.

This way the meta system hierarchy is as below:

```text
MetaRemoteSync
|
v                                      RPC
MetaSync -> MetaCached -> MetaRemote -------> Meta server      Meta server
                                              raft <---------> raft <----..
                                              MetaEmbedded     MetaEmbedded
```

Then an **embedded** sync mode meta store that provides the same API and
function just reuse these components, e.g.:

```text
MetaEmbeddedSync
|
v
MetaSync -> MetaCached -> MetaEmbedded
```

## Changelog




- Improvement


## Related Issues

- #2030