### PR TITLE
refactor: add SchemaApi::get_table_in_db

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -38,6 +38,7 @@ use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
+use databend_common_meta_app::schema::DBIdTableName;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DeleteLockRevReq;
 use databend_common_meta_app::schema::DictionaryMeta;
@@ -202,7 +203,15 @@ pub trait SchemaApi: Send + Sync {
 
     async fn rename_table(&self, req: RenameTableReq) -> Result<RenameTableReply, KVAppError>;
 
+    /// Get a [`TableInfo`] by `tenant, database_name, table_name`.
+    ///
+    /// This method should be deprecated,
+    /// where the database-id is already known and there is no need to re-fetch db by database-name.
+    /// In this case, use [`Self::get_table_in_db`] instead.
     async fn get_table(&self, req: GetTableReq) -> Result<Arc<TableInfo>, KVAppError>;
+
+    /// Get a [`TableNIV`] by `database_id, table_name`.
+    async fn get_table_in_db(&self, req: &DBIdTableName) -> Result<Option<TableNIV>, MetaError>;
 
     async fn get_table_meta_history(
         &self,

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -17,18 +17,20 @@ use std::sync::Arc;
 use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
 use databend_common_meta_api::SchemaApi;
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::UnknownTable;
 use databend_common_meta_app::schema::CatalogInfo;
 use databend_common_meta_app::schema::CommitTableMetaReply;
 use databend_common_meta_app::schema::CommitTableMetaReq;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::DBIdTableName;
 use databend_common_meta_app::schema::DatabaseInfo;
 use databend_common_meta_app::schema::DatabaseType;
 use databend_common_meta_app::schema::DropTableByIdReq;
 use databend_common_meta_app::schema::DropTableReply;
 use databend_common_meta_app::schema::GetTableCopiedFileReply;
 use databend_common_meta_app::schema::GetTableCopiedFileReq;
-use databend_common_meta_app::schema::GetTableReq;
 use databend_common_meta_app::schema::ListTableReq;
 use databend_common_meta_app::schema::RenameTableReply;
 use databend_common_meta_app::schema::RenameTableReq;
@@ -137,15 +139,32 @@ impl Database for DefaultDatabase {
     // Get one table by db and table name.
     #[async_backtrace::framed]
     async fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>> {
-        let table_info = self
-            .ctx
-            .meta
-            .get_table(GetTableReq::new(
-                self.get_tenant(),
-                self.get_db_name(),
+        let name_ident = DBIdTableName::new(self.get_db_info().database_id.db_id, table_name);
+        let table_niv = self.ctx.meta.get_table_in_db(&name_ident).await?;
+
+        let Some(table_niv) = table_niv else {
+            return Err(AppError::from(UnknownTable::new(
                 table_name,
+                format!("get_table: '{}'.'{}'", self.get_db_name(), table_name),
             ))
-            .await?;
+            .into());
+        };
+
+        let (_name, id, seq_meta) = table_niv.unpack();
+
+        let table_info = TableInfo {
+            ident: TableIdent {
+                table_id: id.table_id,
+                seq: seq_meta.seq,
+            },
+            desc: format!("'{}'.'{}'", self.get_db_name(), table_name),
+            name: table_name.to_string(),
+            meta: seq_meta.data,
+            db_type: DatabaseType::NormalDB,
+            catalog_info: Default::default(),
+        };
+
+        let table_info = Arc::new(table_info);
 
         let table_info = if self.ctx.disable_table_info_refresh {
             table_info


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add SchemaApi::get_table_in_db

In cases where the `database-id` is already known, use this method to
get a table as replacement of `get_table()`. `get_table()` re-fetch
database-id by database-name, thus leads to additional unnecessary delay
and potential consistency issues, because a database may already be
renamed, and using the original database-name just gets the wrong
database instance.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16582)
<!-- Reviewable:end -->
