### PR TITLE
chore: disable unprefixed_malloc_on_supported_platforms

### DIFF
--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -17,7 +17,6 @@ disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
 memory-profiling = [
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
-    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
 ]
 
 [dependencies]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

**DO NOT MERGE:**

Disable (remove) cargo feature `tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms` to prevent C libs linking with jemalloc. Performance regressions have been observed in version 636. Checking the impacts on the current main branch.







## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - tweak crate feature

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):  tweak crate feature

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17061)
<!-- Reviewable:end -->
