### PR TITLE
chore(query): add warn log if vacuum temporary file is error

### DIFF
--- a/src/query/service/src/interpreters/hook/vacuum_hook.rs
+++ b/src/query/service/src/interpreters/hook/vacuum_hook.rs
@@ -53,6 +53,10 @@ pub fn hook_vacuum_temp_files(query_ctx: &Arc<QueryContext>) -> Result<()> {
                 )
                 .await;
 
+            if let Err(cause) = &removed_files {
+                log::warn!("Vacuum temporary files has error: {:?}", cause);
+            }
+
             if vacuum_limit != 0 && matches!(removed_files, Ok(res) if res == vacuum_limit as usize)
             {
                 // Have not been removed files


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): add warn log if vacuum temporary file is error

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - add more log

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16646)
<!-- Reviewable:end -->
