### PR TITLE
chore: rename worker_num to worker_id.

### DIFF
--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -309,7 +309,7 @@ impl ScheduleQueue {
                 processor,
                 context.query_id.clone(),
                 executor,
-                context.get_worker_num(),
+                context.get_worker_id(),
                 context.get_workers_condvar().clone(),
                 global.clone(),
             )
@@ -328,7 +328,7 @@ impl ScheduleQueue {
         proc: ProcessorPtr,
         query_id: Arc<String>,
         executor: &PipelineExecutor,
-        wakeup_worker_num: usize,
+        wakeup_worker_id: usize,
         workers_condvar: Arc<WorkersCondvar>,
         global_queue: Arc<ExecutorTasksQueue>,
     ) {
@@ -339,7 +339,7 @@ impl ScheduleQueue {
                 .async_runtime
                 .spawn(TrackedFuture::create(ProcessorAsyncTask::create(
                     query_id,
-                    wakeup_worker_num,
+                    wakeup_worker_id,
                     proc.clone(),
                     global_queue,
                     workers_condvar,

--- a/src/query/service/src/pipelines/executor/executor_tasks.rs
+++ b/src/query/service/src/pipelines/executor/executor_tasks.rs
@@ -52,8 +52,8 @@ impl ExecutorTasksQueue {
             Vec::with_capacity(workers_tasks.workers_waiting_status.waiting_size());
 
         while workers_tasks.workers_waiting_status.waiting_size() != 0 {
-            let worker_num = workers_tasks.workers_waiting_status.wakeup_any_worker();
-            wakeup_workers.push(worker_num);
+            let worker_id = workers_tasks.workers_waiting_status.wakeup_any_worker();
+            wakeup_workers.push(worker_id);
         }
 
         drop(workers_tasks);
@@ -72,7 +72,7 @@ impl ExecutorTasksQueue {
         let mut workers_tasks = self.workers_tasks.lock();
 
         if !workers_tasks.is_empty() {
-            let task = workers_tasks.pop_task(context.get_worker_num());
+            let task = workers_tasks.pop_task(context.get_worker_id());
 
             context.set_task(task);
 
@@ -80,7 +80,7 @@ impl ExecutorTasksQueue {
 
             if !workers_tasks.is_empty() && workers_tasks.workers_waiting_status.waiting_size() != 0
             {
-                let worker_id = context.get_worker_num();
+                let worker_id = context.get_worker_id();
                 let mut wakeup_worker_id = workers_tasks.best_worker_id(worker_id + 1);
 
                 if workers_tasks
@@ -111,12 +111,12 @@ impl ExecutorTasksQueue {
             return;
         }
 
-        let worker_num = context.get_worker_num();
-        workers_tasks.workers_waiting_status.wait_worker(worker_num);
+        let worker_id = context.get_worker_id();
+        workers_tasks.workers_waiting_status.wait_worker(worker_id);
         drop(workers_tasks);
         context
             .get_workers_condvar()
-            .wait(worker_num, self.finished.clone());
+            .wait(worker_id, self.finished.clone());
     }
 
     pub fn init_sync_tasks(&self, tasks: VecDeque<ProcessorPtr>) {
@@ -137,7 +137,7 @@ impl ExecutorTasksQueue {
     pub fn push_tasks(&self, ctx: &mut ExecutorWorkerContext, mut tasks: VecDeque<ExecutorTask>) {
         let mut workers_tasks = self.workers_tasks.lock();
 
-        let worker_id = ctx.get_worker_num();
+        let worker_id = ctx.get_worker_id();
         while let Some(task) = tasks.pop_front() {
             workers_tasks.push_task(worker_id, task);
         }

--- a/src/query/service/src/pipelines/executor/executor_worker_context.rs
+++ b/src/query/service/src/pipelines/executor/executor_worker_context.rs
@@ -32,20 +32,20 @@ pub enum ExecutorTask {
 
 pub struct ExecutorWorkerContext {
     pub query_id: Arc<String>,
-    worker_num: usize,
+    worker_id: usize,
     task: ExecutorTask,
     workers_condvar: Arc<WorkersCondvar>,
 }
 
 impl ExecutorWorkerContext {
     pub fn create(
-        worker_num: usize,
+        worker_id: usize,
         workers_condvar: Arc<WorkersCondvar>,
         query_id: Arc<String>,
     ) -> Self {
         ExecutorWorkerContext {
             query_id,
-            worker_num,
+            worker_id,
             workers_condvar,
             task: ExecutorTask::None,
         }
@@ -55,8 +55,8 @@ impl ExecutorWorkerContext {
         !matches!(&self.task, ExecutorTask::None)
     }
 
-    pub fn get_worker_num(&self) -> usize {
-        self.worker_num
+    pub fn get_worker_id(&self) -> usize {
+        self.worker_id
     }
 
     pub fn set_task(&mut self, task: ExecutorTask) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

currently,  they are used interchangeably,  `worker_id` is easier to to understand.

