### PR TITLE
[Testing] Open tokio `signal` feature to deps

### DIFF
--- a/common/base/Cargo.toml
+++ b/common/base/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 ctrlc = { version = "3.1.9", features = ["termination"] }
 futures = "0.3"
 pprof = { version = "0.5", features = ["flamegraph", "protobuf"] }
-tokio = { version = "1.12.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }
+tokio = { version = "1.12.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "signal"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Open `signal` feature in tokio deps. Without this feature, when we run test isolation like `cargo test -p databend-meta` it will cause errors (failed to resolve: could not find `signal` in `tokio`)

## Changelog

- Build/Testing/CI


## Related Issues


## Test Plan

Unit Tests

Stateless Tests

