### PR TITLE
ci: ignore RUSTSEC-2024-0402.

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -47,4 +47,6 @@ ignore = [
     "RUSTSEC-2024-0351",
     # gix-path: improperly resolves configuration path reported by Git
     "RUSTSEC-2024-0371",
+    # Borsh serialization of HashMap is non-canonical
+    "RUSTSEC-2024-0402",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ gimli = "0.31.0"
 globiter = "0.1"
 goldenfile = "1.4"
 h3o = "0.4.0"
-hashbrown = { version = "0.15.0", default-features = false }
+hashbrown = { version = "0.15.2", default-features = false }
 hashbrown_v0_14 = { package = "hashbrown", version = "0.14.0", default-features = false, features = ["ahash"] }
 hashlink = "0.8"
 headers = "0.4.0"


### PR DESCRIPTION
 https://rustsec.org/advisories/RUSTSEC-2024-0402

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Crate:     hashbrown
Version:   0.15.0
Title:     Borsh serialization of HashMap is non-canonical
Date:      2024-10-11
ID:        RUSTSEC-2024-0402
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0402



we are using

```
hashbrown = { version = "0.15.0", default-features = false }
hashbrown_v0_14 = { package = "hashbrown", version = "0.14.0", default-features = false, features = ["ahash"] }
```

only version 0.15.0 is affected,  but many libs dep on this version

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/16998)
<!-- Reviewable:end -->
