### PR TITLE
feat: databend-meta transaction support generic bool-expression and else-if chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,6 +3652,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "databend-common-base",
  "databend-common-meta-types",
  "fastrace",
  "futures-util",

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -439,18 +439,17 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 }
                 db_meta.drop_on = None;
 
-                let txn_req = TxnRequest {
-                    condition: vec![
+                let txn_req = TxnRequest::new(
+                    vec![
                         txn_cond_seq(name_key, Eq, 0),
                         txn_cond_seq(&dbid_idlist, Eq, db_id_list_seq),
                         txn_cond_seq(&dbid, Eq, db_meta_seq),
                     ],
-                    if_then: vec![
+                    vec![
                         txn_op_put(name_key, serialize_u64(db_id)?), // (tenant, db_name) -> db_id
                         txn_op_put(&dbid, serialize_struct(&db_meta)?), // (db_id) -> db_meta
                     ],
-                    else_then: vec![],
-                };
+                );
 
                 let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -594,11 +593,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 ), /* __fd_database_id_to_name/<db_id> -> (tenant,db_name) */
             ];
 
-            let txn_req = TxnRequest {
-                condition,
-                if_then,
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition, if_then);
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -1203,19 +1198,19 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                     txn_cond_seq(&save_key_table_id_list, Eq, tb_id_list_seq),
                 ]);
 
-                txn.if_then.extend( vec![
-                        // Changing a table in a db has to update the seq of db_meta,
-                        // to block the batch-delete-tables when deleting a db.
-                        txn_op_put(&key_dbid, serialize_struct(&db_meta.data)?), /* (db_id) -> db_meta */
-                        txn_op_put(
-                            key_table_id,
-                            serialize_struct(&req.table_meta)?,
-                        ), /* (tenant, db_id, tb_id) -> tb_meta */
-                        txn_op_put(&save_key_table_id_list, serialize_struct(&tb_id_list)?), /* _fd_table_id_list/db_id/table_name -> tb_id_list */
-                        // This record does not need to assert `table_id_to_name_key == 0`,
-                        // Because this is a reverse index for db_id/table_name -> table_id, and it is unique.
-                        txn_op_put(&key_table_id_to_name, serialize_struct(&key_dbid_tbname)?), /* __fd_table_id_to_name/db_id/table_name -> DBIdTableName */
-                    ]);
+                txn.if_then.extend(vec![
+                    // Changing a table in a db has to update the seq of db_meta,
+                    // to block the batch-delete-tables when deleting a db.
+                    txn_op_put(&key_dbid, serialize_struct(&db_meta.data)?), /* (db_id) -> db_meta */
+                    txn_op_put(
+                        key_table_id,
+                        serialize_struct(&req.table_meta)?,
+                    ), /* (tenant, db_id, tb_id) -> tb_meta */
+                    txn_op_put(&save_key_table_id_list, serialize_struct(&tb_id_list)?), /* _fd_table_id_list/db_id/table_name -> tb_id_list */
+                    // This record does not need to assert `table_id_to_name_key == 0`,
+                    // Because this is a reverse index for db_id/table_name -> table_id, and it is unique.
+                    txn_op_put(&key_table_id_to_name, serialize_struct(&key_dbid_tbname)?), /* __fd_table_id_to_name/db_id/table_name -> DBIdTableName */
+                ]);
 
                 if req.as_dropped {
                     // To create the table in a "dropped" state,
@@ -1401,8 +1396,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 tb_id_list.pop();
                 new_tb_id_list.append(table_id);
 
-                let mut txn = TxnRequest {
-                    condition: vec![
+                let mut txn = TxnRequest::new(
+                    vec![
                         // db has not to change, i.e., no new table is created.
                         // Renaming db is OK and does not affect the seq of db_meta.
                         txn_cond_seq(&seq_db_id.data, Eq, db_meta.seq),
@@ -1416,7 +1411,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         txn_cond_seq(&new_dbid_tbname_idlist, Eq, new_tb_id_list_seq),
                         txn_cond_seq(&table_id_to_name_key, Eq, table_id_to_name_seq),
                     ],
-                    if_then: vec![
+                    vec![
                         txn_op_del(&dbid_tbname), // (db_id, tb_name) -> tb_id
                         txn_op_put(&newdbid_newtbname, serialize_u64(table_id)?), /* (db_id, new_tb_name) -> tb_id */
                         // Changing a table in a db has to update the seq of db_meta,
@@ -1426,8 +1421,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         txn_op_put(&new_dbid_tbname_idlist, serialize_struct(&new_tb_id_list)?), /* _fd_table_id_list/db_id/new_table_name -> tb_id_list */
                         txn_op_put(&table_id_to_name_key, serialize_struct(&db_id_table_name)?), /* __fd_table_id_to_name/db_id/table_name -> DBIdTableName */
                     ],
-                    else_then: vec![],
-                };
+                );
 
                 if *seq_db_id.data != *new_seq_db_id.data {
                     txn.if_then.push(
@@ -1909,8 +1903,8 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 }
                 tb_meta.drop_on = None;
 
-                let txn_req = TxnRequest {
-                    condition: vec![
+                let txn_req = TxnRequest::new(
+                    vec![
                         // db has not to change, i.e., no new table is created.
                         // Renaming db is OK and does not affect the seq of db_meta.
                         txn_cond_seq(&DatabaseId { db_id }, Eq, db_meta_seq),
@@ -1921,7 +1915,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         txn_cond_seq(&orphan_dbid_tbname_idlist, Eq, orphan_tb_id_list.seq),
                         txn_cond_seq(&dbid_tbname_idlist, Eq, tb_id_list.seq),
                     ],
-                    if_then: vec![
+                    vec![
                         // Changing a table in a db has to update the seq of db_meta,
                         // to block the batch-delete-tables when deleting a db.
                         txn_op_put(&DatabaseId { db_id }, serialize_struct(&db_meta)?), /* (db_id) -> db_meta */
@@ -1931,8 +1925,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                         txn_op_del(&orphan_dbid_tbname_idlist),         // del orphan table idlist
                         txn_op_put(&dbid_tbname_idlist, serialize_struct(&tb_id_list.data)?), /* _fd_table_id_list/db_id/table_name -> tb_id_list */
                     ],
-                    else_then: vec![],
-                };
+                );
 
                 let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -2061,16 +2054,15 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         //   non-changed ones.
 
         for chunk in copied_files.chunks(chunk_size as usize) {
-            let txn = TxnRequest {
-                condition: vec![],
-                if_then: chunk
+            let txn = TxnRequest::new(
+                vec![],
+                chunk
                     .iter()
                     .map(|(name, seq_file)| {
                         TxnOp::delete_exact(name.to_string_key(), Some(seq_file.seq()))
                     })
                     .collect(),
-                else_then: vec![],
-            };
+            );
 
             let (_succ, _responses) = send_txn(self, txn).await?;
         }
@@ -2377,16 +2369,15 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 }
             }
 
-            let mut txn_req = TxnRequest {
-                condition: vec![
+            let mut txn_req = TxnRequest::new(
+                vec![
                     // table is not changed
                     txn_cond_seq(&tbid, Eq, seq_meta.seq),
                 ],
-                if_then: vec![
+                vec![
                     txn_op_put(&tbid, serialize_struct(&new_table_meta)?), // tb_id -> tb_meta
                 ],
-                else_then: vec![],
-            };
+            );
 
             let _ = update_mask_policy(self, &req.action, &mut txn_req, &req.tenant, req.table_id)
                 .await;
@@ -2485,13 +2476,13 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             };
             indexes.insert(req.name.clone(), index);
 
-            let txn_req = TxnRequest {
-                condition: vec![txn_cond_eq_seq(&tbid, tb_meta_seq)],
-                if_then: vec![
+            let txn_req = TxnRequest::new(
+                //
+                vec![txn_cond_eq_seq(&tbid, tb_meta_seq)],
+                vec![
                     txn_op_put_pb(&tbid, &table_meta, None)?, // tb_id -> tb_meta
                 ],
-                else_then: vec![],
-            };
+            );
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -2540,16 +2531,15 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             }
             indexes.remove(&req.name);
 
-            let txn_req = TxnRequest {
-                condition: vec![
+            let txn_req = TxnRequest::new(
+                vec![
                     // table is not changed
                     txn_cond_seq(&tbid, Eq, seq_meta.seq),
                 ],
-                if_then: vec![
+                vec![
                     txn_op_put(&tbid, serialize_struct(&table_meta)?), // tb_id -> tb_meta
                 ],
-                else_then: vec![],
-            };
+            );
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
             debug!(id :? =(&tbid),succ = succ;"drop_table_index");
@@ -2742,11 +2732,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 txn_op_put(&id_generator, b"".to_vec()),
                 txn_op_put_pb(&key, &lock_meta, Some(req.ttl))?,
             ];
-            let txn_req = TxnRequest {
-                condition,
-                if_then,
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition, if_then);
             let (succ, _responses) = send_txn(self, txn_req).await?;
 
             if succ {
@@ -3053,11 +3039,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
                 txn_op_put_pb(&new_name_ident, &dict_id.data, None)?, // put new dict name
             ];
 
-            let txn_req = TxnRequest {
-                condition,
-                if_then,
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition, if_then);
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
 
@@ -4042,8 +4024,8 @@ async fn handle_undrop_table(
             // reset drop on time
             seq_table_meta.drop_on = None;
 
-            let txn = TxnRequest {
-                condition: vec![
+            let txn = TxnRequest::new(
+                vec![
                     // db has not to change, i.e., no new table is created.
                     // Renaming db is OK and does not affect the seq of db_meta.
                     txn_cond_eq_seq(&DatabaseId { db_id }, seq_db_meta.seq),
@@ -4052,15 +4034,14 @@ async fn handle_undrop_table(
                     // table is not changed
                     txn_cond_eq_seq(&tbid, seq_table_meta.seq),
                 ],
-                if_then: vec![
+                vec![
                     // Changing a table in a db has to update the seq of db_meta,
                     // to block the batch-delete-tables when deleting a db.
                     txn_op_put_pb(&DatabaseId { db_id }, &seq_db_meta.data, None)?, /* (db_id) -> db_meta */
                     txn_op_put(&dbid_tbname, serialize_u64(table_id)?), /* (tenant, db_id, tb_name) -> tb_id */
                     txn_op_put_pb(&tbid, &seq_table_meta.data, None)?, /* (tenant, db_id, tb_id) -> tb_meta */
                 ],
-                else_then: vec![],
-            };
+            );
 
             let (succ, _responses) = send_txn(kv_api, txn).await?;
 

--- a/src/meta/api/src/sequence_api_impl.rs
+++ b/src/meta/api/src/sequence_api_impl.rs
@@ -142,11 +142,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
                 txn_op_put_pb(&ident, &sequence_meta, None)?, // name -> meta
             ];
 
-            let txn_req = TxnRequest {
-                condition,
-                if_then,
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition, if_then);
 
             let (succ, _responses) = send_txn(self, txn_req).await?;
 

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -298,11 +298,7 @@ async fn benchmark_table_copy_file(
         serde_json::from_str(param).unwrap()
     };
 
-    let mut txn = TxnRequest {
-        condition: vec![],
-        if_then: vec![],
-        else_then: vec![],
-    };
+    let mut txn = TxnRequest::default();
 
     for file_index in 0..param.file_cnt {
         let copied_file_ident = TableCopiedFileNameIdent {

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -117,6 +117,10 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///   🖥 server: add `txn_condition::Target::KeysWithPrefix`,
 ///              to support matching the key count by a prefix.
 ///
+/// - 2024-12-1*: since 1.2.*
+///   🖥 server: add `TxnRequest::condition_tree`,
+///              to specify a complex bool expression.
+///
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/kvapi/Cargo.toml
+++ b/src/meta/kvapi/Cargo.toml
@@ -15,6 +15,7 @@ test = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+databend-common-base = { workspace = true }
 databend-common-meta-types = { workspace = true }
 fastrace = { workspace = true }
 futures-util = { workspace = true }

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -164,11 +164,7 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
                 Ok(Some(LogEntry {
                     txid: log_entry.txid,
                     time_ms: log_entry.time_ms,
-                    cmd: Cmd::Transaction(TxnRequest {
-                        condition,
-                        if_then,
-                        else_then,
-                    }),
+                    cmd: Cmd::Transaction(TxnRequest::new(condition, if_then).with_else(else_then)),
                 }))
             }
         }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -57,6 +57,7 @@ use futures::stream::TryChunksError;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use log::debug;
+use log::error;
 use prost::Message;
 use tokio_stream;
 use tokio_stream::Stream;
@@ -177,12 +178,8 @@ impl MetaServiceImpl {
                 (endpoint, txn_reply)
             }
             Err(err) => {
-                let txn_reply = TxnReply {
-                    success: false,
-                    error: serde_json::to_string(&err).expect("fail to serialize"),
-                    responses: vec![],
-                };
-                (None, txn_reply)
+                error!("txn request failed: {:?}", err);
+                return Err(Status::internal(err.to_string()));
             }
         };
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_transaction.rs
@@ -50,13 +50,7 @@ async fn test_transaction_follower_responds_leader_endpoint() -> anyhow::Result<
         assert_eq!(a1(), eclient.target_endpoint(),);
     }
 
-    let _res = client
-        .request(TxnRequest {
-            condition: vec![],
-            if_then: vec![],
-            else_then: vec![],
-        })
-        .await?;
+    let _res = client.request(TxnRequest::new(vec![], vec![])).await?;
 
     // Current leader endpoint updated, will connect to a0.
     {

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -307,13 +307,7 @@ async fn test_watch() -> anyhow::Result<()> {
             },
         ];
 
-        let else_then: Vec<TxnOp> = vec![];
-
-        let txn = TxnRequest {
-            condition: conditions,
-            if_then,
-            else_then,
-        };
+        let txn = TxnRequest::new(conditions, if_then);
 
         seq = 7;
 
@@ -361,11 +355,7 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
     {
         let client = make_client(&addr)?;
 
-        let mut txn = TxnRequest {
-            condition: vec![],
-            if_then: vec![],
-            else_then: vec![],
-        };
+        let mut txn = TxnRequest::new(vec![], vec![]);
 
         // Every apply() will clean all expired keys.
         for i in 0..(32 + 1) {
@@ -405,19 +395,15 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
 
     info!("--- apply another txn in another thread to override keys");
     {
-        let txn = TxnRequest {
-            condition: vec![],
-            if_then: vec![
-                TxnOp::put("w_b1", b("w_b1_override")),
-                TxnOp::delete("w_b2"),
-                TxnOp {
-                    request: Some(txn_op::Request::DeleteByPrefix(TxnDeleteByPrefixRequest {
-                        prefix: s("w_b3"),
-                    })),
-                },
-            ],
-            else_then: vec![],
-        };
+        let txn = TxnRequest::new(vec![], vec![
+            TxnOp::put("w_b1", b("w_b1_override")),
+            TxnOp::delete("w_b2"),
+            TxnOp {
+                request: Some(txn_op::Request::DeleteByPrefix(TxnDeleteByPrefixRequest {
+                    prefix: s("w_b3"),
+                })),
+            },
+        ]);
 
         let client = make_client(&addr)?;
         let _h = databend_common_base::runtime::spawn(async move {

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -84,6 +84,18 @@ fn build_proto() {
             "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
+            "ConditionalOperation",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
+        )
+        .type_attribute(
+            "BooleanExpression",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
+        )
+        .type_attribute(
+            "BooleanExpression.CombiningOperator",
+            "#[derive(serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
+        )
+        .type_attribute(
             "TxnOp",
             "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
@@ -138,6 +150,10 @@ fn build_proto() {
         .field_attribute(
             "TxnPutRequest.ttl_ms",
             r#"#[serde(skip_serializing_if = "Option::is_none")]"#,
+        )
+        .field_attribute(
+            "TxnRequest.operations",
+            r#"#[serde(skip_serializing_if = "Vec::is_empty")] #[serde(default)]"#,
         )
         .compile_protos_with_config(config, &protos, &[&proto_dir])
         .unwrap();

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -130,8 +130,31 @@ message TxnCondition {
   ConditionResult expected = 4;
 }
 
+// BooleanExpression represents a tree of transaction conditions combined with logical operators.
+// It enables complex condition checking by allowing both simple conditions and nested expressions.
+message BooleanExpression {
+  // Logical operator to combine multiple conditions, including sub compound conditions or simple conditions.
+  enum CombiningOperator {
+    AND = 0;
+    OR = 1;
+  }
+
+  // Operator determining how child expressions and conditions are combined
+  CombiningOperator operator = 1;
+
+  // Nested boolean expressions, allowing tree-like structure
+  // Example: (A AND B) OR (C AND D) where A,B,C,D are conditions
+  repeated BooleanExpression sub_expressions = 2;
+
+  // Leaf-level transaction conditions
+  // These are the actual checks performed against the state.
+  repeated TxnCondition conditions = 3;
+}
+
+
 message TxnOp {
   oneof request {
+    // TODO add Echo to get a response
     TxnGetRequest get = 1;
     TxnPutRequest put = 2;
     TxnDeleteRequest delete = 3;
@@ -148,7 +171,33 @@ message TxnOpResponse {
   }
 }
 
+// Represents a set of operations that execute only when specified conditions are met.
+message ConditionalOperation {
+  // Tree of conditions that must be satisfied for operations to execute
+  BooleanExpression predicate = 1;
+
+  // Operations to execute when condition_tree evaluates to true
+  // These operations are executed in sequence
+  repeated TxnOp operations = 2;
+}
+
+// A Transaction request sent to the databend-meta service.
+//
+// To provide backward compatibility, the `TxnRequest` is processed in the following order:
+//
+// - Loop and evaluate the condition in the `operations`, and execute the corresponding operation, if the condition is met.
+//   This will stop and return once a condition is met and one of the corresponding operations is executed.
+//
+// - If none of the conditions are met, the `condition` as the **last** condition will be evaluated.
+//   And the `if_then` will be executed and return.
+//
+// - If none operation are executed, `else_then` will be executed.
 message TxnRequest {
+
+  // Series of conditional operations to execute.
+  // It will stop once a condition is met and one of the corresponding operations is executed
+  repeated ConditionalOperation operations = 4;
+
   // `condition` is a list of predicates.
   // If all of them success, the `if_then` will be executed,
   // otherwise `else_then` op will be executed.
@@ -163,10 +212,24 @@ message TxnRequest {
   repeated TxnOp else_then = 3;
 }
 
+// TransactionResponse represents the result of executing a transaction.
+//
+// `execution_path` identifies condition that is executed and is identified as:
+// - "operation:{index}": executed operation at index
+// - "then": `condition` field were met, and the `if_then` operation is executed.
+// - "else": neither operations nor condition are met and `else_then` is executed.
+//
+// `success` is set to false only when `else_then` is executed.
 message TxnReply {
   bool success = 1;
+
   repeated TxnOpResponse responses = 2;
+
+  // Not used
   string error = 3;
+
+  // Identifies which execution path was taken
+  string execution_path = 4;
 }
 
 message ClusterStatus {

--- a/src/meta/types/src/cmd/mod.rs
+++ b/src/meta/types/src/cmd/mod.rs
@@ -131,15 +131,14 @@ mod tests {
         assert_eq!(cmd, serde_json::from_str(want)?);
 
         // Transaction
-        let cmd = super::Cmd::Transaction(TxnRequest {
-            condition: vec![TxnCondition::eq_value("k", b("v"))],
-            if_then: vec![TxnOp::put_with_ttl(
+        let cmd = super::Cmd::Transaction(TxnRequest::new(
+            vec![TxnCondition::eq_value("k", b("v"))],
+            vec![TxnOp::put_with_ttl(
                 "k",
                 b("v"),
                 Some(Duration::from_millis(100)),
             )],
-            else_then: vec![],
-        });
+        ));
         let want = concat!(
             r#"{"Transaction":{"#,
             r#""condition":[{"key":"k","expected":0,"target":{"Value":[118]}}],"#,

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -14,21 +14,183 @@
 
 use std::time::Duration;
 
+use pb::boolean_expression::CombiningOperator;
 use pb::txn_condition::ConditionResult;
 use pb::txn_condition::Target;
 
 use crate::protobuf as pb;
 use crate::seq_value::SeqV;
-use crate::TxnRequest;
 
-impl TxnRequest {
+impl pb::TxnRequest {
+    /// Push a new conditional operation branch to the transaction.
+    pub fn push_branch(
+        mut self,
+        expr: Option<pb::BooleanExpression>,
+        ops: impl IntoIterator<Item = pb::TxnOp>,
+    ) -> Self {
+        self.operations
+            .push(pb::ConditionalOperation::new(expr, ops));
+        self
+    }
+
+    /// Push the old version of `condition` and `if_then` to the transaction.
+    pub fn push_if_then(
+        mut self,
+        conditions: impl IntoIterator<Item = pb::TxnCondition>,
+        ops: impl IntoIterator<Item = pb::TxnOp>,
+    ) -> Self {
+        assert!(self.condition.is_empty());
+        assert!(self.if_then.is_empty());
+        self.condition.extend(conditions);
+        self.if_then.extend(ops);
+        self
+    }
+
+    pub fn new(conditions: Vec<pb::TxnCondition>, ops: Vec<pb::TxnOp>) -> Self {
+        Self {
+            operations: vec![],
+            condition: conditions,
+            if_then: ops,
+            else_then: vec![],
+        }
+    }
+
+    /// Adds operations to execute when the conditions are not met.
+    pub fn with_else(mut self, ops: Vec<pb::TxnOp>) -> Self {
+        self.else_then = ops;
+        self
+    }
+
     /// Creates a transaction request that performs the specified operations
     /// unconditionally.
     pub fn unconditional(ops: Vec<pb::TxnOp>) -> Self {
         Self {
+            operations: vec![],
             condition: vec![],
             if_then: ops,
             else_then: vec![],
+        }
+    }
+}
+
+impl pb::TxnReply {
+    pub fn new(execution_path: impl ToString) -> Self {
+        let execution_path = execution_path.to_string();
+        Self {
+            success: execution_path != "else",
+            responses: vec![],
+            error: "".to_string(),
+            execution_path,
+        }
+    }
+
+    /// Return the index of the branch that was executed in [`pb::TxnRequest::operations`].
+    ///
+    /// If none of the branches were executed, return `None`,
+    /// i.e., the `condition` is met and `if_then` is executed, or `else_then` is executed.
+    /// In such case, the caller should then compare `execution_path` against "then" or "else` to determine which branch was executed.
+    ///
+    /// If there is an error parsing the index, return the original `execution_path`.
+    pub fn executed_branch_index(&self) -> Result<Option<usize>, &str> {
+        // if self.execution_path is in form "operation:<index>", return the index.
+        if let Some(index) = self.execution_path.strip_prefix("operation:") {
+            index
+                .parse()
+                .map(Some)
+                .map_err(|_| self.execution_path.as_str())
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(derive_more::From)]
+pub enum ExpressionOrCondition {
+    Expression(#[from] pb::BooleanExpression),
+    Condition(#[from] pb::TxnCondition),
+}
+
+impl pb::BooleanExpression {
+    pub fn from_conditions_and(conditions: impl IntoIterator<Item = pb::TxnCondition>) -> Self {
+        Self::from_conditions(CombiningOperator::And, conditions)
+    }
+
+    pub fn from_conditions_or(conditions: impl IntoIterator<Item = pb::TxnCondition>) -> Self {
+        Self::from_conditions(CombiningOperator::Or, conditions)
+    }
+
+    fn from_conditions(
+        op: CombiningOperator,
+        conditions: impl IntoIterator<Item = pb::TxnCondition>,
+    ) -> Self {
+        Self {
+            conditions: conditions.into_iter().collect(),
+            operator: op as i32,
+            sub_expressions: vec![],
+        }
+    }
+
+    pub fn and(self, expr_or_condition: impl Into<ExpressionOrCondition>) -> Self {
+        self.merge(CombiningOperator::And, expr_or_condition)
+    }
+
+    pub fn or(self, expr_or_condition: impl Into<ExpressionOrCondition>) -> Self {
+        self.merge(CombiningOperator::Or, expr_or_condition)
+    }
+
+    pub fn and_many(self, others: impl IntoIterator<Item = pb::BooleanExpression>) -> Self {
+        self.merge_expressions(CombiningOperator::And, others)
+    }
+
+    pub fn or_many(self, others: impl IntoIterator<Item = pb::BooleanExpression>) -> Self {
+        self.merge_expressions(CombiningOperator::Or, others)
+    }
+
+    fn merge(
+        self,
+        op: CombiningOperator,
+        expr_or_condition: impl Into<ExpressionOrCondition>,
+    ) -> Self {
+        let x = expr_or_condition.into();
+        match x {
+            ExpressionOrCondition::Expression(expr) => self.merge_expressions(op, [expr]),
+            ExpressionOrCondition::Condition(cond) => self.merge_conditions(op, [cond]),
+        }
+    }
+
+    fn merge_conditions(
+        mut self,
+        op: CombiningOperator,
+        condition: impl IntoIterator<Item = pb::TxnCondition>,
+    ) -> Self {
+        if self.operator == op as i32 {
+            self.conditions.extend(condition);
+            self
+        } else {
+            pb::BooleanExpression {
+                operator: op as i32,
+                sub_expressions: vec![self],
+                conditions: condition.into_iter().collect(),
+            }
+        }
+    }
+
+    fn merge_expressions(
+        mut self,
+        op: CombiningOperator,
+        other: impl IntoIterator<Item = pb::BooleanExpression>,
+    ) -> Self {
+        if self.operator == op as i32 {
+            self.sub_expressions.extend(other);
+            self
+        } else {
+            let mut expressions = vec![self];
+            expressions.extend(other);
+            Self {
+                conditions: vec![],
+                operator: op as i32,
+                sub_expressions: expressions,
+            }
         }
     }
 }
@@ -76,6 +238,14 @@ impl pb::TxnCondition {
             expected: op as i32,
             target: Some(Target::KeysWithPrefix(count)),
         }
+    }
+
+    pub fn and(self, other: pb::TxnCondition) -> pb::BooleanExpression {
+        pb::BooleanExpression::from_conditions_and([self, other])
+    }
+
+    pub fn or(self, other: pb::TxnCondition) -> pb::BooleanExpression {
+        pb::BooleanExpression::from_conditions_or([self, other])
     }
 }
 
@@ -180,6 +350,125 @@ impl pb::TxnGetResponse {
         Self {
             key: key.to_string(),
             value,
+        }
+    }
+}
+
+impl pb::ConditionalOperation {
+    pub fn new(
+        expr: Option<pb::BooleanExpression>,
+        ops: impl IntoIterator<Item = pb::TxnOp>,
+    ) -> Self {
+        Self {
+            predicate: expr,
+            operations: ops.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protobuf::BooleanExpression;
+    use crate::TxnCondition;
+
+    #[test]
+    fn test_bool_expression() {
+        use BooleanExpression as Expr;
+
+        let cond = |k: &str, seq| TxnCondition::eq_seq(k, seq);
+
+        // from_conditions_and
+        let expr = Expr::from_conditions_and([cond("a", 1), cond("b", 2)]);
+        assert_eq!(expr.to_string(), "a == seq(1) AND b == seq(2)");
+
+        // from_conditions_or
+        let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]);
+        assert_eq!(expr.to_string(), "a == seq(1) OR b == seq(2)");
+
+        // and_condition
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]).and(cond("c", 3));
+            assert_eq!(
+                expr.to_string(),
+                "(a == seq(1) OR b == seq(2)) AND c == seq(3)"
+            );
+        }
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]).and(cond("e", 5));
+            assert_eq!(
+                expr.to_string(),
+                "(a == seq(1) OR b == seq(2)) AND e == seq(5)"
+            );
+        }
+
+        // or_condition
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]).or(cond("c", 3));
+            assert_eq!(
+                expr.to_string(),
+                "a == seq(1) OR b == seq(2) OR c == seq(3)"
+            );
+        }
+        {
+            let expr = Expr::from_conditions_and([cond("a", 1), cond("b", 2)]).or(cond("e", 5));
+            assert_eq!(
+                expr.to_string(),
+                "(a == seq(1) AND b == seq(2)) OR e == seq(5)"
+            );
+        }
+
+        // and
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)])
+                .and(Expr::from_conditions_or([cond("c", 3), cond("d", 4)]));
+            assert_eq!(
+                expr.to_string(),
+                "(a == seq(1) OR b == seq(2)) AND (c == seq(3) OR d == seq(4))"
+            );
+        }
+        // or
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)])
+                .or(Expr::from_conditions_or([cond("c", 3), cond("d", 4)]));
+            assert_eq!(
+                expr.to_string(),
+                "(c == seq(3) OR d == seq(4)) OR a == seq(1) OR b == seq(2)"
+            );
+        }
+        // and_many
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]).and_many([
+                Expr::from_conditions_or([cond("c", 3), cond("d", 4)]),
+                Expr::from_conditions_or([cond("e", 5), cond("f", 6)]),
+            ]);
+            assert_eq!(
+                expr.to_string(),
+                "(a == seq(1) OR b == seq(2)) AND (c == seq(3) OR d == seq(4)) AND (e == seq(5) OR f == seq(6))"
+            );
+        }
+        // or_many
+        {
+            let expr = Expr::from_conditions_or([cond("a", 1), cond("b", 2)]).or_many([
+                Expr::from_conditions_or([cond("c", 3), cond("d", 4)]),
+                Expr::from_conditions_or([cond("e", 5), cond("f", 6)]),
+            ]);
+            assert_eq!(
+                expr.to_string(),
+                "(c == seq(3) OR d == seq(4)) OR (e == seq(5) OR f == seq(6)) OR a == seq(1) OR b == seq(2)"
+            );
+        }
+        // complex
+        {
+            let expr = cond("a", 1)
+                .or(cond("b", 2))
+                .and(cond("c", 3).or(cond("d", 4)))
+                .or(cond("e", 5)
+                    .or(cond("f", 6))
+                    .and(cond("g", 7).or(cond("h", 8))));
+            assert_eq!(
+                expr.to_string(),
+                "((a == seq(1) OR b == seq(2)) AND (c == seq(3) OR d == seq(4))) OR ((e == seq(5) OR f == seq(6)) AND (g == seq(7) OR h == seq(8)))"
+            );
         }
     }
 }

--- a/src/meta/types/tests/it/main.rs
+++ b/src/meta/types/tests/it/main.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 mod cluster;
+mod txn_serde;
 
 #[test]
 fn test_bin_commit_version() -> anyhow::Result<()> {

--- a/src/meta/types/tests/it/txn_serde.rs
+++ b/src/meta/types/tests/it/txn_serde.rs
@@ -1,0 +1,87 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::time::Duration;
+
+use databend_common_meta_types::protobuf::BooleanExpression;
+use databend_common_meta_types::TxnCondition;
+use databend_common_meta_types::TxnOp;
+use databend_common_meta_types::TxnRequest;
+
+#[test]
+fn test_txn_request_serde() -> anyhow::Result<()> {
+    // Empty operations, with condition
+    let txn = TxnRequest::new(vec![TxnCondition::eq_value("k", b("v"))], vec![
+        TxnOp::put_with_ttl("k", b("v"), Some(Duration::from_millis(100))),
+    ]);
+    let want = concat!(
+        r#"{"#,
+        r#""condition":[{"key":"k","expected":0,"target":{"Value":[118]}}],"#,
+        r#""if_then":[{"request":{"Put":{"key":"k","value":[118],"prev_value":true,"expire_at":null,"ttl_ms":100}}}],"#,
+        r#""else_then":[]"#,
+        r#"}"#
+    );
+    assert_eq!(want, serde_json::to_string(&txn)?);
+    assert_eq!(txn, serde_json::from_str(want)?);
+
+    // Only operations
+
+    let txn = TxnRequest::default().push_branch(
+        Some(BooleanExpression::from_conditions_or([
+            TxnCondition::eq_value("k", b("v")),
+        ])),
+        [TxnOp::get("k")],
+    );
+    let want = r#"{
+  "operations": [
+    {
+      "predicate": {
+        "operator": 1,
+        "sub_expressions": [],
+        "conditions": [
+          {
+            "key": "k",
+            "expected": 0,
+            "target": {
+              "Value": [
+                118
+              ]
+            }
+          }
+        ]
+      },
+      "operations": [
+        {
+          "request": {
+            "Get": {
+              "key": "k"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "condition": [],
+  "if_then": [],
+  "else_then": []
+}"#;
+    assert_eq!(want, serde_json::to_string_pretty(&txn)?);
+    assert_eq!(txn, serde_json::from_str(want)?);
+
+    Ok(())
+}
+
+fn b(x: impl ToString) -> Vec<u8> {
+    x.to_string().into_bytes()
+}

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -311,11 +311,7 @@ impl RoleApi for RoleMgr {
             }
 
             if need_transfer {
-                let txn_req = TxnRequest {
-                    condition: condition.clone(),
-                    if_then: if_then.clone(),
-                    else_then: vec![],
-                };
+                let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
                 let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
                 let (succ, _) = txn_reply_to_api_result(tx_reply)?;
                 debug!(
@@ -378,11 +374,7 @@ impl RoleApi for RoleMgr {
                 }
             }
 
-            let txn_req = TxnRequest {
-                condition: condition.clone(),
-                if_then: if_then.clone(),
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
 
             let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
             let (succ, _) = txn_reply_to_api_result(tx_reply)?;
@@ -467,11 +459,7 @@ impl RoleApi for RoleMgr {
                 }
             }
 
-            let txn_req = TxnRequest {
-                condition: condition.clone(),
-                if_then: if_then.clone(),
-                else_then: vec![],
-            };
+            let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
 
             let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
             let (succ, _) = txn_reply_to_api_result(tx_reply)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: databend-meta transaction support generic bool-expression and else-if chain

Since this commit, application is allowed to specify a complex bool
expressions as the transaction predicate.

For example, the transaction will execute as if running the following
pseudo codes:
```
if (a == 1 || b == 2) && (x == 3 || y == 4) { ops1 }
else if (x == 2 || y == 1) { ops2 }
else if (y == 3 && z == 4) { ops3 }
else { ops4 }
```

```rust
let eq = |key: &str, val: &str| TxnCondition::eq_value(sample(key), b(val));

TxnRequest{
    operations: vec![
                BoolExpression::new(
                    Some(eq("a", 1).or(eq("b", 2))
                         .and(eq("x", 3).or(eq("y", 4)))),
                    ops1),
                BoolExpression::new(
                    Some(eq("x", 2).or(eq("y", 1))),
                    ops2),
            ],

    condition: vec![eq("y", 3), eq("z", 4)],
    if_then: ops3,
    else_then: ops4, 
}
```

For backward compatibility, both already existing `condition` and the new
`operations` will be evaluated: transaction handler evaluate the
`operations` first. If there is a met condition, execute and return.
Otherwise, it evaluate `condition` and then execute `if_then` branch or
`else_then` branch.

TxnReply changes:

Add field `execution_path` to indicate the executed branch, which is one
of:
- `"operation:<index>"`, operation at `index` is executed.
- `"then"`: `if_then` is executed.
- `"else"`: `else_then` is executed.

`TxnReply.success` is set to `false` only when `else` is executed.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17064)
<!-- Reviewable:end -->
