### PR TITLE
feat(query): Reduce serialisation memory usage when spilling to local disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,6 +5279,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.8.19",
  "tonic 0.11.0",
  "tower",
@@ -8543,7 +8544,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -9575,7 +9576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12115,7 +12116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -12259,7 +12260,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -15305,9 +15306,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -15628,7 +15629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,7 +5279,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "toml 0.8.19",
  "tonic 0.11.0",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-list"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56bd1685d994a3e2a3ed802eb1ecee8cb500b0ad4df48cb4d5d1a2f04749c3a"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5141,9 +5150,11 @@ dependencies = [
  "backoff",
  "backon 0.4.4",
  "base64 0.21.7",
+ "buf-list",
  "bumpalo",
  "byte-unit",
  "byteorder",
+ "bytes",
  "chrono",
  "chrono-tz 0.8.6",
  "config",

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ run-debug: build
 run-debug-management: build
 	bash ./scripts/ci/deploy/databend-query-management-mode.sh
 
+kill:
+	killall databend-query
+	killall databend-meta
+
 build:
 	bash ./scripts/build/build-debug.sh
 

--- a/src/common/base/src/base/dma.rs
+++ b/src/common/base/src/base/dma.rs
@@ -33,6 +33,7 @@ use crate::runtime::spawn_blocking;
 
 unsafe impl Send for DmaAllocator {}
 
+#[derive(Clone, Copy)]
 pub struct DmaAllocator(Alignment);
 
 impl DmaAllocator {

--- a/src/common/base/src/base/dma.rs
+++ b/src/common/base/src/base/dma.rs
@@ -19,6 +19,7 @@ use std::alloc::Layout;
 use std::io;
 use std::io::IoSlice;
 use std::io::SeekFrom;
+use std::io::Write;
 use std::ops::Range;
 use std::os::fd::BorrowedFd;
 use std::os::unix::io::AsRawFd;
@@ -116,28 +117,22 @@ pub mod linux {
     use super::*;
 
     impl DmaFile {
-        /// Attempts to open a file in read-only mode.
-        pub(super) async fn open(path: impl AsRef<Path>) -> io::Result<DmaFile> {
-            let file = File::options()
+        pub(super) async fn open_raw(path: impl AsRef<Path>) -> io::Result<File> {
+            File::options()
                 .read(true)
                 .custom_flags(OFlags::DIRECT.bits() as i32)
                 .open(path)
-                .await?;
-
-            open_dma(file).await
+                .await
         }
 
-        /// Opens a file in write-only mode.
-        pub(super) async fn create(path: impl AsRef<Path>) -> io::Result<DmaFile> {
-            let file = File::options()
+        pub(super) async fn create_raw(path: impl AsRef<Path>) -> io::Result<File> {
+            File::options()
                 .write(true)
                 .create(true)
                 .truncate(true)
                 .custom_flags((OFlags::DIRECT | OFlags::EXCL).bits() as i32)
                 .open(path)
-                .await?;
-
-            open_dma(file).await
+                .await
         }
     }
 }
@@ -150,28 +145,36 @@ pub mod not_linux {
 
     impl DmaFile {
         /// Attempts to open a file in read-only mode.
-        pub(super) async fn open(path: impl AsRef<Path>) -> io::Result<DmaFile> {
-            let file = File::options().read(true).open(path).await?;
-
-            open_dma(file).await
+        pub(super) async fn open_raw(path: impl AsRef<Path>) -> io::Result<File> {
+            File::options().read(true).open(path).await
         }
 
         /// Opens a file in write-only mode.
-        pub(super) async fn create(path: impl AsRef<Path>) -> io::Result<DmaFile> {
-            let file = File::options()
+        pub(super) async fn create_raw(path: impl AsRef<Path>) -> io::Result<File> {
+            File::options()
                 .write(true)
                 .create(true)
                 .truncate(true)
                 .custom_flags(OFlags::EXCL.bits() as i32)
                 .open(path)
-                .await?;
-
-            open_dma(file).await
+                .await
         }
     }
 }
 
 impl DmaFile {
+    /// Attempts to open a file in read-only mode.
+    async fn open(path: impl AsRef<Path>) -> io::Result<DmaFile> {
+        let file = DmaFile::open_raw(path).await?;
+        open_dma(file).await
+    }
+
+    /// Opens a file in write-only mode.
+    async fn create(path: impl AsRef<Path>) -> io::Result<DmaFile> {
+        let file = DmaFile::create_raw(path).await?;
+        open_dma(file).await
+    }
+
     fn set_buffer(&mut self, buf: DmaBuffer) {
         self.buf = Some(buf)
     }
@@ -280,6 +283,103 @@ where
             io::ErrorKind::Other,
             "background task failed",
         )),
+    }
+}
+
+pub struct DmaWriteBuf {
+    allocator: DmaAllocator,
+    data: Vec<Vec<u8, DmaAllocator>>,
+    chunk: usize,
+}
+
+impl DmaWriteBuf {
+    pub fn new(align: Alignment, chunk: usize) -> DmaWriteBuf {
+        DmaWriteBuf {
+            allocator: DmaAllocator::new(align),
+            data: Vec::new(),
+            chunk: align_up(align, chunk),
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        if self.data.is_empty() {
+            return 0;
+        }
+
+        (self.data.len() - 1) * self.chunk + self.data.last().unwrap().len()
+    }
+
+    pub async fn into_file(mut self, path: impl AsRef<Path>) -> io::Result<usize> {
+        let mut file = DmaFile {
+            fd: DmaFile::create_raw(path).await?,
+            alignment: self.allocator.0,
+            buf: None,
+        };
+
+        let file_length = self.size();
+
+        let Some(mut last) = self.data.pop() else {
+            return Ok(0);
+        };
+
+        for buf in self.data {
+            debug_assert_eq!(buf.len(), buf.capacity());
+            file.set_buffer(buf);
+            file = asyncify(move || file.write_direct().map(|_| file)).await?;
+        }
+
+        let len = last.len();
+        let align_up = file.align_up(len);
+        if align_up == len {
+            file.set_buffer(last);
+            asyncify(move || file.write_direct()).await?;
+        } else {
+            unsafe { last.set_len(align_up) }
+            file.set_buffer(last);
+            asyncify(move || {
+                file.write_direct()?;
+                file.truncate(file_length)
+            })
+            .await?;
+        }
+        Ok(file_length)
+    }
+
+    pub fn into_data(self) -> Vec<DmaBuffer> {
+        self.data
+    }
+}
+
+impl Write for DmaWriteBuf {
+    fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
+        let n = buf.len();
+        while !buf.is_empty() {
+            let (dst, remain) = match self.data.last_mut() {
+                Some(dst) if dst.len() < dst.capacity() => {
+                    let remian = dst.capacity() - dst.len();
+                    (dst, remian)
+                }
+                _ => {
+                    self.data
+                        .push(Vec::with_capacity_in(self.chunk, self.allocator));
+                    (self.data.last_mut().unwrap(), self.chunk)
+                }
+            };
+
+            if buf.len() <= remain {
+                dst.extend_from_slice(buf);
+                buf = &buf[buf.len()..]
+            } else {
+                let (left, right) = buf.split_at(remain);
+                dst.extend_from_slice(left);
+                buf = right
+            }
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -457,6 +557,18 @@ mod tests {
         let length = dma_read_file(filename, &mut got).await?;
         assert_eq!(length, want.len());
         assert_eq!(got, want);
+
+        let file = DmaFile::open(filename).await?;
+        let align = file.alignment;
+        drop(file);
+
+        std::fs::remove_file(filename)?;
+
+        let mut buf = DmaWriteBuf::new(align, align.as_usize());
+        buf.write_all(&want)?;
+        let length = buf.into_file(filename).await?;
+
+        assert_eq!(length, want.len());
 
         let (buf, range) = dma_read_file_range(filename, 0..length as u64).await?;
         assert_eq!(&buf[range], &want);

--- a/src/common/base/src/base/dma.rs
+++ b/src/common/base/src/base/dma.rs
@@ -356,8 +356,8 @@ impl Write for DmaWriteBuf {
         while !buf.is_empty() {
             let (dst, remain) = match self.data.last_mut() {
                 Some(dst) if dst.len() < dst.capacity() => {
-                    let remian = dst.capacity() - dst.len();
-                    (dst, remian)
+                    let remain = dst.capacity() - dst.len();
+                    (dst, remain)
                 }
                 _ => {
                     self.data

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -33,6 +33,7 @@ pub use dma::dma_read_file;
 pub use dma::dma_read_file_range;
 pub use dma::dma_write_file_vectored;
 pub use dma::DmaAllocator;
+pub use dma::DmaWriteBuf;
 pub use net::get_free_tcp_port;
 pub use net::get_free_udp_port;
 pub use ordered_float::OrderedFloat;

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -32,6 +32,7 @@ pub use dma::dma_buffer_as_vec;
 pub use dma::dma_read_file;
 pub use dma::dma_read_file_range;
 pub use dma::dma_write_file_vectored;
+pub use dma::DmaAllocator;
 pub use net::get_free_tcp_port;
 pub use net::get_free_udp_port;
 pub use ordered_float::OrderedFloat;

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -32,6 +32,7 @@ pub use dma::dma_buffer_as_vec;
 pub use dma::dma_read_file;
 pub use dma::dma_read_file_range;
 pub use dma::dma_write_file_vectored;
+pub use dma::Alignment;
 pub use dma::DmaAllocator;
 pub use dma::DmaWriteBuf;
 pub use net::get_free_tcp_port;

--- a/src/query/expression/src/utils/arrow.rs
+++ b/src/query/expression/src/utils/arrow.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 use std::io::Cursor;
+use std::io::Read;
+use std::io::Seek;
 use std::io::Write;
 
+use databend_common_arrow::arrow;
 use databend_common_arrow::arrow::array::Array;
 use databend_common_arrow::arrow::bitmap::Bitmap;
 use databend_common_arrow::arrow::bitmap::MutableBitmap;
@@ -22,8 +25,9 @@ use databend_common_arrow::arrow::buffer::Buffer;
 use databend_common_arrow::arrow::datatypes::Schema;
 use databend_common_arrow::arrow::io::ipc::read::read_file_metadata;
 use databend_common_arrow::arrow::io::ipc::read::FileReader;
+use databend_common_arrow::arrow::io::ipc::write::Compression;
 use databend_common_arrow::arrow::io::ipc::write::FileWriter;
-use databend_common_arrow::arrow::io::ipc::write::WriteOptions as IpcWriteOptions;
+use databend_common_arrow::arrow::io::ipc::write::WriteOptions;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
@@ -67,32 +71,31 @@ pub fn buffer_into_mut<T: Clone>(mut buffer: Buffer<T>) -> Vec<T> {
 
 pub fn serialize_column(col: &Column) -> Vec<u8> {
     let mut buffer = Vec::new();
-    serialize_column_in(col, &mut buffer).unwrap();
+    write_column(col, &mut buffer).unwrap();
     buffer
 }
 
-pub fn serialize_column_in(
-    col: &Column,
-    w: &mut impl Write,
-) -> databend_common_arrow::arrow::error::Result<()> {
+pub fn write_column(col: &Column, w: &mut impl Write) -> arrow::error::Result<()> {
     let schema = Schema::from(vec![col.arrow_field()]);
-    let mut writer = FileWriter::new(w, schema, None, IpcWriteOptions::default());
+    let mut writer = FileWriter::new(w, schema, None, WriteOptions {
+        compression: Some(Compression::LZ4),
+    });
     writer.start()?;
-    writer.write(
-        &databend_common_arrow::arrow::chunk::Chunk::new(vec![col.as_arrow()]),
-        None,
-    )?;
+    writer.write(&arrow::chunk::Chunk::new(vec![col.as_arrow()]), None)?;
     writer.finish()
 }
 
 pub fn deserialize_column(bytes: &[u8]) -> Result<Column> {
     let mut cursor = Cursor::new(bytes);
+    read_column(&mut cursor)
+}
 
-    let metadata = read_file_metadata(&mut cursor)?;
+pub fn read_column<R: Read + Seek>(r: &mut R) -> Result<Column> {
+    let metadata = read_file_metadata(r)?;
     let f = metadata.schema.fields[0].clone();
     let data_field = DataField::try_from(&f)?;
 
-    let mut reader = FileReader::new(cursor, metadata, None, None);
+    let mut reader = FileReader::new(r, metadata, None, None);
     let col = reader
         .next()
         .ok_or_else(|| ErrorCode::Internal("expected one arrow array"))??

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -170,6 +170,7 @@ tempfile = "3.4.0"
 time = "0.3.14"
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
+tokio-util = "0.7.12"
 toml = { version = "0.8", default-features = false }
 tonic = { workspace = true }
 typetag = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -170,7 +170,6 @@ tempfile = "3.4.0"
 time = "0.3.14"
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
-tokio-util = "0.7.12"
 toml = { version = "0.8", default-features = false }
 tonic = { workspace = true }
 typetag = { workspace = true }

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -44,9 +44,11 @@ async-trait = { workspace = true }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 backon = "0.4"
 base64 = "0.21.0"
+buf-list = "1.0.3"
 bumpalo = { workspace = true }
 byte-unit = "4.0.19"
 byteorder = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 config = { version = "0.13.4", features = [] }

--- a/src/query/service/src/lib.rs
+++ b/src/query/service/src/lib.rs
@@ -17,7 +17,7 @@
 #![allow(clippy::useless_asref)]
 #![allow(clippy::uninlined_format_args)]
 #![feature(ptr_alignment_type)]
-#![feature(allocator_api)]
+#![feature(iter_map_windows)]
 #![feature(hash_raw_entry)]
 #![feature(core_intrinsics)]
 #![feature(arbitrary_self_types)]

--- a/src/query/service/src/lib.rs
+++ b/src/query/service/src/lib.rs
@@ -16,6 +16,8 @@
 #![allow(internal_features)]
 #![allow(clippy::useless_asref)]
 #![allow(clippy::uninlined_format_args)]
+#![feature(ptr_alignment_type)]
+#![feature(allocator_api)]
 #![feature(hash_raw_entry)]
 #![feature(core_intrinsics)]
 #![feature(arbitrary_self_types)]

--- a/src/query/service/src/lib.rs
+++ b/src/query/service/src/lib.rs
@@ -16,7 +16,6 @@
 #![allow(internal_features)]
 #![allow(clippy::useless_asref)]
 #![allow(clippy::uninlined_format_args)]
-#![feature(ptr_alignment_type)]
 #![feature(iter_map_windows)]
 #![feature(hash_raw_entry)]
 #![feature(core_intrinsics)]

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
@@ -34,7 +34,6 @@ use databend_common_pipeline_transforms::processors::sort_merge;
 use databend_common_settings::Settings;
 use databend_common_storage::DataOperator;
 use databend_common_storages_fuse::TableContext;
-use databend_storages_common_cache::TempDir;
 
 use super::WindowPartitionBuffer;
 use super::WindowPartitionMeta;
@@ -42,6 +41,7 @@ use super::WindowSpillSettings;
 use crate::sessions::QueryContext;
 use crate::spillers::Spiller;
 use crate::spillers::SpillerConfig;
+use crate::spillers::SpillerDiskConfig;
 use crate::spillers::SpillerType;
 
 #[derive(Debug, Clone, Copy)]
@@ -99,7 +99,7 @@ impl TransformWindowPartitionCollect {
         num_processors: usize,
         num_partitions: usize,
         spill_settings: WindowSpillSettings,
-        disk_spill: Option<Arc<TempDir>>,
+        disk_spill: Option<SpillerDiskConfig>,
         sort_desc: Vec<SortColumnDescription>,
         schema: DataSchemaRef,
         have_order_col: bool,

--- a/src/query/service/src/spillers/mod.rs
+++ b/src/query/service/src/spillers/mod.rs
@@ -17,8 +17,4 @@ mod spiller;
 
 pub use partition_buffer::PartitionBuffer;
 pub use partition_buffer::PartitionBufferFetchOption;
-pub use spiller::Location;
-pub use spiller::SpilledData;
-pub use spiller::Spiller;
-pub use spiller::SpillerConfig;
-pub use spiller::SpillerType;
+pub use spiller::*;

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -433,18 +433,17 @@ impl BlocksEncoder {
     }
 
     fn add_block(&mut self, block: DataBlock) {
-        let start = self.size();
-        let columns_layout = block
-            .columns()
-            .iter()
-            .map(|entry| {
+        let columns_layout = std::iter::once(self.size())
+            .chain(block.columns().iter().map(|entry| {
                 let column = entry
                     .value
                     .convert_to_full_column(&entry.data_type, block.num_rows());
                 serialize_column_in(&column, &mut self.buf).unwrap();
-                self.size() - start
-            })
+                self.size()
+            }))
+            .map_windows(|x: &[_; 2]| x[1] - x[0])
             .collect();
+
         self.columns_layout.push(columns_layout);
         self.offsets.push(self.size())
     }

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -362,10 +362,10 @@ impl Spiller {
                     let mut file = tokio::fs::File::open(path).await?;
                     file.seek(io::SeekFrom::Start(data_range.start)).await?;
 
-                    let mut data = Vec::new();
-                    file.take(data_range.count() as u64)
-                        .read_to_end(&mut data)
-                        .await?;
+                    let n = data_range.count();
+                    let mut data = Vec::with_capacity(n);
+                    unsafe { data.set_len(n) };
+                    file.read_exact(&mut data).await?;
 
                     record_local_read_profile(&instant, data.len());
                     Ok(deserialize_block(columns_layout, &data))

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -36,6 +36,7 @@ use databend_common_expression::DataBlock;
 use databend_storages_common_cache::TempDir;
 use databend_storages_common_cache::TempPath;
 use opendal::Operator;
+use tokio_util::io::SyncIoBridge;
 
 use crate::sessions::QueryContext;
 

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -273,7 +273,12 @@ impl Spiller {
             }
             (Location::Remote(loc), _) => self.operator.read(loc).await?,
         };
-        record_remote_read_profile(&instant, data.len());
+
+        match location {
+            Location::Remote(_) => record_remote_read_profile(&instant, data.len()),
+            Location::Local(_) => record_local_read_profile(&instant, data.len()),
+        }
+
         let block = deserialize_block(columns_layout, data);
         Ok(block)
     }
@@ -374,7 +379,11 @@ impl Spiller {
             }
             (Location::Remote(loc), _) => self.operator.read_with(loc).range(data_range).await?,
         };
-        record_remote_read_profile(&instant, data.len());
+
+        match location {
+            Location::Remote(_) => record_remote_read_profile(&instant, data.len()),
+            Location::Local(_) => record_local_read_profile(&instant, data.len()),
+        }
         Ok(deserialize_block(columns_layout, data))
     }
 

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -17,12 +17,12 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::ops::Range;
-use std::ptr::Alignment;
 use std::sync::Arc;
 use std::time::Instant;
 
 use databend_common_base::base::dma_buffer_as_vec;
 use databend_common_base::base::dma_read_file_range;
+use databend_common_base::base::Alignment;
 use databend_common_base::base::DmaWriteBuf;
 use databend_common_base::base::GlobalUniqName;
 use databend_common_base::base::ProgressValues;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -273,6 +273,12 @@ impl DefaultSettings {
                     mode: SettingMode::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_dio", DefaultSettingValue{ 
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Enables Direct IO.",
+                    mode: SettingMode::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("disable_join_reorder", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Disable join reorder optimization.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -265,6 +265,10 @@ impl Settings {
         Ok(self.try_get_u64("enable_cbo")? != 0)
     }
 
+    pub fn get_enable_dio(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_dio")? != 0)
+    }
+
     /// # Safety
     pub unsafe fn get_disable_join_reorder(&self) -> Result<bool> {
         Ok(self.unchecked_try_get_u64("disable_join_reorder")? != 0)

--- a/src/query/storages/common/cache/src/lib.rs
+++ b/src/query/storages/common/cache/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(write_all_vectored)]
 #![feature(associated_type_defaults)]
 #![feature(assert_matches)]
+#![feature(ptr_alignment_type)]
 
 mod cache;
 mod caches;

--- a/src/query/storages/common/cache/src/lib.rs
+++ b/src/query/storages/common/cache/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(write_all_vectored)]
 #![feature(associated_type_defaults)]
 #![feature(assert_matches)]
-#![feature(ptr_alignment_type)]
 
 mod cache;
 mod caches;

--- a/src/query/storages/common/cache/src/temp_dir.rs
+++ b/src/query/storages/common/cache/src/temp_dir.rs
@@ -70,6 +70,8 @@ impl TempDirManager {
             if create_dir_all(&path).is_err() {
                 (None, 0, Alignment::MIN)
             } else {
+                let path = path.canonicalize()?.into_boxed_path();
+
                 let stat =
                     statvfs(path.as_ref()).map_err(|e| ErrorCode::StorageOther(e.to_string()))?;
 
@@ -260,6 +262,10 @@ impl TempDir {
     pub fn block_alignment(&self) -> Alignment {
         self.manager.alignment
     }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 struct DirInfo {
@@ -436,10 +442,13 @@ mod tests {
 
         deleted.sort();
 
+        let pwd = std::env::current_dir()?.canonicalize()?;
         assert_eq!(
             vec![
-                PathBuf::from("test_data2/test_tenant/unknown_query1").into_boxed_path(),
-                PathBuf::from("test_data2/test_tenant/unknown_query2").into_boxed_path(),
+                pwd.join("test_data2/test_tenant/unknown_query1")
+                    .into_boxed_path(),
+                pwd.join("test_data2/test_tenant/unknown_query2")
+                    .into_boxed_path(),
             ],
             deleted
         );

--- a/src/query/storages/common/cache/src/temp_dir.rs
+++ b/src/query/storages/common/cache/src/temp_dir.rs
@@ -188,7 +188,10 @@ impl TempDirManager {
     fn insufficient_disk(&self, size: u64) -> Result<bool> {
         let stat = statvfs(self.root.as_ref().unwrap().as_ref())
             .map_err(|e| ErrorCode::Internal(e.to_string()))?;
-        Ok(stat.f_bavail < self.reserved + (size + stat.f_frsize - 1) / stat.f_frsize)
+
+        debug_assert_eq!(stat.f_frsize, self.alignment.as_usize());
+        let n = (size + self.alignment.as_usize() as u64 - 1) >> self.alignment.log2();
+        Ok(stat.f_bavail < self.reserved + n)
     }
 }
 

--- a/src/query/storages/common/cache/src/temp_dir.rs
+++ b/src/query/storages/common/cache/src/temp_dir.rs
@@ -24,13 +24,13 @@ use std::ops::Deref;
 use std::ops::Drop;
 use std::path::Path;
 use std::path::PathBuf;
-use std::ptr::Alignment;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::Once;
 
+use databend_common_base::base::Alignment;
 use databend_common_base::base::GlobalInstance;
 use databend_common_base::base::GlobalUniqName;
 use databend_common_config::SpillConfig;
@@ -189,8 +189,8 @@ impl TempDirManager {
         let stat = statvfs(self.root.as_ref().unwrap().as_ref())
             .map_err(|e| ErrorCode::Internal(e.to_string()))?;
 
-        debug_assert_eq!(stat.f_frsize, self.alignment.as_usize());
-        let n = (size + self.alignment.as_usize() as u64 - 1) >> self.alignment.log2();
+        debug_assert_eq!(stat.f_frsize, self.alignment.as_usize() as u64);
+        let n = self.alignment.align_up_count(size as usize) as u64;
         Ok(stat.f_bavail < self.reserved + n)
     }
 }

--- a/tests/sqllogictests/suites/query/window_function/window_partition_spill.test
+++ b/tests/sqllogictests/suites/query/window_function/window_partition_spill.test
@@ -10,6 +10,9 @@ set window_partition_spilling_bytes_threshold_per_proc = 1024 * 1024 * 1;
 statement ok
 set window_partition_spilling_to_disk_bytes_limit = 1024 * 1024 * 1024;
 
+statement ok
+set enable_dio = 1;
+
 query T
 SELECT SUM(number + a + b)
 FROM (
@@ -34,6 +37,37 @@ FROM (
 );
 ----
 1499998499576
+
+statement ok
+set enable_dio = 0;
+
+query T
+SELECT SUM(number + a + b)
+FROM (
+    SELECT
+        number,
+        LEAD(number, 1, 0) OVER (PARTITION BY number % 16 ORDER BY number + 1) AS a,
+        LEAD(number, 2, 0) OVER (PARTITION BY number % 16 ORDER BY number + 1) AS b
+    FROM numbers(5000000)
+);
+----
+37499992499384
+
+query I
+SELECT SUM(a + b + c)
+FROM (
+    SELECT
+        number,
+        LEAD(number, 1, 0) OVER (PARTITION BY number % 8 ORDER BY number + 2) a,
+        LEAD(number, 2, 0) OVER (PARTITION BY number % 8 ORDER BY number + 2) b,
+        LEAD(number, 3, 0) OVER (PARTITION BY number % 8 ORDER BY number + 2) c
+    FROM numbers(1000000)
+);
+----
+1499998499576
+
+statement ok
+unset enable_dio;
 
 statement ok
 DROP TABLE IF EXISTS customers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Changes:
1. Instead of serializing blocks first and then copying them to the dio buffer, the serialization of blocks is written directly to the aligned dio buffer.
2. Instead of freeing memory after the entire file is written, the buffer is freed incrementally as the file is written.
3. The spill file is compressed with LZ4 to dramatically reduce io.
4. Introduced settings `enable_dio` to disable direct io, i.e. use buffer io to read and write files.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16580)
<!-- Reviewable:end -->
