### PR TITLE
chore: display log.file.limit and prefix_filter

### DIFF
--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -64,8 +64,8 @@ impl Display for FileConfig {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "enabled={}, level={}, dir={}, format={}",
-            self.on, self.level, self.dir, self.format
+            "enabled={}, level={}, dir={}, format={}, limit={}, prefix_filter={}",
+            self.on, self.level, self.dir, self.format, self.limit, self.prefix_filter
         )
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


This pr is not resolve the issue #16702, just display limit in FileConfig. Facilitate problem locating



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16713)
<!-- Reviewable:end -->
