### PR TITLE
feat(meta): refactor watch key range from [start,end] to [start,end)

### DIFF
--- a/common/meta/types/proto/meta.proto
+++ b/common/meta/types/proto/meta.proto
@@ -48,7 +48,7 @@ message WatchRequest {
   // key is the key to register for watching.
   string key = 1;
 
-  // key_end is the end of the range [key, key_end] to watch.
+  // key_end is the end of the range [key, key_end) to watch.
   // if key_end is None, then watch only key.
   optional string key_end = 2;
 

--- a/metasrv/src/watcher/watcher_manager.rs
+++ b/metasrv/src/watcher/watcher_manager.rs
@@ -210,7 +210,7 @@ impl WatcherManagerCore {
                 if &key > key_end {
                     return Err(false);
                 }
-                Ok(key..format!("{}\x00", key_end))
+                Ok(key..key_end.to_string())
             }
             None => Ok(key.clone()..key),
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat(meta): refactor watch key range from [start,end] to [start,end)

Fixes [#issue 6485](https://github.com/datafuselabs/databend/issues/6485)
