### PR TITLE
[query] refactor: InsertIntoInterpreter: fetch table by `ctx.get_table` to get a consistent table instance

### DIFF
--- a/query/src/interpreters/interpreter_insert_into.rs
+++ b/query/src/interpreters/interpreter_insert_into.rs
@@ -19,7 +19,6 @@ use common_planners::InsertIntoPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::catalogs::Catalog;
 use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::DatabendQueryContextRef;
@@ -45,8 +44,9 @@ impl Interpreter for InsertIntoInterpreter {
     }
 
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        let catalog = self.ctx.get_catalog();
-        let table = catalog.get_table_by_id(self.plan.tbl_id, None)?;
+        let table = self
+            .ctx
+            .get_table(&self.plan.db_name, &self.plan.tbl_name)?;
 
         let io_ctx = self.ctx.get_cluster_table_io_context()?;
         let io_ctx = Arc::new(io_ctx);

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -146,6 +146,13 @@ impl DatabendQueryContext {
         self.shared.get_catalog()
     }
 
+    /// Fetch a Table by db and table name.
+    ///
+    /// It guaranteed to return a consistent result for multiple calls, in a same query.
+    /// E.g.:
+    /// ```sql
+    /// SELECT * FROM (SELECT * FROM db.table_name) as subquery_1, (SELECT * FROM db.table_name) AS subquery_2
+    /// ```
     pub fn get_table(&self, database: &str, table: &str) -> Result<Arc<dyn Table>> {
         self.shared.get_table(database, table)
     }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: InsertIntoInterpreter: fetch table by `ctx.get_table` to get a consistent table instance

## Changelog




- Improvement


## Related Issues

- #2030