### PR TITLE
refactor: refine column statistic map serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,6 +5434,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-storage",
  "enum-as-inner 0.5.1",
+ "log",
  "parquet",
  "pot",
  "rmp-serde",

--- a/src/query/storages/common/index/src/index.rs
+++ b/src/query/storages/common/index/src/index.rs
@@ -15,16 +15,5 @@
 use databend_common_expression::types::DataType;
 
 pub trait Index {
-    fn supported_type(data_type: &DataType) -> bool {
-        // we support nullable column but Nulls are not added into the bloom filter.
-        let inner_type = data_type.remove_nullable();
-        matches!(
-            inner_type,
-            DataType::Number(_)
-                | DataType::Date
-                | DataType::Timestamp
-                | DataType::String
-                | DataType::Decimal(_)
-        )
-    }
+    fn supported_type(data_type: &DataType) -> bool;
 }

--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -247,4 +247,8 @@ pub fn statistics_to_domain(mut stats: Vec<&ColumnStatistics>, data_type: &DataT
     }
 }
 
-impl Index for RangeIndex {}
+impl Index for RangeIndex {
+    fn supported_type(data_type: &DataType) -> bool {
+        databend_storages_common_table_meta::meta::supported_stat_type(data_type)
+    }
+}

--- a/src/query/storages/common/table_meta/Cargo.toml
+++ b/src/query/storages/common/table_meta/Cargo.toml
@@ -20,6 +20,7 @@ databend-common-expression = { workspace = true }
 databend-common-io = { workspace = true }
 databend-common-storage = { path = "../../../../common/storage" }
 enum-as-inner = "0.5"
+log = { workspace = true }
 parquet = { workspace = true }
 rmp-serde = "1.1.1"
 serde = { workspace = true }

--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use databend_common_base::base::uuid::Uuid;
+use databend_common_expression::types::DataType;
 use databend_common_expression::ColumnId;
 
 use crate::meta::ColumnStatistics;
@@ -35,4 +36,16 @@ pub struct BlockSlotDescription {
     // `block_index` mod `num_slots` == `slot_index` indicates that the block should be taken care of by current executor
     // otherwise, the block should be taken care of by other executors
     pub slot: u32,
+}
+
+pub fn supported_stat_type(data_type: &DataType) -> bool {
+    let inner_type = data_type.remove_nullable();
+    matches!(
+        inner_type,
+        DataType::Number(_)
+            | DataType::Date
+            | DataType::Timestamp
+            | DataType::String
+            | DataType::Decimal(_)
+    )
 }

--- a/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::hash::Hash;
 use std::marker::PhantomData;
 
 use databend_common_expression::converts::datavalues::from_scalar;
@@ -24,8 +23,10 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
+use log::info;
 use serde::de::Error;
 
+use crate::meta::supported_stat_type;
 use crate::meta::v0;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -367,12 +368,11 @@ pub fn deserialize_col_stats<'de, D>(
 where D: serde::Deserializer<'de> {
     deserializer.deserialize_map(ColStatsVisitor::new())
 }
-
-struct ColStatsVisitor<K, V> {
-    marker: PhantomData<fn() -> HashMap<K, V>>,
+struct ColStatsVisitor {
+    marker: PhantomData<fn() -> HashMap<ColumnId, ColumnStatistics>>,
 }
 
-impl<K, V> ColStatsVisitor<K, V> {
+impl ColStatsVisitor {
     fn new() -> Self {
         ColStatsVisitor {
             marker: PhantomData,
@@ -380,12 +380,8 @@ impl<K, V> ColStatsVisitor<K, V> {
     }
 }
 
-impl<'de, K, V> serde::de::Visitor<'de> for ColStatsVisitor<K, V>
-where
-    K: serde::Deserialize<'de> + Hash + Eq,
-    V: serde::Deserialize<'de>,
-{
-    type Value = HashMap<K, V>;
+impl<'de> serde::de::Visitor<'de> for ColStatsVisitor {
+    type Value = HashMap<ColumnId, ColumnStatistics>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a map")
@@ -395,9 +391,17 @@ where
     where M: serde::de::MapAccess<'de> {
         let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
 
-        while let Some(key) = access.next_key()? {
-            if let Ok(value) = access.next_value() {
-                map.insert(key, value);
+        while let Some(key) = access.next_key::<ColumnId>()? {
+            if let Ok(value) = access.next_value::<ColumnStatistics>() {
+                let data_type = value.max.as_ref().infer_data_type();
+                if supported_stat_type(&data_type) {
+                    map.insert(key, value);
+                } else {
+                    info!(
+                        "column of id {} is excluded from column statistics, unsupported data type {}",
+                        key, data_type
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR modifies the serialization process for the ColumnStatistics map to exclude columns of unsupported types.

When merging snapshots or block metadata, column statistics may include legacy types that are no longer supported. If these columns are not excluded, serialization will fail.

The changes introduced in [#16719](https://github.com/databendlabs/databend/pull/16719) allow legacy type scalars to be de-serialized. If these legacy columns are present in the column statistics during serialization, they will be excluded to prevent runtime errors.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - refactor

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16728)
<!-- Reviewable:end -->
