### PR TITLE
feat(query): support `json_object_delete` and `json_object_pick` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "jsonb"
 version = "0.4.3"
-source = "git+https://github.com/databendlabs/jsonb?rev=672e423#672e4234758889b8fcb79ba43ac00af8c0aef120"
+source = "git+https://github.com/b41sh/jsonb?rev=1f6688aa289a09c2d7c46ac25fad070b795ef5bd#1f6688aa289a09c2d7c46ac25fad070b795ef5bd"
 dependencies = [
  "byteorder",
  "fast-float",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "jsonb"
 version = "0.4.3"
-source = "git+https://github.com/b41sh/jsonb?rev=1f6688aa289a09c2d7c46ac25fad070b795ef5bd#1f6688aa289a09c2d7c46ac25fad070b795ef5bd"
+source = "git+https://github.com/databendlabs/jsonb?rev=ada713c#ada713c16369cd0c0b85f3bbae22183111325ee9"
 dependencies = [
  "byteorder",
  "fast-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,7 +415,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "57795da" }
 ethnum = { git = "https://github.com/datafuse-extras/ethnum-rs", rev = "4cb05f1" }
-jsonb = { git = "https://github.com/b41sh/jsonb", rev = "1f6688aa289a09c2d7c46ac25fad070b795ef5bd" }
+jsonb = { git = "https://github.com/databendlabs/jsonb", rev = "ada713c" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 orc-rust = { git = "https://github.com/datafuse-extras/datafusion-orc", rev = "03372b97" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "6af35a1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,7 +415,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "57795da" }
 ethnum = { git = "https://github.com/datafuse-extras/ethnum-rs", rev = "4cb05f1" }
-jsonb = { git = "https://github.com/databendlabs/jsonb", rev = "672e423" }
+jsonb = { git = "https://github.com/b41sh/jsonb", rev = "1f6688aa289a09c2d7c46ac25fad070b795ef5bd" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 orc-rust = { git = "https://github.com/datafuse-extras/datafusion-orc", rev = "03372b97" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "6af35a1" }

--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::iter::once;
 use std::sync::Arc;
@@ -1679,6 +1680,72 @@ pub fn register(registry: &mut FunctionRegistry) {
             },
         }))
     });
+
+    registry.register_function_factory("json_object_pick", |_, args_type| {
+        if args_type.len() < 2 {
+            return None;
+        }
+        if args_type[0].remove_nullable() != DataType::Variant && args_type[0] != DataType::Null {
+            return None;
+        }
+        for arg_type in args_type.iter().skip(1) {
+            if arg_type.remove_nullable() != DataType::String && *arg_type != DataType::Null {
+                return None;
+            }
+        }
+        let is_nullable = args_type[0].is_nullable_or_null();
+        let return_type = if is_nullable {
+            DataType::Nullable(Box::new(DataType::Variant))
+        } else {
+            DataType::Variant
+        };
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "json_object_pick".to_string(),
+                args_type: args_type.to_vec(),
+                return_type,
+            },
+            eval: FunctionEval::Scalar {
+                calc_domain: Box::new(|_, _| FunctionDomain::MayThrow),
+                eval: Box::new(move |args, ctx| {
+                    json_object_pick_or_delete_fn(args, ctx, true, is_nullable)
+                }),
+            },
+        }))
+    });
+
+    registry.register_function_factory("json_object_delete", |_, args_type| {
+        if args_type.len() < 2 {
+            return None;
+        }
+        if args_type[0].remove_nullable() != DataType::Variant && args_type[0] != DataType::Null {
+            return None;
+        }
+        for arg_type in args_type.iter().skip(1) {
+            if arg_type.remove_nullable() != DataType::String && *arg_type != DataType::Null {
+                return None;
+            }
+        }
+        let is_nullable = args_type[0].is_nullable_or_null();
+        let return_type = if is_nullable {
+            DataType::Nullable(Box::new(DataType::Variant))
+        } else {
+            DataType::Variant
+        };
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "json_object_delete".to_string(),
+                args_type: args_type.to_vec(),
+                return_type,
+            },
+            eval: FunctionEval::Scalar {
+                calc_domain: Box::new(|_, _| FunctionDomain::MayThrow),
+                eval: Box::new(move |args, ctx| {
+                    json_object_pick_or_delete_fn(args, ctx, false, is_nullable)
+                }),
+            },
+        }))
+    });
 }
 
 fn json_array_fn(args: &[ValueRef<AnyType>], ctx: &mut EvalContext) -> Value<AnyType> {
@@ -2118,6 +2185,84 @@ fn json_object_insert_fn(
                 cast_scalar_to_variant(new_val.clone(), ctx.func_ctx.tz, &mut new_val_buf);
                 jsonb::object_insert(value, new_key, &new_val_buf, update_flag, &mut builder.data)
             }
+        };
+        if let Err(err) = res {
+            validity.push(false);
+            ctx.set_error(builder.len(), err.to_string());
+        } else {
+            validity.push(true);
+        }
+        builder.commit_row();
+    }
+    if is_nullable {
+        let validity: Bitmap = validity.into();
+        match len_opt {
+            Some(_) => {
+                Value::Column(Column::Variant(builder.build())).wrap_nullable(Some(validity))
+            }
+            None => {
+                if !validity.get_bit(0) {
+                    Value::Scalar(Scalar::Null)
+                } else {
+                    Value::Scalar(Scalar::Variant(builder.build_scalar()))
+                }
+            }
+        }
+    } else {
+        match len_opt {
+            Some(_) => Value::Column(Column::Variant(builder.build())),
+            None => Value::Scalar(Scalar::Variant(builder.build_scalar())),
+        }
+    }
+}
+
+fn json_object_pick_or_delete_fn(
+    args: &[ValueRef<AnyType>],
+    ctx: &mut EvalContext,
+    is_pick: bool,
+    is_nullable: bool,
+) -> Value<AnyType> {
+    let len_opt = args.iter().find_map(|arg| match arg {
+        ValueRef::Column(col) => Some(col.len()),
+        _ => None,
+    });
+    let len = len_opt.unwrap_or(1);
+    let mut keys = BTreeSet::new();
+    let mut validity = MutableBitmap::with_capacity(len);
+    let mut builder = BinaryColumnBuilder::with_capacity(len, len * 50);
+    for idx in 0..len {
+        let value = match &args[0] {
+            ValueRef::Scalar(scalar) => scalar.clone(),
+            ValueRef::Column(col) => unsafe { col.index_unchecked(idx) },
+        };
+        if value == ScalarRef::Null {
+            builder.commit_row();
+            validity.push(false);
+            continue;
+        }
+        let value = value.as_variant().unwrap();
+        if !is_object(value) {
+            ctx.set_error(builder.len(), "Invalid json object");
+            builder.commit_row();
+            validity.push(false);
+            continue;
+        }
+        keys.clear();
+        for arg in args.iter().skip(1) {
+            let key = match &arg {
+                ValueRef::Scalar(scalar) => scalar.clone(),
+                ValueRef::Column(col) => unsafe { col.index_unchecked(idx) },
+            };
+            if key == ScalarRef::Null {
+                continue;
+            }
+            let key = key.as_string().unwrap();
+            keys.insert(*key);
+        }
+        let res = if is_pick {
+            jsonb::object_pick(value, &keys, &mut builder.data)
+        } else {
+            jsonb::object_delete(value, &keys, &mut builder.data)
         };
         if let Err(err) = res {
             validity.push(false);

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -2312,9 +2312,11 @@ Functions overloads:
 0 json_extract_path_text(String, String) :: String NULL
 1 json_extract_path_text(String NULL, String NULL) :: String NULL
 0 json_object FACTORY
+0 json_object_delete FACTORY
 0 json_object_insert FACTORY
 0 json_object_keep_null FACTORY
 0 json_object_keys(Variant NULL) :: Variant NULL
+0 json_object_pick FACTORY
 0 json_path_exists FACTORY
 0 json_path_match FACTORY
 0 json_path_query FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -5573,3 +5573,137 @@ evaluation (internal):
 +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
+ast            : json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'a', 'b', 'c')
+raw expr       : json_object_delete(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'a', 'b', 'c')
+checked expr   : json_object_delete<Variant, String, String, String>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "a", "b", "c")
+optimized expr : 0x4000000310000001100000011000000120000002500000105000000e646d785022800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant
+output domain  : Undefined
+output         : '{"d":34,"m":[1,2],"x":{"k":"v"}}'
+
+
+ast            : json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'm', 'n', 'm', 'x')
+raw expr       : json_object_delete(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'm', 'n', 'm', 'x')
+checked expr   : json_object_delete<Variant, String, String, String, String>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "m", "n", "m", "x")
+optimized expr : 0x40000002100000011000000120000002200000026264500c5022
+output type    : Variant
+output domain  : Undefined
+output         : '{"b":12,"d":34}'
+
+
+ast            : json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'z', null)
+raw expr       : json_object_delete(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'z', NULL)
+checked expr   : json_object_delete<Variant, String, NULL>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "z", NULL)
+optimized expr : 0x40000004100000011000000110000001100000012000000220000002500000105000000e62646d78500c5022800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant
+output domain  : Undefined
+output         : '{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'
+
+
+ast            : json_object_delete('{}'::variant, 'v', 'vv')
+raw expr       : json_object_delete(CAST('{}' AS Variant), 'v', 'vv')
+checked expr   : json_object_delete<Variant, String, String>(parse_json<String>("{}"), "v", "vv")
+optimized expr : 0x40000000
+output type    : Variant
+output domain  : Undefined
+output         : '{}'
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | json_object_delete('123'::variant, 'v', 'vv')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid json object while evaluating function `json_object_delete('123', 'v', 'vv')` in expr `json_object_delete(parse_json('123'), 'v', 'vv')`
+
+
+
+ast            : json_object_delete(parse_json(v), 'a', 'm')
+raw expr       : json_object_delete(parse_json(v::String NULL), 'a', 'm')
+checked expr   : json_object_delete<Variant NULL, String, String>(parse_json<String NULL>(v), "a", "m")
+evaluation:
++--------+---------------------------------+---------------------+
+|        | v                               | Output              |
++--------+---------------------------------+---------------------+
+| Type   | String NULL                     | Variant NULL        |
+| Domain | {""..="{\"m\":\"n\"}"} ∪ {NULL} | Unknown             |
+| Row 0  | '{"k":"v"}'                     | '{"k":"v"}'         |
+| Row 1  | '{"m":"n"}'                     | '{}'                |
+| Row 2  | NULL                            | NULL                |
+| Row 3  | '{"a":"b","c":"d","y":"z"}'     | '{"c":"d","y":"z"}' |
++--------+---------------------------------+---------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                            |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v      | NullableColumn { column: StringColumn { data: 0x7b226b223a2276227d7b226d223a226e227d7b2261223a2262222c2263223a2264222c2279223a227a227d, offsets: [0, 9, 18, 18, 43] }, validity: [0b____1011] } |
+| Output | NullableColumn { column: BinaryColumn { data: 0x4000000110000001100000016b764000000040000002100000011000000110000001100000016379647a, offsets: [0, 14, 18, 18, 42] }, validity: [0b____1011] }  |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'a', 'b', 'c')
+raw expr       : json_object_pick(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'a', 'b', 'c')
+checked expr   : json_object_pick<Variant, String, String, String>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "a", "b", "c")
+optimized expr : 0x40000001100000012000000262500c
+output type    : Variant
+output domain  : Undefined
+output         : '{"b":12}'
+
+
+ast            : json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'm', 'n', 'm', 'x')
+raw expr       : json_object_pick(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'm', 'n', 'm', 'x')
+checked expr   : json_object_pick<Variant, String, String, String, String>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "m", "n", "m", "x")
+optimized expr : 0x400000021000000110000001500000105000000e6d78800000022000000220000002500150024000000110000001100000016b76
+output type    : Variant
+output domain  : Undefined
+output         : '{"m":[1,2],"x":{"k":"v"}}'
+
+
+ast            : json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'z', null)
+raw expr       : json_object_pick(CAST('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}' AS Variant), 'z', NULL)
+checked expr   : json_object_pick<Variant, String, NULL>(parse_json<String>("{\"b\":12,\"d\":34,\"m\":[1,2],\"x\":{\"k\":\"v\"}}"), "z", NULL)
+optimized expr : 0x40000000
+output type    : Variant
+output domain  : Undefined
+output         : '{}'
+
+
+ast            : json_object_pick('{}'::variant, 'v', 'vv')
+raw expr       : json_object_pick(CAST('{}' AS Variant), 'v', 'vv')
+checked expr   : json_object_pick<Variant, String, String>(parse_json<String>("{}"), "v", "vv")
+optimized expr : 0x40000000
+output type    : Variant
+output domain  : Undefined
+output         : '{}'
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | json_object_pick('123'::variant, 'v', 'vv')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid json object while evaluating function `json_object_pick('123', 'v', 'vv')` in expr `json_object_pick(parse_json('123'), 'v', 'vv')`
+
+
+
+ast            : json_object_pick(parse_json(v), 'a', 'm')
+raw expr       : json_object_pick(parse_json(v::String NULL), 'a', 'm')
+checked expr   : json_object_pick<Variant NULL, String, String>(parse_json<String NULL>(v), "a", "m")
+evaluation:
++--------+---------------------------------+--------------+
+|        | v                               | Output       |
++--------+---------------------------------+--------------+
+| Type   | String NULL                     | Variant NULL |
+| Domain | {""..="{\"m\":\"n\"}"} ∪ {NULL} | Unknown      |
+| Row 0  | '{"k":"v"}'                     | '{}'         |
+| Row 1  | '{"m":"n"}'                     | '{"m":"n"}'  |
+| Row 2  | NULL                            | NULL         |
+| Row 3  | '{"a":"b","c":"d","y":"z"}'     | '{"a":"b"}'  |
++--------+---------------------------------+--------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                            |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v      | NullableColumn { column: StringColumn { data: 0x7b226b223a2276227d7b226d223a226e227d7b2261223a2262222c2263223a2264222c2279223a227a227d, offsets: [0, 9, 18, 18, 43] }, validity: [0b____1011] } |
+| Output | NullableColumn { column: BinaryColumn { data: 0x400000004000000110000001100000016d6e4000000110000001100000016162, offsets: [0, 4, 18, 18, 32] }, validity: [0b____1011] }                       |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -70,6 +70,8 @@ fn test_variant() {
     test_json_array_except(file);
     test_json_array_overlap(file);
     test_json_object_insert(file);
+    test_json_object_delete(file);
+    test_json_object_pick(file);
 }
 
 fn test_parse_json(file: &mut impl Write) {
@@ -2049,4 +2051,71 @@ fn test_json_object_insert(file: &mut impl Write) {
             ),
         ],
     );
+}
+
+fn test_json_object_delete(file: &mut impl Write) {
+    run_ast(
+        file,
+        r#"json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'a', 'b', 'c')"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'm', 'n', 'm', 'x')"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"json_object_delete('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'z', null)"#,
+        &[],
+    );
+    run_ast(file, r#"json_object_delete('{}'::variant, 'v', 'vv')"#, &[]);
+    run_ast(file, r#"json_object_delete('123'::variant, 'v', 'vv')"#, &[
+    ]);
+
+    run_ast(file, "json_object_delete(parse_json(v), 'a', 'm')", &[(
+        "v",
+        StringType::from_data_with_validity(
+            vec![
+                r#"{"k":"v"}"#,
+                r#"{"m":"n"}"#,
+                "",
+                r#"{"a":"b","c":"d","y":"z"}"#,
+            ],
+            vec![true, true, false, true],
+        ),
+    )]);
+}
+
+fn test_json_object_pick(file: &mut impl Write) {
+    run_ast(
+        file,
+        r#"json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'a', 'b', 'c')"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'm', 'n', 'm', 'x')"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"json_object_pick('{"b":12,"d":34,"m":[1,2],"x":{"k":"v"}}'::variant, 'z', null)"#,
+        &[],
+    );
+    run_ast(file, r#"json_object_pick('{}'::variant, 'v', 'vv')"#, &[]);
+    run_ast(file, r#"json_object_pick('123'::variant, 'v', 'vv')"#, &[]);
+
+    run_ast(file, "json_object_pick(parse_json(v), 'a', 'm')", &[(
+        "v",
+        StringType::from_data_with_validity(
+            vec![
+                r#"{"k":"v"}"#,
+                r#"{"m":"n"}"#,
+                "",
+                r#"{"a":"b","c":"d","y":"z"}"#,
+            ],
+            vec![true, true, false, true],
+        ),
+    )]);
 }

--- a/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
+++ b/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
@@ -482,5 +482,15 @@ select '[1,2,"3"]'::Variant a, a::Array(Variant) b, b::Variant = a;
 ----
 [1,2,"3"] ['1','2','"3"'] 1
 
+query TTT
+select '{"k1":"v1","k2":"v2"}'::Variant a, a::Map(String, String) b, b::Variant = a;
+----
+{"k1":"v1","k2":"v2"} {'k1':'v1','k2':'v2'} 1
+
+query TTT
+select '{"a":1,"b":2}'::Variant a, a::Map(String, Int) b, b::Variant = a;
+----
+{"a":1,"b":2} {'a':1,'b':2} 1
+
 statement ok
 drop table t

--- a/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
+++ b/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
@@ -1434,5 +1434,55 @@ SELECT id, json_object_insert(v1, 'b', '100'::variant) from t5
 2 {"a":[1,2,3],"b":100,"c":{"c1":"v1","c2":"v2"},"m":true}
 3 {"a":1,"b":100,"h":2,"m":3,"n":4}
 
+query T
+SELECT json_object_delete('{"a":1,"b":2,"d":4}'::variant, 'a', 'c')
+----
+{"b":2,"d":4}
+
+query T
+SELECT json_object_delete('{"a":1,"b":2,"d":4}'::variant, 'b', 'b', null, 'd')
+----
+{"a":1}
+
+query T
+SELECT json_object_delete('{"a":1,"b":2,"d":4}'::variant, 'A', 'B')
+----
+{"a":1,"b":2,"d":4}
+
+statement error 1006
+SELECT json_object_delete('1234'::variant, 'a')
+
+query IT
+SELECT id, json_object_delete(v1, 'a', 'k1') from t5
+----
+1 {"k2":"v2"}
+2 {"c":{"c1":"v1","c2":"v2"},"m":true}
+3 {"h":2,"m":3,"n":4}
+
+query T
+SELECT json_object_pick('{"a":1,"b":2,"d":4}'::variant, 'a', 'c')
+----
+{"a":1}
+
+query T
+SELECT json_object_pick('{"a":1,"b":2,"d":4}'::variant, 'b', 'b', null, 'd')
+----
+{"b":2,"d":4}
+
+query T
+SELECT json_object_pick('{"a":1,"b":2,"d":4}'::variant, 'A', 'B')
+----
+{}
+
+statement error 1006
+SELECT json_object_pick('1234'::variant, 'a')
+
+query IT
+SELECT id, json_object_pick(v1, 'a', 'k1') from t5
+----
+1 {"k1":"v1"}
+2 {"a":[1,2,3]}
+3 {"a":1}
+
 statement ok
 DROP TABLE IF EXISTS t5


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- support `json_object_delete` function
- support `json_object_pick` function
- allow cast variant to map<string, variant>

for example
```sql
MySQL [(none)]> SELECT json_object_delete('{"a":1,"b":2,"d":4}'::variant, 'a', 'c');
+--------------------------------------------------------------+
| json_object_delete('{"a":1,"b":2,"d":4}'::VARIANT, 'a', 'c') |
+--------------------------------------------------------------+
| {"b":2,"d":4}                                                |
+--------------------------------------------------------------+
1 row in set (0.167 sec)

MySQL [(none)]> SELECT json_object_pick('{"a":1,"b":2,"d":4}'::variant, 'a', 'c');
+------------------------------------------------------------+
| json_object_pick('{"a":1,"b":2,"d":4}'::VARIANT, 'a', 'c') |
+------------------------------------------------------------+
| {"a":1}                                                    |
+------------------------------------------------------------+
1 row in set (0.046 sec)

MySQL [(none)]> select '{"k1":"v1","k2":"v2"}'::Variant a, a::Map(String, String) b, b::Variant = a;
+-----------------------+-----------------------+----------------+
| a                     | b                     | b::VARIANT = a |
+-----------------------+-----------------------+----------------+
| {"k1":"v1","k2":"v2"} | {'k1':'v1','k2':'v2'} |              1 |
+-----------------------+-----------------------+----------------+
1 row in set (0.051 sec)
```

fixes: #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16682)
<!-- Reviewable:end -->
