### PR TITLE
fix(query): fix aggregator_groups_builder to work with string view

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_groups_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/group_by/aggregator_groups_builder.rs
@@ -92,12 +92,16 @@ impl<'a> SerializedKeysGroupColumnsBuilder<'a> {
                         Some(StringColumnBuilder::with_capacity(capacity)),
                         vec![],
                     )
-                } else {
+                } else if params.group_data_types[0].is_binary()
+                    || params.group_data_types[0].is_variant()
+                {
                     (
                         Some(BinaryColumnBuilder::with_capacity(capacity, data_capacity)),
                         None,
                         vec![],
                     )
+                } else {
+                    (None, None, Vec::with_capacity(capacity))
                 }
             } else {
                 (None, None, Vec::with_capacity(capacity))

--- a/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
@@ -21,6 +21,13 @@ SELECT number%3 as c1 FROM numbers_mt(10) where number > 2 group by number%3 ord
 1
 2
 
+query I
+SELECT try_cast(number % 3 as string) c1, count()  FROM numbers_mt(10) where number > 2 group by c1 order by c1
+----
+0 3
+1 2
+2 2
+
 query III
 SELECT a,b,count() from (SELECT cast((number%4) AS bigint) as a, cast((number%20) AS bigint) as b from numbers(100)) group by a,b order by a,b limit 3
 ----

--- a/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by_old.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by_old.test
@@ -1,0 +1,7 @@
+statement ok
+set enable_experimental_aggregate_hashtable = 0;
+
+include ./03_0003_select_group_by.test
+
+statement ok
+unset enable_experimental_aggregate_hashtable;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): fix aggregator_groups_builder to work with string view when working with

```
set enable_experimental_aggregate_hashtable = 0;
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16843)
<!-- Reviewable:end -->
