### PR TITLE
chore: display port number on error from bind to port failure

### DIFF
--- a/src/query/service/src/servers/flight/flight_service.rs
+++ b/src/query/service/src/servers/flight/flight_service.rs
@@ -80,7 +80,7 @@ impl FlightService {
         };
 
         let incoming = TcpIncoming::new(addr, true, None)
-            .map_err(|e| ErrorCode::CannotListenerPort(format!("{e}")))?;
+            .map_err(|e| ErrorCode::CannotListenerPort(format!("{},{}", e, addr)))?;
         let server = builder
             .add_service(
                 FlightServiceServer::new(flight_api_service)

--- a/src/query/service/src/servers/flight_sql/flight_sql_server.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_server.rs
@@ -81,7 +81,7 @@ impl FlightSQLServer {
         };
 
         let incoming = TcpIncoming::new(addr, true, None)
-            .map_err(|e| ErrorCode::CannotListenerPort(format!("{e}")))?;
+            .map_err(|e| ErrorCode::CannotListenerPort(format!("{},{}", e, addr)))?;
 
         let server = builder
             .add_service(FlightServiceServer::new(flight_sql_service))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
display port number on error from bind to port failure
- fixes: [#[16673]](https://github.com/databendlabs/databend/issues/16673)

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_ simple change add more info to err display

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): error msg enhancement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16695)
<!-- Reviewable:end -->
