### PR TITLE
refactor: MetaGrpcClient needs to specify timeout to auto-reconnect to restarted server

### DIFF
--- a/src/meta/service/src/api/grpc_server.rs
+++ b/src/meta/service/src/api/grpc_server.rs
@@ -100,13 +100,19 @@ impl GrpcServer {
                     .add_service(grpc_srv)
                     .serve_with_shutdown(addr, async move {
                         let _ = started_tx.send(());
-                        info!("metasrv starts to wait for stop signal: {}", addr);
+                        info!(
+                            "meta-service gRPC(on {}) starts to wait for stop signal",
+                            addr
+                        );
                         let _ = stop_rx.await;
-                        info!("metasrv receives stop signal: {}", addr);
+                        info!("meta-service gRPC(on {}) receives stop signal", addr);
                     })
                     .await;
 
-                info!("grpc task returned res: {:?}", res);
+                info!(
+                    "meta-service gRPC(on {}) task returned res: {:?}",
+                    addr, res
+                );
             }
             .in_span(Span::enter_with_local_parent("spawn-grpc")),
         );

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -287,7 +287,7 @@ impl MetaNode {
             srv.serve_with_shutdown(socket_addr, async move {
                 let _ = running_rx.changed().await;
                 info!(
-                    "signal received, shutting down: id={} {} ",
+                    "running_rx for Raft server received, shutting down: id={} {} ",
                     node_id, ip_port
                 );
             })
@@ -422,7 +422,10 @@ impl MetaNode {
 
                 if let Err(changed_err) = changed {
                     // Shutting down.
-                    error!("{} when watching metrics_rx", changed_err);
+                    info!(
+                        "{}; when:(watching metrics_rx); quit subscribe_metrics() loop",
+                        changed_err
+                    );
                     break;
                 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: MetaGrpcClient needs to specify timeout to auto-reconnect to restarted server

Before c44ea20bd9a224310ceda536710525a7de086d49, MetaGrpcClient just
auto reconnect if the target meta-service server is restarted.

After c44ea20bd9a224310ceda536710525a7de086d49, the client behavior
changed, if no timeout is set, the client reconnect to the restarted
server but it hangs forever.

In this commit, in the test: test_kv_api_restart_cluster_token_expired,
give the client a fixed timeout to survive a server restart.

- Fix: https://github.com/databendlabs/databend/pull/16704#issuecomment-2443463631

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16733)
<!-- Reviewable:end -->
