### PR TITLE
refactor: SchemaApi::get_table_meta_history()

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -213,13 +213,16 @@ pub trait SchemaApi: Send + Sync {
     /// Get a [`TableNIV`] by `database_id, table_name`.
     async fn get_table_in_db(&self, req: &DBIdTableName) -> Result<Option<TableNIV>, MetaError>;
 
-    async fn get_table_meta_history(
+    /// Retrieves the tables under the given `database-id, table-name`
+    /// that is dropped after retention boundary time, i.e., the table that can be undropped.
+    async fn get_retainable_tables(
         &self,
-        database_name: &str,
-        table_id_history: &TableIdHistoryIdent,
-    ) -> Result<Vec<(TableId, SeqV<TableMeta>)>, KVAppError>;
+        history_ident: &TableIdHistoryIdent,
+    ) -> Result<Vec<(TableId, SeqV<TableMeta>)>, MetaError>;
 
-    async fn get_tables_history(&self, req: ListTableReq) -> Result<Vec<TableNIV>, KVAppError>;
+    /// Get history of all tables in the specified database,
+    /// that are dropped after retention boundary time, i.e., the tables that can be undropped.
+    async fn list_retainable_tables(&self, req: ListTableReq) -> Result<Vec<TableNIV>, KVAppError>;
 
     /// List all tables in the database.
     ///

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1835,7 +1835,7 @@ impl SchemaApiTestSuite {
                     let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
 
                     let got = mt
-                        .get_table_meta_history(db_name, &TableIdHistoryIdent {
+                        .get_retainable_tables(&TableIdHistoryIdent {
                             database_id: cur_db.database_id.db_id,
                             table_name: tbl_name.to_string(),
                         })
@@ -4003,7 +4003,7 @@ impl SchemaApiTestSuite {
             assert!(table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 1);
@@ -4021,7 +4021,7 @@ impl SchemaApiTestSuite {
             upsert_test_data(mt.as_kv_api(), &tbid, data).await?;
             // assert not return out of retention time data
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 0);
@@ -4659,7 +4659,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4691,7 +4691,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4709,7 +4709,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4736,7 +4736,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4759,7 +4759,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4787,7 +4787,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4804,7 +4804,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4837,7 +4837,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _res = mt.create_table(req.clone()).await?;
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
@@ -4876,7 +4876,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
@@ -4905,7 +4905,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .get_tables_history(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -183,13 +183,10 @@ impl Database for DefaultDatabase {
         let metas = self
             .ctx
             .meta
-            .get_table_meta_history(
-                self.db_info.name_ident.database_name(),
-                &TableIdHistoryIdent {
-                    database_id: self.db_info.database_id.db_id,
-                    table_name: table_name.to_string(),
-                },
-            )
+            .get_retainable_tables(&TableIdHistoryIdent {
+                database_id: self.db_info.database_id.db_id,
+                table_name: table_name.to_string(),
+            })
             .await?;
 
         let table_infos: Vec<Arc<TableInfo>> = metas
@@ -233,7 +230,7 @@ impl Database for DefaultDatabase {
         let mut dropped = self
             .ctx
             .meta
-            .get_tables_history(ListTableReq::new(
+            .list_retainable_tables(ListTableReq::new(
                 self.get_tenant(),
                 self.db_info.database_id,
             ))


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: SchemaApi::get_table_meta_history()

It does not need to accept a `database-name` argument just for building
an error.

It does not need to return application level error: if a table is not
found, just return an empty list.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16586)
<!-- Reviewable:end -->
