### PR TITLE
fix(query): Correct sign extension handling in months_days_micros struct

### DIFF
--- a/src/common/column/src/types/native.rs
+++ b/src/common/column/src/types/native.rs
@@ -271,8 +271,10 @@ pub struct months_days_micros(pub i128);
 impl months_days_micros {
     pub fn new(months: i32, days: i32, microseconds: i64) -> Self {
         let months_bits = (months as i128) << 96;
-        let days_bits = (days as i128) << 64;
-        let micros_bits = microseconds as i128;
+        // converting to u32 before i128 ensures we’re working with the raw, unsigned bit pattern of the i32 value,
+        // preventing unwanted sign extension when that value is later used within the i128.
+        let days_bits = ((days as u32) as i128) << 64;
+        let micros_bits = (microseconds as u64) as i128;
 
         Self(months_bits | days_bits | micros_bits)
     }

--- a/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
+++ b/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
@@ -11,7 +11,7 @@ query TT
 select * from t order by c1;
 ----
 -1 year -1 month 0:00:00.000001
--1 month -1 day -1:00:00 0:00:00.001
+-1 month -1:00:00 0:00:00.001
 
 onlyif http
 statement error 1006
@@ -22,3 +22,9 @@ query T
 select to_interval('1 month 1 hour 1 microsecond');
 ----
 1 month 1:00:00.000001
+
+onlyif http
+query T
+select to_interval('1 month 1 hour 1 microsecond ago');
+----
+-1 month -1:00:00.000001


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Casting days to u32 before casting to i128 to prevent sign extension. 
Casting microseconds to u64 before casting to i128 to prevent sign extension.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17086)
<!-- Reviewable:end -->
