### PR TITLE
fix: `Files::remove_file_in_batch` should not swallow errors

### DIFF
--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -28,6 +28,7 @@ use databend_enterprise_query::storages::fuse::operations::vacuum_drop_tables::v
 use databend_enterprise_query::storages::fuse::operations::vacuum_temporary_files::do_vacuum_temporary_files;
 use databend_enterprise_query::storages::fuse::vacuum_drop_tables;
 use databend_query::test_kits::*;
+use databend_storages_common_io::Files;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use opendal::raw::Access;
 use opendal::raw::AccessorInfo;
@@ -173,6 +174,7 @@ mod test_accessor {
     #[derive(Debug)]
     pub(crate) struct AccessorFaultyDeletion {
         hit_delete: AtomicBool,
+        hit_batch: AtomicBool,
         hit_stat: AtomicBool,
         inject_delete_faulty: bool,
         inject_stat_faulty: bool,
@@ -182,6 +184,7 @@ mod test_accessor {
         pub(crate) fn with_delete_fault() -> Self {
             AccessorFaultyDeletion {
                 hit_delete: AtomicBool::new(false),
+                hit_batch: AtomicBool::new(false),
                 hit_stat: AtomicBool::new(false),
                 inject_delete_faulty: true,
                 inject_stat_faulty: false,
@@ -191,6 +194,7 @@ mod test_accessor {
         pub(crate) fn with_stat_fault() -> Self {
             AccessorFaultyDeletion {
                 hit_delete: AtomicBool::new(false),
+                hit_batch: AtomicBool::new(false),
                 hit_stat: AtomicBool::new(false),
                 inject_delete_faulty: false,
                 inject_stat_faulty: true,
@@ -199,6 +203,10 @@ mod test_accessor {
 
         pub(crate) fn hit_delete_operation(&self) -> bool {
             self.hit_delete.load(Ordering::Acquire)
+        }
+
+        pub(crate) fn hit_batch_operation(&self) -> bool {
+            self.hit_batch.load(Ordering::Acquire)
         }
 
         pub(crate) fn hit_stat_operation(&self) -> bool {
@@ -275,6 +283,9 @@ mod test_accessor {
 
         async fn batch(&self, _args: OpBatch) -> opendal::Result<RpBatch> {
             self.hit_delete.store(true, Ordering::Release);
+            self.hit_batch.store(true, Ordering::Release);
+
+            // in our case, there are only batch deletions
             if self.inject_delete_faulty {
                 Err(opendal::Error::new(
                     opendal::ErrorKind::Unexpected,
@@ -452,6 +463,26 @@ async fn test_fuse_do_vacuum_drop_table_external_storage() -> Result<()> {
 
     // verify that accessor.delete() was called
     assert!(!accessor.hit_delete_operation());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remove_files_in_batch_do_not_swallow_errors() -> Result<()> {
+    // errors should not be swallowed in remove_file_in_batch
+    let faulty_accessor = Arc::new(test_accessor::AccessorFaultyDeletion::with_delete_fault());
+    let operator = OperatorBuilder::new(faulty_accessor.clone()).finish();
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let file_util = Files::create(ctx, operator);
+
+    // files to be deleted does not matter, faulty_accessor will always fail to delete
+    let r = file_util.remove_file_in_batch(vec!["1", "2"]).await;
+    assert!(r.is_err());
+
+    // verify that accessor.delete() was called
+    assert!(faulty_accessor.hit_delete_operation());
+    assert!(faulty_accessor.hit_batch_operation());
 
     Ok(())
 }

--- a/src/query/storages/common/io/src/files.rs
+++ b/src/query/storages/common/io/src/files.rs
@@ -74,7 +74,9 @@ impl Files {
                 threads_nums * 2,
                 "batch-remove-files-worker".to_owned(),
             )
-            .await?;
+            .await?
+            .into_iter()
+            .collect::<Result<_>>()?
         }
 
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`Files::remove_file_in_batch` should not swallow errors

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16761)
<!-- Reviewable:end -->
