### PR TITLE
[Query] should be panic when starting error

### DIFF
--- a/query/src/bin/databend-query.rs
+++ b/query/src/bin/databend-query.rs
@@ -74,7 +74,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         let hostname = conf.query.mysql_handler_host.clone();
         let listening = format!("{}:{}", hostname, conf.query.mysql_handler_port);
         let mut handler = MySQLHandler::create(session_manager.clone());
-        let listening = handler.start(listening.parse()?).await?;
+        let listening = handler
+            .start(listening.parse()?)
+            .await
+            .expect("MySQL handler error");
         shutdown_handle.add_service(handler);
 
         info!(
@@ -91,7 +94,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         let listening = format!("{}:{}", hostname, conf.query.clickhouse_handler_port);
 
         let mut srv = ClickHouseHandler::create(session_manager.clone());
-        let listening = srv.start(listening.parse()?).await?;
+        let listening = srv
+            .start(listening.parse()?)
+            .await
+            .expect("Clickhouse handler error");
         shutdown_handle.add_service(srv);
 
         info!(
@@ -107,7 +113,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
         let listening = format!("{}:{}", hostname, conf.query.http_handler_port);
 
         let mut srv = HttpHandler::create(session_manager.clone());
-        let listening = srv.start(listening.parse()?).await?;
+        let listening = srv
+            .start(listening.parse()?)
+            .await
+            .expect("HTTP handler error");
         shutdown_handle.add_service(srv);
 
         info!("Http handler listening on {}", listening);
@@ -117,7 +126,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     {
         let address = conf.query.metric_api_address.clone();
         let mut srv = MetricService::create(session_manager.clone());
-        let listening = srv.start(address.parse()?).await?;
+        let listening = srv
+            .start(address.parse()?)
+            .await
+            .expect("Metric API service error");
         shutdown_handle.add_service(srv);
         info!("Metric API server listening on {}", listening);
     }
@@ -126,7 +138,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     {
         let address = conf.query.http_api_address.clone();
         let mut srv = HttpService::create(session_manager.clone());
-        let listening = srv.start(address.parse()?).await?;
+        let listening = srv
+            .start(address.parse()?)
+            .await
+            .expect("HTTP API service error");
         shutdown_handle.add_service(srv);
         info!("HTTP API server listening on {}", listening);
     }
@@ -135,7 +150,10 @@ async fn main(_global_tracker: Arc<RuntimeTracker>) -> common_exception::Result<
     {
         let address = conf.query.flight_api_address.clone();
         let mut srv = RpcService::create(session_manager.clone());
-        let listening = srv.start(address.parse()?).await?;
+        let listening = srv
+            .start(address.parse()?)
+            .await
+            .expect("RPC API service error");
         shutdown_handle.add_service(srv);
         info!("RPC API server listening on {}", listening);
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Starting databend-query will be blocked without any log when some port conflicts, such as clickhouse 9000 port in use: 

![image](https://user-images.githubusercontent.com/8097526/138906021-0b5bbb0c-ebfb-4012-bd69-a6cebd4a4da8.png)


## Changelog

- Improvement

