### PR TITLE
[ci] setup rust-cache for unittests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,18 +23,9 @@ jobs:
       - name: Rust setup
         run: |
           bash ./scripts/setup/dev_setup.sh
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-testcache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-testcache-${{ secrets.CACHE_RESET_KEY }}-
-            ${{ runner.os }}-cargo-testcache-
-            ${{ runner.os }}-cargo-
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
 
       - name: Run test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

- setup rust-cache for unittests

It doesn't look like it's currently affected by incremental compilation. Save about a dozen minutes of unit tests time on CI.

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Related #913

## Test Plan

Unit Tests

Stateless Tests

