### PR TITLE
add test case for upsert_table_option

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -274,6 +274,26 @@ impl MetaApiTestSuite {
                 assert_eq!(want, got.as_ref().clone(), "get old table");
             }
 
+            tracing::info!("--- update table options with key1=val1");
+            {
+                let table = mt.get_table("db1", "tb2").await.unwrap();
+                let got = mt
+                    .upsert_table_option(
+                        table.table_id,
+                        table.version,
+                        "key1".into(),
+                        "val1".into(),
+                    )
+                    .await;
+                if let Err(ref err) = got {
+                    // TODO: remove this check after upsert_table_option is implemented for MetaEmbedded
+                    assert_eq!(err.code(), ErrorCode::UnImplementCode());
+                } else {
+                    let table = mt.get_table("db1", "tb2").await.unwrap();
+                    assert_eq!(table.options().get("key1"), Some(&"val1".into()));
+                }
+            }
+
             tracing::info!("--- drop table with if_exists = false");
             {
                 let plan = DropTablePlan {

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -235,7 +235,9 @@ impl MetaApi for MetaEmbedded {
         _option_key: String,
         _option_value: String,
     ) -> Result<UpsertTableOptionReply> {
-        todo!()
+        Err(ErrorCode::UnImplement(
+            "not implemented in MetaEmbedded yet",
+        ))
     }
 
     fn name(&self) -> String {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

this PR adds a simple write & read test case for `upsert_table_option`. 

currently `upsert_table_option` is `todo!()` for MetaEmbbed yet, as meta_api_test_suite is reused for all the implementations for the MetaApi trait, we have to take a small workaround: 

1. change the `todo!()` to `ErrorCode::UnImplemented`
2. ignore the assert statement if we got `ErrorCode::UnImplemented`

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2392

## Test Plan

Unit Tests
Stateless Tests

