### PR TITLE
fix(query): interval expr should not print interval keyword

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -705,7 +705,7 @@ impl Display for Expr {
                     write!(f, "}}")?;
                 }
                 Expr::Interval { expr, unit, .. } => {
-                    write!(f, "INTERVAL {expr} {unit}")?;
+                    write!(f, "{expr} {unit}")?;
                 }
                 Expr::DateAdd {
                     unit,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- fixes: #16712


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16767)
<!-- Reviewable:end -->
