### PR TITLE
[common/meta/types] refactor: remove TableInfo::database_id

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -209,7 +209,6 @@ impl MetaApiTestSuite {
                 let got = mt.get_table(db_name, tbl_name).await?;
 
                 let want = TableInfo {
-                    database_id: 1,
                     table_id: 1,
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
@@ -229,7 +228,6 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table(db_name, tbl_name).await?;
                 let want = TableInfo {
-                    database_id: 1,
                     table_id: 1,
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
@@ -258,7 +256,6 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table("db1", "tb2").await.unwrap();
                 let want = TableInfo {
-                    database_id: 1,
                     table_id: 1,
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -117,7 +117,6 @@ impl MetaApi for MetaEmbedded {
             table_id: 0,
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
-            database_id: 0, // this field is unused during the creation of table
             schema: plan.schema.clone(),
             engine: plan.engine.clone(),
             name: table_name.to_string(),
@@ -201,19 +200,9 @@ impl MetaApi for MetaEmbedded {
             .get_table(&table_id)?
             .ok_or_else(|| ErrorCode::UnknownTable(table.to_string()))?;
 
-        let tablei = seq_table.data;
+        let table_info = seq_table.data;
 
-        let rst = TableInfo {
-            database_id: tablei.database_id,
-            table_id: tablei.table_id,
-            version: tablei.version, // placeholder, not yet implemented in meta service
-            desc: tablei.desc.clone(),
-            name: tablei.name.clone(),
-            schema: tablei.schema,
-            engine: tablei.engine.clone(),
-            options: tablei.options,
-        };
-        Ok(Arc::new(rst))
+        Ok(Arc::new(table_info))
     }
 
     async fn get_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>> {
@@ -231,19 +220,9 @@ impl MetaApi for MetaEmbedded {
             ErrorCode::UnknownTable(format!("table of id {} not found", table_id))
         })?;
 
-        let tablei = table.data;
+        let table_info = table.data;
 
-        let rst = TableInfo {
-            database_id: tablei.database_id,
-            table_id: tablei.table_id,
-            version: tablei.version, // placeholder, not yet implemented in meta service
-            desc: tablei.desc.clone(),
-            name: tablei.name.clone(),
-            schema: tablei.schema,
-            engine: tablei.engine.clone(),
-            options: tablei.options,
-        };
-        Ok(Arc::new(rst))
+        Ok(Arc::new(table_info))
     }
 
     async fn upsert_table_option(

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -373,7 +373,6 @@ impl StateMachine {
 
                 let mut table = table.clone();
                 table.table_id = self.incr_seq(SEQ_TABLE_ID).await?;
-                table.database_id = db_id;
 
                 let table_id = table.table_id;
 

--- a/common/meta/types/src/table_info.rs
+++ b/common/meta/types/src/table_info.rs
@@ -24,7 +24,6 @@ use crate::MetaVersion;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TableInfo {
-    pub database_id: u64,
     pub table_id: u64,
 
     /// version of this table snapshot.
@@ -65,7 +64,6 @@ impl TableInfo {
 impl Default for TableInfo {
     fn default() -> Self {
         TableInfo {
-            database_id: 0,
             table_id: 0,
             version: 0,
             desc: "".to_string(),
@@ -81,8 +79,8 @@ impl Display for TableInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "DB.Table: {}-{}, Table: {}-{}, Version: {}, Engine: {}",
-            self.desc, self.database_id, self.name, self.table_id, self.version, self.engine
+            "DB.Table: {}, Table: {}-{}, Version: {}, Engine: {}",
+            self.desc, self.name, self.table_id, self.version, self.engine
         )
     }
 }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -151,7 +151,6 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
             table_id: 0,
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
-            database_id: 0, // this field is unused during the creation of table
             schema: plan.schema.clone(),
             engine: plan.engine.clone(),
             name: table_name.to_string(),

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -166,7 +166,6 @@ impl MetaApiSync for MetaEmbeddedSync {
         let table_name = clone.table.as_str();
 
         let table_info = TableInfo {
-            database_id: 0, // TODO tobe assigned to some real value
             desc: format!("'{}'.'{}'", plan.db, plan.table),
             table_id: self.next_db_id(),
             version: 0,

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -43,7 +43,6 @@ impl ExampleTable {
         table_id: u64,
     ) -> Result<Box<dyn Table>> {
         let table_info = TableInfo {
-            database_id: 0,
             table_id,
             version: 0,
             desc: format!("'{}'.'{}'", db, name),

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -44,7 +44,6 @@ async fn test_csv_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
     let table = CsvTable::try_create(
         TableInfo {
-            database_id: 0,
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
             schema: DataSchemaRefExt::create(vec![DataField::new(
@@ -122,7 +121,6 @@ async fn test_csv_table_parse_error() -> Result<()> {
 
     let table = CsvTable::try_create(
         TableInfo {
-            database_id: 0,
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
             schema: DataSchemaRefExt::create(vec![

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -38,7 +38,6 @@ async fn test_memorytable() -> Result<()> {
     ]);
     let table = MemoryTable::try_create(
         TableInfo {
-            database_id: 0,
             desc: "'default'.'a'".into(),
             name: "a".into(),
             schema: schema.clone(),

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -38,7 +38,6 @@ async fn test_null_table() -> Result<()> {
     ]);
     let table = NullTable::try_create(
         TableInfo {
-            database_id: 0,
             desc: "'default'.'a'".into(),
             name: "a".into(),
 

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -42,7 +42,6 @@ async fn test_parquet_table() -> Result<()> {
 
     let ctx = crate::tests::try_create_context()?;
     let table_info = TableInfo {
-        database_id: 0,
         desc: "'default'.'test_parquet_table'".to_string(),
         table_id: 0,
         version: 0,

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -77,7 +77,6 @@ impl NumbersTable {
         };
 
         let table_info = TableInfo {
-            database_id: 0,
             table_id,
             version: 0,
             desc: format!("'{}'.'{}'", database_name, table_func_name),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] refactor: remove TableInfo::database_id
A table should not need to access its belonging db to work.

## Changelog




- Improvement


## Related Issues

- #2030