### PR TITLE
fix: window in scalar subquery returns wrong results

### DIFF
--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -306,7 +306,7 @@ impl SubqueryRewriter {
                     Arc::new(left.clone()),
                     Arc::new(flatten_plan),
                 );
-                Ok((s_expr, UnnestResult::SingleJoin { output_index: None }))
+                Ok((s_expr, UnnestResult::SingleJoin))
             }
             SubqueryType::Exists | SubqueryType::NotExists => {
                 if is_conjunctive_predicate {

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_push_down_filter_join.rs
@@ -178,13 +178,17 @@ pub fn try_push_down_filter_join(s_expr: &SExpr, metadata: MetadataRef) -> Resul
             }
             JoinPredicate::Other(_) => original_predicates.push(predicate),
             JoinPredicate::Both { is_equal_op, .. } => {
-                if matches!(join.join_type, JoinType::Inner | JoinType::Cross) {
+                if matches!(join.join_type, JoinType::Inner | JoinType::Cross)
+                    || join.single_to_inner.is_some()
+                {
                     if is_equal_op {
                         push_down_predicates.push(predicate);
                     } else {
                         non_equi_predicates.push(predicate);
                     }
-                    join.join_type = JoinType::Inner;
+                    if join.join_type == JoinType::Cross {
+                        join.join_type = JoinType::Inner;
+                    }
                 } else {
                     original_predicates.push(predicate);
                 }

--- a/src/query/sql/src/planner/semantic/distinct_to_groupby.rs
+++ b/src/query/sql/src/planner/semantic/distinct_to_groupby.rs
@@ -53,12 +53,16 @@ impl DistinctToGroupBy {
                                 distinct,
                                 name,
                                 args,
+                                window,
                                 ..
                             },
                     },
                 alias,
             } = &select_list[0]
             {
+                if window.is_some() {
+                    return;
+                }
                 let sub_query_name = "_distinct_group_by_subquery";
                 if ((name.name.to_ascii_lowercase() == "count" && *distinct)
                     || name.name.to_ascii_lowercase() == "count_distinct")

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1098,41 +1098,37 @@ insert into b values (1, 5), (4, 8)
 query T
 explain select * from a where a.id = (select id from b where a.id = b.id);
 ----
-Filter
+HashJoin
 ├── output columns: [a.id (#0), a.c1 (#1)]
-├── filters: [is_true(a.id (#0) = scalar_subquery_2 (#2))]
-├── estimated rows: 0.08
-└── HashJoin
-    ├── output columns: [a.id (#0), a.c1 (#1), b.id (#2)]
-    ├── join type: INNER
-    ├── build keys: [id (#2)]
-    ├── probe keys: [id (#0)]
-    ├── filters: []
-    ├── estimated rows: 0.40
-    ├── Filter(Build)
-    │   ├── output columns: [b.id (#2)]
-    │   ├── filters: [is_true(b.id (#2) = b.id (#2))]
-    │   ├── estimated rows: 0.40
-    │   └── TableScan
-    │       ├── table: default.default.b
-    │       ├── output columns: [id (#2)]
-    │       ├── read rows: 2
-    │       ├── read size: < 1 KiB
-    │       ├── partitions total: 1
-    │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    │       ├── push downs: [filters: [is_true(b.id (#2) = b.id (#2))], limit: NONE]
-    │       └── estimated rows: 2.00
-    └── TableScan(Probe)
-        ├── table: default.default.a
-        ├── output columns: [id (#0), c1 (#1)]
-        ├── read rows: 3
-        ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 3.00
+├── join type: INNER
+├── build keys: [scalar_subquery_2 (#2), id (#2)]
+├── probe keys: [a.id (#0), a.id (#0)]
+├── filters: []
+├── estimated rows: 0.40
+├── Filter(Build)
+│   ├── output columns: [b.id (#2)]
+│   ├── filters: [is_true(b.id (#2) = b.id (#2))]
+│   ├── estimated rows: 0.40
+│   └── TableScan
+│       ├── table: default.default.b
+│       ├── output columns: [id (#2)]
+│       ├── read rows: 2
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [and_filters(b.id (#2) = b.id (#2), b.id (#2) = b.id (#2))], limit: NONE]
+│       └── estimated rows: 2.00
+└── TableScan(Probe)
+    ├── table: default.default.a
+    ├── output columns: [id (#0), c1 (#1)]
+    ├── read rows: 3
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 3.00
 
 statement ok
 drop table a;
@@ -1507,110 +1503,102 @@ create table t2(a int, b int, c varchar(20));
 query T
 explain select * from t2 where c > (select c from t1 where t1.a = t2.a group by c order by count(a));
 ----
-Filter
+HashJoin
 ├── output columns: [t2.a (#0), t2.b (#1), t2.c (#2)]
-├── filters: [is_true(t2.c (#2) > scalar_subquery_5 (#5))]
+├── join type: INNER
+├── build keys: [a (#3)]
+├── probe keys: [a (#0)]
+├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
-└── HashJoin
-    ├── output columns: [t2.a (#0), t2.b (#1), t2.c (#2), t1.c (#5)]
-    ├── join type: INNER
-    ├── build keys: [a (#3)]
-    ├── probe keys: [a (#0)]
-    ├── filters: []
-    ├── estimated rows: 0.00
-    ├── Sort(Build)
-    │   ├── output columns: [t1.c (#5), t1.a (#3), count(a) (#7)]
-    │   ├── sort keys: [count(a) ASC NULLS LAST]
-    │   ├── estimated rows: 0.00
-    │   └── EvalScalar
-    │       ├── output columns: [t1.c (#5), t1.a (#3), count(a) (#7)]
-    │       ├── expressions: [count(a) (#6)]
-    │       ├── estimated rows: 0.00
-    │       └── AggregateFinal
-    │           ├── output columns: [count(a) (#6), t1.c (#5), t1.a (#3)]
-    │           ├── group by: [c, a]
-    │           ├── aggregate functions: [count(a)]
-    │           ├── estimated rows: 0.00
-    │           └── AggregatePartial
-    │               ├── group by: [c, a]
-    │               ├── aggregate functions: [count(a)]
-    │               ├── estimated rows: 0.00
-    │               └── Filter
-    │                   ├── output columns: [t1.a (#3), t1.c (#5)]
-    │                   ├── filters: [is_true(t1.a (#3) = t1.a (#3))]
-    │                   ├── estimated rows: 0.00
-    │                   └── TableScan
-    │                       ├── table: default.default.t1
-    │                       ├── output columns: [a (#3), c (#5)]
-    │                       ├── read rows: 0
-    │                       ├── read size: 0
-    │                       ├── partitions total: 0
-    │                       ├── partitions scanned: 0
-    │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
-    │                       └── estimated rows: 0.00
-    └── TableScan(Probe)
-        ├── table: default.default.t2
-        ├── output columns: [a (#0), b (#1), c (#2)]
-        ├── read rows: 0
-        ├── read size: 0
-        ├── partitions total: 0
-        ├── partitions scanned: 0
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 0.00
+├── Sort(Build)
+│   ├── output columns: [t1.c (#5), t1.a (#3), count(a) (#7)]
+│   ├── sort keys: [count(a) ASC NULLS LAST]
+│   ├── estimated rows: 0.00
+│   └── EvalScalar
+│       ├── output columns: [t1.c (#5), t1.a (#3), count(a) (#7)]
+│       ├── expressions: [count(a) (#6)]
+│       ├── estimated rows: 0.00
+│       └── AggregateFinal
+│           ├── output columns: [count(a) (#6), t1.c (#5), t1.a (#3)]
+│           ├── group by: [c, a]
+│           ├── aggregate functions: [count(a)]
+│           ├── estimated rows: 0.00
+│           └── AggregatePartial
+│               ├── group by: [c, a]
+│               ├── aggregate functions: [count(a)]
+│               ├── estimated rows: 0.00
+│               └── Filter
+│                   ├── output columns: [t1.a (#3), t1.c (#5)]
+│                   ├── filters: [is_true(t1.a (#3) = t1.a (#3))]
+│                   ├── estimated rows: 0.00
+│                   └── TableScan
+│                       ├── table: default.default.t1
+│                       ├── output columns: [a (#3), c (#5)]
+│                       ├── read rows: 0
+│                       ├── read size: 0
+│                       ├── partitions total: 0
+│                       ├── partitions scanned: 0
+│                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
+│                       └── estimated rows: 0.00
+└── TableScan(Probe)
+    ├── table: default.default.t2
+    ├── output columns: [a (#0), b (#1), c (#2)]
+    ├── read rows: 0
+    ├── read size: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 0.00
 
 query T
 explain select * from t2 where c > (select c from t1 where t1.a = t2.a group by c order by count(*));
 ----
-Filter
+HashJoin
 ├── output columns: [t2.a (#0), t2.b (#1), t2.c (#2)]
-├── filters: [is_true(t2.c (#2) > scalar_subquery_5 (#5))]
+├── join type: INNER
+├── build keys: [a (#3)]
+├── probe keys: [a (#0)]
+├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
-└── HashJoin
-    ├── output columns: [t2.a (#0), t2.b (#1), t2.c (#2), t1.c (#5)]
-    ├── join type: INNER
-    ├── build keys: [a (#3)]
-    ├── probe keys: [a (#0)]
-    ├── filters: []
-    ├── estimated rows: 0.00
-    ├── Sort(Build)
-    │   ├── output columns: [t1.c (#5), t1.a (#3), COUNT(*) (#7)]
-    │   ├── sort keys: [COUNT(*) ASC NULLS LAST]
-    │   ├── estimated rows: 0.00
-    │   └── EvalScalar
-    │       ├── output columns: [t1.c (#5), t1.a (#3), COUNT(*) (#7)]
-    │       ├── expressions: [COUNT(*) (#6)]
-    │       ├── estimated rows: 0.00
-    │       └── AggregateFinal
-    │           ├── output columns: [COUNT(*) (#6), t1.c (#5), t1.a (#3)]
-    │           ├── group by: [c, a]
-    │           ├── aggregate functions: [count()]
-    │           ├── estimated rows: 0.00
-    │           └── AggregatePartial
-    │               ├── group by: [c, a]
-    │               ├── aggregate functions: [count()]
-    │               ├── estimated rows: 0.00
-    │               └── Filter
-    │                   ├── output columns: [t1.a (#3), t1.c (#5)]
-    │                   ├── filters: [is_true(a (#3) = a (#3))]
-    │                   ├── estimated rows: 0.00
-    │                   └── TableScan
-    │                       ├── table: default.default.t1
-    │                       ├── output columns: [a (#3), c (#5)]
-    │                       ├── read rows: 0
-    │                       ├── read size: 0
-    │                       ├── partitions total: 0
-    │                       ├── partitions scanned: 0
-    │                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
-    │                       └── estimated rows: 0.00
-    └── TableScan(Probe)
-        ├── table: default.default.t2
-        ├── output columns: [a (#0), b (#1), c (#2)]
-        ├── read rows: 0
-        ├── read size: 0
-        ├── partitions total: 0
-        ├── partitions scanned: 0
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 0.00
+├── Sort(Build)
+│   ├── output columns: [t1.c (#5), t1.a (#3), COUNT(*) (#7)]
+│   ├── sort keys: [COUNT(*) ASC NULLS LAST]
+│   ├── estimated rows: 0.00
+│   └── EvalScalar
+│       ├── output columns: [t1.c (#5), t1.a (#3), COUNT(*) (#7)]
+│       ├── expressions: [COUNT(*) (#6)]
+│       ├── estimated rows: 0.00
+│       └── AggregateFinal
+│           ├── output columns: [COUNT(*) (#6), t1.c (#5), t1.a (#3)]
+│           ├── group by: [c, a]
+│           ├── aggregate functions: [count()]
+│           ├── estimated rows: 0.00
+│           └── AggregatePartial
+│               ├── group by: [c, a]
+│               ├── aggregate functions: [count()]
+│               ├── estimated rows: 0.00
+│               └── Filter
+│                   ├── output columns: [t1.a (#3), t1.c (#5)]
+│                   ├── filters: [is_true(a (#3) = a (#3))]
+│                   ├── estimated rows: 0.00
+│                   └── TableScan
+│                       ├── table: default.default.t1
+│                       ├── output columns: [a (#3), c (#5)]
+│                       ├── read rows: 0
+│                       ├── read size: 0
+│                       ├── partitions total: 0
+│                       ├── partitions scanned: 0
+│                       ├── push downs: [filters: [is_true(t1.a (#3) = t1.a (#3))], limit: NONE]
+│                       └── estimated rows: 0.00
+└── TableScan(Probe)
+    ├── table: default.default.t2
+    ├── output columns: [a (#0), b (#1), c (#2)]
+    ├── read rows: 0
+    ├── read size: 0
+    ├── partitions total: 0
+    ├── partitions scanned: 0
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 0.00
 
 query T
 explain insert into t2 select * from t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -80,91 +80,87 @@ Limit
 ├── output columns: [t.number (#0)]
 ├── limit: 3
 ├── offset: 0
-├── estimated rows: 0.20
+├── estimated rows: 1.00
 └── Sort
     ├── output columns: [t.number (#0)]
     ├── sort keys: [number DESC NULLS LAST]
-    ├── estimated rows: 0.20
+    ├── estimated rows: 1.00
     └── AggregateFinal
         ├── output columns: [t.number (#0)]
         ├── group by: [number]
         ├── aggregate functions: []
-        ├── estimated rows: 0.20
+        ├── estimated rows: 1.00
         └── AggregatePartial
             ├── group by: [number]
             ├── aggregate functions: []
-            ├── estimated rows: 0.20
+            ├── estimated rows: 1.00
             ├── rank limit: 3
-            └── Filter
+            └── HashJoin
                 ├── output columns: [t.number (#0)]
-                ├── filters: [is_true(CAST(t.number (#0) AS UInt64 NULL) = if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0))]
-                ├── estimated rows: 0.20
-                └── HashJoin
-                    ├── output columns: [t.number (#0), COUNT(*) (#4)]
-                    ├── join type: INNER
-                    ├── build keys: [number (#2)]
-                    ├── probe keys: [number (#0)]
+                ├── join type: INNER
+                ├── build keys: [number (#2), if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0)]
+                ├── probe keys: [number (#0), CAST(t.number (#0) AS UInt64 NULL)]
+                ├── filters: []
+                ├── estimated rows: 1.00
+                ├── AggregateFinal(Build)
+                │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
+                │   ├── group by: [number]
+                │   ├── aggregate functions: [count()]
+                │   ├── estimated rows: 1.00
+                │   └── AggregatePartial
+                │       ├── group by: [number]
+                │       ├── aggregate functions: [count()]
+                │       ├── estimated rows: 1.00
+                │       └── HashJoin
+                │           ├── output columns: [t2.number (#2)]
+                │           ├── join type: CROSS
+                │           ├── build keys: []
+                │           ├── probe keys: []
+                │           ├── filters: []
+                │           ├── estimated rows: 1.00
+                │           ├── TableScan(Build)
+                │           │   ├── table: default.system.numbers
+                │           │   ├── output columns: []
+                │           │   ├── read rows: 1
+                │           │   ├── read size: < 1 KiB
+                │           │   ├── partitions total: 1
+                │           │   ├── partitions scanned: 1
+                │           │   ├── push downs: [filters: [], limit: NONE]
+                │           │   └── estimated rows: 1.00
+                │           └── TableScan(Probe)
+                │               ├── table: default.system.numbers
+                │               ├── output columns: [number (#2)]
+                │               ├── read rows: 1
+                │               ├── read size: < 1 KiB
+                │               ├── partitions total: 1
+                │               ├── partitions scanned: 1
+                │               ├── push downs: [filters: [], limit: NONE]
+                │               └── estimated rows: 1.00
+                └── HashJoin(Probe)
+                    ├── output columns: [t.number (#0)]
+                    ├── join type: CROSS
+                    ├── build keys: []
+                    ├── probe keys: []
                     ├── filters: []
                     ├── estimated rows: 1.00
-                    ├── AggregateFinal(Build)
-                    │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
-                    │   ├── group by: [number]
-                    │   ├── aggregate functions: [count()]
-                    │   ├── estimated rows: 1.00
-                    │   └── AggregatePartial
-                    │       ├── group by: [number]
-                    │       ├── aggregate functions: [count()]
-                    │       ├── estimated rows: 1.00
-                    │       └── HashJoin
-                    │           ├── output columns: [t2.number (#2)]
-                    │           ├── join type: CROSS
-                    │           ├── build keys: []
-                    │           ├── probe keys: []
-                    │           ├── filters: []
-                    │           ├── estimated rows: 1.00
-                    │           ├── TableScan(Build)
-                    │           │   ├── table: default.system.numbers
-                    │           │   ├── output columns: []
-                    │           │   ├── read rows: 1
-                    │           │   ├── read size: < 1 KiB
-                    │           │   ├── partitions total: 1
-                    │           │   ├── partitions scanned: 1
-                    │           │   ├── push downs: [filters: [], limit: NONE]
-                    │           │   └── estimated rows: 1.00
-                    │           └── TableScan(Probe)
-                    │               ├── table: default.system.numbers
-                    │               ├── output columns: [number (#2)]
-                    │               ├── read rows: 1
-                    │               ├── read size: < 1 KiB
-                    │               ├── partitions total: 1
-                    │               ├── partitions scanned: 1
-                    │               ├── push downs: [filters: [], limit: NONE]
-                    │               └── estimated rows: 1.00
-                    └── HashJoin(Probe)
-                        ├── output columns: [t.number (#0)]
-                        ├── join type: CROSS
-                        ├── build keys: []
-                        ├── probe keys: []
-                        ├── filters: []
-                        ├── estimated rows: 1.00
-                        ├── TableScan(Build)
-                        │   ├── table: default.system.numbers
-                        │   ├── output columns: []
-                        │   ├── read rows: 1
-                        │   ├── read size: < 1 KiB
-                        │   ├── partitions total: 1
-                        │   ├── partitions scanned: 1
-                        │   ├── push downs: [filters: [], limit: NONE]
-                        │   └── estimated rows: 1.00
-                        └── TableScan(Probe)
-                            ├── table: default.system.numbers
-                            ├── output columns: [number (#0)]
-                            ├── read rows: 1
-                            ├── read size: < 1 KiB
-                            ├── partitions total: 1
-                            ├── partitions scanned: 1
-                            ├── push downs: [filters: [], limit: NONE]
-                            └── estimated rows: 1.00
+                    ├── TableScan(Build)
+                    │   ├── table: default.system.numbers
+                    │   ├── output columns: []
+                    │   ├── read rows: 1
+                    │   ├── read size: < 1 KiB
+                    │   ├── partitions total: 1
+                    │   ├── partitions scanned: 1
+                    │   ├── push downs: [filters: [], limit: NONE]
+                    │   └── estimated rows: 1.00
+                    └── TableScan(Probe)
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#0)]
+                        ├── read rows: 1
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 1.00
 
 query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -116,75 +116,56 @@ explain select t1.a from (select number + 1 as a, number + 1 as b from numbers(2
 HashJoin
 ├── output columns: [a (#1)]
 ├── join type: INNER
-├── build keys: [_if_scalar_subquery (#15)]
-├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── build keys: [scalar_subquery_12 (#12)]
+├── probe keys: [t1.a (#1)]
 ├── filters: []
 ├── estimated rows: 2.00
-├── EvalScalar(Build)
-│   ├── output columns: [_if_scalar_subquery (#15)]
-│   ├── expressions: [if(CAST(_count_scalar_subquery (#13) = 0 AS Boolean NULL), NULL, _any_scalar_subquery (#14))]
+├── AggregateFinal(Build)
+│   ├── output columns: [COUNT(*) (#12)]
+│   ├── group by: []
+│   ├── aggregate functions: [count()]
 │   ├── estimated rows: 1.00
-│   └── Limit
-│       ├── output columns: [_count_scalar_subquery (#13), _any_scalar_subquery (#14)]
-│       ├── limit: 1
-│       ├── offset: 0
+│   └── AggregatePartial
+│       ├── group by: []
+│       ├── aggregate functions: [count()]
 │       ├── estimated rows: 1.00
-│       └── AggregateFinal
-│           ├── output columns: [_count_scalar_subquery (#13), _any_scalar_subquery (#14)]
-│           ├── group by: []
-│           ├── aggregate functions: [count(), any(COUNT(*))]
-│           ├── estimated rows: 1.00
-│           └── AggregatePartial
-│               ├── group by: []
-│               ├── aggregate functions: [count(), any(COUNT(*))]
+│       └── HashJoin
+│           ├── output columns: []
+│           ├── join type: INNER
+│           ├── build keys: [t2.b (#5)]
+│           ├── probe keys: [t3.b (#10)]
+│           ├── filters: []
+│           ├── estimated rows: 0.20
+│           ├── EvalScalar(Build)
+│           │   ├── output columns: [b (#5)]
+│           │   ├── expressions: [numbers.number (#3) + 1]
+│           │   ├── estimated rows: 0.20
+│           │   └── Filter
+│           │       ├── output columns: [numbers.number (#3)]
+│           │       ├── filters: [numbers.number (#3) + 1 = 1]
+│           │       ├── estimated rows: 0.20
+│           │       └── TableScan
+│           │           ├── table: default.system.numbers
+│           │           ├── output columns: [number (#3)]
+│           │           ├── read rows: 1
+│           │           ├── read size: < 1 KiB
+│           │           ├── partitions total: 1
+│           │           ├── partitions scanned: 1
+│           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
+│           │           └── estimated rows: 1.00
+│           └── EvalScalar(Probe)
+│               ├── output columns: [b (#10)]
+│               ├── expressions: [numbers.number (#8) + 1]
 │               ├── estimated rows: 1.00
-│               ├── rank limit: 1
-│               └── AggregateFinal
-│                   ├── output columns: [COUNT(*) (#12)]
-│                   ├── group by: []
-│                   ├── aggregate functions: [count()]
-│                   ├── estimated rows: 1.00
-│                   └── AggregatePartial
-│                       ├── group by: []
-│                       ├── aggregate functions: [count()]
-│                       ├── estimated rows: 1.00
-│                       └── HashJoin
-│                           ├── output columns: []
-│                           ├── join type: INNER
-│                           ├── build keys: [t2.b (#5)]
-│                           ├── probe keys: [t3.b (#10)]
-│                           ├── filters: []
-│                           ├── estimated rows: 0.20
-│                           ├── EvalScalar(Build)
-│                           │   ├── output columns: [b (#5)]
-│                           │   ├── expressions: [numbers.number (#3) + 1]
-│                           │   ├── estimated rows: 0.20
-│                           │   └── Filter
-│                           │       ├── output columns: [numbers.number (#3)]
-│                           │       ├── filters: [numbers.number (#3) + 1 = 1]
-│                           │       ├── estimated rows: 0.20
-│                           │       └── TableScan
-│                           │           ├── table: default.system.numbers
-│                           │           ├── output columns: [number (#3)]
-│                           │           ├── read rows: 1
-│                           │           ├── read size: < 1 KiB
-│                           │           ├── partitions total: 1
-│                           │           ├── partitions scanned: 1
-│                           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
-│                           │           └── estimated rows: 1.00
-│                           └── EvalScalar(Probe)
-│                               ├── output columns: [b (#10)]
-│                               ├── expressions: [numbers.number (#8) + 1]
-│                               ├── estimated rows: 1.00
-│                               └── TableScan
-│                                   ├── table: default.system.numbers
-│                                   ├── output columns: [number (#8)]
-│                                   ├── read rows: 1
-│                                   ├── read size: < 1 KiB
-│                                   ├── partitions total: 1
-│                                   ├── partitions scanned: 1
-│                                   ├── push downs: [filters: [], limit: NONE]
-│                                   └── estimated rows: 1.00
+│               └── TableScan
+│                   ├── table: default.system.numbers
+│                   ├── output columns: [number (#8)]
+│                   ├── read rows: 1
+│                   ├── read size: < 1 KiB
+│                   ├── partitions total: 1
+│                   ├── partitions scanned: 1
+│                   ├── push downs: [filters: [], limit: NONE]
+│                   └── estimated rows: 1.00
 └── EvalScalar(Probe)
     ├── output columns: [a (#1)]
     ├── expressions: [numbers.number (#0) + 1]

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -1,76 +1,72 @@
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number)
 ----
-Filter
+HashJoin
 ├── output columns: [t.number (#0)]
-├── filters: [is_true(CAST(t.number (#0) AS UInt64 NULL) = if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0))]
-├── estimated rows: 0.20
-└── HashJoin
-    ├── output columns: [t.number (#0), COUNT(*) (#4)]
-    ├── join type: INNER
-    ├── build keys: [number (#2)]
-    ├── probe keys: [number (#0)]
+├── join type: INNER
+├── build keys: [number (#2), if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0)]
+├── probe keys: [number (#0), CAST(t.number (#0) AS UInt64 NULL)]
+├── filters: []
+├── estimated rows: 1.00
+├── AggregateFinal(Build)
+│   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
+│   ├── group by: [number]
+│   ├── aggregate functions: [count()]
+│   ├── estimated rows: 1.00
+│   └── AggregatePartial
+│       ├── group by: [number]
+│       ├── aggregate functions: [count()]
+│       ├── estimated rows: 1.00
+│       └── HashJoin
+│           ├── output columns: [t2.number (#2)]
+│           ├── join type: CROSS
+│           ├── build keys: []
+│           ├── probe keys: []
+│           ├── filters: []
+│           ├── estimated rows: 1.00
+│           ├── TableScan(Build)
+│           │   ├── table: default.system.numbers
+│           │   ├── output columns: []
+│           │   ├── read rows: 1
+│           │   ├── read size: < 1 KiB
+│           │   ├── partitions total: 1
+│           │   ├── partitions scanned: 1
+│           │   ├── push downs: [filters: [], limit: NONE]
+│           │   └── estimated rows: 1.00
+│           └── TableScan(Probe)
+│               ├── table: default.system.numbers
+│               ├── output columns: [number (#2)]
+│               ├── read rows: 1
+│               ├── read size: < 1 KiB
+│               ├── partitions total: 1
+│               ├── partitions scanned: 1
+│               ├── push downs: [filters: [], limit: NONE]
+│               └── estimated rows: 1.00
+└── HashJoin(Probe)
+    ├── output columns: [t.number (#0)]
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
     ├── filters: []
     ├── estimated rows: 1.00
-    ├── AggregateFinal(Build)
-    │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
-    │   ├── group by: [number]
-    │   ├── aggregate functions: [count()]
-    │   ├── estimated rows: 1.00
-    │   └── AggregatePartial
-    │       ├── group by: [number]
-    │       ├── aggregate functions: [count()]
-    │       ├── estimated rows: 1.00
-    │       └── HashJoin
-    │           ├── output columns: [t2.number (#2)]
-    │           ├── join type: CROSS
-    │           ├── build keys: []
-    │           ├── probe keys: []
-    │           ├── filters: []
-    │           ├── estimated rows: 1.00
-    │           ├── TableScan(Build)
-    │           │   ├── table: default.system.numbers
-    │           │   ├── output columns: []
-    │           │   ├── read rows: 1
-    │           │   ├── read size: < 1 KiB
-    │           │   ├── partitions total: 1
-    │           │   ├── partitions scanned: 1
-    │           │   ├── push downs: [filters: [], limit: NONE]
-    │           │   └── estimated rows: 1.00
-    │           └── TableScan(Probe)
-    │               ├── table: default.system.numbers
-    │               ├── output columns: [number (#2)]
-    │               ├── read rows: 1
-    │               ├── read size: < 1 KiB
-    │               ├── partitions total: 1
-    │               ├── partitions scanned: 1
-    │               ├── push downs: [filters: [], limit: NONE]
-    │               └── estimated rows: 1.00
-    └── HashJoin(Probe)
-        ├── output columns: [t.number (#0)]
-        ├── join type: CROSS
-        ├── build keys: []
-        ├── probe keys: []
-        ├── filters: []
-        ├── estimated rows: 1.00
-        ├── TableScan(Build)
-        │   ├── table: default.system.numbers
-        │   ├── output columns: []
-        │   ├── read rows: 1
-        │   ├── read size: < 1 KiB
-        │   ├── partitions total: 1
-        │   ├── partitions scanned: 1
-        │   ├── push downs: [filters: [], limit: NONE]
-        │   └── estimated rows: 1.00
-        └── TableScan(Probe)
-            ├── table: default.system.numbers
-            ├── output columns: [number (#0)]
-            ├── read rows: 1
-            ├── read size: < 1 KiB
-            ├── partitions total: 1
-            ├── partitions scanned: 1
-            ├── push downs: [filters: [], limit: NONE]
-            └── estimated rows: 1.00
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── output columns: []
+    │   ├── read rows: 1
+    │   ├── read size: < 1 KiB
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
+    └── TableScan(Probe)
+        ├── table: default.system.numbers
+        ├── output columns: [number (#0)]
+        ├── read rows: 1
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select t1.number from numbers(1) as t1 where t.number = t1.number) or t.number > 1
@@ -162,42 +158,23 @@ explain select t.number from numbers(2) as t where number = (select * from numbe
 HashJoin
 ├── output columns: [t.number (#0)]
 ├── join type: INNER
-├── build keys: [_if_scalar_subquery (#4)]
-├── probe keys: [CAST(t.number (#0) AS UInt64 NULL)]
+├── build keys: [scalar_subquery_1 (#1)]
+├── probe keys: [t.number (#0)]
 ├── filters: []
-├── estimated rows: 2.00
-├── EvalScalar(Build)
-│   ├── output columns: [_if_scalar_subquery (#4)]
-│   ├── expressions: [if(CAST(_count_scalar_subquery (#2) = 0 AS Boolean NULL), NULL, _any_scalar_subquery (#3))]
-│   ├── estimated rows: 1.00
-│   └── Limit
-│       ├── output columns: [_count_scalar_subquery (#2), _any_scalar_subquery (#3)]
-│       ├── limit: 1
-│       ├── offset: 0
-│       ├── estimated rows: 1.00
-│       └── AggregateFinal
-│           ├── output columns: [_count_scalar_subquery (#2), _any_scalar_subquery (#3)]
-│           ├── group by: []
-│           ├── aggregate functions: [count(), any(number)]
-│           ├── estimated rows: 1.00
-│           └── AggregatePartial
-│               ├── group by: []
-│               ├── aggregate functions: [count(), any(number)]
-│               ├── estimated rows: 1.00
-│               ├── rank limit: 1
-│               └── Filter
-│                   ├── output columns: [numbers.number (#1)]
-│                   ├── filters: [numbers.number (#1) = 0]
-│                   ├── estimated rows: 0.00
-│                   └── TableScan
-│                       ├── table: default.system.numbers
-│                       ├── output columns: [number (#1)]
-│                       ├── read rows: 1
-│                       ├── read size: < 1 KiB
-│                       ├── partitions total: 1
-│                       ├── partitions scanned: 1
-│                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
-│                       └── estimated rows: 1.00
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── output columns: [numbers.number (#1)]
+│   ├── filters: [numbers.number (#1) = 0]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.system.numbers
+│       ├── output columns: [number (#1)]
+│       ├── read rows: 1
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
+│       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -80,91 +80,87 @@ Limit
 ├── output columns: [t.number (#0)]
 ├── limit: 3
 ├── offset: 0
-├── estimated rows: 0.20
+├── estimated rows: 1.00
 └── Sort
     ├── output columns: [t.number (#0)]
     ├── sort keys: [number DESC NULLS LAST]
-    ├── estimated rows: 0.20
+    ├── estimated rows: 1.00
     └── AggregateFinal
         ├── output columns: [t.number (#0)]
         ├── group by: [number]
         ├── aggregate functions: []
-        ├── estimated rows: 0.20
+        ├── estimated rows: 1.00
         └── AggregatePartial
             ├── group by: [number]
             ├── aggregate functions: []
-            ├── estimated rows: 0.20
+            ├── estimated rows: 1.00
             ├── rank limit: 3
-            └── Filter
+            └── HashJoin
                 ├── output columns: [t.number (#0)]
-                ├── filters: [is_true(CAST(t.number (#0) AS UInt64 NULL) = if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0))]
-                ├── estimated rows: 0.20
-                └── HashJoin
-                    ├── output columns: [t.number (#0), COUNT(*) (#4)]
-                    ├── join type: INNER
-                    ├── build keys: [number (#2)]
-                    ├── probe keys: [number (#0)]
+                ├── join type: INNER
+                ├── build keys: [number (#2), if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0)]
+                ├── probe keys: [number (#0), CAST(t.number (#0) AS UInt64 NULL)]
+                ├── filters: []
+                ├── estimated rows: 1.00
+                ├── AggregateFinal(Build)
+                │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
+                │   ├── group by: [number]
+                │   ├── aggregate functions: [count()]
+                │   ├── estimated rows: 1.00
+                │   └── AggregatePartial
+                │       ├── group by: [number]
+                │       ├── aggregate functions: [count()]
+                │       ├── estimated rows: 1.00
+                │       └── HashJoin
+                │           ├── output columns: [t2.number (#2)]
+                │           ├── join type: CROSS
+                │           ├── build keys: []
+                │           ├── probe keys: []
+                │           ├── filters: []
+                │           ├── estimated rows: 1.00
+                │           ├── TableScan(Build)
+                │           │   ├── table: default.system.numbers
+                │           │   ├── output columns: []
+                │           │   ├── read rows: 1
+                │           │   ├── read size: < 1 KiB
+                │           │   ├── partitions total: 1
+                │           │   ├── partitions scanned: 1
+                │           │   ├── push downs: [filters: [], limit: NONE]
+                │           │   └── estimated rows: 1.00
+                │           └── TableScan(Probe)
+                │               ├── table: default.system.numbers
+                │               ├── output columns: [number (#2)]
+                │               ├── read rows: 1
+                │               ├── read size: < 1 KiB
+                │               ├── partitions total: 1
+                │               ├── partitions scanned: 1
+                │               ├── push downs: [filters: [], limit: NONE]
+                │               └── estimated rows: 1.00
+                └── HashJoin(Probe)
+                    ├── output columns: [t.number (#0)]
+                    ├── join type: CROSS
+                    ├── build keys: []
+                    ├── probe keys: []
                     ├── filters: []
                     ├── estimated rows: 1.00
-                    ├── AggregateFinal(Build)
-                    │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
-                    │   ├── group by: [number]
-                    │   ├── aggregate functions: [count()]
-                    │   ├── estimated rows: 1.00
-                    │   └── AggregatePartial
-                    │       ├── group by: [number]
-                    │       ├── aggregate functions: [count()]
-                    │       ├── estimated rows: 1.00
-                    │       └── HashJoin
-                    │           ├── output columns: [t2.number (#2)]
-                    │           ├── join type: CROSS
-                    │           ├── build keys: []
-                    │           ├── probe keys: []
-                    │           ├── filters: []
-                    │           ├── estimated rows: 1.00
-                    │           ├── TableScan(Build)
-                    │           │   ├── table: default.system.numbers
-                    │           │   ├── output columns: []
-                    │           │   ├── read rows: 1
-                    │           │   ├── read size: < 1 KiB
-                    │           │   ├── partitions total: 1
-                    │           │   ├── partitions scanned: 1
-                    │           │   ├── push downs: [filters: [], limit: NONE]
-                    │           │   └── estimated rows: 1.00
-                    │           └── TableScan(Probe)
-                    │               ├── table: default.system.numbers
-                    │               ├── output columns: [number (#2)]
-                    │               ├── read rows: 1
-                    │               ├── read size: < 1 KiB
-                    │               ├── partitions total: 1
-                    │               ├── partitions scanned: 1
-                    │               ├── push downs: [filters: [], limit: NONE]
-                    │               └── estimated rows: 1.00
-                    └── HashJoin(Probe)
-                        ├── output columns: [t.number (#0)]
-                        ├── join type: CROSS
-                        ├── build keys: []
-                        ├── probe keys: []
-                        ├── filters: []
-                        ├── estimated rows: 1.00
-                        ├── TableScan(Build)
-                        │   ├── table: default.system.numbers
-                        │   ├── output columns: []
-                        │   ├── read rows: 1
-                        │   ├── read size: < 1 KiB
-                        │   ├── partitions total: 1
-                        │   ├── partitions scanned: 1
-                        │   ├── push downs: [filters: [], limit: NONE]
-                        │   └── estimated rows: 1.00
-                        └── TableScan(Probe)
-                            ├── table: default.system.numbers
-                            ├── output columns: [number (#0)]
-                            ├── read rows: 1
-                            ├── read size: < 1 KiB
-                            ├── partitions total: 1
-                            ├── partitions scanned: 1
-                            ├── push downs: [filters: [], limit: NONE]
-                            └── estimated rows: 1.00
+                    ├── TableScan(Build)
+                    │   ├── table: default.system.numbers
+                    │   ├── output columns: []
+                    │   ├── read rows: 1
+                    │   ├── read size: < 1 KiB
+                    │   ├── partitions total: 1
+                    │   ├── partitions scanned: 1
+                    │   ├── push downs: [filters: [], limit: NONE]
+                    │   └── estimated rows: 1.00
+                    └── TableScan(Probe)
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#0)]
+                        ├── read rows: 1
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 1.00
 
 query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
@@ -116,75 +116,56 @@ explain select t1.a from (select number + 1 as a, number + 1 as b from numbers(2
 HashJoin
 ├── output columns: [a (#1)]
 ├── join type: INNER
-├── build keys: [_if_scalar_subquery (#15)]
-├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── build keys: [scalar_subquery_12 (#12)]
+├── probe keys: [t1.a (#1)]
 ├── filters: []
 ├── estimated rows: 2.00
-├── EvalScalar(Build)
-│   ├── output columns: [_if_scalar_subquery (#15)]
-│   ├── expressions: [if(CAST(_count_scalar_subquery (#13) = 0 AS Boolean NULL), NULL, _any_scalar_subquery (#14))]
+├── AggregateFinal(Build)
+│   ├── output columns: [COUNT(*) (#12)]
+│   ├── group by: []
+│   ├── aggregate functions: [count()]
 │   ├── estimated rows: 1.00
-│   └── Limit
-│       ├── output columns: [_count_scalar_subquery (#13), _any_scalar_subquery (#14)]
-│       ├── limit: 1
-│       ├── offset: 0
+│   └── AggregatePartial
+│       ├── group by: []
+│       ├── aggregate functions: [count()]
 │       ├── estimated rows: 1.00
-│       └── AggregateFinal
-│           ├── output columns: [_count_scalar_subquery (#13), _any_scalar_subquery (#14)]
-│           ├── group by: []
-│           ├── aggregate functions: [count(), any(COUNT(*))]
-│           ├── estimated rows: 1.00
-│           └── AggregatePartial
-│               ├── group by: []
-│               ├── aggregate functions: [count(), any(COUNT(*))]
+│       └── HashJoin
+│           ├── output columns: []
+│           ├── join type: INNER
+│           ├── build keys: [t2.b (#5)]
+│           ├── probe keys: [t3.b (#10)]
+│           ├── filters: []
+│           ├── estimated rows: 0.20
+│           ├── EvalScalar(Build)
+│           │   ├── output columns: [b (#5)]
+│           │   ├── expressions: [numbers.number (#3) + 1]
+│           │   ├── estimated rows: 0.20
+│           │   └── Filter
+│           │       ├── output columns: [numbers.number (#3)]
+│           │       ├── filters: [numbers.number (#3) + 1 = 1]
+│           │       ├── estimated rows: 0.20
+│           │       └── TableScan
+│           │           ├── table: default.system.numbers
+│           │           ├── output columns: [number (#3)]
+│           │           ├── read rows: 1
+│           │           ├── read size: < 1 KiB
+│           │           ├── partitions total: 1
+│           │           ├── partitions scanned: 1
+│           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
+│           │           └── estimated rows: 1.00
+│           └── EvalScalar(Probe)
+│               ├── output columns: [b (#10)]
+│               ├── expressions: [numbers.number (#8) + 1]
 │               ├── estimated rows: 1.00
-│               ├── rank limit: 1
-│               └── AggregateFinal
-│                   ├── output columns: [COUNT(*) (#12)]
-│                   ├── group by: []
-│                   ├── aggregate functions: [count()]
-│                   ├── estimated rows: 1.00
-│                   └── AggregatePartial
-│                       ├── group by: []
-│                       ├── aggregate functions: [count()]
-│                       ├── estimated rows: 1.00
-│                       └── HashJoin
-│                           ├── output columns: []
-│                           ├── join type: INNER
-│                           ├── build keys: [t2.b (#5)]
-│                           ├── probe keys: [t3.b (#10)]
-│                           ├── filters: []
-│                           ├── estimated rows: 0.20
-│                           ├── EvalScalar(Build)
-│                           │   ├── output columns: [b (#5)]
-│                           │   ├── expressions: [numbers.number (#3) + 1]
-│                           │   ├── estimated rows: 0.20
-│                           │   └── Filter
-│                           │       ├── output columns: [numbers.number (#3)]
-│                           │       ├── filters: [numbers.number (#3) + 1 = 1]
-│                           │       ├── estimated rows: 0.20
-│                           │       └── TableScan
-│                           │           ├── table: default.system.numbers
-│                           │           ├── output columns: [number (#3)]
-│                           │           ├── read rows: 1
-│                           │           ├── read size: < 1 KiB
-│                           │           ├── partitions total: 1
-│                           │           ├── partitions scanned: 1
-│                           │           ├── push downs: [filters: [numbers.number (#3) + 1 = 1], limit: NONE]
-│                           │           └── estimated rows: 1.00
-│                           └── EvalScalar(Probe)
-│                               ├── output columns: [b (#10)]
-│                               ├── expressions: [numbers.number (#8) + 1]
-│                               ├── estimated rows: 1.00
-│                               └── TableScan
-│                                   ├── table: default.system.numbers
-│                                   ├── output columns: [number (#8)]
-│                                   ├── read rows: 1
-│                                   ├── read size: < 1 KiB
-│                                   ├── partitions total: 1
-│                                   ├── partitions scanned: 1
-│                                   ├── push downs: [filters: [], limit: NONE]
-│                                   └── estimated rows: 1.00
+│               └── TableScan
+│                   ├── table: default.system.numbers
+│                   ├── output columns: [number (#8)]
+│                   ├── read rows: 1
+│                   ├── read size: < 1 KiB
+│                   ├── partitions total: 1
+│                   ├── partitions scanned: 1
+│                   ├── push downs: [filters: [], limit: NONE]
+│                   └── estimated rows: 1.00
 └── EvalScalar(Probe)
     ├── output columns: [a (#1)]
     ├── expressions: [numbers.number (#0) + 1]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -1,76 +1,72 @@
 query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number)
 ----
-Filter
+HashJoin
 ├── output columns: [t.number (#0)]
-├── filters: [is_true(CAST(t.number (#0) AS UInt64 NULL) = if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0))]
-├── estimated rows: 0.20
-└── HashJoin
-    ├── output columns: [t.number (#0), COUNT(*) (#4)]
-    ├── join type: INNER
-    ├── build keys: [number (#2)]
-    ├── probe keys: [number (#0)]
+├── join type: INNER
+├── build keys: [number (#2), if(true, TRY_CAST(scalar_subquery_4 (#4) AS UInt64 NULL), 0)]
+├── probe keys: [number (#0), CAST(t.number (#0) AS UInt64 NULL)]
+├── filters: []
+├── estimated rows: 1.00
+├── AggregateFinal(Build)
+│   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
+│   ├── group by: [number]
+│   ├── aggregate functions: [count()]
+│   ├── estimated rows: 1.00
+│   └── AggregatePartial
+│       ├── group by: [number]
+│       ├── aggregate functions: [count()]
+│       ├── estimated rows: 1.00
+│       └── HashJoin
+│           ├── output columns: [t2.number (#2)]
+│           ├── join type: CROSS
+│           ├── build keys: []
+│           ├── probe keys: []
+│           ├── filters: []
+│           ├── estimated rows: 1.00
+│           ├── TableScan(Build)
+│           │   ├── table: default.system.numbers
+│           │   ├── output columns: []
+│           │   ├── read rows: 1
+│           │   ├── read size: < 1 KiB
+│           │   ├── partitions total: 1
+│           │   ├── partitions scanned: 1
+│           │   ├── push downs: [filters: [], limit: NONE]
+│           │   └── estimated rows: 1.00
+│           └── TableScan(Probe)
+│               ├── table: default.system.numbers
+│               ├── output columns: [number (#2)]
+│               ├── read rows: 1
+│               ├── read size: < 1 KiB
+│               ├── partitions total: 1
+│               ├── partitions scanned: 1
+│               ├── push downs: [filters: [], limit: NONE]
+│               └── estimated rows: 1.00
+└── HashJoin(Probe)
+    ├── output columns: [t.number (#0)]
+    ├── join type: CROSS
+    ├── build keys: []
+    ├── probe keys: []
     ├── filters: []
     ├── estimated rows: 1.00
-    ├── AggregateFinal(Build)
-    │   ├── output columns: [COUNT(*) (#4), t2.number (#2)]
-    │   ├── group by: [number]
-    │   ├── aggregate functions: [count()]
-    │   ├── estimated rows: 1.00
-    │   └── AggregatePartial
-    │       ├── group by: [number]
-    │       ├── aggregate functions: [count()]
-    │       ├── estimated rows: 1.00
-    │       └── HashJoin
-    │           ├── output columns: [t2.number (#2)]
-    │           ├── join type: CROSS
-    │           ├── build keys: []
-    │           ├── probe keys: []
-    │           ├── filters: []
-    │           ├── estimated rows: 1.00
-    │           ├── TableScan(Build)
-    │           │   ├── table: default.system.numbers
-    │           │   ├── output columns: []
-    │           │   ├── read rows: 1
-    │           │   ├── read size: < 1 KiB
-    │           │   ├── partitions total: 1
-    │           │   ├── partitions scanned: 1
-    │           │   ├── push downs: [filters: [], limit: NONE]
-    │           │   └── estimated rows: 1.00
-    │           └── TableScan(Probe)
-    │               ├── table: default.system.numbers
-    │               ├── output columns: [number (#2)]
-    │               ├── read rows: 1
-    │               ├── read size: < 1 KiB
-    │               ├── partitions total: 1
-    │               ├── partitions scanned: 1
-    │               ├── push downs: [filters: [], limit: NONE]
-    │               └── estimated rows: 1.00
-    └── HashJoin(Probe)
-        ├── output columns: [t.number (#0)]
-        ├── join type: CROSS
-        ├── build keys: []
-        ├── probe keys: []
-        ├── filters: []
-        ├── estimated rows: 1.00
-        ├── TableScan(Build)
-        │   ├── table: default.system.numbers
-        │   ├── output columns: []
-        │   ├── read rows: 1
-        │   ├── read size: < 1 KiB
-        │   ├── partitions total: 1
-        │   ├── partitions scanned: 1
-        │   ├── push downs: [filters: [], limit: NONE]
-        │   └── estimated rows: 1.00
-        └── TableScan(Probe)
-            ├── table: default.system.numbers
-            ├── output columns: [number (#0)]
-            ├── read rows: 1
-            ├── read size: < 1 KiB
-            ├── partitions total: 1
-            ├── partitions scanned: 1
-            ├── push downs: [filters: [], limit: NONE]
-            └── estimated rows: 1.00
+    ├── TableScan(Build)
+    │   ├── table: default.system.numbers
+    │   ├── output columns: []
+    │   ├── read rows: 1
+    │   ├── read size: < 1 KiB
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 1.00
+    └── TableScan(Probe)
+        ├── table: default.system.numbers
+        ├── output columns: [number (#0)]
+        ├── read rows: 1
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 1.00
 
 query T
 explain select t.number from numbers(1) as t where exists (select t1.number from numbers(1) as t1 where t.number = t1.number) or t.number > 1
@@ -162,42 +158,23 @@ explain select t.number from numbers(2) as t where number = (select * from numbe
 HashJoin
 ├── output columns: [t.number (#0)]
 ├── join type: INNER
-├── build keys: [_if_scalar_subquery (#4)]
-├── probe keys: [CAST(t.number (#0) AS UInt64 NULL)]
+├── build keys: [scalar_subquery_1 (#1)]
+├── probe keys: [t.number (#0)]
 ├── filters: []
-├── estimated rows: 2.00
-├── EvalScalar(Build)
-│   ├── output columns: [_if_scalar_subquery (#4)]
-│   ├── expressions: [if(CAST(_count_scalar_subquery (#2) = 0 AS Boolean NULL), NULL, _any_scalar_subquery (#3))]
-│   ├── estimated rows: 1.00
-│   └── Limit
-│       ├── output columns: [_count_scalar_subquery (#2), _any_scalar_subquery (#3)]
-│       ├── limit: 1
-│       ├── offset: 0
-│       ├── estimated rows: 1.00
-│       └── AggregateFinal
-│           ├── output columns: [_count_scalar_subquery (#2), _any_scalar_subquery (#3)]
-│           ├── group by: []
-│           ├── aggregate functions: [count(), any(number)]
-│           ├── estimated rows: 1.00
-│           └── AggregatePartial
-│               ├── group by: []
-│               ├── aggregate functions: [count(), any(number)]
-│               ├── estimated rows: 1.00
-│               ├── rank limit: 1
-│               └── Filter
-│                   ├── output columns: [numbers.number (#1)]
-│                   ├── filters: [numbers.number (#1) = 0]
-│                   ├── estimated rows: 0.00
-│                   └── TableScan
-│                       ├── table: default.system.numbers
-│                       ├── output columns: [number (#1)]
-│                       ├── read rows: 1
-│                       ├── read size: < 1 KiB
-│                       ├── partitions total: 1
-│                       ├── partitions scanned: 1
-│                       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
-│                       └── estimated rows: 1.00
+├── estimated rows: 0.00
+├── Filter(Build)
+│   ├── output columns: [numbers.number (#1)]
+│   ├── filters: [numbers.number (#1) = 0]
+│   ├── estimated rows: 0.00
+│   └── TableScan
+│       ├── table: default.system.numbers
+│       ├── output columns: [number (#1)]
+│       ├── read rows: 1
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── push downs: [filters: [numbers.number (#1) = 0], limit: NONE]
+│       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]

--- a/tests/sqllogictests/suites/query/window_function/window_with_subquery.test
+++ b/tests/sqllogictests/suites/query/window_function/window_with_subquery.test
@@ -1,0 +1,20 @@
+statement ok
+create or replace table t1(a int);
+
+statement ok
+insert into t1 values(1), (2), (2), (3);
+
+statement ok
+create or replace table t2(b int);
+
+statement ok
+insert into t2 values(1), (2), (3);
+
+query error 1001.*Scalar subquery can't return more than one row
+select count(distinct a) over (partition by (select b from t2)) from t1;
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Because we introduced single to inner join optimization, so we don't need to maintain the method `rewrite_uncorrelated_scalar_subquery` instead of rewriting to single join directly.

Then we can solve the issue15977.

Note: `select count(distinct a) over (partition by 1) from t1;` `PARTITION BY 1` is a special syntax that actually means **no partitioning**, i.e., all rows are treated as a partition. So `partition by (select b from t2)` is not semantic if it returns more than one row but if returns only one row, it's valid, meaning **no partitioning**.

- fixes: https://github.com/databendlabs/databend/issues/15977

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16567)
<!-- Reviewable:end -->
