### PR TITLE
[query] refactor: SystemCatalog stores the meta for system db/tables. get_table_by_id no longer need to access trait Database

### DIFF
--- a/query/src/catalogs/impls/in_memory_meta.rs
+++ b/query/src/catalogs/impls/in_memory_meta.rs
@@ -21,29 +21,29 @@ use common_meta_types::MetaId;
 use crate::catalogs::Table;
 
 pub struct InMemoryMetas {
-    pub(crate) name2table: HashMap<String, Arc<dyn Table>>,
-    pub(crate) id2table: HashMap<MetaId, Arc<dyn Table>>,
+    pub(crate) name_to_table: HashMap<String, Arc<dyn Table>>,
+    pub(crate) id_to_table: HashMap<MetaId, Arc<dyn Table>>,
 }
 
 impl InMemoryMetas {
     pub fn create() -> Self {
         InMemoryMetas {
-            name2table: HashMap::default(),
-            id2table: HashMap::default(),
+            name_to_table: HashMap::default(),
+            id_to_table: HashMap::default(),
         }
     }
 
     pub fn insert(&mut self, tbl_ref: Arc<dyn Table>) {
         let name = tbl_ref.name().to_owned();
-        self.name2table.insert(name, tbl_ref.clone());
-        self.id2table.insert(tbl_ref.get_id(), tbl_ref);
+        self.name_to_table.insert(name, tbl_ref.clone());
+        self.id_to_table.insert(tbl_ref.get_id(), tbl_ref);
     }
 
     pub fn get_by_name(&self, name: &str) -> Option<Arc<dyn Table>> {
-        self.name2table.get(name).cloned()
+        self.name_to_table.get(name).cloned()
     }
 
     pub fn get_by_id(&self, id: &MetaId) -> Option<Arc<dyn Table>> {
-        self.id2table.get(id).cloned()
+        self.id_to_table.get(id).cloned()
     }
 }

--- a/query/src/datasources/database/system/system_database.rs
+++ b/query/src/datasources/database/system/system_database.rs
@@ -24,52 +24,15 @@ use common_planners::DropTablePlan;
 use crate::catalogs::Database;
 use crate::catalogs::InMemoryMetas;
 use crate::catalogs::Table;
-use crate::catalogs::SYS_TBL_ID_BEGIN;
-use crate::catalogs::SYS_TBL_ID_END;
-use crate::datasources::database::system;
 
 pub struct SystemDatabase {
     name: String,
-    tables: InMemoryMetas,
+    tables: Arc<InMemoryMetas>,
 }
 
 impl SystemDatabase {
-    pub fn create(name: impl Into<String>) -> Self {
-        let mut id = SYS_TBL_ID_BEGIN;
-        let mut next_id = || -> u64 {
-            // 10000 table ids reserved for system tables
-            if id >= SYS_TBL_ID_END {
-                // Fatal error, gives up
-                panic!("system table id used up")
-            } else {
-                let r = id;
-                id += 1;
-                r
-            }
-        };
-
+    pub fn create(name: impl Into<String>, tables: Arc<InMemoryMetas>) -> Self {
         let name = name.into();
-
-        // Table list.
-        let table_list: Vec<Arc<dyn Table>> = vec![
-            Arc::new(system::OneTable::create(next_id())),
-            Arc::new(system::FunctionsTable::create(next_id())),
-            Arc::new(system::ContributorsTable::create(next_id())),
-            Arc::new(system::CreditsTable::create(next_id())),
-            Arc::new(system::SettingsTable::create(next_id())),
-            Arc::new(system::TablesTable::create(next_id())),
-            Arc::new(system::ClustersTable::create(next_id())),
-            Arc::new(system::DatabasesTable::create(next_id())),
-            Arc::new(system::TracingTable::create(next_id())),
-            Arc::new(system::ProcessesTable::create(next_id())),
-            Arc::new(system::ConfigsTable::create(next_id())),
-        ];
-
-        let mut tables = InMemoryMetas::create();
-        for tbl in table_list.into_iter() {
-            tables.insert(tbl);
-        }
-
         SystemDatabase { name, tables }
     }
 }
@@ -79,28 +42,20 @@ impl Database for SystemDatabase {
         &self.name
     }
 
-    fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>> {
-        let table =
-            self.tables.name2table.get(table_name).ok_or_else(|| {
-                ErrorCode::UnknownTable(format!("Unknown table: '{}'", table_name))
-            })?;
-        Ok(table.clone())
+    fn get_table(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
+        unimplemented!();
     }
 
     fn get_table_by_id(
         &self,
-        table_id: MetaId,
+        _table_id: MetaId,
         _table_version: Option<MetaVersion>,
     ) -> Result<Arc<dyn Table>> {
-        let table =
-            self.tables.id2table.get(&table_id).ok_or_else(|| {
-                ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id))
-            })?;
-        Ok(table.clone())
+        unimplemented!();
     }
 
     fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
-        Ok(self.tables.name2table.values().cloned().collect())
+        Ok(self.tables.name_to_table.values().cloned().collect())
     }
 
     fn create_table(&self, _plan: CreateTablePlan) -> Result<()> {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: SystemCatalog stores the meta for system db/tables. get_table_by_id no longer need to access trait Database
- fix: #2319

## Changelog




- Improvement


## Related Issues

- #2030