### PR TITLE
refactor: `get_history_tables_for_gc()` should not return `TableInfo`, but just table name, id and values

### DIFF
--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -28,6 +28,7 @@ pub mod index_id_to_name_ident;
 pub mod index_name_ident;
 pub mod least_visible_time_ident;
 pub mod table_lock_ident;
+pub mod table_niv;
 pub mod virtual_column_ident;
 
 mod create_option;

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -39,6 +39,7 @@ use super::CatalogInfo;
 use super::CreateOption;
 use super::DatabaseId;
 use crate::schema::database_name_ident::DatabaseNameIdent;
+use crate::schema::table_niv::TableNIV;
 use crate::storage::StorageParams;
 use crate::tenant::Tenant;
 use crate::tenant::ToTenant;
@@ -988,7 +989,18 @@ pub enum DroppedId {
     Table { name: DBIdTableName, id: TableId },
 }
 
+impl From<TableNIV> for DroppedId {
+    fn from(value: TableNIV) -> Self {
+        let (name, id, _) = value.unpack();
+        Self::Table { name, id }
+    }
+}
+
 impl DroppedId {
+    pub fn new_table_name_id(name: DBIdTableName, id: TableId) -> DroppedId {
+        DroppedId::Table { name, id }
+    }
+
     pub fn new_table(db_id: u64, table_id: u64, table_name: impl ToString) -> DroppedId {
         DroppedId::Table {
             name: DBIdTableName::new(db_id, table_name),

--- a/src/meta/app/src/schema/table_niv.rs
+++ b/src/meta/app/src/schema/table_niv.rs
@@ -1,0 +1,49 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_types::SeqV;
+
+use crate::schema::DBIdTableName;
+use crate::schema::TableId;
+use crate::schema::TableMeta;
+
+/// The **Name, ID, Value** for a table metadata stored in meta-service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableNIV {
+    name: DBIdTableName,
+    id: TableId,
+    value: SeqV<TableMeta>,
+}
+
+impl TableNIV {
+    pub fn new(name: DBIdTableName, id: TableId, value: SeqV<TableMeta>) -> Self {
+        TableNIV { name, id, value }
+    }
+
+    pub fn name(&self) -> &DBIdTableName {
+        &self.name
+    }
+
+    pub fn id(&self) -> &TableId {
+        &self.id
+    }
+
+    pub fn value(&self) -> &SeqV<TableMeta> {
+        &self.value
+    }
+
+    pub fn unpack(self) -> (DBIdTableName, TableId, SeqV<TableMeta>) {
+        (self.name, self.id, self.value)
+    }
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: `get_history_tables_for_gc()` should not return `TableInfo`, but just table name, id and values

`SchemaApi` can not provide enough information to build a valid
`TableInfo`, such as, it does not know about catalog type and database
type. Therefore `get_history_tables_for_gc()` should just return `table
name, table id and the table meta` to its caller to let the build a
`TableInfo` if needed.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16545)
<!-- Reviewable:end -->
