### PR TITLE
hint the logs directory on provisioning error

### DIFF
--- a/cli/src/cmds/clusters/create.rs
+++ b/cli/src/cmds/clusters/create.rs
@@ -618,8 +618,9 @@ impl CreateCommand {
                         .await;
                     if res.is_err() {
                         writer.write_err(&*format!(
-                            "❌ Cannot provison meta service, error: {:?}",
-                            res.unwrap_err()
+                            "❌ Cannot provison meta service, error: {:?}, please check the logs output by: tail -n 100 {}/*",
+                            res.unwrap_err(),
+                            meta_config.log_dir.unwrap_or_else(|| "unknown log_dir".into()),
                         ));
                         return Ok(());
                     }
@@ -660,13 +661,17 @@ impl CreateCommand {
                 ));
                 {
                     let res = self
-                        .provision_local_query_service(writer, query_config.unwrap())
+                        .provision_local_query_service(
+                            writer,
+                            query_config.as_ref().unwrap().clone(),
+                        )
                         .await;
                     if res.is_err() {
                         let mut status = Status::read(self.conf.clone())?;
                         writer.write_err(&*format!(
-                            "❌ Cannot provison query service, error: {:?}",
-                            res.unwrap_err()
+                            "❌ Cannot provison query service, error: {:?}, please check the logs output by: tail -n 100 {}/*",
+                            res.unwrap_err(),
+                            query_config.as_ref().unwrap().config.log.log_dir,
                         ));
                         DeleteCommand::stop_current_local_services(&mut status, writer)
                             .await


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

this pr adds a hint on facing error on provision a local cluster, as a newbie, it might take time for she/he to diagnose why it failed without knowing where the log directory is.

before:

![Screen Shot 2021-10-28 at 5 16 03 PM](https://user-images.githubusercontent.com/129800/139226307-835effcc-c942-4d01-b6d6-bb979347553b.png)

after:

![Screen Shot 2021-10-28 at 5 16 27 PM](https://user-images.githubusercontent.com/129800/139226379-90d85046-b71e-4bc1-a1dc-d2c4f7ed8a9d.png)

![Screen Shot 2021-10-28 at 5 16 27 PM](https://user-images.githubusercontent.com/129800/139226722-9124cba4-d456-4b78-90e1-59ccafbad8ff.png)

## Changelog

- Improvement

## Related Issues

## Test Plan

Unit Tests
Stateless Tests

