### PR TITLE
[common/meta/raft-store] feature: add Cmd::UpsertTableOptions

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -222,7 +222,8 @@ build_exceptions! {
 
     ConcurrentSnapshotInstall(2404),
     IllegalSnapshot(2405),
-    TableVersionMissMatch(2406),
+    UnknownTableId(2406),
+    TableVersionMissMatch(2407),
 
     // KVSrv server error
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

##### [common/meta/raft-store] feature: add Cmd::UpsertTableOptions
- Cmd::UpsertTableOptions add, delete or update a table option.
  It returns the TableMeta before and after the update.

- fix: #2520

## Changelog

- New Feature





## Related Issues

- #2030