### PR TITLE
refactor: simplify get_tables_history()

### DIFF
--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -53,7 +53,6 @@ pub use util::deserialize_struct;
 pub use util::deserialize_u64;
 pub use util::fetch_id;
 pub use util::get_u64_value;
-pub use util::list_keys;
 pub use util::list_u64_value;
 pub use util::send_txn;
 pub use util::serialize_struct;

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -20,6 +20,7 @@ use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent
 use databend_common_meta_app::schema::index_id_ident::IndexId;
 use databend_common_meta_app::schema::index_id_ident::IndexIdIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
+use databend_common_meta_app::schema::table_niv::TableNIV;
 use databend_common_meta_app::schema::CatalogInfo;
 use databend_common_meta_app::schema::CatalogMeta;
 use databend_common_meta_app::schema::CatalogNameIdent;
@@ -209,11 +210,7 @@ pub trait SchemaApi: Send + Sync {
         table_id_history: &TableIdHistoryIdent,
     ) -> Result<Vec<(TableId, SeqV<TableMeta>)>, KVAppError>;
 
-    async fn get_tables_history(
-        &self,
-        req: ListTableReq,
-        db_name: &str,
-    ) -> Result<Vec<Arc<TableInfo>>, KVAppError>;
+    async fn get_tables_history(&self, req: ListTableReq) -> Result<Vec<TableNIV>, KVAppError>;
 
     /// List all tables in the database.
     ///

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -44,6 +44,7 @@ use databend_common_meta_app::schema::index_id_ident::IndexId;
 use databend_common_meta_app::schema::index_id_ident::IndexIdIdent;
 use databend_common_meta_app::schema::index_id_to_name_ident::IndexIdToNameIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
+use databend_common_meta_app::schema::table_niv::TableNIV;
 use databend_common_meta_app::schema::CatalogMeta;
 use databend_common_meta_app::schema::CatalogNameIdent;
 use databend_common_meta_app::schema::CatalogOption;
@@ -160,7 +161,6 @@ pub struct SchemaApiTestSuite {}
 #[derive(PartialEq, Default, Debug)]
 struct DroponInfo {
     pub name: String,
-    pub desc: String,
     pub drop_on_cnt: i32,
     pub non_drop_on_cnt: i32,
 }
@@ -182,19 +182,16 @@ fn calc_and_compare_drop_on_db_result(result: Vec<Arc<DatabaseInfo>>, expected: 
     let mut get = BTreeMap::new();
     for item in result.iter() {
         let name = item.name_ident.to_string_key();
-        let drop_on_info = match get.get_mut(&name) {
-            Some(drop_on_info) => drop_on_info,
-            None => {
-                let info = DroponInfo {
-                    name: name.clone(),
-                    desc: "".to_string(),
-                    drop_on_cnt: 0,
-                    non_drop_on_cnt: 0,
-                };
-                get.insert(name.clone(), info);
-                get.get_mut(&name).expect("")
-            }
+        if !get.contains_key(&name) {
+            let info = DroponInfo {
+                name: name.clone(),
+                drop_on_cnt: 0,
+                non_drop_on_cnt: 0,
+            };
+            get.insert(name.clone(), info);
         };
+
+        let drop_on_info = get.get_mut(&name).unwrap();
         if item.meta.drop_on.is_some() {
             drop_on_info.drop_on_cnt += 1;
         } else {
@@ -205,36 +202,33 @@ fn calc_and_compare_drop_on_db_result(result: Vec<Arc<DatabaseInfo>>, expected: 
     assert_eq!(get, expected_map);
 }
 
-fn calc_and_compare_drop_on_table_result(result: Vec<Arc<TableInfo>>, expected: Vec<DroponInfo>) {
+fn calc_and_compare_drop_on_table_result(result: Vec<TableNIV>, expected: Vec<DroponInfo>) {
     let mut expected_map = BTreeMap::new();
     for expected_item in expected {
         expected_map.insert(expected_item.name.clone(), expected_item);
     }
 
-    let mut get = BTreeMap::new();
+    let mut got = BTreeMap::new();
     for item in result.iter() {
-        let name = item.name.clone();
-        let drop_on_info = match get.get_mut(&name) {
-            Some(drop_on_info) => drop_on_info,
-            None => {
-                let info = DroponInfo {
-                    name: item.name.clone(),
-                    desc: item.desc.clone(),
-                    drop_on_cnt: 0,
-                    non_drop_on_cnt: 0,
-                };
-                get.insert(name.clone(), info);
-                get.get_mut(&name).expect("")
-            }
+        let table_name = item.name().to_string_key();
+        if !got.contains_key(&table_name) {
+            let info = DroponInfo {
+                name: table_name.clone(),
+                drop_on_cnt: 0,
+                non_drop_on_cnt: 0,
+            };
+            got.insert(table_name.clone(), info);
         };
-        if item.meta.drop_on.is_some() {
+
+        let drop_on_info = got.get_mut(&table_name).expect("");
+        if item.value().drop_on.is_some() {
             drop_on_info.drop_on_cnt += 1;
         } else {
             drop_on_info.non_drop_on_cnt += 1;
         }
     }
 
-    assert_eq!(get, expected_map);
+    assert_eq!(got, expected_map);
 }
 
 async fn upsert_test_data(
@@ -1184,7 +1178,6 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
                 name: db_name_ident.to_string_key(),
-                desc: "".to_string(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
             }]);
@@ -1205,7 +1198,6 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
                 name: db_name_ident.to_string_key(),
-                desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
             }]);
@@ -1225,7 +1217,6 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
                 name: db_name_ident.to_string_key(),
-                desc: "".to_string(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
             }]);
@@ -1249,7 +1240,6 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
                 name: db_name_ident.to_string_key(),
-                desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
             }]);
@@ -1276,7 +1266,6 @@ impl SchemaApiTestSuite {
                 .await?;
             calc_and_compare_drop_on_db_result(res, vec![DroponInfo {
                 name: db_name_ident.to_string_key(),
-                desc: "".to_string(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 1,
             }]);
@@ -1307,13 +1296,11 @@ impl SchemaApiTestSuite {
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
                     name: db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
                     name: new_db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 0,
                     non_drop_on_cnt: 1,
                 },
@@ -1336,13 +1323,11 @@ impl SchemaApiTestSuite {
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
                     name: db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
                     name: new_db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
                 },
@@ -1366,13 +1351,11 @@ impl SchemaApiTestSuite {
             calc_and_compare_drop_on_db_result(res, vec![
                 DroponInfo {
                     name: db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
                 },
                 DroponInfo {
                     name: new_db_name_ident.to_string_key(),
-                    desc: "".to_string(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
@@ -4020,7 +4003,7 @@ impl SchemaApiTestSuite {
             assert!(table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 1);
@@ -4038,7 +4021,7 @@ impl SchemaApiTestSuite {
             upsert_test_data(mt.as_kv_api(), &tbid, data).await?;
             // assert not return out of retention time data
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 0);
@@ -4676,15 +4659,11 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
             }]);
@@ -4712,14 +4691,10 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
             }]);
@@ -4734,14 +4709,10 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 0,
                 non_drop_on_cnt: 1,
             }]);
@@ -4765,14 +4736,10 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 0,
             }]);
@@ -4792,15 +4759,11 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 1,
             }]);
@@ -4824,14 +4787,10 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 2,
                 non_drop_on_cnt: 0,
             }]);
@@ -4845,15 +4804,11 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
-                name: tbl_name.to_string(),
-                desc: format!(
-                    "'{}'.'{}'",
-                    tbl_name_ident.db_name, tbl_name_ident.table_name
-                ),
+                name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                 drop_on_cnt: 1,
                 non_drop_on_cnt: 1,
             }]);
@@ -4882,27 +4837,19 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _res = mt.create_table(req.clone()).await?;
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
-                    name: tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        tbl_name_ident.db_name, tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
-                    name: new_tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        new_tbl_name_ident.db_name, new_tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, new_tbl_name).to_string_key(),
                     drop_on_cnt: 0,
                     non_drop_on_cnt: 1,
                 },
@@ -4929,24 +4876,16 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
-                    name: tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        tbl_name_ident.db_name, tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },
                 DroponInfo {
-                    name: new_tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        new_tbl_name_ident.db_name, new_tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, new_tbl_name).to_string_key(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
                 },
@@ -4966,24 +4905,16 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id), db_name)
+                .get_tables_history(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
-                    name: tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        tbl_name_ident.db_name, tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 0,
                 },
                 DroponInfo {
-                    name: new_tbl_name.to_string(),
-                    desc: format!(
-                        "'{}'.'{}'",
-                        new_tbl_name_ident.db_name, new_tbl_name_ident.table_name
-                    ),
+                    name: DBIdTableName::new(*db_id, new_tbl_name).to_string_key(),
                     drop_on_cnt: 1,
                     non_drop_on_cnt: 1,
                 },

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -25,7 +25,6 @@ use databend_common_meta_app::primitive::Id;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
 use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::txn_condition::Target;
@@ -42,11 +41,9 @@ use databend_common_meta_types::TxnOp;
 use databend_common_meta_types::TxnOpResponse;
 use databend_common_meta_types::TxnRequest;
 use databend_common_proto_conv::FromToProto;
-use futures::TryStreamExt;
 use log::debug;
 
 use crate::kv_app_error::KVAppError;
-use crate::kv_pb_api::KVPbApi;
 use crate::reply::txn_reply_to_api_result;
 
 pub const DEFAULT_MGET_SIZE: usize = 256;
@@ -142,19 +139,6 @@ where
     }
 
     Ok(seq_values)
-}
-
-/// Return a vec of structured key(such as `DatabaseNameIdent`), such as:
-/// all the `db_name` with prefix `__fd_database/<tenant>/`.
-pub async fn list_keys<K>(
-    kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
-    key: &DirName<K>,
-) -> Result<Vec<K>, MetaError>
-where
-    K: kvapi::Key + 'static,
-{
-    let key_stream = kv_api.list_pb_keys(key).await?;
-    key_stream.try_collect::<Vec<_>>().await
 }
 
 /// List kvs whose value's type is `u64`.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: simplify get_tables_history()

Make this method return `TableNIV` instead of `TableInfo`. TableInfo
includes information that `SchemaApi` can not provide.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16572)
<!-- Reviewable:end -->
