### PR TITLE
chore: Simplifying BlockMetaInfo Definitions

### DIFF
--- a/src/query/catalog/src/plan/agg_index.rs
+++ b/src/query/catalog/src/plan/agg_index.rs
@@ -14,6 +14,7 @@
 
 use std::fmt::Debug;
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::RemoteExpr;
@@ -69,26 +70,10 @@ impl AggIndexMeta {
     }
 }
 
-impl serde::Serialize for AggIndexMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize AggIndexMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for AggIndexMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize AggIndexMeta")
-    }
-}
+local_block_meta_serde!(AggIndexMeta);
 
 #[typetag::serde(name = "agg_index_meta")]
 impl BlockMetaInfo for AggIndexMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals AggIndexMeta")
-    }
-
     fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
         Box::new(self.clone())
     }

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -96,13 +96,11 @@ pub trait BlockMetaInfo: Debug + Send + Sync + Any + 'static {
     }
 }
 
-pub trait BlockMetaInfoDowncast: Sized {
-    fn downcast_from(boxed: BlockMetaInfoPtr) -> Option<Self>;
+pub trait BlockMetaInfoDowncast: Sized + BlockMetaInfo {
+    fn boxed(self) -> BlockMetaInfoPtr {
+        Box::new(self)
+    }
 
-    fn downcast_ref_from(boxed: &BlockMetaInfoPtr) -> Option<&Self>;
-}
-
-impl<T: BlockMetaInfo> BlockMetaInfoDowncast for T {
     fn downcast_from(boxed: BlockMetaInfoPtr) -> Option<Self> {
         let boxed: Box<dyn Any> = boxed;
         boxed.downcast().ok().map(|x| *x)
@@ -113,6 +111,8 @@ impl<T: BlockMetaInfo> BlockMetaInfoDowncast for T {
         boxed.downcast_ref()
     }
 }
+
+impl<T: BlockMetaInfo> BlockMetaInfoDowncast for T {}
 
 impl DataBlock {
     #[inline]

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -83,9 +83,17 @@ impl BlockEntry {
 #[typetag::serde(tag = "type")]
 pub trait BlockMetaInfo: Debug + Send + Sync + Any + 'static {
     #[allow(clippy::borrowed_box)]
-    fn equals(&self, info: &Box<dyn BlockMetaInfo>) -> bool;
+    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
+        panic!(
+            "The reason for not implementing equals is usually because the higher-level logic doesn't allow/need the meta to be compared."
+        )
+    }
 
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo>;
+    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
+        panic!(
+            "The reason for not implementing clone_self is usually because the higher-level logic doesn't allow/need the associated block to be cloned."
+        )
+    }
 }
 
 pub trait BlockMetaInfoDowncast: Sized {
@@ -101,7 +109,7 @@ impl<T: BlockMetaInfo> BlockMetaInfoDowncast for T {
     }
 
     fn downcast_ref_from(boxed: &BlockMetaInfoPtr) -> Option<&Self> {
-        let boxed: &dyn Any = boxed.as_ref();
+        let boxed = boxed.as_ref() as &dyn Any;
         boxed.downcast_ref()
     }
 }
@@ -633,8 +641,8 @@ impl Eq for Box<dyn BlockMetaInfo> {}
 
 impl PartialEq for Box<dyn BlockMetaInfo> {
     fn eq(&self, other: &Self) -> bool {
-        let this_any: &dyn Any = self.as_ref();
-        let other_any: &dyn Any = other.as_ref();
+        let this_any = self.as_ref() as &dyn Any;
+        let other_any = other.as_ref() as &dyn Any;
 
         match this_any.type_id() == other_any.type_id() {
             true => self.equals(other),
@@ -667,4 +675,29 @@ fn check_type(data_type: &DataType, value: &Value<AnyType>) {
         Value::Scalar(s) => assert_eq!(s.as_ref().infer_data_type(), data_type.remove_nullable()),
         Value::Column(c) => assert_eq!(&c.data_type(), data_type),
     }
+}
+
+#[macro_export]
+macro_rules! local_block_meta_serde {
+    ($T:ty) => {
+        impl serde::Serialize for $T {
+            fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
+            where S: serde::Serializer {
+                unreachable!(
+                    "{} must not be exchanged between multiple nodes.",
+                    stringify!($T)
+                )
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $T {
+            fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
+            where D: serde::Deserializer<'de> {
+                unreachable!(
+                    "{} must not be exchanged between multiple nodes.",
+                    stringify!($T)
+                )
+            }
+        }
+    };
 }

--- a/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
@@ -18,13 +18,12 @@ use std::sync::Barrier;
 use databend_common_base::runtime::Thread;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline_core::processors::connect;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
-use serde::Deserializer;
-use serde::Serializer;
 
 #[derive(Clone, Debug)]
 struct TestDataMeta {
@@ -43,26 +42,10 @@ impl TestDataMeta {
     }
 }
 
-impl serde::Serialize for TestDataMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: Serializer {
-        unimplemented!("Serialize is unimplemented for TestDataMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for TestDataMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: Deserializer<'de> {
-        unimplemented!("Deserialize is unimplemented for TestDataMeta")
-    }
-}
+local_block_meta_serde!(TestDataMeta);
 
 #[typetag::serde(name = "test_data_meta")]
 impl BlockMetaInfo for TestDataMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("equals is unimplemented for TestDataMeta")
-    }
-
     fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
         Box::new(self.clone())
     }

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfo;
-use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
@@ -237,12 +236,6 @@ pub struct SortTaskMeta {
     pub id: usize,
     pub total: usize,
     pub input: usize,
-}
-
-impl SortTaskMeta {
-    pub fn as_meta(self) -> BlockMetaInfoPtr {
-        Box::new(self)
-    }
 }
 
 #[typetag::serde(name = "sort_task")]

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfo;
-use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
@@ -247,12 +246,4 @@ impl SortTaskMeta {
 }
 
 #[typetag::serde(name = "sort_task")]
-impl BlockMetaInfo for SortTaskMeta {
-    fn equals(&self, info: &Box<dyn BlockMetaInfo>) -> bool {
-        SortTaskMeta::downcast_ref_from(info).map_or(false, |info| self == info)
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        Box::new(*self)
-    }
-}
+impl BlockMetaInfo for SortTaskMeta {}

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/spill.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/spill.rs
@@ -12,36 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 
 use super::super::SortSpillParams;
 
 /// Mark a partially sorted [`DataBlock`] as a block needs to be spilled.
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Debug)]
 pub struct SortSpillMetaWithParams(pub SortSpillParams);
 
-#[typetag::serde(name = "sort_spill")]
-impl BlockMetaInfo for SortSpillMetaWithParams {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals SortSpillMetaWithParams")
-    }
+local_block_meta_serde!(SortSpillMetaWithParams);
 
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone SortSpillMetaWithParams")
-    }
-}
+#[typetag::serde(name = "sort_spill")]
+impl BlockMetaInfo for SortSpillMetaWithParams {}
 
 /// Mark a partially sorted [`DataBlock`] as a block needs to be spilled.
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Debug)]
 pub struct SortSpillMeta {}
 
-#[typetag::serde(name = "sort_spill")]
-impl BlockMetaInfo for SortSpillMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals SortSpillMeta")
-    }
+local_block_meta_serde!(SortSpillMeta);
 
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone SortSpillMeta")
-    }
-}
+#[typetag::serde(name = "sort_spill")]
+impl BlockMetaInfo for SortSpillMeta {}

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_block.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_block.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 
@@ -42,30 +43,10 @@ impl Debug for BlockCompactMeta {
     }
 }
 
-impl serde::Serialize for BlockCompactMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize BlockCompactMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for BlockCompactMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize BlockCompactMeta")
-    }
-}
+local_block_meta_serde!(BlockCompactMeta);
 
 #[typetag::serde(name = "block_compact")]
-impl BlockMetaInfo for BlockCompactMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals BlockCompactMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone BlockCompactMeta")
-    }
-}
+impl BlockMetaInfo for BlockCompactMeta {}
 
 #[derive(Default)]
 pub struct TransformCompactBlock {

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_k_way_merge_sort.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_k_way_merge_sort.rs
@@ -532,7 +532,7 @@ where A: SortAlgorithm + 'static
                 total: task.total,
                 input: 0,
             }
-            .as_meta();
+            .boxed();
             self.output_data.push_back(block.add_meta(Some(meta))?);
         }
         debug_assert_eq!(rows, task.total);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -246,12 +246,4 @@ impl<Method: HashMethodBounds, V: Send + Sync + 'static> BlockMetaInfo
     fn typetag_name(&self) -> &'static str {
         unimplemented!("AggregateMeta does not support exchanging between multiple nodes")
     }
-
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals for AggregateMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone for AggregateMeta")
-    }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_group_by_serializer.rs
@@ -26,6 +26,7 @@ use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::arrow::serialize_column;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::types::ArgType;
 use databend_common_expression::types::ArrayType;
 use databend_common_expression::types::Int64Type;
@@ -140,30 +141,10 @@ impl Debug for FlightSerializedMeta {
     }
 }
 
-impl serde::Serialize for FlightSerializedMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize FlightSerializedMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for FlightSerializedMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize FlightSerializedMeta")
-    }
-}
+local_block_meta_serde!(FlightSerializedMeta);
 
 #[typetag::serde(name = "exchange_shuffle")]
-impl BlockMetaInfo for FlightSerializedMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals FlightSerializedMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone FlightSerializedMeta")
-    }
-}
+impl BlockMetaInfo for FlightSerializedMeta {}
 
 impl<Method: HashMethodBounds> BlockMetaTransform<ExchangeShuffleMeta>
     for TransformExchangeGroupBySerializer<Method>

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_meta.rs
@@ -15,6 +15,7 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
@@ -30,19 +31,7 @@ impl WindowPartitionMeta {
     }
 }
 
-impl serde::Serialize for WindowPartitionMeta {
-    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unreachable!("WindowPartitionMeta does not support exchanging between multiple nodes")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for WindowPartitionMeta {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unreachable!("WindowPartitionMeta does not support exchanging between multiple nodes")
-    }
-}
+local_block_meta_serde!(WindowPartitionMeta);
 
 impl Debug for WindowPartitionMeta {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -50,20 +39,5 @@ impl Debug for WindowPartitionMeta {
     }
 }
 
-impl BlockMetaInfo for WindowPartitionMeta {
-    fn typetag_deserialize(&self) {
-        unimplemented!("WindowPartitionMeta does not support exchanging between multiple nodes")
-    }
-
-    fn typetag_name(&self) -> &'static str {
-        unimplemented!("WindowPartitionMeta does not support exchanging between multiple nodes")
-    }
-
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals for WindowPartitionMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone for WindowPartitionMeta")
-    }
-}
+#[typetag::serde(name = "window_partition")]
+impl BlockMetaInfo for WindowPartitionMeta {}

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_transform_shuffle.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_transform_shuffle.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::BlockMetaInfoPtr;
@@ -58,30 +59,10 @@ impl Debug for ExchangeShuffleMeta {
     }
 }
 
-impl serde::Serialize for ExchangeShuffleMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize ExchangeShuffleMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ExchangeShuffleMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize ExchangeShuffleMeta")
-    }
-}
+local_block_meta_serde!(ExchangeShuffleMeta);
 
 #[typetag::serde(name = "exchange_shuffle")]
-impl BlockMetaInfo for ExchangeShuffleMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals ExchangeShuffleMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone ExchangeShuffleMeta")
-    }
-}
+impl BlockMetaInfo for ExchangeShuffleMeta {}
 
 struct OutputsBuffer {
     inner: Vec<VecDeque<DataBlock>>,

--- a/src/query/service/src/servers/flight/v1/exchange/serde/exchange_deserializer.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/serde/exchange_deserializer.rs
@@ -23,6 +23,7 @@ use arrow_ipc::root_as_message;
 use arrow_schema::Schema as ArrowSchema;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
@@ -36,8 +37,6 @@ use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_pipeline_transforms::processors::BlockMetaTransform;
 use databend_common_pipeline_transforms::processors::BlockMetaTransformer;
 use databend_common_pipeline_transforms::processors::UnknownMode;
-use serde::Deserializer;
-use serde::Serializer;
 
 use crate::servers::flight::v1::packets::DataPacket;
 use crate::servers::flight::v1::packets::FragmentData;
@@ -150,27 +149,7 @@ impl Debug for ExchangeDeserializeMeta {
     }
 }
 
-impl serde::Serialize for ExchangeDeserializeMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: Serializer {
-        unimplemented!("Unimplemented serialize ExchangeSourceMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ExchangeDeserializeMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize ExchangeSourceMeta")
-    }
-}
+local_block_meta_serde!(ExchangeDeserializeMeta);
 
 #[typetag::serde(name = "exchange_source")]
-impl BlockMetaInfo for ExchangeDeserializeMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals ExchangeSourceMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone ExchangeSourceMeta")
-    }
-}
+impl BlockMetaInfo for ExchangeDeserializeMeta {}

--- a/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
@@ -31,6 +31,7 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
@@ -45,8 +46,6 @@ use databend_common_pipeline_transforms::processors::Transform;
 use databend_common_pipeline_transforms::processors::Transformer;
 use databend_common_pipeline_transforms::processors::UnknownMode;
 use databend_common_settings::FlightCompression;
-use serde::Deserializer;
-use serde::Serializer;
 
 use crate::servers::flight::v1::exchange::ExchangeShuffleMeta;
 use crate::servers::flight::v1::exchange::MergeExchangeParams;
@@ -74,30 +73,10 @@ impl Debug for ExchangeSerializeMeta {
     }
 }
 
-impl serde::Serialize for ExchangeSerializeMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: Serializer {
-        unimplemented!("Unimplemented serialize ExchangeSerializeMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ExchangeSerializeMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize ExchangeSerializeMeta")
-    }
-}
+local_block_meta_serde!(ExchangeSerializeMeta);
 
 #[typetag::serde(name = "exchange_serialize")]
-impl BlockMetaInfo for ExchangeSerializeMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals ExchangeSerializeMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone ExchangeSerializeMeta")
-    }
-}
+impl BlockMetaInfo for ExchangeSerializeMeta {}
 
 pub struct TransformExchangeSerializer {
     options: IpcWriteOptions,

--- a/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_storages_common_table_meta::meta::BlockMeta;
@@ -69,33 +70,13 @@ pub enum CompactSourceMeta {
     Extras(CompactExtraInfo),
 }
 
-#[typetag::serde(name = "compact_data_source")]
-impl BlockMetaInfo for CompactSourceMeta {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals CompactSourceMeta")
-    }
+local_block_meta_serde!(CompactSourceMeta);
 
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone CompactSourceMeta")
-    }
-}
+#[typetag::serde(name = "compact_data_source")]
+impl BlockMetaInfo for CompactSourceMeta {}
 
 impl std::fmt::Debug for CompactSourceMeta {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("CompactSourceMeta").finish()
-    }
-}
-
-impl serde::Serialize for CompactSourceMeta {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize DataSourceMeta")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for CompactSourceMeta {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize DataSourceMeta")
     }
 }

--- a/src/query/storages/fuse/src/operations/read/native_data_source.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_source.rs
@@ -23,12 +23,4 @@ pub enum NativeDataSource {
 }
 
 #[typetag::serde(name = "fuse_data_source")]
-impl BlockMetaInfo for DataSourceWithMeta<NativeDataSource> {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals DataSourceMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone DataSourceMeta")
-    }
-}
+impl BlockMetaInfo for DataSourceWithMeta<NativeDataSource> {}

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source.rs
@@ -25,12 +25,4 @@ pub enum ParquetDataSource {
 }
 
 #[typetag::serde(name = "fuse_data_source")]
-impl BlockMetaInfo for DataSourceWithMeta<ParquetDataSource> {
-    fn equals(&self, _: &Box<dyn BlockMetaInfo>) -> bool {
-        unimplemented!("Unimplemented equals DataSourceMeta")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unimplemented!("Unimplemented clone DataSourceMeta")
-    }
-}
+impl BlockMetaInfo for DataSourceWithMeta<ParquetDataSource> {}

--- a/src/query/storages/orc/Cargo.toml
+++ b/src/query/storages/orc/Cargo.toml
@@ -6,6 +6,9 @@ license = { workspace = true }
 publish = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.cargo-machete]
+ignored = ["serde"]
+
 [lib]
 doctest = false
 test = true

--- a/src/query/storages/orc/src/strip.rs
+++ b/src/query/storages/orc/src/strip.rs
@@ -14,6 +14,7 @@
 
 use std::fmt::Debug;
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use orc_rust::stripe::Stripe;
 
@@ -26,27 +27,7 @@ pub struct StripeInMemory {
     pub schema: Option<HashableSchema>,
 }
 
-impl serde::Serialize for StripeInMemory {
-    fn serialize<S>(&self, _: S) -> std::result::Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unimplemented!("Unimplemented serialize StripeInMemory")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for StripeInMemory {
-    fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unimplemented!("Unimplemented deserialize StripeInMemory")
-    }
-}
+local_block_meta_serde!(StripeInMemory);
 
 #[typetag::serde(name = "orc_stripe")]
-impl BlockMetaInfo for StripeInMemory {
-    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
-        unreachable!("StripeInMemory as BlockMetaInfo is not expected to be compared.")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unreachable!("StripeInMemory as BlockMetaInfo is not expected to be cloned.")
-    }
-}
+impl BlockMetaInfo for StripeInMemory {}

--- a/src/query/storages/stage/src/append/parquet_file/block_batch.rs
+++ b/src/query/storages/stage/src/append/parquet_file/block_batch.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 
@@ -32,27 +33,7 @@ impl Clone for BlockBatch {
     }
 }
 
-impl serde::Serialize for BlockBatch {
-    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unreachable!("Buffers should not be serialized")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for BlockBatch {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unreachable!("Buffers should not be deserialized")
-    }
-}
+local_block_meta_serde!(BlockBatch);
 
 #[typetag::serde(name = "unload_block_batch")]
-impl BlockMetaInfo for BlockBatch {
-    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
-        unreachable!("Buffers should not be compared")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unreachable!("Buffers should not be cloned")
-    }
-}
+impl BlockMetaInfo for BlockBatch {}

--- a/src/query/storages/stage/src/append/row_based_file/buffers.rs
+++ b/src/query/storages/stage/src/append/row_based_file/buffers.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 
@@ -44,27 +45,7 @@ impl Clone for FileOutputBuffers {
     }
 }
 
-impl serde::Serialize for FileOutputBuffers {
-    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        unreachable!("FileOutputBuffers should not be serialized")
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for FileOutputBuffers {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
-        unreachable!("FileOutputBuffers should not be deserialized")
-    }
-}
+local_block_meta_serde!(FileOutputBuffers);
 
 #[typetag::serde(name = "unload_buffers")]
-impl BlockMetaInfo for FileOutputBuffers {
-    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
-        unreachable!("FileOutputBuffers should not be compared")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unreachable!("FileOutputBuffers should not be cloned")
-    }
-}
+impl BlockMetaInfo for FileOutputBuffers {}

--- a/src/query/storages/stage/src/read/row_based/batch.rs
+++ b/src/query/storages/stage/src/read/row_based/batch.rs
@@ -65,15 +65,7 @@ impl BytesBatch {
 }
 
 #[typetag::serde(name = "raw_batch")]
-impl BlockMetaInfo for BytesBatch {
-    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
-        unreachable!("RawBatch as BlockMetaInfo is not expected to be compared.")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unreachable!("RawBatch as BlockMetaInfo is not expected to be cloned.")
-    }
-}
+impl BlockMetaInfo for BytesBatch {}
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct RowBatchWithPosition {
@@ -210,12 +202,4 @@ impl CSVRowBatch {
 }
 
 #[typetag::serde(name = "row_batch")]
-impl BlockMetaInfo for RowBatchWithPosition {
-    fn equals(&self, _info: &Box<dyn BlockMetaInfo>) -> bool {
-        unreachable!("RowBatch as BlockMetaInfo is not expected to be compared.")
-    }
-
-    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
-        unreachable!("RowBatch as BlockMetaInfo is not expected to be cloned.")
-    }
-}
+impl BlockMetaInfo for RowBatchWithPosition {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The node local BlockMetaInfo definition has too much repetitive code, and the lack of explanatory information can be misleading.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16716)
<!-- Reviewable:end -->
