### PR TITLE
Add optimization for literal false filter

### DIFF
--- a/common/planners/src/plan_filter.rs
+++ b/common/planners/src/plan_filter.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
+use common_datavalues::DataValue;
 
 use crate::Expression;
 use crate::PlanNode;
@@ -36,5 +37,12 @@ impl FilterPlan {
 
     pub fn set_input(&mut self, node: &PlanNode) {
         self.input = Arc::new(node.clone());
+    }
+
+    pub fn is_literal_false(&self) -> bool {
+        if let Expression::Literal { value, .. } = &self.predicate {
+            return *value == DataValue::Boolean(Some(false));
+        }
+        false
     }
 }

--- a/query/src/optimizers/optimizer_expression_transform_test.rs
+++ b/query/src/optimizers/optimizer_expression_transform_test.rs
@@ -100,6 +100,14 @@ mod tests {
                 \n  Filter: (number = 0)\
                 \n    ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]",
             },
+            Test {
+                name: "Literal boolean transform",
+                query: "select number from numbers_mt(10) where false",
+                expect: "\
+                Projection: number:UInt64\
+                \n  Filter: false\
+                \n    ReadDataSource: scan partitions: [0], scan schema: [number:UInt64], statistics: [read_rows: 0, read_bytes: 0]",
+            },
         ];
 
         for test in tests {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

For query like select * from table where 1+2=4, optimize it to skip the table scan.

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests


