### PR TITLE
refactor: exclude dropped column  / non support type from snapshot column statistics

### DIFF
--- a/src/query/sql/src/planner/optimizer/aggregate/stats_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/aggregate/stats_aggregate.rs
@@ -16,8 +16,7 @@ use std::sync::Arc;
 
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
-
+use databend_storages_common_table_meta::meta::supported_stat_type;
 use crate::optimizer::SExpr;
 use crate::plans::Aggregate;
 use crate::plans::ConstantExpr;
@@ -88,7 +87,7 @@ impl RuleStatsAggregateOptimizer {
                         if ["min", "max"].contains(&function.func_name.as_str())
                             && function.args.len() == 1
                             && !function.distinct
-                            && Self::supported_stat_type(&function.args[0].data_type()?)
+                            && supported_stat_type(&function.args[0].data_type()?)
                         {
                             if let ScalarExpr::BoundColumnRef(b) = &function.args[0] {
                                 if let Ok(col_id) =
@@ -177,18 +176,5 @@ impl RuleStatsAggregateOptimizer {
             }
         }
         Ok(s_expr.clone())
-    }
-
-    // from RangeIndex::supported_stat_type
-    fn supported_stat_type(data_type: &DataType) -> bool {
-        let inner_type = data_type.remove_nullable();
-        matches!(
-            inner_type,
-            DataType::Number(_)
-                | DataType::Date
-                | DataType::Timestamp
-                | DataType::String
-                | DataType::Decimal(_)
-        )
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use databend_common_base::base::uuid::Uuid;
 use databend_common_expression::ColumnId;
-
+use databend_common_expression::types::DataType;
 use crate::meta::ColumnStatistics;
 
 pub type FormatVersion = u64;
@@ -35,4 +35,17 @@ pub struct BlockSlotDescription {
     // `block_index` mod `num_slots` == `slot_index` indicates that the block should be taken care of by current executor
     // otherwise, the block should be taken care of by other executors
     pub slot: u32,
+}
+
+
+pub fn supported_stat_type(data_type: &DataType) -> bool {
+    let inner_type = data_type.remove_nullable();
+    matches!(
+            inner_type,
+            DataType::Number(_)
+                | DataType::Date
+                | DataType::Timestamp
+                | DataType::String
+                | DataType::Decimal(_)
+        )
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Exclude dropped column non support type from snapshot column statistics.

- while committing new snapshot, filter out column statistics of dropped columns, and columns that of type not supported

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - refactor

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16723)
<!-- Reviewable:end -->
