### PR TITLE
feat: reduce memory copy during the compact process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4917,7 +4917,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-functions",
  "databend-storages-common-table-meta",
- "jsonb 0.3.0 (git+https://github.com/datafuselabs/jsonb?rev=3fe3acd)",
+ "jsonb",
  "log",
  "match-template",
  "minitrace",

--- a/src/query/service/src/test_kits/block_writer.rs
+++ b/src/query/service/src/test_kits/block_writer.rs
@@ -113,7 +113,7 @@ impl<'a> BlockWriter<'a> {
         let maybe_bloom_index = BloomIndex::try_create(
             FunctionContext::default(),
             location.1,
-            &[block],
+            &[block.clone()],
             bloom_columns_map,
         )?;
         if let Some(bloom_index) = maybe_bloom_index {

--- a/src/query/service/src/test_kits/fuse.rs
+++ b/src/query/service/src/test_kits/fuse.rs
@@ -155,7 +155,7 @@ async fn generate_blocks(fuse_table: &FuseTable, num_blocks: usize) -> Result<Ve
 
     let blocks: std::vec::Vec<DataBlock> = stream.try_collect().await?;
     for block in blocks {
-        let stats = gen_columns_statistics(&block, None, &schema)?;
+        let stats = gen_columns_statistics(&[block.clone()], None, &schema)?;
         let (block_meta, _index_meta) = block_writer
             .write(FuseStorageFormat::Parquet, &schema, block, stats, None)
             .await?;

--- a/src/query/service/tests/it/storages/fuse/bloom_index_meta_size.rs
+++ b/src/query/service/tests/it/storages/fuse/bloom_index_meta_size.rs
@@ -393,7 +393,7 @@ async fn setup() -> databend_common_exception::Result<FileMetaData> {
     let block = DataBlock::new_from_columns(columns);
     let operator = Operator::new(opendal::services::Memory::default())?.finish();
     let loc_generator = TableMetaLocationGenerator::with_prefix("/".to_owned());
-    let col_stats = gen_columns_statistics(&block, None, &schema)?;
+    let col_stats = gen_columns_statistics(&[block.clone()], None, &schema)?;
     let block_writer = BlockWriter::new(&operator, &loc_generator);
     let (_block_meta, thrift_file_meta) = block_writer
         .write(FuseStorageFormat::Parquet, &schema, block, col_stats, None)

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -81,7 +81,7 @@ async fn test_compact() -> Result<()> {
         .get_table(&ctx.get_tenant(), &db_name, &tbl_name)
         .await?;
     let res = do_compact(ctx.clone(), table.clone()).await;
-    assert!(res.is_ok());
+    assert!(res.is_ok(), "{:?}", res);
     assert!(res.unwrap());
 
     // check count

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -729,7 +729,7 @@ impl CompactSegmentTestFixture {
                 for block in blocks {
                     let block = block?;
 
-                    let col_stats = gen_columns_statistics(&block, None, &schema)?;
+                    let col_stats = gen_columns_statistics(&[block.clone()], None, &schema)?;
 
                     let cluster_stats = if num_blocks % 5 == 0 {
                         None

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -68,7 +68,7 @@ fn test_ft_stats_block_stats() -> databend_common_exception::Result<()> {
         StringType::from_data(vec!["aa", "aa", "bb"]),
     ]);
 
-    let r = gen_columns_statistics(&block, None, &schema)?;
+    let r = gen_columns_statistics(&[block.clone()], None, &schema)?;
     assert_eq!(2, r.len());
     let col_stats = r.get(&0).unwrap();
     assert_eq!(col_stats.min(), &Scalar::Number(NumberScalar::Int32(1)));
@@ -95,7 +95,7 @@ fn test_ft_stats_block_stats_with_column_distinct_count() -> databend_common_exc
     let mut column_distinct_count = HashMap::new();
     column_distinct_count.insert(0, 3);
     column_distinct_count.insert(1, 2);
-    let r = gen_columns_statistics(&block, Some(column_distinct_count), &schema)?;
+    let r = gen_columns_statistics(&[block.clone()], Some(column_distinct_count), &schema)?;
     assert_eq!(2, r.len());
     let col_stats = r.get(&0).unwrap();
     assert_eq!(col_stats.min(), &Scalar::Number(NumberScalar::Int32(1)));
@@ -129,7 +129,7 @@ fn test_ft_tuple_stats_block_stats() -> databend_common_exception::Result<()> {
 
     let block = DataBlock::new_from_columns(vec![column]);
 
-    let r = gen_columns_statistics(&block, None, &schema)?;
+    let r = gen_columns_statistics(&[block.clone()], None, &schema)?;
     assert_eq!(2, r.len());
     let col0_stats = r.get(&0).unwrap();
     assert_eq!(col0_stats.min(), &Scalar::Number(NumberScalar::Int32(1)));
@@ -151,7 +151,7 @@ fn test_ft_stats_col_stats_reduce() -> databend_common_exception::Result<()> {
         TestFixture::gen_sample_blocks_ex(num_of_blocks, rows_per_block, val_start_with);
     let col_stats = blocks
         .iter()
-        .map(|b| gen_columns_statistics(&b.clone().unwrap(), None, &schema))
+        .map(|b| gen_columns_statistics(&[b.clone().unwrap()], None, &schema))
         .collect::<databend_common_exception::Result<Vec<_>>>()?;
     let r = reducers::reduce_block_statistics(&col_stats);
     assert_eq!(3, r.len());
@@ -320,7 +320,7 @@ async fn test_accumulator() -> databend_common_exception::Result<()> {
     let loc_generator = TableMetaLocationGenerator::with_prefix("/".to_owned());
     for item in blocks {
         let block = item?;
-        let col_stats = gen_columns_statistics(&block, None, &schema)?;
+        let col_stats = gen_columns_statistics(&[block.clone()], None, &schema)?;
         let block_writer = BlockWriter::new(&operator, &loc_generator);
         let (block_meta, _index_meta) = block_writer
             .write(FuseStorageFormat::Parquet, &schema, block, col_stats, None)
@@ -528,7 +528,7 @@ fn test_ft_stats_block_stats_string_columns_trimming_using_eval()
         let max_expr = max_col.0.index(0).unwrap();
 
         // generate the statistics of column
-        let stats_of_columns = gen_columns_statistics(&block, None, &schema).unwrap();
+        let stats_of_columns = gen_columns_statistics(&[block], None, &schema).unwrap();
 
         // check if the max value (untrimmed) is in degenerated condition:
         // - the length of string value is larger or equal than STRING_PREFIX_LEN

--- a/src/query/service/tests/it/storages/statistics/column_statistics.rs
+++ b/src/query/service/tests/it/storages/statistics/column_statistics.rs
@@ -83,7 +83,7 @@ fn gen_sample_block() -> (DataBlock, Vec<Column>, TableSchemaRef) {
 #[test]
 fn test_column_statistic() -> Result<()> {
     let (sample_block, sample_cols, schema) = gen_sample_block();
-    let col_stats = gen_columns_statistics(&sample_block, None, &schema)?;
+    let col_stats = gen_columns_statistics(&[sample_block], None, &schema)?;
 
     assert_eq!(5, col_stats.len());
 

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -178,7 +178,7 @@ impl BloomIndex {
     pub fn try_create(
         func_ctx: FunctionContext,
         version: u64,
-        data_blocks_tobe_indexed: &[&DataBlock],
+        data_blocks_tobe_indexed: &[DataBlock],
         bloom_columns_map: BTreeMap<FieldIndex, TableField>,
     ) -> Result<Option<Self>> {
         if data_blocks_tobe_indexed.is_empty() {

--- a/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
+++ b/src/query/storages/common/index/tests/it/filters/bloom_filter.rs
@@ -144,14 +144,13 @@ fn test_bloom_filter() -> Result<()> {
             )),
         ]),
     ];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
 
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0, 1, 2, 3]);
     let bloom_fields = bloom_columns.values().cloned().collect::<Vec<_>>();
     let index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &blocks,
         bloom_columns,
     )?
     .unwrap();
@@ -316,14 +315,13 @@ fn test_specify_bloom_filter() -> Result<()> {
         UInt8Type::from_data(vec![1, 2]),
         StringType::from_data(vec!["a", "b"]),
     ])];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
 
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0]);
     let fields = bloom_columns.values().cloned().collect::<Vec<_>>();
     let specify_index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &blocks,
         bloom_columns,
     )?
     .unwrap();
@@ -355,7 +353,6 @@ fn test_string_bloom_filter() -> Result<()> {
         UInt8Type::from_data(vec![1, 2]),
         StringType::from_data(vec![&val, "bc"]),
     ])];
-    let blocks_ref = blocks.iter().collect::<Vec<_>>();
 
     // The average length of the string column exceeds 256 bytes.
     let bloom_columns = bloom_columns_map(schema.clone(), vec![0, 1]);
@@ -363,7 +360,7 @@ fn test_string_bloom_filter() -> Result<()> {
     let index = BloomIndex::try_create(
         FunctionContext::default(),
         LatestBloom::VERSION,
-        &blocks_ref,
+        &blocks,
         bloom_columns,
     )?
     .unwrap();

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -41,6 +41,7 @@ pub(crate) use write::create_index_schema;
 pub(crate) use write::create_inverted_index_builders;
 pub(crate) use write::create_tokenizer_manager;
 pub use write::serialize_block;
+pub use write::serialize_blocks;
 pub use write::write_data;
 pub use write::BlockBuilder;
 pub use write::BlockSerialization;

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -94,6 +94,11 @@ pub fn serialize_blocks(
             );
 
             writer.start()?;
+            assert_eq!(
+                blocks.len(),
+                1,
+                "Native format does not support write multiple chunk for now"
+            );
             for block in blocks {
                 let batch = ArrowChunk::try_from(block)?;
                 writer.write(&batch)?;

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -21,6 +21,7 @@ use chrono::Utc;
 use databend_common_arrow::arrow::chunk::Chunk as ArrowChunk;
 use databend_common_arrow::native::write::NativeWriter;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
@@ -50,18 +51,25 @@ use crate::statistics::gen_columns_statistics;
 use crate::statistics::ClusterStatsGenerator;
 use crate::FuseStorageFormat;
 
-// TODO rename this, it is serialization, or pass in a writer(if not rename)
 pub fn serialize_block(
     write_settings: &WriteSettings,
     schema: &TableSchemaRef,
     block: DataBlock,
     buf: &mut Vec<u8>,
 ) -> Result<HashMap<ColumnId, ColumnMeta>> {
+    serialize_blocks(write_settings, schema, vec![block], buf)
+}
+
+pub fn serialize_blocks(
+    write_settings: &WriteSettings,
+    schema: &TableSchemaRef,
+    blocks: Vec<DataBlock>,
+    buf: &mut Vec<u8>,
+) -> Result<HashMap<ColumnId, ColumnMeta>> {
     let schema = Arc::new(schema.remove_virtual_computed_fields());
     match write_settings.storage_format {
         FuseStorageFormat::Parquet => {
-            let result =
-                blocks_to_parquet(&schema, vec![block], buf, write_settings.table_compression)?;
+            let result = blocks_to_parquet(&schema, blocks, buf, write_settings.table_compression)?;
             let meta = column_parquet_metas(&result, &schema)?;
             Ok(meta)
         }
@@ -85,10 +93,11 @@ pub fn serialize_block(
                 },
             );
 
-            let batch = ArrowChunk::try_from(block)?;
-
             writer.start()?;
-            writer.write(&batch)?;
+            for block in blocks {
+                let batch = ArrowChunk::try_from(block)?;
+                writer.write(&batch)?;
+            }
             writer.finish()?;
 
             let mut metas = HashMap::with_capacity(writer.metas.len());
@@ -121,7 +130,7 @@ pub struct BloomIndexState {
 impl BloomIndexState {
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
-        block: &DataBlock,
+        blocks: &[DataBlock],
         location: Location,
         bloom_columns_map: BTreeMap<FieldIndex, TableField>,
     ) -> Result<Option<Self>> {
@@ -129,7 +138,7 @@ impl BloomIndexState {
         let maybe_bloom_index = BloomIndex::try_create(
             ctx.get_function_context()?,
             location.1,
-            &[block],
+            blocks,
             bloom_columns_map,
         )?;
         if let Some(bloom_index) = maybe_bloom_index {
@@ -206,7 +215,7 @@ pub struct InvertedIndexState {
 impl InvertedIndexState {
     pub fn try_create(
         source_schema: &TableSchemaRef,
-        block: &DataBlock,
+        blocks: &[DataBlock],
         block_location: &Location,
         inverted_index_builder: &InvertedIndexBuilder,
     ) -> Result<Self> {
@@ -215,7 +224,9 @@ impl InvertedIndexState {
             Arc::new(inverted_index_builder.schema.clone()),
             &inverted_index_builder.options,
         )?;
-        writer.add_block(source_schema, block)?;
+        for block in blocks {
+            writer.add_block(source_schema, block)?;
+        }
         let data = writer.finalize()?;
         let size = data.len() as u64;
 
@@ -261,16 +272,29 @@ pub struct BlockBuilder {
 }
 
 impl BlockBuilder {
-    pub fn build<F>(&self, data_block: DataBlock, f: F) -> Result<BlockSerialization>
+    pub fn build<F>(&self, mut data_blocks: Vec<DataBlock>, f: F) -> Result<BlockSerialization>
     where F: Fn(DataBlock, &ClusterStatsGenerator) -> Result<(Option<ClusterStatistics>, DataBlock)>
     {
-        let (cluster_stats, data_block) = f(data_block, &self.cluster_stats_gen)?;
+        let cluster_stats = if !self.cluster_stats_gen.cluster_key_index.is_empty() {
+            if data_blocks.len() != 1 {
+                return Err(ErrorCode::Internal(format!(
+                    "Invalid data blocks count: {}",
+                    data_blocks.len(),
+                )));
+            }
+            let (cluster_stats, data_block) =
+                f(data_blocks.pop().unwrap(), &self.cluster_stats_gen)?;
+            data_blocks.push(data_block);
+            cluster_stats
+        } else {
+            None
+        };
         let (block_location, block_id) = self.meta_locations.gen_block_location();
 
         let bloom_index_location = self.meta_locations.block_bloom_index_location(&block_id);
         let bloom_index_state = BloomIndexState::try_create(
             self.ctx.clone(),
-            &data_block,
+            &data_blocks,
             bloom_index_location,
             self.bloom_columns_map.clone(),
         )?;
@@ -282,23 +306,23 @@ impl BlockBuilder {
         for inverted_index_builder in &self.inverted_index_builders {
             let inverted_index_state = InvertedIndexState::try_create(
                 &self.source_schema,
-                &data_block,
+                &data_blocks,
                 &block_location,
                 inverted_index_builder,
             )?;
             inverted_index_states.push(inverted_index_state);
         }
 
-        let row_count = data_block.num_rows() as u64;
-        let block_size = data_block.memory_size() as u64;
+        let row_count = data_blocks.iter().map(|b| b.num_rows()).sum::<usize>() as u64;
+        let block_size = data_blocks.iter().map(|b| b.memory_size()).sum::<usize>() as u64;
         let col_stats =
-            gen_columns_statistics(&data_block, column_distinct_count, &self.source_schema)?;
+            gen_columns_statistics(&data_blocks, column_distinct_count, &self.source_schema)?;
 
         let mut buffer = Vec::with_capacity(DEFAULT_BLOCK_BUFFER_SIZE);
-        let col_metas = serialize_block(
+        let col_metas = serialize_blocks(
             &self.write_settings,
             &self.source_schema,
-            data_block,
+            data_blocks,
             &mut buffer,
         )?;
         let file_size = buffer.len() as u64;

--- a/src/query/storages/fuse/src/io/write/mod.rs
+++ b/src/query/storages/fuse/src/io/write/mod.rs
@@ -20,6 +20,7 @@ mod write_settings;
 
 pub(crate) use block_writer::create_inverted_index_builders;
 pub use block_writer::serialize_block;
+pub use block_writer::serialize_blocks;
 pub use block_writer::write_data;
 pub use block_writer::BlockBuilder;
 pub use block_writer::BlockSerialization;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -193,14 +193,21 @@ impl FuseTable {
         };
         // Add source pipe.
         pipeline.add_source(
-            |output| {
-                CompactSource::try_create(
+            |output| match self.cluster_key_meta() {
+                Some(_) => CompactSource::<false>::try_create(
                     ctx.clone(),
                     self.storage_format,
                     block_reader.clone(),
                     stream_ctx.clone(),
                     output,
-                )
+                ),
+                None => CompactSource::<true>::try_create(
+                    ctx.clone(),
+                    self.storage_format,
+                    block_reader.clone(),
+                    stream_ctx.clone(),
+                    output,
+                ),
             },
             max_threads,
         )?;

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -438,7 +438,7 @@ impl AggregationContext {
 
         let serialized = GlobalIORuntime::instance()
             .spawn(async move {
-                            block_builder.build(res_block, |block, generator| {
+                            block_builder.build(vec![res_block], |block, generator| {
                                 let cluster_stats =
                                     generator.gen_with_origin_stats(&block, origin_stats.clone())?;
                                 info!(

--- a/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use databend_common_expression::BlockMetaInfo;
-use databend_common_expression::BlockMetaInfoDowncast;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
 
 use crate::operations::common::BlockMetaIndex;
 use crate::operations::mutation::CompactExtraInfo;
 use crate::operations::mutation::DeletedSegmentInfo;
+use crate::operations::LazyCompactedBlock;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum SerializeDataMeta {
     SerializeBlock(SerializeBlock),
     DeletedSegment(DeletedSegmentInfo),
@@ -29,8 +29,8 @@ pub enum SerializeDataMeta {
 
 #[typetag::serde(name = "serialize_data_meta")]
 impl BlockMetaInfo for SerializeDataMeta {
-    fn equals(&self, info: &Box<dyn BlockMetaInfo>) -> bool {
-        SerializeDataMeta::downcast_ref_from(info).is_some_and(|other| self == other)
+    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
+        unreachable!("SerializeDataMeta should not be compared")
     }
 
     fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
@@ -44,14 +44,23 @@ pub enum ClusterStatsGenType {
     WithOrigin(Option<ClusterStatistics>),
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct SerializeBlock {
     pub index: BlockMetaIndex,
     pub stats_type: ClusterStatsGenType,
+    pub lazy_compacted_block: Option<LazyCompactedBlock>,
 }
 
 impl SerializeBlock {
-    pub fn create(index: BlockMetaIndex, stats_type: ClusterStatsGenType) -> Self {
-        SerializeBlock { index, stats_type }
+    pub fn create(
+        index: BlockMetaIndex,
+        stats_type: ClusterStatsGenType,
+        lazy_compacted_block: Option<LazyCompactedBlock>,
+    ) -> SerializeBlock {
+        SerializeBlock {
+            index,
+            stats_type,
+            lazy_compacted_block,
+        }
     }
 }

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -178,7 +178,9 @@ impl<const IS_LAZY: bool> Processor for CompactSource<IS_LAZY> {
 
                 let new_block = match IS_LAZY {
                     true => {
-                        let lazy_block = LazyCompactedBlock(blocks);
+                        let lazy_block = LazyCompactedBlock(
+                            blocks.into_iter().map(|x| x.convert_to_full()).collect(),
+                        );
                         let meta =
                             Box::new(SerializeDataMeta::SerializeBlock(SerializeBlock::create(
                                 index,

--- a/src/query/storages/fuse/src/operations/mutation/processors/mod.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mod.rs
@@ -17,6 +17,7 @@ mod mutation_source;
 mod recluster_aggregator;
 
 pub use compact_source::CompactSource;
+pub use compact_source::LazyCompactedBlock;
 pub use mutation_source::MutationAction;
 pub use mutation_source::MutationSource;
 pub use recluster_aggregator::ReclusterAggregator;

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -250,6 +250,7 @@ impl Processor for MutationSource {
                                         SerializeBlock::create(
                                             self.index.clone(),
                                             self.stats_type.clone(),
+                                            None,
                                         ),
                                     ));
                                     self.state = State::Output(
@@ -351,7 +352,7 @@ impl Processor for MutationSource {
                     .iter()
                     .try_fold(data_block, |input, op| op.execute(&func_ctx, input))?;
                 let inner_meta = Box::new(SerializeDataMeta::SerializeBlock(
-                    SerializeBlock::create(self.index.clone(), self.stats_type.clone()),
+                    SerializeBlock::create(self.index.clone(), self.stats_type.clone(), None),
                 ));
                 let meta: BlockMetaInfoPtr = if self.block_reader.update_stream_columns() {
                     Box::new(gen_mutation_stream_meta(Some(inner_meta), &path)?)
@@ -407,7 +408,11 @@ impl Processor for MutationSource {
                             };
                             self.ctx.get_write_progress().incr(&progress_values);
                             let meta = Box::new(SerializeDataMeta::SerializeBlock(
-                                SerializeBlock::create(self.index.clone(), self.stats_type.clone()),
+                                SerializeBlock::create(
+                                    self.index.clone(),
+                                    self.stats_type.clone(),
+                                    None,
+                                ),
                             ));
                             self.state = State::Output(
                                 self.ctx.get_partition(),

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/merge_into_mutator.rs
@@ -549,7 +549,7 @@ impl AggregationContext {
         let origin_stats = block_meta.cluster_stats.clone();
         let serialized = GlobalIORuntime::instance()
             .spawn(async move {
-                block_builder.build(new_block, |block, generator| {
+                block_builder.build(vec![new_block], |block, generator| {
                     let cluster_stats =
                         generator.gen_with_origin_stats(&block, origin_stats.clone())?;
                     Ok((cluster_stats, block))

--- a/src/query/storages/fuse/src/statistics/block_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/block_statistics.rs
@@ -44,7 +44,7 @@ impl BlockStatistics {
             block_rows_size: data_block.num_rows() as u64,
             block_bytes_size: data_block.memory_size() as u64,
             block_column_statistics: column_statistic::gen_columns_statistics(
-                data_block,
+                &[data_block.clone()],
                 column_distinct_count,
                 schema,
             )?,

--- a/src/query/storages/fuse/src/statistics/column_statistic.rs
+++ b/src/query/storages/fuse/src/statistics/column_statistic.rs
@@ -25,7 +25,7 @@ use databend_common_expression::FieldIndex;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COLUMN_ID;
-use databend_common_functions::aggregates::eval_aggr;
+use databend_common_functions::aggregates::eval_unary_aggr_for_discrete_chunks;
 use databend_storages_common_index::Index;
 use databend_storages_common_index::RangeIndex;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
@@ -36,7 +36,7 @@ use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 const DISTINCT_ERROR_RATE: f64 = 0.04;
 
 pub fn calc_column_distinct_of_values(columns: &[Column], rows: usize) -> Result<u64> {
-    let distinct_values = eval_aggr(
+    let distinct_values = eval_unary_aggr_for_discrete_chunks(
         "approx_count_distinct",
         vec![Scalar::Number(NumberScalar::Float64(
             DISTINCT_ERROR_RATE.into(),
@@ -93,8 +93,8 @@ pub fn gen_columns_statistics(
         let mut min = Scalar::Null;
         let mut max = Scalar::Null;
 
-        let (mins, _) = eval_aggr("min", vec![], cols, rows)?;
-        let (maxs, _) = eval_aggr("max", vec![], cols, rows)?;
+        let (mins, _) = eval_unary_aggr_for_discrete_chunks("min", vec![], cols, rows)?;
+        let (maxs, _) = eval_unary_aggr_for_discrete_chunks("max", vec![], cols, rows)?;
 
         if mins.len() > 0 {
             min = if let Some(v) = mins.index(0) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Instead of concatenating multiple DataBlocks into a single DataBlock, directly writing multiple DataBlocks into a single table block.

- Fixes #15340

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datafuselabs/databend/15598)
<!-- Reviewable:end -->
