### PR TITLE
refactor: deprecate: Operation::AsIs and will be removed

### DIFF
--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Instant;
+
 use chrono::Utc;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::background::background_job_id_ident::BackgroundJobId;
@@ -226,14 +228,14 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
                 name_key.to_string_key().as_str(),
                 Any,
                 Operation::Update(serialize_struct(&meta)?),
-                Some(MetaSpec::new_expire(req.expire_at)),
+                Some(MetaSpec::new_ttl(req.ttl)),
             ))
             .await?;
         // confirm a successful update
         assert!(resp.is_changed());
         Ok(UpdateBackgroundTaskReply {
             last_updated: Utc::now(),
-            expire_at: req.expire_at,
+            expire_at: Instant::now() + req.ttl,
         })
     }
 

--- a/src/meta/api/src/background_api_impl.rs
+++ b/src/meta/api/src/background_api_impl.rs
@@ -42,7 +42,6 @@ use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_kvapi::kvapi::Key;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqValue;
 use databend_common_meta_types::MatchSeq::Any;
 use databend_common_meta_types::MetaError;
@@ -50,6 +49,7 @@ use databend_common_meta_types::MetaSpec;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use fastrace::func_name;
 use futures::TryStreamExt;
 use log::debug;
@@ -224,7 +224,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> BackgroundApi for KV {
         let meta = req.task_info.clone();
 
         let resp = self
-            .upsert_kv(UpsertKVReq::new(
+            .upsert_kv(UpsertKV::new(
                 name_key.to_string_key().as_str(),
                 Any,
                 Operation::Update(serialize_struct(&meta)?),

--- a/src/meta/api/src/background_api_test_suite.rs
+++ b/src/meta/api/src/background_api_test_suite.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_meta_app::background::BackgroundJobIdent;
@@ -127,13 +129,11 @@ impl BackgroundApiTestSuite {
 
         info!("--- create a background task");
         let create_on = Utc::now();
-        // expire after 5 secs
-        let expire_at = create_on + chrono::Duration::seconds(5);
         {
             let req = UpdateBackgroundTaskReq {
                 task_name: task_ident.clone(),
                 task_info: new_background_task(BackgroundTaskState::STARTED, create_on),
-                expire_at: expire_at.timestamp() as u64,
+                ttl: Duration::from_secs(5),
             };
 
             let res = mt.update_background_task(req).await;
@@ -155,7 +155,7 @@ impl BackgroundApiTestSuite {
             let req = UpdateBackgroundTaskReq {
                 task_name: task_ident.clone(),
                 task_info: new_background_task(BackgroundTaskState::DONE, create_on),
-                expire_at: expire_at.timestamp() as u64,
+                ttl: Duration::from_secs(5),
             };
 
             let res = mt.update_background_task(req).await;

--- a/src/meta/api/src/kv_pb_api/codec.rs
+++ b/src/meta/api/src/kv_pb_api/codec.rs
@@ -36,7 +36,9 @@ where T: FromToProto {
             Ok(Operation::Update(buf))
         }
         Operation::Delete => Ok(Operation::Delete),
-        Operation::AsIs => Ok(Operation::AsIs),
+        _ => {
+            unreachable!("Operation::AsIs is not supported")
+        }
     }
 }
 

--- a/src/meta/api/src/kv_pb_api/mod.rs
+++ b/src/meta/api/src/kv_pb_api/mod.rs
@@ -516,13 +516,13 @@ mod tests {
     use databend_common_meta_kvapi::kvapi::KVApi;
     use databend_common_meta_kvapi::kvapi::KVStream;
     use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-    use databend_common_meta_kvapi::kvapi::UpsertKVReq;
     use databend_common_meta_types::protobuf::StreamItem;
     use databend_common_meta_types::seq_value::SeqV;
     use databend_common_meta_types::seq_value::SeqValue;
     use databend_common_meta_types::MetaError;
     use databend_common_meta_types::TxnReply;
     use databend_common_meta_types::TxnRequest;
+    use databend_common_meta_types::UpsertKV;
     use databend_common_proto_conv::FromToProto;
     use futures::StreamExt;
     use futures::TryStreamExt;
@@ -541,7 +541,7 @@ mod tests {
     impl KVApi for FooKV {
         type Error = MetaError;
 
-        async fn upsert_kv(&self, _req: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
+        async fn upsert_kv(&self, _req: UpsertKV) -> Result<UpsertKVReply, Self::Error> {
             unimplemented!()
         }
 

--- a/src/meta/api/src/kv_pb_api/upsert_pb.rs
+++ b/src/meta/api/src/kv_pb_api/upsert_pb.rs
@@ -90,10 +90,6 @@ impl<K: kvapi::Key> UpsertPB<K> {
         }
     }
 
-    pub fn with_expire_sec(self, expire_at_sec: u64) -> Self {
-        self.with(MetaSpec::new_expire(expire_at_sec))
-    }
-
     /// Set the time to last for the value.
     /// When the ttl is passed, the value is deleted.
     pub fn with_ttl(self, ttl: Duration) -> Self {

--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -388,12 +388,12 @@ mod tests {
     use databend_common_meta_kvapi::kvapi::KVApi;
     use databend_common_meta_kvapi::kvapi::KVStream;
     use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-    use databend_common_meta_kvapi::kvapi::UpsertKVReq;
     use databend_common_meta_types::protobuf::StreamItem;
     use databend_common_meta_types::seq_value::SeqV;
     use databend_common_meta_types::MetaError;
     use databend_common_meta_types::TxnReply;
     use databend_common_meta_types::TxnRequest;
+    use databend_common_meta_types::UpsertKV;
     use databend_common_proto_conv::FromToProto;
     use futures::StreamExt;
     use prost::Message;
@@ -408,7 +408,7 @@ mod tests {
     impl KVApi for Foo {
         type Error = MetaError;
 
-        async fn upsert_kv(&self, _req: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
+        async fn upsert_kv(&self, _req: UpsertKV) -> Result<UpsertKVReply, Self::Error> {
             unimplemented!()
         }
 

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -130,7 +130,6 @@ use databend_common_meta_app::tenant::ToTenant;
 use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
@@ -238,7 +237,7 @@ async fn upsert_test_data(
     value: Vec<u8>,
 ) -> Result<u64, KVAppError> {
     let res = kv_api
-        .upsert_kv(UpsertKVReq {
+        .upsert_kv(UpsertKV {
             key: key.to_string_key(),
             seq: MatchSeq::GE(0),
             value: Operation::Update(value),
@@ -255,7 +254,7 @@ async fn delete_test_data(
     key: &impl kvapi::Key,
 ) -> Result<(), KVAppError> {
     let _res = kv_api
-        .upsert_kv(UpsertKVReq {
+        .upsert_kv(UpsertKV {
             key: key.to_string_key(),
             seq: MatchSeq::GE(0),
             value: Operation::Delete,

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -25,7 +25,6 @@ use databend_common_meta_app::primitive::Id;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
 use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::txn_condition::Target;
 use databend_common_meta_types::ConditionResult;
@@ -40,6 +39,7 @@ use databend_common_meta_types::TxnGetResponse;
 use databend_common_meta_types::TxnOp;
 use databend_common_meta_types::TxnOpResponse;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use databend_common_proto_conv::FromToProto;
 use log::debug;
 
@@ -200,7 +200,7 @@ pub async fn fetch_id<T: kvapi::Key>(
     generator: T,
 ) -> Result<u64, MetaError> {
     let res = kv_api
-        .upsert_kv(UpsertKVReq {
+        .upsert_kv(UpsertKV {
             key: generator.to_string_key(),
             seq: MatchSeq::GE(0),
             value: Operation::Update(b"".to_vec()),

--- a/src/meta/app/src/background/background_task.rs
+++ b/src/meta/app/src/background/background_task.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::time::Duration;
+use std::time::Instant;
 
 use chrono::DateTime;
 use chrono::Utc;
@@ -156,7 +157,7 @@ impl BackgroundTaskInfo {
 pub struct UpdateBackgroundTaskReq {
     pub task_name: BackgroundTaskIdent,
     pub task_info: BackgroundTaskInfo,
-    pub expire_at: u64,
+    pub ttl: Duration,
 }
 
 impl Display for UpdateBackgroundTaskReq {
@@ -176,7 +177,7 @@ impl Display for UpdateBackgroundTaskReq {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UpdateBackgroundTaskReply {
     pub last_updated: DateTime<Utc>,
-    pub expire_at: u64,
+    pub expire_at: Instant,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/binaries/meta/kvapi.rs
+++ b/src/meta/binaries/meta/kvapi.rs
@@ -15,15 +15,15 @@
 use std::sync::Arc;
 
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaSpec;
+use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 use databend_meta::configs::Config;
 
 pub enum KvApiCommand {
     Get(String),
-    Upsert(UpsertKVReq),
+    Upsert(UpsertKV),
     MGet(Vec<String>),
     List(String),
 }
@@ -36,7 +36,7 @@ impl KvApiCommand {
                     return Err("The number of keys must be 1".to_string());
                 }
 
-                let req = UpsertKVReq::update(config.key[0].as_str(), config.value.as_bytes());
+                let req = UpsertKV::update(config.key[0].as_str(), config.value.as_bytes());
 
                 let req = if let Some(expire_after) = config.expire_after {
                     req.with(MetaSpec::new_ttl(std::time::Duration::from_secs(
@@ -52,7 +52,7 @@ impl KvApiCommand {
                 if config.key.len() != 1 {
                     return Err("The number of keys must be 1".to_string());
                 }
-                Self::Upsert(UpsertKVReq::delete(&config.key[0]))
+                Self::Upsert(UpsertKV::delete(&config.key[0]))
             }
             "get" => {
                 if config.key.len() != 1 {

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -41,10 +41,10 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use databend_common_tracing::init_logging;
 use databend_common_tracing::FileConfig;
 use databend_common_tracing::StderrConfig;
@@ -171,7 +171,7 @@ async fn benchmark_upsert(client: &Arc<ClientHandle>, prefix: u64, client_num: u
     let value = Operation::Update(node_key().as_bytes().to_vec());
 
     let res = client
-        .upsert_kv(UpsertKVReq::new(node_key(), seq, value, None))
+        .upsert_kv(UpsertKV::new(node_key(), seq, value, None))
         .await;
 
     print_res(i, "upsert_kv", &res);

--- a/src/meta/binaries/metaverifier/main.rs
+++ b/src/meta/binaries/metaverifier/main.rs
@@ -31,9 +31,9 @@ use databend_common_exception::Result;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 use databend_common_tracing::init_logging;
 use databend_common_tracing::FileConfig;
 use databend_common_tracing::StderrConfig;
@@ -229,7 +229,7 @@ async fn verifier(
         let value = Operation::Update(node_key.as_bytes().to_vec());
 
         let _res = client
-            .upsert_kv(UpsertKVReq::new(&node_key, seq, value, None))
+            .upsert_kv(UpsertKV::new(&node_key, seq, value, None))
             .await?;
 
         let n: u64 = rng.gen_range(0..=100);
@@ -238,7 +238,7 @@ async fn verifier(
             let value = Operation::Delete;
 
             let _res = client
-                .upsert_kv(UpsertKVReq::new(&node_key, seq, value, None))
+                .upsert_kv(UpsertKV::new(&node_key, seq, value, None))
                 .await?;
         } else {
             kv.insert(node_key);

--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -23,7 +23,6 @@ use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReply;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
 use databend_common_meta_types::protobuf::RaftRequest;
@@ -33,6 +32,7 @@ use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::InvalidArgument;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use log::debug;
 use tonic::codegen::BoxStream;
 use tonic::Request;
@@ -52,7 +52,7 @@ pub trait RequestFor: Clone + fmt::Debug {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, derive_more::From)]
 pub enum MetaGrpcReq {
-    UpsertKV(UpsertKVReq),
+    UpsertKV(UpsertKV),
 }
 
 impl TryInto<MetaGrpcReq> for Request<RaftRequest> {
@@ -177,7 +177,7 @@ impl RequestFor for Streamed<ListKVReq> {
     type Reply = BoxStream<StreamItem>;
 }
 
-impl RequestFor for UpsertKVReq {
+impl RequestFor for UpsertKV {
     type Reply = UpsertKVReply;
 }
 

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -17,10 +17,10 @@ use databend_common_meta_kvapi::kvapi::KVStream;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use futures::StreamExt;
 use futures::TryStreamExt;
 
@@ -32,7 +32,7 @@ impl kvapi::KVApi for ClientHandle {
     type Error = MetaError;
 
     #[fastrace::trace]
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
+    async fn upsert_kv(&self, act: UpsertKV) -> Result<UpsertKVReply, Self::Error> {
         let reply = self.request(act).await?;
         Ok(reply)
     }

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -110,6 +110,9 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///              require the client to call kv_read_v1 for get/mget/list,
 ///              which is added `2024-01-07: since 1.2.287`
 ///
+/// - 2024-11-2*: since 1.2.6**
+///   👥 client: remove use of `Operation::AsIs`
+///
 /// Server feature set:
 /// ```yaml
 /// server_features:

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -20,7 +20,6 @@ use databend_common_base::runtime::TrackingPayload;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
 use databend_common_meta_types::protobuf::ExportedChunk;
@@ -31,6 +30,7 @@ use databend_common_meta_types::MetaClientError;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use fastrace::Span;
 use tonic::codegen::BoxStream;
 
@@ -81,7 +81,7 @@ pub enum Request {
     StreamList(Streamed<ListKVReq>),
 
     /// Update or insert KV
-    Upsert(UpsertKVReq),
+    Upsert(UpsertKV),
 
     /// Run a transaction on remote
     Txn(TxnRequest),

--- a/src/meta/kvapi/src/kvapi/api.rs
+++ b/src/meta/kvapi/src/kvapi/api.rs
@@ -32,7 +32,6 @@ use crate::kvapi::GetKVReply;
 use crate::kvapi::ListKVReply;
 use crate::kvapi::MGetKVReply;
 use crate::kvapi::UpsertKVReply;
-use crate::kvapi::UpsertKVReq;
 
 /// Build an API impl instance or a cluster of API impl
 #[async_trait]
@@ -139,7 +138,7 @@ pub trait KVApi: Send + Sync {
 impl<U: kvapi::KVApi, T: Deref<Target = U> + Send + Sync> kvapi::KVApi for T {
     type Error = U::Error;
 
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
+    async fn upsert_kv(&self, act: UpsertKV) -> Result<UpsertKVReply, Self::Error> {
         self.deref().upsert_kv(act).await
     }
 

--- a/src/meta/kvapi/src/kvapi/message.rs
+++ b/src/meta/kvapi/src/kvapi/message.rs
@@ -17,10 +17,7 @@ use std::fmt::Formatter;
 
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::Change;
-use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::VecDisplay;
-
-pub type UpsertKVReq = UpsertKV;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct GetKVReq {

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -48,7 +48,6 @@ pub use message::ListKVReq;
 pub use message::MGetKVReply;
 pub use message::MGetKVReq;
 pub use message::UpsertKVReply;
-pub use message::UpsertKVReq;
 pub use pair::BasicPair;
 pub use pair::Pair;
 pub use pair::SeqPair;

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -388,7 +388,7 @@ impl kvapi::TestSuite {
             .upsert_kv(UpsertKV::new(
                 test_key,
                 MatchSeq::Exact(seq + 1),
-                Operation::AsIs,
+                Operation::Update(b"v1".to_vec()),
                 Some(MetaSpec::new_ttl(Duration::from_secs(20))),
             ))
             .await?;
@@ -401,7 +401,7 @@ impl kvapi::TestSuite {
             .upsert_kv(UpsertKV::new(
                 test_key,
                 MatchSeq::Exact(seq),
-                Operation::AsIs,
+                Operation::Update(b"v1".to_vec()),
                 Some(MetaSpec::new_ttl(Duration::from_secs(20))),
             ))
             .await?;

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -187,6 +187,7 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
                 }))
             }
             Operation::Delete => Ok(None),
+            #[allow(deprecated)]
             Operation::AsIs => Ok(None),
         }
     }

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -60,6 +60,7 @@ pub trait StateMachineApiExt: StateMachineApi {
                     .await?
             }
             Operation::Delete => self.map_mut().set(upsert_kv.key.clone(), None).await?,
+            #[allow(deprecated)]
             Operation::AsIs => {
                 MapApiExt::update_meta(self.map_mut(), upsert_kv.key.clone(), kv_meta.clone())
                     .await?

--- a/src/meta/service/tests/it/grpc/metasrv_connection_error.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_connection_error.rs
@@ -23,8 +23,8 @@ use databend_common_base::base::Stoppable;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MetaClientError;
+use databend_common_meta_types::UpsertKV;
 use log::info;
 use test_harness::test;
 
@@ -162,7 +162,7 @@ async fn test_write_read(client: &Arc<ClientHandle>, key: impl Display) -> anyho
     info!("--- test write/read: {}", key);
 
     let k = key.to_string();
-    let res = client.upsert_kv(UpsertKVReq::update(&k, &b(&k))).await?;
+    let res = client.upsert_kv(UpsertKV::update(&k, &b(&k))).await?;
 
     info!("--- upsert {} res: {:?}", k, res);
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -19,8 +19,8 @@ use databend_common_base::base::tokio;
 use databend_common_base::base::Stoppable;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
+use databend_common_meta_types::UpsertKV;
 use log::debug;
 use log::info;
 use pretty_assertions::assert_eq;
@@ -46,7 +46,7 @@ async fn test_restart() -> anyhow::Result<()> {
 
     info!("--- upsert kv");
     {
-        let res = client.upsert_kv(UpsertKVReq::update("foo", b"bar")).await;
+        let res = client.upsert_kv(UpsertKV::update("foo", b"bar")).await;
 
         debug!("set kv res: {:?}", res);
         let res = res?;
@@ -171,7 +171,7 @@ async fn test_join() -> anyhow::Result<()> {
             let k = format!("join-{}", i);
 
             let res = cli
-                .upsert_kv(UpsertKVReq::update(k.as_str(), k.as_bytes()))
+                .upsert_kv(UpsertKV::update(k.as_str(), k.as_bytes()))
                 .await;
 
             debug!("set kv res: {:?}", res);
@@ -240,7 +240,7 @@ async fn test_auto_sync_addr() -> anyhow::Result<()> {
     {
         let k = "join-k".to_string();
 
-        let res = client.upsert_kv(UpsertKVReq::update(&k, &b(&k))).await;
+        let res = client.upsert_kv(UpsertKV::update(&k, &b(&k))).await;
 
         debug!("set kv res: {:?}", res);
         let res = res?;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_export.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 
 use databend_common_base::base::tokio::time::sleep;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::protobuf as pb;
+use databend_common_meta_types::UpsertKV;
 use log::info;
 use pretty_assertions::assert_eq;
 use regex::Regex;
@@ -42,7 +42,7 @@ async fn test_export() -> anyhow::Result<()> {
     info!("--- upsert kv");
     {
         for k in ["foo", "bar", "wow"] {
-            client.upsert_kv(UpsertKVReq::update(k, &b(k))).await?;
+            client.upsert_kv(UpsertKV::update(k, &b(k))).await?;
         }
     }
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -21,7 +21,7 @@ use databend_common_base::base::Stoppable;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
+use databend_common_meta_types::UpsertKV;
 use log::info;
 use test_harness::test;
 
@@ -52,7 +52,7 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
             let client = tc.grpc_client().await?;
 
             let k = make_key(tc, key_suffix);
-            let res = client.upsert_kv(UpsertKVReq::update(&k, &b(&k))).await?;
+            let res = client.upsert_kv(UpsertKV::update(&k, &b(&k))).await?;
 
             info!("--- upsert res: {:?}", res);
 
@@ -138,11 +138,11 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
         for (i, tc) in tcs.iter().enumerate() {
             let k = make_key(tc, key_suffix);
             if i == 0 {
-                let res = client.upsert_kv(UpsertKVReq::update(&k, &b(&k))).await?;
+                let res = client.upsert_kv(UpsertKV::update(&k, &b(&k))).await?;
                 info!("--- upsert res: {:?}", res);
             } else {
                 let client = tc.grpc_client().await.unwrap();
-                let res = client.upsert_kv(UpsertKVReq::update(&k, &b(&k))).await?;
+                let res = client.upsert_kv(UpsertKV::update(&k, &b(&k))).await?;
                 info!("--- upsert res: {:?}", res);
             }
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -22,11 +22,11 @@ use databend_common_meta_client::Streamed;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::KvMeta;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MetaSpec;
+use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;
@@ -130,10 +130,10 @@ async fn initialize_kvs(client: &Arc<ClientHandle>) -> anyhow::Result<()> {
     info!("--- prepare keys: a(meta),c,c1,c2");
 
     let updates = vec![
-        UpsertKVReq::insert("a", &b("a")).with(MetaSpec::new_ttl(Duration::from_secs(10))),
-        UpsertKVReq::insert("c", &b("c")),
-        UpsertKVReq::insert("c1", &b("c1")),
-        UpsertKVReq::insert("c2", &b("c2")),
+        UpsertKV::insert("a", &b("a")).with(MetaSpec::new_ttl(Duration::from_secs(10))),
+        UpsertKV::insert("c", &b("c")),
+        UpsertKV::insert("c1", &b("c1")),
+        UpsertKV::insert("c2", &b("c2")),
     ];
 
     for update in updates {

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -24,12 +24,12 @@ use databend_common_meta_embedded::MemMeta;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::KVStream;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use log::info;
 use tokio_stream::Stream;
 
@@ -85,7 +85,7 @@ impl MetaStore {
 impl kvapi::KVApi for MetaStore {
     type Error = MetaError;
 
-    async fn upsert_kv(&self, act: UpsertKVReq) -> Result<UpsertKVReply, Self::Error> {
+    async fn upsert_kv(&self, act: UpsertKV) -> Result<UpsertKVReply, Self::Error> {
         match self {
             MetaStore::L(x) => x.upsert_kv(act).await,
             MetaStore::R(x) => x.upsert_kv(act).await,

--- a/src/meta/types/src/operation.rs
+++ b/src/meta/types/src/operation.rs
@@ -24,6 +24,7 @@ pub type MetaId = u64;
 pub enum Operation<T> {
     Update(T),
     Delete,
+    #[deprecated(note = "not supported and will be removed from server side")]
     AsIs,
 }
 
@@ -32,6 +33,7 @@ impl<T> Debug for Operation<T> {
         match self {
             Operation::Update(_) => f.debug_tuple("Update").field(&"[binary]").finish(),
             Operation::Delete => f.debug_tuple("Delete").finish(),
+            #[allow(deprecated)]
             Operation::AsIs => f.debug_tuple("AsIs").finish(),
         }
     }

--- a/src/meta/types/src/operation.rs
+++ b/src/meta/types/src/operation.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)]
+
 //! This crate defines data types used in meta data storage service.
 
 use std::fmt::Debug;

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -49,21 +49,12 @@ impl pb::TxnCondition {
 impl pb::TxnOp {
     /// Create a txn operation that puts a record.
     pub fn put(key: impl ToString, value: Vec<u8>) -> pb::TxnOp {
-        Self::put_with_expire(key, value, None)
-    }
-
-    /// Create a txn operation that puts a record with expiration time.
-    pub fn put_with_expire(
-        key: impl ToString,
-        value: Vec<u8>,
-        expire_at: Option<u64>,
-    ) -> pb::TxnOp {
         pb::TxnOp {
             request: Some(pb::txn_op::Request::Put(pb::TxnPutRequest {
                 key: key.to_string(),
                 value,
                 prev_value: true,
-                expire_at,
+                expire_at: None,
                 ttl_ms: None,
             })),
         }

--- a/src/query/ee/src/background_service/compaction_job.rs
+++ b/src/query/ee/src/background_service/compaction_job.rs
@@ -332,7 +332,7 @@ impl CompactionJob {
             .update_background_task(UpdateBackgroundTaskReq {
                 task_name: task_ident.clone(),
                 task_info: info.clone(),
-                expire_at: Utc::now().timestamp() as u64 + EXPIRE_SEC,
+                ttl: Duration::from_secs(EXPIRE_SEC),
             })
             .await?;
 
@@ -359,7 +359,7 @@ impl CompactionJob {
                     .update_background_task(UpdateBackgroundTaskReq {
                         task_name: task_ident,
                         task_info: info.clone(),
-                        expire_at: Utc::now().timestamp() as u64 + EXPIRE_SEC,
+                        ttl: Duration::from_secs(EXPIRE_SEC),
                     })
                     .await?;
             }
@@ -370,7 +370,7 @@ impl CompactionJob {
                     .update_background_task(UpdateBackgroundTaskReq {
                         task_name: task_ident,
                         task_info: info.clone(),
-                        expire_at: Utc::now().timestamp() as u64 + EXPIRE_SEC,
+                        ttl: Duration::from_secs(EXPIRE_SEC),
                     })
                     .await?;
             }

--- a/src/query/management/src/client_session.rs
+++ b/src/query/management/src/client_session.rs
@@ -26,10 +26,10 @@ use databend_common_meta_app::principal::user_token_ident::TokenIdent;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 
 pub struct ClientSessionMgr {
@@ -94,7 +94,7 @@ impl ClientSessionMgr {
 
         // simply ignore the result
         self.kv_api
-            .upsert_kv(UpsertKVReq::new(
+            .upsert_kv(UpsertKV::new(
                 &key,
                 MatchSeq::GE(0),
                 Operation::Delete,
@@ -150,7 +150,7 @@ impl ClientSessionMgr {
 
         // simply ignore the result
         self.kv_api
-            .upsert_kv(UpsertKVReq::new(
+            .upsert_kv(UpsertKV::new(
                 &key,
                 MatchSeq::GE(0),
                 Operation::Delete,

--- a/src/query/management/src/cluster/cluster_api.rs
+++ b/src/query/management/src/cluster/cluster_api.rs
@@ -16,19 +16,31 @@ use databend_common_exception::Result;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::NodeInfo;
 
+/// Databend-query cluster management API
 #[async_trait::async_trait]
 pub trait ClusterApi: Sync + Send {
-    // Add a new node info to /tenant/cluster_id/node-name.
-    async fn add_node(&self, node: NodeInfo) -> Result<u64>;
+    /// Add or update a node info to /tenant/cluster_id/node-name.
+    ///
+    /// - To update, use `SeqMatch::GE(1)` to match any present record.
+    /// - To add, use `SeqMatch::Exact(0)` to match no present record.
+    async fn upsert_node(&self, node: NodeInfo, seq: MatchSeq) -> Result<u64>;
 
-    // Get the tenant's cluster all nodes.
+    /// Get the tenant's cluster all nodes.
     async fn get_nodes(&self) -> Result<Vec<NodeInfo>>;
 
-    // Drop the tenant's cluster one node by node.id.
+    /// Drop the tenant's cluster one node by node.id.
     async fn drop_node(&self, node_id: String, seq: MatchSeq) -> Result<()>;
 
-    // Keep the tenant's cluster node alive.
-    async fn heartbeat(&self, node: &NodeInfo, seq: MatchSeq) -> Result<u64>;
-
     async fn get_local_addr(&self) -> Result<Option<String>>;
+
+    /// Add a new node.
+    async fn add_node(&self, node: NodeInfo) -> Result<u64> {
+        self.upsert_node(node, MatchSeq::Exact(0)).await
+    }
+
+    /// Keep the tenant's cluster node alive.
+    async fn heartbeat(&self, node: &NodeInfo) -> Result<u64> {
+        // Update or insert the node with GE(0).
+        self.upsert_node(node.clone(), MatchSeq::GE(0)).await
+    }
 }

--- a/src/query/management/src/cluster/cluster_api.rs
+++ b/src/query/management/src/cluster/cluster_api.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_types::Change;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::NodeInfo;
 
@@ -23,7 +25,7 @@ pub trait ClusterApi: Sync + Send {
     ///
     /// - To update, use `SeqMatch::GE(1)` to match any present record.
     /// - To add, use `SeqMatch::Exact(0)` to match no present record.
-    async fn upsert_node(&self, node: NodeInfo, seq: MatchSeq) -> Result<u64>;
+    async fn upsert_node(&self, node: NodeInfo, seq: MatchSeq) -> Result<Change<Vec<u8>>>;
 
     /// Get the tenant's cluster all nodes.
     async fn get_nodes(&self) -> Result<Vec<NodeInfo>>;
@@ -35,12 +37,30 @@ pub trait ClusterApi: Sync + Send {
 
     /// Add a new node.
     async fn add_node(&self, node: NodeInfo) -> Result<u64> {
-        self.upsert_node(node, MatchSeq::Exact(0)).await
+        let res = self.upsert_node(node.clone(), MatchSeq::Exact(0)).await?;
+
+        let res_seq = res.added_seq_or_else(|_v| {
+            ErrorCode::ClusterNodeAlreadyExists(format!(
+                "Node with ID '{}' already exists in the cluster.",
+                node.id
+            ))
+        })?;
+
+        Ok(res_seq)
     }
 
     /// Keep the tenant's cluster node alive.
     async fn heartbeat(&self, node: &NodeInfo) -> Result<u64> {
         // Update or insert the node with GE(0).
-        self.upsert_node(node.clone(), MatchSeq::GE(0)).await
+        let transition = self.upsert_node(node.clone(), MatchSeq::GE(0)).await?;
+
+        let Some(res) = transition.result else {
+            return Err(ErrorCode::MetaServiceError(format!(
+                "Unexpected None result returned when upsert heartbeat node {}",
+                node.id
+            )));
+        };
+
+        Ok(res.seq)
     }
 }

--- a/src/query/management/src/cluster/cluster_mgr.rs
+++ b/src/query/management/src/cluster/cluster_mgr.rs
@@ -20,13 +20,12 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_store::MetaStore;
-use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaSpec;
 use databend_common_meta_types::NodeInfo;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 
 use crate::cluster::ClusterApi;
 
@@ -72,15 +71,13 @@ impl ClusterMgr {
 impl ClusterApi for ClusterMgr {
     #[async_backtrace::framed]
     #[fastrace::trace]
-    async fn add_node(&self, node: NodeInfo) -> Result<u64> {
-        // Only when there are no record, i.e. seq=0
-        let seq = MatchSeq::Exact(0);
+    async fn upsert_node(&self, node: NodeInfo, seq: MatchSeq) -> Result<u64> {
         let meta = Some(self.new_lift_time());
         let value = Operation::Update(serde_json::to_vec(&node)?);
         let node_key = format!("{}/{}", self.cluster_prefix, escape_for_key(&node.id)?);
         let upsert_node = self
             .metastore
-            .upsert_kv(UpsertKVReq::new(&node_key, seq, value, meta));
+            .upsert_kv(UpsertKV::new(&node_key, seq, value, meta));
 
         let res_seq = upsert_node.await?.added_seq_or_else(|_v| {
             ErrorCode::ClusterNodeAlreadyExists(format!(
@@ -114,7 +111,7 @@ impl ClusterApi for ClusterMgr {
         let node_key = format!("{}/{}", self.cluster_prefix, escape_for_key(&node_id)?);
         let upsert_node =
             self.metastore
-                .upsert_kv(UpsertKVReq::new(&node_key, seq, Operation::Delete, None));
+                .upsert_kv(UpsertKV::new(&node_key, seq, Operation::Delete, None));
 
         match upsert_node.await? {
             UpsertKVReply {
@@ -126,26 +123,6 @@ impl ClusterApi for ClusterMgr {
                 "Node with ID '{}' does not exist in the cluster.",
                 node_id
             ))),
-        }
-    }
-
-    #[async_backtrace::framed]
-    #[fastrace::trace]
-    async fn heartbeat(&self, node: &NodeInfo, seq: MatchSeq) -> Result<u64> {
-        let meta = Some(self.new_lift_time());
-        let node_key = format!("{}/{}", self.cluster_prefix, escape_for_key(&node.id)?);
-
-        let upsert_meta =
-            self.metastore
-                .upsert_kv(UpsertKVReq::new(&node_key, seq, Operation::AsIs, meta));
-
-        match upsert_meta.await? {
-            UpsertKVReply {
-                ident: None,
-                prev: Some(_),
-                result: Some(SeqV { seq: s, .. }),
-            } => Ok(s),
-            UpsertKVReply { .. } => self.add_node(node.clone()).await,
         }
     }
 

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -35,7 +35,6 @@ use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::ListKVReply;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::ConditionResult::Eq;
 use databend_common_meta_types::MatchSeq;
@@ -43,6 +42,7 @@ use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use enumflags2::make_bitflags;
 use fastrace::func_name;
 use log::debug;
@@ -87,7 +87,7 @@ impl RoleMgr {
 
         let res = self
             .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Update(value), None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Update(value), None))
             .await?;
         match res.result {
             Some(SeqV { seq: s, .. }) => Ok(s),
@@ -106,7 +106,7 @@ impl RoleMgr {
         seq: MatchSeq,
     ) -> Result<UpsertKVReply, MetaError> {
         self.kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Update(value), None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Update(value), None))
             .await
     }
 
@@ -145,7 +145,7 @@ impl RoleApi for RoleMgr {
         let key = self.role_ident(role_info.identity()).to_string_key();
         let value = serialize_struct(&role_info, ErrorCode::IllegalUserInfoFormat, || "")?;
 
-        let upsert_kv = self.kv_api.upsert_kv(UpsertKVReq::new(
+        let upsert_kv = self.kv_api.upsert_kv(UpsertKV::new(
             &key,
             match_seq,
             Operation::Update(value),
@@ -493,7 +493,7 @@ impl RoleApi for RoleMgr {
 
         let res = self
             .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Delete, None))
             .await?;
 
         res.removed_or_else(|_p| {

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -18,7 +18,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_exception::ToErrorCode;
 use databend_common_meta_kvapi::kvapi;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
 use databend_common_meta_types::InvalidReply;
@@ -26,6 +25,7 @@ use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 use databend_common_proto_conv::FromToProto;
 
 use crate::serde::Quota;
@@ -102,7 +102,7 @@ where
     let value = databend_common_meta_api::serialize_struct(&data)?;
 
     let res = kv_api
-        .upsert_kv(UpsertKVReq::new(
+        .upsert_kv(UpsertKV::new(
             key,
             MatchSeq::Exact(seq_value.seq),
             Operation::Update(value),

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -21,13 +21,13 @@ use databend_common_meta_app::principal::UserSetting;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 
 use crate::setting::SettingApi;
 
@@ -67,9 +67,7 @@ impl SettingApi for SettingMgr {
         let seq = MatchSeq::GE(0);
         let val = Operation::Update(serde_json::to_vec(&setting)?);
         let key = self.setting_key(&setting.name);
-        let upsert = self
-            .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, val, None));
+        let upsert = self.kv_api.upsert_kv(UpsertKV::new(&key, seq, val, None));
 
         let (_prev, curr) = upsert.await?.unpack();
         let res_seq = curr.seq();
@@ -115,7 +113,7 @@ impl SettingApi for SettingMgr {
         let key = self.setting_key(name);
         let _res = self
             .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Delete, None))
             .await?;
 
         Ok(())

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -25,12 +25,12 @@ use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_kvapi::kvapi::ListKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
+use databend_common_meta_types::UpsertKV;
 
 use crate::serde::deserialize_struct;
 use crate::serde::serialize_struct;
@@ -73,7 +73,7 @@ impl UserMgr {
 
         let kv_api = self.kv_api.clone();
         let res = kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Update(value), None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Update(value), None))
             .await?;
 
         match res.result {
@@ -101,7 +101,7 @@ impl UserApi for UserMgr {
         let kv_api = &self.kv_api;
         let seq = MatchSeq::from(*create_option);
         let res = kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Update(value), None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Update(value), None))
             .await?;
 
         if let CreateOption::Create = create_option {
@@ -187,7 +187,7 @@ impl UserApi for UserMgr {
         let key = self.user_key(&user.username, &user.hostname);
         let res = self
             .kv_api
-            .upsert_kv(UpsertKVReq::new(&key, seq, Operation::Delete, None))
+            .upsert_kv(UpsertKV::new(&key, seq, Operation::Delete, None))
             .await?;
         if res.prev.is_some() && res.result.is_none() {
             Ok(())

--- a/src/query/management/tests/it/cluster.rs
+++ b/src/query/management/tests/it/cluster.rs
@@ -130,7 +130,7 @@ async fn test_successfully_heartbeat_node() -> Result<()> {
     assert!(expire_ms - now_ms >= 59_000);
 
     let now_ms = SeqV::<()>::now_ms();
-    cluster_api.heartbeat(&node_info, MatchSeq::GE(1)).await?;
+    cluster_api.heartbeat(&node_info).await?;
 
     let value = kv_api
         .get_kv("__fd_clusters_v4/test%2dtenant%2did/test%2dcluster%2did/databend_query/test_node")

--- a/src/query/management/tests/it/role.rs
+++ b/src/query/management/tests/it/role.rs
@@ -18,8 +18,8 @@ use databend_common_base::base::tokio;
 use databend_common_management::*;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_embedded::MemMeta;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::UpsertKV;
 use mockall::predicate::*;
 
 fn make_role_key(role: &str) -> String {
@@ -45,7 +45,7 @@ mod add {
             let v = serde_json::to_vec(&role_info)?;
             let kv_api = kv_api.clone();
             let _upsert_kv = kv_api
-                .upsert_kv(UpsertKVReq::new(
+                .upsert_kv(UpsertKV::new(
                     &role_key,
                     MatchSeq::Exact(0),
                     Operation::Update(v),
@@ -69,7 +69,7 @@ mod add {
             let v = serde_json::to_vec(&role_info)?;
             let kv_api = kv_api.clone();
             let _upsert_kv = kv_api
-                .upsert_kv(UpsertKVReq::new(
+                .upsert_kv(UpsertKV::new(
                     &role_key,
                     MatchSeq::Exact(0),
                     Operation::Update(v),

--- a/src/query/management/tests/it/user.rs
+++ b/src/query/management/tests/it/user.rs
@@ -28,13 +28,13 @@ use databend_common_meta_kvapi::kvapi::KVStream;
 use databend_common_meta_kvapi::kvapi::ListKVReply;
 use databend_common_meta_kvapi::kvapi::MGetKVReply;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
-use databend_common_meta_kvapi::kvapi::UpsertKVReq;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
+use databend_common_meta_types::UpsertKV;
 use mockall::predicate::*;
 use mockall::*;
 
@@ -47,7 +47,7 @@ mock! {
 
         async fn upsert_kv(
             &self,
-            act: UpsertKVReq,
+            act: UpsertKV,
         ) -> Result<UpsertKVReply, MetaError>;
 
         async fn get_kv(&self, key: &str) -> Result<GetKVReply,MetaError>;
@@ -112,7 +112,7 @@ mod add {
             let test_key = test_key.clone();
             let mut api = MockKV::new();
             api.expect_upsert_kv()
-                .with(predicate::eq(UpsertKVReq::new(
+                .with(predicate::eq(UpsertKV::new(
                     &test_key,
                     test_seq,
                     value.clone(),
@@ -132,7 +132,7 @@ mod add {
             let test_key = test_key.clone();
             let mut api = MockKV::new();
             api.expect_upsert_kv()
-                .with(predicate::eq(UpsertKVReq::new(
+                .with(predicate::eq(UpsertKV::new(
                     &test_key,
                     test_seq,
                     value.clone(),
@@ -408,7 +408,7 @@ mod drop {
             escape_for_key(&format_user_key(test_user, test_hostname))?
         );
         kv.expect_upsert_kv()
-            .with(predicate::eq(UpsertKVReq::new(
+            .with(predicate::eq(UpsertKV::new(
                 &test_key,
                 MatchSeq::GE(1),
                 Operation::Delete,
@@ -434,7 +434,7 @@ mod drop {
             escape_for_key(&format_user_key(test_user, test_hostname))?
         );
         kv.expect_upsert_kv()
-            .with(predicate::eq(UpsertKVReq::new(
+            .with(predicate::eq(UpsertKV::new(
                 &test_key,
                 MatchSeq::GE(1),
                 Operation::Delete,
@@ -509,7 +509,7 @@ mod update {
             serialize_struct(&new_user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
 
         kv.expect_upsert_kv()
-            .with(predicate::eq(UpsertKVReq::new(
+            .with(predicate::eq(UpsertKV::new(
                 &test_key,
                 MatchSeq::Exact(1),
                 Operation::Update(new_value_with_old_salt.clone()),
@@ -583,7 +583,7 @@ mod update {
 
         // upsert should be called
         kv.expect_upsert_kv()
-            .with(predicate::function(move |act: &UpsertKVReq| {
+            .with(predicate::function(move |act: &UpsertKV| {
                 act.key == test_key.as_str() && act.seq == MatchSeq::Exact(2)
             }))
             .times(1)
@@ -638,7 +638,7 @@ mod set_user_privileges {
         let new_value = serialize_struct(&user_info, ErrorCode::IllegalUserInfoFormat, || "")?;
 
         kv.expect_upsert_kv()
-            .with(predicate::eq(UpsertKVReq::new(
+            .with(predicate::eq(UpsertKV::new(
                 &test_key,
                 MatchSeq::Exact(1),
                 Operation::Update(new_value),

--- a/src/query/service/src/clusters/cluster.rs
+++ b/src/query/service/src/clusters/cluster.rs
@@ -476,7 +476,7 @@ impl ClusterHeartbeat {
                     }
                     Either::Right((_, new_shutdown_notified)) => {
                         shutdown_notified = new_shutdown_notified;
-                        let heartbeat = cluster_api.heartbeat(&node, MatchSeq::GE(1));
+                        let heartbeat = cluster_api.heartbeat(&node);
                         if let Err(failure) = heartbeat.await {
                             metric_incr_cluster_heartbeat_count(
                                 &node.id,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: deprecate: Operation::AsIs and will be removed


##### refactor: simplify ClusterApi::heartbeat.

heartbeat is barely an `upsert` operation no matter the node key present
or not.


##### refactor: remove put_with_expire_at; Use ttl instead of expire_at for BackgroundTask

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16913)
<!-- Reviewable:end -->
