### PR TITLE
refactor: auto split large mget_database_names_by_ids into chunks with `KVPbApi::get_pb_values_vec()`

### DIFF
--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1714,39 +1714,26 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     ) -> Result<Vec<Option<String>>, KVAppError> {
         debug!(req :? =(&db_ids); "SchemaApi: {}", func_name!());
 
-        let mut kv_keys = Vec::with_capacity(db_ids.len());
-        for id in db_ids {
-            let k = DatabaseIdToName { db_id: *id }.to_string_key();
-            kv_keys.push(k);
-        }
+        let id_to_name_keys = db_ids.iter().map(|id| DatabaseIdToName { db_id: *id });
 
-        // Batch get all table-name by id
-        let seq_names = self.mget_kv(&kv_keys).await?;
-        // If multi drop/create db the capacity may not same
-        let mut db_names = Vec::with_capacity(db_ids.len());
+        let seq_names = self.get_pb_values_vec(id_to_name_keys).await?;
 
-        for seq_name in seq_names {
-            if let Some(seq_name) = seq_name {
-                let name_ident: DatabaseNameIdentRaw = deserialize_struct(&seq_name.data)?;
-                db_names.push(Some(name_ident.database_name().to_string()));
-            } else {
-                db_names.push(None);
-            }
-        }
+        let mut db_names = seq_names
+            .into_iter()
+            .map(|seq_name| seq_name.map(|s| s.data.database_name().to_string()))
+            .collect::<Vec<_>>();
 
-        let mut meta_kv_keys = Vec::with_capacity(db_ids.len());
-        for id in db_ids {
-            let k = DatabaseId { db_id: *id }.to_string_key();
-            meta_kv_keys.push(k);
-        }
+        let id_keys = db_ids.iter().map(|id| DatabaseId { db_id: *id });
 
-        let seq_metas = self.mget_kv(&meta_kv_keys).await?;
+        let seq_metas = self.get_pb_values_vec(id_keys).await?;
+
         for (i, seq_meta_opt) in seq_metas.iter().enumerate() {
             if let Some(seq_meta) = seq_meta_opt {
-                let db_meta: DatabaseMeta = deserialize_struct(&seq_meta.data)?;
-                if db_meta.drop_on.is_some() {
+                if seq_meta.data.drop_on.is_some() {
                     db_names[i] = None;
                 }
+            } else {
+                db_names[i] = None;
             }
         }
         Ok(db_names)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: auto split large mget_database_names_by_ids into chunks with `KVPbApi::get_pb_values_vec()`

And fix the issue that when db-meta is not found, the returned db-name
should be set to None too.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17011)
<!-- Reviewable:end -->
