### PR TITLE
chore: (v1.2.636-rc8.1) disable unprefixed_malloc_on_supported_platforms

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -51,4 +51,6 @@ ignore = [
     "RUSTSEC-2024-0376",
     #rustls network-reachable panic in `Acceptor::accept`
     "RUSTSEC-2024-0399",
+    # `idna` accepts Punycode labels that do not produce any non-ASCII when decoded
+    "RUSTSEC-2024-0421",
 ]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -17,7 +17,6 @@ disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
 memory-profiling = [
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
-    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
 ]
 
 [dependencies]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Disable (remove) cargo feature `tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms` to prevent `lz4-sys` from using jemalloc's `calloc`, as significant performance regressions were observed in the flight RPC compression between version 636 and version 307.





## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - use existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17062)
<!-- Reviewable:end -->
