### PR TITLE
chore: (backport to 636-rc3) tweak batch deletion concurrency (#16770)

### DIFF
--- a/src/query/storages/common/io/src/files.rs
+++ b/src/query/storages/common/io/src/files.rs
@@ -68,10 +68,15 @@ impl Files {
                     .map(|location| Self::delete_files(self.operator.clone(), location.to_vec()))
             });
 
+            // At most 3 concurrent batch deletions allowed, mitigate rate limit errors
+            let permit = (threads_nums / 2).clamp(1, 3);
+
+            // IO tasks, 2 threads should be enough
+            let pool_thread_number = 2;
             execute_futures_in_parallel(
                 tasks,
-                threads_nums,
-                threads_nums * 2,
+                pool_thread_number,
+                permit,
                 "batch-remove-files-worker".to_owned(),
             )
             .await?


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

backport PR #16770  to `release/v1.2.636-rc3`

* chore: tweak batch deletion concurrency
* chore: tweak remove file in batch thread pool size



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - tweak default settings

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): tweak default settings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16772)
<!-- Reviewable:end -->
