### PR TITLE
ISSUE-2412: add associated functions to `ErrorCode` for getting error code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "common-arrow",
+ "paste",
  "prost",
  "serde",
  "serde_json",

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 thiserror = "1.0.30"
 tonic = "0.5.2"
 prost = "0.8.0"
+paste = "^1.0"
 
 # Github dependencies
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "cdd2ce1" }

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -109,7 +109,17 @@ macro_rules! build_exceptions {
                         cause: None,
                         backtrace: Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::new()))),
                     }
-                })*
+                }
+                paste::item! {
+                    pub fn [< $body:snake _ code >] ()  -> u16{
+                        $code
+                    }
+
+                    pub fn [< $body  Code >] ()  -> u16{
+                        $code
+                    }
+                }
+                )*
             }
     }
 }

--- a/common/exception/src/exception_test.rs
+++ b/common/exception/src/exception_test.rs
@@ -39,6 +39,16 @@ fn test_format_with_error_codes() {
 }
 
 #[test]
+fn test_error_code() {
+    use crate::exception::*;
+
+    let err = ErrorCode::UnknownException("test message 1");
+
+    assert_eq!(err.code(), ErrorCode::unknown_exception_code(),);
+    assert_eq!(err.code(), ErrorCode::UnknownExceptionCode(),);
+}
+
+#[test]
 fn test_derive_from_std_error() {
     use crate::exception::ErrorCode;
     use crate::exception::ToErrorCode;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

trying to fix 
- issue #2412

both (upper)camel and snake case are provided.
If only one shall be kept, I prefer the snake style - `unknown_exception_code`, but `UnknownExceptionCode` is also acceptable for me. 

## Changelog


- Improvement

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2412

## Test Plan

Unit Tests

Stateless Tests

