### PR TITLE
fix(log): prefix_filter not working.

### DIFF
--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -387,7 +387,7 @@ fn match_prefix(meta: &Metadata, prefixes: &[String]) -> FilterResult {
         }
     }
 
-    FilterResult::Neutral
+    FilterResult::Reject
 }
 
 /// Return true if the log level is considered severe.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

after this fix,  with the following configuration, only Databend’s own logs will be retained in the log.

```
[log]

[log.file]
...
prefix_filter = "databend_,openraft"
```


cc @wubx 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17136)
<!-- Reviewable:end -->
