### PR TITLE
fix: need_sticky field was incorrectly set to true.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,7 +3096,7 @@ dependencies = [
 name = "databend-common-cache"
 version = "0.1.0"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "hashlink 0.8.4",
 ]
 
@@ -7859,9 +7859,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
 ]
@@ -8550,7 +8550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -10272,7 +10272,7 @@ checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "indexmap 2.6.0",
  "memchr",
  "ruzstd",

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -532,12 +532,10 @@ impl HttpQuery {
         let tenant = session.get_current_tenant();
         let user_name = session.get_current_user()?.name;
 
-        let has_temp_table_before_run = if let Some(cid) = session.get_client_session_id() {
+        if let Some(cid) = session.get_client_session_id() {
             ClientSessionManager::instance().on_query_start(&cid, &user_name, &session);
-            true
-        } else {
-            false
         };
+        let has_temp_table_before_run = !session.temp_tbl_mgr().lock().is_empty();
         http_query_runtime_instance.runtime().try_spawn(
             async move {
                 let state = state_clone.clone();
@@ -672,7 +670,7 @@ impl HttpQuery {
                     let mut guard = self.has_temp_table_after_run.lock();
                     match *guard {
                         None => {
-                            let not_empty = !session_state.temp_tbl_mgr.lock().is_empty().0;
+                            let not_empty = !session_state.temp_tbl_mgr.lock().is_empty();
                             *guard = Some(not_empty);
                             ClientSessionManager::instance().on_query_finish(
                                 cid,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 the bug happen only client do not poll pages until query finish or server crashed (server restart or client connect to another server in cluster) before that.

## how to reproduce the bug with bendsql

1. start a long running query

```
🐳 :) select * from numbers(1000000000000) ignore_result;
```

2. restart  server before it end

3. start any new query in the same client session

```
🐳 :) select * from numbers(1000000000000) ignore_result;
error: APIError: QueryFailed: [4004]there are temp tables in session, but the request routed to the wrong server: current server is mTXoTYwSLlABvFt2h4zn41, the last is s0yzbB3qCV8WUp7Feq69w3.
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16997)
<!-- Reviewable:end -->
