### PR TITLE
[query] refactor: Catalog: removed unused get_table_by_id()

### DIFF
--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -47,8 +47,6 @@ pub trait Catalog {
 
     fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<dyn Table>>>;
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>>;
-
     fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
 
     fn drop_table(&self, plan: DropTablePlan) -> Result<()>;

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -146,11 +146,6 @@ impl Catalog for MetaStoreCatalog {
         })
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>> {
-        let table_info = self.meta.get_table_by_id(table_id)?;
-        self.build_table(table_info.as_ref())
-    }
-
     fn upsert_table_option(
         &self,
         table_id: MetaId,

--- a/query/src/catalogs/impls/catalog/overlaid_catalog.rs
+++ b/query/src/catalogs/impls/catalog/overlaid_catalog.rs
@@ -116,12 +116,6 @@ impl Catalog for OverlaidCatalog {
         }
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> common_exception::Result<Arc<dyn Table>> {
-        self.read_only
-            .get_table_by_id(table_id)
-            .or_else(|_e| self.bottom.get_table_by_id(table_id))
-    }
-
     fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {
         self.bottom.create_table(plan)
     }

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -124,14 +124,6 @@ impl Catalog for SystemCatalog {
         Ok(self.sys_db_meta.name_to_table.values().cloned().collect())
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<dyn Table>> {
-        let table =
-            self.sys_db_meta.id_to_table.get(&table_id).ok_or_else(|| {
-                ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id))
-            })?;
-        Ok(table.clone())
-    }
-
     fn upsert_table_option(
         &self,
         table_id: MetaId,
@@ -163,6 +155,12 @@ impl Catalog for SystemCatalog {
 
     fn build_table(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
         let table_id = table_info.table_id;
-        self.get_table_by_id(table_id)
+
+        let table =
+            self.sys_db_meta.id_to_table.get(&table_id).ok_or_else(|| {
+                ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id))
+            })?;
+
+        Ok(table.clone())
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] refactor: Catalog: removed unused get_table_by_id()
After fetching a table from catalog by `db_name, table_name`,
the `TableInfo` should be kept and transferred between query nodes.

There should not be need to re-fetch a table by id, to execute a sql.
If there is, it may be a inappropriate design.

Thus `get_table_by_id()` is removed.
If there will be need to add it back,
we will reconsider it.

## Changelog




- Improvement


## Related Issues

- #2030