### PR TITLE
fix: re-ensure dir before upgrading

### DIFF
--- a/src/meta/raft-store/src/ondisk/upgrade_to_v004.rs
+++ b/src/meta/raft-store/src/ondisk/upgrade_to_v004.rs
@@ -41,6 +41,9 @@ impl OnDisk {
     /// `V004` saves log in WAL based raft log.
     #[fastrace::trace]
     pub(crate) async fn upgrade_v003_to_v004(&mut self) -> Result<(), io::Error> {
+        // The previous cleaning step may remove the dir
+        Self::ensure_dirs(&self.config.raft_dir)?;
+
         self.begin_upgrading(DataVersion::V003).await?;
 
         // 1.1. upgrade raft log


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: re-ensure dir before upgrading

Because upgrade-cleaning would remove the entire dir.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16805)
<!-- Reviewable:end -->
