### PR TITLE
chore: use GlobalIORuntime to prune blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,6 @@ dependencies = [
  "databend-common-exception",
  "databend-common-expression",
  "databend-common-functions",
- "databend-common-management",
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-types",

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use async_channel::Receiver;
+use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_base::runtime::TrySpawn;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartInfoPtr;
@@ -205,7 +206,7 @@ impl FuseTable {
             let ctx = ctx.clone();
             let (tx, rx) = async_channel::bounded(max_io_requests);
             pipeline.set_on_init(move || {
-                ctx.get_runtime()?.try_spawn(
+                GlobalIORuntime::instance().try_spawn(
                     async move {
                         match table
                             .prune_snapshot_blocks(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


DO NOT MERGE (evaluating):

Use `GlobalIORuntime` to prune blocks, avoid dropping ad-hoc `query-ctx` runtime inside itself, and prevent potential hangs.




## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - evaluating


## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17078)
<!-- Reviewable:end -->
