### PR TITLE
[common/meta/types] refactor: wrap table_id and version into TableIdent

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -19,6 +19,7 @@ use common_datavalues::DataSchema;
 use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_meta_types::CreateDatabaseReply;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::CreateDatabasePlan;
@@ -210,8 +211,7 @@ impl MetaApiTestSuite {
                 let got = mt.get_table(db_name, tbl_name).await?;
 
                 let want = TableInfo {
-                    table_id: 1,
-                    version: 0,
+                    ident: TableIdent::new(1, 0),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {
@@ -231,8 +231,7 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table(db_name, tbl_name).await?;
                 let want = TableInfo {
-                    table_id: 1,
-                    version: 0,
+                    ident: TableIdent::new(1, 0),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {
@@ -261,8 +260,7 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table("db1", "tb2").await.unwrap();
                 let want = TableInfo {
-                    table_id: 1,
-                    version: 0,
+                    ident: TableIdent::new(1, 0),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {
@@ -368,8 +366,8 @@ impl MetaApiTestSuite {
             tracing::info!("--- get_tables");
             {
                 let res = mt.get_tables(db_name).await?;
-                assert_eq!(1, res[0].table_id);
-                assert_eq!(2, res[1].table_id);
+                assert_eq!(1, res[0].ident.table_id);
+                assert_eq!(2, res[1].ident.table_id);
             }
         }
 

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -115,8 +115,7 @@ impl MetaApi for MetaEmbedded {
         tracing::info!("create table: {:}: {:?}", &db_name, &table_name);
 
         let table = TableInfo {
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
             desc: format!("'{}'.'{}'", db_name, table_name),
             name: table_name.to_string(),
             meta: TableMeta {
@@ -150,7 +149,7 @@ impl MetaApi for MetaEmbedded {
             )))
         } else {
             Ok(CreateTableReply {
-                table_id: result.unwrap().data.table_id,
+                table_id: result.unwrap().data.ident.table_id,
             })
         }
     }

--- a/common/meta/raft-store/src/state_machine/sm.rs
+++ b/common/meta/raft-store/src/state_machine/sm.rs
@@ -372,9 +372,9 @@ impl StateMachine {
                 }
 
                 let mut table = table.clone();
-                table.table_id = self.incr_seq(SEQ_TABLE_ID).await?;
+                table.ident.table_id = self.incr_seq(SEQ_TABLE_ID).await?;
 
-                let table_id = table.table_id;
+                let table_id = table.ident.table_id;
 
                 self.sub_tree_upsert(
                     table_lookup_tree,
@@ -636,7 +636,7 @@ impl StateMachine {
         seq: &MatchSeq,
     ) -> Result<Option<SeqV<TableInfo>>, ErrorCode> {
         let tables = self.tables();
-        let table_id = tbl.table_id;
+        let table_id = tbl.ident.table_id;
         let (_prev, result) = self
             .sub_tree_upsert(tables, &table_id, seq, Operation::Update(tbl), None)
             .await?;

--- a/common/meta/types/src/lib.rs
+++ b/common/meta/types/src/lib.rs
@@ -40,6 +40,7 @@ pub use raft_types::LogId;
 pub use raft_types::LogIndex;
 pub use raft_types::NodeId;
 pub use raft_types::Term;
+pub use table_info::TableIdent;
 pub use table_info::TableInfo;
 pub use table_info::TableMeta;
 pub use table_reply::CreateTableReply;

--- a/common/meta/types/src/table_info.rs
+++ b/common/meta/types/src/table_info.rs
@@ -22,8 +22,10 @@ use common_datavalues::DataSchema;
 
 use crate::MetaVersion;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct TableInfo {
+/// Globally unique identifier of a version of TableMeta.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct TableIdent {
+    /// Globally unique id to identify a table.
     pub table_id: u64,
 
     /// version of this table snapshot.
@@ -35,6 +37,23 @@ pub struct TableInfo {
     /// A version is not guaranteed to be consecutive.
     ///
     pub version: MetaVersion,
+}
+
+impl TableIdent {
+    pub fn new(table_id: u64, version: MetaVersion) -> Self {
+        TableIdent { table_id, version }
+    }
+}
+
+impl Display for TableIdent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "id:{}, ver:{}", self.table_id, self.version)
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct TableInfo {
+    pub ident: TableIdent,
 
     pub desc: String,
     pub name: String,
@@ -98,24 +117,12 @@ impl Default for TableMeta {
     }
 }
 
-impl Default for TableInfo {
-    fn default() -> Self {
-        TableInfo {
-            table_id: 0,
-            version: 0,
-            desc: "".to_string(),
-            name: "".to_string(),
-            meta: Default::default(),
-        }
-    }
-}
-
 impl Display for TableInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "DB.Table: {}, Table: {}-{}, Version: {}, Engine: {}",
-            self.desc, self.name, self.table_id, self.version, self.meta.engine
+            "DB.Table: {}, Table: {}-{}, Engine: {}",
+            self.desc, self.name, self.ident, self.meta.engine
         )
     }
 }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -149,8 +149,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
         info!("create table: {:}: {:?}", &db_name, &table_name);
 
         let table = TableInfo {
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
             desc: format!("'{}'.'{}'", db_name, table_name),
             name: table_name.to_string(),
             meta: TableMeta {
@@ -187,7 +186,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
         }
 
         Ok(CreateTableReply {
-            table_id: result.unwrap().data.table_id,
+            table_id: result.unwrap().data.ident.table_id,
         })
     }
 }

--- a/metasrv/src/meta_service/raftmeta.rs
+++ b/metasrv/src/meta_service/raftmeta.rs
@@ -1047,14 +1047,14 @@ impl MetaNode {
         if let Some(tbl) = seq_table {
             let seq = tbl.seq;
             let mut tbl = tbl.data;
-            if tbl.version != table_version {
+            if tbl.ident.version != table_version {
                 Err(ErrorCode::TableVersionMissMatch(format!(
                     "targeting version {}, current version {}",
-                    table_version, tbl.version,
+                    table_version, tbl.ident.version,
                 )))
             } else {
                 tbl.meta.options.insert(opt_key, opt_value);
-                tbl.version += 1;
+                tbl.ident.version += 1;
                 sm.upsert_table(tbl, &MatchSeq::Exact(seq)).await?;
                 Ok(())
             }

--- a/query/src/catalogs/backends/impls/meta_cached.rs
+++ b/query/src/catalogs/backends/impls/meta_cached.rs
@@ -96,7 +96,7 @@ impl MetaApi for MetaCached {
 
         let mut cache = self.table_meta_cache.write().await;
         // TODO version
-        cache.put((reply.table_id, 0), reply.clone());
+        cache.put((reply.ident.table_id, 0), reply.clone());
         Ok(reply)
     }
 

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -154,7 +154,7 @@ impl Catalog for SystemCatalog {
     }
 
     fn build_table(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
-        let table_id = table_info.table_id;
+        let table_id = table_info.ident.table_id;
 
         let table =
             self.sys_db_meta.id_to_table.get(&table_id).ok_or_else(|| {

--- a/query/src/catalogs/table.rs
+++ b/query/src/catalogs/table.rs
@@ -46,7 +46,7 @@ pub trait Table: Sync + Send {
     }
 
     fn get_id(&self) -> MetaId {
-        self.get_table_info().table_id
+        self.get_table_info().ident.table_id
     }
 
     fn is_local(&self) -> bool {

--- a/query/src/datasources/database/example/example_table.rs
+++ b/query/src/datasources/database/example/example_table.rs
@@ -19,6 +19,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::InsertIntoPlan;
@@ -44,8 +45,7 @@ impl ExampleTable {
         table_id: u64,
     ) -> Result<Box<dyn Table>> {
         let table_info = TableInfo {
-            table_id,
-            version: 0,
+            ident: TableIdent::new(table_id, 0),
             desc: format!("'{}'.'{}'", db, name),
             name,
 

--- a/query/src/datasources/database/system/clusters_table.rs
+++ b/query/src/datasources/database/system/clusters_table.rs
@@ -20,6 +20,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -43,13 +44,12 @@ impl ClustersTable {
         let table_info = TableInfo {
             desc: "'system'.'clusters'".to_string(),
             name: "clusters".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemClusters".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         ClustersTable { table_info }

--- a/query/src/datasources/database/system/configs_table.rs
+++ b/query/src/datasources/database/system/configs_table.rs
@@ -20,6 +20,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -46,13 +47,12 @@ impl ConfigsTable {
         let table_info = TableInfo {
             desc: "'system'.'configs'".to_string(),
             name: "configs".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemConfigs".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
         ConfigsTable { table_info }
     }

--- a/query/src/datasources/database/system/contributors_table.rs
+++ b/query/src/datasources/database/system/contributors_table.rs
@@ -19,6 +19,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -39,14 +40,12 @@ impl ContributorsTable {
         let table_info = TableInfo {
             desc: "'system'.'contributors'".to_string(),
             name: "contributors".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemContributors".to_string(),
                 ..Default::default()
             },
-
-            ..Default::default()
         };
         ContributorsTable { table_info }
     }

--- a/query/src/datasources/database/system/credits_table.rs
+++ b/query/src/datasources/database/system/credits_table.rs
@@ -19,6 +19,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -42,14 +43,12 @@ impl CreditsTable {
         let table_info = TableInfo {
             desc: "'system'.'credits'".to_string(),
             name: "credits".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemCredits".to_string(),
                 ..Default::default()
             },
-
-            ..Default::default()
         };
         CreditsTable { table_info }
     }

--- a/query/src/datasources/database/system/databases_table.rs
+++ b/query/src/datasources/database/system/databases_table.rs
@@ -20,6 +20,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -42,13 +43,12 @@ impl DatabasesTable {
         let table_info = TableInfo {
             desc: "'system'.'databases'".to_string(),
             name: "databases".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemDatabases".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         DatabasesTable { table_info }

--- a/query/src/datasources/database/system/functions_table.rs
+++ b/query/src/datasources/database/system/functions_table.rs
@@ -21,6 +21,7 @@ use common_datavalues::prelude::*;
 use common_exception::Result;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_functions::scalars::FunctionFactory;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -43,14 +44,13 @@ impl FunctionsTable {
         let table_info = TableInfo {
             desc: "'system'.'functions'".to_string(),
             name: "functions".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemFunctions".to_string(),
 
                 ..Default::default()
             },
-            ..Default::default()
         };
         FunctionsTable { table_info }
     }

--- a/query/src/datasources/database/system/metrics_table.rs
+++ b/query/src/datasources/database/system/metrics_table.rs
@@ -25,6 +25,7 @@ use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_metrics::MetricValue;
@@ -51,13 +52,12 @@ impl MetricsTable {
         let table_info = TableInfo {
             desc: "'system'.'metrics'".to_string(),
             name: "metrics".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemMetrics".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         MetricsTable { table_info }

--- a/query/src/datasources/database/system/one_table.rs
+++ b/query/src/datasources/database/system/one_table.rs
@@ -19,6 +19,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::Extras;
@@ -43,13 +44,12 @@ impl OneTable {
         let table_info = TableInfo {
             desc: "'system'.'one'".to_string(),
             name: "one".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemOne".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
         OneTable { table_info }
     }

--- a/query/src/datasources/database/system/processes_table.rs
+++ b/query/src/datasources/database/system/processes_table.rs
@@ -24,6 +24,7 @@ use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -53,14 +54,13 @@ impl ProcessesTable {
         let table_info = TableInfo {
             desc: "'system'.'processes'".to_string(),
             name: "processes".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemProcesses".to_string(),
 
                 ..Default::default()
             },
-            ..Default::default()
         };
         ProcessesTable { table_info }
     }

--- a/query/src/datasources/database/system/settings_table.rs
+++ b/query/src/datasources/database/system/settings_table.rs
@@ -20,6 +20,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -45,14 +46,13 @@ impl SettingsTable {
         let table_info = TableInfo {
             desc: "'system'.'settings'".to_string(),
             name: "settings".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemSettings".to_string(),
 
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         SettingsTable { table_info }

--- a/query/src/datasources/database/system/tables_table.rs
+++ b/query/src/datasources/database/system/tables_table.rs
@@ -20,6 +20,7 @@ use common_context::TableIOContext;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -45,14 +46,13 @@ impl TablesTable {
         let table_info = TableInfo {
             desc: "'system'.'tables'".to_string(),
             name: "tables".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemTables".to_string(),
 
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         TablesTable { table_info }

--- a/query/src/datasources/database/system/tracing_table.rs
+++ b/query/src/datasources/database/system/tracing_table.rs
@@ -22,6 +22,7 @@ use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::ReadDataSourcePlan;
@@ -54,13 +55,12 @@ impl TracingTable {
         let table_info = TableInfo {
             desc: "'system'.'tracing'".to_string(),
             name: "tracing".to_string(),
-            table_id,
+            ident: TableIdent::new(table_id, 0),
             meta: TableMeta {
                 schema,
                 engine: "SystemTracing".to_string(),
                 ..Default::default()
             },
-            ..Default::default()
         };
 
         TracingTable { table_info }

--- a/query/src/datasources/table/csv/csv_table_test.rs
+++ b/query/src/datasources/table/csv/csv_table_test.rs
@@ -47,8 +47,7 @@ async fn test_csv_table() -> Result<()> {
         TableInfo {
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
             meta: TableMeta {
                 schema: DataSchemaRefExt::create(vec![DataField::new(
                     "column1",
@@ -126,8 +125,7 @@ async fn test_csv_table_parse_error() -> Result<()> {
         TableInfo {
             desc: "'default'.'test_csv'".into(),
             name: "test_csv".into(),
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
             meta: TableMeta {
                 schema: DataSchemaRefExt::create(vec![
                     DataField::new("column1", DataType::UInt64, false),

--- a/query/src/datasources/table/fuse/table_do_append.rs
+++ b/query/src/datasources/table/fuse/table_do_append.rs
@@ -83,7 +83,12 @@ impl FuseTable {
 
             // 5. commit
             let table_id = insert_plan.tbl_id;
-            commit(&io_ctx, table_id, self.table_info.version, snapshot_loc)?;
+            commit(
+                &io_ctx,
+                table_id,
+                self.table_info.ident.version,
+                snapshot_loc,
+            )?;
         }
         Ok(())
     }

--- a/query/src/datasources/table/fuse/table_do_truncate.rs
+++ b/query/src/datasources/table/fuse/table_do_truncate.rs
@@ -56,7 +56,7 @@ impl FuseTable {
             // TODO backoff retry
             catalog.upsert_table_option(
                 table_id,
-                self.table_info.version,
+                self.table_info.ident.version,
                 TBL_OPT_KEY_SNAPSHOT_LOC.to_string(),
                 new_snapshot_loc,
             )?

--- a/query/src/datasources/table/fuse/table_test.rs
+++ b/query/src/datasources/table/fuse/table_test.rs
@@ -48,12 +48,12 @@ async fn test_fuse_table_simple_case() -> Result<()> {
     table.append_data(io_ctx.clone(), insert_into_plan).await?;
 
     // get the latest tbl
-    let prev_version = table.get_table_info().version;
+    let prev_version = table.get_table_info().ident.version;
     let table = catalog.get_table(
         fixture.default_db().as_str(),
         fixture.default_table().as_str(),
     )?;
-    assert_ne!(prev_version, table.get_table_info().version);
+    assert_ne!(prev_version, table.get_table_info().ident.version);
 
     let (stats, parts) = table.read_partitions(io_ctx.clone(), None, None)?;
     assert_eq!(parts.len(), num_blocks as usize);
@@ -125,14 +125,14 @@ async fn test_fuse_table_truncate() -> Result<()> {
     };
 
     // 1. truncate empty table
-    let prev_version = table.get_table_info().version;
+    let prev_version = table.get_table_info().ident.version;
     let r = table.truncate(io_ctx.clone(), truncate_plan.clone()).await;
     let table = catalog.get_table(
         fixture.default_db().as_str(),
         fixture.default_table().as_str(),
     )?;
     // no side effects
-    assert_eq!(prev_version, table.get_table_info().version);
+    assert_eq!(prev_version, table.get_table_info().ident.version);
     assert!(r.is_ok());
 
     // 2. truncate table which has data
@@ -145,12 +145,12 @@ async fn test_fuse_table_truncate() -> Result<()> {
     )?;
 
     // get the latest tbl
-    let prev_version = table.get_table_info().version;
+    let prev_version = table.get_table_info().ident.version;
     let table = catalog.get_table(
         fixture.default_db().as_str(),
         fixture.default_table().as_str(),
     )?;
-    assert_ne!(prev_version, table.get_table_info().version);
+    assert_ne!(prev_version, table.get_table_info().ident.version);
 
     // ensure data ingested
     let (stats, parts) =
@@ -163,12 +163,12 @@ async fn test_fuse_table_truncate() -> Result<()> {
     assert!(r.is_ok());
 
     // get the latest tbl
-    let prev_version = table.get_table_info().version;
+    let prev_version = table.get_table_info().ident.version;
     let table = catalog.get_table(
         fixture.default_db().as_str(),
         fixture.default_table().as_str(),
     )?;
-    assert_ne!(prev_version, table.get_table_info().version);
+    assert_ne!(prev_version, table.get_table_info().ident.version);
     let (stats, parts) =
         table.read_partitions(io_ctx.clone(), source_plan.push_downs.clone(), None)?;
     // cleared?

--- a/query/src/datasources/table/memory/memory_table.rs
+++ b/query/src/datasources/table/memory/memory_table.rs
@@ -55,7 +55,7 @@ impl MemoryTable {
         table_info: TableInfo,
         data_ctx: Arc<dyn DataContext<u64>>,
     ) -> Result<Box<dyn Table>> {
-        let table_id = &table_info.table_id;
+        let table_id = &table_info.ident.table_id;
         let in_memory_data = data_ctx.get_in_memory_data()?;
 
         let blocks = {

--- a/query/src/datasources/table/memory/memory_table_test.rs
+++ b/query/src/datasources/table/memory/memory_table_test.rs
@@ -41,8 +41,7 @@ async fn test_memorytable() -> Result<()> {
         TableInfo {
             desc: "'default'.'a'".into(),
             name: "a".into(),
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
             meta: TableMeta {
                 schema: schema.clone(),
                 engine: "Memory".to_string(),

--- a/query/src/datasources/table/null/null_table_test.rs
+++ b/query/src/datasources/table/null/null_table_test.rs
@@ -41,8 +41,7 @@ async fn test_null_table() -> Result<()> {
         TableInfo {
             desc: "'default'.'a'".into(),
             name: "a".into(),
-            table_id: 0,
-            version: 0,
+            ident: Default::default(),
 
             meta: TableMeta {
                 schema: DataSchemaRefExt::create(vec![DataField::new(

--- a/query/src/datasources/table/parquet/parquet_table_test.rs
+++ b/query/src/datasources/table/parquet/parquet_table_test.rs
@@ -44,8 +44,7 @@ async fn test_parquet_table() -> Result<()> {
     let ctx = crate::tests::try_create_context()?;
     let table_info = TableInfo {
         desc: "'default'.'test_parquet_table'".to_string(),
-        table_id: 0,
-        version: 0,
+        ident: Default::default(),
         name: "test_parquet".to_string(),
 
         meta: TableMeta {

--- a/query/src/datasources/table_func/numbers_table.rs
+++ b/query/src/datasources/table_func/numbers_table.rs
@@ -25,6 +25,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
 use common_meta_types::TableMeta;
 use common_planners::Expression;
@@ -78,8 +79,7 @@ impl NumbersTable {
         };
 
         let table_info = TableInfo {
-            table_id,
-            version: 0,
+            ident: TableIdent::new(table_id, 0),
             desc: format!("'{}'.'{}'", database_name, table_func_name),
             name: table_func_name.to_string(),
             meta: TableMeta {

--- a/query/src/optimizers/optimizer_statistics_exact.rs
+++ b/query/src/optimizers/optimizer_statistics_exact.rs
@@ -64,7 +64,7 @@ impl PlanRewriter for StatisticsExactImpl<'_> {
                     let dummy_read_plan =
                         self.ctx.get_table(db_name, table_name).and_then(|table| {
                             let table_id = table.get_id();
-                            let table_version = Some(table.get_table_info().version);
+                            let table_version = Some(table.get_table_info().ident.version);
 
                             let tbl_scan_info = TableScanInfo {
                                 table_name,

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -706,7 +706,7 @@ impl PlanParser {
 
         self.ctx.get_table(db_name, table_name).and_then(|table| {
             let table_id = table.get_id();
-            let table_version = Some(table.get_table_info().version);
+            let table_version = Some(table.get_table_info().ident.version);
 
             let tbl_scan_info = TableScanInfo {
                 table_name,
@@ -780,13 +780,13 @@ impl PlanParser {
 
                     let table_func = self.ctx.get_table_function(&table_name, Some(table_args))?;
                     meta_id = table_func.get_id();
-                    meta_version = table_func.get_table_info().version;
+                    meta_version = table_func.get_table_info().ident.version;
                     table_name = table_func.name().to_string();
                     table = table_func.as_table();
                 } else {
                     table = self.ctx.get_table(&db_name, &table_name)?;
                     meta_id = table.get_id();
-                    meta_version = table.get_table_info().version;
+                    meta_version = table.get_table_info().ident.version;
                 }
 
                 let scan = {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/types] refactor: wrap table_id and version into TableIdent

## Changelog




- Improvement


## Related Issues

- #2030