### PR TITLE
fix: `JEAllocator` should properly handle nullptr returned

### DIFF
--- a/src/common/base/src/mem_allocator/jemalloc.rs
+++ b/src/common/base/src/mem_allocator/jemalloc.rs
@@ -171,9 +171,13 @@ pub mod linux {
                 // mmap allocator for large frequent memory allocation and take jemalloc
                 // as fallback.
                 let raw = ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) as *mut u8;
-                raw.add(old_layout.size())
-                    .write_bytes(0, new_layout.size() - old_layout.size());
-                NonNull::new(raw as *mut ()).unwrap()
+                if raw.is_null() {
+                    return Err(AllocError);
+                } else {
+                    raw.add(old_layout.size())
+                        .write_bytes(0, new_layout.size() - old_layout.size());
+                    NonNull::new(raw as *mut ()).unwrap()
+                }
             };
 
             Ok(NonNull::<[u8]>::from_raw_parts(
@@ -209,9 +213,13 @@ pub mod linux {
             } else {
                 let data_address =
                     ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) as *mut u8;
-                let metadata = new_layout.size();
-                let slice = std::slice::from_raw_parts_mut(data_address, metadata);
-                NonNull::new(slice).ok_or(AllocError)?
+                if data_address.is_null() {
+                    return Err(AllocError);
+                } else {
+                    let metadata = new_layout.size();
+                    let slice = std::slice::from_raw_parts_mut(data_address, metadata);
+                    NonNull::new(slice).ok_or(AllocError)?
+                }
             };
 
             Ok(new_ptr)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary



In `JEAllocator::grow_zeroed/shrink`,   when je  `rallocx` returns NULL,  stop proceeding, returns `AllocError` error directly.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16692)
<!-- Reviewable:end -->
