### PR TITLE
feat(cache): a variant of sieve, with lazy op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "hashlink",
  "heapsize",
+ "indexmap 1.9.2",
 ]
 
 [[package]]

--- a/src/common/cache/Cargo.toml
+++ b/src/common/cache/Cargo.toml
@@ -19,6 +19,7 @@ heapsize = ["heapsize_"]
 bytes = { workspace = true }
 hashbrown = "0.14"
 hashlink = "0.8"
+indexmap = "1.9.2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 heapsize_ = { package = "heapsize", version = "0.4.2", optional = true }

--- a/src/common/cache/src/cache.rs
+++ b/src/common/cache/src/cache.rs
@@ -23,7 +23,7 @@ use crate::Meter;
 /// A trait for a cache.
 pub trait Cache<K, V, S, M>
 where
-    K: Eq + Hash,
+    K: Eq + Hash + Clone,
     S: BuildHasher,
     M: Meter<K, V>,
 {

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -339,10 +339,13 @@ impl<K: Eq + Hash + Clone, V, S: BuildHasher, M: CountableMeter<K, V>> Cache<K, 
         self.current_measure = self.meter.add(self.current_measure, new_size);
         match self.map.get(&k) {
             Some(old) => {
-            self.current_measure = self
-                .meter
-                .sub(self.current_measure, self.meter.measure(&k, old));},
-            None => {self.visited.insert(k.clone(), false);}
+                self.current_measure = self
+                    .meter
+                    .sub(self.current_measure, self.meter.measure(&k, old));
+            }
+            None => {
+                self.visited.insert(k.clone(), false);
+            }
         }
         let old_val = self.map.replace(k, v);
         while self.size() > self.capacity() {

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -552,7 +552,7 @@ impl<K: Eq + Hash + Clone, V, S: BuildHasher, M: CountableMeter<K, V>> LruCache<
     }
 }
 
-impl<K: Eq + Hash + Clone +Clone, V, S: BuildHasher, M: CountableMeter<K, V>> Extend<(K, V)>
+impl<K: Eq + Hash + Clone + Clone, V, S: BuildHasher, M: CountableMeter<K, V>> Extend<(K, V)>
     for LruCache<K, V, S, M>
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
@@ -562,8 +562,8 @@ impl<K: Eq + Hash + Clone +Clone, V, S: BuildHasher, M: CountableMeter<K, V>> Ex
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash + Clone, V: fmt::Debug, S: BuildHasher, M: CountableMeter<K, V>> fmt::Debug
-    for LruCache<K, V, S, M>
+impl<K: fmt::Debug + Eq + Hash + Clone, V: fmt::Debug, S: BuildHasher, M: CountableMeter<K, V>>
+    fmt::Debug for LruCache<K, V, S, M>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter().rev()).finish()

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -174,11 +174,11 @@ impl<K: Eq + Hash + Clone, V, S: BuildHasher, M: CountableMeter<K, V>> LruCache<
         }
         let mut iter = self.visited.iter_mut().skip(count as usize);
         for (key, value) in &mut iter {
-            if *value == false && p.is_none() {
+            if !(*value) && p.is_none() {
                 p = Some(key.clone());
                 break;
             }
-            count = count + 1;
+            count += 1;
             *value = false;
         }
         self.hand = count;
@@ -194,11 +194,11 @@ impl<K: Eq + Hash + Clone, V, S: BuildHasher, M: CountableMeter<K, V>> LruCache<
         }
         let iter = self.visited.iter().skip(count as usize);
         for (key, value) in iter {
-            if *value == false && p.is_none() {
+            if !(*value) && p.is_none() {
                 p = Some(key.clone());
                 break;
             }
-            count = count + 1;
+            count += 1;
         }
         p
     }

--- a/src/common/cache/tests/it/cache/lru.rs
+++ b/src/common/cache/tests/it/cache/lru.rs
@@ -95,7 +95,7 @@ fn test_debug() {
     cache.get(&3);
     assert_eq!(format!("{:?}", cache), "{6: 60, 3: 30, 2: 22}");
     cache.set_capacity(2);
-    assert_eq!(format!("{:?}", cache), "{6: 60, 3: 30}");
+    assert_eq!(format!("{:?}", cache), "{3: 30, 2: 22}");
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn test_remove() {
     cache.put(8, 80);
     assert!(cache.get(&5).is_none());
     assert_eq!(cache.get(&6), Some(&60));
-    assert_eq!(cache.get(&7), Some(&70));
+    assert_eq!(cache.get(&7), None);
     assert_eq!(cache.get(&8), Some(&80));
 }
 
@@ -139,24 +139,24 @@ fn test_iter() {
     cache.put(4, 40);
     cache.put(5, 50);
     assert_eq!(cache.iter().collect::<Vec<_>>(), [
+        (&2, &20),
         (&3, &30),
-        (&4, &40),
         (&5, &50)
     ]);
     assert_eq!(cache.iter_mut().collect::<Vec<_>>(), [
+        (&2, &mut 20),
         (&3, &mut 30),
-        (&4, &mut 40),
         (&5, &mut 50)
     ]);
     assert_eq!(cache.iter().rev().collect::<Vec<_>>(), [
         (&5, &50),
-        (&4, &40),
-        (&3, &30)
+        (&3, &30),
+        (&2, &20)
     ]);
     assert_eq!(cache.iter_mut().rev().collect::<Vec<_>>(), [
         (&5, &mut 50),
-        (&4, &mut 40),
-        (&3, &mut 30)
+        (&3, &mut 30),
+        (&2, &mut 20)
     ]);
 }
 

--- a/src/common/cache/tests/it/cache/lru.rs
+++ b/src/common/cache/tests/it/cache/lru.rs
@@ -89,13 +89,13 @@ fn test_debug() {
     cache.put(3, 30);
     assert_eq!(format!("{:?}", cache), "{3: 30, 2: 20, 1: 10}");
     cache.put(2, 22);
-    assert_eq!(format!("{:?}", cache), "{2: 22, 3: 30, 1: 10}");
+    assert_eq!(format!("{:?}", cache), "{3: 30, 2: 22, 1: 10}");
     cache.put(6, 60);
-    assert_eq!(format!("{:?}", cache), "{6: 60, 2: 22, 3: 30}");
+    assert_eq!(format!("{:?}", cache), "{6: 60, 3: 30, 2: 22}");
     cache.get(&3);
-    assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60, 2: 22}");
+    assert_eq!(format!("{:?}", cache), "{6: 60, 3: 30, 2: 22}");
     cache.set_capacity(2);
-    assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60}");
+    assert_eq!(format!("{:?}", cache), "{6: 60, 3: 30}");
 }
 
 #[test]

--- a/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
@@ -145,10 +145,10 @@ fn test_evict_until_enough_space() {
 
     // insert a single slice which size bigger than file1 and less than file1 + file2
     c.insert_single_slice("file4", &[3; 2]).unwrap();
-    assert_eq!(c.size(), 3);
+    assert_eq!(c.size(), 4);
     // file1 and file2 MUST be evicted
     assert!(!c.contains_key("file1"));
-    assert!(!c.contains_key("file2"));
+    assert!(!c.contains_key("file3"));
     // file3 MUST be keeped
-    assert!(c.contains_key("file3"));
+    assert!(c.contains_key("file2"));
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This optimization is inspired by the sieve, which can reduce unnecessary element movements and has a potential filtering effect.

Simply put, we maintain the visited status of each key and try to evict those elements that were inserted a long time ago but have not been accessed yet.

- Closes #issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/13904)
<!-- Reviewable:end -->
