### PR TITLE
feat(query): support interval 'string'

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1312,6 +1312,19 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
         },
     );
 
+    let interval_expr = map(
+        rule! {
+            INTERVAL ~ #consumed(literal_string)
+        },
+        |(_, (span, date))| ExprElement::Cast {
+            expr: Box::new(Expr::Literal {
+                span: transform_span(span.tokens),
+                value: Literal::String(date),
+            }),
+            target_type: TypeName::Interval,
+        },
+    );
+
     let is_distinct_from = map(
         rule! {
             IS ~ NOT? ~ DISTINCT ~ FROM
@@ -1360,6 +1373,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
                 | #date_expr : "`DATE <str_literal>`"
                 | #timestamp_expr : "`TIMESTAMP <str_literal>`"
                 | #interval : "`INTERVAL ... (YEAR | QUARTER | MONTH | DAY | HOUR | MINUTE | SECOND | DOY | DOW)`"
+                | #interval_expr : "`INTERVAL <str_literal>`"
                 | #extract : "`EXTRACT((YEAR | QUARTER | MONTH | DAY | HOUR | MINUTE | SECOND | WEEK) FROM ...)`"
                 | #date_part : "`DATE_PART((YEAR | QUARTER | MONTH | DAY | HOUR | MINUTE | SECOND | WEEK), ...)`"
 

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1237,6 +1237,7 @@ fn test_expr() {
         r#"MAP_FILTER({1:1,2:2,3:4}, (k, v) -> k > v)"#,
         r#"MAP_TRANSFORM_KEYS({1:10,2:20,3:30}, (k, v) -> k + 1)"#,
         r#"MAP_TRANSFORM_VALUES({1:10,2:20,3:30}, (k, v) -> v + 1)"#,
+        r#"INTERVAL '1 YEAR'"#,
     ];
 
     for case in cases {

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -5034,3 +5034,25 @@ FunctionCall {
 }
 
 
+---------- Input ----------
+INTERVAL '1 YEAR'
+---------- Output ---------
+CAST('1 YEAR' AS INTERVAL)
+---------- AST ------------
+Cast {
+    span: Some(
+        0..17,
+    ),
+    expr: Literal {
+        span: Some(
+            9..17,
+        ),
+        value: String(
+            "1 YEAR",
+        ),
+    },
+    target_type: Interval,
+    pg_style: false,
+}
+
+

--- a/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
+++ b/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
@@ -1,4 +1,10 @@
 onlyif http
+query T
+select interval '1 month 1 hour 1 microsecond ago'
+----
+-1 month -1:00:00.000001
+
+onlyif http
 statement ok
 create or replace table t(c1 interval, c2 interval);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


```sql
select interval '1 year';
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17105)
<!-- Reviewable:end -->
