### PR TITLE
[common/meta/types] refactor: add TableMeta containing essential table info.

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -20,6 +20,7 @@ use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
@@ -213,9 +214,11 @@ impl MetaApiTestSuite {
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
-                    schema: schema.clone(),
-                    engine: "JSON".to_owned(),
-                    options: options.clone(),
+                    meta: TableMeta {
+                        schema: schema.clone(),
+                        engine: "JSON".to_owned(),
+                        options: options.clone(),
+                    },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get created table");
             }
@@ -232,9 +235,11 @@ impl MetaApiTestSuite {
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
-                    schema: schema.clone(),
-                    engine: "JSON".to_owned(),
-                    options: options.clone(),
+                    meta: TableMeta {
+                        schema: schema.clone(),
+                        engine: "JSON".to_owned(),
+                        options: options.clone(),
+                    },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get created table");
             }
@@ -260,9 +265,11 @@ impl MetaApiTestSuite {
                     version: 0,
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
-                    schema: schema.clone(),
-                    engine: "JSON".to_owned(),
-                    options: options.clone(),
+                    meta: TableMeta {
+                        schema: schema.clone(),
+                        engine: "JSON".to_owned(),
+                        options: options.clone(),
+                    },
                 };
                 assert_eq!(want, got.as_ref().clone(), "get old table");
             }

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -27,6 +27,7 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -117,10 +118,12 @@ impl MetaApi for MetaEmbedded {
             table_id: 0,
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
-            schema: plan.schema.clone(),
-            engine: plan.engine.clone(),
             name: table_name.to_string(),
-            options: plan.options.clone(),
+            meta: TableMeta {
+                schema: plan.schema.clone(),
+                engine: plan.engine.clone(),
+                options: plan.options.clone(),
+            },
         };
 
         let cr = Cmd::CreateTable {

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -41,6 +41,7 @@ pub use raft_types::LogIndex;
 pub use raft_types::NodeId;
 pub use raft_types::Term;
 pub use table_info::TableInfo;
+pub use table_info::TableMeta;
 pub use table_reply::CreateTableReply;
 
 mod cluster;

--- a/common/planners/src/plan_read_datasource.rs
+++ b/common/planners/src/plan_read_datasource.rs
@@ -32,10 +32,10 @@ pub struct ReadDataSourcePlan {
 
     /// Required fields to scan.
     ///
-    /// After optimization, only a sub set of the fields in `table_info.schema.fields` are needed.
-    /// The key is the index of the field in original `table_info.schema.fields`.
+    /// After optimization, only a sub set of the fields in `table_info.schema().fields` are needed.
+    /// The key is the index of the field in original `table_info.schema().fields`.
     ///
-    /// If it is None, one should use `table_info.schema.fields()`.
+    /// If it is None, one should use `table_info.schema().fields()`.
     pub scan_fields: Option<BTreeMap<usize, DataField>>,
 
     pub parts: Partitions,
@@ -54,15 +54,15 @@ impl ReadDataSourcePlan {
             .clone()
             .map(|x| {
                 let fields: Vec<_> = x.iter().map(|(_, f)| f.clone()).collect();
-                Arc::new(self.table_info.schema.project(fields))
+                Arc::new(self.table_info.schema().project(fields))
             })
-            .unwrap_or_else(|| self.table_info.schema.clone())
+            .unwrap_or_else(|| self.table_info.schema())
     }
 
     /// Return designated required fields or all fields in a hash map.
     pub fn scan_fields(&self) -> BTreeMap<usize, DataField> {
         self.scan_fields
             .clone()
-            .unwrap_or_else(|| self.table_info.schema.fields_map())
+            .unwrap_or_else(|| self.table_info.schema().fields_map())
     }
 }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -36,6 +36,7 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::LogEntry;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use log::info;
 
@@ -151,10 +152,12 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
             table_id: 0,
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
-            schema: plan.schema.clone(),
-            engine: plan.engine.clone(),
             name: table_name.to_string(),
-            options: plan.options.clone(),
+            meta: TableMeta {
+                schema: plan.schema.clone(),
+                engine: plan.engine.clone(),
+                options: plan.options.clone(),
+            },
         };
 
         let cr = LogEntry {

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -1053,7 +1053,7 @@ impl MetaNode {
                     table_version, tbl.version,
                 )))
             } else {
-                tbl.options.insert(opt_key, opt_value);
+                tbl.meta.options.insert(opt_key, opt_value);
                 tbl.version += 1;
                 sm.upsert_table(tbl, &MatchSeq::Exact(seq)).await?;
                 Ok(())

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -24,6 +24,7 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -170,9 +171,11 @@ impl MetaApiSync for MetaEmbeddedSync {
             table_id: self.next_db_id(),
             version: 0,
             name: plan.table,
-            schema: plan.schema,
-            options: plan.options,
-            engine: plan.engine,
+            meta: TableMeta {
+                schema: plan.schema,
+                options: plan.options,
+                engine: plan.engine,
+            },
         };
 
         let mut lock = self.databases.write();
@@ -329,6 +332,7 @@ impl MetaApiSync for MetaEmbeddedSync {
                     if tbl.version == table_version {
                         let mut new_tbl_info = tbl.as_ref().clone();
                         new_tbl_info
+                            .meta
                             .options
                             .insert(table_option_name, table_option_value);
                         new_tbl_info.version += 1;

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -188,7 +188,7 @@ impl Catalog for MetaStoreCatalog {
     }
 
     fn build_table(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
-        let engine = &table_info.engine;
+        let engine = table_info.engine();
         let factory = self
             .table_engine_registry
             .get_table_factory(engine)

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -38,11 +38,11 @@ pub trait Table: Sync + Send {
     }
 
     fn engine(&self) -> &str {
-        &self.get_table_info().engine
+        self.get_table_info().engine()
     }
 
     fn schema(&self) -> DataSchemaRef {
-        self.get_table_info().schema.clone()
+        self.get_table_info().schema()
     }
 
     fn get_id(&self) -> MetaId {

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -20,6 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::InsertIntoPlan;
 use common_planners::ReadDataSourcePlan;
 use common_planners::TableOptions;
@@ -48,9 +49,11 @@ impl ExampleTable {
             desc: format!("'{}'.'{}'", db, name),
             name,
 
-            schema,
-            engine: "ExampleNull".to_string(),
-            options,
+            meta: TableMeta {
+                schema,
+                engine: "ExampleNull".to_string(),
+                options,
+            },
         };
 
         Ok(Box::new(Self { table_info }))

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -21,6 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -43,9 +44,11 @@ impl ClustersTable {
             desc: "'system'.'clusters'".to_string(),
             name: "clusters".to_string(),
             table_id,
-            schema,
-            engine: "SystemClusters".to_string(),
-
+            meta: TableMeta {
+                schema,
+                engine: "SystemClusters".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -83,16 +86,13 @@ impl Table for ClustersTable {
         }
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
-            vec![DataBlock::create_by_array(
-                self.table_info.schema.clone(),
-                vec![
-                    names.finish().into_series(),
-                    addresses.finish().into_series(),
-                    addresses_port.finish().into_series(),
-                ],
-            )],
+            vec![DataBlock::create_by_array(self.table_info.schema(), vec![
+                names.finish().into_series(),
+                addresses.finish().into_series(),
+                addresses_port.finish().into_series(),
+            ])],
         )))
     }
 }

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -21,6 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -46,9 +47,11 @@ impl ConfigsTable {
             desc: "'system'.'configs'".to_string(),
             name: "configs".to_string(),
             table_id,
-            schema,
-            engine: "SystemConfigs".to_string(),
-
+            meta: TableMeta {
+                schema,
+                engine: "SystemConfigs".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
         ConfigsTable { table_info }
@@ -138,14 +141,14 @@ impl Table for ConfigsTable {
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let groups: Vec<&str> = groups.iter().map(|x| x.as_str()).collect();
         let descs: Vec<&str> = descs.iter().map(|x| x.as_str()).collect();
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(values),
             Series::new(groups),
             Series::new(descs),
         ]);
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -20,6 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -39,8 +40,11 @@ impl ContributorsTable {
             desc: "'system'.'contributors'".to_string(),
             name: "contributors".to_string(),
             table_id,
-            schema,
-            engine: "SystemContributors".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemContributors".to_string(),
+                ..Default::default()
+            },
 
             ..Default::default()
         };
@@ -67,12 +71,11 @@ impl Table for ContributorsTable {
             .split_terminator(',')
             .map(|x| x.trim().as_bytes())
             .collect();
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![Series::new(
-            contributors,
-        )]);
+        let block =
+            DataBlock::create_by_array(self.table_info.schema(), vec![Series::new(contributors)]);
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -20,6 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -42,8 +43,11 @@ impl CreditsTable {
             desc: "'system'.'credits'".to_string(),
             name: "credits".to_string(),
             table_id,
-            schema,
-            engine: "SystemCredits".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemCredits".to_string(),
+                ..Default::default()
+            },
 
             ..Default::default()
         };
@@ -88,14 +92,14 @@ impl Table for CreditsTable {
             })
             .collect();
 
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(versions),
             Series::new(licenses),
         ]);
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -21,6 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -42,9 +43,11 @@ impl DatabasesTable {
             desc: "'system'.'databases'".to_string(),
             name: "databases".to_string(),
             table_id,
-            schema,
-            engine: "SystemDatabases".to_string(),
-
+            meta: TableMeta {
+                schema,
+                engine: "SystemDatabases".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -80,12 +83,12 @@ impl Table for DatabasesTable {
                     .collect();
 
                 let block =
-                    DataBlock::create_by_array(self.table_info.schema.clone(), vec![Series::new(
+                    DataBlock::create_by_array(self.table_info.schema(), vec![Series::new(
                         databases_name_str,
                     )]);
 
                 Box::pin(DataBlockStream::create(
-                    self.table_info.schema.clone(),
+                    self.table_info.schema(),
                     None,
                     vec![block],
                 ))

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -22,6 +22,7 @@ use common_exception::Result;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::FunctionFactory;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -43,9 +44,12 @@ impl FunctionsTable {
             desc: "'system'.'functions'".to_string(),
             name: "functions".to_string(),
             table_id,
-            schema,
-            engine: "SystemFunctions".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemFunctions".to_string(),
 
+                ..Default::default()
+            },
             ..Default::default()
         };
         FunctionsTable { table_info }
@@ -82,13 +86,13 @@ impl Table for FunctionsTable {
             .map(|i| i >= func_names.len())
             .collect::<Vec<bool>>();
 
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(is_aggregate),
         ]);
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/metrics_table.rs
+++ b/query/src/datasources/database/system/metrics_table.rs
@@ -26,6 +26,7 @@ use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_metrics::MetricValue;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
@@ -51,8 +52,11 @@ impl MetricsTable {
             desc: "'system'.'metrics'".to_string(),
             name: "metrics".to_string(),
             table_id,
-            schema,
-            engine: "SystemMetrics".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemMetrics".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -116,14 +120,14 @@ impl Table for MetricsTable {
             values.push(self.display_sample_value(&sample.value)?.into_bytes());
         }
 
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(metrics),
             Series::new(kinds),
             Series::new(labels),
             Series::new(values),
         ]);
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -20,6 +20,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::Extras;
 use common_planners::Part;
 use common_planners::Partitions;
@@ -43,9 +44,11 @@ impl OneTable {
             desc: "'system'.'one'".to_string(),
             name: "one".to_string(),
             table_id,
-            schema,
-            engine: "SystemOne".to_string(),
-
+            meta: TableMeta {
+                schema,
+                engine: "SystemOne".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
         OneTable { table_info }
@@ -80,11 +83,9 @@ impl Table for OneTable {
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
         let block =
-            DataBlock::create_by_array(self.table_info.schema.clone(), vec![Series::new(vec![
-                1u8,
-            ])]);
+            DataBlock::create_by_array(self.table_info.schema(), vec![Series::new(vec![1u8])]);
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -25,6 +25,7 @@ use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -53,9 +54,12 @@ impl ProcessesTable {
             desc: "'system'.'processes'".to_string(),
             name: "processes".to_string(),
             table_id,
-            schema,
-            engine: "SystemProcesses".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemProcesses".to_string(),
 
+                ..Default::default()
+            },
             ..Default::default()
         };
         ProcessesTable { table_info }
@@ -114,7 +118,7 @@ impl Table for ProcessesTable {
             processes_memory_usage.push(process_info.memory_usage);
         }
 
-        let schema = self.table_info.schema.clone();
+        let schema = self.table_info.schema();
         let block = DataBlock::create_by_array(schema.clone(), vec![
             Series::new(processes_id),
             Series::new(processes_type),

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -21,6 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -45,9 +46,12 @@ impl SettingsTable {
             desc: "'system'.'settings'".to_string(),
             name: "settings".to_string(),
             table_id,
-            schema,
-            engine: "SystemSettings".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemSettings".to_string(),
 
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -93,14 +97,14 @@ impl Table for SettingsTable {
         let values: Vec<&[u8]> = values.iter().map(|x| x.as_bytes()).collect();
         let default_values: Vec<&[u8]> = default_values.iter().map(|x| x.as_bytes()).collect();
         let descs: Vec<&[u8]> = descs.iter().map(|x| x.as_bytes()).collect();
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(names),
             Series::new(values),
             Series::new(default_values),
             Series::new(descs),
         ]);
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -21,6 +21,7 @@ use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
@@ -45,9 +46,12 @@ impl TablesTable {
             desc: "'system'.'tables'".to_string(),
             name: "tables".to_string(),
             table_id,
-            schema,
-            engine: "SystemTables".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemTables".to_string(),
 
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -95,14 +99,14 @@ impl Table for TablesTable {
             .map(|(_, v)| v.engine().as_bytes())
             .collect();
 
-        let block = DataBlock::create_by_array(self.table_info.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.table_info.schema(), vec![
             Series::new(databases),
             Series::new(names),
             Series::new(engines),
         ]);
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -23,6 +23,7 @@ use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
 use common_streams::SendableDataBlockStream;
 use common_tracing::tracing;
@@ -54,8 +55,11 @@ impl TracingTable {
             desc: "'system'.'tracing'".to_string(),
             name: "tracing".to_string(),
             table_id,
-            schema,
-            engine: "SystemTracing".to_string(),
+            meta: TableMeta {
+                schema,
+                engine: "SystemTracing".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -104,7 +108,7 @@ impl Table for TracingTable {
         }
 
         Ok(Box::pin(TracingTableStream::try_create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             log_files,
             limit,
         )?))

--- a/query/src/datasources/table/csv/csv_table.rs
+++ b/query/src/datasources/table/csv/csv_table.rs
@@ -46,7 +46,7 @@ impl CsvTable {
         table_info: TableInfo,
         _data_ctx: Arc<dyn DataContext<u64>>,
     ) -> Result<Box<dyn Table>> {
-        let options = &table_info.options;
+        let options = table_info.options();
         let has_header = options.get("has_header").is_some();
         let file = match options.get("location") {
             None => {
@@ -105,7 +105,7 @@ impl Table for CsvTable {
 
         Ok(Box::pin(CsvTableStream::try_create(
             ctx,
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             self.file.clone(),
         )?))
     }

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -22,6 +22,7 @@ use common_datablocks::assert_blocks_sorted_eq;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::*;
 use futures::TryStreamExt;
 
@@ -46,15 +47,17 @@ async fn test_csv_table() -> Result<()> {
         TableInfo {
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
-            schema: DataSchemaRefExt::create(vec![DataField::new(
-                "column1",
-                DataType::UInt64,
-                false,
-            )]),
-            engine: "Csv".to_string(),
-            options,
             table_id: 0,
             version: 0,
+            meta: TableMeta {
+                schema: DataSchemaRefExt::create(vec![DataField::new(
+                    "column1",
+                    DataType::UInt64,
+                    false,
+                )]),
+                engine: "Csv".to_string(),
+                options,
+            },
         },
         Arc::new(TableDataContext::default()),
     )?;
@@ -123,16 +126,18 @@ async fn test_csv_table_parse_error() -> Result<()> {
         TableInfo {
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
-            schema: DataSchemaRefExt::create(vec![
-                DataField::new("column1", DataType::UInt64, false),
-                DataField::new("column2", DataType::UInt64, false),
-                DataField::new("column3", DataType::UInt64, false),
-                DataField::new("column4", DataType::UInt64, false),
-            ]),
-            engine: "Csv".to_string(),
-            options,
             table_id: 0,
             version: 0,
+            meta: TableMeta {
+                schema: DataSchemaRefExt::create(vec![
+                    DataField::new("column1", DataType::UInt64, false),
+                    DataField::new("column2", DataType::UInt64, false),
+                    DataField::new("column3", DataType::UInt64, false),
+                    DataField::new("column4", DataType::UInt64, false),
+                ]),
+                engine: "Csv".to_string(),
+                options,
+            },
         },
         Arc::new(TableDataContext::default()),
     )?;

--- a/query/src/datasources/table/fuse/index/min_max_test.rs
+++ b/query/src/datasources/table/fuse/index/min_max_test.rs
@@ -93,7 +93,7 @@ async fn test_min_max_index() -> Result<()> {
 
     let snapshot_loc = table
         .get_table_info()
-        .options
+        .options()
         .get(TBL_OPT_KEY_SNAPSHOT_LOC)
         .unwrap();
     let snapshot = read_obj(da.clone(), snapshot_loc.clone()).await?;
@@ -103,7 +103,7 @@ async fn test_min_max_index() -> Result<()> {
     let push_downs = None;
     let blocks = range_filter(
         &snapshot,
-        table.get_table_info().schema.clone(),
+        table.get_table_info().schema(),
         push_downs,
         meta_reader.clone(),
     )?;
@@ -118,7 +118,7 @@ async fn test_min_max_index() -> Result<()> {
 
     let blocks = range_filter(
         &snapshot,
-        table.get_table_info().schema.clone(),
+        table.get_table_info().schema(),
         Some(extra),
         meta_reader.clone(),
     )?;
@@ -131,7 +131,7 @@ async fn test_min_max_index() -> Result<()> {
 
     let blocks = range_filter(
         &snapshot,
-        table.get_table_info().schema.clone(),
+        table.get_table_info().schema(),
         Some(extra),
         meta_reader,
     )?;

--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -100,7 +100,7 @@ impl Table for FuseTable {
 
 impl FuseTable {
     pub fn table_snapshot(&self, io_ctx: &TableIOContext) -> Result<Option<TableSnapshot>> {
-        let option = &self.table_info.options;
+        let option = &self.table_info.options();
         if let Some(loc) = option.get(util::TBL_OPT_KEY_SNAPSHOT_LOC) {
             let da = io_ctx.get_data_accessor()?;
             let r = read_obj(da, loc.to_string()).wait_in(&io_ctx.get_runtime(), None)??;

--- a/query/src/datasources/table/fuse/table_do_append.rs
+++ b/query/src/datasources/table/fuse/table_do_append.rs
@@ -52,9 +52,12 @@ impl FuseTable {
         let da = io_ctx.get_data_accessor()?;
 
         // 2. Append blocks to storage
-        let segment_info =
-            BlockAppender::append_blocks(da.clone(), block_stream, self.table_info.schema.as_ref())
-                .await?;
+        let segment_info = BlockAppender::append_blocks(
+            da.clone(),
+            block_stream,
+            self.table_info.schema().as_ref(),
+        )
+        .await?;
 
         // 3. save segment info
         let seg_loc = util::gen_segment_info_location();
@@ -67,7 +70,7 @@ impl FuseTable {
         // TODO backoff retry this block
         {
             let new_snapshot = merge_snapshot(
-                self.table_info.schema.as_ref(),
+                self.table_info.schema().as_ref(),
                 prev_snapshot,
                 (segment_info, seg_loc),
             )?;

--- a/query/src/datasources/table/fuse/table_do_read.rs
+++ b/query/src/datasources/table/fuse/table_do_read.rs
@@ -38,7 +38,7 @@ impl FuseTable {
             .expect("DatabendQueryContext should not be None");
 
         let default_proj = || {
-            (0..self.table_info.schema.fields().len())
+            (0..self.table_info.schema().fields().len())
                 .into_iter()
                 .collect::<Vec<usize>>()
         };
@@ -64,7 +64,7 @@ impl FuseTable {
             .flatten()
         };
         let da = io_ctx.get_data_accessor()?;
-        let arrow_schema = self.table_info.schema.to_arrow();
+        let arrow_schema = self.table_info.schema().to_arrow();
 
         let stream = futures::stream::iter(iter);
         let stream = stream.then(move |part| {

--- a/query/src/datasources/table/fuse/table_do_read_partitions.rs
+++ b/query/src/datasources/table/fuse/table_do_read_partitions.rs
@@ -35,12 +35,8 @@ impl FuseTable {
         if let Some(snapshot) = tbl_snapshot {
             let da = io_ctx.get_data_accessor()?;
             let meta_reader = MetaInfoReader::new(da, io_ctx.get_runtime());
-            let block_metas = index::range_filter(
-                &snapshot,
-                self.table_info.schema.clone(),
-                push_downs,
-                meta_reader,
-            )?;
+            let block_metas =
+                index::range_filter(&snapshot, self.table_info.schema(), push_downs, meta_reader)?;
             let (statistics, parts) = self.to_partitions(&block_metas);
             Ok((statistics, parts))
         } else {

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -134,7 +134,7 @@ impl Table for MemoryTable {
         }
         .ok_or_else(|| ErrorCode::EmptyData("input stream consumed"))?;
 
-        if _insert_plan.schema().as_ref().fields() != self.table_info.schema.as_ref().fields() {
+        if _insert_plan.schema().as_ref().fields() != self.table_info.schema().as_ref().fields() {
             return Err(ErrorCode::BadArguments("DataBlock schema mismatch"));
         }
 

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -23,6 +23,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_infallible::Mutex;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::*;
 use futures::TryStreamExt;
 
@@ -40,11 +41,13 @@ async fn test_memorytable() -> Result<()> {
         TableInfo {
             desc: "'default'.'a'".into(),
             name: "a".into(),
-            schema: schema.clone(),
-            engine: "Memory".to_string(),
-            options: TableOptions::default(),
             table_id: 0,
             version: 0,
+            meta: TableMeta {
+                schema: schema.clone(),
+                engine: "Memory".to_string(),
+                options: TableOptions::default(),
+            },
         },
         Arc::new(TableDataContext::default()),
     )?;

--- a/query/src/datasources/table/null/null_table.rs
+++ b/query/src/datasources/table/null/null_table.rs
@@ -59,10 +59,10 @@ impl Table for NullTable {
         _io_ctx: Arc<TableIOContext>,
         _plan: &ReadDataSourcePlan,
     ) -> Result<SendableDataBlockStream> {
-        let block = DataBlock::empty_with_schema(self.table_info.schema.clone());
+        let block = DataBlock::empty_with_schema(self.table_info.schema());
 
         Ok(Box::pin(DataBlockStream::create(
-            self.table_info.schema.clone(),
+            self.table_info.schema(),
             None,
             vec![block],
         )))

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -23,6 +23,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_infallible::Mutex;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::*;
 use futures::TryStreamExt;
 
@@ -40,12 +41,18 @@ async fn test_null_table() -> Result<()> {
         TableInfo {
             desc: "'default'.'a'".into(),
             name: "a".into(),
-
-            schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::UInt64, false)]),
-            engine: "Null".to_string(),
-            options: TableOptions::default(),
             table_id: 0,
             version: 0,
+
+            meta: TableMeta {
+                schema: DataSchemaRefExt::create(vec![DataField::new(
+                    "a",
+                    DataType::UInt64,
+                    false,
+                )]),
+                engine: "Null".to_string(),
+                options: TableOptions::default(),
+            },
         },
         Arc::new(TableDataContext::default()),
     )?;

--- a/query/src/datasources/table/parquet/parquet_table.rs
+++ b/query/src/datasources/table/parquet/parquet_table.rs
@@ -44,7 +44,7 @@ impl ParquetTable {
         table_info: TableInfo,
         _data_ctx: Arc<dyn DataContext<u64>>,
     ) -> Result<Box<dyn Table>> {
-        let options = &table_info.options;
+        let options = table_info.options();
         let file = options.get("location").cloned();
         return match file {
             Some(file) => {

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -21,6 +21,7 @@ use common_context::TableDataContext;
 use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::*;
 use futures::TryStreamExt;
 
@@ -47,9 +48,11 @@ async fn test_parquet_table() -> Result<()> {
         version: 0,
         name: "test_parquet".to_string(),
 
-        schema: DataSchemaRefExt::create(vec![DataField::new("id", DataType::Int32, false)]),
-        engine: "test_parquet".into(),
-        options,
+        meta: TableMeta {
+            schema: DataSchemaRefExt::create(vec![DataField::new("id", DataType::Int32, false)]),
+            engine: "test_parquet".into(),
+            options,
+        },
     };
     let table = ParquetTable::try_create(table_info, Arc::new(TableDataContext::default()))?;
 

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -26,6 +26,7 @@ use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_planners::Expression;
 use common_planners::Extras;
 use common_planners::Partitions;
@@ -81,13 +82,15 @@ impl NumbersTable {
             version: 0,
             desc: format!("'{}'.'{}'", database_name, table_func_name),
             name: table_func_name.to_string(),
-            schema: DataSchemaRefExt::create(vec![DataField::new(
-                "number",
-                DataType::UInt64,
-                false,
-            )]),
-            engine: engine.to_string(),
-            options: Default::default(),
+            meta: TableMeta {
+                schema: DataSchemaRefExt::create(vec![DataField::new(
+                    "number",
+                    DataType::UInt64,
+                    false,
+                )]),
+                engine: engine.to_string(),
+                options: Default::default(),
+            },
         };
 
         Ok(Arc::new(NumbersTable { table_info, total }))

--- a/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/query/src/optimizers/optimizer_projection_push_down.rs
@@ -118,7 +118,7 @@ impl PlanRewriter for ProjectionPushDownImpl {
 
     fn rewrite_read_data_source(&mut self, plan: &ReadDataSourcePlan) -> Result<PlanNode> {
         // TODO: rewrite scan
-        self.get_projected_fields(plan.table_info.schema.as_ref())
+        self.get_projected_fields(plan.table_info.schema().as_ref())
             .map(|projected_fields| {
                 PlanNode::ReadSource(ReadDataSourcePlan {
                     table_info: plan.table_info.clone(),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] refactor: add TableDefinition containing essential table info.
`table_name`, `table_id`, `table_version` and `desc` is not part of
what-a-table-is.
They are just about how to find a table etc.

Meta-store should just store what-a-table-is.
Other information should be maintained by upper layer logics.

By moving unnecessary info out of TableDefinition, it prevents
inappropriate usage of these non-critical info, e.g.: trying to get a
table by name in a context in which table name is volatile.

## Changelog




- Improvement


## Related Issues

- #2030