### PR TITLE
refactor: add new raft-log metrics to "metactl status" response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,7 +3325,6 @@ dependencies = [
  "chrono-tz 0.8.6",
  "comfy-table",
  "criterion",
- "dashmap 6.1.0",
  "databend-common-ast",
  "databend-common-base",
  "databend-common-column",

--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -237,6 +237,23 @@ impl App {
         println!("BinaryVersion: {}", res.binary_version);
         println!("DataVersion: {}", res.data_version);
         println!("RaftLogSize: {}", res.raft_log_size);
+        if let Some(s) = res.raft_log_status {
+            println!("RaftLog:");
+            println!("  - CacheItems: {}", s.cache_items);
+            println!("  - CacheUsedSize: {}", s.cache_used_size);
+            println!("  - WALTotalSize: {}", s.wal_total_size);
+            println!("  - WALOpenChunkSize: {}", s.wal_open_chunk_size);
+            println!("  - WALOffset: {}", s.wal_offset);
+            println!("  - WALClosedChunkCount: {}", s.wal_closed_chunk_count);
+            println!(
+                "  - WALClosedChunkTotalSize: {}",
+                s.wal_closed_chunk_total_size
+            );
+            println!("  - WALClosedChunkSizes:");
+            for (k, v) in s.wal_closed_chunk_sizes {
+                println!("    - {}: {}", k, v);
+            }
+        }
         println!("SnapshotKeyCount: {}", res.snapshot_key_count);
         println!("Node: id={} raft={}", res.id, res.endpoint);
         println!("State: {}", res.state);

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -462,7 +462,20 @@ impl MetaService for MetaServiceImpl {
             binary_version: status.binary_version,
             data_version: status.data_version.to_string(),
             endpoint: status.endpoint,
-            raft_log_size: status.raft_log_size,
+
+            raft_log_size: status.raft_log.wal_total_size,
+
+            raft_log_status: Some(pb::RaftLogStatus {
+                cache_items: status.raft_log.cache_items,
+                cache_used_size: status.raft_log.cache_used_size,
+                wal_total_size: status.raft_log.wal_total_size,
+                wal_open_chunk_size: status.raft_log.wal_open_chunk_size,
+                wal_offset: status.raft_log.wal_offset,
+                wal_closed_chunk_count: status.raft_log.wal_closed_chunk_count,
+                wal_closed_chunk_total_size: status.raft_log.wal_closed_chunk_total_size,
+                wal_closed_chunk_sizes: status.raft_log.wal_closed_chunk_sizes,
+            }),
+
             snapshot_key_count: status.snapshot_key_count as u64,
             state: status.state,
             is_leader: status.is_leader,

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -852,8 +852,8 @@ impl MetaNode {
 
         let endpoint = self.sto.get_node_raft_endpoint(&self.sto.id).await?;
 
-        let raft_log_size = self.get_raft_log_size().await;
-        let key_count = self.get_snapshot_key_count().await;
+        let raft_log_status = self.get_raft_log_stat().await.into();
+        let snapshot_key_count = self.get_snapshot_key_count().await;
 
         let metrics = self.raft.metrics().borrow().clone();
 
@@ -870,8 +870,8 @@ impl MetaNode {
             binary_version: METASRV_COMMIT_VERSION.as_str().to_string(),
             data_version: DATA_VERSION,
             endpoint: endpoint.to_string(),
-            raft_log_size,
-            snapshot_key_count: key_count,
+            raft_log: raft_log_status,
+            snapshot_key_count,
             state: format!("{:?}", metrics.state),
             is_leader: metrics.state == openraft::ServerState::Leader,
             current_term: metrics.current_term,

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -45,6 +45,7 @@ fn build_proto() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     tonic_build::configure()
+        .btree_map(["RaftLogStatus.wal_closed_chunk_sizes"])
         .file_descriptor_set_path(out_dir.join("meta_descriptor.bin"))
         .type_attribute(
             "SeqV",

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -36,9 +36,9 @@ message TransferLeaderRequest {
   LogId last_log_id = 3;
 }
 
-message MemberListRequest { string data = 1; }
+message MemberListRequest {string data = 1;}
 
-message MemberListReply { repeated string data = 1; }
+message MemberListReply {repeated string data = 1;}
 
 message HandshakeRequest {
   uint64 protocol_version = 1;
@@ -94,7 +94,7 @@ message Event {
   optional SeqV prev = 3;
 }
 
-message WatchResponse { Event event = 1; }
+message WatchResponse {Event event = 1;}
 
 // messages for txn
 message TxnCondition {
@@ -181,6 +181,19 @@ message ClusterStatus {
   repeated string non_voters = 16;
   uint64 last_seq = 17;
   uint64 snapshot_key_count = 18;
+  RaftLogStatus raft_log_status = 19;
+}
+
+// Status about local raft-log storage
+message RaftLogStatus {
+  uint64 cache_items = 1;
+  uint64 cache_used_size = 2;
+  uint64 wal_total_size = 3;
+  uint64 wal_open_chunk_size = 4;
+  uint64 wal_offset = 5;
+  uint64 wal_closed_chunk_count = 6;
+  uint64 wal_closed_chunk_total_size = 7;
+  map<string, uint64> wal_closed_chunk_sizes = 8;
 }
 
 message ClientInfo {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add new raft-log metrics to "metactl status" response

These new metrics are added to gRPC API `GetClusterStatus` and
corresponding databend-metactl CLI command.

Newly added metrics are:

```
$ databend-metactl status
# ...
RaftLog:
  - CacheItems: 287
  - CacheUsedSize: 4959439
  - WALTotalSize: 4378076
  - WALOpenChunkSize: 4378058
  - WALOffset: 4378076
  - WALClosedChunkCount: 1
  - WALClosedChunkTotalSize: 18
  - WALClosedChunkSizes:
    - ChunkId(00_000_000_000_000_000_000): 18
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16899)
<!-- Reviewable:end -->
