### PR TITLE
fix(query):  add_hours function may panic if the argument is too big

### DIFF
--- a/src/query/expression/src/utils/date_helper.rs
+++ b/src/query/expression/src/utils/date_helper.rs
@@ -293,7 +293,7 @@ impl EvalDaysImpl {
     }
 
     pub fn eval_timestamp(date: i64, delta: impl AsPrimitive<i64>) -> i64 {
-        let mut value = date.wrapping_add(delta.as_() * MICROSECS_PER_DAY);
+        let mut value = date.wrapping_add(delta.as_().wrapping_mul(MICROSECS_PER_DAY));
         clamp_timestamp(&mut value);
         value
     }
@@ -311,12 +311,13 @@ pub struct EvalTimesImpl;
 impl EvalTimesImpl {
     pub fn eval_date(date: i32, delta: impl AsPrimitive<i64>, factor: i64) -> i32 {
         clamp_date(
-            (date as i64 * MICROSECS_PER_DAY).wrapping_add(delta.as_() * factor * MICROS_PER_SEC),
+            (date as i64 * MICROSECS_PER_DAY)
+                .wrapping_add(delta.as_().wrapping_mul(factor * MICROS_PER_SEC)),
         )
     }
 
     pub fn eval_timestamp(us: i64, delta: impl AsPrimitive<i64>, factor: i64) -> i64 {
-        let mut ts = us.wrapping_add(delta.as_() * factor * MICROS_PER_SEC);
+        let mut ts = us.wrapping_add(delta.as_().wrapping_mul(factor * MICROS_PER_SEC));
         clamp_timestamp(&mut ts);
         ts
     }

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1466,3 +1466,23 @@ query T
 select TRY_TO_TIMESTAMP(1, 0), TRY_TO_TIMESTAMP(1, null);
 ----
 1970-01-01 00:00:01.000000 NULL
+
+query T
+SELECT add_hours(to_date(710455), 1512263452497496403);
+----
+1000-01-01 00:00:00.000000
+
+query T
+SELECT add_hours(to_timestamp(710455), 1512263452497496403);
+----
+1000-01-01 00:00:00.000000
+
+query T
+SELECT add_hours(to_date(710455), 2147483647);
+----
+1000-01-01 00:00:00.000000
+
+query T
+SELECT add_hours(to_timestamp(710455), 2147483647);
+----
+1000-01-01 00:00:00.000000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

- fixes: #16928

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16929)
<!-- Reviewable:end -->
