### PR TITLE
fix: evict table from cache before hook recluster

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -191,6 +191,12 @@ async fn compact_table(
         }
     }
 
+    ctx.evict_table_from_cache(
+        &compact_target.catalog,
+        &compact_target.database,
+        &compact_target.table,
+    )?;
+
     if do_recluster {
         let recluster = RelOperator::Recluster(Recluster {
             catalog: compact_target.catalog,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
The expected hook process: `compact operation` read snapshot `s1`, and generate snapshot` s2`, then `recluster operation `read snapshot `s2`, and generate snapshot `s3`.

The issue: Due to table cache, `s1` is cached after `compact operation`, and `recluster operation` get `s1` from cache, which is not the latest snapshot of target table.



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16957)
<!-- Reviewable:end -->
