### PR TITLE
fix: incorrect table data disk cache key

### DIFF
--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -48,6 +48,9 @@ impl BlockReader {
         let column_array_cache = CacheManager::instance().get_table_data_array_cache();
         let mut cached_column_data = vec![];
         let mut cached_column_array = vec![];
+
+        let column_cache_key_builder = ColumnCacheKeyBuilder::new(location);
+
         for (_index, (column_id, ..)) in self.project_indices.iter() {
             if let Some(ignore_column_ids) = ignore_column_ids {
                 if ignore_column_ids.contains(column_id) {
@@ -58,7 +61,7 @@ impl BlockReader {
             if let Some(column_meta) = columns_meta.get(column_id) {
                 let (offset, len) = column_meta.offset_length();
 
-                let column_cache_key = TableDataCacheKey::new(location, *column_id, offset, len);
+                let column_cache_key = column_cache_key_builder.cache_cache(column_id, column_meta);
 
                 // first, check in memory table data cache
                 // column_array_cache
@@ -91,13 +94,8 @@ impl BlockReader {
                 .await?;
 
         if self.put_cache {
-            let table_data_cache = CacheManager::instance().get_table_data_cache();
             // add raw data (compressed raw bytes) to column cache
             for (column_id, (chunk_idx, range)) in &merge_io_result.columns_chunk_offsets {
-                // Safe to unwrap here, since this column has been fetched, its meta must be present.
-                let column_meta = columns_meta.get(column_id).unwrap();
-                let (offset, len) = column_meta.offset_length();
-
                 // Should NOT use `range.start` as part of the cache key,
                 // as they are not stable and can vary for the same column depending on the query's projection.
                 // For instance:
@@ -106,12 +104,15 @@ impl BlockReader {
                 // may result in different ranges for `col2`
                 // This can lead to cache missing or INCONSISTENCIES
 
-                let cache_key = TableDataCacheKey::new(location, *column_id, offset, len);
+                // Safe to unwrap here, since this column has been fetched, its meta must be present.
+                let column_meta = columns_meta.get(column_id).unwrap();
+                let column_cache_key = column_cache_key_builder.cache_cache(column_id, column_meta);
+
                 let chunk_data = merge_io_result
                     .owner_memory
                     .get_chunk(*chunk_idx, &merge_io_result.block_path)?;
                 let data = chunk_data.slice(range.clone());
-                table_data_cache.insert(cache_key.as_ref().to_owned(), data);
+                column_data_cache.insert(column_cache_key.as_ref().to_owned(), data);
             }
         }
 
@@ -121,5 +122,19 @@ impl BlockReader {
         self.report_cache_metrics(&block_read_res, ranges.iter().map(|(_, r)| r));
 
         Ok(block_read_res)
+    }
+}
+
+struct ColumnCacheKeyBuilder<'a> {
+    block_path: &'a str,
+}
+
+impl<'a> ColumnCacheKeyBuilder<'a> {
+    fn new(block_path: &'a str) -> Self {
+        Self { block_path }
+    }
+    fn cache_cache(&self, column_id: &ColumnId, column_meta: &ColumnMeta) -> TableDataCacheKey {
+        let (offset, len) = column_meta.offset_length();
+        TableDataCacheKey::new(self.block_path, *column_id, offset, len)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


`Range` returned by merged reading should not be used as the corresponding parts of table data cache key,
instead `offset` and `len` of column meta should be used.



`range.start`  is not stable and can vary for the same column depending on the query's projection.

For instance:

 - `SELECT col1, col2 FROM t;`
 - `SELECT col2 FROM t;`

may result in different ranges for `col2`, this can lead to cache missing or INCONSISTENCIES



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test -  Ensure consistent cache key through code refactoring.


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16837)
<!-- Reviewable:end -->
