### PR TITLE
fix: HTTP handle lost rows when result set is wide and large.

### DIFF
--- a/src/query/service/src/servers/http/v1/query/page_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/page_manager.rs
@@ -163,6 +163,7 @@ impl PageManager {
                     remain_size -= size;
                     remain_rows -= 1;
                 } else {
+                    self.row_buffer.push_front(row);
                     remain_size = 0;
                 }
             } else {

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -202,7 +202,7 @@ impl TestHttpQueryRequest {
 
 #[derive(Debug, Clone)]
 struct TestHttpQueryFetchReply {
-    resps: Vec<(StatusCode, QueryResponse)>,
+    pub resps: Vec<(StatusCode, QueryResponse)>,
 }
 
 impl TestHttpQueryFetchReply {
@@ -1712,6 +1712,20 @@ async fn test_max_size_per_page() -> Result<()> {
     let target = 10485760; // 10M
     assert!(len < target);
     assert!(len > target - 2000);
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_max_size_per_page_total_rows() -> Result<()> {
+    let _fixture = TestFixture::setup().await?;
+    // bytes_limit / rows_limit = 1024 * 1024 * 10 / 10000 = 1048.567
+    let sql = "select repeat('1', 1050) as a from numbers(20000)";
+    let wait_time_secs = 5;
+    let json = serde_json::json!({"sql": sql.to_string(), "pagination": {"wait_time_secs": wait_time_secs}});
+    let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+    assert!(reply.error().is_none(), "{:?}", reply.error());
+    assert_eq!(reply.resps.len(), 3);
+    assert_eq!(reply.data().len(), 20000, "{:?}", reply.error());
     Ok(())
 }
 


### PR DESCRIPTION



I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

may lost a row starting from the 3rd page, when
1. total size > 20MB.
2. avg row size > 1050B.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16748)
<!-- Reviewable:end -->
