### PR TITLE
[query] refactor: remove trait methods: Database:get_tablexxx

### DIFF
--- a/query/src/catalogs/database.rs
+++ b/query/src/catalogs/database.rs
@@ -15,8 +15,6 @@
 use std::sync::Arc;
 
 use common_exception::Result;
-use common_meta_types::MetaId;
-use common_meta_types::MetaVersion;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
 
@@ -25,16 +23,6 @@ use crate::catalogs::Table;
 pub trait Database: Sync + Send {
     /// Database name.
     fn name(&self) -> &str;
-
-    /// Get the table by name.
-    fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>>;
-
-    /// Get table by meta id
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>>;
 
     /// Get all tables.
     fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>>;

--- a/query/src/datasources/database/default/default_database.rs
+++ b/query/src/datasources/database/default/default_database.rs
@@ -19,8 +19,6 @@ use common_context::TableDataContext;
 use common_dal::InMemoryData;
 use common_exception::ErrorCode;
 use common_infallible::RwLock;
-use common_meta_types::MetaId;
-use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
@@ -80,22 +78,6 @@ impl DefaultDatabase {
 impl Database for DefaultDatabase {
     fn name(&self) -> &str {
         &self.db_name
-    }
-
-    fn get_table(&self, table_name: &str) -> common_exception::Result<Arc<dyn Table>> {
-        let db_name = self.name();
-        let table_info = self.meta.get_table(db_name, table_name)?;
-        self.build_table_instance(table_info.as_ref())
-    }
-
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> common_exception::Result<Arc<dyn Table>> {
-        let table_info = self.meta.get_table_by_id(table_id, table_version)?;
-
-        self.build_table_instance(table_info.as_ref())
     }
 
     fn get_tables(&self) -> common_exception::Result<Vec<Arc<dyn Table>>> {

--- a/query/src/datasources/database/system/system_database.rs
+++ b/query/src/datasources/database/system/system_database.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_meta_types::MetaId;
-use common_meta_types::MetaVersion;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
 
@@ -40,18 +38,6 @@ impl SystemDatabase {
 impl Database for SystemDatabase {
     fn name(&self) -> &str {
         &self.name
-    }
-
-    fn get_table(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
-        unimplemented!();
-    }
-
-    fn get_table_by_id(
-        &self,
-        _table_id: MetaId,
-        _table_version: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>> {
-        unimplemented!();
     }
 
     fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>> {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: remove trait methods: Database:get_tablexxx
Why:
Only catalog knows how to find a table.
It does not need to bother delegating this duty to a Database.

So that when getting table through catalog, it does not need to access
db. A unnecessary dependency is decoupled.

- fix: #2180

## Changelog




- Improvement


## Related Issues

- #2030