### PR TITLE
[query] refactor: move create/drop table method from Database to Catalog

### DIFF
--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -20,7 +20,9 @@ use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 
 use crate::catalogs::Database;
 use crate::catalogs::Table;
@@ -49,6 +51,10 @@ pub trait Catalog {
         table_id: MetaId,
         table_version: Option<MetaVersion>,
     ) -> Result<Arc<dyn Table>>;
+
+    fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
+
+    fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
 
     // Get function by name.
     fn get_table_function(

--- a/query/src/catalogs/database.rs
+++ b/query/src/catalogs/database.rs
@@ -12,15 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_exception::Result;
-use common_planners::CreateTablePlan;
-use common_planners::DropTablePlan;
-
 pub trait Database: Sync + Send {
     /// Database name.
     fn name(&self) -> &str;
-
-    /// DDL
-    fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
-    fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
 }

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -28,7 +28,9 @@ use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
 use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 
 use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::backends::MetaEmbeddedSync;
@@ -99,7 +101,7 @@ impl MetaStoreCatalog {
     }
 
     fn build_db_instance(&self, db_info: &Arc<DatabaseInfo>) -> Result<Arc<dyn Database>> {
-        let db = DefaultDatabase::new(&db_info.db, self.meta.clone());
+        let db = DefaultDatabase::new(&db_info.db);
 
         let db = Arc::new(db);
 
@@ -185,6 +187,16 @@ impl Catalog for MetaStoreCatalog {
     ) -> Result<CommitTableReply> {
         self.meta
             .commit_table(table_id, new_table_version, new_snapshot_location)
+    }
+
+    fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {
+        // TODO validate table parameters by using TableFactory
+        self.meta.create_table(plan)?;
+        Ok(())
+    }
+
+    fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<()> {
+        self.meta.drop_table(plan)
     }
 
     fn create_database(&self, plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {

--- a/query/src/catalogs/impls/catalog/overlaid_catalog.rs
+++ b/query/src/catalogs/impls/catalog/overlaid_catalog.rs
@@ -22,7 +22,9 @@ use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 
 use crate::catalogs::Catalog;
 use crate::catalogs::Database;
@@ -121,6 +123,14 @@ impl Catalog for OverlaidCatalog {
         self.read_only
             .get_table_by_id(table_id, table_version)
             .or_else(|_e| self.bottom.get_table_by_id(table_id, table_version))
+    }
+
+    fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {
+        self.bottom.create_table(plan)
+    }
+
+    fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<()> {
+        self.bottom.drop_table(plan)
     }
 
     fn get_table_function(

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -22,7 +22,9 @@ use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 
 use crate::catalogs::catalog::Catalog;
 use crate::catalogs::Database;
@@ -142,6 +144,14 @@ impl Catalog for SystemCatalog {
             "commit table not allowed for system catalog {}",
             table_id
         )))
+    }
+
+    fn create_table(&self, _plan: CreateTablePlan) -> Result<()> {
+        unimplemented!("programming error: SystemCatalog does not support create table")
+    }
+
+    fn drop_table(&self, _plan: DropTablePlan) -> Result<()> {
+        unimplemented!("programming error: SystemCatalog does not support drop table")
     }
 
     fn create_database(&self, _plan: CreateDatabasePlan) -> Result<CreateDatabaseReply> {

--- a/query/src/datasources/database/default/default_database.rs
+++ b/query/src/datasources/database/default/default_database.rs
@@ -13,24 +13,16 @@
 //  limitations under the License.
 //
 
-use std::sync::Arc;
-
-use common_planners::CreateTablePlan;
-use common_planners::DropTablePlan;
-
-use crate::catalogs::backends::MetaApiSync;
 use crate::catalogs::Database;
 
 pub struct DefaultDatabase {
     db_name: String,
-    meta: Arc<dyn MetaApiSync>,
 }
 
 impl DefaultDatabase {
-    pub fn new(db_name: impl Into<String>, meta: Arc<dyn MetaApiSync>) -> Self {
+    pub fn new(db_name: impl Into<String>) -> Self {
         Self {
             db_name: db_name.into(),
-            meta,
         }
     }
 }
@@ -38,15 +30,5 @@ impl DefaultDatabase {
 impl Database for DefaultDatabase {
     fn name(&self) -> &str {
         &self.db_name
-    }
-
-    fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {
-        // TODO validate table parameters by using TableFactory
-        self.meta.create_table(plan)?;
-        Ok(())
-    }
-
-    fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<()> {
-        self.meta.drop_table(plan)
     }
 }

--- a/query/src/datasources/database/system/system_database.rs
+++ b/query/src/datasources/database/system/system_database.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_exception::ErrorCode;
-use common_exception::Result;
-use common_planners::CreateTablePlan;
-use common_planners::DropTablePlan;
-
 use crate::catalogs::Database;
 
 pub struct SystemDatabase {
@@ -33,17 +28,5 @@ impl SystemDatabase {
 impl Database for SystemDatabase {
     fn name(&self) -> &str {
         &self.name
-    }
-
-    fn create_table(&self, _plan: CreateTablePlan) -> Result<()> {
-        Result::Err(ErrorCode::UnImplement(
-            "Cannot create table for system database",
-        ))
-    }
-
-    fn drop_table(&self, _plan: DropTablePlan) -> Result<()> {
-        Result::Err(ErrorCode::UnImplement(
-            "Cannot drop table for system database",
-        ))
     }
 }

--- a/query/src/datasources/table/fuse/table_test.rs
+++ b/query/src/datasources/table/fuse/table_test.rs
@@ -32,8 +32,7 @@ async fn test_fuse_table_simple_case() -> Result<()> {
     // create test table
     let crate_table_plan = TestFixture::default_crate_table_plan();
     let catalog = ctx.get_catalog();
-    let db = catalog.get_database(TestFixture::default_db().as_str())?;
-    db.create_table(crate_table_plan)?;
+    catalog.create_table(crate_table_plan)?;
 
     // get table
     let table = catalog.get_table(
@@ -84,8 +83,8 @@ async fn test_fuse_table_truncate() -> Result<()> {
 
     let crate_table_plan = TestFixture::default_crate_table_plan();
     let catalog = ctx.get_catalog();
-    let db = catalog.get_database(TestFixture::default_db().as_str())?;
-    db.create_table(crate_table_plan)?;
+    catalog.create_table(crate_table_plan)?;
+
     let table = catalog.get_table(
         TestFixture::default_db().as_str(),
         TestFixture::default_table().as_str(),

--- a/query/src/interpreters/interpreter_table_create.rs
+++ b/query/src/interpreters/interpreter_table_create.rs
@@ -45,9 +45,8 @@ impl Interpreter for CreateTableInterpreter {
     }
 
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        let datasource = self.ctx.get_catalog();
-        let database = datasource.get_database(self.plan.db.as_str())?;
-        database.create_table(self.plan.clone())?;
+        let catalog = self.ctx.get_catalog();
+        catalog.create_table(self.plan.clone())?;
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema.clone(),

--- a/query/src/interpreters/interpreter_table_drop.rs
+++ b/query/src/interpreters/interpreter_table_drop.rs
@@ -42,9 +42,8 @@ impl Interpreter for DropTableInterpreter {
     }
 
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        let datasource = self.ctx.get_catalog();
-        let database = datasource.get_database(self.plan.db.as_str())?;
-        database.drop_table(self.plan.clone())?;
+        let catalog = self.ctx.get_catalog();
+        catalog.drop_table(self.plan.clone())?;
 
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: move create/drop table method from Database to Catalog
It is more smooth for query to use: it does not need to fetch a db
first the create/drop table.

It is a natual way since Catalog does not need share meta with Database
any more.

- fix: #2326

## Changelog




- Improvement


## Related Issues

- #2030