### PR TITLE
fix: handle trailing zeros in Raft log WAL with EXT4 writeback mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11872,9 +11872,9 @@ dependencies = [
 
 [[package]]
 name = "raft-log"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7582480ea22f8268d681f4c5f8cf9b626e7f6c917724da68125c24820b055"
+checksum = "71f53e45db5ca60e7ce71737cdd12cd6c466d694eebfe9040de66f09f7bf0682"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,7 @@ prost = { version = "0.13" }
 prost-build = { version = "0.13" }
 prqlc = "0.11.3"
 quanta = "0.11.1"
-raft-log = { version = "0.2.5" }
+raft-log = { version = "0.2.6" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rayon = "1.9.0"
 recursive = "0.1.1"

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -108,6 +108,7 @@ impl RaftStoreInner {
         info!("RaftLog opened at: {}", raft_log_config.dir);
 
         let state = log.log_state();
+        info!("log_state: {:?}", state);
         let stored_node_id = state.user_data.as_ref().and_then(|x| x.node_id);
 
         let is_open = stored_node_id.is_some();


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: handle trailing zeros in Raft log WAL with EXT4 writeback mode

When EXT4 is mounted with data=writeback, data and metadata (file length)
can be written to disk in arbitrary order, potentially leaving trailing
zeros in the WAL tail.

Fix: Truncate zero bytes starting from the first un-decodable WALRecord
and treat the chunk as successfully opened.

This issue is fixed in the dependent crate:
- https://github.com/drmingdrmer/raft-log/commit/757542bfc6f862184ee6f40a2d98c8222653767f


##### chore: refine logging

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17042)
<!-- Reviewable:end -->
