### PR TITLE
fix(query): fix default values of `SpillConfig` may not take effect

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -155,3 +155,6 @@ data_cache_storage = "none"
 path = "./.databend/_cache"
 # max bytes of cached data 20G
 max_bytes = 21474836480
+
+[spill]
+spill_local_disk_path = "./.databend/temp/_query_spill"

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -2920,7 +2920,7 @@ impl Default for DiskCacheKeyReloadPolicy {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
 #[serde(default, deny_unknown_fields)]
 pub struct DiskCacheConfig {
     /// Max bytes of cached raw table data. Default 20GB, set it to 0 to disable it.
@@ -2952,7 +2952,13 @@ pub struct DiskCacheConfig {
     pub sync_data: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args, Default)]
+impl Default for DiskCacheConfig {
+    fn default() -> Self {
+        inner::DiskCacheConfig::default().into()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
 #[serde(default, deny_unknown_fields)]
 pub struct SpillConfig {
     /// Path of spill to local disk. disable if it's empty.
@@ -2966,6 +2972,12 @@ pub struct SpillConfig {
     #[clap(long, value_name = "VALUE", default_value = "18446744073709551615")]
     /// Allow space in bytes to spill to local disk.
     pub spill_local_disk_max_bytes: u64,
+}
+
+impl Default for SpillConfig {
+    fn default() -> Self {
+        inner::SpillConfig::default().into()
+    }
 }
 
 mod cache_config_converters {

--- a/src/query/service/tests/it/configs.rs
+++ b/src/query/service/tests/it/configs.rs
@@ -935,7 +935,6 @@ fn test_spill_config() -> Result<()> {
         r#"
 [spill]
 spill_local_disk_path = "/data/spill"
-spill_local_disk_reserved_space_percentage = 0.5
 "#
         .as_bytes(),
     )?;
@@ -949,6 +948,7 @@ spill_local_disk_reserved_space_percentage = 0.5
             let cfg = InnerConfig::load_for_test().expect("config load failed");
 
             assert_eq!(cfg.spill.path, "/data/spill");
+            assert_eq!(cfg.spill.reserved_disk_ratio, 0.3);
         },
     );
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. Fix default values of `SpillConfig` may not take effect
2. Enable local spill in ci logic test

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17113)
<!-- Reviewable:end -->
