### PR TITLE
issue-2460: use non-block reading in async methods of fuse tbl

### DIFF
--- a/query/src/datasources/table/fuse/table.rs
+++ b/query/src/datasources/table/fuse/table.rs
@@ -16,7 +16,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_base::BlockingWait;
 use common_context::DataContext;
 use common_context::IOContext;
 use common_context::TableIOContext;
@@ -99,14 +98,21 @@ impl Table for FuseTable {
 }
 
 impl FuseTable {
-    pub fn table_snapshot(&self, io_ctx: &TableIOContext) -> Result<Option<TableSnapshot>> {
-        let option = &self.table_info.options();
-        if let Some(loc) = option.get(util::TBL_OPT_KEY_SNAPSHOT_LOC) {
+    pub(crate) fn snapshot_loc(&self) -> Option<String> {
+        self.table_info
+            .options()
+            .get(util::TBL_OPT_KEY_SNAPSHOT_LOC)
+            .cloned()
+    }
+
+    pub(crate) async fn table_snapshot(
+        &self,
+        io_ctx: &TableIOContext,
+    ) -> Result<Option<TableSnapshot>> {
+        if let Some(loc) = self.snapshot_loc() {
             let da = io_ctx.get_data_accessor()?;
-            let r = read_obj(da, loc.to_string()).wait_in(&io_ctx.get_runtime(), None)??;
-            Ok(Some(r))
+            Ok(Some(read_obj(da, loc.to_string()).await?))
         } else {
-            // TODO distinguish this from invalid TableSnapshot?
             Ok(None)
         }
     }

--- a/query/src/datasources/table/fuse/table_do_append.rs
+++ b/query/src/datasources/table/fuse/table_do_append.rs
@@ -65,7 +65,7 @@ impl FuseTable {
         da.put(&seg_loc, bytes).await?;
 
         // 4. new snapshot
-        let prev_snapshot = self.table_snapshot(io_ctx.as_ref())?;
+        let prev_snapshot = self.table_snapshot(io_ctx.as_ref()).await?;
 
         // TODO backoff retry this block
         {

--- a/query/src/datasources/table/fuse/table_do_read_partitions.rs
+++ b/query/src/datasources/table/fuse/table_do_read_partitions.rs
@@ -13,8 +13,10 @@
 //  limitations under the License.
 //
 
+use common_base::BlockingWait;
 use common_context::IOContext;
 use common_context::TableIOContext;
+use common_dal::read_obj;
 use common_exception::Result;
 use common_planners::Extras;
 use common_planners::Partitions;
@@ -31,9 +33,10 @@ impl FuseTable {
         io_ctx: &TableIOContext,
         push_downs: Option<Extras>,
     ) -> Result<(Statistics, Partitions)> {
-        let tbl_snapshot = self.table_snapshot(io_ctx)?;
-        if let Some(snapshot) = tbl_snapshot {
+        let location = self.snapshot_loc();
+        if let Some(loc) = location {
             let da = io_ctx.get_data_accessor()?;
+            let snapshot = read_obj(da.clone(), loc).wait_in(&io_ctx.get_runtime(), None)??;
             let meta_reader = MetaInfoReader::new(da, io_ctx.get_runtime());
             let block_metas =
                 index::range_filter(&snapshot, self.table_info.schema(), push_downs, meta_reader)?;

--- a/query/src/datasources/table/fuse/table_do_truncate.rs
+++ b/query/src/datasources/table/fuse/table_do_truncate.rs
@@ -35,7 +35,7 @@ impl FuseTable {
         io_ctx: Arc<TableIOContext>,
         _truncate_plan: TruncateTablePlan,
     ) -> Result<()> {
-        if let Some(prev_snapshot) = self.table_snapshot(&io_ctx)? {
+        if let Some(prev_snapshot) = self.table_snapshot(&io_ctx).await? {
             let prev_id = prev_snapshot.snapshot_id;
             let mut new_snapshot = prev_snapshot;
             new_snapshot.segments = vec![];

--- a/query/src/servers/clickhouse/clickhouse_handler_test.rs
+++ b/query/src/servers/clickhouse/clickhouse_handler_test.rs
@@ -22,6 +22,7 @@ use clickhouse_rs::Pool;
 use common_base::tokio;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use tempfile::TempDir;
 
 use crate::servers::ClickHouseHandler;
 use crate::tests::SessionManagerBuilder;
@@ -63,6 +64,40 @@ async fn test_clickhouse_insert_data() -> Result<()> {
     let query_str = "SELECT * from test";
     let block = query(&mut handler, query_str).await?;
     assert_eq!(block.row_count(), 4);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_clickhouse_insert_to_fuse_table() -> Result<()> {
+    let tmp_dir = TempDir::new()?;
+    let data_path = tmp_dir.path().to_str().unwrap().to_string();
+    let mut handler = ClickHouseHandler::create(
+        SessionManagerBuilder::create()
+            .max_sessions(1)
+            .disk_storage_path(data_path)
+            .build()?,
+    );
+
+    let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
+    let listening = handler.start(listening).await?;
+    let mut handler = create_conn(listening.port()).await?;
+
+    let query_str = "CREATE TABLE IF NOT EXISTS t1(a UInt32, b UInt64, c String) Engine = fuse";
+    execute(&mut handler, query_str).await?;
+
+    let block = Block::new();
+    let block = block.column("a", vec![1u32, 2]);
+    let block = block.column("b", vec![1u64, 2]);
+    let block = block.column("c", vec!["1", "'\"2\"-\"2\"'"]);
+    insert(&mut handler, "t1", block.clone()).await?;
+    // we give another insertion here, to test if everything still doing well
+    // see issue #2460 https://github.com/datafuselabs/databend/issues/2460
+    insert(&mut handler, "t1", block).await?;
+
+    let query_str = "SELECT * from t1";
+    let block = query(&mut handler, query_str).await?;
+    assert_eq!(block.row_count(), 4);
+    assert_eq!(block.column_count(), 3);
     Ok(())
 }
 

--- a/query/src/tests/sessions.rs
+++ b/query/src/tests/sessions.rs
@@ -85,6 +85,12 @@ impl SessionManagerBuilder {
         SessionManagerBuilder::inner_create(new_config)
     }
 
+    pub fn disk_storage_path(self, path: String) -> SessionManagerBuilder {
+        let mut new_config = self.config;
+        new_config.storage.disk.data_path = path;
+        SessionManagerBuilder::inner_create(new_config)
+    }
+
     pub fn log_dir_with_relative(self, path: impl Into<String>) -> SessionManagerBuilder {
         let mut new_config = self.config;
         new_config.log.log_dir = env::current_dir()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

fix issue 
-  #2460 

async methods of fuse table should use async readers if possible

## Changelog


- Bug Fix
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2460

## Test Plan

Unit Tests

Stateless Tests

