### PR TITLE
[common/meta] feature: make table version work

### DIFF
--- a/common/meta/api/src/meta_api.rs
+++ b/common/meta/api/src/meta_api.rs
@@ -21,7 +21,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -50,7 +52,7 @@ pub trait MetaApi: Send + Sync {
 
     async fn get_tables(&self, db: &str) -> Result<Vec<Arc<TableInfo>>>;
 
-    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>>;
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)>;
 
     async fn upsert_table_option(
         &self,

--- a/common/meta/api/src/meta_api_test_suite.rs
+++ b/common/meta/api/src/meta_api_test_suite.rs
@@ -213,7 +213,7 @@ impl MetaApiTestSuite {
                 let got = mt.get_table(db_name, tbl_name).await?;
 
                 let want = TableInfo {
-                    ident: TableIdent::new(1, 0),
+                    ident: TableIdent::new(1, 1),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {
@@ -233,7 +233,7 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table(db_name, tbl_name).await?;
                 let want = TableInfo {
-                    ident: TableIdent::new(1, 0),
+                    ident: TableIdent::new(1, 1),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {
@@ -262,7 +262,7 @@ impl MetaApiTestSuite {
 
                 let got = mt.get_table("db1", "tb2").await.unwrap();
                 let want = TableInfo {
-                    ident: TableIdent::new(1, 0),
+                    ident: TableIdent::new(1, 1),
                     desc: format!("'{}'.'{}'", db_name, tbl_name),
                     name: tbl_name.into(),
                     meta: TableMeta {

--- a/common/meta/flight/src/impls/meta_api_impl.rs
+++ b/common/meta/flight/src/impls/meta_api_impl.rs
@@ -21,7 +21,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -96,9 +98,12 @@ impl MetaApi for MetaFlightClient {
         self.do_action(GetTablesAction { db: db.to_string() }).await
     }
 
-    async fn get_table_by_id(&self, tbl_id: MetaId) -> common_exception::Result<Arc<TableInfo>> {
-        let x = self.do_action(GetTableExtReq { tbl_id }).await?;
-        Ok(Arc::new(x))
+    async fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+    ) -> common_exception::Result<(TableIdent, Arc<TableMeta>)> {
+        let x = self.do_action(GetTableExtReq { tbl_id: table_id }).await?;
+        Ok((x.ident, Arc::new(x.meta)))
     }
 
     async fn upsert_table_option(

--- a/common/meta/raft-store/src/sled_key_spaces.rs
+++ b/common/meta/raft-store/src/sled_key_spaces.rs
@@ -21,7 +21,7 @@ use common_meta_types::LogIndex;
 use common_meta_types::Node;
 use common_meta_types::NodeId;
 use common_meta_types::SeqV;
-use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 
 use crate::state::RaftStateKey;
 use crate::state::RaftStateValue;
@@ -106,7 +106,7 @@ impl SledKeySpace for Tables {
     const PREFIX: u8 = 9;
     const NAME: &'static str = "tables";
     type K = u64;
-    type V = SeqV<TableInfo>;
+    type V = SeqV<TableMeta>;
 }
 
 pub struct ClientLastResps {}

--- a/common/meta/types/src/cmd.rs
+++ b/common/meta/types/src/cmd.rs
@@ -23,7 +23,7 @@ use crate::KVMeta;
 use crate::MatchSeq;
 use crate::Node;
 use crate::Operation;
-use crate::TableInfo;
+use crate::TableMeta;
 
 /// A Cmd describes what a user want to do to raft state machine
 /// and is the essential part of a raft log.
@@ -46,7 +46,7 @@ pub enum Cmd {
     CreateTable {
         db_name: String,
         table_name: String,
-        table_info: TableInfo,
+        table_meta: TableMeta,
     },
 
     /// Drop a table if absent
@@ -88,9 +88,9 @@ impl fmt::Display for Cmd {
             Cmd::CreateTable {
                 db_name,
                 table_name,
-                table_info: table,
+                table_meta,
             } => {
-                write!(f, "create_table:{}-{}={}", db_name, table_name, table)
+                write!(f, "create_table:{}-{}={}", db_name, table_name, table_meta)
             }
             Cmd::DropTable {
                 db_name,

--- a/common/meta/types/src/table_info.rs
+++ b/common/meta/types/src/table_info.rs
@@ -89,6 +89,15 @@ impl TableInfo {
         }
     }
 
+    pub fn new(db_name: &str, table_name: &str, ident: TableIdent, meta: TableMeta) -> TableInfo {
+        TableInfo {
+            ident,
+            desc: format!("'{}'.'{}'", db_name, table_name),
+            name: table_name.to_string(),
+            meta,
+        }
+    }
+
     pub fn schema(&self) -> Arc<DataSchema> {
         self.meta.schema.clone()
     }
@@ -114,6 +123,16 @@ impl Default for TableMeta {
             engine: "".to_string(),
             options: HashMap::new(),
         }
+    }
+}
+
+impl Display for TableMeta {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Engine: {}, Schema: {}, Options: {:?}",
+            self.engine, self.schema, self.options
+        )
     }
 }
 

--- a/query/src/catalogs/backends/backend.rs
+++ b/query/src/catalogs/backends/backend.rs
@@ -21,7 +21,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -49,7 +51,7 @@ pub trait MetaApiSync: Send + Sync {
 
     fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<TableInfo>>>;
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>>;
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)>;
 
     fn upsert_table_option(
         &self,

--- a/query/src/catalogs/backends/impls/embedded_backend.rs
+++ b/query/src/catalogs/backends/impls/embedded_backend.rs
@@ -25,6 +25,7 @@ use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
 use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -290,7 +291,10 @@ impl MetaApiSync for MetaEmbeddedSync {
         Ok(res)
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> common_exception::Result<Arc<TableInfo>> {
+    fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+    ) -> common_exception::Result<(TableIdent, Arc<TableMeta>)> {
         let map = self.databases.read();
         for (_, tbl_idx) in map.values() {
             match tbl_idx.id2meta.get(&table_id) {
@@ -298,7 +302,7 @@ impl MetaApiSync for MetaEmbeddedSync {
                     continue;
                 }
                 Some(tbl) => {
-                    return Ok(tbl.clone());
+                    return Ok((tbl.ident.clone(), Arc::new(tbl.meta.clone())));
                 }
             }
         }

--- a/query/src/catalogs/backends/impls/meta_remote.rs
+++ b/query/src/catalogs/backends/impls/meta_remote.rs
@@ -23,7 +23,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -114,7 +116,7 @@ impl MetaApi for MetaRemote {
             .await
     }
 
-    async fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+    async fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
         self.query_backend(move |cli| async move { cli.get_table_by_id(table_id).await })
             .await
     }

--- a/query/src/catalogs/backends/impls/meta_sync.rs
+++ b/query/src/catalogs/backends/impls/meta_sync.rs
@@ -24,7 +24,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -98,7 +100,7 @@ impl MetaApiSync for MetaSync {
         (async move { x.get_tables(&db_name).await }).wait_in(&self.rt, self.timeout)?
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
         let x = self.inner.clone();
         (async move { x.get_table_by_id(table_id).await }).wait_in(&self.rt, self.timeout)?
     }

--- a/query/src/catalogs/backends/impls/remote_backend.rs
+++ b/query/src/catalogs/backends/impls/remote_backend.rs
@@ -23,7 +23,9 @@ use common_meta_types::CreateTableReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -105,7 +107,7 @@ impl<T: MetaApiSync, U: Deref<Target = T> + Send + Sync> MetaApiSync for U {
         self.deref().get_tables(db_name)
     }
 
-    fn get_table_by_id(&self, table_id: MetaId) -> Result<Arc<TableInfo>> {
+    fn get_table_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
         self.deref().get_table_by_id(table_id)
     }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta] feature: make table version work
- Use `seq` as table version. Do not store it in TableInfo any more.
  Previously version is stored but never really used.
  `seq` increment every time a table is updated, thus it is naturally
  the version of a table.

- `MetaApi::get_table_by_id()` and the corresponding sync-mode api no
  longer returns a `TableInfo` but just `id, version, TableMeta`(TableMeta is a field
  of TableInfo).

  Because there are volatile info in `TableInfo` such as table-name and
  `desc`, which are indeterminate for the same table-id.

- API for fetching a table by `db_name, table_name` still
  returns a `TableInfo`, such as `MetaApi::get_table(db, table)`.

  But the other info besides `TableMeta` in the returned `TableInfo` are
  just collected from the input arguments. `:(((`

- fix: #2508

## Changelog

- New Feature





## Related Issues

- #2030