### PR TITLE
fix(query): fix join on not null column cause panic

### DIFF
--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -234,3 +234,17 @@ pub fn wrap_cast(scalar: &ScalarExpr, target_type: &DataType) -> ScalarExpr {
         target_type: Box::new(target_type.clone()),
     })
 }
+
+pub fn wrap_nullable(scalar: ScalarExpr, source_type: &DataType) -> ScalarExpr {
+    if source_type.is_nullable_or_null() {
+        scalar
+    } else {
+        let target_type = source_type.wrap_nullable();
+        ScalarExpr::CastExpr(CastExpr {
+            span: scalar.span(),
+            is_try: false,
+            argument: Box::new(scalar),
+            target_type: Box::new(target_type),
+        })
+    }
+}

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -316,12 +316,12 @@ query T
 explain select sum(a) from (SELECT number AS a FROM numbers(10)) x right join (SELECT number AS a FROM numbers(5)) y using(a);
 ----
 AggregateFinal
-├── output columns: [sum(a) (#2)]
+├── output columns: [sum(a) (#3)]
 ├── group by: []
 ├── aggregate functions: [sum(number)]
 ├── estimated rows: 1.00
 └── Exchange
-    ├── output columns: [sum(a) (#2)]
+    ├── output columns: [sum(a) (#3)]
     ├── exchange type: Merge
     └── AggregatePartial
         ├── group by: []
@@ -331,12 +331,12 @@ AggregateFinal
             ├── output columns: [numbers.number (#1)]
             ├── join type: RIGHT OUTER
             ├── build keys: [CAST(y.a (#1) AS UInt64 NULL)]
-            ├── probe keys: [x.a (#0)]
+            ├── probe keys: [x.a (#2)]
             ├── filters: []
             ├── estimated rows: 50.00
             ├── Exchange(Build)
             │   ├── output columns: [numbers.number (#1)]
-            │   ├── exchange type: Hash(y.a (#1))
+            │   ├── exchange type: Hash(CAST(y.a (#1) AS UInt64 NULL))
             │   └── TableScan
             │       ├── table: default.system.numbers
             │       ├── output columns: [number (#1)]
@@ -347,17 +347,21 @@ AggregateFinal
             │       ├── push downs: [filters: [], limit: NONE]
             │       └── estimated rows: 5.00
             └── Exchange(Probe)
-                ├── output columns: [numbers.number (#0)]
-                ├── exchange type: Hash(x.a (#0))
-                └── TableScan
-                    ├── table: default.system.numbers
-                    ├── output columns: [number (#0)]
-                    ├── read rows: 10
-                    ├── read size: < 1 KiB
-                    ├── partitions total: 1
-                    ├── partitions scanned: 1
-                    ├── push downs: [filters: [], limit: NONE]
-                    └── estimated rows: 10.00
+                ├── output columns: [a (#2)]
+                ├── exchange type: Hash(x.a (#2))
+                └── EvalScalar
+                    ├── output columns: [a (#2)]
+                    ├── expressions: [CAST(x.a (#0) AS UInt64 NULL)]
+                    ├── estimated rows: 10.00
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#0)]
+                        ├── read rows: 10
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 10.00
 
 statement ok
 drop table t1;
@@ -420,39 +424,43 @@ query T
 EXPLAIN SELECT a.cluster_node, b.query_node FROM (SELECT name as cluster_node FROM system.clusters) AS a LEFT JOIN (SELECT DISTINCT node_id as query_node FROM system.query_log) AS b ON a.cluster_node = b.query_node
 ----
 Exchange
-├── output columns: [clusters.name (#0), query_log.node_id (#10)]
+├── output columns: [clusters.name (#0), query_node (#62)]
 ├── exchange type: Merge
 └── HashJoin
-    ├── output columns: [clusters.name (#0), query_log.node_id (#10)]
+    ├── output columns: [clusters.name (#0), query_node (#62)]
     ├── join type: LEFT OUTER
-    ├── build keys: [b.query_node (#10)]
+    ├── build keys: [b.query_node (#62)]
     ├── probe keys: [CAST(a.cluster_node (#0) AS String NULL)]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Exchange(Build)
-    │   ├── output columns: [query_log.node_id (#10)]
+    │   ├── output columns: [query_node (#62)]
     │   ├── exchange type: Broadcast
-    │   └── AggregateFinal
-    │       ├── output columns: [query_log.node_id (#10)]
-    │       ├── group by: [node_id]
-    │       ├── aggregate functions: []
+    │   └── EvalScalar
+    │       ├── output columns: [query_node (#62)]
+    │       ├── expressions: [CAST(b.query_node (#10) AS String NULL)]
     │       ├── estimated rows: 0.00
-    │       └── Exchange
+    │       └── AggregateFinal
     │           ├── output columns: [query_log.node_id (#10)]
-    │           ├── exchange type: Hash(0)
-    │           └── AggregatePartial
-    │               ├── group by: [node_id]
-    │               ├── aggregate functions: []
-    │               ├── estimated rows: 0.00
-    │               └── TableScan
-    │                   ├── table: default.system.query_log
-    │                   ├── output columns: [node_id (#10)]
-    │                   ├── read rows: 0
-    │                   ├── read size: 0
-    │                   ├── partitions total: 0
-    │                   ├── partitions scanned: 0
-    │                   ├── push downs: [filters: [], limit: NONE]
-    │                   └── estimated rows: 0.00
+    │           ├── group by: [node_id]
+    │           ├── aggregate functions: []
+    │           ├── estimated rows: 0.00
+    │           └── Exchange
+    │               ├── output columns: [query_log.node_id (#10)]
+    │               ├── exchange type: Hash(0)
+    │               └── AggregatePartial
+    │                   ├── group by: [node_id]
+    │                   ├── aggregate functions: []
+    │                   ├── estimated rows: 0.00
+    │                   └── TableScan
+    │                       ├── table: default.system.query_log
+    │                       ├── output columns: [node_id (#10)]
+    │                       ├── read rows: 0
+    │                       ├── read size: 0
+    │                       ├── partitions total: 0
+    │                       ├── partitions scanned: 0
+    │                       ├── push downs: [filters: [], limit: NONE]
+    │                       └── estimated rows: 0.00
     └── TableScan(Probe)
         ├── table: default.system.clusters
         ├── output columns: [name (#0)]

--- a/tests/sqllogictests/suites/mode/cluster/shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle.test
@@ -20,23 +20,23 @@ query T
 explain select * from (select t1.number, t2.number from t1 right outer join (SELECT number FROM t2 QUALIFY row_number() OVER ( PARTITION BY number ORDER BY number DESC ) = 1) AS t2 ON t1.number = t2.number) as tt(a, b) order by a;
 ----
 Sort
-├── output columns: [t1.number (#0), t2.number (#1)]
-├── sort keys: [number ASC NULLS LAST]
-├── estimated rows: 0.01
+├── output columns: [a (#3), t2.number (#1)]
+├── sort keys: [a ASC NULLS LAST]
+├── estimated rows: 0.03
 └── Exchange
-    ├── output columns: [t1.number (#0), t2.number (#1), #_order_col]
+    ├── output columns: [a (#3), t2.number (#1), #_order_col]
     ├── exchange type: Merge
     └── Sort
-        ├── output columns: [t1.number (#0), t2.number (#1), #_order_col]
-        ├── sort keys: [number ASC NULLS LAST]
-        ├── estimated rows: 0.01
+        ├── output columns: [a (#3), t2.number (#1), #_order_col]
+        ├── sort keys: [a ASC NULLS LAST]
+        ├── estimated rows: 0.03
         └── HashJoin
-            ├── output columns: [t1.number (#0), t2.number (#1)]
+            ├── output columns: [a (#3), t2.number (#1)]
             ├── join type: RIGHT OUTER
             ├── build keys: [t2.number (#1)]
-            ├── probe keys: [t1.number (#0)]
+            ├── probe keys: [t1.number (#3)]
             ├── filters: []
-            ├── estimated rows: 0.01
+            ├── estimated rows: 0.03
             ├── Filter(Build)
             │   ├── output columns: [t2.number (#1)]
             │   ├── filters: [row_number() OVER ( PARTITION BY number ORDER BY number DESC ) (#2) = 1]
@@ -65,19 +65,22 @@ Sort
             │                   ├── push downs: [filters: [], limit: NONE]
             │                   └── estimated rows: 14.00
             └── Exchange(Probe)
-                ├── output columns: [t1.number (#0)]
-                ├── exchange type: Hash(t1.number (#0))
-                └── TableScan
-                    ├── table: default.default.t1
-                    ├── output columns: [number (#0)]
-                    ├── read rows: 5
-                    ├── read size: < 1 KiB
-                    ├── partitions total: 3
-                    ├── partitions scanned: 3
-                    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
-                    ├── push downs: [filters: [], limit: NONE]
-                    └── estimated rows: 5.00
-
+                ├── output columns: [a (#3)]
+                ├── exchange type: Hash(t1.number (#3))
+                └── EvalScalar
+                    ├── output columns: [a (#3)]
+                    ├── expressions: [CAST(t1.number (#0) AS UInt64 NULL)]
+                    ├── estimated rows: 5.00
+                    └── TableScan
+                        ├── table: default.default.t1
+                        ├── output columns: [number (#0)]
+                        ├── read rows: 5
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 3
+                        ├── partitions scanned: 3
+                        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3>]
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 5.00
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
@@ -99,7 +99,7 @@ query T
 explain select t1.a, v1.c1, v1.c2 from t1 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v1 ("c1", "c2") on t1.a = v1.c2;
 ----
 HashJoin
-├── output columns: [c1 (#3), c2 (#4), t1.a (#0)]
+├── output columns: [c2 (#4), c1 (#8), t1.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
@@ -117,38 +117,42 @@ HashJoin
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
-└── ExpressionScan(Probe)
-    ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
-    ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
-    ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
-    └── AggregateFinal
-        ├── output columns: [t1.c (#2), t1.b (#1)]
-        ├── group by: [c, b]
-        ├── aggregate functions: []
-        ├── estimated rows: 0.00
-        └── AggregatePartial
+└── EvalScalar(Probe)
+    ├── output columns: [c2 (#4), b (#6), c (#7), c1 (#8)]
+    ├── expressions: [CAST(v1.c1 (#3) AS String NULL)]
+    ├── estimated rows: 2.00
+    └── ExpressionScan
+        ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
+        ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
+        ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
+        └── AggregateFinal
+            ├── output columns: [t1.c (#2), t1.b (#1)]
             ├── group by: [c, b]
             ├── aggregate functions: []
             ├── estimated rows: 0.00
-            └── CacheScan
-                ├── output columns: [t1.c (#2), t1.b (#1)]
-                ├── cache index: 0
-                └── column indexes: [1, 2]
+            └── AggregatePartial
+                ├── group by: [c, b]
+                ├── aggregate functions: []
+                ├── estimated rows: 0.00
+                └── CacheScan
+                    ├── output columns: [t1.c (#2), t1.b (#1)]
+                    ├── cache index: 0
+                    └── column indexes: [1, 2]
 
 query T
 explain select t1.a, v1.c1, v1.c2 from t1 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v1 ("c1", "c2") on t1.a = v1.c2 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v2 ("c1", "c2") on t1.a = v2.c2;
 ----
 HashJoin
-├── output columns: [c1 (#3), c2 (#4), t1.a (#0)]
+├── output columns: [c2 (#4), c1 (#8), t1.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
-├── probe keys: [v2.c2 (#9), b (#11), c (#12)]
+├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
 ├── estimated rows: 12.00
 ├── HashJoin(Build)
-│   ├── output columns: [c1 (#3), c2 (#4), t1.a (#0), t1.b (#1), t1.c (#2)]
+│   ├── output columns: [c2 (#4), c1 (#8), t1.a (#0), t1.b (#1), t1.c (#2)]
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
@@ -166,25 +170,29 @@ HashJoin
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 3.00
-│   └── ExpressionScan(Probe)
-│       ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
-│       ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
-│       ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
-│       └── AggregateFinal
-│           ├── output columns: [t1.c (#2), t1.b (#1)]
-│           ├── group by: [c, b]
-│           ├── aggregate functions: []
-│           ├── estimated rows: 0.00
-│           └── AggregatePartial
+│   └── EvalScalar(Probe)
+│       ├── output columns: [c2 (#4), b (#6), c (#7), c1 (#8)]
+│       ├── expressions: [CAST(v1.c1 (#3) AS String NULL)]
+│       ├── estimated rows: 2.00
+│       └── ExpressionScan
+│           ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
+│           ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
+│           ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
+│           └── AggregateFinal
+│               ├── output columns: [t1.c (#2), t1.b (#1)]
 │               ├── group by: [c, b]
 │               ├── aggregate functions: []
 │               ├── estimated rows: 0.00
-│               └── CacheScan
-│                   ├── output columns: [t1.c (#2), t1.b (#1)]
-│                   ├── cache index: 0
-│                   └── column indexes: [1, 2]
+│               └── AggregatePartial
+│                   ├── group by: [c, b]
+│                   ├── aggregate functions: []
+│                   ├── estimated rows: 0.00
+│                   └── CacheScan
+│                       ├── output columns: [t1.c (#2), t1.b (#1)]
+│                       ├── cache index: 0
+│                       └── column indexes: [1, 2]
 └── ExpressionScan(Probe)
-    ├── output columns: [c1 (#8), c2 (#9), b (#11), c (#12)]
+    ├── output columns: [c1 (#9), c2 (#10), b (#12), c (#13)]
     ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
     ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
     └── AggregateFinal

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -317,41 +317,10 @@ query T
 explain select * from t left join t1 on t1.a = t.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#0)]
+├── output columns: [a (#2), t.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
-├── probe keys: [t1.a (#1)]
-├── filters: []
-├── estimated rows: 1.00
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── output columns: [a (#0)]
-│   ├── read rows: 1
-│   ├── read size: < 1 KiB
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│   ├── push downs: [filters: [], limit: NONE]
-│   └── estimated rows: 1.00
-└── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read size: < 1 KiB
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
-
-query T
-explain select * from t right join t1 on t1.a = t.a
-----
-HashJoin
-├── output columns: [t1.a (#1), t.a (#0)]
-├── join type: LEFT OUTER
-├── build keys: [t.a (#0)]
-├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── probe keys: [t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -364,6 +333,45 @@ HashJoin
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
+└── EvalScalar(Probe)
+    ├── output columns: [a (#2)]
+    ├── expressions: [CAST(t1.a (#1) AS UInt64 NULL)]
+    ├── estimated rows: 10.00
+    └── TableScan
+        ├── table: default.join_reorder.t1
+        ├── output columns: [a (#1)]
+        ├── read rows: 10
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 10.00
+
+query T
+explain select * from t right join t1 on t1.a = t.a
+----
+HashJoin
+├── output columns: [t1.a (#1), a (#2)]
+├── join type: LEFT OUTER
+├── build keys: [t.a (#2)]
+├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── filters: []
+├── estimated rows: 10.00
+├── EvalScalar(Build)
+│   ├── output columns: [a (#2)]
+│   ├── expressions: [CAST(t.a (#0) AS UInt64 NULL)]
+│   ├── estimated rows: 1.00
+│   └── TableScan
+│       ├── table: default.join_reorder.t
+│       ├── output columns: [a (#0)]
+│       ├── read rows: 1
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
@@ -89,10 +89,10 @@ query T
 explain select * from numbers(10) t(a) left join lateral(select t.a + t1.a as b from numbers(10) t1(a) where t.a = t1.a) t1 on t.a = t1.b
 ----
 HashJoin
-├── output columns: [b (#2), t.number (#0)]
+├── output columns: [b (#3), t.number (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL), CAST(number (#0) AS UInt64 NULL)]
-├── probe keys: [t1.b (#2), number (#3)]
+├── probe keys: [t1.b (#3), number (#4)]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -105,40 +105,45 @@ HashJoin
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── EvalScalar(Probe)
-    ├── output columns: [number (#3), b (#2)]
-    ├── expressions: [number (#3) + t1.a (#1)]
+    ├── output columns: [number (#4), b (#3)]
+    ├── expressions: [CAST(t1.b (#2) AS UInt64 NULL)]
     ├── estimated rows: 100.00
-    └── HashJoin
-        ├── output columns: [number (#3), t1.number (#1)]
-        ├── join type: INNER
-        ├── build keys: [t1.a (#1)]
-        ├── probe keys: [number (#3)]
-        ├── filters: []
+    └── EvalScalar
+        ├── output columns: [number (#4), b (#2)]
+        ├── expressions: [number (#4) + t1.a (#1)]
         ├── estimated rows: 100.00
-        ├── TableScan(Build)
-        │   ├── table: default.system.numbers
-        │   ├── output columns: [number (#1)]
-        │   ├── read rows: 10
-        │   ├── read size: < 1 KiB
-        │   ├── partitions total: 1
-        │   ├── partitions scanned: 1
-        │   ├── push downs: [filters: [], limit: NONE]
-        │   └── estimated rows: 10.00
-        └── AggregateFinal(Probe)
-            ├── output columns: [number (#3)]
-            ├── group by: [number]
-            ├── aggregate functions: []
-            ├── estimated rows: 10.00
-            └── AggregatePartial
+        └── HashJoin
+            ├── output columns: [number (#4), t1.number (#1)]
+            ├── join type: INNER
+            ├── build keys: [t1.a (#1)]
+            ├── probe keys: [number (#4)]
+            ├── filters: []
+            ├── estimated rows: 100.00
+            ├── TableScan(Build)
+            │   ├── table: default.system.numbers
+            │   ├── output columns: [number (#1)]
+            │   ├── read rows: 10
+            │   ├── read size: < 1 KiB
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   ├── push downs: [filters: [], limit: NONE]
+            │   └── estimated rows: 10.00
+            └── AggregateFinal(Probe)
+                ├── output columns: [number (#4)]
                 ├── group by: [number]
                 ├── aggregate functions: []
                 ├── estimated rows: 10.00
-                └── TableScan
-                    ├── table: default.system.numbers
-                    ├── output columns: [number (#3)]
-                    ├── read rows: 10
-                    ├── read size: < 1 KiB
-                    ├── partitions total: 1
-                    ├── partitions scanned: 1
-                    ├── push downs: [filters: [], limit: NONE]
-                    └── estimated rows: 10.00
+                └── AggregatePartial
+                    ├── group by: [number]
+                    ├── aggregate functions: []
+                    ├── estimated rows: 10.00
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#4)]
+                        ├── read rows: 10
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 10.00
+

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -166,19 +166,19 @@ query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1
 ----
 Limit
-├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+├── output columns: [c (#4), count(t1.number) (#1)]
 ├── limit: 1
 ├── offset: 0
 ├── estimated rows: 1.00
 └── Sort
-    ├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+    ├── output columns: [c (#4), count(t1.number) (#1)]
     ├── sort keys: [count(t1.number) ASC NULLS LAST]
     ├── estimated rows: 2.00
     └── HashJoin
-        ├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+        ├── output columns: [c (#4), count(t1.number) (#1)]
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
-        ├── probe keys: [t4.c (#3)]
+        ├── probe keys: [t4.c (#4)]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)
@@ -199,25 +199,28 @@ Limit
         │           ├── partitions scanned: 1
         │           ├── push downs: [filters: [], limit: NONE]
         │           └── estimated rows: 1.00
-        └── AggregateFinal(Probe)
-            ├── output columns: [count(t.number) (#3), t.number (#2)]
-            ├── group by: [number]
-            ├── aggregate functions: [count()]
+        └── EvalScalar(Probe)
+            ├── output columns: [c (#4)]
+            ├── expressions: [CAST(t4.c (#3) AS UInt64 NULL)]
             ├── estimated rows: 2.00
-            └── AggregatePartial
+            └── AggregateFinal
+                ├── output columns: [count(t.number) (#3), t.number (#2)]
                 ├── group by: [number]
                 ├── aggregate functions: [count()]
                 ├── estimated rows: 2.00
-                └── TableScan
-                    ├── table: default.system.numbers
-                    ├── output columns: [number (#2)]
-                    ├── read rows: 2
-                    ├── read size: < 1 KiB
-                    ├── partitions total: 1
-                    ├── partitions scanned: 1
-                    ├── push downs: [filters: [], limit: NONE]
-                    └── estimated rows: 2.00
-
+                └── AggregatePartial
+                    ├── group by: [number]
+                    ├── aggregate functions: [count()]
+                    ├── estimated rows: 2.00
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#2)]
+                        ├── read rows: 2
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 2.00
 
 query T
 explain select c1 from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 0

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -12,21 +12,25 @@ D as (select * from C)
 select * from D;
 ----
 HashJoin
-├── output columns: [a.a (#0), a.b (#1), a.b (#3), a.a (#2)]
+├── output columns: [a.a (#0), a.b (#1), b (#5), a (#4)]
 ├── join type: INNER
-├── build keys: [b2.a (#2)]
-├── probe keys: [b1.a (#0)]
-├── filters: [d.b (#1) < d.b (#3)]
+├── build keys: [b2.a (#4)]
+├── probe keys: [CAST(b1.a (#0) AS UInt64 NULL)]
+├── filters: [CAST(d.b (#1) AS UInt64 NULL) < d.b (#5)]
 ├── estimated rows: 400.00
-├── TableScan(Build)
-│   ├── table: default.default.a
-│   ├── output columns: [a (#2), b (#3)]
-│   ├── read rows: 20
-│   ├── read size: < 1 KiB
-│   ├── partitions total: 0
-│   ├── partitions scanned: 0
-│   ├── push downs: [filters: [], limit: NONE]
-│   └── estimated rows: 20.00
+├── EvalScalar(Build)
+│   ├── output columns: [a (#4), b (#5)]
+│   ├── expressions: [CAST(b2.a (#2) AS UInt64 NULL), CAST(b2.b (#3) AS UInt64 NULL)]
+│   ├── estimated rows: 20.00
+│   └── TableScan
+│       ├── table: default.default.a
+│       ├── output columns: [a (#2), b (#3)]
+│       ├── read rows: 20
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 0
+│       ├── partitions scanned: 0
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 20.00
 └── TableScan(Probe)
     ├── table: default.default.a
     ├── output columns: [a (#0), b (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
@@ -100,7 +100,7 @@ query T
 explain select t1.a, v1.c1, v1.c2 from t1 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v1 ("c1", "c2") on t1.a = v1.c2;
 ----
 HashJoin
-├── output columns: [c1 (#3), c2 (#4), t1.a (#0)]
+├── output columns: [c2 (#4), c1 (#8), t1.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
@@ -118,38 +118,42 @@ HashJoin
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
-└── ExpressionScan(Probe)
-    ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
-    ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
-    ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
-    └── AggregateFinal
-        ├── output columns: [t1.c (#2), t1.b (#1)]
-        ├── group by: [c, b]
-        ├── aggregate functions: []
-        ├── estimated rows: 0.00
-        └── AggregatePartial
+└── EvalScalar(Probe)
+    ├── output columns: [c2 (#4), b (#6), c (#7), c1 (#8)]
+    ├── expressions: [CAST(v1.c1 (#3) AS String NULL)]
+    ├── estimated rows: 2.00
+    └── ExpressionScan
+        ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
+        ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
+        ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
+        └── AggregateFinal
+            ├── output columns: [t1.c (#2), t1.b (#1)]
             ├── group by: [c, b]
             ├── aggregate functions: []
             ├── estimated rows: 0.00
-            └── CacheScan
-                ├── output columns: [t1.c (#2), t1.b (#1)]
-                ├── cache index: 0
-                └── column indexes: [1, 2]
+            └── AggregatePartial
+                ├── group by: [c, b]
+                ├── aggregate functions: []
+                ├── estimated rows: 0.00
+                └── CacheScan
+                    ├── output columns: [t1.c (#2), t1.b (#1)]
+                    ├── cache index: 0
+                    └── column indexes: [1, 2]
 
 query T
 explain select t1.a, v1.c1, v1.c2 from t1 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v1 ("c1", "c2") on t1.a = v1.c2 left join lateral (values('t1_b', t1.b), ('t1_c', t1.c)) as v2 ("c1", "c2") on t1.a = v2.c2;
 ----
 HashJoin
-├── output columns: [c1 (#3), c2 (#4), t1.a (#0)]
+├── output columns: [c2 (#4), c1 (#8), t1.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
-├── probe keys: [v2.c2 (#9), b (#11), c (#12)]
+├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
 ├── estimated rows: 12.00
 ├── HashJoin(Build)
-│   ├── output columns: [c1 (#3), c2 (#4), t1.a (#0), t1.b (#1), t1.c (#2)]
+│   ├── output columns: [c2 (#4), c1 (#8), t1.a (#0), t1.b (#1), t1.c (#2)]
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
@@ -167,25 +171,29 @@ HashJoin
 │   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 3.00
-│   └── ExpressionScan(Probe)
-│       ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
-│       ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
-│       ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
-│       └── AggregateFinal
-│           ├── output columns: [t1.c (#2), t1.b (#1)]
-│           ├── group by: [c, b]
-│           ├── aggregate functions: []
-│           ├── estimated rows: 0.00
-│           └── AggregatePartial
+│   └── EvalScalar(Probe)
+│       ├── output columns: [c2 (#4), b (#6), c (#7), c1 (#8)]
+│       ├── expressions: [CAST(v1.c1 (#3) AS String NULL)]
+│       ├── estimated rows: 2.00
+│       └── ExpressionScan
+│           ├── output columns: [c1 (#3), c2 (#4), b (#6), c (#7)]
+│           ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
+│           ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
+│           └── AggregateFinal
+│               ├── output columns: [t1.c (#2), t1.b (#1)]
 │               ├── group by: [c, b]
 │               ├── aggregate functions: []
 │               ├── estimated rows: 0.00
-│               └── CacheScan
-│                   ├── output columns: [t1.c (#2), t1.b (#1)]
-│                   ├── cache index: 0
-│                   └── column indexes: [1, 2]
+│               └── AggregatePartial
+│                   ├── group by: [c, b]
+│                   ├── aggregate functions: []
+│                   ├── estimated rows: 0.00
+│                   └── CacheScan
+│                       ├── output columns: [t1.c (#2), t1.b (#1)]
+│                       ├── cache index: 0
+│                       └── column indexes: [1, 2]
 └── ExpressionScan(Probe)
-    ├── output columns: [c1 (#8), c2 (#9), b (#11), c (#12)]
+    ├── output columns: [c1 (#9), c2 (#10), b (#12), c (#13)]
     ├── column 0: ['t1_b', t1.b (#1), t1.b (#1), t1.c (#2)]
     ├── column 1: ['t1_c', t1.c (#2), t1.b (#1), t1.c (#2)]
     └── AggregateFinal

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
@@ -317,41 +317,10 @@ query T
 explain select * from t left join t1 on t1.a = t.a
 ----
 HashJoin
-├── output columns: [t1.a (#1), t.a (#0)]
+├── output columns: [a (#2), t.a (#0)]
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
-├── probe keys: [t1.a (#1)]
-├── filters: []
-├── estimated rows: 1.00
-├── TableScan(Build)
-│   ├── table: default.join_reorder.t
-│   ├── output columns: [a (#0)]
-│   ├── read rows: 1
-│   ├── read size: < 1 KiB
-│   ├── partitions total: 1
-│   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│   ├── push downs: [filters: [], limit: NONE]
-│   └── estimated rows: 1.00
-└── TableScan(Probe)
-    ├── table: default.join_reorder.t1
-    ├── output columns: [a (#1)]
-    ├── read rows: 10
-    ├── read size: < 1 KiB
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 10.00
-
-query T
-explain select * from t right join t1 on t1.a = t.a
-----
-HashJoin
-├── output columns: [t1.a (#1), t.a (#0)]
-├── join type: LEFT OUTER
-├── build keys: [t.a (#0)]
-├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── probe keys: [t1.a (#2)]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -364,6 +333,45 @@ HashJoin
 │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
+└── EvalScalar(Probe)
+    ├── output columns: [a (#2)]
+    ├── expressions: [CAST(t1.a (#1) AS UInt64 NULL)]
+    ├── estimated rows: 10.00
+    └── TableScan
+        ├── table: default.join_reorder.t1
+        ├── output columns: [a (#1)]
+        ├── read rows: 10
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 10.00
+
+query T
+explain select * from t right join t1 on t1.a = t.a
+----
+HashJoin
+├── output columns: [t1.a (#1), a (#2)]
+├── join type: LEFT OUTER
+├── build keys: [t.a (#2)]
+├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── filters: []
+├── estimated rows: 10.00
+├── EvalScalar(Build)
+│   ├── output columns: [a (#2)]
+│   ├── expressions: [CAST(t.a (#0) AS UInt64 NULL)]
+│   ├── estimated rows: 1.00
+│   └── TableScan
+│       ├── table: default.join_reorder.t
+│       ├── output columns: [a (#0)]
+│       ├── read rows: 1
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.join_reorder.t1
     ├── output columns: [a (#1)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -166,19 +166,19 @@ query T
 explain select * from (select count(t1.number) as c1 from numbers(1) as t1 group by number) as t3 left join (select count(t.number) as c from numbers(2) as t group by number) as t4 on t3.c1=t4.c order by t3.c1 limit 1
 ----
 Limit
-├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+├── output columns: [c (#4), count(t1.number) (#1)]
 ├── limit: 1
 ├── offset: 0
 ├── estimated rows: 1.00
 └── Sort
-    ├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+    ├── output columns: [c (#4), count(t1.number) (#1)]
     ├── sort keys: [count(t1.number) ASC NULLS LAST]
     ├── estimated rows: 2.00
     └── HashJoin
-        ├── output columns: [count(t.number) (#3), count(t1.number) (#1)]
+        ├── output columns: [c (#4), count(t1.number) (#1)]
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
-        ├── probe keys: [t4.c (#3)]
+        ├── probe keys: [t4.c (#4)]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)
@@ -199,21 +199,26 @@ Limit
         │           ├── partitions scanned: 1
         │           ├── push downs: [filters: [], limit: NONE]
         │           └── estimated rows: 1.00
-        └── AggregateFinal(Probe)
-            ├── output columns: [count(t.number) (#3), t.number (#2)]
-            ├── group by: [number]
-            ├── aggregate functions: [count()]
+        └── EvalScalar(Probe)
+            ├── output columns: [c (#4)]
+            ├── expressions: [CAST(t4.c (#3) AS UInt64 NULL)]
             ├── estimated rows: 2.00
-            └── AggregatePartial
+            └── AggregateFinal
+                ├── output columns: [count(t.number) (#3), t.number (#2)]
                 ├── group by: [number]
                 ├── aggregate functions: [count()]
                 ├── estimated rows: 2.00
-                └── TableScan
-                    ├── table: default.system.numbers
-                    ├── output columns: [number (#2)]
-                    ├── read rows: 2
-                    ├── read size: < 1 KiB
-                    ├── partitions total: 1
-                    ├── partitions scanned: 1
-                    ├── push downs: [filters: [], limit: NONE]
-                    └── estimated rows: 2.00
+                └── AggregatePartial
+                    ├── group by: [number]
+                    ├── aggregate functions: [count()]
+                    ├── estimated rows: 2.00
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#2)]
+                        ├── read rows: 2
+                        ├── read size: < 1 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 2.00
+

--- a/tests/sqllogictests/suites/query/join/left_outer.test
+++ b/tests/sqllogictests/suites/query/join/left_outer.test
@@ -311,8 +311,33 @@ select * from (
    select 'SN0LL' as k  from t1
 ) as a1  left  join (select * from t2) as a2 on a1.k = a2.a;
 
+# https://github.com/databendlabs/databend/issues/17067
+statement ok
+drop table if exists t3;
+
+statement ok
+CREATE TABLE t3(id int, flag int not null, user_id json);
+
+statement ok
+INSERT INTO t3 VALUES(1, 1, '10'),(2, 2, '20');
+
+query T
+with t2 as (
+  select t1.* from (
+   select b.flag from t3 a left join t3 b on a.flag = b.flag where b.user_id is not null
+   union all select flag from t3
+  )t1
+)
+select distinct try_cast(flag as int) from t2;
+----
+2
+1
+
 statement ok
 DROP TABLE IF EXISTS t1;
 
 statement ok
 DROP TABLE IF EXISTS t2;
+
+statement ok
+DROP TABLE IF EXISTS t3;

--- a/tests/sqllogictests/suites/query/join/left_outer.test
+++ b/tests/sqllogictests/suites/query/join/left_outer.test
@@ -328,10 +328,10 @@ with t2 as (
    union all select flag from t3
   )t1
 )
-select distinct try_cast(flag as int) from t2;
+select distinct try_cast(flag as int) as f from t2 order by f;
 ----
-2
 1
+2
 
 statement ok
 DROP TABLE IF EXISTS t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

bind join left and right column wrap nullable will cause not null column have a nullable data type, and evaluator checks the data type of the column data when it is executed. If the data type does not match, the check fails and panic occurs. After the modification, add additional `EvalScalar` plan to generate derived nullable columns if join operator need.

- fixes: #17067

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17069)
<!-- Reviewable:end -->
