### PR TITLE
refactor: `DroppedId` for listing db/tables for gc

### DIFF
--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -984,15 +984,8 @@ impl ListDroppedTableReq {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DroppedId {
-    Db {
-        db_id: u64,
-        db_name: String,
-        tables: Vec<(u64, String)>,
-    },
-    Table {
-        name: DBIdTableName,
-        id: TableId,
-    },
+    Db { db_id: u64, db_name: String },
+    Table { name: DBIdTableName, id: TableId },
 }
 
 impl DroppedId {

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -172,23 +172,9 @@ impl Interpreter for VacuumDropTablesInterpreter {
             let mut success_dropped_ids = vec![];
             for drop_id in drop_ids {
                 match &drop_id {
-                    DroppedId::Db {
-                        db_id,
-                        db_name,
-                        tables,
-                    } => {
+                    DroppedId::Db { db_id: _, db_name } => {
                         if !failed_dbs.contains(db_name) {
                             success_dropped_ids.push(drop_id);
-                        } else {
-                            for (table_id, table_name) in tables.iter() {
-                                if !failed_tables.contains(table_id) {
-                                    success_dropped_ids.push(DroppedId::new_table(
-                                        *db_id,
-                                        *table_id,
-                                        table_name.clone(),
-                                    ));
-                                }
-                            }
                         }
                     }
                     DroppedId::Table { name: _, id } => {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: `DroppedId` for listing db/tables for gc

There is no need to store tables inside `DroppedId::Db`:
the tables belonging to a DB for gc can still be stored in `DroppedId::Table`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16542)
<!-- Reviewable:end -->
