### PR TITLE
fix(query): union all panic in mysql client

### DIFF
--- a/src/query/sql/src/executor/physical_plans/physical_union_all.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_union_all.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use databend_common_exception::Result;
 use databend_common_expression::DataField;
+use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::RemoteExpr;
@@ -24,6 +27,7 @@ use crate::executor::PhysicalPlanBuilder;
 use crate::optimizer::SExpr;
 use crate::ColumnSet;
 use crate::IndexType;
+use crate::ScalarExpr;
 use crate::TypeCheck;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -52,25 +56,41 @@ impl PhysicalPlanBuilder {
         &mut self,
         s_expr: &SExpr,
         union_all: &crate::plans::UnionAll,
-        required: ColumnSet,
+        mut required: ColumnSet,
         stat_info: PlanStatsInfo,
     ) -> Result<PhysicalPlan> {
         // 1. Prune unused Columns.
-        let left_required = union_all
+        let metadata = self.metadata.read().clone();
+        let lazy_columns = metadata.lazy_columns();
+        required.extend(lazy_columns.clone());
+        let indices: Vec<_> = union_all
             .left_outputs
             .iter()
-            .fold(required.clone(), |mut acc, v| {
-                acc.insert(v.0);
-                acc
-            });
-        let right_required = union_all.right_outputs.iter().fold(required, |mut acc, v| {
-            acc.insert(v.0);
-            acc
-        });
+            .enumerate()
+            .filter_map(|(index, v)| required.contains(&v.0).then_some(index))
+            .collect();
+        let (left_required, right_required) = if indices.is_empty() {
+            (
+                HashSet::from([union_all.left_outputs[0].0]),
+                HashSet::from([union_all.right_outputs[0].0]),
+            )
+        } else {
+            indices.iter().fold(
+                (
+                    HashSet::with_capacity(indices.len()),
+                    HashSet::with_capacity(indices.len()),
+                ),
+                |(mut left, mut right), &index| {
+                    left.insert(union_all.left_outputs[index].0);
+                    right.insert(union_all.right_outputs[index].0);
+                    (left, right)
+                },
+            )
+        };
 
         // 2. Build physical plan.
-        let left_plan = self.build(s_expr.child(0)?, left_required).await?;
-        let right_plan = self.build(s_expr.child(1)?, right_required).await?;
+        let left_plan = self.build(s_expr.child(0)?, left_required.clone()).await?;
+        let right_plan = self.build(s_expr.child(1)?, right_required.clone()).await?;
 
         let left_schema = left_plan.output_schema()?;
         let right_schema = right_plan.output_schema()?;
@@ -78,6 +98,7 @@ impl PhysicalPlanBuilder {
         let fields = union_all
             .left_outputs
             .iter()
+            .filter(|(index, _)| left_required.contains(index))
             .map(|(index, expr)| {
                 if let Some(expr) = expr {
                     Ok(DataField::new(&index.to_string(), expr.data_type()?))
@@ -87,35 +108,9 @@ impl PhysicalPlanBuilder {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let left_outputs = union_all
-            .left_outputs
-            .iter()
-            .map(|(index, scalar_expr)| {
-                if let Some(scalar_expr) = scalar_expr {
-                    let expr = scalar_expr
-                        .type_check(left_schema.as_ref())?
-                        .project_column_ref(|idx| left_schema.index_of(&idx.to_string()).unwrap());
-                    Ok((*index, Some(expr.as_remote_expr())))
-                } else {
-                    Ok((*index, None))
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let right_outputs = union_all
-            .right_outputs
-            .iter()
-            .map(|(index, scalar_expr)| {
-                if let Some(scalar_expr) = scalar_expr {
-                    let expr = scalar_expr
-                        .type_check(right_schema.as_ref())?
-                        .project_column_ref(|idx| right_schema.index_of(&idx.to_string()).unwrap());
-                    Ok((*index, Some(expr.as_remote_expr())))
-                } else {
-                    Ok((*index, None))
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let left_outputs = process_outputs(&union_all.left_outputs, &left_required, &left_schema)?;
+        let right_outputs =
+            process_outputs(&union_all.right_outputs, &right_required, &right_schema)?;
 
         Ok(PhysicalPlan::UnionAll(UnionAll {
             plan_id: 0,
@@ -129,4 +124,25 @@ impl PhysicalPlanBuilder {
             stat_info: Some(stat_info),
         }))
     }
+}
+
+fn process_outputs(
+    outputs: &[(IndexType, Option<ScalarExpr>)],
+    required: &ColumnSet,
+    schema: &DataSchema,
+) -> Result<Vec<(IndexType, Option<RemoteExpr>)>> {
+    outputs
+        .iter()
+        .filter(|(index, _)| required.contains(index))
+        .map(|(index, scalar_expr)| {
+            if let Some(scalar_expr) = scalar_expr {
+                let expr = scalar_expr
+                    .type_check(schema)?
+                    .project_column_ref(|idx| schema.index_of(&idx.to_string()).unwrap());
+                Ok((*index, Some(expr.as_remote_expr())))
+            } else {
+                Ok((*index, None))
+            }
+        })
+        .collect()
 }

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -349,6 +349,12 @@ select a, b, change$action, change$is_update from s3 as _change_delete order by 
 4 4 INSERT 0
 6 5 INSERT 0
 
+# ISSUE 17085
+query I
+select a from s3 where a > 5
+----
+6
+
 statement ok
 create table t4(a int, b int)
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
@@ -61,93 +61,81 @@ AggregateFinal
     ├── aggregate functions: []
     ├── estimated rows: 0.00
     └── UnionAll
-        ├── output columns: [t.id (#0), de (#6)]
+        ├── output columns: [t.id (#0)]
         ├── estimated rows: 0.00
-        ├── EvalScalar
-        │   ├── output columns: [t.id (#0), de (#6)]
-        │   ├── expressions: [if(CAST(is_not_null(sum(tb.de) (#5)) AS Boolean NULL), CAST(assume_not_null(sum(tb.de) (#5)) AS Int64 NULL), true, 0, NULL)]
+        ├── AggregateFinal
+        │   ├── output columns: [t.id (#0)]
+        │   ├── group by: [id]
+        │   ├── aggregate functions: []
         │   ├── estimated rows: 0.00
-        │   └── AggregateFinal
-        │       ├── output columns: [sum(tb.de) (#5), t.id (#0)]
+        │   └── AggregatePartial
         │       ├── group by: [id]
-        │       ├── aggregate functions: [sum(sum(coalesce(t3.val, 0)))]
+        │       ├── aggregate functions: []
         │       ├── estimated rows: 0.00
-        │       └── AggregatePartial
-        │           ├── group by: [id]
-        │           ├── aggregate functions: [sum(sum(coalesce(t3.val, 0)))]
+        │       └── HashJoin
+        │           ├── output columns: [t.id (#0)]
+        │           ├── join type: LEFT OUTER
+        │           ├── build keys: [tb.sid (#1)]
+        │           ├── probe keys: [t.id (#0)]
+        │           ├── filters: []
         │           ├── estimated rows: 0.00
-        │           └── HashJoin
-        │               ├── output columns: [t.id (#0), sum(coalesce(t3.val, 0)) (#4)]
-        │               ├── join type: LEFT OUTER
-        │               ├── build keys: [tb.sid (#1)]
-        │               ├── probe keys: [t.id (#0)]
-        │               ├── filters: []
+        │           ├── AggregateFinal(Build)
+        │           │   ├── output columns: [t2.sid (#1)]
+        │           │   ├── group by: [sid]
+        │           │   ├── aggregate functions: []
+        │           │   ├── estimated rows: 0.00
+        │           │   └── AggregatePartial
+        │           │       ├── group by: [sid]
+        │           │       ├── aggregate functions: []
+        │           │       ├── estimated rows: 0.00
+        │           │       └── Filter
+        │           │           ├── output columns: [t2.sid (#1)]
+        │           │           ├── filters: [is_true(t3.sid (#1) = 1)]
+        │           │           ├── estimated rows: 0.00
+        │           │           └── TableScan
+        │           │               ├── table: default.default.t2
+        │           │               ├── output columns: [sid (#1)]
+        │           │               ├── read rows: 0
+        │           │               ├── read size: 0
+        │           │               ├── partitions total: 0
+        │           │               ├── partitions scanned: 0
+        │           │               ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
+        │           │               └── estimated rows: 0.00
+        │           └── Filter(Probe)
+        │               ├── output columns: [t.id (#0)]
+        │               ├── filters: [is_true(t.id (#0) = 1)]
         │               ├── estimated rows: 0.00
-        │               ├── AggregateFinal(Build)
-        │               │   ├── output columns: [sum(coalesce(t3.val, 0)) (#4), t2.sid (#1)]
-        │               │   ├── group by: [sid]
-        │               │   ├── aggregate functions: [sum(sum_arg_0)]
-        │               │   ├── estimated rows: 0.00
-        │               │   └── AggregatePartial
-        │               │       ├── group by: [sid]
-        │               │       ├── aggregate functions: [sum(sum_arg_0)]
-        │               │       ├── estimated rows: 0.00
-        │               │       └── EvalScalar
-        │               │           ├── output columns: [t2.sid (#1), sum_arg_0 (#3)]
-        │               │           ├── expressions: [if(CAST(is_not_null(t3.val (#2)) AS Boolean NULL), CAST(assume_not_null(t3.val (#2)) AS Int32 NULL), true, 0, NULL)]
-        │               │           ├── estimated rows: 0.00
-        │               │           └── Filter
-        │               │               ├── output columns: [t2.sid (#1), t2.val (#2)]
-        │               │               ├── filters: [is_true(t3.sid (#1) = 1)]
-        │               │               ├── estimated rows: 0.00
-        │               │               └── TableScan
-        │               │                   ├── table: default.default.t2
-        │               │                   ├── output columns: [sid (#1), val (#2)]
-        │               │                   ├── read rows: 0
-        │               │                   ├── read size: 0
-        │               │                   ├── partitions total: 0
-        │               │                   ├── partitions scanned: 0
-        │               │                   ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
-        │               │                   └── estimated rows: 0.00
-        │               └── Filter(Probe)
-        │                   ├── output columns: [t.id (#0)]
-        │                   ├── filters: [is_true(t.id (#0) = 1)]
-        │                   ├── estimated rows: 0.00
-        │                   └── TableScan
-        │                       ├── table: default.default.t1
-        │                       ├── output columns: [id (#0)]
-        │                       ├── read rows: 0
-        │                       ├── read size: 0
-        │                       ├── partitions total: 0
-        │                       ├── partitions scanned: 0
-        │                       ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
-        │                       └── estimated rows: 0.00
-        └── EvalScalar
-            ├── output columns: [t.id (#7), de (#8)]
-            ├── expressions: [0]
+        │               └── TableScan
+        │                   ├── table: default.default.t1
+        │                   ├── output columns: [id (#0)]
+        │                   ├── read rows: 0
+        │                   ├── read size: 0
+        │                   ├── partitions total: 0
+        │                   ├── partitions scanned: 0
+        │                   ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
+        │                   └── estimated rows: 0.00
+        └── AggregateFinal
+            ├── output columns: [t.id (#7)]
+            ├── group by: [id]
+            ├── aggregate functions: []
             ├── estimated rows: 0.00
-            └── AggregateFinal
-                ├── output columns: [t.id (#7)]
+            └── AggregatePartial
                 ├── group by: [id]
                 ├── aggregate functions: []
                 ├── estimated rows: 0.00
-                └── AggregatePartial
-                    ├── group by: [id]
-                    ├── aggregate functions: []
+                └── Filter
+                    ├── output columns: [t.id (#7)]
+                    ├── filters: [is_true(t.id (#7) = 1)]
                     ├── estimated rows: 0.00
-                    └── Filter
-                        ├── output columns: [t.id (#7)]
-                        ├── filters: [is_true(t.id (#7) = 1)]
-                        ├── estimated rows: 0.00
-                        └── TableScan
-                            ├── table: default.default.t1
-                            ├── output columns: [id (#7)]
-                            ├── read rows: 0
-                            ├── read size: 0
-                            ├── partitions total: 0
-                            ├── partitions scanned: 0
-                            ├── push downs: [filters: [is_true(t1.id (#7) = 1)], limit: NONE]
-                            └── estimated rows: 0.00
+                    └── TableScan
+                        ├── table: default.default.t1
+                        ├── output columns: [id (#7)]
+                        ├── read rows: 0
+                        ├── read size: 0
+                        ├── partitions total: 0
+                        ├── partitions scanned: 0
+                        ├── push downs: [filters: [is_true(t1.id (#7) = 1)], limit: NONE]
+                        └── estimated rows: 0.00
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -218,6 +218,42 @@ Limit
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 2.00
 
+# ISSUE 17085
+query T
+explain select b from (select * from t1 where a>1 union all select * from t2 where b>2)
+----
+UnionAll
+├── output columns: [t1.b (#1)]
+├── estimated rows: 2.00
+├── Filter
+│   ├── output columns: [t1.b (#1)]
+│   ├── filters: [is_true(t1.a (#0) > 1)]
+│   ├── estimated rows: 1.00
+│   └── TableScan
+│       ├── table: default.default.t1
+│       ├── output columns: [a (#0), b (#1)]
+│       ├── read rows: 2
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
+│       └── estimated rows: 2.00
+└── Filter
+    ├── output columns: [t2.b (#3)]
+    ├── filters: [is_true(t2.b (#3) > 2)]
+    ├── estimated rows: 1.00
+    └── TableScan
+        ├── table: default.default.t2
+        ├── output columns: [b (#3)]
+        ├── read rows: 2
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+        ├── push downs: [filters: [is_true(t2.b (#3) > 2)], limit: NONE]
+        └── estimated rows: 2.00
+
 statement ok
 drop table t1
 

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
@@ -61,81 +61,69 @@ AggregateFinal
     ├── aggregate functions: []
     ├── estimated rows: 0.00
     └── UnionAll
-        ├── output columns: [t.id (#0), de (#6)]
+        ├── output columns: [t.id (#0)]
         ├── estimated rows: 0.00
-        ├── EvalScalar
-        │   ├── output columns: [t.id (#0), de (#6)]
-        │   ├── expressions: [if(CAST(is_not_null(sum(tb.de) (#5)) AS Boolean NULL), CAST(assume_not_null(sum(tb.de) (#5)) AS Int64 NULL), true, 0, NULL)]
+        ├── AggregateFinal
+        │   ├── output columns: [t.id (#0)]
+        │   ├── group by: [id]
+        │   ├── aggregate functions: []
         │   ├── estimated rows: 0.00
-        │   └── AggregateFinal
-        │       ├── output columns: [sum(tb.de) (#5), t.id (#0)]
+        │   └── AggregatePartial
         │       ├── group by: [id]
-        │       ├── aggregate functions: [sum(sum(coalesce(t3.val, 0)))]
+        │       ├── aggregate functions: []
         │       ├── estimated rows: 0.00
-        │       └── AggregatePartial
-        │           ├── group by: [id]
-        │           ├── aggregate functions: [sum(sum(coalesce(t3.val, 0)))]
+        │       └── HashJoin
+        │           ├── output columns: [t.id (#0)]
+        │           ├── join type: LEFT OUTER
+        │           ├── build keys: [tb.sid (#1)]
+        │           ├── probe keys: [t.id (#0)]
+        │           ├── filters: []
         │           ├── estimated rows: 0.00
-        │           └── HashJoin
-        │               ├── output columns: [t.id (#0), sum(coalesce(t3.val, 0)) (#4)]
-        │               ├── join type: LEFT OUTER
-        │               ├── build keys: [tb.sid (#1)]
-        │               ├── probe keys: [t.id (#0)]
-        │               ├── filters: []
-        │               ├── estimated rows: 0.00
-        │               ├── AggregateFinal(Build)
-        │               │   ├── output columns: [sum(coalesce(t3.val, 0)) (#4), t2.sid (#1)]
-        │               │   ├── group by: [sid]
-        │               │   ├── aggregate functions: [sum(sum_arg_0)]
-        │               │   ├── estimated rows: 0.00
-        │               │   └── AggregatePartial
-        │               │       ├── group by: [sid]
-        │               │       ├── aggregate functions: [sum(sum_arg_0)]
-        │               │       ├── estimated rows: 0.00
-        │               │       └── EvalScalar
-        │               │           ├── output columns: [t2.sid (#1), sum_arg_0 (#3)]
-        │               │           ├── expressions: [if(CAST(is_not_null(t3.val (#2)) AS Boolean NULL), CAST(assume_not_null(t3.val (#2)) AS Int32 NULL), true, 0, NULL)]
-        │               │           ├── estimated rows: 0.00
-        │               │           └── TableScan
-        │               │               ├── table: default.default.t2
-        │               │               ├── output columns: [sid (#1), val (#2)]
-        │               │               ├── read rows: 0
-        │               │               ├── read size: 0
-        │               │               ├── partitions total: 0
-        │               │               ├── partitions scanned: 0
-        │               │               ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
-        │               │               └── estimated rows: 0.00
-        │               └── TableScan(Probe)
-        │                   ├── table: default.default.t1
-        │                   ├── output columns: [id (#0)]
-        │                   ├── read rows: 0
-        │                   ├── read size: 0
-        │                   ├── partitions total: 0
-        │                   ├── partitions scanned: 0
-        │                   ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
-        │                   └── estimated rows: 0.00
-        └── EvalScalar
-            ├── output columns: [t.id (#7), de (#8)]
-            ├── expressions: [0]
+        │           ├── AggregateFinal(Build)
+        │           │   ├── output columns: [t2.sid (#1)]
+        │           │   ├── group by: [sid]
+        │           │   ├── aggregate functions: []
+        │           │   ├── estimated rows: 0.00
+        │           │   └── AggregatePartial
+        │           │       ├── group by: [sid]
+        │           │       ├── aggregate functions: []
+        │           │       ├── estimated rows: 0.00
+        │           │       └── TableScan
+        │           │           ├── table: default.default.t2
+        │           │           ├── output columns: [sid (#1)]
+        │           │           ├── read rows: 0
+        │           │           ├── read size: 0
+        │           │           ├── partitions total: 0
+        │           │           ├── partitions scanned: 0
+        │           │           ├── push downs: [filters: [is_true(t2.sid (#1) = 1)], limit: NONE]
+        │           │           └── estimated rows: 0.00
+        │           └── TableScan(Probe)
+        │               ├── table: default.default.t1
+        │               ├── output columns: [id (#0)]
+        │               ├── read rows: 0
+        │               ├── read size: 0
+        │               ├── partitions total: 0
+        │               ├── partitions scanned: 0
+        │               ├── push downs: [filters: [is_true(t1.id (#0) = 1)], limit: NONE]
+        │               └── estimated rows: 0.00
+        └── AggregateFinal
+            ├── output columns: [t.id (#7)]
+            ├── group by: [id]
+            ├── aggregate functions: []
             ├── estimated rows: 0.00
-            └── AggregateFinal
-                ├── output columns: [t.id (#7)]
+            └── AggregatePartial
                 ├── group by: [id]
                 ├── aggregate functions: []
                 ├── estimated rows: 0.00
-                └── AggregatePartial
-                    ├── group by: [id]
-                    ├── aggregate functions: []
-                    ├── estimated rows: 0.00
-                    └── TableScan
-                        ├── table: default.default.t1
-                        ├── output columns: [id (#7)]
-                        ├── read rows: 0
-                        ├── read size: 0
-                        ├── partitions total: 0
-                        ├── partitions scanned: 0
-                        ├── push downs: [filters: [is_true(t1.id (#7) = 1)], limit: NONE]
-                        └── estimated rows: 0.00
+                └── TableScan
+                    ├── table: default.default.t1
+                    ├── output columns: [id (#7)]
+                    ├── read rows: 0
+                    ├── read size: 0
+                    ├── partitions total: 0
+                    ├── partitions scanned: 0
+                    ├── push downs: [filters: [is_true(t1.id (#7) = 1)], limit: NONE]
+                    └── estimated rows: 0.00
 
 statement ok
 drop table if exists t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix panic bug in Union All due to incorrect **output projection**.

This PR addresses a panic issue that occurs when executing a **Union All** operation. The root cause of the bug was that the out project for Union All was not correctly set, leading to panic.

```sql
mysql> create table t1(a int, b int);
Query OK, 0 rows affected (0.18 sec)

mysql> insert into t1 values(1,1),(2,2);
+-------------------------+
| number of rows inserted |
+-------------------------+
|                       2 |
+-------------------------+
1 row in set (0.19 sec)
Read 2 rows, 18.00 B in 0.112 sec., 17.82 rows/sec., 160.42 B/sec.

mysql> create table t2(a int, b int);
Query OK, 0 rows affected (0.05 sec)

mysql> insert into t2 values(3,3),(4,4);
+-------------------------+
| number of rows inserted |
+-------------------------+
|                       2 |
+-------------------------+
1 row in set (0.22 sec)
Read 2 rows, 18.00 B in 0.123 sec., 16.27 rows/sec., 146.41 B/sec.

mysql> select a from (select a, b from t1 where a>1 union all select a, b from t2 where b<4);
+------+
| a    |
+------+
|    3 |
|    2 |
+------+
2 rows in set (0.21 sec)
Read 4 rows, 27.00 B in 0.076 sec., 52.64 rows/sec., 355.35 B/sec.

mysql> explain select a from (select a, b from t1 where a>1 union all select a, b from t2 where b<4);
+---------------------------------------------------------------------------------------------------------+
| explain                                                                                                 |
+---------------------------------------------------------------------------------------------------------+
| UnionAll                                                                                                |
| ├── output columns: [t1.a (#0)]                                                                         |
| ├── estimated rows: 2.00                                                                                |
| ├── Filter                                                                                              |
| │   ├── output columns: [t1.a (#0)]                                                                     |
| │   ├── filters: [is_true(t1.a (#0) > 1)]                                                               |
| │   ├── estimated rows: 1.00                                                                            |
| │   └── TableScan                                                                                       |
| │       ├── table: default.default.t1                                                                   |
| │       ├── output columns: [a (#0)]                                                                    |
| │       ├── read rows: 2                                                                                |
| │       ├── read size: < 1 KiB                                                                          |
| │       ├── partitions total: 1                                                                         |
| │       ├── partitions scanned: 1                                                                       |
| │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]         |
| │       ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]                                |
| │       └── estimated rows: 2.00                                                                        |
| └── Filter                                                                                              |
|     ├── output columns: [t2.a (#2)]                                                                     |
|     ├── filters: [is_true(t2.b (#3) < 4)]                                                               |
|     ├── estimated rows: 1.00                                                                            |
|     └── TableScan                                                                                       |
|         ├── table: default.default.t2                                                                   |
|         ├── output columns: [a (#2), b (#3)]                                                            |
|         ├── read rows: 2                                                                                |
|         ├── read size: < 1 KiB                                                                          |
|         ├── partitions total: 1                                                                         |
|         ├── partitions scanned: 1                                                                       |
|         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]         |
|         ├── push downs: [filters: [is_true(t2.b (#3) < 4)], limit: NONE]                                |
|         └── estimated rows: 2.00                                                                        |
+---------------------------------------------------------------------------------------------------------+
31 rows in set (0.13 sec)
Read 0 rows, 0.00 B in 0.017 sec., 0 rows/sec., 0.00 B/sec.
```

- fixes: #17085

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17095)
<!-- Reviewable:end -->
