### PR TITLE
[Install/Doc] add Installer script to install bendctl on local

### DIFF
--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -66,6 +66,7 @@ impl CreateCommand {
                     .long("profile")
                     .about("Profile for deployment, support local and cluster")
                     .required(false)
+                    .takes_value(true)
                     .possible_values(&["local"]).default_value("local"),
             )
             .arg(

--- a/cli/src/cmds/config.rs
+++ b/cli/src/cmds/config.rs
@@ -31,7 +31,7 @@ use crate::cmds::VersionCommand;
 use crate::cmds::Writer;
 use crate::error::CliError;
 
-const GITHUB_BASE_URL: &str = "https://github.com";
+const GITHUB_BASE_URL: &str = "https://api.github.com/repos/datafuselabs/databend/tags";
 const GITHUB_DATABEND_URL: &str = "https://github.com/datafuselabs/databend/releases/download";
 const GITHUB_DATABEND_TAG_URL: &str = "https://api.github.com/repos/datafuselabs/databend/tags";
 const GITHUB_CLIENT_URL: &str = "https://github.com/ZhiHanZ/usql/releases/download";

--- a/cli/src/cmds/packages/fetch.rs
+++ b/cli/src/cmds/packages/fetch.rs
@@ -106,7 +106,7 @@ pub fn download(url: &str, target_file: &str) -> Result<()> {
     Ok(())
 }
 
-//(TODO(zhihanz)) general get_architecture similar to install-databend.sh
+//(TODO(zhihanz)) general get_architecture similar to install-bendctl.sh
 pub fn get_rust_architecture() -> Result<String> {
     let os = std::env::consts::OS;
     let arch = std::env::consts::ARCH;

--- a/website/databend/docs/overview/building-and-running.md
+++ b/website/databend/docs/overview/building-and-running.md
@@ -18,7 +18,9 @@ This document describes how to build and run [DatabendQuery](https://github.com/
 === "Release binary"
 
     ```markdown
-    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/databend/main/scripts/installer/install-databend.sh | bash
+    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/databend/main/scripts/installer/install-bendctl.sh | bash
+    $ export PATH="${HOME}/.databend/bin:${PATH}"
+    $ bendctl cluster create --profile local
     ```
 
 === "From source"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

bendctl is an all-in-one tool to manage databend cluster on local or on cloud, we built up a simple script to install it on local machine

## Changelog

- New Feature
- Build/Testing/CI
- Need Documentation (Need to add documentation to https://databend.rs)
- Documentation

## Related Issues

Fixes #1267 

## Test Plan

Unit Tests

Stateless Tests

