### PR TITLE
feat(query): virtual column allow cast to other type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "databend-common-base",
  "databend-common-catalog",
  "databend-common-exception",
+ "databend-common-expression",
  "databend-common-meta-app",
  "databend-common-pipeline-core",
  "databend-common-storages-fuse",

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -6425,6 +6425,16 @@ impl SchemaApiTestSuite {
                         "variant[1]".to_string(),
                         TableDataType::Nullable(Box::new(TableDataType::Variant)),
                     ),
+                    (
+                        "variant:k1:k2".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                    (
+                        "variant:k1:k3".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::UInt64,
+                        ))),
+                    ),
                 ],
             };
 
@@ -6442,6 +6452,16 @@ impl SchemaApiTestSuite {
                     (
                         "variant[1]".to_string(),
                         TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant:k1:k2".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                    (
+                        "variant:k1:k3".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::UInt64,
+                        ))),
                     ),
                 ],
             };
@@ -6465,6 +6485,16 @@ impl SchemaApiTestSuite {
                     "variant[1]".to_string(),
                     TableDataType::Nullable(Box::new(TableDataType::Variant))
                 ),
+                (
+                    "variant:k1:k2".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::String)),
+                ),
+                (
+                    "variant:k1:k3".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Number(
+                        NumberDataType::UInt64
+                    ))),
+                ),
             ]);
 
             let req = ListVirtualColumnsReq::new(&tenant, Some(u64::MAX));
@@ -6487,6 +6517,16 @@ impl SchemaApiTestSuite {
                         "variant[2]".to_string(),
                         TableDataType::Nullable(Box::new(TableDataType::Variant)),
                     ),
+                    (
+                        "variant:k2:k3".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                    (
+                        "variant:k2:k4".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::UInt64,
+                        ))),
+                    ),
                 ],
             };
 
@@ -6507,6 +6547,16 @@ impl SchemaApiTestSuite {
                 (
                     "variant[2]".to_string(),
                     TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
+                (
+                    "variant:k2:k3".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::String)),
+                ),
+                (
+                    "variant:k2:k4".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Number(
+                        NumberDataType::UInt64
+                    ))),
                 ),
             ]);
         }
@@ -6543,6 +6593,16 @@ impl SchemaApiTestSuite {
                         "variant[3]".to_string(),
                         TableDataType::Nullable(Box::new(TableDataType::Variant)),
                     ),
+                    (
+                        "variant:k3:k4".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                    (
+                        "variant:k3:k5".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::UInt64,
+                        ))),
+                    ),
                 ],
             };
 
@@ -6564,6 +6624,16 @@ impl SchemaApiTestSuite {
                         "variant[1]".to_string(),
                         TableDataType::Nullable(Box::new(TableDataType::Variant)),
                     ),
+                    (
+                        "variant:k1:k4".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                    (
+                        "variant:k1:k5".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::UInt64,
+                        ))),
+                    ),
                 ],
             };
 
@@ -6582,15 +6652,31 @@ impl SchemaApiTestSuite {
                     "variant[1]".to_string(),
                     TableDataType::Nullable(Box::new(TableDataType::Variant))
                 ),
+                (
+                    "variant:k1:k4".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::String)),
+                ),
+                (
+                    "variant:k1:k5".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Number(
+                        NumberDataType::UInt64
+                    ))),
+                ),
             ]);
 
             let req = CreateVirtualColumnReq {
                 create_option: CreateOption::CreateOrReplace,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec![(
-                    "variant:k2".to_string(),
-                    TableDataType::Nullable(Box::new(TableDataType::Variant)),
-                )],
+                virtual_columns: vec![
+                    (
+                        "variant:k2".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant:k3".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::String)),
+                    ),
+                ],
             };
 
             mt.create_virtual_column(req.clone()).await?;
@@ -6599,10 +6685,16 @@ impl SchemaApiTestSuite {
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
-            assert_eq!(res[0].virtual_columns, vec![(
-                "variant:k2".to_string(),
-                TableDataType::Nullable(Box::new(TableDataType::Variant))
-            ),]);
+            assert_eq!(res[0].virtual_columns, vec![
+                (
+                    "variant:k2".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
+                (
+                    "variant:k3".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::String)),
+                )
+            ]);
         }
 
         Ok(())

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -6416,7 +6416,16 @@ impl SchemaApiTestSuite {
             let req = CreateVirtualColumnReq {
                 create_option: CreateOption::Create,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k1".to_string(), "variant[1]".to_string()],
+                virtual_columns: vec![
+                    (
+                        "variant:k1".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant[1]".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                ],
             };
 
             mt.create_virtual_column(req.clone()).await?;
@@ -6425,7 +6434,16 @@ impl SchemaApiTestSuite {
             let req = CreateVirtualColumnReq {
                 create_option: CreateOption::Create,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k1".to_string(), "variant[1]".to_string()],
+                virtual_columns: vec![
+                    (
+                        "variant:k1".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant[1]".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                ],
             };
 
             let res = mt.create_virtual_column(req).await;
@@ -6439,8 +6457,14 @@ impl SchemaApiTestSuite {
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
             assert_eq!(res[0].virtual_columns, vec![
-                "variant:k1".to_string(),
-                "variant[1]".to_string(),
+                (
+                    "variant:k1".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
+                (
+                    "variant[1]".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
             ]);
 
             let req = ListVirtualColumnsReq::new(&tenant, Some(u64::MAX));
@@ -6454,7 +6478,16 @@ impl SchemaApiTestSuite {
             let req = UpdateVirtualColumnReq {
                 if_exists: false,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k2".to_string(), "variant[2]".to_string()],
+                virtual_columns: vec![
+                    (
+                        "variant:k2".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant[2]".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                ],
             };
 
             mt.update_virtual_column(req).await?;
@@ -6467,8 +6500,14 @@ impl SchemaApiTestSuite {
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
             assert_eq!(res[0].virtual_columns, vec![
-                "variant:k2".to_string(),
-                "variant[2]".to_string(),
+                (
+                    "variant:k2".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
+                (
+                    "variant[2]".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
             ]);
         }
 
@@ -6495,7 +6534,16 @@ impl SchemaApiTestSuite {
             let req = UpdateVirtualColumnReq {
                 if_exists: false,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k3".to_string(), "variant[3]".to_string()],
+                virtual_columns: vec![
+                    (
+                        "variant:k3".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant[3]".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                ],
             };
 
             let res = mt.update_virtual_column(req).await;
@@ -6507,7 +6555,16 @@ impl SchemaApiTestSuite {
             let req = CreateVirtualColumnReq {
                 create_option: CreateOption::Create,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k1".to_string(), "variant[1]".to_string()],
+                virtual_columns: vec![
+                    (
+                        "variant:k1".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                    (
+                        "variant[1]".to_string(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    ),
+                ],
             };
 
             mt.create_virtual_column(req.clone()).await?;
@@ -6517,14 +6574,23 @@ impl SchemaApiTestSuite {
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
             assert_eq!(res[0].virtual_columns, vec![
-                "variant:k1".to_string(),
-                "variant[1]".to_string(),
+                (
+                    "variant:k1".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
+                (
+                    "variant[1]".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant))
+                ),
             ]);
 
             let req = CreateVirtualColumnReq {
                 create_option: CreateOption::CreateOrReplace,
                 name_ident: name_ident.clone(),
-                virtual_columns: vec!["variant:k2".to_string()],
+                virtual_columns: vec![(
+                    "variant:k2".to_string(),
+                    TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                )],
             };
 
             mt.create_virtual_column(req.clone()).await?;
@@ -6533,7 +6599,10 @@ impl SchemaApiTestSuite {
 
             let res = mt.list_virtual_columns(req).await?;
             assert_eq!(1, res.len());
-            assert_eq!(res[0].virtual_columns, vec!["variant:k2".to_string(),]);
+            assert_eq!(res[0].virtual_columns, vec![(
+                "variant:k2".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::Variant))
+            ),]);
         }
 
         Ok(())

--- a/src/meta/app/src/schema/virtual_column.rs
+++ b/src/meta/app/src/schema/virtual_column.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 
 use chrono::DateTime;
 use chrono::Utc;
+use databend_common_expression::TableDataType;
 use databend_common_meta_types::MetaId;
 
 use super::CreateOption;
@@ -29,7 +30,7 @@ use crate::tenant::ToTenant;
 pub struct VirtualColumnMeta {
     pub table_id: MetaId,
 
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
     pub created_on: DateTime<Utc>,
     pub updated_on: Option<DateTime<Utc>>,
 }
@@ -38,7 +39,7 @@ pub struct VirtualColumnMeta {
 pub struct CreateVirtualColumnReq {
     pub create_option: CreateOption,
     pub name_ident: VirtualColumnIdent,
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
 }
 
 impl Display for CreateVirtualColumnReq {
@@ -56,7 +57,7 @@ impl Display for CreateVirtualColumnReq {
 pub struct UpdateVirtualColumnReq {
     pub if_exists: bool,
     pub name_ident: VirtualColumnIdent,
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
 }
 
 impl Display for UpdateVirtualColumnReq {

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -141,6 +141,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (109, "2024-08-29: Refactor: ProcedureMeta add arg_names"),
     (110, "2024-09-18: Add: database.proto: DatabaseMeta.gc_in_progress"),
     (111, "2024-11-13: Add: Enable AWS Glue as an Apache Iceberg type when creating a catalog."),
+    (112, "2024-11-28: Add: virtual_column add data_types field"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
@@ -48,6 +48,15 @@ impl FromToProto for mt::VirtualColumnMeta {
                 })
                 .collect()
         } else {
+            if p.virtual_columns.len() != p.data_types.len() {
+                return Err(Incompatible {
+                    reason: format!(
+                        "Incompatible virtual columns length is {}, but data types length is {}",
+                        p.virtual_columns.len(),
+                        p.data_types.len()
+                    ),
+                });
+            }
             let mut virtual_columns = Vec::new();
             for (v, ty) in p.virtual_columns.iter().zip(p.data_types.iter()) {
                 virtual_columns.push((v.clone(), TableDataType::from_pb(ty.clone())?));

--- a/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
@@ -17,6 +17,7 @@
 
 use chrono::DateTime;
 use chrono::Utc;
+use databend_common_expression::TableDataType;
 use databend_common_meta_app::schema as mt;
 use databend_common_protos::pb;
 
@@ -36,10 +37,27 @@ impl FromToProto for mt::VirtualColumnMeta {
     fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
+        let virtual_columns = if p.data_types.is_empty() {
+            p.virtual_columns
+                .iter()
+                .map(|v| {
+                    (
+                        v.clone(),
+                        TableDataType::Nullable(Box::new(TableDataType::Variant)),
+                    )
+                })
+                .collect()
+        } else {
+            let mut virtual_columns = Vec::new();
+            for (v, ty) in p.virtual_columns.iter().zip(p.data_types.iter()) {
+                virtual_columns.push((v.clone(), TableDataType::from_pb(ty.clone())?));
+            }
+            virtual_columns
+        };
 
         let v = Self {
             table_id: p.table_id,
-            virtual_columns: p.virtual_columns,
+            virtual_columns,
             created_on: DateTime::<Utc>::from_pb(p.created_on)?,
             updated_on: match p.updated_on {
                 Some(updated_on) => Some(DateTime::<Utc>::from_pb(updated_on)?),
@@ -50,16 +68,23 @@ impl FromToProto for mt::VirtualColumnMeta {
     }
 
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let mut data_types = Vec::new();
+        let mut virtual_columns = Vec::new();
+        for (v, ty) in self.virtual_columns.iter() {
+            data_types.push(ty.to_pb()?);
+            virtual_columns.push(v.clone());
+        }
         let p = pb::VirtualColumnMeta {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
             table_id: self.table_id,
-            virtual_columns: self.virtual_columns.clone(),
+            virtual_columns,
             created_on: self.created_on.to_pb()?,
             updated_on: match self.updated_on {
                 Some(updated_on) => Some(updated_on.to_pb()?),
                 None => None,
             },
+            data_types,
         };
         Ok(p)
     }

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -108,3 +108,5 @@ mod v107_geography_datatype;
 mod v108_procedure;
 mod v109_procedure_with_args;
 mod v110_database_meta_gc_in_progress;
+mod v111_add_glue_as_iceberg_catalog_option;
+mod v112_virtual_column;

--- a/src/meta/proto-conv/tests/it/v041_virtual_column.rs
+++ b/src/meta/proto-conv/tests/it/v041_virtual_column.rs
@@ -14,6 +14,7 @@
 
 use chrono::TimeZone;
 use chrono::Utc;
+use databend_common_expression::TableDataType;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use fastrace::func_name;
 
@@ -40,7 +41,16 @@ fn test_decode_v41_virtual_column() -> anyhow::Result<()> {
 
     let want = || {
         let table_id = 7;
-        let virtual_columns = vec!["v:k1:k2".to_string(), "v[1][2]".to_string()];
+        let virtual_columns = vec![
+            (
+                "v:k1:k2".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::Variant)),
+            ),
+            (
+                "v[1][2]".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::Variant)),
+            ),
+        ];
         let created_on = Utc.with_ymd_and_hms(2023, 3, 9, 10, 0, 0).unwrap();
         let updated_on = Some(Utc.with_ymd_and_hms(2023, 5, 29, 10, 0, 0).unwrap());
 

--- a/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
+++ b/src/meta/proto-conv/tests/it/v111_add_glue_as_iceberg_catalog_option.rs
@@ -18,7 +18,7 @@ use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
 use databend_common_meta_app::schema::IcebergGlueCatalogOption;
 use fastrace::func_name;
-use std::collections::HashMap;
+use maplit::hashmap;
 
 use crate::common;
 
@@ -35,24 +35,27 @@ use crate::common;
 #[test]
 fn test_v111_add_glue_as_iceberg_catalog_option() -> anyhow::Result<()> {
     let catalog_meta_v111 = vec![
-        18, 55, 26, 53, 18, 45, 10, 21, 104, 116, 116, 112, 58, 47, 47, 49, 50, 55, 46, 48, 46, 48,
-        46, 49, 58, 57, 57, 48, 48, 18, 14, 115, 51, 58, 47, 47, 109, 121, 95, 98, 117, 99, 107,
-        101, 116, 160, 6, 98, 168, 6, 24, 160, 6, 98, 168, 6, 24, 162, 1, 23, 50, 48, 49, 52, 45,
-        49, 49, 45, 50, 56, 32, 49, 50, 58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 160, 6, 98, 168, 6,
-        24,
+        18, 169, 1, 26, 166, 1, 34, 157, 1, 10, 14, 115, 51, 58, 47, 47, 109, 121, 95, 98, 117, 99,
+        107, 101, 116, 18, 37, 10, 10, 65, 87, 83, 95, 75, 69, 89, 95, 73, 68, 18, 23, 115, 117,
+        112, 101, 114, 32, 115, 101, 99, 117, 114, 101, 32, 97, 99, 99, 101, 115, 115, 32, 107,
+        101, 121, 18, 45, 10, 14, 65, 87, 83, 95, 83, 69, 67, 82, 69, 84, 95, 75, 69, 89, 18, 27,
+        101, 118, 101, 110, 32, 109, 111, 114, 101, 32, 115, 101, 99, 117, 114, 101, 32, 115, 101,
+        99, 114, 101, 116, 32, 107, 101, 121, 18, 47, 10, 6, 82, 69, 71, 73, 79, 78, 18, 37, 117,
+        115, 45, 101, 97, 115, 116, 45, 49, 32, 97, 107, 97, 32, 97, 110, 116, 105, 45, 109, 117,
+        108, 116, 105, 45, 97, 118, 97, 105, 108, 97, 98, 105, 108, 105, 116, 121, 160, 6, 111,
+        168, 6, 24, 160, 6, 111, 168, 6, 24, 162, 1, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 56,
+        32, 49, 50, 58, 48, 48, 58, 48, 57, 32, 85, 84, 67, 160, 6, 111, 168, 6, 24,
     ];
 
-    let mut props = HashMap::new();
-    props.insert("AWS_KEY_ID".to_string(), "super secure access key".to_string());
-    props.insert("AWS_SECRET_KEY".to_string(), "even more secure secret key".to_string());
-    props.insert("REGION".to_string(), "us-east-1 aka anti-multi-availability".to_string());
-
     let want = || databend_common_meta_app::schema::CatalogMeta {
-        catalog_option: CatalogOption::Iceberg(IcebergGlueCatalogOption::Rest(
+        catalog_option: CatalogOption::Iceberg(IcebergCatalogOption::Glue(
             IcebergGlueCatalogOption {
-                address: "http://127.0.0.1:9900".to_string(),
                 warehouse: "s3://my_bucket".to_string(),
-                props,
+                props: hashmap! {
+                    s("AWS_KEY_ID") => s("super secure access key"),
+                    s("AWS_SECRET_KEY") => s("even more secure secret key"),
+                    s("REGION") => s("us-east-1 aka anti-multi-availability"),
+                },
             },
         )),
         created_on: Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),
@@ -62,4 +65,8 @@ fn test_v111_add_glue_as_iceberg_catalog_option() -> anyhow::Result<()> {
     common::test_load_old(func_name!(), catalog_meta_v111.as_slice(), 111, want())?;
 
     Ok(())
+}
+
+fn s(ss: impl ToString) -> String {
+    ss.to_string()
 }

--- a/src/meta/proto-conv/tests/it/v112_virtual_column.rs
+++ b/src/meta/proto-conv/tests/it/v112_virtual_column.rs
@@ -1,0 +1,76 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::TimeZone;
+use chrono::Utc;
+use databend_common_expression::TableDataType;
+use databend_common_meta_app::schema::VirtualColumnMeta;
+use fastrace::func_name;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+// The message bytes are built from the output of `proto_conv::test_build_pb_buf()`
+#[test]
+fn test_decode_v112_virtual_column() -> anyhow::Result<()> {
+    let schema_v112 = vec![
+        8, 7, 18, 7, 118, 58, 107, 49, 58, 107, 50, 18, 7, 118, 91, 49, 93, 91, 50, 93, 18, 7, 118,
+        58, 107, 51, 58, 107, 52, 26, 23, 50, 48, 50, 51, 45, 48, 51, 45, 48, 57, 32, 49, 48, 58,
+        48, 48, 58, 48, 48, 32, 85, 84, 67, 34, 23, 50, 48, 50, 51, 45, 48, 53, 45, 50, 57, 32, 49,
+        48, 58, 48, 48, 58, 48, 48, 32, 85, 84, 67, 42, 18, 178, 2, 9, 210, 2, 0, 160, 6, 111, 168,
+        6, 24, 160, 6, 111, 168, 6, 24, 42, 18, 178, 2, 9, 210, 2, 0, 160, 6, 111, 168, 6, 24, 160,
+        6, 111, 168, 6, 24, 42, 18, 178, 2, 9, 146, 2, 0, 160, 6, 111, 168, 6, 24, 160, 6, 111,
+        168, 6, 24, 160, 6, 112, 168, 6, 24,
+    ];
+
+    let want = || {
+        let table_id = 7;
+        let virtual_columns = vec![
+            (
+                "v:k1:k2".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::Variant)),
+            ),
+            (
+                "v[1][2]".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::Variant)),
+            ),
+            (
+                "v:k3:k4".to_string(),
+                TableDataType::Nullable(Box::new(TableDataType::String)),
+            ),
+        ];
+        let created_on = Utc.with_ymd_and_hms(2023, 3, 9, 10, 0, 0).unwrap();
+        let updated_on = Some(Utc.with_ymd_and_hms(2023, 5, 29, 10, 0, 0).unwrap());
+
+        VirtualColumnMeta {
+            table_id,
+            virtual_columns,
+            created_on,
+            updated_on,
+        }
+    };
+
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), schema_v112.as_slice(), 112, want())?;
+
+    Ok(())
+}

--- a/src/meta/protos/proto/virtual_column.proto
+++ b/src/meta/protos/proto/virtual_column.proto
@@ -20,6 +20,8 @@ syntax = "proto3";
 
 package databend_proto;
 
+import "datatype.proto";
+
 // VirtualColumnMeta is a container of virtual columns information.
 message VirtualColumnMeta {
   uint64 ver = 100;
@@ -36,4 +38,7 @@ message VirtualColumnMeta {
 
   // The time virtual column updated.
   optional string updated_on = 4;
+
+  // virtual column data type
+  repeated DataType data_types = 5;
 }

--- a/src/query/catalog/src/plan/pushdown.rs
+++ b/src/query/catalog/src/plan/pushdown.rs
@@ -60,6 +60,8 @@ pub struct VirtualColumnField {
     pub name: String,
     /// Paths to generate virtual column from source column.
     pub key_paths: Scalar,
+    /// optional cast function name, used to cast value to other type.
+    pub cast_func_name: Option<String>,
     /// Virtual column data type.
     pub data_type: Box<TableDataType>,
     /// Is the virtual column is created,

--- a/src/query/ee/src/virtual_column/virtual_column_handler.rs
+++ b/src/query/ee/src/virtual_column/virtual_column_handler.rs
@@ -18,6 +18,7 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
+use databend_common_expression::TableDataType;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
 use databend_common_meta_app::schema::DropVirtualColumnReq;
 use databend_common_meta_app::schema::ListVirtualColumnsReq;
@@ -75,7 +76,7 @@ impl VirtualColumnHandler for RealVirtualColumnHandler {
         &self,
         ctx: Arc<dyn TableContext>,
         fuse_table: &FuseTable,
-        virtual_columns: Vec<String>,
+        virtual_columns: Vec<(String, TableDataType)>,
         segment_locs: Option<Vec<Location>>,
         pipeline: &mut Pipeline,
     ) -> Result<()> {

--- a/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
@@ -14,6 +14,7 @@
 
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
+use databend_common_expression::TableDataType;
 use databend_common_storage::read_parquet_schema_async_rs;
 use databend_common_storages_fuse::io::BlockReader;
 use databend_common_storages_fuse::io::MetaReaders;
@@ -47,7 +48,16 @@ async fn test_fuse_do_refresh_virtual_column() -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let dal = fuse_table.get_operator_ref();
 
-    let virtual_columns = vec!["v['a']".to_string(), "v[0]".to_string()];
+    let virtual_columns = vec![
+        (
+            "v['a']".to_string(),
+            TableDataType::Nullable(Box::new(TableDataType::Variant)),
+        ),
+        (
+            "v[0]".to_string(),
+            TableDataType::Nullable(Box::new(TableDataType::Variant)),
+        ),
+    ];
     let table_ctx = fixture.new_query_ctx().await?;
 
     let snapshot_opt = fuse_table.read_table_snapshot().await?;

--- a/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
@@ -14,6 +14,7 @@
 
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
+use databend_common_expression::types::NumberDataType;
 use databend_common_expression::TableDataType;
 use databend_common_storage::read_parquet_schema_async_rs;
 use databend_common_storages_fuse::io::BlockReader;
@@ -56,6 +57,10 @@ async fn test_fuse_do_refresh_virtual_column() -> Result<()> {
         (
             "v[0]".to_string(),
             TableDataType::Nullable(Box::new(TableDataType::Variant)),
+        ),
+        (
+            "v['b']".to_string(),
+            TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::Int64))),
         ),
     ];
     let table_ctx = fixture.new_query_ctx().await?;
@@ -121,9 +126,10 @@ async fn test_fuse_do_refresh_virtual_column() -> Result<()> {
             };
             assert!(schema.is_some());
             let schema = schema.unwrap();
-            assert_eq!(schema.fields.len(), 2);
+            assert_eq!(schema.fields.len(), 3);
             assert_eq!(schema.fields[0].name(), "v['a']");
             assert_eq!(schema.fields[1].name(), "v[0]");
+            assert_eq!(schema.fields[2].name(), "v['b']");
         }
     }
 

--- a/src/query/ee_features/virtual_column/Cargo.toml
+++ b/src/query/ee_features/virtual_column/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-catalog = { workspace = true }
 databend-common-exception = { workspace = true }
+databend-common-expression = { workspace = true }
 databend-common-meta-app = { workspace = true }
 databend-common-pipeline-core = { workspace = true }
 databend-common-storages-fuse = { workspace = true }

--- a/src/query/ee_features/virtual_column/src/virtual_column.rs
+++ b/src/query/ee_features/virtual_column/src/virtual_column.rs
@@ -18,6 +18,7 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
+use databend_common_expression::TableDataType;
 use databend_common_meta_app::schema::CreateVirtualColumnReq;
 use databend_common_meta_app::schema::DropVirtualColumnReq;
 use databend_common_meta_app::schema::ListVirtualColumnsReq;
@@ -57,7 +58,7 @@ pub trait VirtualColumnHandler: Sync + Send {
         &self,
         ctx: Arc<dyn TableContext>,
         fuse_table: &FuseTable,
-        virtual_columns: Vec<String>,
+        virtual_columns: Vec<(String, TableDataType)>,
         segment_locs: Option<Vec<Location>>,
         pipeline: &mut Pipeline,
     ) -> Result<()>;
@@ -113,7 +114,7 @@ impl VirtualColumnHandlerWrapper {
         &self,
         ctx: Arc<dyn TableContext>,
         fuse_table: &FuseTable,
-        virtual_columns: Vec<String>,
+        virtual_columns: Vec<(String, TableDataType)>,
         segment_locs: Option<Vec<Location>>,
         pipeline: &mut Pipeline,
     ) -> Result<()> {

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -114,7 +114,7 @@ pub enum NameResolutionResult {
 pub struct VirtualColumnContext {
     /// Whether allow rewrite as virtual column and pushdown.
     pub allow_pushdown: bool,
-    /// The table indics of the virtual column has been readed,
+    /// The table indics of the virtual column has been readded,
     /// used to avoid repeated reading
     pub table_indices: HashSet<IndexType>,
     /// Mapping: (table index) -> (derived virtual column indices)

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -100,7 +100,7 @@ impl Binder {
             self.bind_table_reference(bind_context, &cross_joins)?
         };
 
-        // only
+        // whether allow rewrite virtual column and pushdown
         let allow_pushdown = LicenseManagerSwitch::instance()
             .check_enterprise_enabled(self.ctx.get_license_key(), Feature::VirtualColumn)
             .is_ok();

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -38,6 +38,8 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::ScalarRef;
+use databend_common_license::license::Feature;
+use databend_common_license::license_manager::LicenseManagerSwitch;
 use derive_visitor::Drive;
 use derive_visitor::Visitor;
 use log::warn;
@@ -48,7 +50,6 @@ use crate::planner::binder::Binder;
 use crate::planner::query_executor::QueryExecutor;
 use crate::AsyncFunctionRewriter;
 use crate::ColumnBinding;
-use crate::VirtualColumnRewriter;
 
 // A normalized IR for `SELECT` clause.
 #[derive(Debug, Default)]
@@ -98,6 +99,12 @@ impl Binder {
                 .unwrap();
             self.bind_table_reference(bind_context, &cross_joins)?
         };
+
+        // only
+        let allow_pushdown = LicenseManagerSwitch::instance()
+            .check_enterprise_enabled(self.ctx.get_license_key(), Feature::VirtualColumn)
+            .is_ok();
+        from_context.virtual_column_context.allow_pushdown = allow_pushdown;
 
         let mut rewriter = SelectRewriter::new(
             from_context.all_column_bindings(),
@@ -248,9 +255,13 @@ impl Binder {
         s_expr = self.rewrite_udf(&mut from_context, s_expr)?;
 
         // rewrite variant inner fields as virtual columns
-        let mut virtual_column_rewriter =
-            VirtualColumnRewriter::new(self.ctx.clone(), self.metadata.clone());
-        s_expr = virtual_column_rewriter.rewrite(&s_expr)?;
+        if !from_context
+            .virtual_column_context
+            .virtual_column_indices
+            .is_empty()
+        {
+            s_expr = self.rewrite_virtual_column(&mut from_context, s_expr)?;
+        }
 
         // add internal column binding into expr
         s_expr = self.add_internal_column_into_expr(&mut from_context, s_expr)?;

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -231,6 +231,7 @@ impl Binder {
             have_udf_script: false,
             have_udf_server: false,
             inverted_index_map: Box::default(),
+            virtual_column_context: Default::default(),
             expr_context: ExprContext::default(),
             planning_agg_index: false,
             window_definitions: DashMap::new(),

--- a/src/query/sql/src/planner/plans/ddl/virtual_column.rs
+++ b/src/query/sql/src/planner/plans/ddl/virtual_column.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
+use databend_common_expression::TableDataType;
 use databend_common_meta_app::schema::CreateOption;
 use databend_storages_common_table_meta::meta::Location;
 
@@ -25,7 +26,7 @@ pub struct CreateVirtualColumnPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
 }
 
 impl CreateVirtualColumnPlan {
@@ -40,7 +41,7 @@ pub struct AlterVirtualColumnPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
 }
 
 impl AlterVirtualColumnPlan {
@@ -68,7 +69,7 @@ pub struct RefreshVirtualColumnPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
-    pub virtual_columns: Vec<String>,
+    pub virtual_columns: Vec<(String, TableDataType)>,
     pub segment_locs: Option<Vec<Location>>,
 }
 

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -52,6 +52,7 @@ use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::InternalColumnType;
 use databend_common_catalog::plan::InvertedIndexInfo;
 use databend_common_catalog::plan::InvertedIndexOption;
+use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_compress::CompressAlgorithm;
 use databend_common_compress::DecompressDecoder;
@@ -97,6 +98,7 @@ use databend_common_meta_app::principal::UDFServer;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::DictionaryIdentity;
 use databend_common_meta_app::schema::GetSequenceReq;
+use databend_common_meta_app::schema::ListVirtualColumnsReq;
 use databend_common_meta_app::schema::SequenceIdent;
 use databend_common_storage::init_stage_operator;
 use databend_common_users::UserApiProvider;
@@ -158,8 +160,11 @@ use crate::plans::WindowOrderBy;
 use crate::BaseTableColumn;
 use crate::BindContext;
 use crate::ColumnBinding;
+use crate::ColumnBindingBuilder;
 use crate::ColumnEntry;
 use crate::MetadataRef;
+use crate::TableEntry;
+use crate::Visibility;
 
 /// A helper for type checking.
 ///
@@ -4524,6 +4529,178 @@ impl<'a> TypeChecker<'a> {
         Ok(Box::new((subquery_expr.into(), data_type)))
     }
 
+    async fn get_virtual_columns(
+        &self,
+        table_entry: &TableEntry,
+        table: Arc<dyn Table>,
+    ) -> Result<Option<HashMap<String, TableDataType>>> {
+        let table_id = table.get_id();
+        let req = ListVirtualColumnsReq::new(self.ctx.get_tenant(), Some(table_id));
+        let catalog = self.ctx.get_catalog(table_entry.catalog()).await?;
+
+        if let Ok(virtual_column_metas) = catalog.list_virtual_columns(req).await {
+            if !virtual_column_metas.is_empty() {
+                let mut virtual_column_name_map =
+                    HashMap::with_capacity(virtual_column_metas[0].virtual_columns.len());
+                for (name, typ) in virtual_column_metas[0].virtual_columns.iter() {
+                    virtual_column_name_map.insert(name.clone(), typ.clone());
+                }
+                return Ok(Some(virtual_column_name_map));
+            }
+        }
+        Ok(None)
+    }
+
+    fn try_rewrite_virtual_column(
+        &mut self,
+        base_column: &BaseTableColumn,
+        keypaths: &KeyPaths,
+    ) -> Result<Option<Box<(ScalarExpr, DataType)>>> {
+        if !self.bind_context.virtual_column_context.allow_pushdown {
+            return Ok(None);
+        }
+
+        let metadata = self.metadata.read().clone();
+        let table_entry = metadata.table(base_column.table_index);
+
+        let table = table_entry.table();
+        // Ignore tables that do not support virtual columns
+        if !table.support_virtual_columns() {
+            return Ok(None);
+        }
+        let schema = table.schema();
+
+        if !self
+            .bind_context
+            .virtual_column_context
+            .table_indices
+            .contains(&base_column.table_index)
+        {
+            let virtual_column_name_map = databend_common_base::runtime::block_on(
+                self.get_virtual_columns(table_entry, table),
+            )?;
+            self.bind_context
+                .virtual_column_context
+                .table_indices
+                .insert(base_column.table_index);
+            if let Some(virtual_column_name_map) = virtual_column_name_map {
+                self.bind_context
+                    .virtual_column_context
+                    .virtual_column_names
+                    .insert(base_column.table_index, virtual_column_name_map);
+                self.bind_context
+                    .virtual_column_context
+                    .next_column_ids
+                    .insert(base_column.table_index, schema.next_column_id);
+            }
+        }
+
+        if let Some(virtual_column_name_map) = self
+            .bind_context
+            .virtual_column_context
+            .virtual_column_names
+            .get(&base_column.table_index)
+        {
+            let mut name = String::new();
+            name.push_str(&base_column.column_name);
+            for path in &keypaths.paths {
+                name.push('[');
+                match path {
+                    KeyPath::Index(idx) => {
+                        name.push_str(&idx.to_string());
+                    }
+                    KeyPath::QuotedName(field) | KeyPath::Name(field) => {
+                        name.push('\'');
+                        name.push_str(field.as_ref());
+                        name.push('\'');
+                    }
+                }
+                name.push(']');
+            }
+
+            let virtual_type = virtual_column_name_map.get(&name);
+            let is_created = virtual_type.is_some();
+
+            let mut index = 0;
+            // Check for duplicate virtual columns
+            for table_column in metadata.virtual_columns_by_table_index(base_column.table_index) {
+                if table_column.name() == name {
+                    index = table_column.index();
+                    break;
+                }
+            }
+
+            let table_data_type = if let Some(virtual_type) = virtual_type {
+                virtual_type.wrap_nullable()
+            } else {
+                TableDataType::Nullable(Box::new(TableDataType::Variant))
+            };
+
+            if index == 0 {
+                let column_id = self
+                    .bind_context
+                    .virtual_column_context
+                    .next_column_ids
+                    .get(&base_column.table_index)
+                    .unwrap();
+
+                let keypaths_str = format!("{}", keypaths);
+                let keypaths_value = Scalar::String(keypaths_str);
+
+                index = self.metadata.write().add_virtual_column(
+                    base_column,
+                    *column_id,
+                    name.clone(),
+                    table_data_type.clone(),
+                    keypaths_value.clone(),
+                    None,
+                    is_created,
+                );
+
+                // Increments the column id of the virtual column.
+                let column_id = self
+                    .bind_context
+                    .virtual_column_context
+                    .next_column_ids
+                    .get_mut(&base_column.table_index)
+                    .unwrap();
+                *column_id += 1;
+            }
+
+            if let Some(indices) = self
+                .bind_context
+                .virtual_column_context
+                .virtual_column_indices
+                .get_mut(&base_column.table_index)
+            {
+                indices.push(index);
+            } else {
+                self.bind_context
+                    .virtual_column_context
+                    .virtual_column_indices
+                    .insert(base_column.table_index, vec![index]);
+            }
+
+            let data_type = DataType::from(&table_data_type);
+            let column_binding = ColumnBindingBuilder::new(
+                name,
+                index,
+                Box::new(data_type.clone()),
+                Visibility::InVisible,
+            )
+            .table_index(Some(base_column.table_index))
+            .build();
+
+            let virtual_column = ScalarExpr::BoundColumnRef(BoundColumnRef {
+                span: None,
+                column: column_binding,
+            });
+            Ok(Some(Box::new((virtual_column, data_type))))
+        } else {
+            Ok(None)
+        }
+    }
+
     // Rewrite variant map access as `get_by_keypath` function
     fn resolve_variant_map_access(
         &mut self,
@@ -4550,7 +4727,22 @@ impl<'a> TypeChecker<'a> {
             };
             key_paths.push(key_path);
         }
+
         let keypaths = KeyPaths { paths: key_paths };
+
+        // try rewrite as virtual column and pushdown to storage layer.
+        if let ScalarExpr::BoundColumnRef(BoundColumnRef { ref column, .. }) = scalar {
+            if column.index < self.metadata.read().columns().len() {
+                let column_entry = self.metadata.read().column(column.index).clone();
+                if let ColumnEntry::BaseTableColumn(base_column) = column_entry {
+                    if let Some(box (scalar, data_type)) =
+                        self.try_rewrite_virtual_column(&base_column, &keypaths)?
+                    {
+                        return Ok(Box::new((scalar, data_type)));
+                    }
+                }
+            }
+        }
 
         let keypaths_str = format!("{}", keypaths);
         let path_scalar = ScalarExpr::ConstantExpr(ConstantExpr {

--- a/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/virtual_column_rewriter.rs
@@ -15,333 +15,48 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use databend_common_catalog::table::Table;
-use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
-use databend_common_expression::Scalar;
-use databend_common_expression::TableDataType;
-use databend_common_license::license::Feature::VirtualColumn;
-use databend_common_license::license_manager::LicenseManagerSwitch;
-use databend_common_meta_app::schema::ListVirtualColumnsReq;
-use jsonb::keypath::parse_key_paths;
-use jsonb::keypath::KeyPath;
 
 use crate::optimizer::SExpr;
-use crate::plans::walk_expr_mut;
-use crate::plans::BoundColumnRef;
-use crate::plans::FunctionCall;
 use crate::plans::RelOperator;
-use crate::plans::ScalarExpr;
-use crate::plans::VisitorMut;
-use crate::ColumnBindingBuilder;
-use crate::ColumnEntry;
 use crate::IndexType;
-use crate::MetadataRef;
-use crate::TableEntry;
-use crate::Visibility;
 
 pub(crate) struct VirtualColumnRewriter {
-    ctx: Arc<dyn TableContext>,
-    metadata: MetadataRef,
-
     /// Mapping: (table index) -> (derived virtual column indices)
     /// This is used to add virtual column indices to Scan plan
-    table_virtual_columns: HashMap<IndexType, Vec<IndexType>>,
-
-    /// Mapping: (table index) -> (virtual column names)
-    /// This is used to check whether the virtual column has be created
-    virtual_column_names: HashMap<IndexType, HashMap<String, TableDataType>>,
-
-    /// Mapping: (table index) -> (next virtual column id)
-    /// The is used to generate virtual column id for virtual columns.
-    /// Not a real column id, only used to identify a virtual column.
-    next_column_ids: HashMap<IndexType, u32>,
+    virtual_column_indices: HashMap<IndexType, Vec<IndexType>>,
 }
 
 impl VirtualColumnRewriter {
-    pub(crate) fn new(ctx: Arc<dyn TableContext>, metadata: MetadataRef) -> Self {
+    pub(crate) fn new(virtual_column_indices: HashMap<IndexType, Vec<IndexType>>) -> Self {
         Self {
-            ctx,
-            metadata,
-            table_virtual_columns: Default::default(),
-            virtual_column_names: Default::default(),
-            next_column_ids: Default::default(),
+            virtual_column_indices,
         }
     }
 
-    pub(crate) fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
-        if LicenseManagerSwitch::instance()
-            .check_enterprise_enabled(self.ctx.get_license_key(), VirtualColumn)
-            .is_err()
-        {
-            return Ok(s_expr.clone());
-        }
-
-        let metadata = self.metadata.read().clone();
-        for table_entry in metadata.tables() {
-            let table = table_entry.table();
-            // Ignore tables that do not support virtual columns
-            if !table.support_virtual_columns() {
-                continue;
-            }
-
-            let schema = table.schema();
-            let has_variant_column = schema
-                .fields
-                .iter()
-                .any(|field| field.data_type.remove_nullable() == TableDataType::Variant);
-            // Ignore tables that do not have fields of variant type
-            if !has_variant_column {
-                continue;
-            }
-            self.next_column_ids
-                .insert(table_entry.index(), schema.next_column_id);
-
-            databend_common_base::runtime::block_on(self.get_virtual_columns(table_entry, table))?;
-        }
-        // If all tables do not have virtual columns created,
-        // there is no need to continue checking for rewrites as virtual columns
-        if self.virtual_column_names.is_empty() {
-            return Ok(s_expr.clone());
-        }
-
-        self.rewrite_virtual_column(s_expr)
-    }
-
-    async fn get_virtual_columns(
-        &mut self,
-        table_entry: &TableEntry,
-        table: Arc<dyn Table>,
-    ) -> Result<()> {
-        let table_id = table.get_id();
-        let req = ListVirtualColumnsReq::new(self.ctx.get_tenant(), Some(table_id));
-        let catalog = self.ctx.get_catalog(table_entry.catalog()).await?;
-
-        if let Ok(virtual_column_metas) = catalog.list_virtual_columns(req).await {
-            if !virtual_column_metas.is_empty() {
-                let mut virtual_column_name_map =
-                    HashMap::with_capacity(virtual_column_metas[0].virtual_columns.len());
-                for (name, typ) in virtual_column_metas[0].virtual_columns.iter() {
-                    virtual_column_name_map.insert(name.clone(), typ.clone());
-                }
-                self.virtual_column_names
-                    .insert(table_entry.index(), virtual_column_name_map);
-            }
-        }
-        Ok(())
-    }
-
-    // Find the functions that reads the inner fields of variant columns, rewrite them as virtual columns.
-    // Add the indices of the virtual columns to the Scan plan of the corresponding table
+    // Add the indices of the virtual columns to the Scan plan of the table
     // to read the virtual columns at the storage layer.
     #[recursive::recursive]
-    fn rewrite_virtual_column(&mut self, s_expr: &SExpr) -> Result<SExpr> {
+    pub(crate) fn rewrite(&mut self, s_expr: &SExpr) -> Result<SExpr> {
         let mut s_expr = s_expr.clone();
 
-        match (*s_expr.plan).clone() {
-            RelOperator::Scan(mut scan) => {
-                let virtual_indices = self.table_virtual_columns.get(&scan.table_index);
-                if let Some(indices) = virtual_indices {
-                    for index in indices {
-                        scan.columns.insert(*index);
-                    }
-                    s_expr.plan = Arc::new(scan.into());
+        if let RelOperator::Scan(mut scan) = (*s_expr.plan).clone() {
+            if let Some(indices) = self.virtual_column_indices.remove(&scan.table_index) {
+                for index in indices {
+                    scan.columns.insert(index);
                 }
+                s_expr.plan = Arc::new(scan.into());
             }
-            RelOperator::EvalScalar(mut eval_scalar) => {
-                for item in &mut eval_scalar.items {
-                    if self
-                        .try_replace_virtual_column(&mut item.scalar, Some(item.index))
-                        .is_some()
-                    {
-                        continue;
-                    }
-                    self.visit(&mut item.scalar)?;
-                }
-                s_expr.plan = Arc::new(eval_scalar.into());
-            }
-            RelOperator::Filter(mut filter) => {
-                for scalar in &mut filter.predicates {
-                    self.visit(scalar)?;
-                }
-                s_expr.plan = Arc::new(filter.into());
-            }
-            RelOperator::ProjectSet(mut project_set) => {
-                for item in &mut project_set.srfs {
-                    if self
-                        .try_replace_virtual_column(&mut item.scalar, Some(item.index))
-                        .is_some()
-                    {
-                        continue;
-                    }
-                    self.visit(&mut item.scalar)?;
-                }
-                s_expr.plan = Arc::new(project_set.into());
-            }
-            _ => {}
         }
 
         if !s_expr.children.is_empty() {
             let mut children = Vec::with_capacity(s_expr.children.len());
             for child in s_expr.children.iter() {
-                children.push(Arc::new(self.rewrite_virtual_column(child)?));
+                children.push(Arc::new(self.rewrite(child)?));
             }
             s_expr.children = children;
         }
 
         Ok(s_expr)
-    }
-
-    // Find the `get_by_keypath` function that takes a variant column and a constant path value as arguments.
-    // Generate a virtual column in its place so that we can push down the reading virtual column to the storage layer.
-    // This allows us to using the already generated and stored virtual column data to speed up queries.
-    // TODO: Support other variant `get` functions.
-    fn try_replace_virtual_column(
-        &mut self,
-        expr: &mut ScalarExpr,
-        item_index: Option<IndexType>,
-    ) -> Option<()> {
-        match expr {
-            ScalarExpr::FunctionCall(FunctionCall {
-                func_name,
-                arguments,
-                ..
-            }) if func_name == "get_by_keypath" && arguments.len() == 2 => {
-                if let (
-                    ScalarExpr::BoundColumnRef(column_ref),
-                    ScalarExpr::ConstantExpr(constant),
-                ) = (arguments[0].clone(), arguments[1].clone())
-                {
-                    let column_entry = self.metadata.read().column(column_ref.column.index).clone();
-                    if let ColumnEntry::BaseTableColumn(base_column) = column_entry {
-                        if base_column.data_type.remove_nullable() != TableDataType::Variant {
-                            return Some(());
-                        }
-                        let name = match constant.value.clone() {
-                            Scalar::String(v) => match parse_key_paths(v.as_bytes()) {
-                                Ok(key_paths) => {
-                                    let mut name = String::new();
-                                    name.push_str(&base_column.column_name);
-                                    for path in key_paths.paths {
-                                        name.push('[');
-                                        match path {
-                                            KeyPath::Index(idx) => {
-                                                name.push_str(&idx.to_string());
-                                            }
-                                            KeyPath::QuotedName(field) | KeyPath::Name(field) => {
-                                                name.push('\'');
-                                                name.push_str(field.as_ref());
-                                                name.push('\'');
-                                            }
-                                        }
-                                        name.push(']');
-                                    }
-                                    name
-                                }
-                                Err(_) => {
-                                    return Some(());
-                                }
-                            },
-                            _ => {
-                                return Some(());
-                            }
-                        };
-                        // If this field name does not have a virtual column created,
-                        // we can't read this data directly, but we can still generate a virtual column
-                        // and push down to the storage layer.
-                        // Those virtual columns can be generated from the source column.
-                        // This can be used to reminder user to create it to speed up the query.
-                        let virtual_type = self
-                            .virtual_column_names
-                            .get(&base_column.table_index)
-                            .and_then(|names| names.get(&name));
-
-                        let is_created = virtual_type.is_some();
-
-                        let mut index = 0;
-                        // Check for duplicate virtual columns
-                        for table_column in self
-                            .metadata
-                            .read()
-                            .virtual_columns_by_table_index(base_column.table_index)
-                        {
-                            if table_column.name() == name {
-                                index = table_column.index();
-                                break;
-                            }
-                        }
-
-                        let table_data_type = if let Some(virtual_type) = virtual_type {
-                            virtual_type.wrap_nullable()
-                        } else {
-                            TableDataType::Nullable(Box::new(TableDataType::Variant))
-                        };
-
-                        if index == 0 {
-                            let column_id =
-                                self.next_column_ids.get(&base_column.table_index).unwrap();
-
-                            index = self.metadata.write().add_virtual_column(
-                                &base_column,
-                                *column_id,
-                                name.clone(),
-                                table_data_type.clone(),
-                                constant.value.clone(),
-                                item_index,
-                                is_created,
-                            );
-
-                            // Increments the column id of the virtual column.
-                            let column_id = self
-                                .next_column_ids
-                                .get_mut(&base_column.table_index)
-                                .unwrap();
-                            *column_id += 1;
-                        }
-
-                        if let Some(indices) =
-                            self.table_virtual_columns.get_mut(&base_column.table_index)
-                        {
-                            indices.push(index);
-                        } else {
-                            self.table_virtual_columns
-                                .insert(base_column.table_index, vec![index]);
-                        }
-
-                        let data_type = DataType::from(&table_data_type);
-                        let column_binding = ColumnBindingBuilder::new(
-                            name,
-                            index,
-                            Box::new(data_type),
-                            Visibility::InVisible,
-                        )
-                        .table_index(Some(base_column.table_index))
-                        .build();
-
-                        let virtual_column = ScalarExpr::BoundColumnRef(BoundColumnRef {
-                            span: None,
-                            column: column_binding,
-                        });
-                        *expr = virtual_column;
-                        return Some(());
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        None
-    }
-}
-
-impl<'a> VisitorMut<'a> for VirtualColumnRewriter {
-    fn visit(&mut self, expr: &'a mut ScalarExpr) -> Result<()> {
-        if self.try_replace_virtual_column(expr, None).is_some() {
-            return Ok(());
-        }
-        walk_expr_mut(self, expr)?;
-
-        Ok(())
     }
 }

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -287,9 +287,10 @@ impl BlockReader {
 
     pub(crate) fn build_virtual_column_iter(
         name: String,
+        data_type: TableDataType,
         readers: Vec<NativeReader<Box<dyn NativeReaderExt>>>,
     ) -> Result<ColumnIter<'static>> {
-        let field = TableField::new(&name, TableDataType::Variant.wrap_nullable());
+        let field = TableField::new(&name, data_type);
 
         let native_column_reader = NativeColumnsReader::new()?;
         match native_column_reader.column_iters(readers, field, vec![]) {

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
@@ -178,7 +178,19 @@ impl VirtualColumnReader {
                 &BUILTIN_FUNCTIONS,
             )?;
 
-            let column = BlockEntry::new(data_type, value);
+            let column = if let Some(cast_func_name) = &virtual_column_field.cast_func_name {
+                let (cast_value, cast_data_type) = eval_function(
+                    None,
+                    cast_func_name,
+                    [(value, data_type)],
+                    &func_ctx,
+                    data_block.num_rows(),
+                    &BUILTIN_FUNCTIONS,
+                )?;
+                BlockEntry::new(cast_data_type, cast_value)
+            } else {
+                BlockEntry::new(data_type, value)
+            };
             data_block.add_column(column);
         }
 

--- a/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
@@ -471,7 +471,19 @@ impl NativeDeserializeDataTransform {
                     &BUILTIN_FUNCTIONS,
                 )?;
 
-                let column = BlockEntry::new(data_type, value);
+                let column = if let Some(cast_func_name) = &virtual_column_field.cast_func_name {
+                    let (cast_value, cast_data_type) = eval_function(
+                        None,
+                        cast_func_name,
+                        [(value, data_type)],
+                        &self.func_ctx,
+                        block.num_rows(),
+                        &BUILTIN_FUNCTIONS,
+                    )?;
+                    BlockEntry::new(cast_data_type, cast_value)
+                } else {
+                    BlockEntry::new(data_type, value)
+                };
                 block.add_column(column);
             }
         }

--- a/src/query/storages/system/src/virtual_columns_table.rs
+++ b/src/query/storages/system/src/virtual_columns_table.rs
@@ -33,6 +33,7 @@ use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_types::MetaId;
 use databend_common_storages_fuse::TableContext;
+use itertools::Itertools;
 
 use crate::columns_table::dump_tables;
 use crate::table::AsyncOneBlockSystemTable;
@@ -79,7 +80,13 @@ impl AsyncSystemTable for VirtualColumnsTable {
                     if let Some(virtual_column_meta) = virtual_column_meta_map.remove(&table_id) {
                         database_names.push(database.clone());
                         table_names.push(table.name().to_string());
-                        virtual_columns.push(virtual_column_meta.virtual_columns.join(", "));
+                        virtual_columns.push(
+                            virtual_column_meta
+                                .virtual_columns
+                                .iter()
+                                .map(|col| format!("{} {}", col.0, col.1))
+                                .join(", "),
+                        );
                         created_on_columns.push(virtual_column_meta.created_on.timestamp_micros());
                         updated_on_columns
                             .push(virtual_column_meta.updated_on.map(|u| u.timestamp_micros()));

--- a/src/query/storages/system/src/virtual_columns_table.rs
+++ b/src/query/storages/system/src/virtual_columns_table.rs
@@ -84,7 +84,13 @@ impl AsyncSystemTable for VirtualColumnsTable {
                             virtual_column_meta
                                 .virtual_columns
                                 .iter()
-                                .map(|col| format!("{} {}", col.0, col.1))
+                                .map(|(name, ty)| {
+                                    if ty.remove_nullable() == TableDataType::Variant {
+                                        name.to_string()
+                                    } else {
+                                        format!("{}::{}", name, ty.remove_nullable())
+                                    }
+                                })
                                 .join(", "),
                         );
                         created_on_columns.push(virtual_column_meta.created_on.timestamp_micros());

--- a/src/tests/sqlsmith/src/sql_gen/ddl.rs
+++ b/src/tests/sqlsmith/src/sql_gen/ddl.rs
@@ -66,6 +66,11 @@ const SIMPLE_COLUMN_TYPES: [TypeName; 21] = [
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     pub(crate) fn gen_base_tables(&mut self) -> Vec<(DropTableStmt, CreateTableStmt)> {
         let mut tables = Vec::with_capacity(BASE_TABLE_NAMES.len());
+
+        let mut table_options = BTreeMap::new();
+        if self.rng.gen_bool(0.3) {
+            table_options.insert("storage_format".to_string(), "native".to_string());
+        }
         for table_name in BASE_TABLE_NAMES {
             let source = self.gen_table_source();
 
@@ -76,6 +81,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 table: Identifier::from_name(None, table_name),
                 all: false,
             };
+
             let create_table = CreateTableStmt {
                 create_option: CreateOption::CreateIfNotExists,
                 catalog: None,
@@ -85,7 +91,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 engine: Some(Engine::Fuse),
                 uri_location: None,
                 cluster_by: None,
-                table_options: BTreeMap::new(),
+                table_options: table_options.clone(),
                 as_query: None,
                 table_type: TableType::Normal,
             };

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
@@ -28,10 +28,10 @@ statement ok
 create table t1(id int, val json) storage_format = 'native'
 
 statement ok
-insert into t1 values(1, '{"a":11,"b":1}'), (2, '{"a":22}'), (3, '3')
+insert into t1 values(1, '{"a":11,"b":1,"c":"test"}'), (2, '{"a":22,"b":2,"c":"data"}'), (3, '3')
 
 statement ok
-create virtual column (val['a'], val['b']) for t1
+create virtual column (val['a'], val['b']::int, val['c']::string) for t1
 
 statement ok
 refresh virtual column for t1
@@ -39,46 +39,46 @@ refresh virtual column for t1
 query TTT
 show virtual columns from t1
 ----
-test_virtual_column t1 val['a'], val['b']
+test_virtual_column t1 val['a'], val['b']::Int32, val['c']::String
 
 statement ok
-insert into t1 values(4, '{"a":44,"b":4}'), (5, '{"a":55}'), (6, '6')
+insert into t1 values(4, '{"a":44,"b":4,"c":"value"}'), (5, '{"a":55,"b":5,"c":"bend"}'), (6, '6')
 
-query ITT
-select id, val['a'], val['b'] from t1 order by id
-----
-1 11 1
-2 22 NULL
-3 NULL NULL
-4 44 4
-5 55 NULL
-6 NULL NULL
-
-query ITTT
-select id, val['a'], val['b'], val from t1 order by id
-----
-1 11 1 {"a":11,"b":1}
-2 22 NULL {"a":22}
-3 NULL NULL 3
-4 44 4 {"a":44,"b":4}
-5 55 NULL {"a":55}
-6 NULL NULL 6
-
-query ITTT
+query ITIT
 select id, val['a'], val['b'], val['c'] from t1 order by id
 ----
-1 11 1 NULL
-2 22 NULL NULL
+1 11 1 test
+2 22 2 data
 3 NULL NULL NULL
-4 44 4 NULL
-5 55 NULL NULL
+4 44 4 value
+5 55 5 bend
 6 NULL NULL NULL
 
-query ITT
-select id, val['a'], val['b'] from t1 where val=3 or val=6 order by id
+query ITITT
+select id, val['a'], val['b'], val['c'], val from t1 order by id
 ----
-3 NULL NULL
-6 NULL NULL
+1 11 1 test {"a":11,"b":1,"c":"test"}
+2 22 2 data {"a":22,"b":2,"c":"data"}
+3 NULL NULL NULL 3
+4 44 4 value {"a":44,"b":4,"c":"value"}
+5 55 5 bend {"a":55,"b":5,"c":"bend"}
+6 NULL NULL NULL 6
+
+query ITITT
+select id, val['a'], val['b'], val['c'], val['d'] from t1 order by id
+----
+1 11 1 test NULL
+2 22 2 data NULL
+3 NULL NULL NULL NULL
+4 44 4 value NULL
+5 55 5 bend NULL
+6 NULL NULL NULL NULL
+
+query ITIT
+select id, val['a'], val['b'], val['c'] from t1 where val=3 or val=6 order by id
+----
+3 NULL NULL NULL
+6 NULL NULL NULL
 
 query ITTT
 select id, val['a'], val['b'], val from t1 where val=3 or val=6 order by id
@@ -86,17 +86,17 @@ select id, val['a'], val['b'], val from t1 where val=3 or val=6 order by id
 3 NULL NULL 3
 6 NULL NULL 6
 
-query ITT
-select id, val['a'], val['b'] from t1 where val['a']=11 or val['a']=44 order by id
+query ITIT
+select id, val['a'], val['b'], val['c'] from t1 where val['a']=11 or val['a']=44 order by id
 ----
-1 11 1
-4 44 4
+1 11 1 test
+4 44 4 value
 
-query ITTT
-select id, val['a'], val['b'], val from t1 where val['a']=11 or val['a']=44 order by id
+query ITITT
+select id, val['a'], val['b'], val['c'], val from t1 where val['a']=11 or val['a']=44 order by id
 ----
-1 11 1 {"a":11,"b":1}
-4 44 4 {"a":44,"b":4}
+1 11 1 test {"a":11,"b":1,"c":"test"}
+4 44 4 value {"a":44,"b":4,"c":"value"}
 
 query IT
 select max(id), val:a from t1 group by val:a order by val:a
@@ -115,15 +115,15 @@ select t11.id, t11.a, t12.id, t12.a from(select id, val:a as a from t1)t11 join 
 4 44 4 44
 5 55 5 55
 
-query ITT
-SELECT r.id, r.val['a'], r.nval:a FROM ( SELECT r.id, r.val, r.val as nval FROM t1 AS r) AS r order by id
+query ITITI
+SELECT r.id, r.val['a'], r.val['b'], r.nval:a, r.nval:b FROM ( SELECT r.id, r.val, r.val as nval FROM t1 AS r) AS r order by id
 ----
-1 11 11
-2 22 22
-3 NULL NULL
-4 44 44
-5 55 55
-6 NULL NULL
+1 11 1 11 1
+2 22 2 22 2
+3 NULL NULL NULL NULL
+4 44 4 44 4
+5 55 5 55 5
+6 NULL NULL NULL NULL
 
 statement ok
 drop table if exists t2
@@ -132,10 +132,10 @@ statement ok
 create table t2(id int, val json) storage_format = 'parquet'
 
 statement ok
-insert into t2 values(1, '{"a":11,"b":1}'), (2, '{"a":22}'), (3, '3')
+insert into t2 values(1, '{"a":11,"b":1,"c":"test"}'), (2, '{"a":22,"b":2,"c":"data"}'), (3, '3')
 
 statement ok
-create virtual column (val['a'], val['b']) for t2
+create virtual column (val['a'], val['b']::int, val['c']::string) for t2
 
 statement ok
 refresh virtual column for t2
@@ -143,46 +143,46 @@ refresh virtual column for t2
 query TTT
 show virtual columns from t2
 ----
-test_virtual_column t2 val['a'], val['b']
+test_virtual_column t2 val['a'], val['b']::Int32, val['c']::String
 
 statement ok
-insert into t2 values(4, '{"a":44,"b":4}'), (5, '{"a":55}'), (6, '6')
+insert into t2 values(4, '{"a":44,"b":4,"c":"value"}'), (5, '{"a":55,"b":5,"c":"bend"}'), (6, '6')
 
-query ITT
-select id, val['a'], val['b'] from t2 order by id
-----
-1 11 1
-2 22 NULL
-3 NULL NULL
-4 44 4
-5 55 NULL
-6 NULL NULL
-
-query ITTT
-select id, val['a'], val['b'], val from t2 order by id
-----
-1 11 1 {"a":11,"b":1}
-2 22 NULL {"a":22}
-3 NULL NULL 3
-4 44 4 {"a":44,"b":4}
-5 55 NULL {"a":55}
-6 NULL NULL 6
-
-query ITTT
+query ITIT
 select id, val['a'], val['b'], val['c'] from t2 order by id
 ----
-1 11 1 NULL
-2 22 NULL NULL
+1 11 1 test
+2 22 2 data
 3 NULL NULL NULL
-4 44 4 NULL
-5 55 NULL NULL
+4 44 4 value
+5 55 5 bend
 6 NULL NULL NULL
 
-query ITT
-select id, val['a'], val['b'] from t2 where val=3 or val=6 order by id
+query ITITT
+select id, val['a'], val['b'], val['c'], val from t2 order by id
 ----
-3 NULL NULL
-6 NULL NULL
+1 11 1 test {"a":11,"b":1,"c":"test"}
+2 22 2 data {"a":22,"b":2,"c":"data"}
+3 NULL NULL NULL 3
+4 44 4 value {"a":44,"b":4,"c":"value"}
+5 55 5 bend {"a":55,"b":5,"c":"bend"}
+6 NULL NULL NULL 6
+
+query ITITT
+select id, val['a'], val['b'], val['c'], val['d'] from t2 order by id
+----
+1 11 1 test NULL
+2 22 2 data NULL
+3 NULL NULL NULL NULL
+4 44 4 value NULL
+5 55 5 bend NULL
+6 NULL NULL NULL NULL
+
+query ITIT
+select id, val['a'], val['b'], val['c'] from t2 where val=3 or val=6 order by id
+----
+3 NULL NULL NULL
+6 NULL NULL NULL
 
 query ITTT
 select id, val['a'], val['b'], val from t2 where val=3 or val=6 order by id
@@ -190,17 +190,17 @@ select id, val['a'], val['b'], val from t2 where val=3 or val=6 order by id
 3 NULL NULL 3
 6 NULL NULL 6
 
-query ITT
-select id, val['a'], val['b'] from t2 where val['a']=11 or val['a']=44 order by id
+query ITIT
+select id, val['a'], val['b'], val['c'] from t2 where val['a']=11 or val['a']=44 order by id
 ----
-1 11 1
-4 44 4
+1 11 1 test
+4 44 4 value
 
-query ITTT
-select id, val['a'], val['b'], val from t2 where val['a']=11 or val['a']=44 order by id
+query ITITT
+select id, val['a'], val['b'], val['c'], val from t2 where val['a']=11 or val['a']=44 order by id
 ----
-1 11 1 {"a":11,"b":1}
-4 44 4 {"a":44,"b":4}
+1 11 1 test {"a":11,"b":1,"c":"test"}
+4 44 4 value {"a":44,"b":4,"c":"value"}
 
 query IT
 select max(id), val:a from t2 group by val:a order by val:a
@@ -212,22 +212,22 @@ select max(id), val:a from t2 group by val:a order by val:a
 6 NULL
 
 query ITIT
-select t11.id, t11.a, t12.id, t12.a from(select id, val:a as a from t2)t11 join (select id, val:a as a from t2)t12 on t11.a = t12.a order by t11.a
+select t21.id, t21.a, t22.id, t22.a from(select id, val:a as a from t2)t21 join (select id, val:a as a from t2)t22 on t21.a = t22.a order by t21.a
 ----
 1 11 1 11
 2 22 2 22
 4 44 4 44
 5 55 5 55
 
-query ITT
-SELECT r.id, r.val['a'], r.nval:a FROM ( SELECT r.id, r.val, r.val as nval FROM t2 AS r) AS r order by id
+query ITITI
+SELECT r.id, r.val['a'], r.val['b'], r.nval:a, r.nval:b FROM ( SELECT r.id, r.val, r.val as nval FROM t2 AS r) AS r order by id
 ----
-1 11 11
-2 22 22
-3 NULL NULL
-4 44 44
-5 55 55
-6 NULL NULL
+1 11 1 11 1
+2 22 2 22 2
+3 NULL NULL NULL NULL
+4 44 4 44 4
+5 55 5 55 5
+6 NULL NULL NULL NULL
 
 statement ok
 create or replace virtual column (val['a']) for t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

allow virtual column cast to other type, avoiding jsonb value deserialization to improve performance.

- fix meta proto-conv v111 add glue meta test
- virtual column proto add `data_types` field
- allow virtual column cast to other types, this can avoids jsonb value deserialization to improve performance

From the following example, we can see that the execution time has been reduced from 291.674 sec to 235.888 sec, and the amount of data read has been reduced from 11.01 GiB to 9.16 GiB

```sql
root@0.0.0.0:48000/default> CREATE OR REPLACE TABLE user_activity_logs AS
SELECT 
    number % 100000000 AS id,
    JSON_OBJECT(
        'id', CAST(number % 100000000 AS STRING),
        'email', CONCAT('user', CAST(number % 100000000 AS STRING), '@example.com'),
        'nickname', CONCAT('user', CAST(number % 100000000 AS STRING)),
        'phone', CONCAT('******', CAST(number % 10000 + 1000 AS STRING))
    ) AS data
FROM numbers(100000000);

-- create virtual columns
root@0.0.0.0:48000/default> CREATE or replace VIRTUAL COLUMN (
    data['id'],
    data['email'],
    data['nickname'],
    data['phone']
) FOR user_activity_logs;

-- Refresh the virtual columns to activate them
root@0.0.0.0:48000/default> REFRESH VIRTUAL COLUMN FOR user_activity_logs;

root@0.0.0.0:48000/default> select data['id'], data['email'], data['nickname'], data['phone'] from user_activity_logs;
┌────────────────────────────────────────────────────────────────────────────────────────┐
│     data['id']    │        data['email']       │  data['nickname'] │   data['phone']   │
│ Nullable(Variant) │      Nullable(Variant)     │ Nullable(Variant) │ Nullable(Variant) │
├───────────────────┼────────────────────────────┼───────────────────┼───────────────────┤
│ "91732188"        │ "user91732188@example.com" │ "user91732188"    │ "******3188"      │
│ "91732189"        │ "user91732189@example.com" │ "user91732189"    │ "******3189"      │
│ ·                 │ ·                          │ ·                 │ ·                 │
│ ·                 │ ·                          │ ·                 │ ·                 │
│ ·                 │ ·                          │ ·                 │ ·                 │
│ "37499993"        │ "user37499993@example.com" │ "user37499993"    │ "******10993"     │
│ 100000000 rows    │                            │                   │                   │
│ (1000 shown)      │                            │                   │                   │
└────────────────────────────────────────────────────────────────────────────────────────┘
100000000 rows read in 291.674 sec. Processed 100 million rows, 11.01 GiB (342.85 thousand rows/s, 38.67 MiB/s)


root@0.0.0.0:48000/default> CREATE OR REPLACE TABLE user_activity_logs2 AS
SELECT 
    number % 100000000 AS id,
    JSON_OBJECT(
        'id', CAST(number % 100000000 AS STRING),
        'email', CONCAT('user', CAST(number % 100000000 AS STRING), '@example.com'),
        'nickname', CONCAT('user', CAST(number % 100000000 AS STRING)),
        'phone', CONCAT('******', CAST(number % 10000 + 1000 AS STRING))
    ) AS data
FROM numbers(100000000);

-- create virtual columns
root@0.0.0.0:48000/default> CREATE or replace VIRTUAL COLUMN (
    data['id']::int,
    data['email']::string,
    data['nickname']::string,
    data['phone']::string
) FOR user_activity_logs2;

-- Refresh the virtual columns to activate them
root@0.0.0.0:48000/default> REFRESH VIRTUAL COLUMN FOR user_activity_logs2;

root@0.0.0.0:48000/default> select data['id'], data['email'], data['nickname'], data['phone'] from user_activity_logs2;
┌──────────────────────────────────────────────────────────────────────────────────┐
│    data['id']   │       data['email']      │ data['nickname'] │   data['phone']  │
│ Nullable(Int32) │     Nullable(String)     │ Nullable(String) │ Nullable(String) │
├─────────────────┼──────────────────────────┼──────────────────┼──────────────────┤
│        66666656 │ user66666656@example.com │ user66666656     │ ******7656       │
│        66666657 │ user66666657@example.com │ user66666657     │ ******7657       │
│               · │ ·                        │ ·                │ ·                │
│               · │ ·                        │ ·                │ ·                │
│               · │ ·                        │ ·                │ ·                │
│         4166665 │ user4166665@example.com  │ user4166665      │ ******7665       │
│  100000000 rows │                          │                  │                  │
│    (1000 shown) │                          │                  │                  │
└──────────────────────────────────────────────────────────────────────────────────┘
100000000 rows read in 235.888 sec. Processed 100 million rows, 9.16 GiB (423.93 thousand rows/s, 39.77 MiB/s)
```


- fixes: #[Link the issue here]

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16903)
<!-- Reviewable:end -->
