### PR TITLE
feat: support calculating table storage size(including time travel)

### DIFF
--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -105,10 +105,7 @@ pub trait Database: DynClone + Sync + Send {
 
     #[async_backtrace::framed]
     async fn list_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
-        Err(ErrorCode::Unimplemented(format!(
-            "UnImplement list_tables in {} Database",
-            self.name()
-        )))
+        Ok(vec![])
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -25,6 +25,7 @@ use databend_common_storages_fuse::table_functions::FuseBlockFunc;
 use databend_common_storages_fuse::table_functions::FuseColumnFunc;
 use databend_common_storages_fuse::table_functions::FuseEncodingFunc;
 use databend_common_storages_fuse::table_functions::FuseStatisticsFunc;
+use databend_common_storages_fuse::table_functions::FuseTimeTravelSizeFunc;
 use databend_common_storages_fuse::table_functions::FuseVacuumTemporaryTable;
 use databend_common_storages_fuse::table_functions::TableFunctionTemplate;
 use databend_common_storages_stream::stream_status_table_func::StreamStatusTable;
@@ -287,6 +288,14 @@ impl TableFunctionFactory {
         creators.insert(
             "show_variables".to_string(),
             (next_id(), Arc::new(ShowVariables::create)),
+        );
+
+        creators.insert(
+            "fuse_time_travel_size".to_string(),
+            (
+                next_id(),
+                Arc::new(TableFunctionTemplate::<FuseTimeTravelSizeFunc>::create),
+            ),
         );
 
         TableFunctionFactory {

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -465,6 +465,10 @@ impl FuseTable {
     pub fn get_storage_format(&self) -> FuseStorageFormat {
         self.storage_format
     }
+
+    pub fn get_storage_prefix(&self) -> &str {
+        self.meta_location_generator.prefix()
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -1,0 +1,167 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::catalog_kind::CATALOG_DEFAULT;
+use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::table_args::TableArgs;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::UInt64Type;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchemaRef;
+use databend_common_expression::TableSchemaRefExt;
+use databend_common_storage::DataOperator;
+use futures_util::TryStreamExt;
+use opendal::Metakey;
+use opendal::Operator;
+
+use super::parse_opt_opt_args;
+use crate::table_functions::string_literal;
+use crate::table_functions::SimpleArgFunc;
+use crate::FuseTable;
+
+pub struct FuseTimeTravelSizeArgs {
+    pub database_name: Option<String>,
+    pub table_name: Option<String>,
+}
+
+impl From<&FuseTimeTravelSizeArgs> for TableArgs {
+    fn from(args: &FuseTimeTravelSizeArgs) -> Self {
+        let mut table_args = Vec::new();
+        if let Some(database_name) = &args.database_name {
+            table_args.push(string_literal(database_name));
+        }
+        if let Some(table_name) = &args.table_name {
+            table_args.push(string_literal(table_name));
+        }
+        TableArgs::new_positioned(table_args)
+    }
+}
+
+impl TryFrom<(&str, TableArgs)> for FuseTimeTravelSizeArgs {
+    type Error = ErrorCode;
+    fn try_from((func_name, table_args): (&str, TableArgs)) -> Result<Self> {
+        let (database_name, table_name) = parse_opt_opt_args(&table_args, func_name)?;
+        Ok(Self {
+            database_name,
+            table_name,
+        })
+    }
+}
+
+pub struct FuseTimeTravelSize;
+
+#[async_trait::async_trait]
+impl SimpleArgFunc for FuseTimeTravelSize {
+    type Args = FuseTimeTravelSizeArgs;
+
+    fn schema() -> TableSchemaRef {
+        TableSchemaRefExt::create(vec![
+            TableField::new("database_name", TableDataType::String),
+            TableField::new("table_name", TableDataType::String),
+            TableField::new(
+                "time_travel_size",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+        ])
+    }
+
+    // TODO(sky): reduce access to meta service
+    async fn apply(
+        ctx: &Arc<dyn TableContext>,
+        args: &Self::Args,
+        _plan: &DataSourcePlan,
+    ) -> Result<DataBlock> {
+        let operator = DataOperator::instance().operator();
+        let mut database_names = Vec::new();
+        let mut table_names = Vec::new();
+        let mut sizes = Vec::new();
+        match (&args.database_name, &args.table_name) {
+            (Some(database_name), Some(table_name)) => {
+                let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
+                let db = catalog
+                    .get_database(&ctx.get_tenant(), database_name.as_str())
+                    .await?;
+                let tbl = db.get_table(table_name.as_str()).await?;
+                let fuse_table = FuseTable::try_from_table(tbl.as_ref())?;
+                let storage_prefix = fuse_table.get_storage_prefix();
+                let size = get_time_travel_size(storage_prefix, &operator).await?;
+                database_names.push(database_name.clone());
+                table_names.push(table_name.clone());
+                sizes.push(size);
+            }
+            (Some(database_name), None) => {
+                let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
+                let database = catalog
+                    .get_database(&ctx.get_tenant(), database_name.as_str())
+                    .await?;
+                let tables = database.list_tables().await?;
+                for tbl in tables {
+                    let Ok(fuse_table) = FuseTable::try_from_table(tbl.as_ref()) else {
+                        continue;
+                    };
+                    let storage_prefix = fuse_table.get_storage_prefix();
+                    let size = get_time_travel_size(storage_prefix, &operator).await?;
+                    database_names.push(database_name.clone());
+                    table_names.push(tbl.name().to_string());
+                    sizes.push(size);
+                }
+            }
+            (None, None) => {
+                let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
+                let databases = catalog.list_databases(&ctx.get_tenant()).await?;
+                for db in databases {
+                    let tables = db.list_tables().await?;
+                    for tbl in tables {
+                        let Ok(fuse_table) = FuseTable::try_from_table(tbl.as_ref()) else {
+                            continue;
+                        };
+                        let storage_prefix = fuse_table.get_storage_prefix();
+                        let size = get_time_travel_size(storage_prefix, &operator).await?;
+                        database_names.push(db.name().to_string());
+                        table_names.push(tbl.name().to_string());
+                        sizes.push(size);
+                    }
+                }
+            }
+            (None, Some(_)) => unreachable!(),
+        }
+        Ok(DataBlock::new_from_columns(vec![
+            StringType::from_data(database_names),
+            StringType::from_data(table_names),
+            UInt64Type::from_data(sizes),
+        ]))
+    }
+}
+
+async fn get_time_travel_size(storage_prefix: &str, op: &Operator) -> Result<u64> {
+    let mut lister = op
+        .lister_with(storage_prefix)
+        .recursive(true)
+        .metakey(Metakey::ContentLength)
+        .await?;
+    let mut size = 0;
+    while let Some(entry) = lister.try_next().await? {
+        size += entry.metadata().content_length();
+    }
+    Ok(size)
+}

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -22,6 +22,7 @@ mod fuse_encoding;
 mod fuse_segment;
 mod fuse_snapshot;
 mod fuse_statistic;
+mod fuse_time_travel_size;
 mod fuse_vacuum_temporary_table;
 mod table_args;
 

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -40,5 +40,7 @@ pub use fuse_encoding::FuseEncodingFunc;
 pub use fuse_segment::FuseSegmentFunc;
 pub use fuse_snapshot::FuseSnapshotFunc;
 pub use fuse_statistic::FuseStatisticsFunc;
+pub use fuse_time_travel_size::FuseTimeTravelSize;
+pub use fuse_time_travel_size::FuseTimeTravelSizeFunc;
 pub use fuse_vacuum_temporary_table::FuseVacuumTemporaryTable;
 pub use table_args::*;

--- a/src/query/storages/fuse/src/table_functions/table_args.rs
+++ b/src/query/storages/fuse/src/table_functions/table_args.rs
@@ -82,6 +82,29 @@ pub fn parse_db_tb_opt_args(
     }
 }
 
+pub fn parse_opt_opt_args(
+    table_args: &TableArgs,
+    func_name: &str,
+) -> Result<(Option<String>, Option<String>)> {
+    let args = table_args.expect_all_positioned(func_name, None)?;
+    match args.len() {
+        2 => {
+            let arg1 = string_value(&args[0])?;
+            let arg2 = string_value(&args[1])?;
+            Ok((Some(arg1), Some(arg2)))
+        }
+        1 => {
+            let arg1 = string_value(&args[0])?;
+            Ok((Some(arg1), None))
+        }
+        0 => Ok((None, None)),
+        _ => Err(ErrorCode::BadArguments(format!(
+            "expecting <opt_arg1> and <opt_arg2> (as string literals), but got {:?}",
+            args
+        ))),
+    }
+}
+
 pub fn parse_db_tb_col_args(table_args: &TableArgs, func_name: &str) -> Result<String> {
     let args = table_args.expect_all_positioned(func_name, Some(1))?;
     let db = string_value(&args[0])?;

--- a/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
@@ -15,6 +15,7 @@ fuse_encoding
 fuse_segment
 fuse_snapshot
 fuse_statistic
+fuse_time_travel_size
 fuse_vacuum_temporary_table
 
 query T

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.result
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.result
@@ -1,0 +1,4 @@
+>>>> create or replace database test_fuse_time_travel_size
+>>>> create table test_fuse_time_travel_size.t(c int) 'fs:///tmp/test_fuse_time_travel_size/'
+>>>> insert into test_fuse_time_travel_size.t values (1),(2)
+Size difference is less than 10 bytes

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+stmt "create or replace database test_fuse_time_travel_size" 
+
+rm -rf /tmp/test_fuse_time_travel_size/
+
+mkdir -p /tmp/test_fuse_time_travel_size/
+
+chmod 777 /tmp/test_fuse_time_travel_size/
+
+stmt "create table test_fuse_time_travel_size.t(c int) 'fs:///tmp/test_fuse_time_travel_size/'" 
+
+stmt "insert into test_fuse_time_travel_size.t values (1),(2)" 
+
+result_size=$(echo "select time_travel_size from fuse_time_travel_size('test_fuse_time_travel_size')" | $BENDSQL_CLIENT_CONNECT)
+
+expected_size=$(find /tmp/test_fuse_time_travel_size/ -type f -exec du -b  {} + | awk '{sum += $1} END {print sum}')
+
+echo $result_size
+echo $expected_size
+

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
@@ -19,6 +19,11 @@ result_size=$(echo "select time_travel_size from fuse_time_travel_size('test_fus
 
 expected_size=$(find /tmp/test_fuse_time_travel_size/ -type f -exec du -b  {} + | awk '{sum += $1} END {print sum}')
 
-echo $result_size
-echo $expected_size
+if [ $((result_size - expected_size)) -lt 10 ] && [ $((expected_size - result_size)) -lt 10 ]; then
+    echo "Size difference is less than 10 bytes"
+else
+    echo "Size difference is too large: result_size=$result_size, expected_size=$expected_size"
+    exit 1
+fi
+
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Calculate the table's total storage space to guide users or the cloud in prioritizing vacuum for larger tables.
```
root@localhost:8000/db2> select database_name, table_name, humanize_size(time_travel_size) from fuse_time_travel_size();

SELECT
    database_name, table_name, humanize_size(time_travel_size)
FROM
    fuse_time_travel_size()

┌──────────────────────────────────────────────────────────────┐
│ database_name │ table_name │ humanize_size(time_travel_size) │
│     String    │   String   │              String             │
├───────────────┼────────────┼─────────────────────────────────┤
│ db1           │ t1         │ 1.91 KiB                        │
│ db2           │ t2         │ 1.91 KiB                        │
│ db2           │ t3         │ 1.91 KiB                        │
└──────────────────────────────────────────────────────────────┘
3 rows read in 0.041 sec. Processed 3 rows, 103 B (73.17 rows/s, 2.45 KiB/s)
```
```
root@localhost:8000/db2> select database_name, table_name, humanize_size(time_travel_size) from fuse_time_travel_size('db2');

SELECT
    database_name, table_name, humanize_size(time_travel_size)
FROM
    fuse_time_travel_size('db2')

┌──────────────────────────────────────────────────────────────┐
│ database_name │ table_name │ humanize_size(time_travel_size) │
│     String    │   String   │              String             │
├───────────────┼────────────┼─────────────────────────────────┤
│ db2           │ t2         │ 1.91 KiB                        │
│ db2           │ t3         │ 1.91 KiB                        │
└──────────────────────────────────────────────────────────────┘
2 rows read in 0.030 sec. Processed 2 rows, 74 B (66.67 rows/s, 2.41 KiB/s)
```
```
root@localhost:8000/db2> select database_name, table_name, humanize_size(time_travel_size) from fuse_time_travel_size('db2','t2');

SELECT
    database_name, table_name, humanize_size(time_travel_size)
FROM
    fuse_time_travel_size('db2', 't2')

┌──────────────────────────────────────────────────────────────┐
│ database_name │ table_name │ humanize_size(time_travel_size) │
│     String    │   String   │              String             │
├───────────────┼────────────┼─────────────────────────────────┤
│ db2           │ t2         │ 1.91 KiB                        │
└──────────────────────────────────────────────────────────────┘
1 row read in 0.031 sec. Processed 1 row, 45 B (32.26 rows/s, 1.42 KiB/s)
```

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16698)
<!-- Reviewable:end -->
