### PR TITLE
chore: using patched opendal based on v0.49.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11077,8 +11077,7 @@ dependencies = [
 [[package]]
 name = "opendal"
 version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d516adf7db912c38af382c3e92c27cd62fbbc240e630920555d784c2ab1494"
+source = "git+https://github.com/datafuse-extras/opendal-for-release-v1.2.636?rev=6c490a0#6c490a00e1a128edbbc15017cef47d010c3a47c0"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,8 @@ color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "57795da" }
 ethnum = { git = "https://github.com/ariesdevil/ethnum-rs", rev = "4cb05f1" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
+# patched opendal which categories the XML dersierialization errors as recoverable
+opendal = { git = "https://github.com/datafuse-extras/opendal-for-release-v1.2.636", rev = "6c490a0" }
 orc-rust = { git = "https://github.com/youngsofun/datafusion-orc", rev = "1745375" }
 recursive = { git = "https://github.com/zhang2014/recursive.git", rev = "6af35a1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

using [patched opendal](https://github.com/datafuse-extras/opendal-for-release-v1.2.636/commit/6c490a00e1a128edbbc15017cef47d010c3a47c0).

which categories the XML dersierialization errors as recoverable and is based on opendal v0.49.0


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Use existing unit tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16784)
<!-- Reviewable:end -->
