### PR TITLE
fix: Revert "chore: add snapshot location cache for attached table (#16795)"

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 
 use chrono::Duration;
 use chrono::TimeDelta;
-use databend_common_base::base::tokio;
 use databend_common_catalog::catalog::StorageDescription;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartStatistics;
@@ -131,11 +130,8 @@ pub struct FuseTable {
 
     table_type: FuseTableType,
 
-    // If this is set, reading from fuse_table should only return the increment blocks
+    // If this is set, reading from fuse_table should only returns the increment blocks
     pub(crate) changes_desc: Option<ChangesDesc>,
-
-    // A table instance level cache of snapshot_location, if this table is attaching to someone else.
-    attached_table_location: tokio::sync::OnceCell<String>,
 }
 
 impl FuseTable {
@@ -242,7 +238,6 @@ impl FuseTable {
             table_compression: table_compression.as_str().try_into()?,
             table_type,
             changes_desc: None,
-            attached_table_location: Default::default(),
         }))
     }
 
@@ -373,25 +368,15 @@ impl FuseTable {
                 let options = self.table_info.options();
 
                 if let Some(storage_prefix) = options.get(OPT_KEY_STORAGE_PREFIX) {
-                    // If the table is attaching to someone else,
-                    // parse the snapshot location from the hint file.
-                    //
-                    // The snapshot location is allowed
-                    // to be fetched from the table level instance cache.
-                    let snapshot_location = self
-                        .attached_table_location
-                        .get_or_try_init(|| async {
-                            let hint =
-                                format!("{}/{}", storage_prefix, FUSE_TBL_LAST_SNAPSHOT_HINT);
-                            let hint_content = self.operator.read(&hint).await?.to_vec();
-                            let snapshot_full_path = String::from_utf8(hint_content)?;
-                            let operator_info = self.operator.info();
-                            Ok::<_, ErrorCode>(
-                                snapshot_full_path[operator_info.root().len()..].to_string(),
-                            )
-                        })
-                        .await?;
-                    Ok(Some(snapshot_location.to_owned()))
+                    // if table is attached, parse snapshot location from hint file
+                    let hint = format!("{}/{}", storage_prefix, FUSE_TBL_LAST_SNAPSHOT_HINT);
+                    let snapshot_loc = {
+                        let hint_content = self.operator.read(&hint).await?.to_vec();
+                        let snapshot_full_path = String::from_utf8(hint_content)?;
+                        let operator_info = self.operator.info();
+                        snapshot_full_path[operator_info.root().len()..].to_string()
+                    };
+                    Ok(Some(snapshot_loc))
                 } else {
                     Ok(options
                         .get(OPT_KEY_SNAPSHOT_LOCATION)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Since a table may be instantiated multi times within a single query context, the location
cache introduced in PR #16795 is not safe:

The hint file might be updated by other transactions, it the hint file is loaded multiple times, inconsistent snapshot locations might be used inside a single query context (which is NOT expected).





## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16947)
<!-- Reviewable:end -->
