### PR TITLE
chore: refine vacuum

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
@@ -139,28 +139,16 @@ pub async fn get_snapshot_referenced_files(
 #[async_backtrace::framed]
 async fn get_orphan_files_to_be_purged(
     fuse_table: &FuseTable,
+    prefix: &str,
     referenced_files: HashSet<String>,
     retention_time: DateTime<Utc>,
 ) -> Result<Vec<String>> {
-    let files_to_be_purged = match referenced_files.iter().next().cloned() {
-        Some(location) => {
-            let prefix = SnapshotsIO::get_s3_prefix_from_file(&location);
-            if let Some(prefix) = prefix {
-                fuse_table
-                    .list_files(prefix, |location, modified| {
-                        modified <= retention_time && !referenced_files.contains(&location)
-                    })
-                    .await?
-            } else {
-                vec![]
-            }
-        }
-        None => {
-            vec![]
-        }
-    };
-
-    Ok(files_to_be_purged)
+    let prefix = prefix.to_string();
+    fuse_table
+        .list_files(prefix, |location, modified| {
+            modified <= retention_time && !referenced_files.contains(&location)
+        })
+        .await
 }
 
 #[async_backtrace::framed]
@@ -186,9 +174,14 @@ pub async fn do_gc_orphan_files(
 
     // 2. Purge orphan segment files.
     // 2.1 Get orphan segment files to be purged
-    let segment_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
-            .await?;
+    let location_gen = fuse_table.meta_location_generator();
+    let segment_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.segment_info_prefix(),
+        referenced_files.segments,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read segment_locations_to_be_purged:{}, cost:{:?}, retention_time: {}",
         segment_locations_to_be_purged.len(),
@@ -215,8 +208,13 @@ pub async fn do_gc_orphan_files(
 
     // 3. Purge orphan block files.
     // 3.1 Get orphan block files to be purged
-    let block_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
+    let block_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_location_prefix(),
+        referenced_files.blocks,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
@@ -241,9 +239,13 @@ pub async fn do_gc_orphan_files(
 
     // 4. Purge orphan block index files.
     // 4.1 Get orphan block index files to be purged
-    let index_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
-            .await?;
+    let index_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_bloom_index_prefix(),
+        referenced_files.blocks_index,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),
@@ -292,10 +294,15 @@ pub async fn do_dry_run_orphan_files(
     );
     ctx.set_status_info(&status);
 
+    let location_gen = fuse_table.meta_location_generator();
     // 2. Get purge orphan segment files.
-    let segment_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
-            .await?;
+    let segment_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.segment_info_prefix(),
+        referenced_files.segments,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read segment_locations_to_be_purged:{}, cost:{:?}",
         segment_locations_to_be_purged.len(),
@@ -309,8 +316,13 @@ pub async fn do_dry_run_orphan_files(
     }
 
     // 3. Get purge orphan block files.
-    let block_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
+    let block_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_location_prefix(),
+        referenced_files.blocks,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
@@ -323,9 +335,13 @@ pub async fn do_dry_run_orphan_files(
     }
 
     // 4. Get purge orphan block index files.
-    let index_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
-            .await?;
+    let index_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_bloom_index_prefix(),
+        referenced_files.blocks_index,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),

--- a/src/query/storages/fuse/src/io/locations.rs
+++ b/src/query/storages/fuse/src/io/locations.rs
@@ -54,7 +54,13 @@ static SNAPSHOT_STATISTICS_V3: TableSnapshotStatisticsVersion =
 #[derive(Clone)]
 pub struct TableMetaLocationGenerator {
     prefix: String,
+
+    // TODO @dantengsky remove this? seems no longer supported https://docs.databend.com/sql/sql-commands/ddl/table/ddl-create-table-external-location
     part_prefix: String,
+
+    block_location_prefix: String,
+    segment_info_location_prefix: String,
+    bloom_index_location_prefix: String,
 }
 
 impl TableMetaLocationGenerator {
@@ -62,11 +68,30 @@ impl TableMetaLocationGenerator {
         Self {
             prefix,
             part_prefix: "".to_string(),
+            block_location_prefix: "".to_string(),
+            segment_info_location_prefix: "".to_string(),
+            bloom_index_location_prefix: "".to_string(),
         }
+        .gen_prefixes()
     }
 
     pub fn with_part_prefix(mut self, part_prefix: String) -> Self {
         self.part_prefix = part_prefix;
+        self.gen_prefixes()
+    }
+
+    fn gen_prefixes(mut self) -> Self {
+        let block_location_prefix = format!(
+            "{}/{}/{}",
+            &self.prefix, FUSE_TBL_BLOCK_PREFIX, &self.part_prefix,
+        );
+        let bloom_index_location_prefix =
+            format!("{}/{}/", &self.prefix, FUSE_TBL_XOR_BLOOM_INDEX_PREFIX);
+        let segment_info_location_prefix = format!("{}/{}/", &self.prefix, FUSE_TBL_SEGMENT_PREFIX);
+
+        self.block_location_prefix = block_location_prefix;
+        self.bloom_index_location_prefix = bloom_index_location_prefix;
+        self.segment_info_location_prefix = segment_info_location_prefix;
         self
     }
 
@@ -81,10 +106,8 @@ impl TableMetaLocationGenerator {
     pub fn gen_block_location(&self) -> (Location, Uuid) {
         let part_uuid = Uuid::new_v4();
         let location_path = format!(
-            "{}/{}/{}{}_v{}.parquet",
-            &self.prefix,
-            FUSE_TBL_BLOCK_PREFIX,
-            &self.part_prefix,
+            "{}{}_v{}.parquet",
+            self.block_location_prefix(),
             part_uuid.as_simple(),
             DataBlock::VERSION,
         );
@@ -92,12 +115,15 @@ impl TableMetaLocationGenerator {
         ((location_path, DataBlock::VERSION), part_uuid)
     }
 
+    pub fn block_location_prefix(&self) -> &str {
+        &self.block_location_prefix
+    }
+
     pub fn block_bloom_index_location(&self, block_id: &Uuid) -> Location {
         (
             format!(
-                "{}/{}/{}_v{}.parquet",
-                &self.prefix,
-                FUSE_TBL_XOR_BLOOM_INDEX_PREFIX,
+                "{}{}_v{}.parquet",
+                self.block_bloom_index_prefix(),
                 block_id.as_simple(),
                 BlockFilter::VERSION,
             ),
@@ -105,15 +131,22 @@ impl TableMetaLocationGenerator {
         )
     }
 
+    pub fn block_bloom_index_prefix(&self) -> &str {
+        &self.bloom_index_location_prefix
+    }
+
     pub fn gen_segment_info_location(&self) -> String {
         let segment_uuid = Uuid::new_v4().simple().to_string();
         format!(
-            "{}/{}/{}_v{}.mpk",
-            &self.prefix,
-            FUSE_TBL_SEGMENT_PREFIX,
+            "{}{}_v{}.mpk",
+            self.segment_info_prefix(),
             segment_uuid,
             SegmentInfo::VERSION,
         )
+    }
+
+    pub fn segment_info_prefix(&self) -> &str {
+        &self.segment_info_location_prefix
     }
 
     pub fn snapshot_location_from_uuid(&self, id: &Uuid, version: u64) -> Result<String> {

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
@@ -1,0 +1,25 @@
+>>>> create or replace database test_vacuum_table_only_orphans
+>>>> create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'
+>>>> insert into test_vacuum_table_only_orphans.a values (1)
+>>>> insert into test_vacuum_table_only_orphans.a values (2)
+>>>> insert into test_vacuum_table_only_orphans.a values (3)
+before purge
+4
+4
+4
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> set data_retention_time_in_days=0; optimize table test_vacuum_table_only_orphans.a purge
+after purge
+1
+1
+1
+after add pure orphan files
+4
+4
+4
+after vacuum
+1
+1
+1

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+stmt "create or replace database test_vacuum_table_only_orphans"
+
+mkdir -p /tmp/test_vacuum_table_only_orphans/
+
+stmt "create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'"
+
+
+stmt "insert into test_vacuum_table_only_orphans.a values (1)"
+stmt "insert into test_vacuum_table_only_orphans.a values (2)"
+stmt "insert into test_vacuum_table_only_orphans.a values (3)"
+
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_table_only_orphans','a') limit 1" | $BENDSQL_CLIENT_CONNECT)
+PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
+
+echo "before purge"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+stmt "truncate table test_vacuum_table_only_orphans.a"
+stmt "truncate table test_vacuum_table_only_orphans.a"
+stmt "truncate table test_vacuum_table_only_orphans.a"
+
+stmt "set data_retention_time_in_days=0; optimize table test_vacuum_table_only_orphans.a purge"
+
+echo "after purge"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+# simulates orphans
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o3
+
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg3
+
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf3
+
+echo "after add pure orphan files"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+stmt "set data_retention_time_in_days=0; vacuum table test_vacuum_table_only_orphans.a" > /dev/null
+
+echo "after vacuum"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If only orphans left, the vacuum should continue working as expected (purge all the orphans).

Instead of using prefix extracted from the "path" of object belong to the GC root, using block/bloom_filter_index/segment prefix directly.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16743)
<!-- Reviewable:end -->
