### PR TITLE
[common/meta/types] refator: add TableMeta for CreateTablePlan

### DIFF
--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -198,9 +198,11 @@ impl MetaApiTestSuite {
                 if_not_exists: false,
                 db: db_name.to_string(),
                 table: tbl_name.to_string(),
-                schema: schema.clone(),
-                options: options.clone(),
-                engine: "JSON".to_string(),
+                table_meta: TableMeta {
+                    schema: schema.clone(),
+                    engine: "JSON".to_string(),
+                    options: options.clone(),
+                },
             };
 
             {
@@ -371,9 +373,11 @@ impl MetaApiTestSuite {
                 if_not_exists: false,
                 db: db_name.to_string(),
                 table: "tb1".to_string(),
-                schema: schema.clone(),
-                options: options.clone(),
-                engine: "JSON".to_string(),
+                table_meta: TableMeta {
+                    schema: schema.clone(),
+                    engine: "JSON".to_string(),
+                    options: options.clone(),
+                },
             };
 
             {

--- a/common/meta/embedded/src/meta_api_impl.rs
+++ b/common/meta/embedded/src/meta_api_impl.rs
@@ -27,7 +27,6 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
-use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -119,11 +118,7 @@ impl MetaApi for MetaEmbedded {
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
             name: table_name.to_string(),
-            meta: TableMeta {
-                schema: plan.schema.clone(),
-                engine: plan.engine.clone(),
-                options: plan.options.clone(),
-            },
+            meta: plan.table_meta,
         };
 
         let cr = Cmd::CreateTable {

--- a/common/planners/src/plan_display_indent.rs
+++ b/common/planners/src/plan_display_indent.rs
@@ -227,11 +227,11 @@ impl<'a> PlanNodeIndentFormatDisplay<'a> {
 
     fn format_create_table(f: &mut Formatter, plan: &CreateTablePlan) -> fmt::Result {
         write!(f, "Create table {:}.{:}", plan.db, plan.table)?;
-        write!(f, " {:},", plan.schema)?;
+        write!(f, " {:},", plan.schema())?;
         // need engine to impl Display
-        write!(f, " engine: {},", plan.engine.to_string())?;
+        write!(f, " engine: {},", plan.engine().to_string())?;
         write!(f, " if_not_exists:{:},", plan.if_not_exists)?;
-        write!(f, " option: {:?}", plan.options)
+        write!(f, " option: {:?}", plan.options())
     }
 
     fn format_drop_table(f: &mut Formatter, plan: &DropTablePlan) -> fmt::Result {

--- a/common/planners/src/plan_display_test.rs
+++ b/common/planners/src/plan_display_test.rs
@@ -18,6 +18,7 @@ use common_datavalues::DataField;
 use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
+use common_meta_types::TableMeta;
 
 use crate::*;
 
@@ -35,9 +36,11 @@ fn test_plan_display_indent() -> Result<()> {
         if_not_exists: true,
         db: "foo".into(),
         table: "bar".into(),
-        schema,
-        engine: "JSON".to_string(),
-        options,
+        table_meta: TableMeta {
+            schema,
+            engine: "JSON".to_string(),
+            options,
+        },
     });
 
     assert_eq!(

--- a/common/planners/src/plan_table_create.rs
+++ b/common/planners/src/plan_table_create.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use common_datavalues::DataSchemaRef;
+use common_meta_types::TableMeta;
 
 pub type TableOptions = HashMap<String, String>;
 
@@ -24,15 +25,20 @@ pub struct CreateTablePlan {
     pub db: String,
     /// The table name
     pub table: String,
-    /// The table schema
-    pub schema: DataSchemaRef,
-    /// The file type of physical file
-    pub engine: String,
-    pub options: TableOptions,
+
+    pub table_meta: TableMeta,
 }
 
 impl CreateTablePlan {
     pub fn schema(&self) -> DataSchemaRef {
-        self.schema.clone()
+        self.table_meta.schema.clone()
+    }
+
+    pub fn options(&self) -> &HashMap<String, String> {
+        &self.table_meta.options
+    }
+
+    pub fn engine(&self) -> &str {
+        &self.table_meta.engine
     }
 }

--- a/metasrv/src/executor/meta_handlers.rs
+++ b/metasrv/src/executor/meta_handlers.rs
@@ -36,7 +36,6 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::LogEntry;
 use common_meta_types::TableInfo;
-use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use log::info;
 
@@ -153,11 +152,7 @@ impl RequestHandler<CreateTableAction> for ActionHandler {
             version: 0,
             desc: format!("'{}'.'{}'", db_name, table_name),
             name: table_name.to_string(),
-            meta: TableMeta {
-                schema: plan.schema.clone(),
-                engine: plan.engine.clone(),
-                options: plan.options.clone(),
-            },
+            meta: plan.table_meta,
         };
 
         let cr = LogEntry {

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -24,7 +24,6 @@ use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableInfo;
-use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -171,11 +170,7 @@ impl MetaApiSync for MetaEmbeddedSync {
             table_id: self.next_db_id(),
             version: 0,
             name: plan.table,
-            meta: TableMeta {
-                schema: plan.schema,
-                options: plan.options,
-                engine: plan.engine,
-            },
+            meta: plan.table_meta,
         };
 
         let mut lock = self.databases.write();

--- a/query/src/datasources/table/fuse/index/min_max_test.rs
+++ b/query/src/datasources/table/fuse/index/min_max_test.rs
@@ -26,6 +26,7 @@ use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_exception::Result;
 use common_infallible::Mutex;
+use common_meta_types::TableMeta;
 use common_planners::col;
 use common_planners::lit;
 use common_planners::CreateTablePlan;
@@ -54,9 +55,11 @@ async fn test_min_max_index() -> Result<()> {
         if_not_exists: false,
         db: fixture.default_db(),
         table: test_tbl_name.to_string(),
-        schema: test_schema.clone(),
-        engine: "FUSE".to_string(),
-        options: Default::default(),
+        table_meta: TableMeta {
+            schema: test_schema.clone(),
+            engine: "FUSE".to_string(),
+            options: Default::default(),
+        },
     };
 
     let catalog = ctx.get_catalog();

--- a/query/src/datasources/table/fuse/table_test_fixture.rs
+++ b/query/src/datasources/table/fuse/table_test_fixture.rs
@@ -23,6 +23,7 @@ use common_datavalues::DataSchemaRef;
 use common_datavalues::DataSchemaRefExt;
 use common_datavalues::DataType;
 use common_infallible::Mutex;
+use common_meta_types::TableMeta;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::InsertIntoPlan;
@@ -88,9 +89,11 @@ impl TestFixture {
             if_not_exists: false,
             db: self.default_db(),
             table: self.default_table(),
-            schema: TestFixture::default_schema(),
-            engine: "FUSE".to_string(),
-            options: Default::default(),
+            table_meta: TableMeta {
+                schema: TestFixture::default_schema(),
+                engine: "FUSE".to_string(),
+                options: Default::default(),
+            },
         }
     }
 

--- a/query/src/interpreters/interpreter_table_create.rs
+++ b/query/src/interpreters/interpreter_table_create.rs
@@ -49,7 +49,7 @@ impl Interpreter for CreateTableInterpreter {
         catalog.create_table(self.plan.clone())?;
 
         Ok(Box::pin(DataBlockStream::create(
-            self.plan.schema.clone(),
+            self.plan.schema(),
             None,
             vec![],
         )))

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -21,6 +21,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_functions::aggregates::AggregateFunctionFactory;
 use common_infallible::Mutex;
+use common_meta_types::TableMeta;
 use common_planners::expand_aggregate_arg_exprs;
 use common_planners::expand_wildcard;
 use common_planners::expr_as_column_expr;
@@ -321,9 +322,11 @@ impl PlanParser {
             if_not_exists: create.if_not_exists,
             db,
             table,
-            schema,
-            engine: create.engine.clone(),
-            options,
+            table_meta: TableMeta {
+                schema,
+                engine: create.engine.clone(),
+                options,
+            },
         }))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

Wrap schema,engine,options of CreateTablePlan into a field table_meta: TableMeta. 

## Changelog

- Improvement

## Related Issues

Fixes https://github.com/datafuselabs/databend/issues/2501

