### PR TITLE
feat: new settings `stream_consume_batch_size_hint`

### DIFF
--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -404,23 +404,6 @@ impl QueryContext {
         table: &str,
         max_batch_size: Option<u64>,
     ) -> Result<Arc<dyn Table>> {
-        let max_batch_size = {
-            match max_batch_size {
-                Some(v) => {
-                    // use the batch size specified in the statement
-                    Some(v)
-                }
-                None => {
-                    if let Some(v) = self.get_settings().get_stream_consume_batch_size()? {
-                        info!("overriding max_batch_size of stream consumption using value specified in setting: {}", v);
-                        Some(v)
-                    } else {
-                        None
-                    }
-                }
-            }
-        };
-
         let table = self
             .shared
             .get_table(catalog, database, table, max_batch_size)
@@ -1063,7 +1046,8 @@ impl TableContext for QueryContext {
         database: &str,
         table: &str,
     ) -> Result<Arc<dyn Table>> {
-        self.get_table_from_shared(catalog, database, table, None)
+        let batch_size = self.get_settings().get_stream_consume_batch_size_hint()?;
+        self.get_table_from_shared(catalog, database, table, batch_size)
             .await
     }
 
@@ -1079,6 +1063,23 @@ impl TableContext for QueryContext {
         table: &str,
         max_batch_size: Option<u64>,
     ) -> Result<Arc<dyn Table>> {
+        let max_batch_size = {
+            match max_batch_size {
+                Some(v) => {
+                    // use the batch size specified in the statement
+                    Some(v)
+                }
+                None => {
+                    if let Some(v) = self.get_settings().get_stream_consume_batch_size_hint()? {
+                        info!("overriding max_batch_size of stream consumption using value specified in setting: {}", v);
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+            }
+        };
+
         let table = self
             .get_table_from_shared(catalog, database, table, max_batch_size)
             .await?;
@@ -1087,7 +1088,11 @@ impl TableContext for QueryContext {
             let actual_batch_limit = stream.max_batch_size();
             if actual_batch_limit != max_batch_size {
                 return Err(ErrorCode::StorageUnsupported(
-                    "Within the same transaction, the batch size for a stream must remain consistent",
+                    format!(
+                    "Within the same transaction, the batch size for a stream must remain consistent {:?} {:?}",
+                        actual_batch_limit, max_batch_size
+                    )
+
                 ));
             }
         } else if max_batch_size.is_some() {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -404,6 +404,23 @@ impl QueryContext {
         table: &str,
         max_batch_size: Option<u64>,
     ) -> Result<Arc<dyn Table>> {
+        let max_batch_size = {
+            match max_batch_size {
+                Some(v) => {
+                    // use the batch size specified in the statement
+                    Some(v)
+                }
+                None => {
+                    if let Some(v) = self.get_settings().get_stream_consume_batch_size()? {
+                        info!("overriding max_batch_size of stream consumption using value specified in setting: {}", v);
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+            }
+        };
+
         let table = self
             .shared
             .get_table(catalog, database, table, max_batch_size)

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1144,6 +1144,13 @@ impl DefaultSettings {
                     scope: SettingScope::Global,
                     range: None,
                 }),
+                ("stream_consume_batch_size", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(u64::MAX),
+                    desc: "Hint for batch size during stream consumption. Larger values may improve throughput but could impose greater pressure on stream consumers.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Global,
+                    range: Some(SettingRange::Numeric(5000..=u64::MAX)),
+                }),
             ]);
 
             Ok(Arc::new(DefaultSettings {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1144,12 +1144,12 @@ impl DefaultSettings {
                     scope: SettingScope::Global,
                     range: None,
                 }),
-                ("stream_consume_batch_size", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(u64::MAX),
-                    desc: "Hint for batch size during stream consumption. Larger values may improve throughput but could impose greater pressure on stream consumers.",
+                ("stream_consume_batch_size_hint", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Hint for batch size during stream consumption. Set it to 0 to disable it. Larger values may improve throughput but could impose greater pressure on stream consumers.",
                     mode: SettingMode::Both,
-                    scope: SettingScope::Global,
-                    range: Some(SettingRange::Numeric(5000..=u64::MAX)),
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
             ]);
 

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -844,8 +844,8 @@ impl Settings {
         self.try_get_string("network_policy")
     }
 
-    pub fn get_stream_consume_batch_size(&self) -> Result<Option<u64>> {
-        let v = self.try_get_u64("stream_consume_batch_size")?;
-        Ok(if v == u64::MAX { None } else { Some(v) })
+    pub fn get_stream_consume_batch_size_hint(&self) -> Result<Option<u64>> {
+        let v = self.try_get_u64("stream_consume_batch_size_hint")?;
+        Ok(if v == 0 { None } else { Some(v) })
     }
 }

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -843,4 +843,9 @@ impl Settings {
     pub fn get_network_policy(&self) -> Result<String> {
         self.try_get_string("network_policy")
     }
+
+    pub fn get_stream_consume_batch_size(&self) -> Result<Option<u64>> {
+        let v = self.try_get_u64("stream_consume_batch_size")?;
+        Ok(if v == u64::MAX { None } else { Some(v) })
+    }
 }

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0006_stream_batch_limit.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0006_stream_batch_limit.test
@@ -302,7 +302,7 @@ statement ok
 INSERT INTO t_settings values(3);
 
 #####################################
-# expect 2 rows, without batch size #
+# expect 3 rows, without batch size #
 #####################################
 query I
 select c from s_t_settings order by c;
@@ -333,6 +333,22 @@ query I
 select c from s_t_settings with (max_batch_size = 1);
 ----
 1
+
+##################################
+# set hint to 0, will disable it #
+##################################
+
+statement ok
+set stream_consume_batch_size_hint = 0;
+
+# expects 3 rows
+query I
+select c from s_t_settings order by c;
+----
+1
+2
+3
+
 
 statement ok
 DROP STREAM s;

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0006_stream_batch_limit.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0006_stream_batch_limit.test
@@ -282,7 +282,57 @@ select a from s order by a;
 statement error 2735
 select a from s with (xx = 2);
 
+#################################################
+# test setting `stream_consume_batch_size_hint` #
+#################################################
 
+statement ok
+create table t_settings (c int);
+
+statement ok
+CREATE STREAM s_t_settings ON TABLE t_settings;
+
+statement ok
+INSERT INTO t_settings values(1);
+
+statement ok
+INSERT INTO t_settings values(2);
+
+statement ok
+INSERT INTO t_settings values(3);
+
+#####################################
+# expect 2 rows, without batch size #
+#####################################
+query I
+select c from s_t_settings order by c;
+----
+1
+2
+3
+
+############################################
+# set max_batch_size using session setting #
+# expects 2 rows                           #
+############################################
+
+statement ok
+set stream_consume_batch_size_hint = 2;
+
+query I
+select c from s_t_settings order by c;
+----
+1
+2
+
+#######################################################
+# max_batch_size specified in query has high priority #
+#######################################################
+
+query I
+select c from s_t_settings with (max_batch_size = 1);
+----
+1
 
 statement ok
 DROP STREAM s;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Introduce new settings `stream_consume_batch_size_hint`,  

- by default, it is set to 0. in this case,  `stream_consume_batch_size_hint` has no effects

 if `stream_consume_batch_size_hint` is set to a non-zero value, streams will reference this setting during the process of capturing change sets and will try to keep the number of rows in the captured change set close to the specified value.

-  `MAX_BATCH_SIZE` specified in the[ WITH clause ](https://docs.databend.com/sql/sql-commands/query-syntax/with-stream-hints) have a higher priority

   e.g. 
   
~~~
statement ok
create table t_settings (c int);

statement ok
CREATE STREAM s_t_settings ON TABLE t_settings;

statement ok
INSERT INTO t_settings values(1);

statement ok
INSERT INTO t_settings values(2);

statement ok
INSERT INTO t_settings values(3);

statement ok
set stream_consume_batch_size_hint = 2;

#########################################################
# max_batch_size specified in query has higher priority #
#########################################################

query I
select c from s_t_settings with (max_batch_size = 1);
----
1
~~~

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17102)
<!-- Reviewable:end -->
