### PR TITLE
[ci] add another parallel fast-unit-test with incremental-compile=1, to get a ut-failure earlier

### DIFF
--- a/.github/workflows/fast-unit-test.yml
+++ b/.github/workflows/fast-unit-test.yml
@@ -35,20 +35,23 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-fast-ut-cache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-fast-ut-cache-${{ secrets.CACHE_RESET_KEY }}-
-            ${{ runner.os }}-cargo-fast-ut-cache-
-            ${{ runner.os }}-cargo-
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
+
+      # - name: Cache cargo registry
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #       target/
+      #     key: ${{ runner.os }}-cargo-fast-ut-cache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-cargo-fast-ut-cache-${{ secrets.CACHE_RESET_KEY }}-
+      #       ${{ runner.os }}-cargo-fast-ut-cache-
+      #       ${{ runner.os }}-cargo-
 
       - name: Run test with incremental compile:1
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [ci] add another parallel fast-unit-test with incremental-compile=1, to get a ut-failure earlier

## Changelog







## Related Issues
