### PR TITLE
fix: Disable `prewhere` for iceberg table for now

### DIFF
--- a/src/query/expression/src/converts/arrow/from.rs
+++ b/src/query/expression/src/converts/arrow/from.rs
@@ -73,7 +73,13 @@ impl DataBlock {
         schema: &DataSchema,
         batch: &RecordBatch,
     ) -> Result<(Self, DataSchema)> {
-        assert_eq!(schema.num_fields(), batch.num_columns());
+        assert_eq!(
+            schema.num_fields(),
+            batch.num_columns(),
+            "expect schema: {:?}, actual schema: {:?}",
+            schema.fields,
+            batch.schema().fields
+        );
 
         if schema.fields().len() != batch.num_columns() {
             return Err(ErrorCode::Internal(format!(

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -25,6 +25,7 @@ use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::plan::PartitionsShuffleKind;
+use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_args::TableArgs;
@@ -170,7 +171,34 @@ impl IcebergTable {
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
         let max_threads = std::cmp::min(parts_len, max_threads);
 
-        let output_schema = Arc::new(DataSchema::from(plan.schema()));
+        let mut output_projection =
+            PushDownInfo::projection_of_push_downs(&self.schema(), plan.push_downs.as_ref());
+        let inner_projection = matches!(output_projection, Projection::InnerColumns(_));
+
+        if let Some(prewhere) = plan.push_downs.as_ref().and_then(|p| p.prewhere.as_ref()) {
+            output_projection = prewhere.output_columns.clone();
+            debug_assert_eq!(
+                inner_projection,
+                matches!(output_projection, Projection::InnerColumns(_))
+            );
+        }
+
+        let output_table_schema = output_projection.project_schema(&self.schema());
+        let output_schema = Arc::new(DataSchema::from(&output_table_schema));
+
+        // Build projection mask and field paths for transforming `RecordBatch` to output block.
+        // The number of columns in `output_projection` may be less than the number of actual read columns.
+        //
+        // TODO: we need to build  projection mask here to support nest schema.
+        //
+        // let (projection, output_leaves) = output_projection.to_arrow_projection();
+        // let output_field_paths = Arc::new(compute_output_field_paths(
+        //     &self.schema_desc,
+        //     &projection,
+        //     &output_table_schema,
+        //     inner_projection,
+        // )?);
+
         pipeline.add_source(
             |output| {
                 IcebergTableSource::create(ctx.clone(), output, output_schema.clone(), self.clone())

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -281,6 +281,6 @@ impl Table for IcebergTable {
     }
 
     fn support_prewhere(&self) -> bool {
-        true
+        false
     }
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes https://github.com/databendlabs/databend/issues/16594

Iceberg Engine doesn't support `prewhere` yet. Enabling prewhere in wrong will lead to read our schema has less fields than expected.

After this fix, we can run tpch now:

![image](https://github.com/user-attachments/assets/0acfc23d-a1ae-4cda-8765-b2b0c987ee58)


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16597)
<!-- Reviewable:end -->
