### PR TITLE
[common/meta/api] refactor: remove "version" from get_table_by_id(table_id, version); it is not used at all

### DIFF
--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -50,11 +50,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn get_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>>;
 
-    async fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>>;
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>>;
 
     async fn upsert_table_option(
         &self,

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -225,11 +225,7 @@ impl MetaApi for MetaEmbedded {
             .collect::<Vec<_>>())
     }
 
-    async fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        _table_version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>> {
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
         let sm = self.inner.lock().await;
         let table = sm.get_table(&table_id)?.ok_or_else(|| {
             ErrorCode::UnknownTable(format!("table of id {} not found", table_id))

--- a/common/meta/flight/src/flight_action.rs
+++ b/common/meta/flight/src/flight_action.rs
@@ -248,7 +248,6 @@ action_declare!(GetTableAction, TableInfo, MetaFlightAction::GetTable);
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetTableExtReq {
     pub tbl_id: MetaId,
-    pub tbl_ver: Option<MetaVersion>,
 }
 action_declare!(GetTableExtReq, TableInfo, MetaFlightAction::GetTableExt);
 

--- a/common/meta/flight/src/impls/meta_api_impl.rs
+++ b/common/meta/flight/src/impls/meta_api_impl.rs
@@ -96,12 +96,8 @@ impl MetaApi for MetaFlightClient {
         self.do_action(GetTablesAction { db: db.to_string() }).await
     }
 
-    async fn get_table_by_id(
-        &self,
-        tbl_id: MetaId,
-        tbl_ver: Option<MetaVersion>,
-    ) -> common_exception::Result<Arc<TableInfo>> {
-        let x = self.do_action(GetTableExtReq { tbl_id, tbl_ver }).await?;
+    async fn get_table_by_id(&self, tbl_id: MetaId) -> common_exception::Result<Arc<TableInfo>> {
+        let x = self.do_action(GetTableExtReq { tbl_id }).await?;
         Ok(Arc::new(x))
     }
 

--- a/query/src/catalogs/backends/backend.rs
+++ b/query/src/catalogs/backends/backend.rs
@@ -49,11 +49,7 @@ pub trait MetaApiSync: Send + Sync {
 
     fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>>;
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>>;
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>>;
 
     fn upsert_table_option(
         &self,

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -294,11 +294,7 @@ impl MetaApiSync for MetaEmbeddedSync {
         Ok(res)
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        _table_version: Option<MetaVersion>,
-    ) -> common_exception::Result<Arc<TableInfo>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> common_exception::Result<Arc<TableInfo>> {
         let map = self.databases.read();
         for (_, tbl_idx) in map.values() {
             match tbl_idx.id2meta.get(&table_id) {

--- a/query/src/catalogs/backends/impls/meta_cached.rs
+++ b/query/src/catalogs/backends/impls/meta_cached.rs
@@ -84,19 +84,15 @@ impl MetaApi for MetaCached {
         self.inner.get_tables(db_name).await
     }
 
-    async fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>> {
-        if let Some(ver) = version {
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+        {
             let mut cached = self.table_meta_cache.write().await;
-            if let Some(meta) = cached.get(&(table_id, ver)) {
+            if let Some(meta) = cached.get(&(table_id, 0)) {
                 return Ok(meta.clone());
             }
         }
 
-        let reply = self.inner.get_table_by_id(table_id, version).await?;
+        let reply = self.inner.get_table_by_id(table_id).await?;
 
         let mut cache = self.table_meta_cache.write().await;
         // TODO version

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -114,13 +114,8 @@ impl MetaApi for MetaRemote {
             .await
     }
 
-    async fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>> {
-        // TODO(xp): version
-        self.query_backend(move |cli| async move { cli.get_table_by_id(table_id, version).await })
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+        self.query_backend(move |cli| async move { cli.get_table_by_id(table_id).await })
             .await
     }
 

--- a/query/src/catalogs/backends/impls/meta_sync.rs
+++ b/query/src/catalogs/backends/impls/meta_sync.rs
@@ -98,14 +98,9 @@ impl MetaApiSync for MetaSync {
         (async move { x.get_tables(&db_name).await }).wait_in(&self.rt, self.timeout)?
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
         let x = self.inner.clone();
-        (async move { x.get_table_by_id(table_id, version).await })
-            .wait_in(&self.rt, self.timeout)?
+        (async move { x.get_table_by_id(table_id).await }).wait_in(&self.rt, self.timeout)?
     }
 
     fn upsert_table_option(

--- a/query/src/catalogs/backends/impls/remote_backend.rs
+++ b/query/src/catalogs/backends/impls/remote_backend.rs
@@ -105,12 +105,8 @@ impl<T: MetaApiSync, U: Deref<Target = T> + Send + Sync> MetaApiSync for U {
         self.deref().get_tables(db_name)
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<TableInfo>> {
-        self.deref().get_table_by_id(table_id, table_version)
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+        self.deref().get_table_by_id(table_id)
     }
 
     fn upsert_table_option(

--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -47,11 +47,7 @@ pub trait Catalog {
 
     fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<dyn Table>>>;
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>>;
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>>;
 
     fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
 

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -146,12 +146,8 @@ impl Catalog for MetaStoreCatalog {
         })
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>> {
-        let table_info = self.meta.get_table_by_id(table_id, table_version)?;
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>> {
+        let table_info = self.meta.get_table_by_id(table_id)?;
         self.build_table(table_info.as_ref())
     }
 

--- a/query/src/catalogs/impls/catalog/overlaid_catalog.rs
+++ b/query/src/catalogs/impls/catalog/overlaid_catalog.rs
@@ -116,14 +116,10 @@ impl Catalog for OverlaidCatalog {
         }
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        table_version: Option<MetaVersion>,
-    ) -> common_exception::Result<Arc<dyn Table>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> common_exception::Result<Arc<dyn Table>> {
         self.read_only
-            .get_table_by_id(table_id, table_version)
-            .or_else(|_e| self.bottom.get_table_by_id(table_id, table_version))
+            .get_table_by_id(table_id)
+            .or_else(|_e| self.bottom.get_table_by_id(table_id))
     }
 
     fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -124,11 +124,7 @@ impl Catalog for SystemCatalog {
         Ok(self.sys_db_meta.name_to_table.values().cloned().collect())
     }
 
-    fn get_table_by_id(
-        &self,
-        table_id: MetaId,
-        _table_version: Option<MetaVersion>,
-    ) -> Result<Arc<dyn Table>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>> {
         let table =
             self.sys_db_meta.id_to_table.get(&table_id).ok_or_else(|| {
                 ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id))
@@ -167,6 +163,6 @@ impl Catalog for SystemCatalog {
 
     fn build_table(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
         let table_id = table_info.table_id;
-        self.get_table_by_id(table_id, None)
+        self.get_table_by_id(table_id)
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/api] refactor: remove "version" from get_table_by_id(table_id, version); it is not used at all
- fix: #2031

## Changelog




- Improvement


## Related Issues

- #2030