### PR TITLE
fix: replace risky `dma_buffer_as_vec` implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,6 +3100,7 @@ dependencies = [
  "async-backtrace",
  "async-trait",
  "borsh",
+ "bytes",
  "bytesize",
  "chrono",
  "ctrlc",

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -26,6 +26,7 @@ databend-common-exception = { workspace = true }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 borsh = { workspace = true }
+bytes = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }
 ctrlc = { workspace = true }

--- a/src/common/base/src/base/dma.rs
+++ b/src/common/base/src/base/dma.rs
@@ -706,7 +706,7 @@ mod tests {
 
     #[test]
     fn test_dma_buffer_to_bytes() {
-        let want = (0..10_u8).into_iter().collect::<Vec<_>>();
+        let want = (0..10_u8).collect::<Vec<_>>();
         let alloc = DmaAllocator::new(Alignment::new(4096).unwrap());
         let mut buf = DmaBuffer::with_capacity_in(3000, alloc);
         buf.extend_from_slice(&want);

--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -28,7 +28,7 @@ mod take_mut;
 mod uniq_id;
 mod watch_notify;
 
-pub use dma::dma_buffer_as_vec;
+pub use dma::dma_buffer_to_bytes;
 pub use dma::dma_read_file;
 pub use dma::dma_read_file_range;
 pub use dma::dma_write_file_vectored;

--- a/src/common/base/src/lib.rs
+++ b/src/common/base/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(slice_swap_unchecked)]
 #![feature(variant_count)]
 #![feature(ptr_alignment_type)]
+#![feature(vec_into_raw_parts)]
 
 pub mod base;
 pub mod containers;

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -20,7 +20,6 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
-use bytes::Bytes;
 use databend_common_base::base::dma_buffer_to_bytes;
 use databend_common_base::base::dma_read_file_range;
 use databend_common_base::base::Alignment;
@@ -410,7 +409,7 @@ impl Spiller {
         let buf = buf
             .into_data()
             .into_iter()
-            .map(|x| Bytes::from(dma_buffer_to_bytes(x)))
+            .map(dma_buffer_to_bytes)
             .collect::<Buffer>();
         let written = buf.len();
         writer.write(buf).await?;

--- a/src/query/service/src/spillers/spiller.rs
+++ b/src/query/service/src/spillers/spiller.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::Bytes;
-use databend_common_base::base::dma_buffer_as_vec;
+use databend_common_base::base::dma_buffer_to_bytes;
 use databend_common_base::base::dma_read_file_range;
 use databend_common_base::base::Alignment;
 use databend_common_base::base::DmaWriteBuf;
@@ -277,7 +277,7 @@ impl Spiller {
                     None => {
                         let file_size = path.size();
                         let (buf, range) = dma_read_file_range(path, 0..file_size as u64).await?;
-                        Buffer::from(dma_buffer_as_vec(buf)).slice(range)
+                        Buffer::from(dma_buffer_to_bytes(buf)).slice(range)
                     }
                 }
             }
@@ -330,7 +330,7 @@ impl Spiller {
                 );
 
                 let (buf, range) = dma_read_file_range(path, 0..file_size as u64).await?;
-                Buffer::from(dma_buffer_as_vec(buf)).slice(range)
+                Buffer::from(dma_buffer_to_bytes(buf)).slice(range)
             }
             (Location::Local(path), Some(ref local)) => {
                 local
@@ -371,7 +371,7 @@ impl Spiller {
                 }
                 None => {
                     let (buf, range) = dma_read_file_range(path, data_range).await?;
-                    Buffer::from(dma_buffer_as_vec(buf)).slice(range)
+                    Buffer::from(dma_buffer_to_bytes(buf)).slice(range)
                 }
             },
             Location::Remote(loc) => self.operator.read_with(loc).range(data_range).await?,
@@ -410,7 +410,7 @@ impl Spiller {
         let buf = buf
             .into_data()
             .into_iter()
-            .map(|x| Bytes::from(dma_buffer_as_vec(x)))
+            .map(|x| Bytes::from(dma_buffer_to_bytes(x)))
             .collect::<Buffer>();
         let written = buf.len();
         writer.write(buf).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Fix incorrect cap,
Modify the implementation to match the [Allocator api](https://doc.rust-lang.org/std/alloc/trait.Allocator.html#memory-fitting)

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16829)
<!-- Reviewable:end -->
