### PR TITLE
fix: (backport to 636-rc3) keep column statistics of all NULL column (#16753)

### DIFF
--- a/src/common/arrow/src/arrow/compute/merge_sort/mod.rs
+++ b/src/common/arrow/src/arrow/compute/merge_sort/mod.rs
@@ -491,7 +491,7 @@ pub fn build_comparator<'a>(
 }
 
 /// returns a comparison function between any two arrays of each pair of arrays, according to `SortOptions`.
-/// Implementing custom `build_compare_fn` for unsupportd data types.
+/// Implementing custom `build_compare_fn` for unsupported data types.
 pub fn build_comparator_impl<'a>(
     pairs: &'a [(&'a [&'a dyn Array], &SortOptions)],
     build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,

--- a/src/common/arrow/src/arrow/compute/sort/lex_sort.rs
+++ b/src/common/arrow/src/arrow/compute/sort/lex_sort.rs
@@ -175,7 +175,7 @@ pub fn lexsort_to_indices<I: Index>(
 
 /// Sorts a list of [`SortColumn`] into a non-nullable [`PrimitiveArray`]
 /// representing the indices that would sort the columns.
-/// Implementing custom `build_compare_fn` for unsupportd data types.
+/// Implementing custom `build_compare_fn` for unsupported data types.
 pub fn lexsort_to_indices_impl<I: Index>(
     columns: &[SortColumn],
     limit: Option<usize>,

--- a/src/common/io/src/cursor_ext/cursor_read_bytes_ext.rs
+++ b/src/common/io/src/cursor_ext/cursor_read_bytes_ext.rs
@@ -112,8 +112,8 @@ where T: AsRef<[u8]>
         if available.is_empty() {
             return 0;
         }
-        for (index, byt) in available.iter().enumerate() {
-            if !f(*byt) {
+        for (index, bytes) in available.iter().enumerate() {
+            if !f(*bytes) {
                 self.consume(index);
                 return index;
             }

--- a/src/query/script/src/ir.rs
+++ b/src/query/script/src/ir.rs
@@ -84,7 +84,7 @@ pub enum ScriptIR {
         condition: VarRef,
         to_label: LabelRef,
     },
-    /// Uncoditionally jumps to a specified label.
+    /// Unconditionally jumps to a specified label.
     Goto { to_label: LabelRef },
     /// Returns from the script.
     Return,

--- a/tests/sqllogictests/suites/no_table_meta_cache/col_stats_of_all_null.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/col_stats_of_all_null.test
@@ -1,0 +1,53 @@
+statement ok
+create or replace database col_stats_all_null;
+
+statement ok
+use col_stats_all_null;
+
+
+statement ok
+create or replace table t(c int) STORAGE_FORMAT=parquet;
+
+statement ok
+insert into t values(NULL);
+
+# segments should be pruned
+query T
+explain select * from t where c > 6;
+----
+Filter
+├── output columns: [t.c (#0)]
+├── filters: [is_true(t.c (#0) > 6)]
+├── estimated rows: 0.00
+└── TableScan
+    ├── table: default.col_stats_all_null.t
+    ├── output columns: [c (#0)]
+    ├── read rows: 0
+    ├── read size: 0
+    ├── partitions total: 1
+    ├── partitions scanned: 0
+    ├── pruning stats: [segments: <range pruning: 1 to 0>]
+    ├── push downs: [filters: [is_true(t.c (#0) > 6)], limit: NONE]
+    └── estimated rows: 1.00
+
+
+statement ok
+create or replace table t(c int) STORAGE_FORMAT=native;
+
+statement ok
+insert into t values(NULL);
+
+# segments should be pruned
+query T
+explain select * from t where c > 6;
+----
+TableScan
+├── table: default.col_stats_all_null.t
+├── output columns: [c (#0)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 1
+├── partitions scanned: 0
+├── pruning stats: [segments: <range pruning: 1 to 0>]
+├── push downs: [filters: [is_true(t.c (#0) > 6)], limit: NONE]
+└── estimated rows: 0.00


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

**backport** https://github.com/databendlabs/databend/pull/16753 to release/v1.2.636-rc3



------------------


### Summary copied from PR #16753 :


In [PR #16728](https://github.com/databendlabs/databend/pull/16728), statistics for columns with unsupported data types are excluded. 

However,  the data type is inferred from the the scalar, instead of the the type of column, thus, an edge case may arise for columns that contain only NULL values:

For such columns, both the min and max scalar values are NULL, causing them to be incorrectly classified as "supported_stat_type" and subsequently excluded. This leads to issues during pruning because `RangePruner` cannot prune these columns without available statistics.

Although the table data is safe, and the correctness of filtering also retained,  the execution of pruning may be inefficient:

#### Example


please disable table meta cache in query config file to reproduce this issue:
~~~
[cache]
...
enable_table_meta_cache = false
~~~


~~~
create or replace database col_stats_all_null;
use col_stats_all_null;
create or replace table t(c int);
insert into t values(NULL);

-- segments should be pruned (BUT NOT)
explain select * from t where c > 6;
Filter
├── output columns: [t.c (#0)]
├── filters: [is_true(t.c (#0) > 6)]
├── estimated rows: 0.00
└── TableScan
    ├── table: default.col_stats_all_null.t
    ├── output columns: [c (#0)]
    ├── read rows: 0
    ├── read size: 0
    ├── partitions total: 1
    ├── partitions scanned: 0
    ├── pruning stats: [segments: <range pruning: 1 to 1>]
    ├── push downs: [filters: [is_true(t.c (#0) > 6)], limit: NONE]
    └── estimated rows: 1.00
~~~

### Changes

In this PR, column statistics with both NULL min and max values are retained. since they will be  stored as `Scalar::Null`, they cloud be  ser/deserialized without issue.

**Note:** 
   - Columns containing at least one non-NULL value will always have non-NULL min/max values.
   - Tweak `databend_storages_common_table_meta::meta::supported_stat_type` may also work, but to minimize the risks (since other components also rely on it), changes are kept in `ColStatsVisitor`

For tables have been processed(compact/insert, etc.) with PR #16728, it is safe to apply the changes of this PR:

- newly created blocks with this PR will keep the correct column statistics
- newly created segment/snapshot with this PR, which may contain columns statistics merged from legacy block/segments will also be safe.





## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): backport

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16756)
<!-- Reviewable:end -->
