### PR TITLE
[metasrv] refactor: use `async_entry::test` to replace tokio::test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-entry"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54fb3976c0d3c2730a4c0904061fb6b3d255e7e67a56939955ef8ce6aa4175f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1910,7 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
+ "async-entry",
  "async-trait",
  "clap 3.1.18",
  "common-arrow",

--- a/metasrv/Cargo.toml
+++ b/metasrv/Cargo.toml
@@ -63,6 +63,8 @@ tonic-reflection = "=0.4.0"
 
 [dev-dependencies]
 common-meta-api = { path = "../common/meta/api" }
+
+async-entry = "0.3.1"
 env_logger = "0.9.0"
 maplit = "1.0.2"
 pretty_assertions = "1.2.1"

--- a/metasrv/tests/it/api/http/cluster_state_test.rs
+++ b/metasrv/tests/it/api/http/cluster_state_test.rs
@@ -21,6 +21,7 @@ use std::string::String;
 use common_base::base::tokio;
 use common_base::base::Stoppable;
 use common_meta_types::Node;
+use common_tracing::tracing;
 use databend_meta::api::http::v1::cluster_state::nodes_handler;
 use databend_meta::api::http::v1::cluster_state::state_handler;
 use databend_meta::api::HttpService;
@@ -42,11 +43,8 @@ use crate::tests::tls_constants::TEST_CN_NAME;
 use crate::tests::tls_constants::TEST_SERVER_CERT;
 use crate::tests::tls_constants::TEST_SERVER_KEY;
 
-#[tokio::test]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_cluster_nodes() -> common_exception::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tc0 = MetaSrvTestContext::new(0);
     let mut tc1 = MetaSrvTestContext::new(1);
 
@@ -81,11 +79,8 @@ async fn test_cluster_nodes() -> common_exception::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_cluster_state() -> common_exception::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tc0 = MetaSrvTestContext::new(0);
     let mut tc1 = MetaSrvTestContext::new(1);
 
@@ -126,12 +121,9 @@ async fn test_cluster_state() -> common_exception::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_http_service_cluster_state() -> common_exception::Result<()> {
     let addr_str = "127.0.0.1:30003";
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
     let tc0 = MetaSrvTestContext::new(0);
     let mut tc1 = MetaSrvTestContext::new(1);

--- a/metasrv/tests/it/api/http/metrics.rs
+++ b/metasrv/tests/it/api/http/metrics.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_base::base::tokio;
+use common_tracing::tracing;
 use databend_meta::api::http::v1::metrics::metrics_handler;
 use databend_meta::meta_service::MetaNode;
 use poem::get;
@@ -28,11 +29,8 @@ use pretty_assertions::assert_eq;
 use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 
-#[tokio::test]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_metrics() -> common_exception::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tc = MetaSrvTestContext::new(0);
 
     let meta_node = MetaNode::start(&tc.config.raft_config).await?;

--- a/metasrv/tests/it/api/http_service.rs
+++ b/metasrv/tests/it/api/http_service.rs
@@ -18,6 +18,7 @@ use std::io::Read;
 use common_base::base::tokio;
 use common_base::base::Stoppable;
 use common_exception::Result;
+use common_tracing::tracing;
 use databend_meta::api::HttpService;
 use databend_meta::configs::Config;
 use databend_meta::meta_service::MetaNode;
@@ -30,11 +31,8 @@ use crate::tests::tls_constants::TEST_SERVER_CERT;
 use crate::tests::tls_constants::TEST_SERVER_KEY;
 
 // TODO(zhihanz) add tls fail case
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_http_service_tls_server() -> Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let mut conf = Config::default();
     let addr_str = "127.0.0.1:30002";
 

--- a/metasrv/tests/it/grpc/metasrv_grpc_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_api.rs
@@ -32,16 +32,13 @@ use crate::init_meta_ut;
 use crate::tests::service::MetaSrvTestContext;
 use crate::tests::start_metasrv_with_context;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_restart() -> anyhow::Result<()> {
     // Fix: Issue 1134  https://github.com/datafuselabs/databend/issues/1134
     // - Start a metasrv server.
     // - create db and create table
     // - restart
     // - Test read the db and read the table.
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
     let (mut tc, addr) = crate::tests::start_metasrv().await?;
 
@@ -126,14 +123,11 @@ async fn test_restart() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_retry_join() -> anyhow::Result<()> {
     // - Start 2 metasrv.
     // - Join node-1 to node-0
     // - Test metasrv retry cluster case
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
     let mut tc0 = MetaSrvTestContext::new(0);
     start_metasrv_with_context(&mut tc0).await?;
@@ -179,14 +173,11 @@ async fn test_retry_join() -> anyhow::Result<()> {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_join() -> anyhow::Result<()> {
     // - Start 2 metasrv.
     // - Join node-1 to node-0
     // - Test metasrv api
-
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
 
     let mut tc0 = MetaSrvTestContext::new(0);
     let mut tc1 = MetaSrvTestContext::new(1);

--- a/metasrv/tests/it/grpc/metasrv_grpc_export.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_export.rs
@@ -20,113 +20,106 @@ use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::UpsertKVReq;
 use common_tracing::tracing;
-use common_tracing::tracing::Instrument;
 use regex::Regex;
 use tokio_stream::StreamExt;
 
 use crate::init_meta_ut;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_export() -> anyhow::Result<()> {
     // - Start a metasrv server.
     // - Write some data
     // - Export all data in json and check it.
 
-    let (_log_guards, ut_span) = init_meta_ut!();
+    let (_tc, addr) = crate::tests::start_metasrv().await?;
 
-    async {
-        let (_tc, addr) = crate::tests::start_metasrv().await?;
+    let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
 
-        let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
-
-        tracing::info!("--- upsert kv");
-        {
-            for k in ["foo", "bar", "wow"] {
-                client
-                    .upsert_kv(UpsertKVReq::new(
-                        k,
-                        MatchSeq::Any,
-                        Operation::Update(k.as_bytes().to_vec()),
-                        None,
-                    ))
-                    .await?;
-            }
+    tracing::info!("--- upsert kv");
+    {
+        for k in ["foo", "bar", "wow"] {
+            client
+                .upsert_kv(UpsertKVReq::new(
+                    k,
+                    MatchSeq::Any,
+                    Operation::Update(k.as_bytes().to_vec()),
+                    None,
+                ))
+                .await?;
         }
-
-        let mut grpc_client = client.make_client().await?;
-
-        let exported = grpc_client.export(tonic::Request::new(Empty {})).await?;
-
-        let mut stream = exported.into_inner();
-
-        let mut lines = vec![];
-        while let Some(chunk_res) = stream.next().await {
-            let chunk = chunk_res?;
-
-            lines.extend_from_slice(&chunk.data);
-        }
-
-        let want = vec![
-            r#"["test-29000-raft_state",{"RaftStateKV":{"key":"Id","value":{"NodeId":0}}}]"#, //
-            r#"["test-29000-raft_state",{"RaftStateKV":{"key":"HardState","value":{"HardState":{"current_term":1,"voted_for":0}}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":0,"value":{"log_id":{"term":0,"index":0},"payload":{"Membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":1,"value":{"log_id":{"term":1,"index":1},"payload":"Blank"}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":2,"value":{"log_id":{"term":1,"index":2},"payload":{"Normal":{"txid":null,"cmd":{"AddNode":{"node_id":0,"node":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}}}}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":3,"value":{"log_id":{"term":1,"index":3},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"foo","seq":"Any","value":{"Update":[102,111,111]},"value_meta":null}}}}}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":4,"value":{"log_id":{"term":1,"index":4},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"bar","seq":"Any","value":{"Update":[98,97,114]},"value_meta":null}}}}}}}]"#, //
-            r#"["test-29000-raft_log",{"Logs":{"key":5,"value":{"log_id":{"term":1,"index":5},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"wow","seq":"Any","value":{"Update":[119,111,119]},"value_meta":null}}}}}}}]"#, //
-            r#"["test-29000-state_machine/0",{"Nodes":{"key":0,"value":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}]"#, //
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastApplied","value":{"LogId":{"term":1,"index":5}}}}]"#, //
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"Initialized","value":{"Bool":true}}}]"#, //
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastMembership","value":{"Membership":{"log_id":{"term":0,"index":0},"membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#, //
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"bar","value":{"seq":2,"meta":null,"data":[98,97,114]}}}]"#, //
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"foo","value":{"seq":1,"meta":null,"data":[102,111,111]}}}]"#, //
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"wow","value":{"seq":3,"meta":null,"data":[119,111,119]}}}]"#, //
-            r#"["test-29000-state_machine/0",{"Sequences":{"key":"generic-kv","value":3}}]"#, //
-        ];
-
-        let _want = vec![
-            r#"["test-29000-raft_state",{"RaftStateKV":{"key":"Id","value":{"NodeId":0}}}]"#,
-            r#"["test-29000-raft_state",{"RaftStateKV":{"key":"HardState","value":{"HardState":{"current_term":1,"voted_for":0}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":0,"value":{"log_id":{"term":0,"index":0},"payload":{"Membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":1,"value":{"log_id":{"term":1,"index":1},"payload":"Blank"}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":2,"value":{"log_id":{"term":1,"index":2},"payload":{"Normal":{"txid":null,"cmd":{"AddNode":{"node_id":0,"node":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}}}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":3,"value":{"log_id":{"term":1,"index":3},"payload":{"Normal":{"txid":null,"cmd":{"AddMetaSrvAddr":{"metasrv_name":"127.0.0.1:29000","metasrv_addr":"127.0.0.1:29000"}}}}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":4,"value":{"log_id":{"term":1,"index":4},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"foo","seq":"Any","value":{"Update":[102,111,111]},"value_meta":null}}}}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":5,"value":{"log_id":{"term":1,"index":5},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"bar","seq":"Any","value":{"Update":[98,97,114]},"value_meta":null}}}}}}}]"#,
-            r#"["test-29000-raft_log",{"Logs":{"key":6,"value":{"log_id":{"term":1,"index":6},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"wow","seq":"Any","value":{"Update":[119,111,119]},"value_meta":null}}}}}}}]"#,
-            r#"["test-29000-state_machine/0",{"Nodes":{"key":0,"value":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}]"#,
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastApplied","value":{"LogId":{"term":1,"index":6}}}}]"#,
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"Initialized","value":{"Bool":true}}}]"#,
-            r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastMembership","value":{"Membership":{"log_id":{"term":0,"index":0},"membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#,
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"bar","value":{"seq":2,"meta":null,"data":[98,97,114]}}}]"#,
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"foo","value":{"seq":1,"meta":null,"data":[102,111,111]}}}]"#,
-            r#"["test-29000-state_machine/0",{"GenericKV":{"key":"wow","value":{"seq":3,"meta":null,"data":[119,111,119]}}}]"#,
-            r#"["test-29000-state_machine/0",{"Sequences":{"key":"generic-kv","value":3}}]"#,
-            r#"["test-29000-state_machine/0",{"MetaSrvAddrs":{"key":"127.0.0.1:29000","value":"127.0.0.1:29000"}}]"#,
-        ];
-        // The addresses are built from random number.
-        // Wash them.
-        let lines = lines
-            .iter()
-            .map(|x| {
-                Regex::new(r"29\d\d\d")
-                    .unwrap()
-                    .replace_all(x, "29000")
-                    .to_string()
-            })
-            .map(|x| {
-                Regex::new(r"test-29\d\d\d")
-                    .unwrap()
-                    .replace_all(&x, "test-29000")
-                    .to_string()
-            })
-            .collect::<Vec<_>>();
-
-        assert_eq!(want, lines);
-
-        Ok(())
     }
-    .instrument(ut_span)
-    .await
+
+    let mut grpc_client = client.make_client().await?;
+
+    let exported = grpc_client.export(tonic::Request::new(Empty {})).await?;
+
+    let mut stream = exported.into_inner();
+
+    let mut lines = vec![];
+    while let Some(chunk_res) = stream.next().await {
+        let chunk = chunk_res?;
+
+        lines.extend_from_slice(&chunk.data);
+    }
+
+    let want = vec![
+        r#"["test-29000-raft_state",{"RaftStateKV":{"key":"Id","value":{"NodeId":0}}}]"#, //
+        r#"["test-29000-raft_state",{"RaftStateKV":{"key":"HardState","value":{"HardState":{"current_term":1,"voted_for":0}}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":0,"value":{"log_id":{"term":0,"index":0},"payload":{"Membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":1,"value":{"log_id":{"term":1,"index":1},"payload":"Blank"}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":2,"value":{"log_id":{"term":1,"index":2},"payload":{"Normal":{"txid":null,"cmd":{"AddNode":{"node_id":0,"node":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}}}}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":3,"value":{"log_id":{"term":1,"index":3},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"foo","seq":"Any","value":{"Update":[102,111,111]},"value_meta":null}}}}}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":4,"value":{"log_id":{"term":1,"index":4},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"bar","seq":"Any","value":{"Update":[98,97,114]},"value_meta":null}}}}}}}]"#, //
+        r#"["test-29000-raft_log",{"Logs":{"key":5,"value":{"log_id":{"term":1,"index":5},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"wow","seq":"Any","value":{"Update":[119,111,119]},"value_meta":null}}}}}}}]"#, //
+        r#"["test-29000-state_machine/0",{"Nodes":{"key":0,"value":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}]"#, //
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastApplied","value":{"LogId":{"term":1,"index":5}}}}]"#, //
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"Initialized","value":{"Bool":true}}}]"#, //
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastMembership","value":{"Membership":{"log_id":{"term":0,"index":0},"membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#, //
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"bar","value":{"seq":2,"meta":null,"data":[98,97,114]}}}]"#, //
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"foo","value":{"seq":1,"meta":null,"data":[102,111,111]}}}]"#, //
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"wow","value":{"seq":3,"meta":null,"data":[119,111,119]}}}]"#, //
+        r#"["test-29000-state_machine/0",{"Sequences":{"key":"generic-kv","value":3}}]"#, //
+    ];
+
+    let _want = vec![
+        r#"["test-29000-raft_state",{"RaftStateKV":{"key":"Id","value":{"NodeId":0}}}]"#,
+        r#"["test-29000-raft_state",{"RaftStateKV":{"key":"HardState","value":{"HardState":{"current_term":1,"voted_for":0}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":0,"value":{"log_id":{"term":0,"index":0},"payload":{"Membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":1,"value":{"log_id":{"term":1,"index":1},"payload":"Blank"}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":2,"value":{"log_id":{"term":1,"index":2},"payload":{"Normal":{"txid":null,"cmd":{"AddNode":{"node_id":0,"node":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}}}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":3,"value":{"log_id":{"term":1,"index":3},"payload":{"Normal":{"txid":null,"cmd":{"AddMetaSrvAddr":{"metasrv_name":"127.0.0.1:29000","metasrv_addr":"127.0.0.1:29000"}}}}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":4,"value":{"log_id":{"term":1,"index":4},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"foo","seq":"Any","value":{"Update":[102,111,111]},"value_meta":null}}}}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":5,"value":{"log_id":{"term":1,"index":5},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"bar","seq":"Any","value":{"Update":[98,97,114]},"value_meta":null}}}}}}}]"#,
+        r#"["test-29000-raft_log",{"Logs":{"key":6,"value":{"log_id":{"term":1,"index":6},"payload":{"Normal":{"txid":null,"cmd":{"UpsertKV":{"key":"wow","seq":"Any","value":{"Update":[119,111,119]},"value_meta":null}}}}}}}]"#,
+        r#"["test-29000-state_machine/0",{"Nodes":{"key":0,"value":{"name":"0","endpoint":{"addr":"localhost","port":29000}}}}]"#,
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastApplied","value":{"LogId":{"term":1,"index":6}}}}]"#,
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"Initialized","value":{"Bool":true}}}]"#,
+        r#"["test-29000-state_machine/0",{"StateMachineMeta":{"key":"LastMembership","value":{"Membership":{"log_id":{"term":0,"index":0},"membership":{"configs":[[0]],"all_nodes":[0]}}}}}]"#,
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"bar","value":{"seq":2,"meta":null,"data":[98,97,114]}}}]"#,
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"foo","value":{"seq":1,"meta":null,"data":[102,111,111]}}}]"#,
+        r#"["test-29000-state_machine/0",{"GenericKV":{"key":"wow","value":{"seq":3,"meta":null,"data":[119,111,119]}}}]"#,
+        r#"["test-29000-state_machine/0",{"Sequences":{"key":"generic-kv","value":3}}]"#,
+        r#"["test-29000-state_machine/0",{"MetaSrvAddrs":{"key":"127.0.0.1:29000","value":"127.0.0.1:29000"}}]"#,
+    ];
+    // The addresses are built from random number.
+    // Wash them.
+    let lines = lines
+        .iter()
+        .map(|x| {
+            Regex::new(r"29\d\d\d")
+                .unwrap()
+                .replace_all(x, "29000")
+                .to_string()
+        })
+        .map(|x| {
+            Regex::new(r"test-29\d\d\d")
+                .unwrap()
+                .replace_all(&x, "test-29000")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(want, lines);
+
+    Ok(())
 }

--- a/metasrv/tests/it/grpc/metasrv_grpc_handshake.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_handshake.rs
@@ -35,11 +35,8 @@ use crate::tests::start_metasrv;
 
 /// - Test client version < serverside min-compatible-client-ver.
 /// - Test metasrv version < client min-compatible-metasrv-ver.
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_metasrv_handshake() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     fn smaller_ver(v: &Version) -> Version {
         if v.major > 0 {
             Version::new(v.major - 1, v.minor, v.patch)

--- a/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -36,11 +36,8 @@ use crate::tests::start_metasrv_with_context;
 /// - Test upsert kv and read on different nodes.
 /// - Stop and restart the cluster.
 /// - Test upsert kv and read on different nodes.
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     fn make_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
         let x = &tc.config.raft_config;
         format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)
@@ -131,11 +128,8 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
 /// - Test upsert kv and read on different nodes.
 /// - Stop and restart the cluster.
 /// - Test read kv using same grpc client.
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     fn make_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
         let x = &tc.config.raft_config;
         format!("t-restart-cluster-{}-{}-{}", x.config_id, x.id, k)

--- a/metasrv/tests/it/grpc/metasrv_grpc_schema_api.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_schema_api.rs
@@ -17,15 +17,13 @@
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
 use common_meta_grpc::MetaGrpcClient;
+use common_tracing::tracing;
 
 use crate::init_meta_ut;
 use crate::tests::start_metasrv;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -35,11 +33,8 @@ async fn test_meta_grpc_client_database_create_get_drop() -> anyhow::Result<()> 
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_create_get_drop_in_diff_tenant() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -49,11 +44,8 @@ async fn test_meta_grpc_client_database_create_get_drop_in_diff_tenant() -> anyh
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_list() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -61,11 +53,8 @@ async fn test_meta_grpc_client_database_list() -> anyhow::Result<()> {
     SchemaApiTestSuite {}.database_list(client.as_ref()).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_list_in_diff_tenant() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -75,11 +64,8 @@ async fn test_meta_grpc_client_database_list_in_diff_tenant() -> anyhow::Result<
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_rename() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -87,11 +73,8 @@ async fn test_meta_grpc_client_database_rename() -> anyhow::Result<()> {
     SchemaApiTestSuite {}.database_rename(&client).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_drop_undrop_list_history() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -101,11 +84,8 @@ async fn test_meta_grpc_client_database_drop_undrop_list_history() -> anyhow::Re
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -115,11 +95,8 @@ async fn test_meta_grpc_client_table_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_rename() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -127,11 +104,8 @@ async fn test_meta_grpc_client_table_rename() -> anyhow::Result<()> {
     SchemaApiTestSuite {}.table_rename(client.as_ref()).await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_upsert_option() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -141,11 +115,8 @@ async fn test_meta_grpc_client_table_upsert_option() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_drop_undrop_list_history() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;
@@ -155,11 +126,8 @@ async fn test_meta_grpc_client_table_drop_undrop_list_history() -> anyhow::Resul
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_list() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let (_tc, addr) = start_metasrv().await?;
 
     let client = MetaGrpcClient::try_create(vec![addr], "root", "xxx", None, None)?;

--- a/metasrv/tests/it/grpc/metasrv_grpc_schema_api_follower_follower.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_schema_api_follower_follower.rs
@@ -16,15 +16,13 @@
 
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
+use common_tracing::tracing;
 
 use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_database_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
 
     let follower1 = tcs[1].grpc_client().await?;
@@ -35,11 +33,8 @@ async fn test_meta_grpc_client_database_create_get_drop() -> anyhow::Result<()> 
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_list_database() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
 
     let follower1 = tcs[1].grpc_client().await?;
@@ -50,11 +45,8 @@ async fn test_meta_grpc_client_list_database() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_table_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
 
     let follower1 = tcs[1].grpc_client().await?;
@@ -65,11 +57,8 @@ async fn test_meta_grpc_client_table_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_grpc_client_list_table() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
 
     let follower1 = tcs[1].grpc_client().await?;

--- a/metasrv/tests/it/grpc/metasrv_grpc_schema_api_leader_follower.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_schema_api_leader_follower.rs
@@ -15,15 +15,13 @@
 //! Test metasrv SchemaApi by writing to leader and then reading from a follower.
 use common_base::base::tokio;
 use common_meta_api::SchemaApiTestSuite;
+use common_tracing::tracing;
 
 use crate::init_meta_ut;
 use crate::tests::service::start_metasrv_cluster;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1]).await?;
 
     let client0 = tcs[0].grpc_client().await?;
@@ -34,11 +32,8 @@ async fn test_meta_api_database_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_api_list_database() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1]).await?;
 
     let client0 = tcs[0].grpc_client().await?;
@@ -49,11 +44,8 @@ async fn test_meta_api_list_database() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1]).await?;
 
     let client0 = tcs[0].grpc_client().await?;
@@ -63,11 +55,8 @@ async fn test_meta_api_table_create_get_drop() -> anyhow::Result<()> {
         .await
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_api_list_table() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tcs = start_metasrv_cluster(&[0, 1]).await?;
 
     let client0 = tcs[0].grpc_client().await?;

--- a/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_tls.rs
@@ -18,6 +18,7 @@ use common_grpc::RpcClientTlsConfig;
 use common_meta_api::KVApi;
 use common_meta_api::SchemaApi;
 use common_meta_grpc::MetaGrpcClient;
+use common_tracing::tracing;
 use pretty_assertions::assert_eq;
 
 use crate::init_meta_ut;
@@ -28,11 +29,8 @@ use crate::tests::tls_constants::TEST_CN_NAME;
 use crate::tests::tls_constants::TEST_SERVER_CERT;
 use crate::tests::tls_constants::TEST_SERVER_KEY;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_tls_server() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let mut tc = MetaSrvTestContext::new(0);
 
     tc.config.grpc_tls_server_key = TEST_SERVER_KEY.to_owned();
@@ -58,11 +56,8 @@ async fn test_tls_server() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_tls_server_config_failure() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let mut tc = MetaSrvTestContext::new(0);
 
     tc.config.grpc_tls_server_key = "../tests/data/certs/not_exist.key".to_owned();
@@ -73,11 +68,8 @@ async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_tls_client_config_failure() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
-
     let tls_conf = RpcClientTlsConfig {
         rpc_tls_server_root_ca_cert: "../tests/data/certs/not_exist.pem".to_string(),
         domain_name: TEST_CN_NAME.to_string(),

--- a/metasrv/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/metasrv/tests/it/grpc/metasrv_grpc_watch.rs
@@ -22,6 +22,7 @@ use common_meta_types::protobuf::WatchRequest;
 use common_meta_types::MatchSeq;
 use common_meta_types::Operation;
 use common_meta_types::UpsertKVReq;
+use common_tracing::tracing;
 
 use crate::init_meta_ut;
 
@@ -68,15 +69,13 @@ async fn test_watch_main(
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_watch() -> anyhow::Result<()> {
     // - Start a metasrv server.
     // - Watch some key.
     // - Write some data.
     // - Assert watcher get all the update.
 
-    let (_log_guards, ut_span) = init_meta_ut!();
-    let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_metasrv().await?;
 
     let mut seq: u64 = 1;

--- a/metasrv/tests/it/meta_node/meta_node_kv_api.rs
+++ b/metasrv/tests/it/meta_node/meta_node_kv_api.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use common_base::base::tokio;
 use common_meta_api::KVApiBuilder;
 use common_meta_api::KVApiTestSuite;
-use common_tracing::tracing::Instrument;
+use common_tracing::tracing;
 use databend_meta::meta_service::MetaNode;
 use maplit::btreeset;
 
@@ -69,15 +69,11 @@ impl KVApiBuilder<Arc<MetaNode>> for MetaNodeUnitTestBuilder {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_node_kv_api() -> anyhow::Result<()> {
-    let (_log_guards, ut_span) = init_meta_ut!();
-
     let builder = MetaNodeUnitTestBuilder {
         test_contexts: Arc::new(Mutex::new(vec![])),
     };
 
-    async { KVApiTestSuite {}.test_all(builder).await }
-        .instrument(ut_span)
-        .await
+    KVApiTestSuite {}.test_all(builder).await
 }

--- a/metasrv/tests/it/store.rs
+++ b/metasrv/tests/it/store.rs
@@ -31,7 +31,6 @@ use common_meta_sled_store::openraft::RaftStorage;
 use common_meta_types::AppliedState;
 use common_meta_types::LogEntry;
 use common_tracing::tracing;
-use common_tracing::tracing_futures::Instrument;
 use databend_meta::store::MetaRaftStore;
 use databend_meta::Opened;
 use maplit::btreeset;
@@ -71,243 +70,220 @@ fn test_impl_raft_storage() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_store_restart() -> anyhow::Result<()> {
     // - Create a meta store
     // - Update meta store
     // - Close and reopen it
     // - Test state is restored: hard state, log, state machine
 
-    let (_log_guards, ut_span) = init_meta_ut!();
+    let id = 3;
+    let tc = MetaSrvTestContext::new(id);
 
-    async {
-        let id = 3;
-        let tc = MetaSrvTestContext::new(id);
+    tracing::info!("--- new meta store");
+    {
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+        assert_eq!(id, sto.id);
+        assert!(!sto.is_opened());
+        assert_eq!(None, sto.read_hard_state().await?);
 
-        tracing::info!("--- new meta store");
-        {
-            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-            assert_eq!(id, sto.id);
-            assert!(!sto.is_opened());
-            assert_eq!(None, sto.read_hard_state().await?);
+        tracing::info!("--- update metasrv");
 
-            tracing::info!("--- update metasrv");
+        sto.save_hard_state(&HardState {
+            current_term: 10,
+            voted_for: Some(5),
+        })
+        .await?;
 
-            sto.save_hard_state(&HardState {
+        sto.append_to_log(&[&Entry {
+            log_id: LogId::new(1, 1),
+            payload: EntryPayload::Blank,
+        }])
+        .await?;
+
+        sto.apply_to_state_machine(&[&Entry {
+            log_id: LogId::new(1, 2),
+            payload: EntryPayload::Blank,
+        }])
+        .await?;
+    }
+
+    tracing::info!("--- reopen meta store");
+    {
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, Some(()), None).await?;
+        assert_eq!(id, sto.id);
+        assert!(sto.is_opened());
+        assert_eq!(
+            Some(HardState {
                 current_term: 10,
                 voted_for: Some(5),
-            })
-            .await?;
+            }),
+            sto.read_hard_state().await?
+        );
 
-            sto.append_to_log(&[&Entry {
-                log_id: LogId::new(1, 1),
-                payload: EntryPayload::Blank,
-            }])
-            .await?;
-
-            sto.apply_to_state_machine(&[&Entry {
-                log_id: LogId::new(1, 2),
-                payload: EntryPayload::Blank,
-            }])
-            .await?;
-        }
-
-        tracing::info!("--- reopen meta store");
-        {
-            let sto = MetaRaftStore::open_create(&tc.config.raft_config, Some(()), None).await?;
-            assert_eq!(id, sto.id);
-            assert!(sto.is_opened());
-            assert_eq!(
-                Some(HardState {
-                    current_term: 10,
-                    voted_for: Some(5),
-                }),
-                sto.read_hard_state().await?
-            );
-
-            assert_eq!(LogId::new(1, 1), sto.get_log_id(1).await?);
-            assert_eq!(Some(LogId::new(1, 2)), sto.last_applied_state().await?.0);
-        }
-        Ok(())
+        assert_eq!(LogId::new(1, 1), sto.get_log_id(1).await?);
+        assert_eq!(Some(LogId::new(1, 2)), sto.last_applied_state().await?.0);
     }
-    .instrument(ut_span)
-    .await
+    Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_store_build_snapshot() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    let (_log_guards, ut_span) = init_meta_ut!();
+    let id = 3;
+    let tc = MetaSrvTestContext::new(id);
 
-    async {
-        let id = 3;
-        let tc = MetaSrvTestContext::new(id);
+    let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
-        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+    tracing::info!("--- feed logs and state machine");
 
-        tracing::info!("--- feed logs and state machine");
+    let (logs, want) = snapshot_logs();
 
-        let (logs, want) = snapshot_logs();
-
-        for l in logs.iter() {
-            sto.log.insert(l).await?;
-            sto.state_machine.write().await.apply(l).await?;
-        }
-
-        let curr_snap = sto.build_snapshot().await?;
-        assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
-
-        tracing::info!("--- check snapshot");
-        {
-            let data = curr_snap.snapshot.into_inner();
-
-            let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-            let res = pretty_snapshot(&ser_snap.kvs);
-            tracing::debug!("res: {:?}", res);
-
-            assert_eq!(want, res);
-        }
-
-        Ok(())
+    for l in logs.iter() {
+        sto.log.insert(l).await?;
+        sto.state_machine.write().await.apply(l).await?;
     }
-    .instrument(ut_span)
-    .await
+
+    let curr_snap = sto.build_snapshot().await?;
+    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        assert_eq!(want, res);
+    }
+
+    Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_store_current_snapshot() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    let (_log_guards, ut_span) = init_meta_ut!();
-    async {
-        let id = 3;
-        let tc = MetaSrvTestContext::new(id);
+    let id = 3;
+    let tc = MetaSrvTestContext::new(id);
 
-        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+    let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
-        tracing::info!("--- feed logs and state machine");
+    tracing::info!("--- feed logs and state machine");
 
-        let (logs, want) = snapshot_logs();
+    let (logs, want) = snapshot_logs();
 
-        for l in logs.iter() {
-            sto.log.insert(l).await?;
-            sto.state_machine.write().await.apply(l).await?;
-        }
-
-        sto.build_snapshot().await?;
-
-        tracing::info!("--- check get_current_snapshot");
-
-        let curr_snap = sto.get_current_snapshot().await?.unwrap();
-        assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
-
-        tracing::info!("--- check snapshot");
-        {
-            let data = curr_snap.snapshot.into_inner();
-
-            let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-            let res = pretty_snapshot(&ser_snap.kvs);
-            tracing::debug!("res: {:?}", res);
-
-            assert_eq!(want, res);
-        }
-
-        Ok(())
+    for l in logs.iter() {
+        sto.log.insert(l).await?;
+        sto.state_machine.write().await.apply(l).await?;
     }
-    .instrument(ut_span)
-    .await
+
+    sto.build_snapshot().await?;
+
+    tracing::info!("--- check get_current_snapshot");
+
+    let curr_snap = sto.get_current_snapshot().await?.unwrap();
+    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        assert_eq!(want, res);
+    }
+
+    Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[async_entry::test(worker_threads = 3, init = "init_meta_ut!()", tracing_span = "debug")]
 async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
     // - Create a metasrv
     // - Feed logs
     // - Create a snapshot
     // - Create a new metasrv and restore it by install the snapshot
 
-    let (_log_guards, ut_span) = init_meta_ut!();
+    let (logs, want) = snapshot_logs();
 
-    async {
-        let (logs, want) = snapshot_logs();
+    let id = 3;
+    let snap;
+    {
+        let tc = MetaSrvTestContext::new(id);
 
-        let id = 3;
-        let snap;
-        {
-            let tc = MetaSrvTestContext::new(id);
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
 
-            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+        tracing::info!("--- feed logs and state machine");
 
-            tracing::info!("--- feed logs and state machine");
-
-            for l in logs.iter() {
-                sto.log.insert(l).await?;
-                sto.state_machine.write().await.apply(l).await?;
-            }
-            snap = sto.build_snapshot().await?;
+        for l in logs.iter() {
+            sto.log.insert(l).await?;
+            sto.state_machine.write().await.apply(l).await?;
         }
-
-        let data = snap.snapshot.into_inner();
-
-        tracing::info!("--- reopen a new metasrv to install snapshot");
-        {
-            let tc = MetaSrvTestContext::new(id);
-
-            let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
-
-            tracing::info!("--- rejected because old sm is not cleaned");
-            {
-                sto.raft_state.write_state_machine_id(&(1, 2)).await?;
-                let res = sto.install_snapshot(&data).await;
-                assert!(res.is_err(), "different ids disallow installing snapshot");
-                assert!(res
-                    .unwrap_err()
-                    .to_string()
-                    .starts_with("another snapshot install is not finished yet: 1 2"));
-            }
-
-            tracing::info!("--- install snapshot");
-            {
-                sto.raft_state.write_state_machine_id(&(0, 0)).await?;
-                sto.install_snapshot(&data).await?;
-            }
-
-            tracing::info!("--- check installed meta");
-            {
-                assert_eq!((1, 1), sto.raft_state.read_state_machine_id()?);
-
-                let mem = sto.state_machine.write().await.get_membership()?;
-                assert_eq!(
-                    Some(EffectiveMembership {
-                        log_id: LogId::new(1, 5),
-                        membership: Membership::new_single(btreeset! {4,5,6})
-                    }),
-                    mem
-                );
-
-                let last_applied = sto.state_machine.write().await.get_last_applied()?;
-                assert_eq!(Some(LogId::new(1, 9)), last_applied);
-            }
-
-            tracing::info!("--- check snapshot");
-            {
-                let curr_snap = sto.build_snapshot().await?;
-                let data = curr_snap.snapshot.into_inner();
-
-                let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
-                let res = pretty_snapshot(&ser_snap.kvs);
-                tracing::debug!("res: {:?}", res);
-
-                assert_eq!(want, res);
-            }
-        }
-
-        Ok(())
+        snap = sto.build_snapshot().await?;
     }
-    .instrument(ut_span)
-    .await
+
+    let data = snap.snapshot.into_inner();
+
+    tracing::info!("--- reopen a new metasrv to install snapshot");
+    {
+        let tc = MetaSrvTestContext::new(id);
+
+        let sto = MetaRaftStore::open_create(&tc.config.raft_config, None, Some(())).await?;
+
+        tracing::info!("--- rejected because old sm is not cleaned");
+        {
+            sto.raft_state.write_state_machine_id(&(1, 2)).await?;
+            let res = sto.install_snapshot(&data).await;
+            assert!(res.is_err(), "different ids disallow installing snapshot");
+            assert!(res
+                .unwrap_err()
+                .to_string()
+                .starts_with("another snapshot install is not finished yet: 1 2"));
+        }
+
+        tracing::info!("--- install snapshot");
+        {
+            sto.raft_state.write_state_machine_id(&(0, 0)).await?;
+            sto.install_snapshot(&data).await?;
+        }
+
+        tracing::info!("--- check installed meta");
+        {
+            assert_eq!((1, 1), sto.raft_state.read_state_machine_id()?);
+
+            let mem = sto.state_machine.write().await.get_membership()?;
+            assert_eq!(
+                Some(EffectiveMembership {
+                    log_id: LogId::new(1, 5),
+                    membership: Membership::new_single(btreeset! {4,5,6})
+                }),
+                mem
+            );
+
+            let last_applied = sto.state_machine.write().await.get_last_applied()?;
+            assert_eq!(Some(LogId::new(1, 9)), last_applied);
+        }
+
+        tracing::info!("--- check snapshot");
+        {
+            let curr_snap = sto.build_snapshot().await?;
+            let data = curr_snap.snapshot.into_inner();
+
+            let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+            let res = pretty_snapshot(&ser_snap.kvs);
+            tracing::debug!("res: {:?}", res);
+
+            assert_eq!(want, res);
+        }
+    }
+
+    Ok(())
 }

--- a/tests/logictest/http_connector.py
+++ b/tests/logictest/http_connector.py
@@ -121,19 +121,22 @@ class HttpConnector():
         query_sql = {'sql': parseSQL(statement)}
         if session is not None:
             query_sql['session'] = session
-        log.debug("http headers: {}".format({**headers,**self._additonal_headers}))
-        if "Authorization" not in self._additonal_headers:  
+        log.debug("http headers: {}".format({
+            **headers,
+            **self._additonal_headers
+        }))
+        if "Authorization" not in self._additonal_headers:
             response = requests.post(url,
-                                 data=json.dumps(query_sql),
-                                 auth=(self._user, ""),
-                                 headers=headers)
+                                     data=json.dumps(query_sql),
+                                     auth=(self._user, ""),
+                                     headers=headers)
         else:
             response = requests.post(url,
-                                 data=json.dumps(query_sql),
-                                 headers={
-                                     **headers,
-                                     **self._additonal_headers
-                                 })
+                                     data=json.dumps(query_sql),
+                                     headers={
+                                         **headers,
+                                         **self._additonal_headers
+                                     })
 
         try:
             return json.loads(response.content)

--- a/tests/logictest/logictest.py
+++ b/tests/logictest/logictest.py
@@ -238,7 +238,7 @@ class SuiteRunner(object):
     # return all files under the path
     # format: a list of file absolute path and name(relative path)
     def fetch_files(self):
-        skip_files=os.getenv("SKIP_TEST_FILES")
+        skip_files = os.getenv("SKIP_TEST_FILES")
         skip_tests = skip_files.split(",") if skip_files is not None else []
         log.debug("Skip test file list {}".format(skip_tests))
         for filename in glob.iglob('{}/**'.format(self.path), recursive=True):

--- a/tests/logictest/mysql_runner.py
+++ b/tests/logictest/mysql_runner.py
@@ -54,7 +54,7 @@ class TestMySQL(logictest.SuiteRunner, ABC):
                 if isinstance(v, NoneType):
                     vals.append("NULL")
                     continue
-                
+
                 if query_type[i] == 'I':
                     if not isinstance(v, int):
                         log.error(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### [metasrv] refactor: use `async_entry::test` to replace tokio::test
`#[async_entry::test(
    worker_threads = 3,
    init = "init_meta_ut!()",
    tracing_span = "debug"
)]` is compatible with tokio::test and is able to:

- Build a span to contain the entire test fn. Saves several lines of
  `async {}.instrument().await`.

- Evaluate a initializing expr, it can be a function call or macro call.
  To initialize logging etc.

## Changelog




- Improvement


## Related Issues