### PR TITLE
chore: fix cargo check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ humantime = "2.1.0"
 hyper = "1"
 hyper-tls = "0.5.0"
 hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio", "service"] }
-hyper_v014 = { package = "hyper", version = "0.14" }
+hyper_v014 = { package = "hyper", version = "0.14",  features = ["client", "tcp"] }
 iceberg = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }
 iceberg-catalog-glue = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }
 iceberg-catalog-hms = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ humantime = "2.1.0"
 hyper = "1"
 hyper-tls = "0.5.0"
 hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio", "service"] }
-hyper_v014 = { package = "hyper", version = "0.14",  features = ["client", "tcp"] }
+hyper_v014 = { package = "hyper", version = "0.14", features = ["client", "tcp"] }
 iceberg = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }
 iceberg-catalog-glue = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }
 iceberg-catalog-hms = { version = "0.3.0", git = "https://github.com/Xuanwo/iceberg-rust/", rev = "01d706a1" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If not add features client and TCP, will return error when run `cargo c --timings` under `src/query/functions`

```
➜  functions git:(main) ✗ cargo c --timings        
warning: patch for `backtrace` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
    Checking databend-common-hashtable v0.1.0 (/data1/eason/databend/src/common/hashtable)
    Checking databend-common-grpc v0.1.0 (/data1/eason/databend/src/common/grpc)
    Checking databend-common-openai v0.1.0 (/data1/eason/databend/src/common/openai)
error[E0433]: failed to resolve: could not find `client` in `hyper_v014`
   --> src/common/grpc/src/dns_resolver.rs:35:17
    |
35  | use hyper_v014::client::connect::dns::Name as Hyperv014Name;
    |                 ^^^^^^ could not find `client` in `hyper_v014`
    |
note: found an item that was configured out
   --> /home/eason/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.30/src/lib.rs:100:13
    |
100 |     pub mod client;
    |             ^^^^^^
note: the item is gated behind the `client` feature
   --> /home/eason/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.30/src/lib.rs:98:8
    |
98  |     #![feature = "client"]
    |        ^^^^^^^

For more information about this error, try `rustc --explain E0433`.
error: could not compile `databend-common-grpc` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
      Timing report saved to /data1/eason/databend/target/cargo-timings/cargo-timing-20250102T033209Z.html


➜  functions git:(main) ✗ cargo c --timings
warning: patch for `backtrace` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism

    Blocking waiting for file lock on build directory
    Checking hyper v0.14.30
    Checking databend-common-grpc v0.1.0 (/data1/eason/databend/src/common/grpc)
error[E0432]: unresolved import `hyper_v014::client::connect::dns`
  --> src/common/grpc/src/dns_resolver.rs:35:34
   |
35 | use hyper_v014::client::connect::dns::Name as Hyperv014Name;
   |                                  ^^^ could not find `dns` in `connect`
   |
note: found an item that was configured out
  --> /home/eason/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.30/src/client/connect/mod.rs:96:13
   |
96 |     pub mod dns;
   |             ^^^
note: the item is gated behind the `tcp` feature
  --> /home/eason/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.30/src/client/connect/mod.rs:92:8
   |
92 |     #![feature = "tcp"]
   |        ^^^^^^^

For more information about this error, try `rustc --explain E0432`.
error: could not compile `databend-common-grpc` (lib) due to 1 previous error
      Timing report saved to /data1/eason/databend/target/cargo-timings/cargo-timing-20250102T033719Z.html

```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17152)
<!-- Reviewable:end -->
