### PR TITLE
refactor: optimize query system.tables when query single table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,6 +4563,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-expression",
  "databend-common-functions",
+ "databend-common-management",
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-types",

--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -102,6 +102,7 @@ pub use user_defined_function::UserDefinedFunction;
 pub use user_grant::GrantEntry;
 pub use user_grant::GrantObject;
 pub use user_grant::UserGrantSet;
+pub use user_grant::SYSTEM_TABLES_ALLOW_LIST;
 pub use user_identity::UserIdentity;
 pub use user_info::UserInfo;
 pub use user_info::UserOption;

--- a/src/meta/app/src/principal/user_grant.rs
+++ b/src/meta/app/src/principal/user_grant.rs
@@ -21,6 +21,33 @@ use enumflags2::BitFlags;
 use crate::principal::UserPrivilegeSet;
 use crate::principal::UserPrivilegeType;
 
+// some statements like `SELECT 1`, `SHOW USERS`, `SHOW ROLES`, `SHOW TABLES` will be
+// rewritten to the queries on the system tables, we need to skip the privilege check on
+// these tables.
+pub const SYSTEM_TABLES_ALLOW_LIST: [&str; 21] = [
+    "catalogs",
+    "columns",
+    "databases",
+    "databases_with_history",
+    "dictionaries",
+    "tables",
+    "views",
+    "tables_with_history",
+    "views_with_history",
+    "password_policies",
+    "streams",
+    "streams_terse",
+    "virtual_columns",
+    "users",
+    "roles",
+    "stages",
+    "one",
+    "processes",
+    "user_functions",
+    "functions",
+    "indexes",
+];
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum GrantObject {
     Global,

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -224,7 +224,10 @@ pub trait TableContext: Send + Sync {
         check_current_role_only: bool,
     ) -> Result<()>;
     async fn get_available_roles(&self) -> Result<Vec<RoleInfo>>;
-    async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker>;
+    async fn get_visibility_checker(
+        &self,
+        ignore_ownership: bool,
+    ) -> Result<GrantObjectVisibilityChecker>;
     fn get_fuse_version(&self) -> String;
     fn get_format_settings(&self) -> Result<FormatSettings>;
     fn get_tenant(&self) -> Tenant;

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -29,6 +29,7 @@ use databend_common_meta_app::principal::StageType;
 use databend_common_meta_app::principal::UserGrantSet;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
+use databend_common_meta_app::principal::SYSTEM_TABLES_ALLOW_LIST;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_sql::binder::MutationType;
@@ -57,33 +58,6 @@ enum ObjectId {
     Database(u64),
     Table(u64, u64),
 }
-
-// some statements like `SELECT 1`, `SHOW USERS`, `SHOW ROLES`, `SHOW TABLES` will be
-// rewritten to the queries on the system tables, we need to skip the privilege check on
-// these tables.
-const SYSTEM_TABLES_ALLOW_LIST: [&str; 21] = [
-    "catalogs",
-    "columns",
-    "databases",
-    "databases_with_history",
-    "dictionaries",
-    "tables",
-    "views",
-    "tables_with_history",
-    "views_with_history",
-    "password_policies",
-    "streams",
-    "streams_terse",
-    "virtual_columns",
-    "users",
-    "roles",
-    "stages",
-    "one",
-    "processes",
-    "user_functions",
-    "functions",
-    "indexes",
-];
 
 // table functions that need `Super` privilege
 const SYSTEM_TABLE_FUNCTIONS: [&str; 1] = ["fuse_amend"];

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -692,8 +692,14 @@ impl TableContext for QueryContext {
         self.get_current_session().get_id()
     }
 
-    async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker> {
-        self.shared.session.get_visibility_checker().await
+    async fn get_visibility_checker(
+        &self,
+        ignore_ownership: bool,
+    ) -> Result<GrantObjectVisibilityChecker> {
+        self.shared
+            .session
+            .get_visibility_checker(ignore_ownership)
+            .await
     }
 
     fn get_fuse_version(&self) -> String {

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -310,8 +310,13 @@ impl Session {
     }
 
     #[async_backtrace::framed]
-    pub async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker> {
-        self.privilege_mgr().get_visibility_checker().await
+    pub async fn get_visibility_checker(
+        &self,
+        ignore_ownership: bool,
+    ) -> Result<GrantObjectVisibilityChecker> {
+        self.privilege_mgr()
+            .get_visibility_checker(ignore_ownership)
+            .await
     }
 
     pub fn get_settings(&self) -> Arc<Settings> {

--- a/src/query/service/src/table_functions/infer_schema/parquet.rs
+++ b/src/query/service/src/table_functions/infer_schema/parquet.rs
@@ -99,7 +99,7 @@ impl AsyncSource for ParquetInferSchemaSource {
             .get_settings()
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
-            let visibility_checker = self.ctx.get_visibility_checker().await?;
+            let visibility_checker = self.ctx.get_visibility_checker(false).await?;
             if !(stage_info.is_temporary
                 || visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
                 || stage_info.stage_type == StageType::User

--- a/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
+++ b/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
@@ -213,7 +213,7 @@ impl AsyncSource for InspectParquetSource {
             .get_settings()
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
-            let visibility_checker = self.ctx.get_visibility_checker().await?;
+            let visibility_checker = self.ctx.get_visibility_checker(false).await?;
             if !(stage_info.is_temporary
                 || visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
                 || stage_info.stage_type == StageType::User

--- a/src/query/service/src/table_functions/list_stage/list_stage_table.rs
+++ b/src/query/service/src/table_functions/list_stage/list_stage_table.rs
@@ -187,7 +187,7 @@ impl ListStagesSource {
             .get_settings()
             .get_enable_experimental_rbac_check()?;
         if enable_experimental_rbac_check {
-            let visibility_checker = self.ctx.get_visibility_checker().await?;
+            let visibility_checker = self.ctx.get_visibility_checker(false).await?;
             if !(stage_info.is_temporary
                 || visibility_checker.check_stage_read_visibility(&stage_info.stage_name)
                 || stage_info.stage_type == StageType::User

--- a/src/query/service/src/table_functions/show_grants/show_grants_table.rs
+++ b/src/query/service/src/table_functions/show_grants/show_grants_table.rs
@@ -566,7 +566,7 @@ async fn show_object_grant(
     let tenant = ctx.get_tenant();
     let user_api = UserApiProvider::instance();
     let roles = user_api.get_roles(&tenant).await?;
-    let visibility_checker = ctx.get_visibility_checker().await?;
+    let visibility_checker = ctx.get_visibility_checker(false).await?;
     let current_user = ctx.get_current_user()?.identity().username;
     let (object, owner_object, object_id, object_name) = match grant_type {
         "table" => {

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -690,7 +690,10 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker> {
+    async fn get_visibility_checker(
+        &self,
+        _ignore_ownership: bool,
+    ) -> Result<GrantObjectVisibilityChecker> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -594,7 +594,10 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
-    async fn get_visibility_checker(&self) -> Result<GrantObjectVisibilityChecker> {
+    async fn get_visibility_checker(
+        &self,
+        _ignore_ownership: bool,
+    ) -> Result<GrantObjectVisibilityChecker> {
         todo!()
     }
 

--- a/src/query/storages/system/Cargo.toml
+++ b/src/query/storages/system/Cargo.toml
@@ -26,6 +26,7 @@ databend-common-config = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-expression = { workspace = true }
 databend-common-functions = { workspace = true }
+databend-common-management = { workspace = true }
 databend-common-meta-api = { workspace = true }
 databend-common-meta-app = { workspace = true }
 databend-common-meta-types = { workspace = true }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -274,7 +274,7 @@ pub(crate) async fn dump_tables(
         }
     }
 
-    let visibility_checker = ctx.get_visibility_checker().await?;
+    let visibility_checker = ctx.get_visibility_checker(false).await?;
 
     let mut final_dbs: Vec<(String, u64)> = Vec::new();
 

--- a/src/query/storages/system/src/databases_table.rs
+++ b/src/query/storages/system/src/databases_table.rs
@@ -117,7 +117,7 @@ where DatabasesTable<WITH_HISTORY>: HistoryAware
         let mut owners: Vec<Option<String>> = vec![];
         let mut dropped_on: Vec<Option<i64>> = vec![];
 
-        let visibility_checker = ctx.get_visibility_checker().await?;
+        let visibility_checker = ctx.get_visibility_checker(false).await?;
         let catalog_dbs = visibility_checker.get_visibility_database();
         // None means has global level privileges
         if let Some(catalog_dbs) = catalog_dbs {

--- a/src/query/storages/system/src/indexes_table.rs
+++ b/src/query/storages/system/src/indexes_table.rs
@@ -154,7 +154,7 @@ impl IndexesTable {
         ctx: Arc<dyn TableContext>,
     ) -> Result<Vec<TableInfo>> {
         let tenant = ctx.get_tenant();
-        let visibility_checker = ctx.get_visibility_checker().await?;
+        let visibility_checker = ctx.get_visibility_checker(false).await?;
         let catalog = ctx.get_catalog(CATALOG_DEFAULT).await?;
 
         let ctl_name = catalog.name();

--- a/src/query/storages/system/src/stages_table.rs
+++ b/src/query/storages/system/src/stages_table.rs
@@ -62,7 +62,7 @@ impl AsyncSystemTable for StagesTable {
         let enable_experimental_rbac_check =
             ctx.get_settings().get_enable_experimental_rbac_check()?;
         let stages = if enable_experimental_rbac_check {
-            let visibility_checker = ctx.get_visibility_checker().await?;
+            let visibility_checker = ctx.get_visibility_checker(false).await?;
             stages
                 .into_iter()
                 .filter(|stage| {

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -80,7 +80,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
             .iter()
             .map(|e| (e.name(), e.clone()))
             .collect::<Vec<_>>();
-        let visibility_checker = ctx.get_visibility_checker().await?;
+        let visibility_checker = ctx.get_visibility_checker(false).await?;
         let user_api = UserApiProvider::instance();
 
         let mut catalogs = vec![];

--- a/src/query/storages/system/src/user_functions_table.rs
+++ b/src/query/storages/system/src/user_functions_table.rs
@@ -60,7 +60,7 @@ impl AsyncSystemTable for UserFunctionsTable {
         let enable_experimental_rbac_check =
             ctx.get_settings().get_enable_experimental_rbac_check()?;
         let user_functions = if enable_experimental_rbac_check {
-            let visibility_checker = ctx.get_visibility_checker().await?;
+            let visibility_checker = ctx.get_visibility_checker(false).await?;
             let udfs = UserFunctionsTable::get_udfs(&ctx.get_tenant()).await?;
             udfs.into_iter()
                 .filter(|udf| visibility_checker.check_udf_visibility(&udf.name))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. moved SYSTEM_TABLES_ALLOW_LIST to src/meta/app/src/principal/user_grant.rs. I also refactored the get_visibility_checker function and added a new parameter: ignore_ownership.

2. The purpose of this parameter is to optimize the performance of querying table information from system.tables. When this parameter is set, we can skip listing all ownerships and directly fetch a single ownership object, then perform only one get operation, thus reducing query time. In short, this change aims to improve the efficiency of querying table information from system.tables by avoiding unnecessary operations on the list of ownerships.


<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16869)
<!-- Reviewable:end -->
