### PR TITLE
fix: identify failed vacuum db by id

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -2723,25 +2723,17 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         )
         .await;
 
-        let (seq_db_id, db_meta) = match res {
+        let (seq_db_id, _db_meta) = match res {
             Ok(x) => x,
             Err(e) => {
                 return Err(e);
             }
         };
 
-        let db_info = Arc::new(DatabaseInfo {
-            database_id: seq_db_id.data,
-            name_ident: tenant_dbname.clone(),
-            meta: db_meta,
-        });
-        let table_nivs = get_history_tables_for_gc(
-            self,
-            drop_time_range.clone(),
-            db_info.database_id.db_id,
-            the_limit,
-        )
-        .await?;
+        let database_id = seq_db_id.data;
+        let table_nivs =
+            get_history_tables_for_gc(self, drop_time_range.clone(), database_id.db_id, the_limit)
+                .await?;
 
         let mut drop_ids = vec![];
         let mut vacuum_tables = vec![];

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -308,7 +308,6 @@ async fn test_fuse_do_vacuum_drop_table_deletion_error() -> Result<()> {
     let tables = vec![(table_info, operator)];
     let result = do_vacuum_drop_table(tables, None).await?;
     assert!(!result.1.is_empty());
-    assert!(!result.2.is_empty());
     // verify that accessor.delete() was called
     assert!(faulty_accessor.hit_delete_operation());
 
@@ -341,7 +340,6 @@ async fn test_fuse_vacuum_drop_tables_in_parallel_with_deletion_error() -> Resul
 
         // verify that errors of deletions are not swallowed
         assert!(!result.1.is_empty());
-        assert!(!result.2.is_empty());
     }
 
     // Case 2: parallel vacuum dropped tables
@@ -358,7 +356,6 @@ async fn test_fuse_vacuum_drop_tables_in_parallel_with_deletion_error() -> Resul
         assert!(faulty_accessor.hit_delete_operation());
         // verify that errors of deletions are not swallowed
         assert!(!result.1.is_empty());
-        assert!(!result.2.is_empty());
     }
 
     Ok(())
@@ -433,7 +430,6 @@ async fn test_fuse_do_vacuum_drop_table_external_storage() -> Result<()> {
     let tables = vec![(table_info, operator)];
     let result = do_vacuum_drop_table(tables, None).await?;
     assert!(!result.1.is_empty());
-    assert!(!result.2.is_empty());
 
     // verify that accessor.delete() was called
     assert!(!accessor.hit_delete_operation());

--- a/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
+++ b/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
@@ -26,12 +26,8 @@ use databend_common_storages_fuse::FuseTable;
 // (TableName, file, file size)
 pub type VacuumDropFileInfo = (String, String, u64);
 
-// (drop_files, failed_dbs, failed_tables)
-pub type VacuumDropTablesResult = Result<(
-    Option<Vec<VacuumDropFileInfo>>,
-    HashSet<String>,
-    HashSet<u64>,
-)>;
+// (drop_files, failed_tables)
+pub type VacuumDropTablesResult = Result<(Option<Vec<VacuumDropFileInfo>>, HashSet<u64>)>;
 
 #[async_trait::async_trait]
 pub trait VacuumHandler: Sync + Send {

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -142,13 +142,10 @@ impl Interpreter for VacuumDropTablesInterpreter {
             .await?;
 
         // map: table id to its belonging db id
-        let mut belonging_db = BTreeMap::new();
+        let mut containing_db = BTreeMap::new();
         for drop_id in drop_ids.iter() {
-            match drop_id {
-                DroppedId::Table { name, id } => {
-                    belonging_db.insert(id.table_id, name.db_id);
-                }
-                _ => {}
+            if let DroppedId::Table { name, id } = drop_id {
+                containing_db.insert(id.table_id, name.db_id);
             }
         }
 
@@ -184,7 +181,7 @@ impl Interpreter for VacuumDropTablesInterpreter {
         let failed_db_ids = failed_tables
             .iter()
             // Safe unwrap: the map is built from drop_ids
-            .map(|id| *belonging_db.get(id).unwrap())
+            .map(|id| *containing_db.get(id).unwrap())
             .collect::<HashSet<_>>();
 
         // gc metadata only when not dry run


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: identify failed vacuum db by id

Database-name in string can not be used to identify a database.
A database can be renamed and leads to a undefined behaviors.

In this commit, when a table is failed to vacuum, mark the belonging
database as failed by database-id, instead of by database-name.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16553)
<!-- Reviewable:end -->
