### PR TITLE
fix(query): list_dictionaries should not ignore db_id

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -3025,8 +3025,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             req.tenant.clone(),
             DictionaryIdentity::new(req.db_id, "dummy".to_string()),
         );
-        let dir = DirName::new_with_level(dictionary_ident, 2);
-
+        let dir = DirName::new(dictionary_ident);
         let name_id_values = self.list_id_value(&dir).await?;
         Ok(name_id_values
             .map(|(name, _seq_id, seq_meta)| (name.dict_name(), seq_meta.data))

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -7395,17 +7395,11 @@ impl SchemaApiTestSuite {
                 util.create_db().await?;
             }
 
-            let db_name_ident =
-                DatabaseNameIdent::new(Tenant::new_literal(tenant_name), db_name.to_string());
-            let get_db_req = GetDatabaseReq {
-                inner: db_name_ident.clone(),
-            };
-            let db_info = mt.get_database(get_db_req).await?;
-            let db_id = db_info.database_id.db_id;
+            let db_id = util.db_id();
 
             {
                 info!("--- list dictionary from db2 with no create before");
-                let req = ListDictionaryReq::new(dict_tenant.clone(), db_id);
+                let req = ListDictionaryReq::new(dict_tenant.clone(), *db_id);
                 let res = mt.list_dictionaries(req).await?;
                 assert!(res.is_empty());
             }

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -7388,6 +7388,30 @@ impl SchemaApiTestSuite {
         }
 
         {
+            info!("--- prepare db2");
+            let db_name = "db2";
+            let mut util = Util::new(mt, tenant_name, db_name, tbl_name, "eng1");
+            {
+                util.create_db().await?;
+            }
+
+            let db_name_ident =
+                DatabaseNameIdent::new(Tenant::new_literal(tenant_name), db_name.to_string());
+            let get_db_req = GetDatabaseReq {
+                inner: db_name_ident.clone(),
+            };
+            let db_info = mt.get_database(get_db_req).await?;
+            let db_id = db_info.database_id.db_id;
+
+            {
+                info!("--- list dictionary from db2 with no create before");
+                let req = ListDictionaryReq::new(dict_tenant.clone(), db_id);
+                let res = mt.list_dictionaries(req).await?;
+                assert!(res.is_empty());
+            }
+        }
+
+        {
             info!("--- get dictionary");
             let req = dict_ident1.clone();
             let res = mt.get_dictionary(req).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

list_dictionaries should not ignore db_id

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16587)
<!-- Reviewable:end -->
