### PR TITLE
refactor: Bump OpenDAL to 0.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10327,8 +10327,7 @@ dependencies = [
 [[package]]
 name = "object_store_opendal"
 version = "0.48.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70d87264e70879e4d6184641c4e8faa1a44bb8d228ebe731a488678a04e03c5"
+source = "git+https://github.com/apache/opendal?rev=f7f9990#f7f9990f95146400c3aef8afc11804e4a6e3afe3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10409,8 +10408,7 @@ dependencies = [
 [[package]]
 name = "opendal"
 version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8cd8697b917793c15a7b4a8afcba44e35e2abbc55c363064851776f7c81136"
+source = "git+https://github.com/apache/opendal?rev=f7f9990#f7f9990f95146400c3aef8afc11804e4a6e3afe3"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,7 +2961,7 @@ dependencies = [
  "databend-storages-common-table-meta",
  "limits-rs",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "serde",
  "serde_json",
  "serfig",
@@ -3238,7 +3238,7 @@ dependencies = [
  "libc",
  "object",
  "once_cell",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "paste",
  "prost",
@@ -3586,7 +3586,7 @@ dependencies = [
  "maplit",
  "num-derive",
  "num-traits",
- "opendal",
+ "opendal 0.51.0",
  "paste",
  "prost",
  "serde",
@@ -3824,7 +3824,7 @@ dependencies = [
  "lz4",
  "match-template",
  "num",
- "opendal",
+ "opendal 0.51.0",
  "rand",
  "ringbuffer",
  "roaring",
@@ -4035,7 +4035,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
- "opendal",
+ "opendal 0.51.0",
  "parking_lot 0.12.3",
  "prqlc",
  "rand",
@@ -4072,7 +4072,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "prometheus-client",
  "regex",
@@ -4181,7 +4181,7 @@ dependencies = [
  "itertools 0.13.0",
  "jsonb",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "parking_lot 0.12.3",
  "parquet",
  "rand",
@@ -4229,7 +4229,7 @@ dependencies = [
  "futures",
  "hive_metastore",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "recursive",
  "serde",
@@ -4339,7 +4339,7 @@ dependencies = [
  "databend-storages-common-table-meta",
  "futures-util",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "orc-rust",
  "serde",
  "serde_json",
@@ -4375,7 +4375,7 @@ dependencies = [
  "ethnum",
  "futures",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "rand",
  "serde",
@@ -4420,7 +4420,7 @@ dependencies = [
  "databend-common-storages-parquet",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "serde",
  "serde_json",
@@ -4461,7 +4461,7 @@ dependencies = [
  "enum-as-inner",
  "futures",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "parquet",
  "serde",
  "serde_json",
@@ -4526,7 +4526,7 @@ dependencies = [
  "jsonb",
  "log",
  "once_cell",
- "opendal",
+ "opendal 0.51.0",
  "parking_lot 0.12.3",
  "regex",
  "serde",
@@ -4755,7 +4755,7 @@ dependencies = [
  "jsonb",
  "jwt-simple",
  "log",
- "opendal",
+ "opendal 0.51.0",
  "tantivy",
  "tempfile",
 ]
@@ -5110,7 +5110,7 @@ dependencies = [
  "mysql_async",
  "naive-cityhash",
  "num_cpus",
- "opendal",
+ "opendal 0.51.0",
  "opensrv-mysql",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -5293,7 +5293,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
- "opendal",
+ "opendal 0.51.0",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "murmur3",
  "num-bigint",
  "once_cell",
- "opendal",
+ "opendal 0.50.1",
  "ordered-float 4.5.0",
  "parquet",
  "paste",
@@ -10327,9 +10327,9 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.48.1"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d37d6ca6cad56e446feab00d1378b0aae992f71bd9e04fe0454e8937ce1f9c9"
+checksum = "b70d87264e70879e4d6184641c4e8faa1a44bb8d228ebe731a488678a04e03c5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10337,7 +10337,7 @@ dependencies = [
  "futures",
  "futures-util",
  "object_store",
- "opendal",
+ "opendal 0.51.0",
  "pin-project",
  "tokio",
 ]
@@ -10384,6 +10384,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213222b6c86949314d8f51acb26d8241e7c8dd0879b016a79471d49f21ee592f"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "flagset",
+ "futures",
+ "getrandom",
+ "http 1.1.0",
+ "log",
+ "md-5",
+ "once_cell",
+ "percent-encoding",
+ "quick-xml 0.36.1",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "opendal"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8cd8697b917793c15a7b4a8afcba44e35e2abbc55c363064851776f7c81136"
+dependencies = [
+ "anyhow",
  "async-backtrace",
  "async-trait",
  "backon",
@@ -10392,7 +10422,6 @@ dependencies = [
  "chrono",
  "crc32c",
  "fastrace",
- "flagset",
  "futures",
  "getrandom",
  "hdrs",
@@ -12172,9 +12201,9 @@ checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "reqsign"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
+checksum = "eb0075a66c8bfbf4cc8b70dca166e722e1f55a3ea9250ecbb85f4d92a5f64149"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,7 +4068,6 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-native",
  "databend-enterprise-storage-encryption",
- "flagset",
  "futures",
  "http 1.1.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,10 +363,11 @@ num-derive = "0.3.3"
 num-traits = "0.2.19"
 num_cpus = "1.13.1"
 object = "0.36.5"
-object_store_opendal = "0.48.1"
+# We have to use this yanked versions to allow use opendal 0.51, will be fixed in next version.
+object_store_opendal = "=0.48.3"
 once_cell = "1.15.0"
 openai_api_rust = "0.1"
-opendal = { version = "0.50.1", features = [
+opendal = { version = "0.51", features = [
     "layers-fastrace",
     "layers-prometheus-client",
     "layers-async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,6 @@ ethnum = { version = "1.5.0" }
 fallible-streaming-iterator = "0.1"
 faststr = "0.2"
 feature-set = { version = "0.1.1" }
-flagset = "0.4"
 flatbuffers = "24" # Must use the same version with arrow-ipc
 flate2 = "1"
 foreign_vec = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,11 +362,10 @@ num-derive = "0.3.3"
 num-traits = "0.2.19"
 num_cpus = "1.13.1"
 object = "0.36.5"
-# We have to use this yanked versions to allow use opendal 0.51, will be fixed in next version.
-object_store_opendal = "=0.48.3"
+object_store_opendal = { git = "https://github.com/apache/opendal", package = "object_store_opendal", rev = "f7f9990" }
 once_cell = "1.15.0"
 openai_api_rust = "0.1"
-opendal = { version = "0.51", features = [
+opendal = { version = "0.51", git = "https://github.com/apache/opendal", rev = "f7f9990", features = [
     "layers-fastrace",
     "layers-prometheus-client",
     "layers-async-backtrace",

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -24,7 +24,6 @@ databend-common-meta-app = { workspace = true }
 databend-common-metrics = { workspace = true }
 databend-common-native = { workspace = true }
 databend-enterprise-storage-encryption = { workspace = true }
-flagset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }

--- a/src/common/storage/src/metrics.rs
+++ b/src/common/storage/src/metrics.rs
@@ -25,6 +25,7 @@ use opendal::raw::LayeredAccess;
 use opendal::raw::OpList;
 use opendal::raw::OpRead;
 use opendal::raw::OpWrite;
+use opendal::raw::RpDelete;
 use opendal::raw::RpList;
 use opendal::raw::RpRead;
 use opendal::raw::RpWrite;
@@ -167,6 +168,8 @@ impl<A: Access> LayeredAccess for StorageMetricsAccessor<A> {
     type BlockingWriter = StorageMetricsWrapper<A::BlockingWriter>;
     type Lister = A::Lister;
     type BlockingLister = A::BlockingLister;
+    type Deleter = A::Deleter;
+    type BlockingDeleter = A::BlockingDeleter;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -193,6 +196,11 @@ impl<A: Access> LayeredAccess for StorageMetricsAccessor<A> {
         self.inner.list(path, args).await
     }
 
+    #[async_backtrace::framed]
+    async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
+        self.inner.delete().await
+    }
+
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.inner
             .blocking_read(path, args)
@@ -207,6 +215,10 @@ impl<A: Access> LayeredAccess for StorageMetricsAccessor<A> {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         self.inner.blocking_list(path, args)
+    }
+
+    fn blocking_delete(&self) -> Result<(RpDelete, Self::BlockingDeleter)> {
+        self.inner.blocking_delete()
     }
 }
 

--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -30,7 +30,6 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use opendal::EntryMode;
 use opendal::Metadata;
-use opendal::Metakey;
 use opendal::Operator;
 use regex::Regex;
 
@@ -65,11 +64,6 @@ impl StageFileInfo {
             status: StageFileStatus::NeedCopy,
             creator: None,
         }
-    }
-
-    /// NOTE: update this query when add new meta
-    pub fn meta_query() -> flagset::FlagSet<Metakey> {
-        Metakey::ContentLength | Metakey::ContentMd5 | Metakey::LastModified | Metakey::Etag
     }
 }
 
@@ -278,11 +272,7 @@ impl StageFilesInfo {
         };
         let file_exact_stream = stream::iter(file_exact.clone().into_iter());
 
-        let lister = operator
-            .lister_with(path)
-            .recursive(true)
-            .metakey(StageFileInfo::meta_query())
-            .await?;
+        let lister = operator.lister_with(path).recursive(true).await?;
 
         let pattern = Arc::new(pattern);
         let files_with_prefix = lister.filter_map(move |result| {
@@ -389,11 +379,7 @@ fn blocking_list_files_with_pattern(
         _ => {}
     };
     let prefix_len = if path == "/" { 0 } else { path.len() };
-    let list = operator
-        .lister_with(path)
-        .recursive(true)
-        .metakey(StageFileInfo::meta_query())
-        .call()?;
+    let list = operator.lister_with(path).recursive(true).call()?;
     if files.len() == max_files {
         return Ok(files);
     }

--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -27,7 +27,6 @@ use futures_util::TryStreamExt;
 use log::error;
 use log::info;
 use opendal::EntryMode;
-use opendal::Metakey;
 use opendal::Operator;
 #[async_backtrace::framed]
 pub async fn do_vacuum_drop_table(
@@ -80,12 +79,7 @@ async fn vacuum_drop_single_table(
             result?;
         }
         Some(dry_run_limit) => {
-            let mut ds = operator
-                .lister_with(&dir)
-                .recursive(true)
-                .metakey(Metakey::Mode)
-                .metakey(Metakey::ContentLength)
-                .await?;
+            let mut ds = operator.lister_with(&dir).recursive(true).await?;
 
             loop {
                 let entry = ds.try_next().await;

--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -87,10 +87,15 @@ async fn vacuum_drop_single_table(
                     Ok(Some(de)) => {
                         let meta = de.metadata();
                         if EntryMode::FILE == meta.mode() {
+                            let mut content_length = meta.content_length();
+                            if content_length == 0 {
+                                content_length = operator.stat(de.path()).await?.content_length();
+                            }
+
                             list_files.push((
                                 table_info.name.clone(),
                                 de.name().to_string(),
-                                meta.content_length(),
+                                content_length,
                             ));
                             if list_files.len() >= dry_run_limit {
                                 break;

--- a/src/query/service/src/interpreters/interpreter_table_vacuum.rs
+++ b/src/query/service/src/interpreters/interpreter_table_vacuum.rs
@@ -29,7 +29,6 @@ use databend_common_storages_fuse::FUSE_TBL_SEGMENT_PREFIX;
 use databend_common_storages_fuse::FUSE_TBL_SNAPSHOT_PREFIX;
 use databend_common_storages_fuse::FUSE_TBL_XOR_BLOOM_INDEX_PREFIX;
 use databend_enterprise_vacuum_handler::get_vacuum_handler;
-use opendal::Metakey;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -75,7 +74,6 @@ impl VacuumTableInterpreter {
         for (dir_prefix, stat) in prefix_with_stats {
             for entry in operator
                 .list_with(&format!("{}/{}/", table_data_prefix, dir_prefix))
-                .metakey(Metakey::ContentLength)
                 .await?
             {
                 if entry.metadata().is_file() {

--- a/src/query/service/src/interpreters/interpreter_table_vacuum.rs
+++ b/src/query/service/src/interpreters/interpreter_table_vacuum.rs
@@ -77,8 +77,13 @@ impl VacuumTableInterpreter {
                 .await?
             {
                 if entry.metadata().is_file() {
+                    let mut content_length = entry.metadata().content_length();
+                    if content_length == 0 {
+                        content_length = operator.stat(entry.path()).await?.content_length();
+                    }
+
                     stat.0 += 1;
-                    stat.1 += entry.metadata().content_length();
+                    stat.1 += content_length;
                 }
             }
         }

--- a/src/query/storages/common/io/src/files.rs
+++ b/src/query/storages/common/io/src/files.rs
@@ -99,7 +99,7 @@ impl Files {
         info!("deleting files {:?}", &locations);
         let num_of_files = locations.len();
 
-        op.remove(locations).await?;
+        op.delete_iter(locations).await?;
 
         info!(
             "deleted files, number of files {}, time used {:?}",

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -37,7 +37,6 @@ use futures_util::TryStreamExt;
 use log::info;
 use log::warn;
 use opendal::EntryMode;
-use opendal::Metakey;
 use opendal::Operator;
 
 use crate::io::MetaReaders;
@@ -360,10 +359,7 @@ impl SnapshotsIO {
         exclude_file: Option<&str>,
     ) -> Result<Vec<String>> {
         let mut file_list = vec![];
-        let mut ds = op
-            .lister_with(prefix)
-            .metakey(Metakey::Mode | Metakey::LastModified)
-            .await?;
+        let mut ds = op.lister_with(prefix).await?;
         while let Some(de) = ds.try_next().await? {
             let meta = de.metadata();
             match meta.mode() {

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -366,9 +366,14 @@ impl SnapshotsIO {
                 EntryMode::FILE => match exclude_file {
                     Some(path) if de.path() == path => continue,
                     _ => {
+                        let last_modified = if let Some(last_modified) = meta.last_modified() {
+                            Some(last_modified)
+                        } else {
+                            op.stat(de.path()).await?.last_modified()
+                        };
+
                         let location = de.path().to_string();
-                        let modified = meta.last_modified();
-                        file_list.push((location, modified));
+                        file_list.push((location, last_modified));
                     }
                 },
                 _ => {

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -30,7 +30,6 @@ use databend_storages_common_table_meta::table::OPT_KEY_SOURCE_TABLE_ID;
 use futures::TryStreamExt;
 use log::warn;
 use opendal::EntryMode;
-use opendal::Metakey;
 
 use crate::io::MetaReaders;
 use crate::io::SnapshotHistoryReader;
@@ -362,10 +361,7 @@ impl FuseTable {
     where F: FnMut(String, DateTime<Utc>) -> bool {
         let mut file_list = vec![];
         let op = self.operator.clone();
-        let mut ds = op
-            .lister_with(&prefix)
-            .metakey(Metakey::Mode | Metakey::LastModified)
-            .await?;
+        let mut ds = op.lister_with(&prefix).await?;
         while let Some(de) = ds.try_next().await? {
             let meta = de.metadata();
             match meta.mode() {

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -199,7 +199,11 @@ async fn get_time_travel_size(storage_prefix: &str, op: &Operator) -> Result<u64
     let mut lister = op.lister_with(storage_prefix).recursive(true).await?;
     let mut size = 0;
     while let Some(entry) = lister.try_next().await? {
-        size += entry.metadata().content_length();
+        let mut content_length = entry.metadata().content_length();
+        if content_length == 0 {
+            content_length = op.stat(entry.path()).await?.content_length();
+        }
+        size += content_length;
     }
     Ok(size)
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -32,7 +32,6 @@ use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TableSchemaRefExt;
 use futures_util::TryStreamExt;
 use log::info;
-use opendal::Metakey;
 use opendal::Operator;
 
 use super::parse_opt_opt_args;
@@ -197,11 +196,7 @@ impl SimpleArgFunc for FuseTimeTravelSize {
 }
 
 async fn get_time_travel_size(storage_prefix: &str, op: &Operator) -> Result<u64> {
-    let mut lister = op
-        .lister_with(storage_prefix)
-        .recursive(true)
-        .metakey(Metakey::ContentLength)
-        .await?;
+    let mut lister = op.lister_with(storage_prefix).recursive(true).await?;
     let mut size = 0;
     while let Some(entry) = lister.try_next().await? {
         size += entry.metadata().content_length();

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -199,6 +199,10 @@ async fn get_time_travel_size(storage_prefix: &str, op: &Operator) -> Result<u64
     let mut lister = op.lister_with(storage_prefix).recursive(true).await?;
     let mut size = 0;
     while let Some(entry) = lister.try_next().await? {
+        // Skip directories while calculating size
+        if entry.metadata().is_dir() {
+            continue;
+        }
         let mut content_length = entry.metadata().content_length();
         if content_length == 0 {
             content_length = op.stat(entry.path()).await?.content_length();

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -618,9 +618,11 @@ async fn do_list_files_from_dir(
 
         match meta.mode() {
             EntryMode::FILE => {
-                let meta = operator.stat(path).await?;
+                let mut length = meta.content_length();
+                if length == 0 {
+                    length = operator.stat(path).await?.content_length();
+                }
                 let location = path.to_string();
-                let length = meta.content_length();
                 all_files.push(HivePartInfo::create(location, vec![], length));
             }
             EntryMode::DIR => {

--- a/src/query/storages/system/src/temp_files_table.rs
+++ b/src/query/storages/system/src/temp_files_table.rs
@@ -52,8 +52,9 @@ use futures::stream::Chunks;
 use futures::stream::Take;
 use futures::StreamExt;
 use opendal::operator_futures::FutureLister;
-use opendal::Entry;
 use opendal::Lister;
+use opendal::Metadata;
+use opendal::Operator;
 
 use crate::table::SystemTablePart;
 
@@ -160,7 +161,7 @@ impl TempFilesTable {
             let prefix = location_prefix.clone();
             let mut counter = 0;
             let ctx = ctx.clone();
-            let builder = ListerStreamSourceBuilder::with_lister_fut(lister);
+            let builder = ListerStreamSourceBuilder::with_lister_fut(operator, lister);
             builder
                 .limit_opt(limit)
                 .chunk_size(MAX_BATCH_SIZE)
@@ -204,15 +205,17 @@ impl TempFilesTable {
         )
     }
 
-    fn block_from_entries(location_prefix: &str, entries: Vec<Entry>) -> Result<DataBlock> {
+    fn block_from_entries(
+        location_prefix: &str,
+        entries: Vec<(String, Metadata)>,
+    ) -> Result<DataBlock> {
         let num_items = entries.len();
         let mut temp_files_name: Vec<String> = Vec::with_capacity(num_items);
         let mut temp_files_content_length = Vec::with_capacity(num_items);
         let mut temp_files_last_modified = Vec::with_capacity(num_items);
-        for entry in entries {
-            let metadata = entry.metadata();
+        for (path, metadata) in entries {
             if metadata.is_file() {
-                temp_files_name.push(entry.path().trim_start_matches(location_prefix).to_string());
+                temp_files_name.push(path.trim_start_matches(location_prefix).to_string());
 
                 temp_files_last_modified
                     .push(metadata.last_modified().map(|x| x.timestamp_micros()));
@@ -234,6 +237,7 @@ const MAX_BATCH_SIZE: usize = 1000;
 pub struct ListerStreamSourceBuilder<T>
 where T: Future<Output = opendal::Result<Lister>> + Send + 'static
 {
+    op: Operator,
     lister_fut: FutureLister<T>,
     limit: Option<usize>,
     chunk_size: usize,
@@ -242,8 +246,9 @@ where T: Future<Output = opendal::Result<Lister>> + Send + 'static
 impl<T> ListerStreamSourceBuilder<T>
 where T: Future<Output = opendal::Result<Lister>> + Send + 'static
 {
-    pub fn with_lister_fut(lister_fut: FutureLister<T>) -> Self {
+    pub fn with_lister_fut(op: Operator, lister_fut: FutureLister<T>) -> Self {
         Self {
+            op,
             lister_fut,
             limit: None,
             chunk_size: MAX_BATCH_SIZE,
@@ -262,9 +267,13 @@ where T: Future<Output = opendal::Result<Lister>> + Send + 'static
 
     pub fn build(
         self,
-        block_builder: (impl FnMut(Vec<Entry>) -> Result<DataBlock> + Sync + Send + 'static),
+        block_builder: (impl FnMut(Vec<(String, Metadata)>) -> Result<DataBlock>
+             + Sync
+             + Send
+             + 'static),
     ) -> Result<SendableDataBlockStream> {
         stream_source_from_entry_lister_with_chunk_size(
+            self.op.clone(),
             self.lister_fut,
             self.limit,
             self.chunk_size,
@@ -274,10 +283,11 @@ where T: Future<Output = opendal::Result<Lister>> + Send + 'static
 }
 
 fn stream_source_from_entry_lister_with_chunk_size<T>(
+    op: Operator,
     lister_fut: FutureLister<T>,
     limit: Option<usize>,
     chunk_size: usize,
-    block_builder: (impl FnMut(Vec<Entry>) -> Result<DataBlock> + Sync + Send + 'static),
+    block_builder: (impl FnMut(Vec<(String, Metadata)>) -> Result<DataBlock> + Sync + Send + 'static),
 ) -> Result<SendableDataBlockStream>
 where
     T: Future<Output = opendal::Result<Lister>> + Send + 'static,
@@ -289,9 +299,9 @@ where
 
     let state = ListerState::<T>::Uninitialized(lister_fut);
 
-    let stream = stream::try_unfold(
-        (state, block_builder),
-        move |(mut state, mut builder)| async move {
+    let stream = stream::try_unfold((state, block_builder), move |(mut state, mut builder)| {
+        let op = op.clone();
+        async move {
             let mut lister = {
                 match state {
                     ListerState::Uninitialized(fut) => {
@@ -302,15 +312,23 @@ where
                 }
             };
             if let Some(entries) = lister.next().await {
-                let entries = entries.into_iter().collect::<opendal::Result<Vec<_>>>()?;
-                let data_block = builder(entries)?;
+                let mut items = Vec::with_capacity(entries.len());
+                for entry in entries {
+                    let (path, mut metadata) = entry?.into_parts();
+                    if metadata.is_file() && metadata.last_modified().is_none() {
+                        metadata = op.stat(&path).await?;
+                    }
+                    items.push((path, metadata))
+                }
+
+                let data_block = builder(items)?;
                 state = ListerState::Initialized(lister);
                 Ok(Some((data_block, (state, builder))))
             } else {
                 Ok(None)
             }
-        },
-    );
+        }
+    });
 
     Ok(stream.boxed())
 }

--- a/src/query/storages/system/src/temp_files_table.rs
+++ b/src/query/storages/system/src/temp_files_table.rs
@@ -54,7 +54,6 @@ use futures::StreamExt;
 use opendal::operator_futures::FutureLister;
 use opendal::Entry;
 use opendal::Lister;
-use opendal::Metakey;
 
 use crate::table::SystemTablePart;
 
@@ -155,10 +154,7 @@ impl TempFilesTable {
         let limit = push_downs.as_ref().and_then(|x| x.limit);
 
         let operator = DataOperator::instance().operator();
-        let lister = operator
-            .lister_with(&location_prefix)
-            .recursive(true)
-            .metakey(Metakey::LastModified | Metakey::ContentLength);
+        let lister = operator.lister_with(&location_prefix).recursive(true);
 
         let stream = {
             let prefix = location_prefix.clone();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Bump OpenDAL to 0.51 to get databend ready for the following new features.

This PR just upgrade opendal and didn't change any logic yet.

The biggest change is opendal won't call `stat` during `list` anymore. So for services like `fs` that doesn't return content_length in list, we will need an extra stat for them. This change doesn't affect services like s3.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17161)
<!-- Reviewable:end -->
