### PR TITLE
[query] fix /v1/config.

### DIFF
--- a/query/src/api/http_service.rs
+++ b/query/src/api/http_service.rs
@@ -138,6 +138,7 @@ impl HttpService {
                 get(super::http::debug::pprof::debug_pprof_handler),
             )
             .layer(AddExtensionLayer::new(self.sessions.clone()))
+            .layer(AddExtensionLayer::new(self.sessions.get_conf().clone()))
             .boxed()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

forgot to AddExtensionLayer for Config.

test passed because the it was add in test.
https://github.com/datafuselabs/databend/blob/main/query/src/api/http/v1/config_test.rs#L37

alternatively, we could use the session directly in handler.  @zhang2014 

## Changelog


- Bug Fix

## Related Issues

Fixes #2482 

## Test Plan

Unit Tests

