### PR TITLE
chore: bump ruzstd from 0.7.2 to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12724,9 +12724,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 dependencies = [
  "twox-hash",
 ]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
[0.7.3: Security update, unsoundness in RingBuffer](https://github.com/KillingSpark/zstd-rs/releases/tag/v0.7.3)  
```
cargo audit --db ./target/advisory-db
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 689 security advisories (from ./target/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (1346 crate dependencies)
Crate:     ruzstd
Version:   0.7.2
Title:     `ruzstd` uninit and out-of-bounds memory reads
Date:      2024-11-28
ID:        RUSTSEC-2024-0400
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0400
Solution:  Upgrade to >=0.7.3
```
This block our CI
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - simple dep update

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (dep update):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16969)
<!-- Reviewable:end -->
