### PR TITLE
chore: refine vacuum (backport PR #16743 to release/v1.2.636-rc3)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -47,4 +47,6 @@ ignore = [
     "RUSTSEC-2024-0351",
     # gix-path: improperly resolves configuration path reported by Git
     "RUSTSEC-2024-0371",
+    # Remotely exploitable Denial of Service in Tonic, ignored temporarily 
+    "RUSTSEC-2024-0376",
 ]

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
       - reopened
     branches:
-      - main
+      - 'release/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
@@ -139,28 +139,16 @@ pub async fn get_snapshot_referenced_files(
 #[async_backtrace::framed]
 async fn get_orphan_files_to_be_purged(
     fuse_table: &FuseTable,
+    prefix: &str,
     referenced_files: HashSet<String>,
     retention_time: DateTime<Utc>,
 ) -> Result<Vec<String>> {
-    let files_to_be_purged = match referenced_files.iter().next().cloned() {
-        Some(location) => {
-            let prefix = SnapshotsIO::get_s3_prefix_from_file(&location);
-            if let Some(prefix) = prefix {
-                fuse_table
-                    .list_files(prefix, |location, modified| {
-                        modified <= retention_time && !referenced_files.contains(&location)
-                    })
-                    .await?
-            } else {
-                vec![]
-            }
-        }
-        None => {
-            vec![]
-        }
-    };
-
-    Ok(files_to_be_purged)
+    let prefix = prefix.to_string();
+    fuse_table
+        .list_files(prefix, |location, modified| {
+            modified <= retention_time && !referenced_files.contains(&location)
+        })
+        .await
 }
 
 #[async_backtrace::framed]
@@ -186,9 +174,14 @@ pub async fn do_gc_orphan_files(
 
     // 2. Purge orphan segment files.
     // 2.1 Get orphan segment files to be purged
-    let segment_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
-            .await?;
+    let location_gen = fuse_table.meta_location_generator();
+    let segment_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.segment_info_prefix(),
+        referenced_files.segments,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read segment_locations_to_be_purged:{}, cost:{:?}, retention_time: {}",
         segment_locations_to_be_purged.len(),
@@ -215,8 +208,13 @@ pub async fn do_gc_orphan_files(
 
     // 3. Purge orphan block files.
     // 3.1 Get orphan block files to be purged
-    let block_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
+    let block_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_location_prefix(),
+        referenced_files.blocks,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
@@ -241,9 +239,13 @@ pub async fn do_gc_orphan_files(
 
     // 4. Purge orphan block index files.
     // 4.1 Get orphan block index files to be purged
-    let index_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
-            .await?;
+    let index_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_bloom_index_prefix(),
+        referenced_files.blocks_index,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "gc orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),
@@ -292,10 +294,15 @@ pub async fn do_dry_run_orphan_files(
     );
     ctx.set_status_info(&status);
 
+    let location_gen = fuse_table.meta_location_generator();
     // 2. Get purge orphan segment files.
-    let segment_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.segments, retention_time)
-            .await?;
+    let segment_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.segment_info_prefix(),
+        referenced_files.segments,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read segment_locations_to_be_purged:{}, cost:{:?}",
         segment_locations_to_be_purged.len(),
@@ -309,8 +316,13 @@ pub async fn do_dry_run_orphan_files(
     }
 
     // 3. Get purge orphan block files.
-    let block_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks, retention_time).await?;
+    let block_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_location_prefix(),
+        referenced_files.blocks,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read block_locations_to_be_purged:{}, cost:{:?}",
         block_locations_to_be_purged.len(),
@@ -323,9 +335,13 @@ pub async fn do_dry_run_orphan_files(
     }
 
     // 4. Get purge orphan block index files.
-    let index_locations_to_be_purged =
-        get_orphan_files_to_be_purged(fuse_table, referenced_files.blocks_index, retention_time)
-            .await?;
+    let index_locations_to_be_purged = get_orphan_files_to_be_purged(
+        fuse_table,
+        location_gen.block_bloom_index_prefix(),
+        referenced_files.blocks_index,
+        retention_time,
+    )
+    .await?;
     let status = format!(
         "dry_run orphan: read index_locations_to_be_purged:{}, cost:{:?}",
         index_locations_to_be_purged.len(),

--- a/src/query/ee/tests/it/aggregating_index/index_refresh.rs
+++ b/src/query/ee/tests/it/aggregating_index/index_refresh.rs
@@ -40,6 +40,7 @@ use databend_enterprise_query::test_kits::context::EESetup;
 use databend_query::interpreters::InterpreterFactory;
 use databend_query::sessions::QueryContext;
 use databend_query::test_kits::*;
+use databend_storages_common_table_meta::meta::VACUUM2_OBJECT_KEY_PREFIX;
 use derive_visitor::DriveMut;
 use futures_util::TryStreamExt;
 
@@ -84,7 +85,9 @@ async fn test_refresh_agg_index() -> Result<()> {
 
     blocks.sort();
     indexes.sort();
-    assert_eq!(blocks, indexes);
+
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes);
 
     // Check aggregating index is correct.
     {
@@ -122,7 +125,8 @@ async fn test_refresh_agg_index() -> Result<()> {
 
         blocks.sort();
         indexes.sort();
-        assert_eq!(blocks, indexes);
+        let stripped_block_names = strip_block_names(&blocks);
+        assert_eq!(stripped_block_names, indexes);
 
         let new_block = {
             blocks.retain(|s| s != &pre_block);
@@ -264,7 +268,9 @@ async fn test_sync_agg_index_after_update() -> Result<()> {
 
     blocks.sort();
     indexes_0.sort();
-    assert_eq!(blocks, indexes_0);
+
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes_0);
 
     // Check aggregating index_0 is correct.
     {
@@ -303,7 +309,8 @@ async fn test_sync_agg_index_after_update() -> Result<()> {
 
     blocks.sort();
     indexes_0.sort();
-    assert_eq!(blocks, indexes_0);
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes_0);
 
     // Check aggregating index_0 is correct after update.
     {
@@ -388,7 +395,8 @@ async fn test_sync_agg_index_after_insert() -> Result<()> {
 
     blocks.sort();
     indexes_1.sort();
-    assert_eq!(blocks, indexes_1);
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes_0);
 
     // Check aggregating index_0 is correct.
     {
@@ -446,13 +454,14 @@ async fn test_sync_agg_index_after_insert() -> Result<()> {
 
     blocks.sort();
     indexes_0.sort();
-    assert_eq!(blocks, indexes_0);
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes_0);
 
     // check index1
     let mut indexes_1 = collect_file_names(&agg_index_path_1)?;
 
     indexes_1.sort();
-    assert_eq!(blocks, indexes_1);
+    assert_eq!(stripped_block_names, indexes_1);
 
     Ok(())
 }
@@ -494,7 +503,8 @@ async fn test_sync_agg_index_after_copy_into() -> Result<()> {
 
     blocks.sort();
     indexes_0.sort();
-    assert_eq!(blocks, indexes_0);
+    let stripped_block_names = strip_block_names(&blocks);
+    assert_eq!(stripped_block_names, indexes_0);
 
     // Check aggregating index_0 is correct.
     {
@@ -652,4 +662,22 @@ fn collect_file_names<P: AsRef<Path>>(dir: P) -> Result<Vec<String>> {
     }
 
     Ok(file_names)
+}
+
+fn strip_block_names(blocks: &[String]) -> Vec<String> {
+    // newly created block's "filename" should start with VACUUM2_OBJECT_KEY_PREFIX
+    assert!(
+        blocks
+            .iter()
+            .all(|v| v.starts_with(VACUUM2_OBJECT_KEY_PREFIX))
+    );
+
+    blocks
+        .iter()
+        .map(|v| {
+            v.strip_prefix(VACUUM2_OBJECT_KEY_PREFIX)
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<Vec<_>>()
 }

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
@@ -1,10 +1,10 @@
 -- reset users
 -- prepare user and tables for tests
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
-Error: APIError: ResponseError with 401: {"error":{"code":5100,"message":"wrong password"}}
-Error: APIError: ResponseError with 401: {"error":{"code":5100,"message":"wrong password"}}
+1
+1
+1
+1
+1
 testuser1 password is 123
 testuser2 password not modify
 -- reset users

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.result
@@ -3,8 +3,8 @@
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
 Error: APIError: ResponseError with 1063: Permission denied: privilege [Alter] is required on *.* for user 'testuser1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Database|Table|UDF|Stage.
-Error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":5100,"message":"wrong password"}}
-Error: APIError: RequestError: Start Query failed with status 401 Unauthorized: {"error":{"code":5100,"message":"wrong password"}}
+Error: APIError: ResponseError with 401: {"error":{"code":5100,"message":"wrong password"}}
+Error: APIError: ResponseError with 401: {"error":{"code":5100,"message":"wrong password"}}
 testuser1 password is 123
 testuser2 password not modify
 -- reset users

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
@@ -14,18 +14,18 @@ echo "DROP USER IF EXISTS 'testuser2'" | $BENDSQL_CLIENT_CONNECT
 echo '-- prepare user and tables for tests'
 echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
 echo "CREATE USER 'testuser2' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
-echo "alter user 'testuser2' identified by '123'" | $TEST_USER_CONNECT
-echo "alter user 'testuser1' identified by '123' with default_role='role1'" | $TEST_USER_CONNECT
-echo "alter user 'testuser1' identified by '123' with disabled=true" | $TEST_USER_CONNECT
+echo "alter user 'testuser2' identified by '123'" | $TEST_USER_CONNECT 2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
+echo "alter user 'testuser1' identified by '123' with default_role='role1'" | $TEST_USER_CONNECT  2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
+echo "alter user 'testuser1' identified by '123' with disabled=true" | $TEST_USER_CONNECT  2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
 
 # Note: this query in bendsql will return err, because bendsql will call auth in poll, after password modified, in next poll the auth failed, it will return err.
 # testuser1@localhost:8000/default> alter user 'testuser1' identified by '123';
 # error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}
-echo "alter user 'testuser1' identified by '123'" | $TEST_USER_CONNECT
+echo "alter user 'testuser1' identified by '123'" | $TEST_USER_CONNECT 2>&1 | grep 'wrong password' | wc -l
 
 export TEST_USER_MODIFY_CONNECT="bendsql --user=testuser1 --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 
-echo "select 1" | $TEST_USER_CONNECT
+echo "select 1" | $TEST_USER_CONNECT  2>&1 | grep 'wrong password' | wc -l
 echo "select 'testuser1 password is 123'" | $TEST_USER_MODIFY_CONNECT
 echo "select 'testuser2 password not modify'" | $TEST_USER2_CONNECT
 

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
@@ -1,0 +1,25 @@
+>>>> create or replace database test_vacuum_table_only_orphans
+>>>> create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'
+>>>> insert into test_vacuum_table_only_orphans.a values (1)
+>>>> insert into test_vacuum_table_only_orphans.a values (2)
+>>>> insert into test_vacuum_table_only_orphans.a values (3)
+before purge
+4
+4
+4
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> truncate table test_vacuum_table_only_orphans.a
+>>>> set data_retention_time_in_days=0; optimize table test_vacuum_table_only_orphans.a purge
+after purge
+1
+1
+1
+after add pure orphan files
+4
+4
+4
+after vacuum
+1
+1
+1

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+stmt "create or replace database test_vacuum_table_only_orphans"
+
+mkdir -p /tmp/test_vacuum_table_only_orphans/
+
+stmt "create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'"
+
+
+stmt "insert into test_vacuum_table_only_orphans.a values (1)"
+stmt "insert into test_vacuum_table_only_orphans.a values (2)"
+stmt "insert into test_vacuum_table_only_orphans.a values (3)"
+
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_table_only_orphans','a') limit 1" | $BENDSQL_CLIENT_CONNECT)
+PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
+
+echo "before purge"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+stmt "truncate table test_vacuum_table_only_orphans.a"
+stmt "truncate table test_vacuum_table_only_orphans.a"
+stmt "truncate table test_vacuum_table_only_orphans.a"
+
+stmt "set data_retention_time_in_days=0; optimize table test_vacuum_table_only_orphans.a purge"
+
+echo "after purge"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+# simulates orphans
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/o3
+
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/sg3
+
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf1
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf2
+touch /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/bf3
+
+echo "after add pure orphan files"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+
+stmt "set data_retention_time_in_days=0; vacuum table test_vacuum_table_only_orphans.a" > /dev/null
+
+echo "after vacuum"
+
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_b/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_sg/ | wc -l
+ls -l /tmp/test_vacuum_table_only_orphans/"$PREFIX"/_i_b_v2/ | wc -l
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

backport PR  https://github.com/databendlabs/databend/pull/16743 to release/v1.2.636-rc3.

If only orphans left, the vacuum should continue working as expected (purge all the orphans).

Instead of using prefix extracted from the "path" of object belong to the GC root, using block/bloom_filter_index/segment prefix directly.

Different from PR #16743 (which is being merged into main branch):

1. the block name is (kept as) prefixed with 'g' in this PR, as PR https://github.com/databendlabs/databend/pull/16585 has not been merged into main yet (or will not be).

   https://github.com/databendlabs/databend/pull/16744/files#diff-9d4aa60a0f7398a38f14b3c0ba1009a992cd2cd5b65f1e00642f5f1ba5d430d8R109

  related unit test has been tweaked accordingly.

2. Logic test "tests/suites/0_stateless/18_rbac/18_0011_alter_own_username"  also tweaked to align with the main branch


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16744)
<!-- Reviewable:end -->
