### PR TITLE
chore: adjust default value of setting `max_storage_io_requests`

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -955,7 +955,8 @@ impl DefaultSettings {
             None => std::cmp::min(num_cpus, 64),
             Some(conf) => match conf.storage.params.is_fs() {
                 true => 48,
-                false => std::cmp::min(num_cpus, 64),
+                // This value is chosen based on the performance test of pruning phase on cloud platform.
+                false => 64,
             },
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Using a small-sized warehouse (16c) for testing, 3,000 segments were randomly generated. Pruning was performed using different values for max_storage_io_requests. The results show that when max_storage_io_requests=64, the performance is close to optimal.
```sql
deploy@(bench-vacuum2-1)/default> set max_storage_io_requests = 16;

SET max_storage_io_requests = 16

0 row read in 0.027 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

deploy@(bench-vacuum2-1)/default> explain select * from test_order where id > 1;

EXPLAIN SELECT * FROM test_order WHERE id > 1

-[ EXPLAIN ]-----------------------------------
Filter
├── output columns: [test_order.id (#0), test_order.id1 (#1), test_order.id2 (#2), test_order.id3 (#3), test_order.id4 (#4), test_order.id5 (#5), test_order.id6 (#6), test_order.id7 (#7), test_order.s1 (#8), test_order.s2 (#9), test_order.s3 (#10), test_order.s4 (#11), test_order.s5 (#12), test_order.s6 (#13), test_order.s7 (#14), test_order.s8 (#15), test_order.s9 (#16), test_order.s10 (#17), test_order.s11 (#18), test_order.s12 (#19), test_order.s13 (#20), test_order.d1 (#21), test_order.d2 (#22), test_order.d3 (#23), test_order.d4 (#24), test_order.d5 (#25), test_order.d6 (#26), test_order.d7 (#27), test_order.d8 (#28), test_order.d9 (#29), test_order.d10 (#30), test_order.insert_time (#31), test_order.insert_time1 (#32), test_order.insert_time2 (#33), test_order.insert_time3 (#34), test_order.i (#35)]
├── filters: [is_true(test_order.id (#0) > 1)]
├── estimated rows: 1500001.08
└── TableScan
    ├── table: default.default.test_order
    ├── output columns: [id (#0), id1 (#1), id2 (#2), id3 (#3), id4 (#4), id5 (#5), id6 (#6), id7 (#7), s1 (#8), s2 (#9), s3 (#10), s4 (#11), s5 (#12), s6 (#13), s7 (#14), s8 (#15), s9 (#16), s10 (#17), s11 (#18), s12 (#19), s13 (#20), d1 (#21), d2 (#22), d3 (#23), d4 (#24), d5 (#25), d6 (#26), d7 (#27), d8 (#28), d9 (#29), d10 (#30), insert_time (#31), insert_time1 (#32), insert_time2 (#33), insert_time3 (#34), i (#35)]
    ├── read rows: 1500180
    ├── read size: 1.84 GiB
    ├── partitions total: 3000000
    ├── partitions scanned: 1500180
    ├── pruning stats: [segments: <range pruning: 3000 to 3000>, blocks: <range pruning: 3000000 to 1500180>]
    ├── push downs: [filters: [is_true(test_order.id (#0) > 1)], limit: NONE]
    └── estimated rows: 3000000.00

14 rows explain in 45.113 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)

----------------------------------------------- restart warehouse--------------------------------------------------
deploy@(bench-vacuum2-1)/default> alter warehouse 'bench-vacuum2-1' suspend;
processed in (1.085 sec)

deploy@(bench-vacuum2-1)/default> set max_storage_io_requests = 32;

SET max_storage_io_requests = 32

0 row read in 0.027 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

deploy@(bench-vacuum2-1)/default> explain select * from test_order where id > 1;

EXPLAIN SELECT * FROM test_order WHERE id > 1

-[ EXPLAIN ]-----------------------------------
Filter
├── output columns: [test_order.id (#0), test_order.id1 (#1), test_order.id2 (#2), test_order.id3 (#3), test_order.id4 (#4), test_order.id5 (#5), test_order.id6 (#6), test_order.id7 (#7), test_order.s1 (#8), test_order.s2 (#9), test_order.s3 (#10), test_order.s4 (#11), test_order.s5 (#12), test_order.s6 (#13), test_order.s7 (#14), test_order.s8 (#15), test_order.s9 (#16), test_order.s10 (#17), test_order.s11 (#18), test_order.s12 (#19), test_order.s13 (#20), test_order.d1 (#21), test_order.d2 (#22), test_order.d3 (#23), test_order.d4 (#24), test_order.d5 (#25), test_order.d6 (#26), test_order.d7 (#27), test_order.d8 (#28), test_order.d9 (#29), test_order.d10 (#30), test_order.insert_time (#31), test_order.insert_time1 (#32), test_order.insert_time2 (#33), test_order.insert_time3 (#34), test_order.i (#35)]
├── filters: [is_true(test_order.id (#0) > 1)]
├── estimated rows: 1500001.08
└── TableScan
    ├── table: default.default.test_order
    ├── output columns: [id (#0), id1 (#1), id2 (#2), id3 (#3), id4 (#4), id5 (#5), id6 (#6), id7 (#7), s1 (#8), s2 (#9), s3 (#10), s4 (#11), s5 (#12), s6 (#13), s7 (#14), s8 (#15), s9 (#16), s10 (#17), s11 (#18), s12 (#19), s13 (#20), d1 (#21), d2 (#22), d3 (#23), d4 (#24), d5 (#25), d6 (#26), d7 (#27), d8 (#28), d9 (#29), d10 (#30), insert_time (#31), insert_time1 (#32), insert_time2 (#33), insert_time3 (#34), i (#35)]
    ├── read rows: 1500180
    ├── read size: 1.84 GiB
    ├── partitions total: 3000000
    ├── partitions scanned: 1500180
    ├── pruning stats: [segments: <range pruning: 3000 to 3000>, blocks: <range pruning: 3000000 to 1500180>]
    ├── push downs: [filters: [is_true(test_order.id (#0) > 1)], limit: NONE]
    └── estimated rows: 3000000.00

14 rows explain in 32.248 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)

----------------------------------------------- restart warehouse--------------------------------------------------
deploy@(bench-vacuum2-1)/default> alter warehouse 'bench-vacuum2-1' suspend;
processed in (1.054 sec)

deploy@(bench-vacuum2-1)/default> set max_storage_io_requests = 64;

SET max_storage_io_requests = 64

0 row read in 0.027 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

deploy@(bench-vacuum2-1)/default> explain select * from test_order where id > 1;

EXPLAIN SELECT * FROM test_order WHERE id > 1

-[ EXPLAIN ]-----------------------------------
Filter
├── output columns: [test_order.id (#0), test_order.id1 (#1), test_order.id2 (#2), test_order.id3 (#3), test_order.id4 (#4), test_order.id5 (#5), test_order.id6 (#6), test_order.id7 (#7), test_order.s1 (#8), test_order.s2 (#9), test_order.s3 (#10), test_order.s4 (#11), test_order.s5 (#12), test_order.s6 (#13), test_order.s7 (#14), test_order.s8 (#15), test_order.s9 (#16), test_order.s10 (#17), test_order.s11 (#18), test_order.s12 (#19), test_order.s13 (#20), test_order.d1 (#21), test_order.d2 (#22), test_order.d3 (#23), test_order.d4 (#24), test_order.d5 (#25), test_order.d6 (#26), test_order.d7 (#27), test_order.d8 (#28), test_order.d9 (#29), test_order.d10 (#30), test_order.insert_time (#31), test_order.insert_time1 (#32), test_order.insert_time2 (#33), test_order.insert_time3 (#34), test_order.i (#35)]
├── filters: [is_true(test_order.id (#0) > 1)]
├── estimated rows: 1500001.08
└── TableScan
    ├── table: default.default.test_order
    ├── output columns: [id (#0), id1 (#1), id2 (#2), id3 (#3), id4 (#4), id5 (#5), id6 (#6), id7 (#7), s1 (#8), s2 (#9), s3 (#10), s4 (#11), s5 (#12), s6 (#13), s7 (#14), s8 (#15), s9 (#16), s10 (#17), s11 (#18), s12 (#19), s13 (#20), d1 (#21), d2 (#22), d3 (#23), d4 (#24), d5 (#25), d6 (#26), d7 (#27), d8 (#28), d9 (#29), d10 (#30), insert_time (#31), insert_time1 (#32), insert_time2 (#33), insert_time3 (#34), i (#35)]
    ├── read rows: 1500180
    ├── read size: 1.84 GiB
    ├── partitions total: 3000000
    ├── partitions scanned: 1500180
    ├── pruning stats: [segments: <range pruning: 3000 to 3000>, blocks: <range pruning: 3000000 to 1500180>]
    ├── push downs: [filters: [is_true(test_order.id (#0) > 1)], limit: NONE]
    └── estimated rows: 3000000.00

14 rows explain in 29.687 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)

----------------------------------------------- restart warehouse--------------------------------------------------
deploy@(bench-vacuum2-1)/default> alter warehouse 'bench-vacuum2-1' suspend;
processed in (1.040 sec)

deploy@(bench-vacuum2-1)/default> set max_storage_io_requests = 128;

SET max_storage_io_requests = 128

0 row read in 0.027 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

deploy@(bench-vacuum2-1)/default> explain select * from test_order where id > 1;

EXPLAIN SELECT * FROM test_order WHERE id > 1

-[ EXPLAIN ]-----------------------------------
Filter
├── output columns: [test_order.id (#0), test_order.id1 (#1), test_order.id2 (#2), test_order.id3 (#3), test_order.id4 (#4), test_order.id5 (#5), test_order.id6 (#6), test_order.id7 (#7), test_order.s1 (#8), test_order.s2 (#9), test_order.s3 (#10), test_order.s4 (#11), test_order.s5 (#12), test_order.s6 (#13), test_order.s7 (#14), test_order.s8 (#15), test_order.s9 (#16), test_order.s10 (#17), test_order.s11 (#18), test_order.s12 (#19), test_order.s13 (#20), test_order.d1 (#21), test_order.d2 (#22), test_order.d3 (#23), test_order.d4 (#24), test_order.d5 (#25), test_order.d6 (#26), test_order.d7 (#27), test_order.d8 (#28), test_order.d9 (#29), test_order.d10 (#30), test_order.insert_time (#31), test_order.insert_time1 (#32), test_order.insert_time2 (#33), test_order.insert_time3 (#34), test_order.i (#35)]
├── filters: [is_true(test_order.id (#0) > 1)]
├── estimated rows: 1500001.08
└── TableScan
    ├── table: default.default.test_order
    ├── output columns: [id (#0), id1 (#1), id2 (#2), id3 (#3), id4 (#4), id5 (#5), id6 (#6), id7 (#7), s1 (#8), s2 (#9), s3 (#10), s4 (#11), s5 (#12), s6 (#13), s7 (#14), s8 (#15), s9 (#16), s10 (#17), s11 (#18), s12 (#19), s13 (#20), d1 (#21), d2 (#22), d3 (#23), d4 (#24), d5 (#25), d6 (#26), d7 (#27), d8 (#28), d9 (#29), d10 (#30), insert_time (#31), insert_time1 (#32), insert_time2 (#33), insert_time3 (#34), i (#35)]
    ├── read rows: 1500180
    ├── read size: 1.84 GiB
    ├── partitions total: 3000000
    ├── partitions scanned: 1500180
    ├── pruning stats: [segments: <range pruning: 3000 to 3000>, blocks: <range pruning: 3000000 to 1500180>]
    ├── push downs: [filters: [is_true(test_order.id (#0) > 1)], limit: NONE]
    └── estimated rows: 3000000.00

14 rows explain in 27.179 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16680)
<!-- Reviewable:end -->
