### PR TITLE
feat: uuid function from v4 to v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -494,7 +494,7 @@ typetag = "0.2.3"
 unicode-segmentation = "1.10.1"
 unindent = "0.2"
 url = "2.3.1"
-uuid = { version = "1.10.0", features = ["serde", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["std", "serde", "v4", "v7"] }
 volo-thrift = "0.10"
 walkdir = "2.3.2"
 wiremock = "0.6"

--- a/src/query/functions/src/scalars/other.rs
+++ b/src/query/functions/src/scalars/other.rs
@@ -234,7 +234,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             let mut builder = BinaryColumnBuilder::with_capacity(ctx.num_rows, 0);
 
             for _ in 0..ctx.num_rows {
-                let value = Uuid::new_v4();
+                let value = Uuid::now_v7();
                 write!(&mut builder.data, "{}", value).unwrap();
                 builder.commit_row();
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

## Overview
Change UUID functions([GEN_RANDOM_UUID](https://docs.databend.com/sql/sql-functions/uuid-functions/gen-random-uuid)/[UUID](https://docs.databend.com/sql/sql-functions/uuid-functions/uuid))output format from v4 to v7 for improved performance and ordering

### Why v7 over v4?
* **Time-ordered**: v7 includes timestamp, making IDs chronologically sortable
* **Uniqueness**: Same uniqueness guarantees as v4 with added time component
* **Sequential**: Improves database insert performance vs random v4 values

### Example
Before (v4): `9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d` (random)
After (v7):  `018df296-2bcd-7000-9876-000000000000` (time-ordered)

### Impact
* No changes needed for existing v4 UUID usage
* New IDs will be sortable by creation time

fixes: #16818 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Existing tests coverd

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16827)
<!-- Reviewable:end -->
