### PR TITLE
fix: dropped temporary table should not be shown in system.temporary_tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,7 +3325,6 @@ dependencies = [
  "chrono-tz 0.8.6",
  "comfy-table",
  "criterion",
- "dashmap 6.1.0",
  "databend-common-ast",
  "databend-common-base",
  "databend-common-column",

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -123,7 +123,10 @@ impl TempTblMgr {
                     .as_ref()
                     .map(|o| format!("{}.{}", name_ident.db_name, o))
                     .unwrap_or(desc);
-                self.name_to_id.insert(desc, table_id);
+                let old_id = self.name_to_id.insert(desc, table_id);
+                if let Some(old_id) = old_id {
+                    self.id_to_table.remove(&old_id);
+                }
                 self.id_to_table.insert(table_id, TempTable {
                     db_name: name_ident.db_name,
                     table_name: orphan_table_name.clone().unwrap_or(name_ident.table_name),

--- a/tests/sqllogictests/suites/temp_table/rename_temp_tables.sql
+++ b/tests/sqllogictests/suites/temp_table/rename_temp_tables.sql
@@ -84,6 +84,12 @@ SELECT * FROM t1
 ----
 1
 
+statement ok
+CREATE TEMP TABLE t2(c int)
+
+statement error 2302
+RENAME TABLE t1 to t2
+
 statement error 1006
 RENAME TABLE t1 to system.t1
 

--- a/tests/sqllogictests/suites/temp_table/temporary_tables_table.sql
+++ b/tests/sqllogictests/suites/temp_table/temporary_tables_table.sql
@@ -20,3 +20,21 @@ default t0 4611686018427407904 FUSE
 d1 t1 4611686018427407905 FUSE
 d2 t2 4611686018427407906 MEMORY
 
+statement ok
+CREATE OR REPLACE TEMP TABLE d1.t1(a int not null, b int not null);
+
+query T
+select * from system.temporary_tables order by table_id;
+----
+default t0 4611686018427407904 FUSE
+d2 t2 4611686018427407906 MEMORY
+d1 t1 4611686018427407907 FUSE
+
+statement ok
+drop table d2.t2;
+
+query T
+select * from system.temporary_tables order by table_id;
+----
+default t0 4611686018427407904 FUSE
+d1 t1 4611686018427407907 FUSE

--- a/tests/sqllogictests/suites/temp_table/temporary_tables_table.sql
+++ b/tests/sqllogictests/suites/temp_table/temporary_tables_table.sql
@@ -38,3 +38,21 @@ select * from system.temporary_tables order by table_id;
 ----
 default t0 4611686018427407904 FUSE
 d1 t1 4611686018427407907 FUSE
+
+statement ok
+CREATE OR REPLACE TEMP TABLE d1.t1(a int not null, b int not null) as select * from d1.t1;
+
+query T
+select * from system.temporary_tables order by table_id;
+----
+default t0 4611686018427407904 FUSE
+d1 t1 4611686018427407908 FUSE
+
+statement ok
+CREATE OR REPLACE TEMP TABLE d1.t1(a int not null, b int not null) as select * from d1.t1;
+
+query T
+select * from system.temporary_tables order by table_id;
+----
+default t0 4611686018427407904 FUSE
+d1 t1 4611686018427407909 FUSE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The table meta of temp table is not cleared totally when it is replaced due to `create or replace` statement, which causes it to be displayed in the system tables. Thanks @xudong963 for reporting this.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16911)
<!-- Reviewable:end -->
