### PR TITLE
feat: add key prefix count assertions to transactions

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -110,8 +110,13 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///              require the client to call kv_read_v1 for get/mget/list,
 ///              which is added `2024-01-07: since 1.2.287`
 ///
-/// - 2024-11-2*: since 1.2.6**
+/// - 2024-11-23: since 1.2.663
 ///   👥 client: remove use of `Operation::AsIs`
+///
+/// - 2024-12-1*: since 1.2.*
+///   🖥 server: add `txn_condition::Target::KeysWithPrefix`,
+///              to support matching the key count by a prefix.
+///
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -92,6 +92,8 @@ impl kvapi::TestSuite {
         self.kv_transaction_with_ttl(&builder.build().await).await?;
         self.kv_transaction_delete_match_seq_none(&builder.build().await)
             .await?;
+        self.kv_transaction_condition_keys_with_prefix(&builder.build().await)
+            .await?;
         self.kv_transaction_delete_match_seq_some_not_match(&builder.build().await)
             .await?;
         self.kv_transaction_delete_match_seq_some_match(&builder.build().await)
@@ -1078,6 +1080,78 @@ impl kvapi::TestSuite {
         Ok(())
     }
 
+    /// A transaction that checks the number of keys with given prefix.
+    pub async fn kv_transaction_condition_keys_with_prefix<KV: kvapi::KVApi>(
+        &self,
+        kv: &KV,
+    ) -> anyhow::Result<()> {
+        let prefix = func_name!();
+
+        let sample_keys_prefix = format!("{}/xxx", prefix);
+
+        let sample = |suffix| format!("{}/{}", sample_keys_prefix, suffix);
+        let positive = format!("{prefix}/positive");
+        let negative = format!("{prefix}/negative");
+
+        kv.upsert_kv(UpsertKV::update(sample("a"), &b("a"))).await?;
+        kv.upsert_kv(UpsertKV::update(sample("b"), &b("b"))).await?;
+        kv.upsert_kv(UpsertKV::update(sample("c"), &b("c"))).await?;
+
+        use ConditionResult::*;
+
+        // A transaction that set positive key if succeeded,
+        // otherwise set the negative key.
+        let txn = |op: ConditionResult, n: u64| TxnRequest {
+            condition: vec![TxnCondition::match_keys_with_prefix(
+                &sample_keys_prefix,
+                op,
+                n,
+            )],
+            if_then: vec![TxnOp::put(&positive, b(format!("{op:?}")))],
+            else_then: vec![TxnOp::put(&negative, b(format!("{op:?}")))],
+        };
+
+        for (op, n, expected) in [
+            (Eq, 2, false),
+            (Eq, 3, true),
+            (Eq, 4, false),
+            (Ne, 2, true),
+            (Ne, 3, false),
+            (Ne, 4, true),
+            (Lt, 3, false),
+            (Lt, 4, true),
+            (Lt, 5, true),
+            (Le, 2, false),
+            (Le, 3, true),
+            (Le, 4, true),
+            (Gt, 2, true),
+            (Gt, 3, false),
+            (Gt, 4, false),
+            (Ge, 2, true),
+            (Ge, 3, true),
+            (Ge, 4, false),
+        ] {
+            kv.upsert_kv(UpsertKV::update(&positive, &b(""))).await?;
+            kv.upsert_kv(UpsertKV::update(&negative, &b(""))).await?;
+
+            let resp = kv.transaction(txn(op, n)).await?;
+            assert_eq!(
+                resp.success, expected,
+                "case: {op:?} {n}, expected: {expected}"
+            );
+
+            let expected_key = if expected { &positive } else { &negative };
+            let got = kv.get_kv(expected_key).await?.unwrap().data;
+            assert_eq!(
+                got,
+                b(format!("{op:?}")),
+                "case: {op:?} {n}, expected: {expected}"
+            );
+        }
+
+        Ok(())
+    }
+
     /// If `TxnDeleteRequest.match_seq` is not set,
     /// the delete operation will always be executed.
     pub async fn kv_transaction_delete_match_seq_none<KV: kvapi::KVApi>(
@@ -1250,6 +1324,6 @@ impl kvapi::TestSuite {
     }
 }
 
-fn b(s: &str) -> Vec<u8> {
-    s.as_bytes().to_vec()
+fn b(x: impl ToString) -> Vec<u8> {
+    x.to_string().as_bytes().to_vec()
 }

--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::ready;
 use std::io;
 use std::time::Duration;
 
@@ -22,7 +23,7 @@ use databend_common_meta_types::raft_types::EntryPayload;
 use databend_common_meta_types::raft_types::StoredMembership;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
-use databend_common_meta_types::txn_condition;
+use databend_common_meta_types::txn_condition::Target;
 use databend_common_meta_types::txn_op;
 use databend_common_meta_types::txn_op_response;
 use databend_common_meta_types::AppliedState;
@@ -49,9 +50,11 @@ use databend_common_meta_types::TxnRequest;
 use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 use futures::stream::TryStreamExt;
+use futures_util::StreamExt;
 use log::debug;
 use log::error;
 use log::info;
+use log::warn;
 use num::FromPrimitive;
 
 use crate::state_machine_api::StateMachineApi;
@@ -299,48 +302,52 @@ where SM: StateMachineApi + 'static
             seqv.value()
         );
 
-        let target = if let Some(target) = &cond.target {
-            target
-        } else {
+        let op = FromPrimitive::from_i32(cond.expected);
+        let Some(op) = op else {
+            warn!(
+                "Invalid condition: {}; TxnCondition: {}",
+                cond.expected, cond
+            );
             return Ok(false);
         };
 
-        let positive = match target {
-            txn_condition::Target::Seq(right) => {
-                Self::eval_seq_condition(seqv.seq(), cond.expected, right)
-            }
-            txn_condition::Target::Value(right) => {
-                if let Some(v) = seqv.value() {
-                    Self::eval_value_condition(v, cond.expected, right)
+        let Some(against) = &cond.target else {
+            return Ok(false);
+        };
+
+        let positive = match against {
+            Target::Seq(against_seq) => Self::eval_compare(seqv.seq(), op, *against_seq),
+            Target::Value(against_value) => {
+                if let Some(stored) = seqv.value() {
+                    Self::eval_compare(stored, op, against_value)
                 } else {
                     false
                 }
+            }
+            Target::KeysWithPrefix(against_n) => {
+                let against_n = *against_n;
+
+                let strm = self.sm.list_kv(key).await?;
+                // Taking at most `against_n + 1` keys is just enough for every predicate.
+                let strm = strm.take((against_n + 1) as usize);
+                let count: u64 = strm.try_fold(0, |acc, _| ready(Ok(acc + 1))).await?;
+
+                Self::eval_compare(count, op, against_n)
             }
         };
         Ok(positive)
     }
 
-    fn eval_seq_condition(left: u64, op: i32, right: &u64) -> bool {
-        match FromPrimitive::from_i32(op) {
-            Some(ConditionResult::Eq) => left == *right,
-            Some(ConditionResult::Gt) => left > *right,
-            Some(ConditionResult::Lt) => left < *right,
-            Some(ConditionResult::Ne) => left != *right,
-            Some(ConditionResult::Ge) => left >= *right,
-            Some(ConditionResult::Le) => left <= *right,
-            _ => false,
-        }
-    }
-
-    fn eval_value_condition(left: &Vec<u8>, op: i32, right: &Vec<u8>) -> bool {
-        match FromPrimitive::from_i32(op) {
-            Some(ConditionResult::Eq) => left == right,
-            Some(ConditionResult::Gt) => left > right,
-            Some(ConditionResult::Lt) => left < right,
-            Some(ConditionResult::Ne) => left != right,
-            Some(ConditionResult::Ge) => left >= right,
-            Some(ConditionResult::Le) => left <= right,
-            _ => false,
+    fn eval_compare<T>(left: T, op: ConditionResult, right: T) -> bool
+    where T: PartialOrd + PartialEq {
+        use ConditionResult::*;
+        match op {
+            Eq => left == right,
+            Gt => left > right,
+            Lt => left < right,
+            Ne => left != right,
+            Ge => left >= right,
+            Le => left <= right,
         }
     }
 

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -111,10 +111,17 @@ message TxnCondition {
   string key = 1;
 
   oneof target {
-    // used when compare value
+    // Compare the stored value of `key` against the given value.
     bytes value = 2;
-    // used when compare seq
+
+    // Compare the stored seq of `key` against the given seq.
     uint64 seq = 3;
+
+    // Compare the count of keys having the prefix `key` against the given value.
+    //
+    // Usually when using this option, append a slash `/` to the end of the prefix `key`.
+    // For example, if you want to count the keys with prefix `foo`, you should use `foo/` as the `key`.
+    uint64 keys_with_prefix = 5;
   }
 
   // the expected result of condition, if `expected` match the condition result,

--- a/src/meta/types/src/proto_display.rs
+++ b/src/meta/types/src/proto_display.rs
@@ -201,6 +201,9 @@ impl Display for Target {
             Target::Seq(seq) => {
                 write!(f, "seq({})", seq)
             }
+            Target::KeysWithPrefix(n) => {
+                write!(f, "keys_with_prefix({})", n)
+            }
         }
     }
 }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -14,6 +14,9 @@
 
 use std::time::Duration;
 
+use pb::txn_condition::ConditionResult;
+use pb::txn_condition::Target;
+
 use crate::protobuf as pb;
 use crate::seq_value::SeqV;
 use crate::TxnRequest;
@@ -33,31 +36,45 @@ impl TxnRequest {
 impl pb::TxnCondition {
     /// Create a txn condition that checks if the `seq` matches.
     pub fn eq_seq(key: impl ToString, seq: u64) -> Self {
-        Self::match_seq(key, pb::txn_condition::ConditionResult::Eq, seq)
+        Self::match_seq(key, ConditionResult::Eq, seq)
     }
 
     /// Create a txn condition that checks if the `seq` match.
-    pub fn match_seq(key: impl ToString, op: pb::txn_condition::ConditionResult, seq: u64) -> Self {
+    pub fn match_seq(key: impl ToString, op: ConditionResult, seq: u64) -> Self {
         Self {
             key: key.to_string(),
             expected: op as i32,
-            target: Some(pb::txn_condition::Target::Seq(seq)),
+            target: Some(Target::Seq(seq)),
         }
     }
 
     pub fn eq_value(key: impl ToString, value: Vec<u8>) -> Self {
-        Self::match_value(key, pb::txn_condition::ConditionResult::Eq, value)
+        Self::match_value(key, ConditionResult::Eq, value)
     }
 
-    pub fn match_value(
-        key: impl ToString,
-        op: pb::txn_condition::ConditionResult,
-        value: Vec<u8>,
-    ) -> Self {
+    pub fn match_value(key: impl ToString, op: ConditionResult, value: Vec<u8>) -> Self {
         Self {
             key: key.to_string(),
             expected: op as i32,
-            target: Some(pb::txn_condition::Target::Value(value)),
+            target: Some(Target::Value(value)),
+        }
+    }
+
+    /// Assert that there are exact `n` keys with the given prefix.
+    ///
+    /// Usually, the prefix should end with a slash `/`.
+    pub fn keys_with_prefix(prefix: impl ToString, n: u64) -> Self {
+        Self::match_keys_with_prefix(prefix, ConditionResult::Eq, n)
+    }
+
+    /// Compare the number of keys with the given prefix against the given `count`.
+    ///
+    /// Usually, the prefix should end with a slash `/`.
+    pub fn match_keys_with_prefix(prefix: impl ToString, op: ConditionResult, count: u64) -> Self {
+        Self {
+            key: prefix.to_string(),
+            expected: op as i32,
+            target: Some(Target::KeysWithPrefix(count)),
         }
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: add key prefix count assertions to transactions

Enable transaction conditions based on the number of keys matching a prefix.
Example:
```rust
let txn = TxnRequest {
    condition: vec![ TxnCondition::match_keys_with_prefix("key/", Eq, 3) ],
    //...
}
```

This allows transactions to proceed only when a prefix matches an expected
number of keys, providing atomic prefix-based cardinality checks.

This commit involves a databend-meta server side change:
- Add `txn_condition::Target::KeysWithPrefix`.

To provide compatibility, any change to the client that uses this
feature must update the compatibility doc and upgrade the databend-meta
cluster first.


##### MM src/meta/kvapi/src/kvapi/test_suite.rs

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17053)
<!-- Reviewable:end -->
