### PR TITLE
chore: tweak cargo feature "jemalloc"

### DIFF
--- a/src/binaries/Cargo.toml
+++ b/src/binaries/Cargo.toml
@@ -15,7 +15,7 @@ memory-profiling = [
 ]
 python-udf = ["databend-query/python-udf"]
 simd = ["databend-query/simd"]
-jemalloc = ["databend-common-base/jemalloc"]
+jemalloc = ["databend-common-base/jemalloc", "databend-query/jemalloc"]
 io-uring = [
     "databend-query/io-uring",
 ]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -12,9 +12,10 @@ test = true
 
 [features]
 tracing = ["tokio/tracing"]
-jemalloc = []
+jemalloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
 memory-profiling = [
+    "jemalloc",
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
     "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
@@ -54,8 +55,8 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 state = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true }
-tikv-jemalloc-sys = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
+tikv-jemalloc-sys = { workspace = true, optional = true }
 tokio = { workspace = true }
 unicode-segmentation = { workspace = true }
 uuid = { workspace = true }

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -15,7 +15,6 @@ tracing = ["tokio/tracing"]
 jemalloc = ["tikv-jemalloc-sys", "tikv-jemalloc-ctl"]
 disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
 memory-profiling = [
-    "jemalloc",
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
     "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",

--- a/src/common/base/src/mem_allocator/mmap.rs
+++ b/src/common/base/src/mem_allocator/mmap.rs
@@ -16,19 +16,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::mem_allocator::JEAllocator;
-
 /// mmap allocator.
 /// For better performance, we use jemalloc as the inner allocator.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MmapAllocator {
-    allocator: JEAllocator,
+    #[cfg(feature = "jemalloc")]
+    allocator: crate::mem_allocator::JEAllocator,
+    #[cfg(not(feature = "jemalloc"))]
+    allocator: crate::mem_allocator::StdAllocator,
 }
 
 impl MmapAllocator {
     pub fn new() -> Self {
         Self {
-            allocator: JEAllocator,
+            #[cfg(feature = "jemalloc")]
+            allocator: crate::mem_allocator::JEAllocator,
+            #[cfg(not(feature = "jemalloc"))]
+            allocator: crate::mem_allocator::StdAllocator,
         }
     }
 }

--- a/src/common/base/src/mem_allocator/mod.rs
+++ b/src/common/base/src/mem_allocator/mod.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 mod global;
+#[cfg(feature = "jemalloc")]
 mod jemalloc;
 mod mmap;
 mod std_;
 
 pub use default::DefaultAllocator;
 pub use global::GlobalAllocator;
+#[cfg(feature = "jemalloc")]
 pub use jemalloc::JEAllocator;
 pub use mmap::MmapAllocator;
 pub use std_::StdAllocator;

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 test = true
 
 [features]
-default = ["simd", "memory-profiling"]
+default = ["simd"]
 memory-profiling = ["databend-common-base/memory-profiling", "databend-common-http/memory-profiling"]
 simd = ["databend-common-arrow/simd"]
 io-uring = [

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -16,7 +16,7 @@ default = ["simd"]
 simd = ["databend-common-arrow/simd"]
 python-udf = ["arrow-udf-python"]
 disable_initial_exec_tls = ["databend-common-base/disable_initial_exec_tls"]
-
+jemalloc = ["databend-common-storages-system/jemalloc"]
 memory-profiling = ["databend-common-base/memory-profiling", "databend-common-http/memory-profiling"]
 storage-hdfs = ["opendal/services-hdfs", "databend-common-storage/storage-hdfs"]
 io-uring = [

--- a/src/query/service/src/databases/system/system_database.rs
+++ b/src/query/service/src/databases/system/system_database.rs
@@ -41,7 +41,9 @@ use databend_common_storages_system::FullStreamsTable;
 use databend_common_storages_system::FunctionsTable;
 use databend_common_storages_system::IndexesTable;
 use databend_common_storages_system::LocksTable;
+#[cfg(feature = "jemalloc")]
 use databend_common_storages_system::MallocStatsTable;
+#[cfg(feature = "jemalloc")]
 use databend_common_storages_system::MallocStatsTotalsTable;
 use databend_common_storages_system::MetricsTable;
 use databend_common_storages_system::NotificationHistoryTable;
@@ -107,7 +109,9 @@ impl SystemDatabase {
             ProcessesTable::create(sys_db_meta.next_table_id()),
             ConfigsTable::create(sys_db_meta.next_table_id()),
             MetricsTable::create(sys_db_meta.next_table_id()),
+            #[cfg(feature = "jemalloc")]
             MallocStatsTable::create(sys_db_meta.next_table_id()),
+            #[cfg(feature = "jemalloc")]
             MallocStatsTotalsTable::create(sys_db_meta.next_table_id()),
             ColumnsTable::create(sys_db_meta.next_table_id()),
             UsersTable::create(sys_db_meta.next_table_id()),

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -10,6 +10,9 @@ edition = { workspace = true }
 doctest = false
 test = true
 
+[features]
+jemalloc = ["databend-common-base/jemalloc", "tikv-jemalloc-ctl"]
+
 [dependencies]
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
@@ -49,7 +52,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = "0.1.9"
 snailquote = "0.3.1"
-tikv-jemalloc-ctl = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 typetag = { workspace = true }
 
 [build-dependencies]

--- a/src/query/storages/system/src/lib.rs
+++ b/src/query/storages/system/src/lib.rs
@@ -39,7 +39,9 @@ mod functions_table;
 mod indexes_table;
 mod locks_table;
 mod log_queue;
+#[cfg(feature = "jemalloc")]
 mod malloc_stats_table;
+#[cfg(feature = "jemalloc")]
 mod malloc_stats_totals_table;
 mod metrics_table;
 mod notification_history_table;
@@ -90,7 +92,9 @@ pub use locks_table::LocksTable;
 pub use log_queue::SystemLogElement;
 pub use log_queue::SystemLogQueue;
 pub use log_queue::SystemLogTable;
+#[cfg(feature = "jemalloc")]
 pub use malloc_stats_table::MallocStatsTable;
+#[cfg(feature = "jemalloc")]
 pub use malloc_stats_totals_table::MallocStatsTotalsTable;
 pub use metrics_table::MetricsTable;
 pub use notification_history_table::NotificationHistoryTable;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Tweaks cargo features  so that when the "jemalloc" feature is not enabled, binaries will no longer contain jemalloc symbols. 

This helps us avoid issues caused by jemalloc when using sanitizers or Valgrind.

- `jemalloc` is enabled by default. 

- to disable it:  `cargo b --no-default-features -F simd`.

   in this case, `mem_allocator::StdAllocator` will be used as the  "fallback allocator" of `MmapAllocator`
   
   during query node starting up,  memory allocator name will no longer be jemalloc:
   ~~~
   ...
   Memory:
    limit: unlimited
    allocator: std
    config: 
  ...
  ~~~

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - cargo refactoring

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16693)
<!-- Reviewable:end -->
