### PR TITLE
feat: add aws glue as an iceberg connection type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4101,7 +4101,6 @@ dependencies = [
  "serde",
  "sha2",
  "simsearch",
- "time",
  "tokio",
  "url",
 ]
@@ -5183,7 +5182,6 @@ dependencies = [
  "sysinfo",
  "temp-env",
  "tempfile",
- "time",
  "tokio",
  "tokio-stream",
  "toml 0.8.19",
@@ -5264,7 +5262,6 @@ dependencies = [
 name = "databend-storages-common-cache"
 version = "0.1.0"
 dependencies = [
- "arrow",
  "async-backtrace",
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-glue"
+version = "1.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf27e013b137b3f441372300d540bf35960db4a87b123ccafe4a36e314502550"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,6 +4318,7 @@ dependencies = [
  "fastrace",
  "futures",
  "iceberg",
+ "iceberg-catalog-glue",
  "iceberg-catalog-hms",
  "iceberg-catalog-rest",
  "match-template",
@@ -8501,6 +8524,23 @@ dependencies = [
  "tokio",
  "typed-builder 0.20.0",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "iceberg-catalog-glue"
+version = "0.3.0"
+source = "git+https://github.com/Xuanwo/iceberg-rust/?rev=fe5df3f#fe5df3fc432f6f3c0e235bca710a3c7db0c5f369"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-glue",
+ "iceberg",
+ "log",
+ "serde_json",
+ "tokio",
+ "typed-builder 0.20.0",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,7 @@ hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio"
 iceberg = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 iceberg-catalog-hms = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 iceberg-catalog-rest = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
+iceberg-catalog-glue = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 indexmap = "2.0.0"
 indicatif = "0.17.5"
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,9 +308,9 @@ humantime = "2.1.0"
 hyper = "1"
 hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio", "service"] }
 iceberg = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
+iceberg-catalog-glue = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 iceberg-catalog-hms = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 iceberg-catalog-rest = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
-iceberg-catalog-glue = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "fe5df3f" }
 indexmap = "2.0.0"
 indicatif = "0.17.5"
 itertools = "0.13.0"

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -77,6 +77,7 @@ pub struct HiveCatalogOption {
 pub enum IcebergCatalogType {
     Rest = 1,
     Hms = 2,
+    Glue = 3
 }
 
 /// Option for creating a iceberg catalog
@@ -84,6 +85,7 @@ pub enum IcebergCatalogType {
 pub enum IcebergCatalogOption {
     Rest(IcebergRestCatalogOption),
     Hms(IcebergHmsCatalogOption),
+    Glue(IcebergGlueCatalogOption)
 }
 
 impl IcebergCatalogOption {
@@ -92,6 +94,7 @@ impl IcebergCatalogOption {
         match self {
             IcebergCatalogOption::Rest(_) => IcebergCatalogType::Rest,
             IcebergCatalogOption::Hms(_) => IcebergCatalogType::Hms,
+            IcebergCatalogOption::Glue(_) => IcebergCatalogType::Glue
         }
     }
 }
@@ -113,6 +116,12 @@ pub struct IcebergRestCatalogOption {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IcebergHmsCatalogOption {
     pub address: String,
+    pub warehouse: String,
+    pub props: HashMap<String, String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct IcebergGlueCatalogOption {
     pub warehouse: String,
     pub props: HashMap<String, String>,
 }

--- a/src/meta/app/src/schema/catalog.rs
+++ b/src/meta/app/src/schema/catalog.rs
@@ -77,7 +77,7 @@ pub struct HiveCatalogOption {
 pub enum IcebergCatalogType {
     Rest = 1,
     Hms = 2,
-    Glue = 3
+    Glue = 3,
 }
 
 /// Option for creating a iceberg catalog
@@ -85,7 +85,7 @@ pub enum IcebergCatalogType {
 pub enum IcebergCatalogOption {
     Rest(IcebergRestCatalogOption),
     Hms(IcebergHmsCatalogOption),
-    Glue(IcebergGlueCatalogOption)
+    Glue(IcebergGlueCatalogOption),
 }
 
 impl IcebergCatalogOption {
@@ -94,7 +94,7 @@ impl IcebergCatalogOption {
         match self {
             IcebergCatalogOption::Rest(_) => IcebergCatalogType::Rest,
             IcebergCatalogOption::Hms(_) => IcebergCatalogType::Hms,
-            IcebergCatalogOption::Glue(_) => IcebergCatalogType::Glue
+            IcebergCatalogOption::Glue(_) => IcebergCatalogType::Glue,
         }
     }
 }

--- a/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
@@ -126,6 +126,9 @@ impl FromToProto for mt::IcebergCatalogOption {
             pb::iceberg_catalog_option::IcebergCatalogOption::HmsCatalog(v) => {
                 mt::IcebergCatalogOption::Hms(mt::IcebergHmsCatalogOption::from_pb(v)?)
             }
+            pb::iceberg_catalog_option::IcebergCatalogOption::GlueCatalog(v) => {
+                mt::IcebergCatalogOption::Glue(mt::IcebergGlueCatalogOption::from_pb(v)?)
+            }
         })
     }
 
@@ -139,7 +142,10 @@ impl FromToProto for mt::IcebergCatalogOption {
                 }
                 mt::IcebergCatalogOption::Hms(v) => {
                     pb::iceberg_catalog_option::IcebergCatalogOption::HmsCatalog(v.to_pb()?)
-                }
+                },
+                mt::IcebergCatalogOption::Glue(v) => {
+                    pb::iceberg_catalog_option::IcebergCatalogOption::GlueCatalog(v.to_pb()?)
+                },
             }),
         })
     }
@@ -205,6 +211,39 @@ impl FromToProto for mt::IcebergHmsCatalogOption {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
             address: self.address.clone(),
+            warehouse: self.warehouse.clone(),
+            props: self
+                .props
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        })
+    }
+}
+
+impl FromToProto for mt::IcebergGlueCatalogOption {
+    type PB = pb::IcebergGlueCatalogOption;
+
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        Ok(Self {
+            warehouse: p.warehouse,
+            props: p
+                .props
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        })
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        Ok(pb::IcebergGlueCatalogOption {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
             warehouse: self.warehouse.clone(),
             props: self
                 .props

--- a/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
@@ -142,10 +142,10 @@ impl FromToProto for mt::IcebergCatalogOption {
                 }
                 mt::IcebergCatalogOption::Hms(v) => {
                     pb::iceberg_catalog_option::IcebergCatalogOption::HmsCatalog(v.to_pb()?)
-                },
+                }
                 mt::IcebergCatalogOption::Glue(v) => {
                     pb::iceberg_catalog_option::IcebergCatalogOption::GlueCatalog(v.to_pb()?)
-                },
+                }
             }),
         })
     }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -140,6 +140,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (108, "2024-08-29: Add: procedure.proto: ProcedureMeta and ProcedureIdentity"),
     (109, "2024-08-29: Refactor: ProcedureMeta add arg_names"),
     (110, "2024-09-18: Add: database.proto: DatabaseMeta.gc_in_progress"),
+    (111, "2024-11-13: Add: Enable AWS Glue as an Apache Iceberg type when creating a catalog."),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
+++ b/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
@@ -18,6 +18,7 @@ use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
 use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use fastrace::func_name;
+use std::collections::HashMap;
 
 use crate::common;
 
@@ -41,12 +42,17 @@ fn test_v111_add_glue_as_iceberg_catalog_option() -> anyhow::Result<()> {
         24,
     ];
 
+    let mut props = HashMap::new();
+    props.insert("AWS_KEY_ID".to_string(), "super secure access key".to_string());
+    props.insert("AWS_SECRET_KEY".to_string(), "even more secure secret key".to_string());
+    props.insert("REGION".to_string(), "us-east-1 aka anti-multi-availability".to_string());
+
     let want = || databend_common_meta_app::schema::CatalogMeta {
         catalog_option: CatalogOption::Iceberg(IcebergGlueCatalogOption::Rest(
             IcebergGlueCatalogOption {
                 address: "http://127.0.0.1:9900".to_string(),
                 warehouse: "s3://my_bucket".to_string(),
-                props: Default::default(),
+                props,
             },
         )),
         created_on: Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),

--- a/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
+++ b/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
@@ -14,9 +14,10 @@
 
 use chrono::TimeZone;
 use chrono::Utc;
-use databend_common_meta_app::schema as mt;
+use databend_common_meta_app::schema::CatalogOption;
+use databend_common_meta_app::schema::IcebergCatalogOption;
+use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use fastrace::func_name;
-use maplit::btreemap;
 
 use crate::common;
 
@@ -32,29 +33,27 @@ use crate::common;
 // The message bytes are built from the output of `test_pb_from_to()`
 #[test]
 fn test_v111_add_glue_as_iceberg_catalog_option() -> anyhow::Result<()> {
-    let database_meta_v111 = vec![
-        34, 10, 10, 3, 120, 121, 122, 18, 3, 102, 111, 111, 42, 2, 52, 52, 50, 10, 10, 3, 97, 98,
-        99, 18, 3, 100, 101, 102, 162, 1, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 56, 32, 49, 50,
-        58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 170, 1, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 57,
-        32, 49, 50, 58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 178, 1, 7, 102, 111, 111, 32, 98, 97,
-        114, 232, 1, 1, 160, 6, 110, 168, 6, 24,
+    let catalog_meta_v111 = vec![
+        18, 55, 26, 53, 18, 45, 10, 21, 104, 116, 116, 112, 58, 47, 47, 49, 50, 55, 46, 48, 46, 48,
+        46, 49, 58, 57, 57, 48, 48, 18, 14, 115, 51, 58, 47, 47, 109, 121, 95, 98, 117, 99, 107,
+        101, 116, 160, 6, 98, 168, 6, 24, 160, 6, 98, 168, 6, 24, 162, 1, 23, 50, 48, 49, 52, 45,
+        49, 49, 45, 50, 56, 32, 49, 50, 58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 160, 6, 98, 168, 6,
+        24,
     ];
 
-    let want = || mt::DatabaseMeta {
-        engine: "44".to_string(),
-        engine_options: btreemap! {s("abc") => s("def")},
-        options: btreemap! {s("xyz") => s("foo")},
+    let want = || databend_common_meta_app::schema::CatalogMeta {
+        catalog_option: CatalogOption::Iceberg(IcebergGlueCatalogOption::Rest(
+            IcebergGlueCatalogOption {
+                address: "http://127.0.0.1:9900".to_string(),
+                warehouse: "s3://my_bucket".to_string(),
+                props: Default::default(),
+            },
+        )),
         created_on: Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),
-        updated_on: Utc.with_ymd_and_hms(2014, 11, 29, 12, 0, 9).unwrap(),
-        comment: "foo bar".to_string(),
-        drop_on: None,
-        gc_in_progress: true,
     };
 
     common::test_pb_from_to(func_name!(), want())?;
-    common::test_load_old(func_name!(), database_meta_v111.as_slice(), 111, want())
-}
+    common::test_load_old(func_name!(), catalog_meta_v111.as_slice(), 111, want())?;
 
-fn s(ss: impl ToString) -> String {
-    ss.to_string()
+    Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
+++ b/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
@@ -1,0 +1,60 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::TimeZone;
+use chrono::Utc;
+use databend_common_meta_app::schema as mt;
+use fastrace::func_name;
+use maplit::btreemap;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+// The message bytes are built from the output of `test_pb_from_to()`
+#[test]
+fn test_v111_add_glue_as_iceberg_catalog_option() -> anyhow::Result<()> {
+    let database_meta_v111 = vec![
+        34, 10, 10, 3, 120, 121, 122, 18, 3, 102, 111, 111, 42, 2, 52, 52, 50, 10, 10, 3, 97, 98,
+        99, 18, 3, 100, 101, 102, 162, 1, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 56, 32, 49, 50,
+        58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 170, 1, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 57,
+        32, 49, 50, 58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 178, 1, 7, 102, 111, 111, 32, 98, 97,
+        114, 232, 1, 1, 160, 6, 110, 168, 6, 24,
+    ];
+
+    let want = || mt::DatabaseMeta {
+        engine: "44".to_string(),
+        engine_options: btreemap! {s("abc") => s("def")},
+        options: btreemap! {s("xyz") => s("foo")},
+        created_on: Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),
+        updated_on: Utc.with_ymd_and_hms(2014, 11, 29, 12, 0, 9).unwrap(),
+        comment: "foo bar".to_string(),
+        drop_on: None,
+        gc_in_progress: true,
+    };
+
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), database_meta_v111.as_slice(), 111, want())
+}
+
+fn s(ss: impl ToString) -> String {
+    ss.to_string()
+}

--- a/src/meta/protos/proto/catalog.proto
+++ b/src/meta/protos/proto/catalog.proto
@@ -57,6 +57,7 @@ message IcebergCatalogOption {
   oneof iceberg_catalog_option {
     IcebergRestCatalogOption rest_catalog = 2;
     IcebergHmsCatalogOption hms_catalog = 3;
+    IcebergGlueCatalogOption glue_catalog = 4;
   }
 }
 
@@ -76,6 +77,14 @@ message IcebergHmsCatalogOption {
   string address = 1;
   string warehouse = 2;
   map<string, string> props = 3;
+}
+
+message IcebergGlueCatalogOption {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+
+  string warehouse = 1;
+  map<string, string> props = 2;
 }
 
 message ShareCatalogOption {

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -168,7 +168,6 @@ sqlx = { workspace = true }
 strength_reduce = { workspace = true }
 sysinfo = { workspace = true }
 tempfile = { workspace = true }
-time = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
 toml = { workspace = true, default-features = false }

--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -78,6 +78,9 @@ impl Interpreter for ShowCreateCatalogInterpreter {
                 IcebergCatalogOption::Hms(cfg) => {
                     format!("ADDRESS\n{}\nWAREHOUSE\n{}", cfg.address, cfg.warehouse)
                 }
+                IcebergCatalogOption::Glue(cfg) => {
+                    format!("WAREHOUSE\n{}", cfg.warehouse)
+                }
             }),
         };
 

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -71,7 +71,6 @@ roaring = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 simsearch = { workspace = true }
-time = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 

--- a/src/query/sql/src/planner/binder/ddl/catalog.rs
+++ b/src/query/sql/src/planner/binder/ddl/catalog.rs
@@ -35,9 +35,9 @@ use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::CatalogType;
 use databend_common_meta_app::schema::HiveCatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
+use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use databend_common_meta_app::schema::IcebergHmsCatalogOption;
 use databend_common_meta_app::schema::IcebergRestCatalogOption;
-use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use databend_common_meta_app::storage::StorageParams;
 
 use crate::binder::parse_storage_params_from_uri;

--- a/src/query/sql/src/planner/binder/ddl/catalog.rs
+++ b/src/query/sql/src/planner/binder/ddl/catalog.rs
@@ -37,6 +37,7 @@ use databend_common_meta_app::schema::HiveCatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
 use databend_common_meta_app::schema::IcebergHmsCatalogOption;
 use databend_common_meta_app::schema::IcebergRestCatalogOption;
+use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use databend_common_meta_app::storage::StorageParams;
 
 use crate::binder::parse_storage_params_from_uri;
@@ -231,6 +232,10 @@ fn parse_iceberg_rest_catalog(
         }),
         "hive" => IcebergCatalogOption::Hms(IcebergHmsCatalogOption {
             address,
+            warehouse,
+            props: HashMap::from_iter(options),
+        }),
+        "glue" => IcebergCatalogOption::Glue(IcebergGlueCatalogOption {
             warehouse,
             props: HashMap::from_iter(options),
         }),

--- a/src/query/storages/common/cache/Cargo.toml
+++ b/src/query/storages/common/cache/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 test = true
 
 [dependencies]
-arrow = { workspace = true }
 databend-common-arrow = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-cache = { workspace = true }

--- a/src/query/storages/iceberg/Cargo.toml
+++ b/src/query/storages/iceberg/Cargo.toml
@@ -27,6 +27,7 @@ futures = { workspace = true }
 iceberg = { workspace = true }
 iceberg-catalog-hms = { workspace = true }
 iceberg-catalog-rest = { workspace = true }
+iceberg-catalog-glue = { workspace = true }
 match-template = { workspace = true }
 ordered-float = { workspace = true }
 serde = { workspace = true }

--- a/src/query/storages/iceberg/Cargo.toml
+++ b/src/query/storages/iceberg/Cargo.toml
@@ -25,9 +25,9 @@ databend-storages-common-table-meta = { workspace = true }
 fastrace = { workspace = true }
 futures = { workspace = true }
 iceberg = { workspace = true }
+iceberg-catalog-glue = { workspace = true }
 iceberg-catalog-hms = { workspace = true }
 iceberg-catalog-rest = { workspace = true }
-iceberg-catalog-glue = { workspace = true }
 match-template = { workspace = true }
 ordered-float = { workspace = true }
 serde = { workspace = true }

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -211,12 +211,13 @@ impl IcebergCatalog {
                     .build();
 
                 // Due to the AWS Glue catalog creation being asynchronous, forced to run it a bit different way, so we don't have to make the outer function asynchronous.
-                let ctl = databend_common_base::runtime::block_on(GlueCatalog::new(cfg))
-                .map_err(|err| {
-                    ErrorCode::BadArguments(format!(
-                        "There was an error building the AWS Glue catalog: {err:?}"
-                    ))
-                })?;
+                let ctl = databend_common_base::runtime::block_on(GlueCatalog::new(cfg)).map_err(
+                    |err| {
+                        ErrorCode::BadArguments(format!(
+                            "There was an error building the AWS Glue catalog: {err:?}"
+                        ))
+                    },
+                )?;
                 Arc::new(ctl)
             }
         };

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -211,9 +211,7 @@ impl IcebergCatalog {
                     .build();
 
                 // Due to the AWS Glue catalog creation being asynchronous, forced to run it a bit different way, so we don't have to make the outer function asynchronous.
-                let ctl = tokio::task::block_in_place(|| {
-                    databend_common_base::runtime::block_on(GlueCatalog::new(cfg))
-                })
+                let ctl = databend_common_base::runtime::block_on(GlueCatalog::new(cfg))
                 .map_err(|err| {
                     ErrorCode::BadArguments(format!(
                         "There was an error building the AWS Glue catalog: {err:?}"

--- a/tests/sqllogictests/suites/glue/queries.test
+++ b/tests/sqllogictests/suites/glue/queries.test
@@ -1,0 +1,9 @@
+statement ok
+CREATE CATALOG ctl
+TYPE = ICEBERG
+CONNECTION = (
+    TYPE = 'glue',
+    WAREHOUSE = 's3://bucket'
+);
+
+SHOW CREATE CATALOG ctl;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- This pull request enables AWS Glue to be used as a connection type when creating an Apache Iceberg catalog.
- Started work on this because I noticed there was support for REST & Hive, but not AWS Glue.
- fixes: #[https://github.com/databendlabs/databend/issues/16793]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16824)
<!-- Reviewable:end -->
