### PR TITLE
fix: date_add/sub need respect timezone

### DIFF
--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -356,7 +356,8 @@ macro_rules! impl_interval_year_month {
                 let ts = us.to_timestamp(tz.tz);
                 let new_ts = $op(ts.year(), ts.month(), ts.day(), delta.as_())?;
                 let mut ts = NaiveDateTime::new(new_ts, ts.time())
-                    .and_utc()
+                    .and_local_timezone(tz.tz)
+                    .unwrap()
                     .timestamp_micros();
                 clamp_timestamp(&mut ts);
                 Ok(ts)

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -305,9 +305,9 @@ statement ok
 set timezone = 'Asia/Shanghai'
 
 query T
-select add_months(to_timestamp(1619822911999000), 1)
+select add_months(to_timestamp(1619822911999000), 1), to_timestamp(1619822911999000)
 ----
-2021-06-01 14:48:31.999000
+2021-06-01 06:48:31.999000 2021-05-01 06:48:31.999000
 
 query T
 select to_timestamp(1583013600000000)
@@ -315,9 +315,9 @@ select to_timestamp(1583013600000000)
 2020-03-01 06:00:00.000000
 
 query T
-select add_years(to_timestamp(1583013600000000), 1)
+select add_years(to_timestamp(1583013600000000), 1), to_timestamp(1583013600000000)
 ----
-2021-03-01 14:00:00.000000
+2021-03-01 06:00:00.000000 2020-03-01 06:00:00.000000
 
 statement ok
 set timezone= 'UTC';
@@ -679,6 +679,46 @@ statement ok
 set enable_dst_hour_fix=1;
 
 query T
+SELECT DATE_ADD(month, 1, '1941-03-15 00:00:00'::timestamp);
+----
+1941-04-15 01:00:00.000000
+
+query T
+SELECT DATE_ADD(year, 1, '1941-03-15 00:00:00'::timestamp);
+----
+1942-03-15 01:00:00.000000
+
+# format: -10-29 11:46:11.267412
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 5)=substr(now()::String, 5);
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 1, 4)=substr(now()::String, 1, 4)+1;
+----
+1
+
+# format: -29 11:47:46.704107
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 8)=substr(now()::String, 8);
+----
+1
+
+# format: 11
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 6,2)=substr(now()::String, 6, 2)+1;
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 1,4)=substr(now()::String, 1,4);
+----
+1
+
+query T
 select to_monday(to_date('1919-04-13','%Y-%m-%d'));
 ----
 1919-04-07
@@ -689,7 +729,43 @@ select to_year(to_date('1919-04-13','%Y-%m-%d'));
 1919
 
 statement ok
-unset timezone;
+unset enable_dst_hour_fix;
+
+statement error 1006
+SELECT DATE_ADD(month, 1, '1941-03-15 00:00:00'::timestamp);
+
+statement error 1006
+SELECT DATE_ADD(year, 1, '1941-03-15 00:00:00'::timestamp);
 
 statement ok
-unset enable_dst_hour_fix;
+unset timezone;
+
+# format: -10-29 11:46:11.267412
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 5)=substr(now()::String, 5);
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 1, 4)=substr(now()::String, 1, 4)+1;
+----
+1
+
+# format: -29 11:47:46.704107
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 8)=substr(now()::String, 8);
+----
+1
+
+# format: 11
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 6,2)=substr(now()::String, 6, 2)+1;
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 1,4)=substr(now()::String, 1,4);
+----
+1

--- a/tests/sqllogictests/suites/query/functions/02_0075_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0075_function_datetimes_tz.test
@@ -308,9 +308,9 @@ statement ok
 set timezone = 'Asia/Shanghai'
 
 query T
-select add_months(to_timestamp(1619822911999000), 1)
+select add_months(to_timestamp(1619822911999000), 1), to_timestamp(1619822911999000)
 ----
-2021-06-01 14:48:31.999000
+2021-06-01 06:48:31.999000 2021-05-01 06:48:31.999000
 
 query T
 select to_timestamp(1583013600000000)
@@ -318,9 +318,9 @@ select to_timestamp(1583013600000000)
 2020-03-01 06:00:00.000000
 
 query T
-select add_years(to_timestamp(1583013600000000), 1)
+select add_years(to_timestamp(1583013600000000), 1), to_timestamp(1583013600000000)
 ----
-2021-03-01 14:00:00.000000
+2021-03-01 06:00:00.000000 2020-03-01 06:00:00.000000
 
 statement ok
 set timezone= 'UTC';
@@ -720,11 +720,88 @@ select to_year(to_date('1919-04-13','%Y-%m-%d'));
 ----
 1919
 
-statement ok
-unset timezone;
+query T
+SELECT DATE_ADD(month, 1, '1941-03-15 00:00:00'::timestamp);
+----
+1941-04-15 01:00:00.000000
+
+query T
+SELECT DATE_ADD(year, 1, '1941-03-15 00:00:00'::timestamp);
+----
+1942-03-15 01:00:00.000000
+
+# format: -10-29 11:46:11.267412
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 5)=substr(now()::String, 5);
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 1, 4)=substr(now()::String, 1, 4)+1;
+----
+1
+
+# format: -29 11:47:46.704107
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 8)=substr(now()::String, 8);
+----
+1
+
+# format: 11
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 6,2)=substr(now()::String, 6, 2)+1;
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 1,4)=substr(now()::String, 1,4);
+----
+1
 
 statement ok
 unset enable_dst_hour_fix;
+
+statement error 1006
+SELECT DATE_ADD(month, 1, '1941-03-15 00:00:00'::timestamp);
+
+statement error 1006
+SELECT DATE_ADD(year, 1, '1941-03-15 00:00:00'::timestamp);
+
+statement ok
+unset timezone;
+
+# format: -10-29 11:46:11.267412
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 5)=substr(now()::String, 5);
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(year, 1, now())::String, 1, 4)=substr(now()::String, 1, 4)+1;
+----
+1
+
+# format: -29 11:47:46.704107
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 8)=substr(now()::String, 8);
+----
+1
+
+# format: 11
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 6,2)=substr(now()::String, 6, 2)+1;
+----
+1
+
+# format: 2024
+query T
+SELECT substr(DATE_ADD(month, 1, now())::String, 1,4)=substr(now()::String, 1,4);
+----
+1
+
 
 statement ok
 unset enable_strict_datetime_parser;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Before fix:

```sql
:) select version();

SELECT version()

┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                            version()                                           │
│                                             String                                             │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Databend Query v1.2.574-nightly-bd380eeeea(rust-1.81.0-nightly-2024-10-29T08:01:25.246023988Z) │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
1 row read in 0.074 sec. Processed 1 row, 1B (13.45 rows/s, 13B/s)

:) select date_add(month,-1,now()),now(), date_add(month,1,now());

SELECT
    DATE_ADD(MONTH, INTERVAL (- 1), now()),
    now(),
    DATE_ADD(MONTH, INTERVAL 1, now())

┌───────────────────────────────────────────────────────────────────────────────────────┐
│ DATE_ADD(MONTH, - 1, now()) │            now()           │  DATE_ADD(MONTH, 1, now()) │
│          Timestamp          │          Timestamp         │          Timestamp         │
├─────────────────────────────┼────────────────────────────┼────────────────────────────┤
│ 2024-09-30 00:12:04.481309  │ 2024-10-29 16:12:04.481309 │ 2024-11-30 00:12:04.481309 │
└───────────────────────────────────────────────────────────────────────────────────────┘
1 row read in 0.063 sec. Processed 1 row, 1B (15.76 rows/s, 15B/s)

:) select date_sub(month,1,now()),now(),date_sub(month,-1,now());

SELECT
    DATE_SUB(MONTH, INTERVAL 1, now()),
    now(),
    DATE_SUB(MONTH, INTERVAL (- 1), now())

┌───────────────────────────────────────────────────────────────────────────────────────┐
│  DATE_SUB(MONTH, 1, now()) │            now()           │ DATE_SUB(MONTH, - 1, now()) │
│          Timestamp         │          Timestamp         │          Timestamp          │
├────────────────────────────┼────────────────────────────┼─────────────────────────────┤
│ 2024-09-30 00:20:53.894801 │ 2024-10-29 16:20:53.894801 │ 2024-11-30 00:20:53.894801  │
└───────────────────────────────────────────────────────────────────────────────────────┘
1 row read in 0.045 sec. Processed 1 row, 1B (22.38 rows/s, 22B/s)

```

This pr:

```sql
:) select date_add(month,-1,now()),now(), date_add(month,1,now());

SELECT
    DATE_ADD(MONTH, INTERVAL (- 1), now()),
    now(),
    DATE_ADD(MONTH, INTERVAL 1, now())

┌───────────────────────────────────────────────────────────────────────────────────┐
│ DATE_ADD(MONTH, - 1, now()) │          now()          │ DATE_ADD(MONTH, 1, now()) │
│          Timestamp          │        Timestamp        │         Timestamp         │
├─────────────────────────────┼─────────────────────────┼───────────────────────────┤
│ 2024-09-29 16:12:31.977     │ 2024-10-29 16:12:31.977 │ 2024-11-29 16:12:31.977   │
└───────────────────────────────────────────────────────────────────────────────────┘
1 row read in 2.457 sec. Processed 1 row, 1B (0.41 row/s, 0B/s)

:) select date_sub(month,1,now()),now(),date_sub(month,-1,now());

SELECT
    DATE_SUB(MONTH, INTERVAL 1, now()),
    now(),
    DATE_SUB(MONTH, INTERVAL (- 1), now())

┌───────────────────────────────────────────────────────────────────────────────────────┐
│  DATE_SUB(MONTH, 1, now()) │            now()           │ DATE_SUB(MONTH, - 1, now()) │
│          Timestamp         │          Timestamp         │          Timestamp          │
├────────────────────────────┼────────────────────────────┼─────────────────────────────┤
│ 2024-09-29 16:20:31.223259 │ 2024-10-29 16:20:31.223259 │ 2024-11-29 16:20:31.223259  │
└───────────────────────────────────────────────────────────────────────────────────────┘
```


- fixes: https://github.com/databendlabs/databend/issues/16711


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16721)
<!-- Reviewable:end -->
