### PR TITLE
feat: databend-meta adds more metrics about raft-log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11998,9 +11998,9 @@ dependencies = [
 
 [[package]]
 name = "raft-log"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5edc50b7d30e6b04683575129a996cf210951fc36c6e5856eb8dc746fef77a"
+checksum = "b2e7582480ea22f8268d681f4c5f8cf9b626e7f6c917724da68125c24820b055"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,7 +405,7 @@ prost = { version = "0.13" }
 prost-build = { version = "0.13" }
 prqlc = "0.11.3"
 quanta = "0.11.1"
-raft-log = { version = "0.2.3" }
+raft-log = { version = "0.2.5" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rayon = "1.9.0"
 recursive = "0.1.1"

--- a/src/meta/raft-store/src/raft_log_v004/mod.rs
+++ b/src/meta/raft-store/src/raft_log_v004/mod.rs
@@ -27,6 +27,7 @@ pub const TREE_RAFT_LOG: &str = "raft_log";
 
 pub type RaftLogV004 = raft_log::RaftLog<RaftLogTypes>;
 pub type RaftLogConfig = raft_log::Config;
+pub type RaftLogStat = raft_log::Stat<RaftLogTypes>;
 
 pub use callback::Callback;
 pub use callback_data::CallbackData;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: databend-meta adds more metrics about raft-log

- "raft_log_cache_items"                 : number of items in raft log cache;
- "raft_log_cache_used_size"             : size of used space in raft log cache;
- "raft_log_wal_open_chunk_size"         : size of open chunk in raft log wal;
- "raft_log_wal_offset"                  : global offset of raft log WAL;
- "raft_log_wal_closed_chunk_count"      : number of closed chunks in raft log WAL;
- "raft_log_wal_closed_chunk_total_size" : total size of closed chunks in raft log WAL;

Example output of these new metrics:

```text
metasrv_server_raft_log_cache_items                 35496
metasrv_server_raft_log_cache_used_size             659024620
metasrv_server_raft_log_wal_open_chunk_size         803
metasrv_server_raft_log_wal_offset                  3536913654
metasrv_server_raft_log_wal_closed_chunk_count      3
metasrv_server_raft_log_wal_closed_chunk_total_size 584045971
metasrv_server_raft_log_size                        584046774
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16884)
<!-- Reviewable:end -->
