### PR TITLE
fix: lock mgr may failed to release lock in time

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -5,6 +5,8 @@
 max_active_sessions = 256
 shutdown_wait_timeout_ms = 5000
 
+max_running_queries = 2
+
 # For flight rpc.
 flight_api_address = "0.0.0.0:9091"
 
@@ -80,7 +82,7 @@ join_spilling_memory_ratio = 60
 [log]
 
 [log.file]
-level = "DEBUG"
+level = "INFO"
 format = "text"
 dir = "./.databend/logs_1"
 prefix_filter = ""

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -5,8 +5,6 @@
 max_active_sessions = 256
 shutdown_wait_timeout_ms = 5000
 
-max_running_queries = 2
-
 # For flight rpc.
 flight_api_address = "0.0.0.0:9091"
 
@@ -82,7 +80,7 @@ join_spilling_memory_ratio = 60
 [log]
 
 [log.file]
-level = "INFO"
+level = "DEBUG"
 format = "text"
 dir = "./.databend/logs_1"
 prefix_filter = ""

--- a/src/common/base/src/base/watch_notify.rs
+++ b/src/common/base/src/base/watch_notify.rs
@@ -44,6 +44,10 @@ impl WatchNotify {
     pub fn notify_waiters(&self) {
         let _ = self.tx.send_replace(true);
     }
+
+    pub fn notify_one(&self) {
+        self.notify_waiters()
+    }
 }
 
 #[cfg(test)]
@@ -63,6 +67,17 @@ mod tests {
         let notify = WatchNotify::new();
         // notify_waiters ahead of notified being instantiated and awaited
         notify.notify_waiters();
+
+        // this should not await indefinitely
+        let notified = notify.notified();
+        notified.await;
+    }
+
+    #[tokio::test]
+    async fn test_notify_one() {
+        let notify = WatchNotify::new();
+        // notify_waiters ahead of notified being instantiated and awaited
+        notify.notify_one();
 
         // this should not await indefinitely
         let notified = notify.notified();

--- a/src/query/service/src/locks/lock_holder.rs
+++ b/src/query/service/src/locks/lock_holder.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use backoff::backoff::Backoff;
-use databend_common_base::base::tokio::sync::Notify;
 use databend_common_base::base::tokio::time::sleep;
+use databend_common_base::base::WatchNotify;
 use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_base::runtime::TrySpawn;
 use databend_common_catalog::catalog::Catalog;
@@ -41,7 +41,7 @@ use crate::sessions::SessionManager;
 #[derive(Default)]
 pub struct LockHolder {
     shutdown_flag: AtomicBool,
-    shutdown_notify: Notify,
+    shutdown_notify: WatchNotify,
 }
 
 impl LockHolder {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Replaces `tokio::sync::Notify` with `WatchNotify` which is safe to `nofity_one` before `Notified` future has been  polled, otherwise, we risk not being able to release the lock in time. 


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16611)
<!-- Reviewable:end -->
