### PR TITLE
fix: http handler set cookie only when cookie_enabled=true.

### DIFF
--- a/src/query/service/src/servers/http/middleware/session.rs
+++ b/src/query/service/src/servers/http/middleware/session.rs
@@ -397,9 +397,11 @@ impl<E> HTTPSessionEndpoint<E> {
             }
         }
 
-        let ts = unix_ts().as_secs().to_string();
-        req.cookie()
-            .add(Cookie::new_with_str(COOKIE_LAST_ACCESS_TIME, ts));
+        if cookie_enabled {
+            let ts = unix_ts().as_secs().to_string();
+            req.cookie()
+                .add(Cookie::new_with_str(COOKIE_LAST_ACCESS_TIME, ts));
+        }
 
         let session = session_manager.register_session(session)?;
 

--- a/tests/suites/1_stateful/09_http_handler/09_0009_cookie.py
+++ b/tests/suites/1_stateful/09_http_handler/09_0009_cookie.py
@@ -96,9 +96,17 @@ def test_temp_table():
     assert not session_state["need_keep_alive"]
 
 
+def test_no_cookie_if_not_enabled():
+    client = requests.session()
+    resp = do_query(client, "select 1")
+    assert resp.status_code == 200, resp.text
+    assert len(client.cookies.items()) == 0
+
+
 def main():
     test_simple()
     test_temp_table()
+    test_no_cookie_if_not_enabled()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

http handler set cookie only when `cookie_enabled=true`, otherwise, may lead to problem when client enabled cookie by mistake


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16992)
<!-- Reviewable:end -->
