### PR TITLE
[common/meta] refactor: rename Cmd::CreateTable.table to Cmd::CreateTable.table_info

### DIFF
--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -127,7 +127,7 @@ impl MetaApi for MetaEmbedded {
         let cr = Cmd::CreateTable {
             db_name: db_name.clone(),
             table_name: table_name.clone(),
-            table,
+            table_info: table,
         };
 
         let mut sm = self.inner.lock().await;

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -355,7 +355,7 @@ impl StateMachine {
             Cmd::CreateTable {
                 ref db_name,
                 ref table_name,
-                ref table,
+                table_info: ref table,
             } => {
                 let dbi = self
                     .databases()

--- a/common/meta/types/src/cmd.rs
+++ b/common/meta/types/src/cmd.rs
@@ -37,36 +37,20 @@ pub enum Cmd {
     AddNode { node_id: NodeId, node: Node },
 
     /// Add a database if absent
-    CreateDatabase {
-        // TODO(ariesdevil): add `seq` for distinguish between the results of the execution of
-        // the two commands (failed `add` and successful `delete`)
-        name: String,
-        db: DatabaseInfo,
-    },
+    CreateDatabase { name: String, db: DatabaseInfo },
 
     /// Drop a database if absent
-    DropDatabase {
-        // TODO(ariesdevil): add `seq` for distinguish between the results of the execution of
-        // the two commands (failed `add` and successful `delete`)
-        name: String,
-    },
+    DropDatabase { name: String },
 
     /// Create a table if absent
     CreateTable {
-        // TODO(ariesdevil): add `seq` for distinguish between the results of the execution of
-        // the two commands (failed `add` and successful `delete`)
         db_name: String,
         table_name: String,
-        table: TableInfo,
+        table_info: TableInfo,
     },
 
     /// Drop a table if absent
-    DropTable {
-        // TODO(ariesdevil): add `seq` for distinguish between the results of the execution of
-        // the two commands (failed `add` and successful `delete`)
-        db_name: String,
-        table_name: String,
-    },
+    DropTable { db_name: String, table_name: String },
 
     /// Update or insert a general purpose kv store
     UpsertKV {
@@ -104,7 +88,7 @@ impl fmt::Display for Cmd {
             Cmd::CreateTable {
                 db_name,
                 table_name,
-                table,
+                table_info: table,
             } => {
                 write!(f, "create_table:{}-{}={}", db_name, table_name, table)
             }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -163,7 +163,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
             cmd: CreateTable {
                 db_name: db_name.clone(),
                 table_name: table_name.clone(),
-                table,
+                table_info: table,
             },
         };
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta] refactor: rename Cmd::CreateTable.table to Cmd::CreateTable.table_info

## Changelog




- Improvement


## Related Issues

- #2030