### PR TITLE
chore: rm memory-profiling from databend-meta default feature

### DIFF
--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 test = true
 
 [features]
-default = ["simd", "memory-profiling"]
+default = ["simd"]
 memory-profiling = ["databend-common-base/memory-profiling", "databend-common-http/memory-profiling"]
 simd = ["databend-common-arrow/simd"]
 io-uring = [


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

rm memory-profiling from databend-meta default feature

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - tweak cargo feature

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): tweak cargo feature

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17074)
<!-- Reviewable:end -->
