### PR TITLE
fix(query):  sort spilling use arrow file format painc

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/sort/spill.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/spill.rs
@@ -14,21 +14,20 @@
 
 use databend_common_expression::BlockMetaInfo;
 
+use super::super::SortSpillParams;
+
 /// Mark a partially sorted [`DataBlock`] as a block needs to be spilled.
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub struct SortSpillMetaWithParams {
-    pub batch_rows: usize,
-    pub num_merge: usize,
-}
+pub struct SortSpillMetaWithParams(pub SortSpillParams);
 
 #[typetag::serde(name = "sort_spill")]
 impl BlockMetaInfo for SortSpillMetaWithParams {
     fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals SortSpillMeta")
+        unimplemented!("Unimplemented equals SortSpillMetaWithParams")
     }
 
     fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone SortSpillMeta")
+        unimplemented!("Unimplemented clone SortSpillMetaWithParams")
     }
 }
 

--- a/src/query/service/src/pipelines/builders/builder_sort.rs
+++ b/src/query/service/src/pipelines/builders/builder_sort.rs
@@ -207,25 +207,20 @@ impl SortPipelineBuilder {
         let bytes_limit_per_proc = settings.get_sort_spilling_bytes_threshold_per_proc()?;
         if memory_ratio == 0 && bytes_limit_per_proc == 0 {
             // If these two settings are not set, do not enable sort spill.
-            // TODO(spill): enable sort spill by default like aggregate.
             return Ok((0, 0));
         }
-        let memory_ratio = (memory_ratio as f64 / 100_f64).min(1_f64);
-        let max_memory_usage = match settings.get_max_memory_usage()? {
-            0 => usize::MAX,
-            max_memory_usage => {
-                if memory_ratio == 0_f64 {
-                    usize::MAX
-                } else {
-                    (max_memory_usage as f64 * memory_ratio) as usize
-                }
-            }
+
+        let max_memory_usage = match (
+            settings.get_max_memory_usage()?,
+            (memory_ratio as f64 / 100_f64).min(1_f64),
+        ) {
+            (0, _) | (_, 0.0) => usize::MAX,
+            (memory, ratio) => (memory as f64 * ratio) as usize,
         };
-        let spill_threshold_per_core =
-            match settings.get_sort_spilling_bytes_threshold_per_proc()? {
-                0 => max_memory_usage / num_threads,
-                bytes => bytes,
-            };
+        let spill_threshold_per_core = match bytes_limit_per_proc {
+            0 => max_memory_usage / num_threads,
+            bytes => bytes,
+        };
 
         Ok((max_memory_usage, spill_threshold_per_core))
     }

--- a/tests/sqllogictests/suites/query/order.test
+++ b/tests/sqllogictests/suites/query/order.test
@@ -52,3 +52,22 @@ select number from numbers(10) as a order by b.number
 
 statement error
 select number from (select * from numbers(10) as b) as a order by b.number
+
+statement ok
+set sort_spilling_bytes_threshold_per_proc = 1;
+
+statement ok
+set spilling_file_format = 'arrow';
+
+query I
+select number from numbers(1000) order by number offset 997;
+----
+997
+998
+999
+
+statement ok
+unset sort_spilling_bytes_threshold_per_proc;
+
+statement ok
+unset spilling_file_format;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fixes: #16660

`SortSpillMetaWithParams` is not allowed to be cloned, but `DataBlock::concat` will clone it, so we need take out the meta from block before spilling.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16658)
<!-- Reviewable:end -->
