### PR TITLE
[Wensite] retarget install script to repo.databend.rs

### DIFF
--- a/website/databend/docs/overview/building-and-running.md
+++ b/website/databend/docs/overview/building-and-running.md
@@ -18,7 +18,7 @@ This document describes how to build and run [DatabendQuery](https://github.com/
 === "Release binary"
 
     ```markdown
-    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/databend/main/scripts/installer/install-bendctl.sh | bash
+    $ curl -fsS https://repo.databend.rs/databend/install-bendctl.sh | bash
     $ export PATH="${HOME}/.databend/bin:${PATH}"
     $ bendctl cluster create --profile local
     ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

retarget install script to repo.databend.rs

## Changelog

- Documentation

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

