### PR TITLE
refactor: remove obsolete gRPC read API

### DIFF
--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -86,7 +86,8 @@ The following is an illustration of the latest query-meta compatibility:
 | [1.1.32, 1.2.63)   | ✅                | ✅              | ❌          |❌          |
 | [1.2.63, 1.2.226)  | ✅                | ✅              | ❌          |❌          |
 | [1.2.226, 1.2.258) | ✅                | ✅              | ✅          |❌          |
-| [1.2.258, +∞)      | ✅                | ✅              | ✅          |✅          |
+| [1.2.258, 1.2.663) | ✅                | ✅              | ✅          |✅          |
+| [1.2.663, +∞)      | ❌                | ❌              | ✅          |✅          |
 
 History versions that are not included in the above chart:
 

--- a/src/meta/api/src/background_api.rs
+++ b/src/meta/api/src/background_api.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_meta_app::background::BackgroundJobInfo;
+use databend_common_meta_app::background::BackgroundTaskIdent;
 use databend_common_meta_app::background::BackgroundTaskInfo;
 use databend_common_meta_app::background::CreateBackgroundJobReply;
 use databend_common_meta_app::background::CreateBackgroundJobReq;
@@ -70,7 +71,7 @@ pub trait BackgroundApi: Send + Sync {
     async fn list_background_tasks(
         &self,
         req: ListBackgroundTasksReq,
-    ) -> Result<Vec<(u64, String, BackgroundTaskInfo)>, KVAppError>;
+    ) -> Result<Vec<(BackgroundTaskIdent, SeqV<BackgroundTaskInfo>)>, KVAppError>;
 
     async fn update_background_task(
         &self,

--- a/src/meta/api/src/background_api_test_suite.rs
+++ b/src/meta/api/src/background_api_test_suite.rs
@@ -180,10 +180,10 @@ impl BackgroundApiTestSuite {
             info!("update log res: {:?}", res);
             let res = res.unwrap();
             assert_eq!(1, res.len(), "there is one task");
-            assert_eq!(task_id, res[0].1, "task name");
+            assert_eq!(task_id, res[0].0.name(), "task name");
             assert_eq!(
                 BackgroundTaskState::DONE,
-                res[0].2.task_state,
+                res[0].1.task_state,
                 "first state is done"
             );
         }

--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -53,10 +53,6 @@ pub trait RequestFor: Clone + fmt::Debug {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, derive_more::From)]
 pub enum MetaGrpcReq {
     UpsertKV(UpsertKVReq),
-
-    GetKV(GetKVReq),
-    MGetKV(MGetKVReq),
-    ListKV(ListKVReq),
 }
 
 impl TryInto<MetaGrpcReq> for Request<RaftRequest> {
@@ -123,16 +119,6 @@ pub enum MetaGrpcReadReq {
 // All Read requests returns a stream of KV pairs.
 impl RequestFor for MetaGrpcReadReq {
     type Reply = BoxStream<StreamItem>;
-}
-
-impl From<MetaGrpcReadReq> for MetaGrpcReq {
-    fn from(v: MetaGrpcReadReq) -> Self {
-        match v {
-            MetaGrpcReadReq::GetKV(v) => MetaGrpcReq::GetKV(v),
-            MetaGrpcReadReq::MGetKV(v) => MetaGrpcReq::MGetKV(v),
-            MetaGrpcReadReq::ListKV(v) => MetaGrpcReq::ListKV(v),
-        }
-    }
 }
 
 impl From<MetaGrpcReadReq> for RaftRequest {

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -105,6 +105,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2024-03-04: since: 1.2.361
 ///   👥 client: `MetaSpec` use `ttl`, remove `expire_at`, require 1.2.258
 ///
+/// - 2024-11-22: since 1.2.663
+///   🖥 server: remove `MetaGrpcReq::GetKV/MGetKV/ListKV`,
+///              require the client to call kv_read_v1 for get/mget/list,
+///              which is added `2024-01-07: since 1.2.287`
+///
 /// Server feature set:
 /// ```yaml
 /// server_features:

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -120,27 +120,6 @@ impl MetaServiceImpl {
                     .await;
                 RaftReply::from(res)
             }
-            MetaGrpcReq::GetKV(a) => {
-                let res = m
-                    .get_kv(&a.key)
-                    .log_elapsed_info(format!("GetKV: {:?}", a))
-                    .await;
-                RaftReply::from(res)
-            }
-            MetaGrpcReq::MGetKV(a) => {
-                let res = m
-                    .mget_kv(&a.keys)
-                    .log_elapsed_info(format!("MGetKV: {:?}", a))
-                    .await;
-                RaftReply::from(res)
-            }
-            MetaGrpcReq::ListKV(a) => {
-                let res = m
-                    .prefix_list_kv(&a.prefix)
-                    .log_elapsed_info(format!("ListKV: {:?}", a))
-                    .await;
-                RaftReply::from(res)
-            }
         };
 
         network_metrics::incr_request_result(reply.error.is_empty());

--- a/src/meta/service/src/version.rs
+++ b/src/meta/service/src/version.rs
@@ -54,7 +54,7 @@ pub static METASRV_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 });
 
 /// Oldest compatible nightly meta-client version
-pub static MIN_METACLI_SEMVER: Version = Version::new(0, 9, 41);
+pub static MIN_METACLI_SEMVER: Version = Version::new(1, 2, 287);
 
 /// The min meta-server version that can be deployed together in a cluster,
 /// i.e., the network APIs are compatible.

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -24,7 +24,6 @@ use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
-use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
@@ -135,25 +134,15 @@ impl UdfMgr {
     #[async_backtrace::framed]
     #[fastrace::trace]
     pub async fn list_udf_fallback(&self) -> Result<Vec<UserDefinedFunction>, ErrorCode> {
-        let key = UdfIdent::new(&self.tenant, "");
-        let values = self.kv_api.prefix_list_kv(&key.to_string_key()).await?;
+        let key = UdfIdent::new(&self.tenant, "dummy");
+        let dir = DirName::new(key);
+        let udfs = self
+            .kv_api
+            .list_pb_values(&dir)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
 
-        let mut udfs = Vec::with_capacity(values.len());
-        // At begin udf is serialize to json. https://github.com/datafuselabs/databend/pull/12729/files#diff-9c992028e59caebc313d761b8488b17f142618fb89db64c51c1655689d68c41b
-        // But we can not deserialize the UserDefinedFunction from json now,
-        // because add a new field created_on and the field `definition` refactor to a ENUM type.
-        for (name, value) in values {
-            let udf = crate::deserialize_struct(&value.data, ErrorCode::IllegalUDFFormat, || {
-                format!(
-                    "Encountered invalid json data for LambdaUDF '{}', \
-                please drop this invalid udf and re-create it. \n\
-                Example: `DROP FUNCTION <invalid_udf>;` then `CREATE FUNCTION <invalid_udf> AS <udf_definition>;`\n\
-                ",
-                    name
-                )
-            })?;
-            udfs.push(udf);
-        }
         Ok(udfs)
     }
 

--- a/src/query/service/src/servers/admin/v1/background_tasks.rs
+++ b/src/query/service/src/servers/admin/v1/background_tasks.rs
@@ -61,30 +61,33 @@ async fn load_background_tasks(
         tasks.len()
     );
     let mut task_infos = Vec::with_capacity(tasks.len());
-    for (_, name, task) in tasks {
-        if params.task_state.is_some() && task.task_state != *params.task_state.as_ref().unwrap() {
+    for (name, seq_task) in tasks {
+        if params.task_state.is_some()
+            && seq_task.task_state != *params.task_state.as_ref().unwrap()
+        {
             continue;
         }
-        if params.task_type.is_some() && task.task_type != *params.task_type.as_ref().unwrap() {
+        if params.task_type.is_some() && seq_task.task_type != *params.task_type.as_ref().unwrap() {
             continue;
         }
-        if task.task_type == BackgroundTaskType::COMPACTION {
-            if task.compaction_task_stats.is_none() {
+        if seq_task.task_type == BackgroundTaskType::COMPACTION {
+            if seq_task.compaction_task_stats.is_none() {
                 continue;
             }
             if params.table_id.is_some()
-                && task.compaction_task_stats.as_ref().unwrap().table_id != params.table_id.unwrap()
+                && seq_task.compaction_task_stats.as_ref().unwrap().table_id
+                    != params.table_id.unwrap()
             {
                 continue;
             }
         }
         if params.timestamp.as_ref().is_some()
-            && task.last_updated.is_some()
-            && task.last_updated.unwrap() < params.timestamp.unwrap()
+            && seq_task.last_updated.is_some()
+            && seq_task.last_updated.unwrap() < params.timestamp.unwrap()
         {
             continue;
         }
-        task_infos.push((name, task));
+        task_infos.push((name.name().to_string(), seq_task.data));
     }
     Ok(ListBackgroundTasksResponse {
         task_infos,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove obsolete gRPC read API


##### chore: simplify list_udf


##### refactor: list_background_tasks() use structured return values

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues