### PR TITLE
chore: remove unused config_id from RaftConfig

### DIFF
--- a/src/meta/binaries/meta/entry.rs
+++ b/src/meta/binaries/meta/entry.rs
@@ -197,7 +197,7 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
 }
 
 async fn do_register(meta_node: &Arc<MetaNode>, conf: &Config) -> Result<(), MetaAPIError> {
-    let node_id = meta_node.sto.id;
+    let node_id = meta_node.raft_store.id;
     let raft_endpoint = conf.raft_config.raft_api_advertise_host_endpoint();
     let node = Node::new(node_id, raft_endpoint)
         .with_grpc_advertise_address(conf.grpc_api_advertise_address());

--- a/src/meta/binaries/metactl/export_from_disk.rs
+++ b/src/meta/binaries/metactl/export_from_disk.rs
@@ -17,7 +17,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use databend_common_meta_raft_store::config::RaftConfig;
-use databend_meta::store::StoreInner;
+use databend_meta::store::RaftStoreInner;
 use futures::TryStreamExt;
 
 use crate::upgrade;
@@ -36,7 +36,7 @@ pub async fn export_from_dir(args: &ExportArgs) -> anyhow::Result<()> {
     eprintln!();
     eprintln!("Export:");
 
-    let sto_inn = StoreInner::open(&raft_config).await?;
+    let sto_inn = RaftStoreInner::open(&raft_config).await?;
     let mut lines = Arc::new(sto_inn).export();
 
     eprintln!("    From: {}", raft_config.raft_dir);

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -362,7 +362,7 @@ impl MetaService for MetaServiceImpl {
         let _guard = RequestInFlight::guard();
 
         let meta_node = &self.meta_node;
-        let strm = meta_node.sto.inner().export();
+        let strm = meta_node.raft_store.inner().export();
 
         let chunk_size = 32;
         // - Chunk up upto 32 Ok items inside a Vec<String>;
@@ -390,7 +390,7 @@ impl MetaService for MetaServiceImpl {
         let _guard = RequestInFlight::guard();
 
         let meta_node = &self.meta_node;
-        let strm = meta_node.sto.inner().export();
+        let strm = meta_node.raft_store.inner().export();
 
         let chunk_size = request.get_ref().chunk_size.unwrap_or(32) as usize;
         // - Chunk up upto `chunk_size` Ok items inside a Vec<String>;

--- a/src/meta/service/src/configs/outer_v0.rs
+++ b/src/meta/service/src/configs/outer_v0.rs
@@ -279,7 +279,6 @@ pub struct ConfigViaEnv {
     pub grpc_tls_server_cert: String,
     pub grpc_tls_server_key: String,
 
-    pub config_id: String,
     pub kvsrv_listen_host: String,
     pub kvsrv_advertise_host: String,
     pub kvsrv_api_port: u16,
@@ -338,7 +337,6 @@ impl From<Config> for ConfigViaEnv {
             metasrv_grpc_api_advertise_host: cfg.grpc_api_advertise_host,
             grpc_tls_server_cert: cfg.grpc_tls_server_cert,
             grpc_tls_server_key: cfg.grpc_tls_server_key,
-            config_id: cfg.raft_config.config_id,
             kvsrv_listen_host: cfg.raft_config.raft_listen_host,
             kvsrv_advertise_host: cfg.raft_config.raft_advertise_host,
             kvsrv_api_port: cfg.raft_config.raft_api_port,
@@ -377,7 +375,6 @@ impl From<Config> for ConfigViaEnv {
 impl Into<Config> for ConfigViaEnv {
     fn into(self) -> Config {
         let raft_config = RaftConfig {
-            config_id: self.config_id,
             raft_listen_host: self.kvsrv_listen_host,
             raft_advertise_host: self.kvsrv_advertise_host,
             raft_api_port: self.kvsrv_api_port,
@@ -457,11 +454,6 @@ impl Into<Config> for ConfigViaEnv {
 #[clap(about, version, author)]
 #[serde(default)]
 pub struct RaftConfig {
-    /// Identify a config.
-    /// This is only meant to make debugging easier with more than one Config involved.
-    #[clap(long, default_value = "")]
-    pub config_id: String,
-
     /// The local listening host for metadata communication.
     /// This config does not need to be stored in raft-store,
     /// only used when metasrv startup and listen to.
@@ -610,7 +602,7 @@ impl Default for RaftConfig {
 impl From<RaftConfig> for InnerRaftConfig {
     fn from(x: RaftConfig) -> InnerRaftConfig {
         InnerRaftConfig {
-            config_id: x.config_id,
+            config_id: "".to_string(),
             raft_listen_host: x.raft_listen_host,
             raft_advertise_host: x.raft_advertise_host,
             raft_api_port: x.raft_api_port,
@@ -649,7 +641,6 @@ impl From<RaftConfig> for InnerRaftConfig {
 impl From<InnerRaftConfig> for RaftConfig {
     fn from(inner: InnerRaftConfig) -> Self {
         Self {
-            config_id: inner.config_id,
             raft_listen_host: inner.raft_listen_host,
             raft_advertise_host: inner.raft_advertise_host,
             raft_api_port: inner.raft_api_port,

--- a/src/meta/service/src/lib.rs
+++ b/src/meta/service/src/lib.rs
@@ -27,9 +27,3 @@ pub(crate) mod request_handling;
 pub mod store;
 pub mod version;
 pub mod watcher;
-
-pub trait Opened {
-    /// Return true if it is opened from a previous persistent state.
-    /// Otherwise it is just created.
-    fn is_opened(&self) -> bool;
-}

--- a/src/meta/service/src/meta_service/forwarder.rs
+++ b/src/meta/service/src/meta_service/forwarder.rs
@@ -47,7 +47,7 @@ pub struct MetaForwarder<'a> {
 impl<'a> MetaForwarder<'a> {
     pub fn new(meta_node: &'a MetaNode) -> Self {
         Self {
-            sto: &meta_node.sto,
+            sto: &meta_node.raft_store,
             raft: &meta_node.raft,
         }
     }

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -167,7 +167,7 @@ impl<'a> Handler<MetaGrpcReadReq> for MetaLeader<'a> {
 impl<'a> MetaLeader<'a> {
     pub fn new(meta_node: &'a MetaNode) -> MetaLeader {
         MetaLeader {
-            sto: &meta_node.sto,
+            sto: &meta_node.raft_store,
             raft: &meta_node.raft,
         }
     }

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -34,6 +34,7 @@ use databend_common_meta_raft_store::config::RaftConfig;
 use databend_common_meta_raft_store::ondisk::DATA_VERSION;
 use databend_common_meta_raft_store::raft_log_v004::RaftLogStat;
 use databend_common_meta_sled_store::openraft;
+use databend_common_meta_sled_store::openraft::error::RaftError;
 use databend_common_meta_sled_store::openraft::ChangeMembers;
 use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::protobuf::raft_service_client::RaftServiceClient;
@@ -41,6 +42,7 @@ use databend_common_meta_types::protobuf::raft_service_server::RaftServiceServer
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::raft_types::CommittedLeaderId;
 use databend_common_meta_types::raft_types::ForwardToLeader;
+use databend_common_meta_types::raft_types::InitializeError;
 use databend_common_meta_types::raft_types::LogId;
 use databend_common_meta_types::raft_types::MembershipNode;
 use databend_common_meta_types::raft_types::NodeId;
@@ -95,17 +97,16 @@ use crate::watcher::EventDispatcher;
 use crate::watcher::EventDispatcherHandle;
 use crate::watcher::Watcher;
 use crate::watcher::WatcherSender;
-use crate::Opened;
 
 pub type LogStore = RaftStore;
 pub type SMStore = RaftStore;
 
-/// MetaRaft is a implementation of the generic Raft handling meta data R/W.
+/// MetaRaft is an implementation of the generic Raft handling metadata R/W.
 pub type MetaRaft = Raft<TypeConfig>;
 
-/// MetaNode is the container of meta data related components and threads, such as storage, the raft node and a raft-state monitor.
+/// MetaNode is the container of metadata related components and threads, such as storage, the raft node and a raft-state monitor.
 pub struct MetaNode {
-    pub sto: RaftStore,
+    pub raft_store: RaftStore,
     pub dispatcher_handle: EventDispatcherHandle,
     pub raft: MetaRaft,
     pub running_tx: watch::Sender<()>,
@@ -118,15 +119,9 @@ impl Drop for MetaNode {
     fn drop(&mut self) {
         info!(
             "MetaNode(id={}, raft={}) is dropping",
-            self.sto.id,
-            self.sto.config.raft_api_advertise_host_string()
+            self.raft_store.id,
+            self.raft_store.config.raft_api_advertise_host_string()
         );
-    }
-}
-
-impl Opened for MetaNode {
-    fn is_opened(&self) -> bool {
-        self.sto.is_opened()
     }
 }
 
@@ -171,7 +166,7 @@ impl MetaNodeBuilder {
             .set_subscriber(Box::new(DispatcherSender(dispatcher_tx.clone())));
 
         let meta_node = Arc::new(MetaNode {
-            sto: sto.clone(),
+            raft_store: sto.clone(),
             dispatcher_handle: EventDispatcherHandle::new(dispatcher_tx),
             raft: raft.clone(),
             running_tx: tx,
@@ -290,7 +285,7 @@ impl MetaNode {
         info!("about to start raft grpc on: {}", ip_port);
 
         let socket_addr = ip_port.parse::<std::net::SocketAddr>()?;
-        let node_id = meta_node.sto.id;
+        let node_id = meta_node.raft_store.id;
 
         let srv = tonic::transport::Server::builder().add_service(raft_server);
 
@@ -331,13 +326,17 @@ impl MetaNode {
             config.no_sync = true;
         }
 
-        let sto = RaftStore::open(&config).await?;
+        let log_store = RaftStore::open(&config).await?;
 
         // config.id only used for the first time
-        let self_node_id = if sto.is_opened() { sto.id } else { config.id };
+        let self_node_id = if log_store.is_opened {
+            log_store.id
+        } else {
+            config.id
+        };
 
         let builder = MetaNode::builder(&config)
-            .sto(sto.clone())
+            .sto(log_store.clone())
             .node_id(self_node_id)
             .raft_service_endpoint(config.raft_api_listen_host_endpoint());
         let mn = builder.build().await?;
@@ -404,7 +403,7 @@ impl MetaNode {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
-        info!("shutdown: id={}", self.sto.id);
+        info!("shutdown: id={}", self.raft_store.id);
         let joined = self.joined_tasks.load(std::sync::atomic::Ordering::Relaxed);
         Ok(joined)
     }
@@ -439,7 +438,7 @@ impl MetaNode {
                     server_metrics::incr_leader_change();
                 }
                 server_metrics::set_current_leader(mm.current_leader.unwrap_or_default());
-                server_metrics::set_is_leader(mm.current_leader == Some(meta_node.sto.id));
+                server_metrics::set_is_leader(mm.current_leader == Some(meta_node.raft_store.id));
 
                 // metrics about raft log and state machine.
                 server_metrics::set_current_term(mm.current_term);
@@ -630,7 +629,7 @@ impl MetaNode {
 
         Err(MetaManagementError::Join(AnyError::error(format!(
             "fail to join node-{} to cluster via {:?}, errors: {}",
-            self.sto.id,
+            self.raft_store.id,
             addrs,
             errors.into_iter().map(|e| e.to_string()).join(", ")
         ))))
@@ -724,20 +723,23 @@ impl MetaNode {
     ///   Only when the membership is committed, this node can be sure it is in a cluster.
     async fn is_in_cluster(&self) -> Result<Result<String, String>, MetaStorageError> {
         let membership = {
-            let sm = self.sto.get_state_machine().await;
+            let sm = self.raft_store.get_state_machine().await;
             sm.sys_data_ref().last_membership_ref().membership().clone()
         };
         info!("is_in_cluster: membership: {:?}", membership);
 
         let voter_ids = membership.voter_ids().collect::<BTreeSet<_>>();
 
-        if voter_ids.contains(&self.sto.id) {
-            return Ok(Ok(format!("node {} already in cluster", self.sto.id)));
+        if voter_ids.contains(&self.raft_store.id) {
+            return Ok(Ok(format!(
+                "node {} already in cluster",
+                self.raft_store.id
+            )));
         }
 
         Ok(Err(format!(
             "node {} has membership but not in it",
-            self.sto.id
+            self.raft_store.id
         )))
     }
 
@@ -768,14 +770,9 @@ impl MetaNode {
     /// - Adding current node into the meta data.
     #[fastrace::trace]
     pub async fn init_cluster(&self, node: Node) -> Result<(), MetaStartupError> {
-        info!("init_cluster: node: {:?}", node);
+        info!("Initialize node as single node cluster: {:?}", node);
 
-        if self.is_opened() {
-            info!("It is opened, skip initializing cluster");
-            return Ok(());
-        }
-
-        let node_id = self.sto.id;
+        let node_id = self.raft_store.id;
 
         let mut cluster_node_ids = BTreeSet::new();
         cluster_node_ids.insert(node_id);
@@ -783,19 +780,45 @@ impl MetaNode {
         // initialize() and add_node() are not done atomically.
         // There is an issue that just after initializing the cluster,
         // the node will be used but no node info is found.
-        // Thus meta-server can only be initialized with a single node.
+        // Thus, meta-server can only be initialized with a single node.
         //
         // We do not store node info in membership config,
         // because every start a meta-server node updates its latest configured address.
-        self.raft.initialize(cluster_node_ids).await?;
+        let res = self.raft.initialize(cluster_node_ids.clone()).await;
+        match res {
+            Ok(_) => {
+                info!("Initialized with: {:?}", cluster_node_ids);
+            }
+            Err(e) => match e {
+                RaftError::APIError(e) => match e {
+                    InitializeError::NotAllowed(e) => {
+                        info!("Already initialized: {}", e);
+                    }
+                    InitializeError::NotInMembers(e) => {
+                        return Err(MetaStartupError::InvalidConfig(e.to_string()));
+                    }
+                },
+                RaftError::Fatal(fatal) => {
+                    return Err(MetaStartupError::MetaServiceError(fatal.to_string()));
+                }
+            },
+        }
 
-        info!("initialized cluster");
-
-        self.add_node(node_id, node)
-            .await
-            .map_err(|e| MetaStartupError::AddNodeError {
-                source: AnyError::new(&e),
+        if self.get_node(&node_id).await.is_none() {
+            info!(
+                "This node not found in state-machine; add node: {}:{:?}",
+                node_id, node
+            );
+            self.add_node(node_id, node.clone()).await.map_err(|e| {
+                MetaStartupError::AddNodeError {
+                    source: AnyError::new(&e),
+                }
             })?;
+        } else {
+            info!("This node already in state-machine; No need to add");
+        }
+
+        info!("Done initializing node as single node cluster: {:?}", node);
 
         Ok(())
     }
@@ -804,7 +827,7 @@ impl MetaNode {
     pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         // inconsistent get: from local state machine
 
-        let sm = self.sto.state_machine.read().await;
+        let sm = self.raft_store.state_machine.read().await;
         let n = sm.sys_data_ref().nodes_ref().get(node_id).cloned();
         n
     }
@@ -813,7 +836,7 @@ impl MetaNode {
     pub async fn get_nodes(&self) -> Vec<Node> {
         // inconsistent get: from local state machine
 
-        let sm = self.sto.state_machine.read().await;
+        let sm = self.raft_store.state_machine.read().await;
         let nodes = sm
             .sys_data_ref()
             .nodes_ref()
@@ -825,15 +848,15 @@ impl MetaNode {
 
     /// Get the size in bytes of the on disk files of the raft log storage.
     async fn get_raft_log_size(&self) -> u64 {
-        self.sto.log.read().await.on_disk_size()
+        self.raft_store.log.read().await.on_disk_size()
     }
 
     async fn get_raft_log_stat(&self) -> RaftLogStat {
-        self.sto.log.read().await.stat()
+        self.raft_store.log.read().await.stat()
     }
 
     async fn get_snapshot_key_count(&self) -> u64 {
-        self.sto
+        self.raft_store
             .try_get_snapshot_key_count()
             .await
             .unwrap_or_default()
@@ -841,16 +864,19 @@ impl MetaNode {
 
     pub async fn get_status(&self) -> Result<MetaNodeStatus, MetaError> {
         let voters = self
-            .sto
+            .raft_store
             .get_nodes(|ms| ms.voter_ids().collect::<Vec<_>>())
             .await;
 
         let learners = self
-            .sto
+            .raft_store
             .get_nodes(|ms| ms.learner_ids().collect::<Vec<_>>())
             .await;
 
-        let endpoint = self.sto.get_node_raft_endpoint(&self.sto.id).await?;
+        let endpoint = self
+            .raft_store
+            .get_node_raft_endpoint(&self.raft_store.id)
+            .await?;
 
         let raft_log_status = self.get_raft_log_stat().await.into();
         let snapshot_key_count = self.get_snapshot_key_count().await;
@@ -866,7 +892,7 @@ impl MetaNode {
         let last_seq = self.get_last_seq().await;
 
         Ok(MetaNodeStatus {
-            id: self.sto.id,
+            id: self.raft_store.id,
             binary_version: METASRV_COMMIT_VERSION.as_str().to_string(),
             data_version: DATA_VERSION,
             endpoint: endpoint.to_string(),
@@ -890,7 +916,7 @@ impl MetaNode {
     }
 
     pub(crate) async fn get_last_seq(&self) -> u64 {
-        let sm = self.sto.state_machine.read().await;
+        let sm = self.raft_store.state_machine.read().await;
         sm.sys_data_ref().curr_seq()
     }
 
@@ -899,7 +925,7 @@ impl MetaNode {
         // Maybe stale get: from local state machine
 
         let nodes = {
-            let sm = self.sto.state_machine.read().await;
+            let sm = self.raft_store.state_machine.read().await;
             sm.sys_data_ref()
                 .nodes_ref()
                 .values()
@@ -1036,7 +1062,7 @@ impl MetaNode {
 
         debug!("curr_leader_id: {:?}", leader_id);
 
-        if leader_id == Some(self.sto.id) {
+        if leader_id == Some(self.raft_store.id) {
             return Ok(MetaLeader::new(self));
         }
 

--- a/src/meta/service/src/meta_service/raft_service_impl.rs
+++ b/src/meta/service/src/meta_service/raft_service_impl.rs
@@ -148,7 +148,7 @@ impl RaftServiceImpl {
 
         let resp = InstallSnapshotResponse { vote: my_vote };
 
-        let ss_store = self.meta_node.sto.snapshot_store();
+        let ss_store = self.meta_node.raft_store.snapshot_store();
 
         let finished_snapshot = {
             let mut receiver_v1 = self.receiver_v1.lock().await;
@@ -194,7 +194,7 @@ impl RaftServiceImpl {
             ..
         } = received;
 
-        let raft_config = &self.meta_node.sto.config;
+        let raft_config = &self.meta_node.raft_store.config;
 
         let db = DB::open_snapshot(&temp_path, snapshot_meta.snapshot_id.clone(), raft_config)
             .map_err(|e| {
@@ -235,7 +235,7 @@ impl RaftServiceImpl {
 
         let _guard = snapshot_recv_inflight(&addr).counter_guard();
 
-        let ss_store = self.meta_node.sto.snapshot_store();
+        let ss_store = self.meta_node.raft_store.snapshot_store();
 
         let mut receiver_v003 = ss_store.new_receiver(&addr).map_err(io_err_to_status)?;
         receiver_v003.set_on_recv_callback(new_incr_recvfrom_bytes(addr.clone()));

--- a/src/meta/service/src/store/mod.rs
+++ b/src/meta/service/src/store/mod.rs
@@ -19,4 +19,4 @@ mod store;
 mod store_inner;
 
 pub use store::RaftStore;
-pub use store_inner::StoreInner;
+pub use store_inner::RaftStoreInner;

--- a/src/meta/service/src/store/store.rs
+++ b/src/meta/service/src/store/store.rs
@@ -18,36 +18,32 @@ use std::sync::Arc;
 use databend_common_meta_raft_store::config::RaftConfig;
 use databend_common_meta_types::MetaStartupError;
 
-use crate::store::StoreInner;
+use crate::store::RaftStoreInner;
 
 /// A store that implements `RaftStorage` trait and provides full functions.
 ///
 /// It is designed to be cloneable in order to be shared by MetaNode and Raft.
 #[derive(Clone)]
 pub struct RaftStore {
-    pub(crate) inner: Arc<StoreInner>,
+    pub(crate) inner: Arc<RaftStoreInner>,
 }
 
 impl RaftStore {
-    pub fn new(sto: StoreInner) -> Self {
-        Self {
-            inner: Arc::new(sto),
-        }
-    }
-
     #[fastrace::trace]
     pub async fn open(config: &RaftConfig) -> Result<Self, MetaStartupError> {
-        let sto = StoreInner::open(config).await?;
-        Ok(Self::new(sto))
+        let inner = RaftStoreInner::open(config).await?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
-    pub fn inner(&self) -> Arc<StoreInner> {
+    pub fn inner(&self) -> Arc<RaftStoreInner> {
         self.inner.clone()
     }
 }
 
 impl Deref for RaftStore {
-    type Target = StoreInner;
+    type Target = RaftStoreInner;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -84,10 +84,7 @@ impl RaftStoreInner {
     /// Open an existent raft-store or create a new one.
     #[fastrace::trace]
     pub async fn open(config: &RaftConfig) -> Result<RaftStoreInner, MetaStartupError> {
-        info!(
-            "open_or_create StoreInner: id={}, config_id={}",
-            config.id, config.config_id
-        );
+        info!("open_or_create StoreInner: id={}", config.id);
 
         fn to_startup_err(e: impl std::error::Error + 'static) -> MetaStartupError {
             let ae = AnyError::new(&e);

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -54,14 +54,8 @@ use log::info;
 use raft_log::api::raft_log_writer::RaftLogWriter;
 use tokio::time::sleep;
 
-use crate::Opened;
-
-/// This is the inner store that provides support utilities for implementing the raft storage API.
-///
-/// This store include two parts:
-///   log(including id, vote, committed, and purged)
-///   state_machine
-pub struct StoreInner {
+/// This is the inner store that implements the raft log storage API.
+pub struct RaftStoreInner {
     /// The ID of the Raft node for which this storage instances is configured.
     /// ID is also stored in raft-log.
     ///
@@ -71,7 +65,7 @@ pub struct StoreInner {
     pub(crate) config: RaftConfig,
 
     /// If the instance is opened from an existent state(e.g. load from fs) or created.
-    is_opened: bool,
+    pub is_opened: bool,
 
     /// A series of raft logs.
     pub log: Arc<RwLock<RaftLogV004>>,
@@ -80,23 +74,16 @@ pub struct StoreInner {
     pub state_machine: Arc<RwLock<SMV003>>,
 }
 
-impl AsRef<StoreInner> for StoreInner {
-    fn as_ref(&self) -> &StoreInner {
+impl AsRef<RaftStoreInner> for RaftStoreInner {
+    fn as_ref(&self) -> &RaftStoreInner {
         self
     }
 }
 
-impl Opened for StoreInner {
-    /// If the instance is opened(true) from an existent state(e.g. load from fs) or created(false).
-    fn is_opened(&self) -> bool {
-        self.is_opened
-    }
-}
-
-impl StoreInner {
+impl RaftStoreInner {
     /// Open an existent raft-store or create a new one.
     #[fastrace::trace]
-    pub async fn open(config: &RaftConfig) -> Result<StoreInner, MetaStartupError> {
+    pub async fn open(config: &RaftConfig) -> Result<RaftStoreInner, MetaStartupError> {
         info!(
             "open_or_create StoreInner: id={}, config_id={}",
             config.id, config.config_id
@@ -315,7 +302,7 @@ impl StoreInner {
     ///
     /// Returns a `BoxStream<'a, Result<String, io::Error>>` that yields a series of JSON strings.
     #[futures_async_stream::try_stream(boxed, ok = String, error = io::Error)]
-    pub async fn export(self: Arc<StoreInner>) {
+    pub async fn export(self: Arc<RaftStoreInner>) {
         info!("StoreInner::export start");
 
         // Convert an error occurred during export to `io::Error(InvalidData)`.

--- a/src/meta/service/tests/it/configs.rs
+++ b/src/meta/service/tests/it/configs.rs
@@ -78,7 +78,6 @@ cluster_name = "foo_cluster"
         assert_eq!(cfg.grpc_api_address, "127.0.0.1:10000");
         assert_eq!(cfg.grpc_tls_server_cert, "grpc server cert");
         assert_eq!(cfg.grpc_tls_server_key, "grpc server key");
-        assert_eq!(cfg.raft_config.config_id, "raft config id");
         assert_eq!(cfg.raft_config.raft_listen_host, "127.0.0.1");
         assert_eq!(cfg.raft_config.raft_api_port, 11000);
         assert_eq!(cfg.raft_config.raft_dir, "raft dir");

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -115,7 +115,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     // This way on every node applying a log always get the same result.
     info!("--- get updated kv with new expire, assert the updated value");
     {
-        let sm = learner.sto.state_machine.read().await;
+        let sm = learner.raft_store.state_machine.read().await;
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
         assert_eq!(Some(KVMeta::new_expire(now_sec + 1000)), seq_v.meta);

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -130,7 +130,10 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
         for mn in all.iter() {
             mn.raft
                 .wait(timeout())
-                .voter_ids(btreeset! {0,2}, format!("node-2 is joined: {}", mn.sto.id))
+                .voter_ids(
+                    btreeset! {0,2},
+                    format!("node-2 is joined: {}", mn.raft_store.id),
+                )
                 .await?;
         }
     }
@@ -165,7 +168,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
             .wait(timeout())
             .voter_ids(
                 btreeset! {0,2,3},
-                format!("node-3 is joined: {}", mn.sto.id),
+                format!("node-3 is joined: {}", mn.raft_store.id),
             )
             .await?;
     }
@@ -198,7 +201,10 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
     for mn in all.iter() {
         mn.raft
             .wait(timeout())
-            .voter_ids(btreeset! {0,2,3}, format!("node-{} membership", mn.sto.id))
+            .voter_ids(
+                btreeset! {0,2,3},
+                format!("node-{} membership", mn.raft_store.id),
+            )
             .await?;
     }
 
@@ -242,7 +248,10 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
         for mn in all.iter() {
             mn.raft
                 .wait(timeout())
-                .voter_ids(btreeset! {0,1}, format!("node-1 is joined: {}", mn.sto.id))
+                .voter_ids(
+                    btreeset! {0,1},
+                    format!("node-1 is joined: {}", mn.raft_store.id),
+                )
                 .await?;
         }
     }
@@ -284,7 +293,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
             .wait(timeout())
             .voter_ids(
                 btreeset! {0,1,2},
-                format!("node-2 is joined: {}", mn.sto.id),
+                format!("node-2 is joined: {}", mn.raft_store.id),
             )
             .await?;
     }
@@ -497,7 +506,10 @@ async fn test_meta_node_leave() -> anyhow::Result<()> {
     for mn in all.iter() {
         mn.raft
             .wait(timeout())
-            .voter_ids(btreeset! {0,2}, format!("node-{} membership", mn.sto.id))
+            .voter_ids(
+                btreeset! {0,2},
+                format!("node-{} membership", mn.raft_store.id),
+            )
             .await?;
     }
 
@@ -605,8 +617,8 @@ async fn test_meta_node_restart() -> anyhow::Result<()> {
     // add node, update membership
     log_index += 2;
 
-    let sto0 = mn0.sto.clone();
-    let sto1 = mn1.sto.clone();
+    let sto0 = mn0.raft_store.clone();
+    let sto1 = mn1.raft_store.clone();
 
     let meta_nodes = vec![mn0.clone(), mn1.clone()];
 
@@ -714,7 +726,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
             .await?;
         log_index += 1;
 
-        want_hs = leader.sto.clone().read_vote().await?;
+        want_hs = leader.raft_store.clone().read_vote().await?;
 
         leader.stop().await?;
     }
@@ -741,27 +753,27 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
             Some(log_index),
             format!(
                 "reopened: applied index at {} for node-{}",
-                log_index, leader.sto.id
+                log_index, leader.raft_store.id
             ),
         )
         .await?;
 
     info!("--- check hard state");
     {
-        let hs = leader.sto.clone().read_vote().await?;
+        let hs = leader.raft_store.clone().read_vote().await?;
         assert_eq!(want_hs, hs);
     }
 
     info!("--- check logs");
     {
-        let logs = leader.sto.clone().try_get_log_entries(..).await?;
+        let logs = leader.raft_store.clone().try_get_log_entries(..).await?;
         info!("logs: {:?}", logs);
         assert_eq!(log_index as usize + 1, logs.len());
     }
 
     info!("--- check state machine: nodes");
     {
-        let node = leader.sto.get_node(&0).await.unwrap();
+        let node = leader.raft_store.get_node(&0).await.unwrap();
         assert_eq!(
             tc.config.raft_config.raft_api_advertise_host_endpoint(),
             node.endpoint
@@ -816,7 +828,7 @@ async fn assert_upsert_kv_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> a
                 format!(
                     "check upsert-kv has applied index at {} for node-{}",
                     last_applied.next_index(),
-                    mn.sto.id
+                    mn.raft_store.id
                 ),
             )
             .await?;

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -143,7 +143,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
 
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
-        let sm = mn1.sto.get_state_machine().await;
+        let sm = mn1.raft_store.get_state_machine().await;
         let got = sm.get_maybe_expired_kv(&key).await?;
         match got {
             None => {

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -36,7 +36,6 @@ use databend_common_meta_types::snapshot_db::DB;
 use databend_meta::meta_service::meta_node::LogStore;
 use databend_meta::meta_service::meta_node::SMStore;
 use databend_meta::store::RaftStore;
-use databend_meta::Opened;
 use futures::TryStreamExt;
 use log::debug;
 use log::info;

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -83,7 +83,7 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
     {
         let mut sto = RaftStore::open(&tc.config.raft_config).await?;
         assert_eq!(id, sto.id);
-        assert!(!sto.is_opened());
+        assert!(!sto.is_opened);
         assert_eq!(None, sto.read_vote().await?);
 
         info!("--- update metasrv");
@@ -102,7 +102,7 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
     {
         let mut sto = RaftStore::open(&tc.config.raft_config).await?;
         assert_eq!(id, sto.id);
-        assert!(sto.is_opened());
+        assert!(sto.is_opened);
         assert_eq!(Some(Vote::new(10, 5)), sto.read_vote().await?);
 
         assert_eq!(log_id(1, 2, 1), sto.get_log_id(1).await?);

--- a/src/meta/service/tests/it/tests/meta_node.rs
+++ b/src/meta/service/tests/it/tests/meta_node.rs
@@ -106,7 +106,7 @@ pub(crate) async fn start_meta_node_cluster(
                 .wait(timeout())
                 .state(
                     ServerState::Follower,
-                    format!("check follower-{} state", item.meta_node().sto.id),
+                    format!("check follower-{} state", item.meta_node().raft_store.id),
                 )
                 .await?;
         }
@@ -120,7 +120,7 @@ pub(crate) async fn start_meta_node_cluster(
                 .wait(timeout())
                 .state(
                     ServerState::Learner,
-                    format!("check learner-{} state", item.meta_node().sto.id),
+                    format!("check learner-{} state", item.meta_node().raft_store.id),
                 )
                 .await?;
         }
@@ -137,7 +137,7 @@ pub(crate) async fn start_meta_node_cluster(
                     format!(
                         "check applied index: {} for node-{}",
                         log_index,
-                        tc.meta_node().sto.id
+                        tc.meta_node().raft_store.id
                     ),
                 )
                 .await?;
@@ -199,7 +199,7 @@ pub(crate) async fn start_meta_node_non_voter(
     // // Log index becomes non-deterministic.
     // mn.raft.enable_heartbeat(false);
 
-    assert!(!mn.is_opened());
+    assert!(!mn.raft_store.is_opened);
 
     tc.meta_node = Some(mn.clone());
 

--- a/src/meta/service/tests/it/tests/meta_node.rs
+++ b/src/meta/service/tests/it/tests/meta_node.rs
@@ -23,7 +23,6 @@ use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::AppliedState;
 use databend_common_meta_types::Node;
 use databend_meta::meta_service::MetaNode;
-use databend_meta::Opened;
 use log::info;
 use maplit::btreeset;
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: remove unused config_id from RaftConfig

`config_id` is used for separate sled-db key spaces for parallel tests.
Since sled db is removed, this `config_id` is useless.


##### chore: optimize meta-service initialization

Try initialize instead of check `is_open` flag.
This flag may not be accurate: the raft storage is opend but no
initialization is done yet.

And remove trait `Opened` and refactor related struct names

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16902)
<!-- Reviewable:end -->
