### PR TITLE
fix: merge into panic

### DIFF
--- a/src/query/sql/src/executor/physical_plans/physical_mutation.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_mutation.rs
@@ -370,7 +370,7 @@ impl PhysicalPlanBuilder {
 
         let mut field_index_of_input_schema = HashMap::<FieldIndex, usize>::new();
         for (field_index, value) in field_index_map {
-            // Safe to set field index, to fix issue #16581.
+            // Safe to set field index, to fix issue #16588.
             if let Ok(value) = output_schema.index_of(value) {
                 field_index_of_input_schema.insert(*field_index, value);
             }

--- a/src/query/sql/src/executor/physical_plans/physical_mutation.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_mutation.rs
@@ -370,8 +370,9 @@ impl PhysicalPlanBuilder {
 
         let mut field_index_of_input_schema = HashMap::<FieldIndex, usize>::new();
         for (field_index, value) in field_index_map {
-            field_index_of_input_schema
-                .insert(*field_index, output_schema.index_of(value).unwrap());
+            if let Ok(value) = output_schema.index_of(value) {
+                field_index_of_input_schema.insert(*field_index, value);
+            }
         }
 
         plan = PhysicalPlan::MutationManipulate(Box::new(MutationManipulate {

--- a/src/query/sql/src/executor/physical_plans/physical_mutation.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_mutation.rs
@@ -370,6 +370,7 @@ impl PhysicalPlanBuilder {
 
         let mut field_index_of_input_schema = HashMap::<FieldIndex, usize>::new();
         for (field_index, value) in field_index_map {
+            // Safe to set field index, to fix issue #16581.
             if let Ok(value) = output_schema.index_of(value) {
                 field_index_of_input_schema.insert(*field_index, value);
             }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0042_merge_into_issue_16581.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0042_merge_into_issue_16581.test
@@ -1,0 +1,24 @@
+statement ok
+create or replace database i16581;
+
+statement ok
+use i16581;
+
+statement ok
+create table base(a int);
+
+statement ok
+create table sink(a int);
+
+query I
+merge into sink using base on 1 != 1 when matched then update * when not matched then insert *;
+----
+0
+
+query I
+merge into sink using base on 1 != 1 when matched then update *;
+----
+0
+
+statement ok
+drop database i16581;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0042_merge_into_issue_16588.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0042_merge_into_issue_16588.test
@@ -1,8 +1,8 @@
 statement ok
-create or replace database i16581;
+create or replace database i16588;
 
 statement ok
-use i16581;
+use i16588;
 
 statement ok
 create table base(a int);
@@ -10,10 +10,10 @@ create table base(a int);
 statement ok
 create table sink(a int);
 
-query I
+query II
 merge into sink using base on 1 != 1 when matched then update * when not matched then insert *;
 ----
-0
+0 0
 
 query I
 merge into sink using base on 1 != 1 when matched then update *;
@@ -21,4 +21,4 @@ merge into sink using base on 1 != 1 when matched then update *;
 0
 
 statement ok
-drop database i16581;
+drop database i16588;

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -52,6 +52,61 @@ select * from t2 order by a;
 ----
 8
 
+## issue 16588
+query T
+explain merge into t1 using (select * from t2) as t on 1 <> 1 when matched then update * when not matched then insert *
+----
+CommitSink
+└── Exchange
+    ├── output columns: []
+    ├── exchange type: Merge
+    └── DataMutation
+        ├── target table: [catalog: default] [database: default] [table: t1]
+        ├── matched delete: [condition: None]
+        ├── unmatched insert: [condition: None, insert into (a) values(a (#0))]
+        └── Exchange
+            ├── output columns: [t2.a (#0), t1._row_id (#2)]
+            ├── exchange type: Hash(bit_and(bit_shift_right(t1._row_id (#2), CAST(31 AS UInt64 NULL)), CAST(2047 AS UInt64 NULL)))
+            └── HashJoin
+                ├── output columns: [t2.a (#0), t1._row_id (#2)]
+                ├── join type: LEFT OUTER
+                ├── build keys: []
+                ├── probe keys: []
+                ├── filters: []
+                ├── estimated rows: 1.00
+                ├── Exchange(Build)
+                │   ├── output columns: [t1._row_id (#2)]
+                │   ├── exchange type: Hash()
+                │   └── EmptyResultScan
+                └── Exchange(Probe)
+                    ├── output columns: [t2.a (#0)]
+                    ├── exchange type: Hash()
+                    └── TableScan
+                        ├── table: default.default.t2
+                        ├── output columns: [a (#0)]
+                        ├── read rows: 1
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 1.00
+
+query T
+explain merge into t1 using (select * from t2) as t on 1 <> 1 when matched then update *
+----
+CommitSink
+└── Exchange
+    ├── output columns: []
+    ├── exchange type: Merge
+    └── DataMutation
+        ├── target table: [catalog: default] [database: default] [table: t1]
+        ├── matched delete: [condition: None]
+        └── Exchange
+            ├── output columns: [t2.a (#0), t1._row_id (#2)]
+            ├── exchange type: Hash(bit_and(bit_shift_right(t1._row_id (#2), 31), 2047))
+            └── EmptyResultScan
+
 ## check there is add row_number.
 query T
 explain merge into t1 using (select * from t2) as t on t1.a > t.a when matched then update * when not matched then insert *;

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -24,6 +24,43 @@ MERGE INTO salaries2 USING (SELECT * FROM employees2) as employees2 ON salaries2
 ----
 2 2
 
+## issue 16588
+query T
+explain merge into salaries2 using employees2 on 1 != 1 when matched AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00 WHEN NOT MATCHED THEN INSERT (employee_id, salary) VALUES (employees2.employee_id, 55000.00)
+----
+CommitSink
+└── DataMutation
+    ├── target table: [catalog: default] [database: default] [table: salaries2]
+    ├── matched delete: [condition: None]
+    ├── unmatched insert: [condition: None, insert into (employee_id,salary) values(employees2.employee_id (#0),55000.00)]
+    └── HashJoin
+        ├── output columns: [employees2.employee_id (#0), employees2.employee_name (#1), employees2.department (#2), salaries2._row_id (#5)]
+        ├── join type: LEFT OUTER
+        ├── build keys: []
+        ├── probe keys: []
+        ├── filters: []
+        ├── estimated rows: 4.00
+        ├── EmptyResultScan(Build)
+        └── TableScan(Probe)
+            ├── table: default.default.employees2
+            ├── output columns: [employee_id (#0), employee_name (#1), department (#2)]
+            ├── read rows: 4
+            ├── read size: < 1 KiB
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 4.00
+
+query T
+explain merge into salaries2 using employees2 on 1 != 1 when matched AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00
+----
+CommitSink
+└── DataMutation
+    ├── target table: [catalog: default] [database: default] [table: salaries2]
+    ├── matched delete: [condition: None]
+    └── EmptyResultScan
+
 query T
 explain MERGE INTO salaries2 USING (SELECT * FROM employees2) as employees2 ON salaries2.employee_id = employees2.employee_id WHEN MATCHED AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00 WHEN NOT MATCHED THEN INSERT (employee_id, salary) VALUES (employees2.employee_id, 55000.00);
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The reason is that the condition is false, after `RuleEliminateFilter`, it is converted to `ConstantTableScan`, which makes the fileds in mutation invalid.

```sql
mysql> create table t(a int);
Query OK, 0 rows affected (0.05 sec)

mysql> create table s(a int);
Query OK, 0 rows affected (0.05 sec)

mysql> merge into s using t on 1 != 1 when matched and s.a>0 then update * when not matched then insert *;
+-------------------------+------------------------+
| number of rows inserted | number of rows updated |
+-------------------------+------------------------+
|                       0 |                      0 |
+-------------------------+------------------------+
1 row in set (0.15 sec)
Read 0 rows, 0.00 B in 0.067 sec., 0 rows/sec., 0.00 B/sec.
```
- fixes: #16588 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16581)
<!-- Reviewable:end -->
