### PR TITLE
chore: purge dropped view metadata during vacuum

### DIFF
--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0002_vacuum_views.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0002_vacuum_views.test
@@ -30,6 +30,12 @@ create view v as select * from t;
 statement ok
 drop view v;
 
+# the dropped view vacuum_view_test.v should be there
+query I
+select count() from system.tables_with_history where database = 'vacuum_view_test' and name = 'v';
+----
+1
+
 statement ok
 set data_retention_time_in_days = 0;
 

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0002_vacuum_views.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0002_vacuum_views.test
@@ -1,0 +1,46 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+drop database if exists vacuum_view_test;
+
+statement ok
+create database vacuum_view_test;
+
+statement ok
+use vacuum_view_test;
+
+statement ok
+create table t as select * from numbers(1);
+
+statement ok
+create view v as select * from t;
+
+statement ok
+drop view v;
+
+statement ok
+set data_retention_time_in_days = 0;
+
+statement ok
+vacuum drop table from vacuum_view_test;
+
+# the dropped view vacuum_view_test.v should be vacuumed
+query I
+select count() from system.tables_with_history where database = 'vacuum_view_test' and name = 'v';
+----
+0
+
+statement ok
+drop database vacuum_view_test;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Purge dropped view's metadata during `vacuum` operation


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16819)
<!-- Reviewable:end -->
