### PR TITLE
chore: bump opensrv

### DIFF
--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   linux:
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 8c16g, aws]
+    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 4c16g, aws]
     strategy:
       matrix:
         include:

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -45,7 +45,7 @@ jobs:
 
   build:
     needs: info
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 16c32g, aws]
+    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 8c32g, aws]
     strategy:
       matrix:
         include:
@@ -69,7 +69,7 @@ jobs:
   docker:
     needs: [info, build]
     timeout-minutes: 10
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
     steps:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -36,7 +36,7 @@ jobs:
 
   build:
     needs: info
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 16c32g, aws]
+    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 8c32g, aws]
     strategy:
       matrix:
         include:
@@ -56,7 +56,7 @@ jobs:
 
   chaos:
     needs: [info, build]
-    runs-on: [self-hosted, X64, Linux, 8c16g, aws]
+    runs-on: [self-hosted, X64, Linux, 4c16g, aws]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Docs
         uses: actions/checkout@v4
         with:
-          repository: datafuselabs/databend-docs
+          repository: databendlabs/databend-docs
           ref: main
       - name: Get date
         shell: bash
@@ -83,10 +83,10 @@ jobs:
           mkdir -p docs/release-stable
           df="docs/release-stable/${{ env.DATE }}_${{ needs.create_release.outputs.version }}.md"
           echo "---" > $df
-          gh release view --repo datafuselabs/databend ${{ needs.create_release.outputs.version }} >> $df
+          gh release view --repo databendlabs/databend ${{ needs.create_release.outputs.version }} >> $df
           sed -i -E 's/^--$/---/g' $df
           sed -i -E '/^asset:/d' $df
-          sed -i -E 's_https://github.com/datafuselabs/databend/pull/([0-9]+)_[#\1](https://github.com/datafuselabs/databend/pull/\1)_g' $df
+          sed -i -E 's_https://github.com/databendlabs/databend/pull/([0-9]+)_[#\1](https://github.com/databendlabs/databend/pull/\1)_g' $df
           git add docs/release-stable
           git status
       - uses: peter-evans/create-pull-request@v4
@@ -99,7 +99,7 @@ jobs:
           delete-branch: true
 
   build_default:
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 16c32g, aws]
+    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 8c32g, aws]
     needs: create_release
     strategy:
       fail-fast: false
@@ -117,6 +117,7 @@ jobs:
         uses: ./.github/actions/build_linux
         env:
           DATABEND_RELEASE_VERSION: ${{ needs.create_release.outputs.version }}
+          DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.target }}
@@ -130,8 +131,33 @@ jobs:
           cp ./target/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/databend-* ./target/${{ env.BUILD_PROFILE }}/
           bash ./scripts/ci/ci-run-sqllogic-tests.sh base
 
+  build_musl:
+    runs-on: [self-hosted, X64, Linux, 8c32g, aws]
+    needs: create_release
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create_release.outputs.sha }}
+          fetch-depth: 0
+      - name: Build Release
+        uses: ./.github/actions/build_linux
+        env:
+          DATABEND_RELEASE_VERSION: ${{ needs.create_release.outputs.version }}
+          DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
+        with:
+          sha: ${{ github.sha }}
+          target: ${{ matrix.target }}
+          artifacts: query,meta,metactl
+
   build_udf:
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 16c32g, aws]
+    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 8c32g, aws]
     needs: create_release
     strategy:
       fail-fast: false
@@ -149,6 +175,7 @@ jobs:
         uses: ./.github/actions/build_linux
         env:
           DATABEND_RELEASE_VERSION: ${{ needs.create_release.outputs.version }}
+          DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.target }}
@@ -156,51 +183,21 @@ jobs:
           features: python-udf
           category: udf
 
-  build_hdfs:
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 16c32g, aws]
-    needs: create_release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { target: x86_64-unknown-linux-gnu, runner: X64 }
-          - { target: aarch64-unknown-linux-gnu, runner: ARM64 }
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.create_release.outputs.sha }}
-          fetch-depth: 0
-      - name: Build Release
-        uses: ./.github/actions/build_linux
-        env:
-          DATABEND_RELEASE_VERSION: ${{ needs.create_release.outputs.version }}
-        with:
-          sha: ${{ github.sha }}
-          target: ${{ matrix.target }}
-          artifacts: sqllogictests,sqlsmith,metactl,meta,query
-          features: storage-hdfs
-          category: hdfs
-
   publish:
-    runs-on: [self-hosted, "${{ matrix.runner }}", Linux, 4c8g, aws]
-    needs: [create_release, build_default, build_hdfs]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
+    needs: [create_release, build_default, build_musl]
     strategy:
       fail-fast: false
       matrix:
         include:
           - category: default
             target: x86_64-unknown-linux-gnu
-            runner: X64
           - category: default
             target: aarch64-unknown-linux-gnu
-            runner: ARM64
-          - category: hdfs
-            target: x86_64-unknown-linux-gnu
-            runner: X64
-          - category: hdfs
-            target: aarch64-unknown-linux-gnu
-            runner: ARM64
+          - category: default
+            target: x86_64-unknown-linux-musl
+          - category: default
+            target: aarch64-unknown-linux-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -254,7 +251,7 @@ jobs:
           category: ${{ matrix.category }}
 
   publish_testsuite:
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     needs: [create_release, build_default]
     strategy:
       fail-fast: false
@@ -298,7 +295,7 @@ jobs:
           category: testsuite
 
   docker_all_in_one:
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     needs: [create_release, build_default]
     steps:
       - name: Checkout
@@ -373,7 +370,7 @@ jobs:
           readme-filepath: ./docker/README.md
 
   docker_service:
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     needs: [create_release, build_udf]
     strategy:
       fail-fast: false
@@ -444,7 +441,7 @@ jobs:
           file: ./docker/service/${{ matrix.service }}.Dockerfile
 
   distribution:
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     needs: [create_release, build_default]
     strategy:
       matrix:
@@ -595,7 +592,7 @@ jobs:
 
   sqlsmith:
     needs: [create_release, notify]
-    runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+    runs-on: [self-hosted, X64, Linux, 2c8g, aws]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -620,7 +617,7 @@ jobs:
 
   metachaos:
     needs: [create_release, notify]
-    runs-on: [self-hosted, X64, Linux, 8c16g, aws]
+    runs-on: [self-hosted, X64, Linux, 4c16g, aws]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -646,7 +643,7 @@ jobs:
             await script({context, core})
 
   # sharing:
-  #   runs-on: [self-hosted, X64, Linux, 4c8g, aws]
+  #   runs-on: [self-hosted, X64, Linux, 2c8g, aws]
   #   needs: [create_release, notify]
   #   steps:
   #     - uses: actions/checkout@v4
@@ -655,7 +652,7 @@ jobs:
   #     - name: checkout share endpoint
   #       uses: actions/checkout@v4
   #       with:
-  #         repository: datafuselabs/share-endpoint
+  #         repository: databendlabs/share-endpoint
   #         token: ${{ secrets.DATABEND_BOT_TOKEN }}
   #         path: share-endpoint
   #     - name: Download artifacts

--- a/.github/workflows/reuse.benchmark.yml
+++ b/.github/workflows/reuse.benchmark.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   local:
     timeout-minutes: 60
-    runs-on: [self-hosted, X64, Linux, 16c32g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 8c32g, "${{ inputs.runner_provider }}"]
     strategy:
       matrix:
         dataset:

--- a/.github/workflows/reuse.linux.hive.yml
+++ b/.github/workflows/reuse.linux.hive.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, X64, Linux, 8c16g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 4c16g, "${{ inputs.runner_provider }}"]
     strategy:
       matrix:
         include:
@@ -41,7 +41,7 @@ jobs:
 
   test_stateful_hive_standalone:
     needs: build
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_stateful_hive_standalone

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
         default: "aws"
+      license_type:
+        description: "License type, enterprise or trial"
+        type: string
+        required: true
+        default: "trial"
 
 env:
   BUILD_PROFILE: ${{ inputs.build_profile }}
@@ -20,7 +25,7 @@ env:
 
 jobs:
   check:
-    runs-on: [ self-hosted, X64, Linux, 16c32g, "${{ inputs.runner_provider }}" ]
+    runs-on: [self-hosted, X64, Linux, 8c32g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,7 +41,7 @@ jobs:
       - self-hosted
       - "${{ matrix.runner }}"
       - Linux
-      - 16c32g
+      - 8c32g
       - "${{ inputs.runner_provider }}"
     strategy:
       fail-fast: false
@@ -50,6 +55,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/build_linux
         timeout-minutes: 60
+        env:
+          DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.arch }}-unknown-linux-gnu
@@ -60,7 +67,7 @@ jobs:
       - self-hosted
       - "${{ matrix.runner }}"
       - Linux
-      - 16c32g
+      - 8c32g
       - "${{ inputs.runner_provider }}"
     strategy:
       fail-fast: false
@@ -75,6 +82,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/build_linux
         timeout-minutes: 60
+        env:
+          DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.arch }}-unknown-linux-gnu
@@ -87,7 +96,7 @@ jobs:
   #     - self-hosted
   #     - "${{ matrix.runner }}"
   #     - Linux
-  #     - 16c32g
+  #     - 8c32g
   #     - "${{ inputs.runner_provider }}"
   #   strategy:
   #     fail-fast: false
@@ -106,7 +115,7 @@ jobs:
   #         artifacts: query
 
   test_unit:
-    runs-on: [ self-hosted, X64, Linux, 16c32g, "${{ inputs.runner_provider }}" ]
+    runs-on: [self-hosted, X64, Linux, 8c32g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -116,75 +125,76 @@ jobs:
         timeout-minutes: 60
 
   test_metactl:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_metactl
         timeout-minutes: 10
 
   test_compat_meta_query:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_compat_meta_query
         timeout-minutes: 10
 
   test_compat_fuse:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_compat_fuse
         timeout-minutes: 20
 
   test_compat_meta_meta:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_compat_meta_meta
         timeout-minutes: 20
 
   test_logs:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_logs
         timeout-minutes: 20
 
   test_meta_cluster:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_meta_cluster
         timeout-minutes: 10
 
   test_stateless_standalone:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_stateless_standalone_linux
         timeout-minutes: 15
 
   test_stateless_cluster:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_stateless_cluster_linux
         timeout-minutes: 15
 
   test_stateful_standalone:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_stateful_standalone_linux
@@ -196,13 +206,14 @@ jobs:
           name: test-stateful-standalone-linux
 
   test_stateful_cluster:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_stateful_cluster_linux
         timeout-minutes: 15
       - name: Upload failure
@@ -213,16 +224,16 @@ jobs:
 
   test_stateful_large_data:
     if: contains(github.event.pull_request.labels.*.name, 'ci-largedata')
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_stateful_large_data
         timeout-minutes: 60
 
   test_stateful_iceberg_rest:
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
-    needs: [ build, check ]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
+    needs: [build, check]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_stateful_iceberg_rest_standalone
@@ -234,7 +245,7 @@ jobs:
           name: test-stateful-iceberg-rest-standalone
 
   # test_fuzz_standalone:
-  #   runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+  #   runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
   #   needs: [build, check]
   #   steps:
   #     - uses: actions/checkout@v4
@@ -243,13 +254,14 @@ jobs:
   #       continue-on-error: true
 
   test_ee_standalone:
-    needs: [ build, check ]
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
+    needs: [build, check]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_ee_standalone_linux
         timeout-minutes: 10
       - name: Upload failure
@@ -259,14 +271,15 @@ jobs:
           name: test-stateful-standalone-linux
 
   test_ee_standalone_background:
-    needs: [ build, check ]
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
+    needs: [build, check]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_bendsql
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_ee_standalone_background_linux
         timeout-minutes: 10
       - name: Upload failure
@@ -282,12 +295,13 @@ jobs:
   #
   #  test_ee_standalone_fake_time:
   #    needs: [build, check]
-  #    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+  #    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
   #    steps:
   #      - uses: actions/checkout@v4
   #      - uses: ./.github/actions/setup_license
   #        with:
   #          runner_provider: ${{ inputs.runner_provider }}
+  #          type: ${{ inputs.license_type }}
   #      - uses: ./.github/actions/test_ee_standalone_fake_time_linux
   #        timeout-minutes: 10
   #      - name: Upload failure
@@ -297,14 +311,15 @@ jobs:
   #          name: test-stateful-standalone-fake-time-linux
 
   test_ee_management_mode:
-    needs: [ build, check ]
-    runs-on: [ self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}" ]
+    needs: [build, check]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_bendsql
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_ee_management_mode_linux
         timeout-minutes: 10
       - name: Upload failure
@@ -314,9 +329,10 @@ jobs:
           name: test-ee-management-mode-linux
 
   sqllogic:
-    needs: [ build, check ]
+    needs: [build, check]
     uses: ./.github/workflows/reuse.sqllogic.yml
     secrets: inherit
     with:
       build_profile: ${{ inputs.build_profile }}
       runner_provider: ${{ inputs.runner_provider }}
+      license_type: ${{ inputs.license_type }}

--- a/.github/workflows/reuse.sqllogic.yml
+++ b/.github/workflows/reuse.sqllogic.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
         default: "aws"
+      license_type:
+        description: "License type, enterprise or trial"
+        type: string
+        required: true
+        default: "trial"
 
 env:
   BUILD_PROFILE: ${{ inputs.build_profile }}
@@ -20,7 +25,7 @@ env:
 
 jobs:
   management_mode:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test_sqllogic_management_mode_linux
@@ -30,19 +35,24 @@ jobs:
           handlers: mysql,http
 
   standalone:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on:
+      - self-hosted
+      - X64
+      - Linux
+      - "${{ matrix.tests.runner }}"
+      - "${{ inputs.runner_provider }}"
     strategy:
       fail-fast: false
       matrix:
-        dirs:
-          - "query"
-          - "standalone"
-          - "crdb"
-          - "duckdb"
-          - "base"
-          - "ydb"
-          - "tpcds"
-          - "tpch"
+        tests:
+          - { dirs: "query", runner: "4c16g" }
+          - { dirs: "duckdb", runner: "4c16g" }
+          - { dirs: "crdb", runner: "2c8g" }
+          - { dirs: "base", runner: "2c8g" }
+          - { dirs: "ydb", runner: "2c8g" }
+          - { dirs: "tpcds", runner: "2c8g" }
+          - { dirs: "tpch", runner: "2c8g" }
+          - { dirs: "standalone", runner: "2c8g" }
         handler:
           - "mysql"
           - "http"
@@ -51,22 +61,22 @@ jobs:
       - uses: ./.github/actions/test_sqllogic_standalone_linux
         timeout-minutes: 15
         with:
-          dirs: ${{ matrix.dirs }}
+          dirs: ${{ matrix.tests.dirs }}
           handlers: ${{ matrix.handler }}
           storage-format: all
       - name: Upload failure
         if: failure()
         uses: ./.github/actions/artifact_failure
         with:
-          name: test-sqllogic-standalone-${{ matrix.dirs }}-${{ matrix.handler }}
+          name: test-sqllogic-standalone-${{ matrix.tests.dirs }}-${{ matrix.handler }}
 
   standalone_udf_server:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - name: Start UDF Server
         run: |
-          pip install databend-udf
+          pip install databend-udf>=0.2.6
           python3 tests/udf/udf_server.py &
           sleep 2
       - uses: ./.github/actions/test_sqllogic_standalone_linux
@@ -82,7 +92,7 @@ jobs:
           name: test-sqllogic-standalone-udf-server
 
   standalone_cloud:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 4c16g, "${{ inputs.runner_provider }}"]
     steps:
       - uses: actions/checkout@v4
       - name: Start Cloud Control Server
@@ -103,7 +113,7 @@ jobs:
           name: test-sqllogic-standalone-cloud
 
   standalone_minio:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     strategy:
       fail-fast: false
       matrix:
@@ -129,20 +139,44 @@ jobs:
         with:
           name: test-sqllogic-standalone-minio-${{ matrix.dirs }}-${{ matrix.handler }}-${{ matrix.format }}
 
+  standalone_iceberg_tpch:
+    runs-on: [self-hosted, X64, Linux, 4c16g, "${{ inputs.runner_provider }}"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - uses: ./.github/actions/test_sqllogic_iceberg_tpch
+        timeout-minutes: 15
+        with:
+          dirs: tpch_iceberg
+          handlers: mysql,http
+      - name: Upload failure
+        if: failure()
+        uses: ./.github/actions/artifact_failure
+        with:
+          name: test-sqllogic-standalone-iceberg-tpch
+
   cluster:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on:
+      - self-hosted
+      - X64
+      - Linux
+      - "${{ matrix.tests.runner }}"
+      - "${{ inputs.runner_provider }}"
     strategy:
       fail-fast: false
       matrix:
-        dirs:
-          - "query"
-          - "crdb"
-          - "duckdb"
-          - "base"
-          - "ydb"
-          - "tpcds"
-          - "tpch"
-          - "cluster"
+        tests:
+          - { dirs: "query", runner: "4c16g" }
+          - { dirs: "duckdb", runner: "4c16g" }
+          - { dirs: "crdb", runner: "2c8g" }
+          - { dirs: "base", runner: "2c8g" }
+          - { dirs: "ydb", runner: "2c8g" }
+          - { dirs: "tpcds", runner: "2c8g" }
+          - { dirs: "tpch", runner: "2c8g" }
+          - { dirs: "cluster", runner: "2c8g" }
         handler:
           - "mysql"
           - "http"
@@ -151,19 +185,20 @@ jobs:
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_sqllogic_cluster_linux
         timeout-minutes: 15
         with:
-          dirs: ${{ matrix.dirs }}
+          dirs: ${{ matrix.tests.dirs }}
           handlers: ${{ matrix.handler }}
       - name: Upload failure
         if: failure()
         uses: ./.github/actions/artifact_failure
         with:
-          name: test-sqllogic-cluster-${{ matrix.dirs }}-${{ matrix.handler }}
+          name: test-sqllogic-cluster-${{ matrix.tests.dirs }}-${{ matrix.handler }}
 
   stage:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     strategy:
       fail-fast: false
       matrix:
@@ -185,7 +220,7 @@ jobs:
           name: test-sqllogic-stage-${{ matrix.storage }}
 
   standalone_no_table_meta_cache:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     strategy:
       fail-fast: false
       matrix:
@@ -209,7 +244,7 @@ jobs:
           name: test-sqllogic-standalone-no-table-meta-cache-${{ matrix.dirs }}-${{ matrix.handler }}
 
   ee:
-    runs-on: [self-hosted, X64, Linux, 4c8g, "${{ inputs.runner_provider }}"]
+    runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]
     strategy:
       fail-fast: false
       matrix:
@@ -221,6 +256,7 @@ jobs:
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
+          type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_ee_sqllogic_standalone_linux
         timeout-minutes: 15
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,12 +1593,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.58",
+ "which",
 ]
 
 [[package]]
@@ -5267,7 +5297,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmp-serde",
- "rustls 0.22.4",
+ "rustls 0.23.12",
  "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "rustyline",
@@ -10396,6 +10426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "mockall"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11148,17 +11184,17 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148ab944991b0a33be74d2636a815268974578812a9e4cf7dc785325e858154"
+source = "git+https://github.com/databendlabs/opensrv?rev=6cbb806#6cbb80670116e8acce5dd4c473356e8df039804f"
 dependencies = [
  "async-trait",
  "byteorder",
+ "bytes",
  "chrono",
  "mysql_common 0.32.4",
  "nom",
  "pin-project-lite",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
 ]
 
 [[package]]
@@ -13591,6 +13627,7 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -13666,6 +13703,7 @@ version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -16893,6 +16931,18 @@ dependencies = [
  "libc",
  "memory_units",
  "winapi",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,10 +364,6 @@ opt-level = "s"
 # databend-query = { codegen-units = 4 }
 # databend-binaries = { codegen-units = 4 }
 
-[profile.bench]
-debug = true
-overflow-checks = false
-
 [profile.dev]
 split-debuginfo = "unpacked"
 overflow-checks = false
@@ -381,6 +377,10 @@ gimli = { opt-level = 3 }
 miniz_oxide = { opt-level = 3 }
 object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
+
+[profile.bench]
+debug = true
+overflow-checks = false
 
 [profile.test]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,7 +405,9 @@ ethnum = { git = "https://github.com/ariesdevil/ethnum-rs", rev = "4cb05f1" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 # patched opendal which categories the XML dersierialization errors as recoverable
 opendal = { git = "https://github.com/datafuse-extras/opendal-for-release-v1.2.636", rev = "6c490a0" }
+opensrv-mysql = { git = "https://github.com/databendlabs/opensrv", rev = "6cbb806" }
 orc-rust = { git = "https://github.com/youngsofun/datafusion-orc", rev = "1745375" }
 recursive = { git = "https://github.com/zhang2014/recursive.git", rev = "6af35a1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }
+

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -153,7 +153,7 @@ rand = { workspace = true }
 recursive = "0.1.1"
 regex = { workspace = true }
 reqwest = { workspace = true }
-rustls = "0.22"
+rustls = "0.23"
 rustls-pemfile = "2"
 rustls-pki-types = "1"
 rustyline = "14"

--- a/tests/sqllogictests/suites/query/set.test
+++ b/tests/sqllogictests/suites/query/set.test
@@ -1,14 +1,14 @@
 statement ok
-SET GLOBAL (max_threads, storage_io_min_bytes_for_seek) = (4, 56);
+SET GLOBAL (max_threads, storage_io_min_bytes_for_seek) = (13, 56);
 
 query TT
 select value, default = value  from system.settings where name in ('max_threads', 'storage_io_min_bytes_for_seek') order by value;
 ----
-4 0
+13 0
 56 0
 
 statement ok
-set variable (a, b) = (select 3, 55)
+set variable (a, b) = (select 12, 55)
 
 
 statement ok
@@ -17,7 +17,7 @@ SET GLOBAL (max_threads, storage_io_min_bytes_for_seek) = select $a + 1, $b + 1;
 query TT
 select value, default = value  from system.settings where name in ('max_threads', 'storage_io_min_bytes_for_seek') order by value;
 ----
-4 0
+13 0
 56 0
 
 statement ok
@@ -36,7 +36,7 @@ statement ok
 set variable (b, c) = ('yy', 'zz');
 
 query ITT
-select $a + getvariable('a') + $a, getvariable('b'), getvariable('c'), getvariable('d')  
+select $a + getvariable('a') + $a, getvariable('b'), getvariable('c'), getvariable('d')
 ----
 3 yy zz NULL
 
@@ -44,7 +44,7 @@ statement ok
 unset variable (a, b)
 
 query ITT
-select getvariable('a'), getvariable('b'), 'xx' || 'yy' || getvariable('c') , getvariable('d')  
+select getvariable('a'), getvariable('b'), 'xx' || 'yy' || getvariable('c') , getvariable('d')
 ----
 NULL NULL xxyyzz NULL
 

--- a/tests/sqllogictests/suites/tpch_iceberg/prune.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/prune.test
@@ -1,0 +1,141 @@
+statement ok
+DROP CATALOG IF EXISTS ctl;
+
+statement ok
+CREATE CATALOG ctl
+TYPE=ICEBERG
+CONNECTION=(
+    TYPE='rest'
+    ADDRESS='http://127.0.0.1:8181'
+    WAREHOUSE='s3://iceberg-tpch'
+    "s3.region"='us-east-1'
+    "s3.endpoint"='http://127.0.0.1:9000'
+);
+
+## note: the tests only cover standalone mode
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1;
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [is_true(lineitem.l_orderkey (#0) < 1)]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true(lineitem.l_orderkey (#0) < 1)], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1 or l_commitdate < '1992-01-31';
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [is_true((lineitem.l_orderkey (#0) < 1 OR lineitem.l_commitdate (#11) < '1992-01-31'))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0), l_commitdate (#11)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [is_true((lineitem.l_orderkey (#0) < 1 OR lineitem.l_commitdate (#11) < '1992-01-31'))], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1 and l_commitdate > '1992-01-31';
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [is_true(lineitem.l_orderkey (#0) < 1), is_true(lineitem.l_commitdate (#11) > '1992-01-31')]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0), l_commitdate (#11)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [and_filters(lineitem.l_orderkey (#0) < 1, lineitem.l_commitdate (#11) > '1992-01-31')], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey > 1 and l_commitdate = '1992-01-22';
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [is_true(lineitem.l_orderkey (#0) > 1), is_true(lineitem.l_commitdate (#11) = '1992-01-22')]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0), l_commitdate (#11)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [and_filters(lineitem.l_orderkey (#0) > 1, lineitem.l_commitdate (#11) = '1992-01-22')], limit: NONE]
+        └── estimated rows: 0.00
+
+
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey is null;
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [NOT is_not_null(lineitem.l_orderkey (#0))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0)]
+        ├── read rows: 0
+        ├── read size: 0
+        ├── partitions total: 0
+        ├── partitions scanned: 0
+        ├── push downs: [filters: [NOT is_not_null(lineitem.l_orderkey (#0))], limit: NONE]
+        └── estimated rows: 0.00
+
+query T
+explain select 1 from  ctl.tpch.lineitem where l_orderkey is null or l_commitdate is not null;
+----
+EvalScalar
+├── output columns: [1 (#16)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: []
+    ├── filters: [(NOT is_not_null(lineitem.l_orderkey (#0)) OR is_not_null(lineitem.l_commitdate (#11)))]
+    ├── estimated rows: 0.00
+    └── TableScan
+        ├── table: ctl.tpch.lineitem
+        ├── output columns: [l_orderkey (#0), l_commitdate (#11)]
+        ├── read rows: 600572
+        ├── read size: 14.27 MiB
+        ├── partitions total: 4
+        ├── partitions scanned: 4
+        ├── push downs: [filters: [(NOT is_not_null(lineitem.l_orderkey (#0)) OR is_not_null(lineitem.l_commitdate (#11)))], limit: NONE]
+        └── estimated rows: 0.00


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

## Summary

The issue described in [#16892](https://github.com/databendlabs/databend/issues/16892), is caused by a read-after-use bug in the `opersrv` crate (ver 0.7).

### Description:
Valgrind identifies that, during the connection establishment between the MariaDB JDBC client and Databend's MySQL service, memory freed by `opensrv_mysql::packet_reader::PacketReader` is being accessed, leading to the failure of MySQL connection establishment (failed to process the input MySQL protocol command correctly).

### Resolution:
Fortunately, this issue has been fixed by [@discord9](https://github.com/discord9) in [PR #67](https://github.com/databendlabs/opensrv/pull/67). As a result, in this PR, the `opensrv` version used has been updated to commit `#6cbb806` (and `rustls` has been bumped to version `0.23` to align with the version needed by `opensrv`)

### Note:
To "reproduce" the following valgrind messages, Databend should be compiled using the standard memory allocator. Using the default `jemalloc` , valgrind can not detect any issues.


~~~
--1403874-- When reading debug info from /home/usr/workspace/fuse-query/target/debug/databend-query:
--1403874-- confused by the above DIE
==1403874== Warning: set address range perms: large range [0x7a8b000, 0x1e45e000) (defined)
==1403874== Thread 52 mysql-query-exe:
==1403874== Invalid read of size 1
==1403874==    at 0xCB0436A: core::cmp::impls::<impl core::cmp::PartialEq for u8>::ne (cmp.rs:1481)
==1403874==    by 0xCB04398: core::cmp::impls::<impl core::cmp::PartialEq<&B> for &A>::ne (cmp.rs:1665)
==1403874==    by 0xCB00909: <&[u8] as nom::traits::Compare<&[u8]>>::compare::{{closure}} (traits.rs:740)
==1403874==    by 0xCAFF860: core::iter::traits::iterator::Iterator::position::check::{{closure}} (iterator.rs:3055)
==1403874==    by 0xCAFF987: core::iter::traits::iterator::Iterator::try_fold (iterator.rs:2410)
==1403874==    by 0xCAFF7E6: core::iter::traits::iterator::Iterator::position (iterator.rs:3065)
==1403874==    by 0xCAFE103: nom::bytes::complete::tag::{{closure}} (traits.rs:740)
==1403874==    by 0xCAFFFE0: <F as nom::internal::Parser<I,O,E>>::parse (internal.rs:325)
==1403874==    by 0xCB03E60: nom::sequence::preceded::{{closure}} (mod.rs:72)
==1403874==    by 0xCB04490: <F as nom::internal::Parser<I,O,E>>::parse (internal.rs:325)
==1403874==    by 0xCAFBC48: nom::combinator::map::{{closure}} (mod.rs:79)
==1403874==    by 0xCAFD0D0: <F as nom::internal::Parser<I,O,E>>::parse (internal.rs:325)
==1403874==  Address 0x577556b4 is 4 bytes inside a block of size 4,096 free'd
==1403874==    at 0x2020427F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1403874==    by 0x7AE1053: <std::alloc::System as core::alloc::Allocator>::deallocate (alloc.rs:48)
==1403874==    by 0x7AE8577: <databend_common_base::mem_allocator::global::GlobalAllocator as core::alloc::global::GlobalAlloc>::dealloc (std_.rs:53)
==1403874==    by 0x7AED912: __rust_dealloc (ee_main.rs:35)
==1403874==    by 0x18FCF96C: <alloc::alloc::Global as core::alloc::Allocator>::deallocate (alloc.rs:119)
==1403874==    by 0x18FCFBCE: <alloc::raw_vec::RawVec<T,A> as core::ops::drop::Drop>::drop (raw_vec.rs:600)
==1403874==    by 0x18FCF4DA: core::ptr::drop_in_place<alloc::raw_vec::RawVec<u8>> (mod.rs:542)
==1403874==    by 0x18FCF473: core::ptr::drop_in_place<alloc::vec::Vec<u8>> (mod.rs:542)
==1403874==    by 0x8F7875F: opensrv_mysql::packet_reader::PacketReader<R>::next_async::{{closure}} (packet_reader.rs:138)
==1403874==    by 0xB05BA24: opensrv_mysql::AsyncMysqlIntermediary<B,R,W>::run::{{closure}} (lib.rs:562)
==1403874==    by 0x97EE0B0: opensrv_mysql::tls::plain_run_with_options::{{closure}} (tls.rs:57)
==1403874==    by 0x920F83F: databend_query::servers::mysql::mysql_session::MySQLConnection::run_on_stream::{{closure}}::{{closure}} (mysql_session.rs:92)
==1403874==  Block was alloc'd at
==1403874==    at 0x20201899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1403874==    by 0x7ADF339: std::sys::pal::unix::alloc::<impl core::alloc::global::GlobalAlloc for std::alloc::System>::alloc (alloc.rs:14)
==1403874==    by 0x7ADF55D: std::alloc::System::alloc_impl (alloc.rs:145)
==1403874==    by 0x7AE16A8: <std::alloc::System as core::alloc::Allocator>::allocate (alloc.rs:208)
==1403874==    by 0x7AE83D8: <databend_common_base::mem_allocator::global::GlobalAllocator as core::alloc::global::GlobalAlloc>::alloc (std_.rs:41)
==1403874==    by 0x7AED8B1: __rust_alloc (ee_main.rs:35)
==1403874==    by 0x1DB66D6A: alloc::alloc::alloc (alloc.rs:100)
==1403874==    by 0x1DB66EB0: alloc::alloc::Global::alloc_impl (alloc.rs:183)
==1403874==    by 0x1DB67E98: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:243)
==1403874==    by 0x1DB6992A: alloc::raw_vec::finish_grow (raw_vec.rs:590)
==1403874==    by 0x1DB69E20: alloc::raw_vec::RawVec<T,A>::grow_amortized (raw_vec.rs:486)
==1403874==    by 0x1DB6A778: alloc::raw_vec::RawVec<T,A>::reserve::do_reserve_and_handle (raw_vec.rs:349)

....
~~~

- related issue : #16892


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - manually tested
## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe): 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16893)
<!-- Reviewable:end -->
