### PR TITLE
chore: adjust fuse_time_travel_size()

### DIFF
--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -88,8 +88,9 @@ impl SimpleArgFunc for FuseTimeTravelSize {
             ),
             TableField::new(
                 "latest_snapshot_size",
-                TableDataType::Number(NumberDataType::UInt64),
+                TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
             ),
+            TableField::new("error", TableDataType::String.wrap_nullable()),
         ])
     }
 
@@ -103,6 +104,7 @@ impl SimpleArgFunc for FuseTimeTravelSize {
         let mut table_names = Vec::new();
         let mut sizes = Vec::new();
         let mut latest_snapshot_sizes = Vec::new();
+        let mut errors = Vec::new();
         let catalog = ctx.get_default_catalog()?;
         let dbs = match &args.database_name {
             Some(db_name) => {
@@ -148,14 +150,24 @@ impl SimpleArgFunc for FuseTimeTravelSize {
                 database_names.push(db.name().to_string());
                 table_names.push(tbl.name().to_string());
                 sizes.push(time_travel_size);
-                latest_snapshot_sizes.push(latest_snapshot_size);
+                match latest_snapshot_size {
+                    Ok(size) => {
+                        latest_snapshot_sizes.push(Some(size));
+                        errors.push(None);
+                    }
+                    Err(e) => {
+                        latest_snapshot_sizes.push(None);
+                        errors.push(Some(e.to_string()));
+                    }
+                }
             }
         }
         Ok(DataBlock::new_from_columns(vec![
             StringType::from_data(database_names),
             StringType::from_data(table_names),
             UInt64Type::from_data(sizes),
-            UInt64Type::from_data(latest_snapshot_sizes),
+            UInt64Type::from_opt_data(latest_snapshot_sizes),
+            StringType::from_opt_data(errors),
         ]))
     }
 }
@@ -173,7 +185,7 @@ async fn get_time_travel_size(storage_prefix: &str, op: &Operator) -> Result<u64
     Ok(size)
 }
 
-async fn calc_tbl_size(tbl: &FuseTable) -> Result<(u64, u64)> {
+async fn calc_tbl_size(tbl: &FuseTable) -> Result<(u64, Result<u64>)> {
     info!(
         "fuse_time_travel_size start calc_tbl_size:{}",
         tbl.get_table_info().desc
@@ -188,11 +200,13 @@ async fn calc_tbl_size(tbl: &FuseTable) -> Result<(u64, u64)> {
         Some(snapshot_location) => {
             let start = std::time::Instant::now();
             info!("fuse_time_travel_size will read: {}", snapshot_location);
-            let (snapshot, _) = SnapshotsIO::read_snapshot(snapshot_location, operator).await?;
+            let snapshot = SnapshotsIO::read_snapshot(snapshot_location, operator).await;
             info!("read_snapshot cost: {:?}", start.elapsed());
-            snapshot.summary.compressed_byte_size + snapshot.summary.index_size
+            snapshot.map(|(snapshot, _)| {
+                snapshot.summary.compressed_byte_size + snapshot.summary.index_size
+            })
         }
-        None => 0,
+        None => Ok(0),
     };
     Ok((time_travel_size, latest_snapshot_size))
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
If an error occurs when reading the latest snapshot, the function will continue execution instead of stopping. And the error will be recorded in the result set.

For example:
```
root@localhost:8000/default> select * from fuse_time_travel_size('test_fuse_time_travel_size');

SELECT * FROM fuse_time_travel_size('test_fuse_time_travel_size')

┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│        database_name       │ table_name │ time_travel_size │ latest_snapshot_size │                                                                                                                     error                                                                                                                    │
│           String           │   String   │      UInt64      │   Nullable(UInt64)   │                                                                                                               Nullable(String)                                                                                                               │
├────────────────────────────┼────────────┼──────────────────┼──────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ test_fuse_time_travel_size │ t          │                0 │                 NULL │ StorageNotFound. Code: 3001, Text = NotFound (persistent) at read, context: { service: fs, path: 116848/116855/_ss/f28e516bda394d8ca3b6efea1007e362_v4.mpk, range: 0- } => entity not found, source: No such file or directory (os error 2). │
│ test_fuse_time_travel_size │ t2         │                0 │                    0 │ NULL                                                                                                                                                                                                                                         │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
2 rows read in 0.029 sec. Processed 2 rows, 394 B (68.97 rows/s, 13.27 KiB/s)
``` 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16995)
<!-- Reviewable:end -->
