### PR TITLE
fix: raft-log wont write when exceeding 256M

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12018,9 +12018,9 @@ dependencies = [
 
 [[package]]
 name = "raft-log"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e7f06d77e694fc984ba36494c091169d9c6695ce2af174e8f1e167a05f588"
+checksum = "3d5edc50b7d30e6b04683575129a996cf210951fc36c6e5856eb8dc746fef77a"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,7 @@ prost = { version = "0.13" }
 prost-build = { version = "0.13" }
 prqlc = "0.11.3"
 quanta = "0.11.1"
-raft-log = { version = "0.2.2" }
+raft-log = { version = "0.2.3" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rayon = "1.9.0"
 recursive = "0.1.1"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: raft-log wont write when exceeding 256M

- Fixed in: https://github.com/drmingdrmer/raft-log/commit/2693db500efe3862d775ed986f46824a7c5660e9

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16876)
<!-- Reviewable:end -->
