### PR TITLE
fix: avoid eliminating the left child of union in `RuleEliminateUnion`

### DIFF
--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_union.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_union.rs
@@ -75,6 +75,9 @@ impl Rule for RuleEliminateUnion {
         let left_child = s_expr.child(0)?;
         let right_child = s_expr.child(1)?;
 
+        // If left child is empty, we won't eliminate it
+        // Because the schema of the union is from left child, and the union node's parent relies on the schema
+        // And the parent's schema has been binded during the binder phase.
         if Self::is_empty_scan(left_child)? && Self::is_empty_scan(right_child)? {
             // If both children are empty, replace with EmptyResultScan
             let union_output_columns = union
@@ -96,9 +99,6 @@ impl Rule for RuleEliminateUnion {
             );
             let result = SExpr::create_leaf(Arc::new(RelOperator::ConstantTableScan(empty_scan)));
             state.add_result(result);
-        } else if Self::is_empty_scan(left_child)? {
-            // If left child is empty, use right child
-            state.add_result(right_child.clone());
         } else if Self::is_empty_scan(right_child)? {
             // If right child is empty, use left child
             state.add_result(left_child.clone());

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -240,16 +240,20 @@ query T
 ----
 explain select * from t1 where t1.a < 0 union all select * from t2 ;
 ----
-TableScan
-├── table: default.default.t2
-├── output columns: []
-├── read rows: 10000
-├── read size: 0
-├── partitions total: 1
-├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-├── push downs: [filters: [], limit: NONE]
-└── estimated rows: 10000.00
+UnionAll
+├── output columns: [t1.a (#0)]
+├── estimated rows: 10000.00
+├── EmptyResultScan
+└── TableScan
+    ├── table: default.default.t2
+    ├── output columns: [b (#1)]
+    ├── read rows: 10000
+    ├── read size: 10.59 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 10000.00
 
 
 query T

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -323,3 +323,16 @@ query I
 select * from numbers(100) union all select * from numbers(100) ignore_result;
 ----
 
+statement ok
+create or replace table t1 (test bigint);
+
+statement ok
+insert into t1 values(1), (0);
+
+query I
+WITH cte1 AS ( SELECT t1.test FROM t1 WHERE t1.test = 0 ) ,cte2 AS ( SELECT cte1.test FROM cte1 WHERE cte1.test = 1  UNION ALL  SELECT cte1.test FROM cte1 WHERE cte1.test = 0 ) SELECT * FROM cte2;
+----
+0
+
+statement ok
+drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- fixes: https://github.com/databendlabs/databend/issues/16564


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16584)
<!-- Reviewable:end -->
