### PR TITLE
[query] feature: add Catalog::get_table_meta_by_id()

### DIFF
--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -18,7 +18,9 @@ use common_exception::Result;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -46,6 +48,8 @@ pub trait Catalog {
     fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn Table>>;
 
     fn get_tables(&self, db_name: &str) -> Result<Vec<Arc<dyn Table>>>;
+
+    fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)>;
 
     fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
 

--- a/query/src/catalogs/impls/catalog/metastore_catalog.rs
+++ b/query/src/catalogs/impls/catalog/metastore_catalog.rs
@@ -25,7 +25,9 @@ use common_meta_types::CreateDatabaseReply;
 use common_meta_types::DatabaseInfo;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -144,6 +146,10 @@ impl Catalog for MetaStoreCatalog {
             acc.push(tbl);
             Ok(acc)
         })
+    }
+
+    fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
+        self.meta.get_table_by_id(table_id)
     }
 
     fn upsert_table_option(

--- a/query/src/catalogs/impls/catalog/overlaid_catalog.rs
+++ b/query/src/catalogs/impls/catalog/overlaid_catalog.rs
@@ -20,7 +20,9 @@ use common_exception::ErrorCode;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -114,6 +116,15 @@ impl Catalog for OverlaidCatalog {
                 }
             }
         }
+    }
+
+    fn get_table_meta_by_id(
+        &self,
+        table_id: MetaId,
+    ) -> common_exception::Result<(TableIdent, Arc<TableMeta>)> {
+        self.read_only
+            .get_table_meta_by_id(table_id)
+            .or_else(|_e| self.bottom.get_table_meta_by_id(table_id))
     }
 
     fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()> {

--- a/query/src/catalogs/impls/catalog/system_catalog.rs
+++ b/query/src/catalogs/impls/catalog/system_catalog.rs
@@ -20,7 +20,9 @@ use common_exception::Result;
 use common_meta_types::CreateDatabaseReply;
 use common_meta_types::MetaId;
 use common_meta_types::MetaVersion;
+use common_meta_types::TableIdent;
 use common_meta_types::TableInfo;
+use common_meta_types::TableMeta;
 use common_meta_types::UpsertTableOptionReply;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
@@ -122,6 +124,15 @@ impl Catalog for SystemCatalog {
         let _db = self.get_database(db_name)?;
 
         Ok(self.sys_db_meta.name_to_table.values().cloned().collect())
+    }
+
+    fn get_table_meta_by_id(&self, table_id: MetaId) -> Result<(TableIdent, Arc<TableMeta>)> {
+        let table =
+            self.sys_db_meta.id_to_table.get(&table_id).ok_or_else(|| {
+                ErrorCode::UnknownTable(format!("Unknown table id: '{}'", table_id))
+            })?;
+        let ti = table.get_table_info();
+        Ok((ti.ident.clone(), Arc::new(ti.meta.clone())))
     }
 
     fn upsert_table_option(


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [query] feature: add Catalog::get_table_meta_by_id()
This func is meant to be used by the table-commit operation.
E.g. upsert-table.

In a CAS loop when trying to commit a table change, it only needs to
re-fetch the `TableMeta` but not a `dyn Table`.

## Changelog

- New Feature





## Related Issues

- #2030