### PR TITLE
[query] fix: two cooperating bugs hide each other: get_table bug and parquet table bug.

### DIFF
--- a/common/datavalues/src/data_schema.rs
+++ b/common/datavalues/src/data_schema.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::fmt;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -53,6 +54,11 @@ impl DataSchema {
     #[inline]
     pub const fn fields(&self) -> &Vec<DataField> {
         &self.fields
+    }
+
+    pub fn fields_map(&self) -> BTreeMap<usize, DataField> {
+        let x = self.fields().iter().cloned().enumerate();
+        x.collect::<BTreeMap<_, _>>()
     }
 
     /// Returns an immutable reference of a specific `Field` instance selected using an

--- a/common/planners/src/plan_display.rs
+++ b/common/planners/src/plan_display.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Display;
 
+use common_datavalues::DataField;
 use common_datavalues::DataSchema;
 
 use crate::plan_display_indent::PlanNodeIndentFormatDisplay;
@@ -66,6 +68,31 @@ impl PlanNode {
             }
         }
         Wrapper(schema)
+    }
+
+    pub fn display_scan_fields(fields: &BTreeMap<usize, DataField>) -> impl fmt::Display + '_ {
+        struct Wrapper<'a>(&'a BTreeMap<usize, DataField>);
+
+        impl<'a> fmt::Display for Wrapper<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "[")?;
+                for (i, (_idx, field)) in self.0.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    let nullable_str = if field.is_nullable() { ";N" } else { "" };
+                    write!(
+                        f,
+                        "{}:{:?}{}",
+                        field.name(),
+                        field.data_type(),
+                        nullable_str
+                    )?;
+                }
+                write!(f, "]")
+            }
+        }
+        Wrapper(fields)
     }
 }
 

--- a/common/planners/src/plan_display_indent.rs
+++ b/common/planners/src/plan_display_indent.rs
@@ -208,7 +208,7 @@ impl<'a> PlanNodeIndentFormatDisplay<'a> {
             f,
             "ReadDataSource: scan partitions: [{}], scan schema: {}, statistics: [read_rows: {:?}, read_bytes: {:?}]",
             plan.parts.len(),
-            PlanNode::display_schema(plan.table_info.schema.as_ref()),
+            PlanNode::display_scan_fields(&plan.scan_fields()),
             plan.statistics.read_rows,
             plan.statistics.read_bytes,
         )

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -46,6 +46,7 @@ impl Test {
 
         Ok(PlanNode::ReadSource(ReadDataSourcePlan {
             table_info: TableInfo::simple("system", "numbers_mt", schema),
+            scan_fields: None,
             parts: Self::generate_partitions(8, total as u64),
             statistics: statistics.clone(),
             description: format!(

--- a/query/src/api/http/v1/logs.rs
+++ b/query/src/api/http/v1/logs.rs
@@ -80,7 +80,5 @@ async fn execute_query(context: DatabendQueryContextRef) -> Result<SendableDataB
         Some(context.get_settings().get_max_threads()? as usize),
     )?;
 
-    tracing_table
-        .read(io_ctx, &tracing_table_read_plan.push_downs)
-        .await
+    tracing_table.read(io_ctx, &tracing_table_read_plan).await
 }

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -78,7 +78,7 @@ pub trait Table: Sync + Send {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream>;
 
     // temporary added, pls feel free to rm it
@@ -146,6 +146,8 @@ impl ToReadDataSourcePlan for dyn Table {
 
         Ok(ReadDataSourcePlan {
             table_info: table_info.clone(),
+
+            scan_fields: None,
             parts,
             statistics,
             description,

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -20,8 +20,8 @@ use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
 use common_planners::InsertIntoPlan;
+use common_planners::ReadDataSourcePlan;
 use common_planners::TableOptions;
 use common_planners::TruncateTablePlan;
 use common_streams::DataBlockStream;
@@ -71,7 +71,7 @@ impl Table for ExampleTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.schema());
 

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -66,7 +66,7 @@ impl Table for ClustersTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let cluster_nodes = io_ctx.get_query_nodes();
 

--- a/query/src/datasources/database/system/clusters_table_test.rs
+++ b/query/src/datasources/database/system/clusters_table_test.rs
@@ -35,7 +35,7 @@ async fn test_clusters_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use serde_json::Value;
@@ -88,7 +88,7 @@ impl Table for ConfigsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/configs_table_test.rs
+++ b/query/src/datasources/database/system/configs_table_test.rs
@@ -40,7 +40,7 @@ async fn test_configs_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -20,7 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -61,7 +61,7 @@ impl Table for ContributorsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let contributors: Vec<&[u8]> = env!("DATABEND_COMMIT_AUTHORS")
             .split_terminator(',')

--- a/query/src/datasources/database/system/contributors_table_test.rs
+++ b/query/src/datasources/database/system/contributors_table_test.rs
@@ -34,7 +34,7 @@ async fn test_contributors_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -20,7 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -64,7 +64,7 @@ impl Table for CreditsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let metadata_command = cargo_metadata::MetadataCommand::new();
 

--- a/query/src/datasources/database/system/credits_table_test.rs
+++ b/query/src/datasources/database/system/credits_table_test.rs
@@ -35,7 +35,7 @@ async fn test_credits_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -65,7 +65,7 @@ impl Table for DatabasesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/databases_table_test.rs
+++ b/query/src/datasources/database/system/databases_table_test.rs
@@ -34,7 +34,7 @@ async fn test_tables_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -22,7 +22,7 @@ use common_exception::Result;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::FunctionFactory;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -65,7 +65,7 @@ impl Table for FunctionsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let function_factory = FunctionFactory::instance();
         let aggregate_function_factory = AggregateFunctionFactory::instance();

--- a/query/src/datasources/database/system/functions_table_test.rs
+++ b/query/src/datasources/database/system/functions_table_test.rs
@@ -34,7 +34,7 @@ async fn test_functions_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 2);

--- a/query/src/datasources/database/system/metrics_table.rs
+++ b/query/src/datasources/database/system/metrics_table.rs
@@ -27,7 +27,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
 use common_metrics::MetricValue;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use serde_json;
@@ -98,7 +98,7 @@ impl Table for MetricsTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let prometheus_handle = common_metrics::try_handle().ok_or_else(|| {
             ErrorCode::InitPrometheusFailure("Prometheus recorder is not initialized yet.")

--- a/query/src/datasources/database/system/metrics_table_test.rs
+++ b/query/src/datasources/database/system/metrics_table_test.rs
@@ -39,7 +39,7 @@ async fn test_metrics_table() -> Result<()> {
     metrics::counter!("test.test_metrics_table_count", 1);
     metrics::histogram!("test.test_metrics_table_histogram", 1.0);
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -23,6 +23,7 @@ use common_meta_types::TableInfo;
 use common_planners::Extras;
 use common_planners::Part;
 use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -76,7 +77,7 @@ impl Table for OneTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block =
             DataBlock::create_by_array(self.table_info.schema.clone(), vec![Series::new(vec![

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -25,7 +25,7 @@ use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -87,7 +87,7 @@ impl Table for ProcessesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -68,7 +68,7 @@ impl Table for SettingsTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/settings_table_test.rs
+++ b/query/src/datasources/database/system/settings_table_test.rs
@@ -37,7 +37,7 @@ async fn test_settings_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 4);

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -21,7 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
@@ -68,7 +68,7 @@ impl Table for TablesTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/database/system/tables_table_test.rs
+++ b/query/src/datasources/database/system/tables_table_test.rs
@@ -34,7 +34,7 @@ async fn test_tables_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 3);

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -23,7 +23,7 @@ use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
 use walkdir::WalkDir;
@@ -76,7 +76,7 @@ impl Table for TracingTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        push_downs: &Option<Extras>,
+        plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let mut log_files = vec![];
 
@@ -95,9 +95,9 @@ impl Table for TracingTable {
 
         // Default limit.
         let mut limit = 100000000_usize;
-        tracing::debug!("read push_down:{:?}", push_downs);
+        tracing::debug!("read push_down:{:?}", &plan.push_downs);
 
-        if let Some(extras) = push_downs {
+        if let Some(extras) = &plan.push_downs {
             if let Some(limit_push_down) = extras.limit {
                 limit = limit_push_down;
             }

--- a/query/src/datasources/database/system/tracing_table_test.rs
+++ b/query/src/datasources/database/system/tracing_table_test.rs
@@ -34,7 +34,7 @@ async fn test_tracing_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 7);

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -25,6 +25,7 @@ use common_exception::Result;
 use common_meta_types::TableInfo;
 use common_planners::Extras;
 use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_streams::SendableDataBlockStream;
 
@@ -96,7 +97,7 @@ impl Table for CsvTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -83,7 +83,7 @@ async fn test_csv_table() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);
@@ -162,7 +162,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await;
     // integer parse error will result to Null value
     assert!(!result.is_err());

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -27,6 +27,7 @@ use common_planners::Extras;
 use common_planners::InsertIntoPlan;
 use common_planners::Part;
 use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
@@ -75,9 +76,9 @@ impl Table for FuseTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        push_downs: &Option<Extras>,
+        plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
-        self.do_read(io_ctx, push_downs).await
+        self.do_read(io_ctx, &plan.push_downs).await
     }
 
     async fn append_data(

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -28,6 +28,7 @@ use common_meta_types::TableInfo;
 use common_planners::Extras;
 use common_planners::InsertIntoPlan;
 use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_planners::TruncateTablePlan;
 use common_streams::SendableDataBlockStream;
@@ -109,7 +110,7 @@ impl Table for MemoryTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -89,7 +89,7 @@ async fn test_memorytable() -> Result<()> {
         ctx.try_set_partitions(source_plan.parts.clone())?;
         assert_eq!(table.engine(), "Memory");
 
-        let stream = table.read(io_ctx.clone(), &source_plan.push_downs).await?;
+        let stream = table.read(io_ctx.clone(), &source_plan).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(
             vec![
@@ -121,7 +121,7 @@ async fn test_memorytable() -> Result<()> {
             None,
             Some(ctx.get_settings().get_max_threads()? as usize),
         )?;
-        let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+        let stream = table.read(io_ctx, &source_plan).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         assert_blocks_sorted_eq(vec!["++", "++"], &result);
     }

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -21,8 +21,8 @@ use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
 use common_planners::InsertIntoPlan;
+use common_planners::ReadDataSourcePlan;
 use common_planners::TruncateTablePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -57,7 +57,7 @@ impl Table for NullTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block = DataBlock::empty_with_schema(self.table_info.schema.clone());
 

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -85,7 +85,7 @@ async fn test_null_table() -> Result<()> {
         )?;
         assert_eq!(table.engine(), "Null");
 
-        let stream = table.read(io_ctx.clone(), &source_plan.push_downs).await?;
+        let stream = table.read(io_ctx.clone(), &source_plan).await?;
         let result = stream.try_collect::<Vec<_>>().await?;
         let block = &result[0];
         assert_eq!(block.num_columns(), 1);

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -25,7 +25,7 @@ use common_datablocks::DataBlock;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
-use common_planners::Extras;
+use common_planners::ReadDataSourcePlan;
 use common_streams::ParquetStream;
 use common_streams::SendableDataBlockStream;
 use crossbeam::channel::bounded;
@@ -104,7 +104,7 @@ impl Table for ParquetTable {
     async fn read(
         &self,
         _io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         type BlockSender = Sender<Option<Result<DataBlock>>>;
         type BlockReceiver = Receiver<Option<Result<DataBlock>>>;
@@ -112,6 +112,19 @@ impl Table for ParquetTable {
         let (response_tx, response_rx): (BlockSender, BlockReceiver) = bounded(2);
 
         let file = self.file.clone();
+
+        // TODO(xp): Optimized fields does not used, because:
+        //           - CorrectWithSchemaStream.schema should contains only optimized fields.
+        //           - There is a big chain through which some `schema` is passed from one to another.
+        //             E.g. SourceTransform::execute() pass schema to CorrectWithSchemaStream,
+        //                  FilterPlan.schema is passed to WhereTransform then to CorrectWithSchemaStream ...
+        //           That will be a change affects a lot components. Maybe complete unittest first before applying this change.
+        //
+        // This fails the stateless test:
+        // let projection: Vec<usize> = plan.scan_fields().keys().cloned().collect::<Vec<_>>();
+        //
+        // Now just using the entire fields list from table_info.scheme to let tests pass.
+
         let projection: Vec<usize> = (0..self.table_info.schema.fields().len()).collect();
         task::spawn_blocking(move || {
             if let Err(e) = read_file(&file, response_tx, &projection) {

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -62,7 +62,7 @@ async fn test_parquet_table() -> Result<()> {
         Some(ctx.get_settings().get_max_threads()? as usize),
     )?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let blocks = stream.try_collect::<Vec<_>>().await?;
     let rows: usize = blocks.iter().map(|block| block.num_rows()).sum();
 

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -29,6 +29,7 @@ use common_meta_types::TableInfo;
 use common_planners::Expression;
 use common_planners::Extras;
 use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
 use common_planners::Statistics;
 use common_streams::SendableDataBlockStream;
 
@@ -132,7 +133,7 @@ impl Table for NumbersTable {
     async fn read(
         &self,
         io_ctx: Arc<TableIOContext>,
-        _push_downs: &Option<Extras>,
+        _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let ctx: Arc<DatabendQueryContext> = io_ctx
             .get_user_data()?

--- a/query/src/datasources/table_func/numbers_table_test.rs
+++ b/query/src/datasources/table_func/numbers_table_test.rs
@@ -53,7 +53,7 @@ async fn test_number_table() -> Result<()> {
     )?;
     ctx.try_set_partitions(source_plan.parts.clone())?;
 
-    let stream = table.read(io_ctx, &source_plan.push_downs).await?;
+    let stream = table.read(io_ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
     assert_eq!(block.num_columns(), 1);

--- a/query/src/interpreters/plan_scheduler.rs
+++ b/query/src/interpreters/plan_scheduler.rs
@@ -48,6 +48,7 @@ use common_tracing::tracing;
 use crate::api::BroadcastAction;
 use crate::api::FlightAction;
 use crate::api::ShuffleAction;
+use crate::catalogs::Catalog;
 use crate::catalogs::TablePtr;
 use crate::catalogs::ToReadDataSourcePlan;
 use crate::sessions::DatabendQueryContext;
@@ -784,8 +785,8 @@ impl PlanScheduler {
 
     fn visit_data_source(&mut self, plan: &ReadDataSourcePlan, _: &mut Tasks) -> Result<()> {
         let table = if plan.tbl_args.is_none() {
-            self.query_context
-                .get_table(&plan.table_info.db, &plan.table_info.name)?
+            let catalog = self.query_context.get_catalog();
+            catalog.build_table(&plan.table_info)?
         } else {
             self.query_context
                 .get_table_function(&plan.table_info.name, plan.tbl_args.clone())?

--- a/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -101,6 +101,7 @@ fn test_projection_push_down_optimizer_2() -> Result<()> {
                 DataField::new("c", DataType::String, false),
             ]),
         ),
+        scan_fields: None,
         parts: generate_partitions(8, total as u64),
         statistics: statistics.clone(),
         description: format!(
@@ -159,6 +160,7 @@ fn test_projection_push_down_optimizer_3() -> Result<()> {
                 DataField::new("g", DataType::String, false),
             ]),
         ),
+        scan_fields: None,
         parts: generate_partitions(8, total as u64),
         statistics: statistics.clone(),
         description: format!(

--- a/query/src/optimizers/optimizer_scatters.rs
+++ b/query/src/optimizers/optimizer_scatters.rs
@@ -32,6 +32,7 @@ use common_planners::SortPlan;
 use common_planners::StageKind;
 use common_planners::StagePlan;
 
+use crate::catalogs::Catalog;
 use crate::optimizers::Optimizer;
 use crate::sessions::DatabendQueryContext;
 use crate::sessions::DatabendQueryContextRef;
@@ -282,7 +283,8 @@ impl PlanRewriter for ScattersOptimizerImpl {
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
         let context = self.ctx.clone();
         let select_table = if plan.tbl_args.is_none() {
-            context.get_table(&plan.table_info.db, &plan.table_info.name)?
+            let catalog = context.get_catalog();
+            catalog.build_table(&plan.table_info)?
         } else {
             context
                 .get_table_function(&plan.table_info.name, plan.tbl_args.clone())?

--- a/query/src/optimizers/optimizer_statistics_exact_test.rs
+++ b/query/src/optimizers/optimizer_statistics_exact_test.rs
@@ -44,6 +44,7 @@ mod tests {
                     DataField::new("c", DataType::String, false),
                 ]),
             ),
+            scan_fields: None,
             parts: generate_partitions(8, total as u64),
             statistics: statistics.clone(),
             description: format!(

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -27,8 +27,6 @@ use common_context::TableIOContext;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::RwLock;
-use common_meta_types::MetaId;
-use common_meta_types::MetaVersion;
 use common_meta_types::NodeInfo;
 use common_planners::Part;
 use common_planners::Partitions;
@@ -155,14 +153,6 @@ impl DatabendQueryContext {
     /// ```
     pub fn get_table(&self, database: &str, table: &str) -> Result<Arc<dyn Table>> {
         self.shared.get_table(database, table)
-    }
-
-    pub fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_ver: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>> {
-        self.get_catalog().get_table_by_id(table_id, table_ver)
     }
 
     pub fn get_table_function(

--- a/query/src/sessions/context_shared.rs
+++ b/query/src/sessions/context_shared.rs
@@ -118,14 +118,17 @@ impl DatabendQueryContextShared {
 
         let mut tables_refs = self.tables_refs.lock();
 
-        Ok(match tables_refs.entry(table_meta_key) {
+        let ent = match tables_refs.entry(table_meta_key) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
                 let catalog = self.get_catalog();
-                let table = catalog.get_table(database, table)?;
-                entry.insert(table).clone()
+                let t = catalog.get_table(database, table)?;
+
+                entry.insert(t).clone()
             }
-        })
+        };
+
+        Ok(ent)
     }
 
     /// Init runtime when first get


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

### [query] fix: two cooperating bugs hide each other: get_table bug and parquet table bug.
- Bug 1: optimized projection fields is overrided by get_table();

  Problem:

  ReadDataSource.table_info.schema.fileds may be optimized: it contains
  only the required ones.

  get_tablexxx() reload schema from meta and overrides the optimized
  ones.

  Solution:

  - Keep ReadDataSource.table_info untouched. Add another field
    `scan_fields` to store the optimized fields list.

  - Build a `dyn Table` from TableInfo instead of refetching from
    catalog.

- Bug 2: ParquetTable use optimized fields list as if it is the original fields list.

  Problem:

  The `fields` in `table_info` may be optimized and contains only
  required fields instead of all fields(in `rewrite_read_data_source()`).
  ParquetTable assumes it is list of all fields.

  Currently it passes CI because of bug 1: `get_table_by_id()` overrides
  the optimized fields and restores it to the unoptimized full field
  list.

- TODO ReadDataSource::scan_fields() can not be used because it requires
  a lot modification to many components.

- feature: add new field: ReadDataSource.scan_fields to store only the
  required fields after optimization.

  Avoid changing the original `plan.table_info.schema.fields`.
  In case the original fields will be used.

- feature: add ReadDataSourcePlan::scan_fields() to return optimized
  fields, which includes only fields a plan needs to read.

- fix: add back arg ReadDataSourcePlan to `Table::read()`.
  `read()` needs the `scan_fields` to optimized reading.

- refactor: use catalog.build_table() to build a `dyn Table` from
  TableInfo if possible.
  Avoid using `get_table(), get_table_by_id()`: re-fetching has
  potential consistency issues. Although they are not difficault to fix,
  but why bother to solve a problem we do not have to solve?
## Changelog




- Improvement


## Related Issues

- #2030
- #2364