### PR TITLE
fix the typo about upsert in meta_api_test_suite

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -274,7 +274,7 @@ impl MetaApiTestSuite {
                 assert_eq!(want, got.as_ref().clone(), "get old table");
             }
 
-            tracing::info!("--- update table options with key1=val1");
+            tracing::info!("--- upsert table options with key1=val1");
             {
                 let table = mt.get_table("db1", "tb2").await.unwrap();
                 let got = mt


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

This pr fix a typo in the meta_api_test_suite which introduced in #2489 >.<

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #2489

## Test Plan

Unit Tests

Stateless Tests

