### PR TITLE
feat(query): DATE_ADD Functions to support week as a unit

### DIFF
--- a/src/query/functions/src/scalars/datetime.rs
+++ b/src/query/functions/src/scalars/datetime.rs
@@ -916,6 +916,39 @@ macro_rules! impl_register_arith_functions {
                 ),
             );
 
+            registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, DateType, _, _>(
+                concat!($op, "_weeks"),
+
+                |_, _, _| FunctionDomain::MayThrow,
+                vectorize_with_builder_2_arg::<DateType, Int64Type, DateType>(|date, delta, builder, ctx| {
+                    let delta = 7 * delta;
+                    match AddDaysImpl::eval_date(date, $signed_wrapper!{delta}) {
+                        Ok(t) => builder.push(t),
+                        Err(e) => {
+                            ctx.set_error(builder.len(), e);
+                            builder.push(0);
+                        },
+                    }
+                }),
+            );
+            registry.register_passthrough_nullable_2_arg::<TimestampType, Int64Type, TimestampType, _, _>(
+                concat!($op, "_weeks"),
+
+                |_, _, _| FunctionDomain::MayThrow,
+                vectorize_with_builder_2_arg::<TimestampType, Int64Type, TimestampType>(
+                    |ts, delta, builder, ctx| {
+                        let delta = 7 * delta;
+                        match AddDaysImpl::eval_timestamp(ts, $signed_wrapper!{delta}) {
+                            Ok(t) => builder.push(t),
+                            Err(e) => {
+                                ctx.set_error(builder.len(), e);
+                                builder.push(0);
+                            },
+                        }
+                    },
+                ),
+            );
+
             registry.register_passthrough_nullable_2_arg::<DateType, Int64Type, TimestampType, _, _>(
                 concat!($op, "_hours"),
 

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -108,6 +108,10 @@ Functions overloads:
 1 add_seconds(Date NULL, Int64 NULL) :: Timestamp NULL
 2 add_seconds(Timestamp, Int64) :: Timestamp
 3 add_seconds(Timestamp NULL, Int64 NULL) :: Timestamp NULL
+0 add_weeks(Date, Int64) :: Date
+1 add_weeks(Date NULL, Int64 NULL) :: Date NULL
+2 add_weeks(Timestamp, Int64) :: Timestamp
+3 add_weeks(Timestamp NULL, Int64 NULL) :: Timestamp NULL
 0 add_years(Date, Int64) :: Date
 1 add_years(Date NULL, Int64 NULL) :: Date NULL
 2 add_years(Timestamp, Int64) :: Timestamp
@@ -3686,6 +3690,10 @@ Functions overloads:
 1 subtract_seconds(Date NULL, Int64 NULL) :: Timestamp NULL
 2 subtract_seconds(Timestamp, Int64) :: Timestamp
 3 subtract_seconds(Timestamp NULL, Int64 NULL) :: Timestamp NULL
+0 subtract_weeks(Date, Int64) :: Date
+1 subtract_weeks(Date NULL, Int64 NULL) :: Date NULL
+2 subtract_weeks(Timestamp, Int64) :: Timestamp
+3 subtract_weeks(Timestamp NULL, Int64 NULL) :: Timestamp NULL
 0 subtract_years(Date, Int64) :: Date
 1 subtract_years(Date NULL, Int64 NULL) :: Date NULL
 2 subtract_years(Timestamp, Int64) :: Timestamp

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1132,3 +1132,8 @@ query T
 select to_timestamp('2022-03-27 07:54:31.12');
 ----
 2022-03-27 07:54:31.120000
+
+query T
+SELECT DATE_ADD('week', 1, TODAY())=DATE_ADD('day', 7, TODAY())
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

date_add support week as unit.

SELECT DATE_ADD('week', 1, TODAY())=DATE_ADD('day', 7, TODAY())

- fixes:  https://github.com/databendlabs/databend/issues/16402
## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16530)
<!-- Reviewable:end -->
