### PR TITLE
fix roles is empty

### DIFF
--- a/query/src/users/auth/auth_mgr.rs
+++ b/query/src/users/auth/auth_mgr.rs
@@ -72,8 +72,10 @@ impl AuthMgr {
                     .unwrap_or_else(|| self.tenant.clone());
                 if let Some(ref ensure_user) = claims.extra.ensure_user {
                     let mut user_info = UserInfo::new(user_name, "%", AuthInfo::JWT);
-                    for role in ensure_user.roles.clone().into_iter() {
-                        user_info.grants.grant_role(role);
+                    if let Some(ref roles) = ensure_user.roles {
+                        for role in roles.clone().into_iter() {
+                            user_info.grants.grant_role(role);
+                        }
                     }
                     self.user_mgr.add_user(&tenant, user_info, true).await?;
                 }

--- a/query/src/users/auth/jwt/authenticator.rs
+++ b/query/src/users/auth/jwt/authenticator.rs
@@ -30,7 +30,7 @@ pub struct JwtAuthenticator {
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct EnsureUser {
-    pub roles: Vec<String>,
+    pub roles: Option<Vec<String>>,
 }
 
 #[derive(Default, Deserialize, Serialize)]

--- a/query/tests/it/users/auth/auth_mgr.rs
+++ b/query/tests/it/users/auth/auth_mgr.rs
@@ -130,7 +130,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
     // with create user again
     {
         let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
-            roles: vec!["role1".to_string()],
+            roles: Some(vec!["role1".to_string()]),
         });
         let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
             .with_subject(user_name.to_string());
@@ -145,7 +145,7 @@ async fn test_auth_mgr_with_jwt() -> Result<()> {
         let user_name = "test-user2";
         let role_name = "test-role";
         let custom_claims = CustomClaims::new().with_ensure_user(EnsureUser {
-            roles: vec![role_name.to_string()],
+            roles: Some(vec![role_name.to_string()]),
         });
         let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
             .with_subject(user_name.to_string());


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

roles may be empty in ensure_user.

## Changelog

- Improvement

## Related Issues

Fixes #issue

