### PR TITLE
fix: lock attach table's snapshot location 

### DIFF
--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -382,6 +382,10 @@ impl TableInfo {
         &self.meta.options
     }
 
+    pub fn options_mut(&mut self) -> &mut BTreeMap<String, String> {
+        &mut self.meta.options
+    }
+
     pub fn catalog(&self) -> &str {
         &self.catalog_info.name_ident.catalog_name
     }

--- a/src/query/ee/src/fail_safe/handler.rs
+++ b/src/query/ee/src/fail_safe/handler.rs
@@ -152,7 +152,7 @@ impl Amender {
             Ok(None) => (),
             Err(e) => {
                 if e.code() == ErrorCode::STORAGE_NOT_FOUND {
-                    let snapshot_location = table.snapshot_loc().await?.unwrap();
+                    let snapshot_location = table.snapshot_loc().unwrap();
                     self.recover_object(&snapshot_location).await?;
                     let snapshot = table.read_table_snapshot().await?;
                     let schema = table.schema();

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
@@ -65,7 +65,7 @@ pub async fn get_snapshot_referenced_files(
     ctx: &Arc<dyn TableContext>,
 ) -> Result<Option<SnapshotReferencedFiles>> {
     // 1. Read the root snapshot.
-    let root_snapshot_location_op = fuse_table.snapshot_loc().await?;
+    let root_snapshot_location_op = fuse_table.snapshot_loc();
     if root_snapshot_location_op.is_none() {
         return Ok(None);
     }

--- a/src/query/service/src/interpreters/common/stream.rs
+++ b/src/query/service/src/interpreters/common/stream.rs
@@ -63,7 +63,7 @@ pub async fn dml_build_update_stream_req(
         let table_version = inner_fuse.get_table_info().ident.seq;
         let mut options = stream.options().clone();
         options.insert(OPT_KEY_TABLE_VER.to_string(), table_version.to_string());
-        if let Some(snapshot_loc) = inner_fuse.snapshot_loc().await? {
+        if let Some(snapshot_loc) = inner_fuse.snapshot_loc() {
             options.insert(OPT_KEY_SNAPSHOT_LOCATION.to_string(), snapshot_loc);
         }
 
@@ -147,7 +147,7 @@ pub async fn query_build_update_stream_req(
         let table_version = inner_fuse.get_table_info().ident.seq;
         let mut options = stream.options().clone();
         options.insert(OPT_KEY_TABLE_VER.to_string(), table_version.to_string());
-        if let Some(snapshot_loc) = inner_fuse.snapshot_loc().await? {
+        if let Some(snapshot_loc) = inner_fuse.snapshot_loc() {
             options.insert(OPT_KEY_SNAPSHOT_LOCATION.to_string(), snapshot_loc);
         }
         let mut new_table_meta = stream_info.meta.clone();

--- a/src/query/service/src/test_kits/check.rs
+++ b/src/query/service/src/test_kits/check.rs
@@ -162,7 +162,7 @@ pub async fn check_data_dir(
     if check_last_snapshot.is_some() {
         let table = fixture.latest_default_table().await?;
         let fuse_table = FuseTable::try_from_table(table.as_ref())?;
-        let snapshot_loc = fuse_table.snapshot_loc().await?;
+        let snapshot_loc = fuse_table.snapshot_loc();
         let snapshot_loc = snapshot_loc.unwrap();
         assert!(last_snapshot_loc.contains(&snapshot_loc));
         assert_eq!(

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -243,7 +243,7 @@ async fn test_last_snapshot_hint() -> Result<()> {
     // check last snapshot hit file
     let table = fixture.latest_default_table().await?;
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
-    let last_snapshot_location = fuse_table.snapshot_loc().await?.unwrap();
+    let last_snapshot_location = fuse_table.snapshot_loc().unwrap();
     let operator = fuse_table.get_operator();
     let location = fuse_table
         .meta_location_generator()

--- a/src/query/service/tests/it/storages/fuse/operations/gc.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/gc.rs
@@ -265,7 +265,7 @@ async fn test_fuse_purge_older_version() -> Result<()> {
         let fuse_table = FuseTable::try_from_table(latest_table.as_ref())?;
         let snapshot_files = fuse_table.list_snapshot_files().await?;
         let time_point = now - Duration::hours(12);
-        let snapshot_loc = fuse_table.snapshot_loc().await?.unwrap();
+        let snapshot_loc = fuse_table.snapshot_loc().unwrap();
         let table = fuse_table
             .navigate_to_time_point(snapshot_loc, time_point, ctx.clone().get_abort_checker())
             .await?;

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -56,7 +56,6 @@ async fn test_fuse_navigate() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let first_snapshot = FuseTable::try_from_table(table.as_ref())?
         .snapshot_loc()
-        .await?
         .unwrap();
 
     // take a nap
@@ -73,7 +72,6 @@ async fn test_fuse_navigate() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let second_snapshot = FuseTable::try_from_table(table.as_ref())?
         .snapshot_loc()
-        .await?
         .unwrap();
     assert_ne!(second_snapshot, first_snapshot);
 
@@ -81,7 +79,7 @@ async fn test_fuse_navigate() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
-    let loc = fuse_table.snapshot_loc().await?.unwrap();
+    let loc = fuse_table.snapshot_loc().unwrap();
     assert_eq!(second_snapshot, loc);
     let version = TableMetaLocationGenerator::snapshot_version(loc.as_str());
     let snapshots: Vec<_> = reader
@@ -111,7 +109,7 @@ async fn test_fuse_navigate() -> Result<()> {
         .await?;
 
     // check we got the snapshot of the first insertion
-    assert_eq!(first_snapshot, tbl.snapshot_loc().await?.unwrap());
+    assert_eq!(first_snapshot, tbl.snapshot_loc().unwrap());
 
     // 4. navigate beyond the first snapshot
     let (first_insertion, _ver) = &snapshots[1];
@@ -170,7 +168,6 @@ async fn test_navigate_for_purge() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let _first_snapshot = FuseTable::try_from_table(table.as_ref())?
         .snapshot_loc()
-        .await?
         .unwrap();
 
     // take a nap
@@ -187,7 +184,6 @@ async fn test_navigate_for_purge() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let second_snapshot = FuseTable::try_from_table(table.as_ref())?
         .snapshot_loc()
-        .await?
         .unwrap();
 
     // take a nap
@@ -203,14 +199,13 @@ async fn test_navigate_for_purge() -> Result<()> {
     let table = fixture.latest_default_table().await?;
     let third_snapshot = FuseTable::try_from_table(table.as_ref())?
         .snapshot_loc()
-        .await?
         .unwrap();
 
     // 2. grab the history
     let table = fixture.latest_default_table().await?;
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let reader = MetaReaders::table_snapshot_reader(fuse_table.get_operator());
-    let loc = fuse_table.snapshot_loc().await?.unwrap();
+    let loc = fuse_table.snapshot_loc().unwrap();
     assert_eq!(third_snapshot, loc);
     let version = TableMetaLocationGenerator::snapshot_version(loc.as_str());
     let snapshots: Vec<_> = reader

--- a/src/query/storages/common/table_meta/src/table/table_keys.rs
+++ b/src/query/storages/common/table_meta/src/table/table_keys.rs
@@ -20,6 +20,7 @@ pub const OPT_KEY_DATABASE_ID: &str = "database_id";
 pub const OPT_KEY_STORAGE_PREFIX: &str = "storage_prefix";
 pub const OPT_KEY_TEMP_PREFIX: &str = "temp_prefix";
 pub const OPT_KEY_SNAPSHOT_LOCATION: &str = "snapshot_location";
+pub const OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG: &str = "snapshot_location_fixed";
 pub const OPT_KEY_STORAGE_FORMAT: &str = "storage_format";
 pub const OPT_KEY_TABLE_COMPRESSION: &str = "compression";
 pub const OPT_KEY_COMMENT: &str = "comment";

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -186,17 +186,21 @@ impl FuseTable {
                         // it means that this table info has been tweaked according to the rules of
                         // resolving snapshot location from the hint file, it should not be tweaked again.
 
-                        if !table_meta_options.contains_key(OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG) {
-                            let operator = init_operator(&sp)?;
+                        let operator = init_operator(&sp)?;
+                        let table_type = if !table_meta_options
+                            .contains_key(OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG)
+                        {
                             // Extract snapshot location from last snapshot hit file.
-                            let table_type = if Self::is_table_attached(table_meta_options) {
-                                let location =
-                                    Self::load_snapshot_location_from_hint(&operator, &storage_prefix)?;
+                            if Self::is_table_attached(table_meta_options) {
+                                let location = Self::load_snapshot_location_from_hint(
+                                    &operator,
+                                    &storage_prefix,
+                                )?;
 
                                 info!(
-                                "extracted snapshot location [{:?}] of table {}, with id {:?} from the last snapshot hint file.",
-                                location, table_info.desc, table_info.ident
-                            );
+                                    "extracted snapshot location [{:?}] of table {}, with id {:?} from the last snapshot hint file.",
+                                    location, table_info.desc, table_info.ident
+                                );
 
                                 // Adjust snapshot location to the values extracted from the last snapshot hint
                                 match location {
@@ -204,9 +208,10 @@ impl FuseTable {
                                         table_info.options_mut().remove(OPT_KEY_SNAPSHOT_LOCATION);
                                     }
                                     Some(location) => {
-                                        table_info
-                                            .options_mut()
-                                            .insert(OPT_KEY_SNAPSHOT_LOCATION.to_string(), location);
+                                        table_info.options_mut().insert(
+                                            OPT_KEY_SNAPSHOT_LOCATION.to_string(),
+                                            location,
+                                        );
                                     }
                                 }
 
@@ -221,7 +226,7 @@ impl FuseTable {
                                     OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG.to_string(),
                                     "does not matter".to_string(),
                                 );
-                            }
+                            };
 
                             FuseTableType::Attached
                         } else {
@@ -571,7 +576,7 @@ impl Table for FuseTable {
                 ClusterType::Linear => parse_cluster_keys(ctx, table_meta.clone(), order),
                 ClusterType::Hilbert => parse_hilbert_cluster_key(ctx, table_meta.clone(), order),
             }
-                .unwrap();
+            .unwrap();
 
             let cluster_keys = cluster_keys
                 .iter()
@@ -579,7 +584,7 @@ impl Table for FuseTable {
                     k.project_column_ref(|index| {
                         table_meta.schema().field(*index).name().to_string()
                     })
-                        .as_remote_expr()
+                    .as_remote_expr()
                 })
                 .collect();
             return cluster_keys;
@@ -679,7 +684,7 @@ impl Table for FuseTable {
             &None,
             &self.operator,
         )
-            .await
+        .await
     }
 
     #[async_backtrace::framed]
@@ -733,7 +738,7 @@ impl Table for FuseTable {
             &None,
             &self.operator,
         )
-            .await
+        .await
     }
 
     #[fastrace::trace]
@@ -922,7 +927,7 @@ impl Table for FuseTable {
             ctx.get_settings().get_max_threads()? as usize * 4,
             num_segments,
         )
-            .max(1);
+        .max(1);
 
         ctx.set_status_info(&format!(
             "processing {} segments, chunk size {}",
@@ -1013,11 +1018,11 @@ impl Table for FuseTable {
     ) -> Result<String> {
         let db_tb_name = format!("'{}'.'{}'", database_name, table_name);
         let Some(ChangesDesc {
-                     seq,
-                     desc,
-                     mode,
-                     location,
-                 }) = self.changes_desc.as_ref()
+            seq,
+            desc,
+            mode,
+            location,
+        }) = self.changes_desc.as_ref()
         else {
             return Err(ErrorCode::Internal(format!(
                 "No changes descriptor found in table {db_tb_name}"
@@ -1031,7 +1036,7 @@ impl Table for FuseTable {
             format!("{}.{} {}", database_name, table_name, desc),
             *seq,
         )
-            .await
+        .await
     }
 
     fn get_block_thresholds(&self) -> BlockThresholds {

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -220,7 +220,8 @@ impl FuseTable {
                                 // - Attached tables do not commit `table_info` to the meta server,
                                 //   except when the table is created by a DDL statement for the first time.
                                 // - As a result, the key `OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG` is transient
-                                //   and only appears when this table is resolved within another query context.
+                                //   and will NOT appear when this table is resolved within another query context
+                                //   for the first time.
 
                                 table_info.options_mut().insert(
                                     OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG.to_string(),

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -210,12 +210,17 @@ impl FuseTable {
                                     }
                                 }
 
-                                // Mark the snapshot is fixed, no need to be reloaded from hint,
+                                // Mark the snapshot as fixed, indicating it doesn't need to be reloaded from the hint.
+                                // NOTE:
+                                // - Attached tables do not commit `table_info` to the meta server,
+                                //   except when the table is created by a DDL statement for the first time.
+                                // - As a result, the key `OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG` is transient
+                                //   and only appears when this table is resolved within another query context.
+
                                 table_info.options_mut().insert(
                                     OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG.to_string(),
                                     "does not matter".to_string(),
                                 );
-
                             }
 
                             FuseTableType::Attached
@@ -566,7 +571,7 @@ impl Table for FuseTable {
                 ClusterType::Linear => parse_cluster_keys(ctx, table_meta.clone(), order),
                 ClusterType::Hilbert => parse_hilbert_cluster_key(ctx, table_meta.clone(), order),
             }
-            .unwrap();
+                .unwrap();
 
             let cluster_keys = cluster_keys
                 .iter()
@@ -574,7 +579,7 @@ impl Table for FuseTable {
                     k.project_column_ref(|index| {
                         table_meta.schema().field(*index).name().to_string()
                     })
-                    .as_remote_expr()
+                        .as_remote_expr()
                 })
                 .collect();
             return cluster_keys;
@@ -674,7 +679,7 @@ impl Table for FuseTable {
             &None,
             &self.operator,
         )
-        .await
+            .await
     }
 
     #[async_backtrace::framed]
@@ -728,7 +733,7 @@ impl Table for FuseTable {
             &None,
             &self.operator,
         )
-        .await
+            .await
     }
 
     #[fastrace::trace]
@@ -917,7 +922,7 @@ impl Table for FuseTable {
             ctx.get_settings().get_max_threads()? as usize * 4,
             num_segments,
         )
-        .max(1);
+            .max(1);
 
         ctx.set_status_info(&format!(
             "processing {} segments, chunk size {}",
@@ -1008,11 +1013,11 @@ impl Table for FuseTable {
     ) -> Result<String> {
         let db_tb_name = format!("'{}'.'{}'", database_name, table_name);
         let Some(ChangesDesc {
-            seq,
-            desc,
-            mode,
-            location,
-        }) = self.changes_desc.as_ref()
+                     seq,
+                     desc,
+                     mode,
+                     location,
+                 }) = self.changes_desc.as_ref()
         else {
             return Err(ErrorCode::Internal(format!(
                 "No changes descriptor found in table {db_tb_name}"
@@ -1026,7 +1031,7 @@ impl Table for FuseTable {
             format!("{}.{} {}", database_name, table_name, desc),
             *seq,
         )
-        .await
+            .await
     }
 
     fn get_block_thresholds(&self) -> BlockThresholds {

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -75,7 +75,7 @@ impl FuseTable {
         } else {
             self.clone()
         };
-        let location = source.snapshot_loc().await?;
+        let location = source.snapshot_loc();
         let seq = match navigation {
             Some(NavigationPoint::StreamInfo(info)) => info
                 .options()
@@ -338,7 +338,7 @@ impl FuseTable {
         ctx: Arc<dyn TableContext>,
         base: &Option<String>,
     ) -> Result<(Vec<Arc<BlockMeta>>, Vec<Arc<BlockMeta>>)> {
-        let latest = self.snapshot_loc().await?;
+        let latest = self.snapshot_loc();
 
         let latest_segments = if let Some(snapshot) = latest {
             let (sn, _) =

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -298,7 +298,7 @@ impl FuseTable {
         ctx: &Arc<dyn TableContext>,
         put_cache: bool,
     ) -> Result<Option<RootSnapshotInfo>> {
-        let root_snapshot_location_op = self.snapshot_loc().await?;
+        let root_snapshot_location_op = self.snapshot_loc();
         if root_snapshot_location_op.is_none() {
             return Ok(None);
         }

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -53,7 +53,7 @@ impl FuseTable {
                     .await
             }
             NavigationPoint::TimePoint(time_point) => {
-                let Some(location) = self.snapshot_loc().await? else {
+                let Some(location) = self.snapshot_loc() else {
                     return Err(ErrorCode::TableHistoricalDataNotFound(
                         "Empty Table has no historical data",
                     ));
@@ -114,7 +114,7 @@ impl FuseTable {
         snapshot_id: &str,
         abort_checker: AbortChecker,
     ) -> Result<Arc<FuseTable>> {
-        let Some(location) = self.snapshot_loc().await? else {
+        let Some(location) = self.snapshot_loc() else {
             return Err(ErrorCode::TableHistoricalDataNotFound(
                 "Empty Table has no historical data",
             ));
@@ -273,7 +273,7 @@ impl FuseTable {
             ));
         }
 
-        let Some(location) = self.snapshot_loc().await? else {
+        let Some(location) = self.snapshot_loc() else {
             return Err(ErrorCode::TableHistoricalDataNotFound("No historical data"));
         };
 

--- a/src/query/storages/fuse/src/operations/revert.rs
+++ b/src/query/storages/fuse/src/operations/revert.rs
@@ -42,7 +42,7 @@ impl FuseTable {
         let table_info = table_reverting_to.get_table_info();
 
         // shortcut. if reverting to the same point, just return ok
-        if self.snapshot_loc().await? == table_reverting_to.snapshot_loc().await? {
+        if self.snapshot_loc() == table_reverting_to.snapshot_loc() {
             return Ok(());
         }
 
@@ -64,7 +64,7 @@ impl FuseTable {
         let reply = catalog.update_single_table_meta(req, table_info).await;
         if reply.is_ok() {
             // try keeping the snapshot hit
-            let snapshot_location = table_reverting_to.snapshot_loc().await?.ok_or_else(|| {
+            let snapshot_location = table_reverting_to.snapshot_loc().ok_or_else(|| {
                     ErrorCode::Internal("internal error, fuse table which navigated to given point has no snapshot location")
                 })?;
             Self::write_last_snapshot_hint(

--- a/src/query/storages/fuse/src/table_functions/function_template/fuse_table_meta_func.rs
+++ b/src/query/storages/fuse/src/table_functions/function_template/fuse_table_meta_func.rs
@@ -77,7 +77,7 @@ async fn location_snapshot(
     if let Some(snapshot) = maybe_snapshot {
         if let Some(snapshot_id) = snapshot_id {
             // prepare the stream of snapshot
-            let snapshot_version = tbl.snapshot_format_version(None).await?;
+            let snapshot_version = tbl.snapshot_format_version(None)?;
             let snapshot_location = tbl
                 .meta_location_generator
                 .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot_version)?;

--- a/src/query/storages/fuse/src/table_functions/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshot.rs
@@ -173,7 +173,7 @@ impl SimpleTableFunc for FuseSnapshotFunc {
         })?;
 
         let meta_location_generator = table.meta_location_generator.clone();
-        let snapshot_location = table.snapshot_loc().await?;
+        let snapshot_location = table.snapshot_loc();
         let snapshot = table.read_table_snapshot().await?;
         if let Some(snapshot_location) = snapshot_location {
             let snapshot_version =

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -183,7 +183,7 @@ async fn calc_tbl_size(tbl: &FuseTable) -> Result<(u64, u64)> {
     let start = std::time::Instant::now();
     let time_travel_size = get_time_travel_size(storage_prefix, &operator).await?;
     info!("get_time_travel_size cost: {:?}", start.elapsed());
-    let snapshot_location = tbl.snapshot_loc().await?;
+    let snapshot_location = tbl.snapshot_loc();
     let latest_snapshot_size = match snapshot_location {
         Some(snapshot_location) => {
             let start = std::time::Instant::now();

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -180,7 +180,7 @@ impl StreamTable {
             (0, None)
         };
 
-        let Some(location) = fuse_table.snapshot_loc().await? else {
+        let Some(location) = fuse_table.snapshot_loc() else {
             return Ok(source);
         };
         let snapshot_version = TableMetaLocationGenerator::snapshot_version(location.as_str());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

During instantiating attach table instance, "lock" table's snapshot location( which is extracted from the last_snapshot_hint file), by

- putting the snapshot location extracted from hint file into table_info's options as the value of opt key `OPT_KEY_SNAPSHOT_LOCATION`
- for those table instances that created "from" the above  table_info, they will use the same snapshot location


NOTE:

 [`databend_common_base::runtime::Runtime::block_on`] (not tokio's) is used to execute async code within a sync context. It seems to be safe (not blocking other async tasks), but I am not quite sure.
 
@zhang2014  Please help review this usage.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - use existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16952)
<!-- Reviewable:end -->
