### PR TITLE
[deps] bump clap to 3.0.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ name = "bendctl"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "clap 3.0.0-beta.4",
+ "clap 3.0.0-beta.5",
  "clap_generate",
  "colored",
  "comfy-table",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
+checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
 dependencies = [
  "atty",
  "bitflags",
@@ -894,14 +894,14 @@ dependencies = [
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.14.2",
- "vec_map",
+ "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -912,11 +912,11 @@ dependencies = [
 
 [[package]]
 name = "clap_generate"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9b1abef93569f290952eff3c4a0a92d6767bb5158db095b4dc9a512b1c3643"
+checksum = "097ab5db1c3417442270cd57c8dd39f6c3114d3ce09d595f9efddbb1fcfaa799"
 dependencies = [
- "clap 3.0.0-beta.4",
+ "clap 3.0.0-beta.5",
 ]
 
 [[package]]
@@ -4185,9 +4185,12 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "output_vt100"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/bin/benctl.rs"
 [dependencies]
 # Workspace dependencies
 databend-query = {path = "../query"}
-clap = "3.0.0-beta.4"
-clap_generate = "3.0.0-beta.4"
+clap = "3.0.0-beta.5"
+clap_generate = "3.0.0-beta.5"
 databend-meta = {path = "../metasrv" }
 common-meta-raft-store= {path = "../common/meta/raft-store"}
 colored = "2.0.0"

--- a/cli/src/cmds/clusters/cluster.rs
+++ b/cli/src/cmds/clusters/cluster.rs
@@ -65,7 +65,6 @@ impl ClusterCommand {
     }
     pub fn generate() -> App<'static> {
         let app = App::new("cluster")
-            .setting(AppSettings::ColoredHelp)
             .setting(AppSettings::DisableVersionFlag)
             .about("Cluster life cycle management")
             .subcommand(CreateCommand::generate())

--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -57,7 +57,6 @@ impl CreateCommand {
     }
     pub fn generate() -> App<'static> {
         App::new("create")
-            .setting(AppSettings::ColoredHelp)
             .setting(AppSettings::DisableVersionFlag)
             .about("Create a databend cluster based on profile")
             .arg(

--- a/cli/src/cmds/clusters/delete.rs
+++ b/cli/src/cmds/clusters/delete.rs
@@ -36,7 +36,6 @@ impl DeleteCommand {
     }
     pub fn generate() -> App<'static> {
         App::new("delete")
-            .setting(AppSettings::ColoredHelp)
             .setting(AppSettings::DisableVersionFlag)
             .about("Delete a databend cluster (delete current cluster by default) ")
             .arg(

--- a/cli/src/cmds/clusters/view.rs
+++ b/cli/src/cmds/clusters/view.rs
@@ -56,7 +56,6 @@ impl ViewCommand {
     }
     pub fn generate() -> App<'static> {
         App::new("view")
-            .setting(AppSettings::ColoredHelp)
             .setting(AppSettings::DisableVersionFlag)
             .about("View health status of current profile")
             .arg(

--- a/cli/src/cmds/config.rs
+++ b/cli/src/cmds/config.rs
@@ -189,7 +189,6 @@ pub fn choose_mirror(conf: &Config) -> Result<CustomMirror, CliError> {
 impl Config {
     pub(crate) fn build_cli() -> App<'static> {
         App::new("bendctl")
-            .setting(AppSettings::ColoredHelp)
             .arg(
                 Arg::new("group")
                     .long("group")
@@ -247,7 +246,6 @@ impl Config {
             )
             .subcommand(
                 App::new("completion")
-                    .setting(AppSettings::ColoredHelp)
                     .setting(AppSettings::DisableVersionFlag)
                     .about("Generate auto completion scripts for bash or zsh terminal")
                     .arg(

--- a/cli/src/cmds/packages/package.rs
+++ b/cli/src/cmds/packages/package.rs
@@ -15,7 +15,6 @@
 use std::borrow::Borrow;
 
 use clap::App;
-use clap::AppSettings;
 use clap::Arg;
 use clap::ArgMatches;
 
@@ -40,22 +39,18 @@ impl PackageCommand {
     }
     pub fn generate() -> App<'static> {
         return App::new("package")
-            .setting(AppSettings::ColoredHelp)
             .about("Package manage databend binary releases")
             .subcommand(
                 App::new("fetch")
-                    .setting(AppSettings::ColoredHelp)
                     .about("Fetch the given version binary package")
                     .arg(Arg::new("version").about("Version of databend package to fetch").default_value("latest")),
             )
             .subcommand(
                 App::new("list")
-                    .setting(AppSettings::ColoredHelp)
                     .about("List all the packages"),
             )
             .subcommand(
                 App::new("switch")
-                    .setting(AppSettings::ColoredHelp)
                     .about("Switch the active databend to a specified version")
                     .arg(Arg::new("version").required(true).about(
                         "Version of databend package, e.g. v0.4.69-nightly. Check the versions: package list"

--- a/cli/src/cmds/processor.rs
+++ b/cli/src/cmds/processor.rs
@@ -42,8 +42,8 @@ pub struct Processor {
     commands: Vec<Box<dyn Command>>,
 }
 
-fn print_completions<G: Generator>(app: &mut App) {
-    generate::<G, _>(app, app.get_name().to_string(), &mut io::stdout());
+fn print_completions<G: Generator>(gen: G, app: &mut App) {
+    generate::<G, _>(gen, app, app.get_name().to_string(), &mut io::stdout());
 }
 
 impl Processor {
@@ -124,8 +124,8 @@ impl Processor {
                     let mut app = Config::build_cli();
                     eprintln!("Generating completion file for {}...", generator);
                     match generator {
-                        "bash" => print_completions::<Bash>(&mut app),
-                        "zsh" => print_completions::<Zsh>(&mut app),
+                        "bash" => print_completions::<Bash>(Bash, &mut app),
+                        "zsh" => print_completions::<Zsh>(Zsh, &mut app),
                         _ => panic!("Unknown generator"),
                     }
                 }

--- a/cli/src/cmds/queries/query.rs
+++ b/cli/src/cmds/queries/query.rs
@@ -63,7 +63,6 @@ impl QueryCommand {
     }
     pub fn generate() -> App<'static> {
         let app = App::new("query")
-            .setting(AppSettings::ColoredHelp)
             .setting(AppSettings::DisableVersionFlag)
             .about("Query on databend cluster")
             .arg(

--- a/cli/src/cmds/versions/version.rs
+++ b/cli/src/cmds/versions/version.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use clap::App;
-use clap::AppSettings;
 use sha2::Digest;
 use sha2::Sha256;
 use sysinfo::SystemExt;
@@ -31,9 +30,7 @@ impl VersionCommand {
     }
 
     pub fn generate() -> App<'static> {
-        return App::new("version")
-            .setting(AppSettings::ColoredHelp)
-            .about("Version info for local cli and remote cluster");
+        return App::new("version").about("Version info for local cli and remote cluster");
     }
     fn cli_sha_info(&self) -> Option<String> {
         let path = std::env::current_exe().ok()?;


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

for bendctl

- bump clap/clap_generate to 3.0.0-beta.5
  - rm `AppSettings::ColoredHelp`
  - fix `generate`
- bump nix to 0.23

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2311

## Test Plan

Unit Tests

Stateless Tests

