### PR TITLE
chore: adjust fuse_time_travel_size()

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -223,7 +223,7 @@ pub trait SchemaApi: Send + Sync {
 
     /// Get history of all tables in the specified database,
     /// that are dropped after retention boundary time, i.e., the tables that can be undropped.
-    async fn list_retainable_tables(
+    async fn list_history_tables(
         &self,
         include_non_retainable: bool,
         req: ListTableReq,

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -223,7 +223,11 @@ pub trait SchemaApi: Send + Sync {
 
     /// Get history of all tables in the specified database,
     /// that are dropped after retention boundary time, i.e., the tables that can be undropped.
-    async fn list_retainable_tables(&self, req: ListTableReq) -> Result<Vec<TableNIV>, KVAppError>;
+    async fn list_retainable_tables(
+        &self,
+        include_non_retainable: bool,
+        req: ListTableReq,
+    ) -> Result<Vec<TableNIV>, KVAppError>;
 
     /// List all tables in the database.
     ///

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1551,12 +1551,16 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             return Ok(vec![]);
         };
 
-        get_retainable_table_metas(self, &Utc::now(), seq_table_id_list.data).await
+        get_retainable_table_metas(self, false, &Utc::now(), seq_table_id_list.data).await
     }
 
     #[logcall::logcall]
     #[fastrace::trace]
-    async fn list_retainable_tables(&self, req: ListTableReq) -> Result<Vec<TableNIV>, KVAppError> {
+    async fn list_retainable_tables(
+        &self,
+        include_non_retainable: bool,
+        req: ListTableReq,
+    ) -> Result<Vec<TableNIV>, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
         // List tables by tenant, db_id.
@@ -1575,7 +1579,9 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         for (ident, history) in ident_histories {
             debug!(name :% =(&ident); "get_tables_history");
 
-            let id_metas = get_retainable_table_metas(self, &now, history.data).await?;
+            let id_metas =
+                get_retainable_table_metas(self, include_non_retainable, &now, history.data)
+                    .await?;
 
             let table_nivs = id_metas.into_iter().map(|(table_id, seq_meta)| {
                 let name = DBIdTableName::new(ident.database_id, ident.table_name.clone());
@@ -3060,6 +3066,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
 
 async fn get_retainable_table_metas(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
+    include_non_retainable: bool,
     now: &DateTime<Utc>,
     tb_id_list: TableIdList,
 ) -> Result<Vec<(TableId, SeqV<TableMeta>)>, MetaError> {
@@ -3075,7 +3082,7 @@ async fn get_retainable_table_metas(
             continue;
         };
 
-        if is_drop_time_retainable(table_meta.drop_on, *now) {
+        if include_non_retainable || is_drop_time_retainable(table_meta.drop_on, *now) {
             tb_metas.push((k, table_meta));
         }
     }

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -1551,12 +1551,12 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             return Ok(vec![]);
         };
 
-        get_retainable_table_metas(self, false, &Utc::now(), seq_table_id_list.data).await
+        get_history_table_metas(self, false, &Utc::now(), seq_table_id_list.data).await
     }
 
     #[logcall::logcall]
     #[fastrace::trace]
-    async fn list_retainable_tables(
+    async fn list_history_tables(
         &self,
         include_non_retainable: bool,
         req: ListTableReq,
@@ -1580,8 +1580,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             debug!(name :% =(&ident); "get_tables_history");
 
             let id_metas =
-                get_retainable_table_metas(self, include_non_retainable, &now, history.data)
-                    .await?;
+                get_history_table_metas(self, include_non_retainable, &now, history.data).await?;
 
             let table_nivs = id_metas.into_iter().map(|(table_id, seq_meta)| {
                 let name = DBIdTableName::new(ident.database_id, ident.table_name.clone());
@@ -3064,7 +3063,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
     }
 }
 
-async fn get_retainable_table_metas(
+async fn get_history_table_metas(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     include_non_retainable: bool,
     now: &DateTime<Utc>,

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -4002,7 +4002,7 @@ impl SchemaApiTestSuite {
             assert!(table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 1);
@@ -4020,7 +4020,7 @@ impl SchemaApiTestSuite {
             upsert_test_data(mt.as_kv_api(), &tbid, data).await?;
             // assert not return out of retention time data
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 0);
@@ -4658,7 +4658,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4690,7 +4690,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4708,7 +4708,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4735,7 +4735,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4758,7 +4758,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4786,7 +4786,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4803,7 +4803,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4836,7 +4836,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _res = mt.create_table(req.clone()).await?;
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
@@ -4875,7 +4875,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
@@ -4904,7 +4904,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
+                .list_history_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -4002,7 +4002,7 @@ impl SchemaApiTestSuite {
             assert!(table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 1);
@@ -4020,7 +4020,7 @@ impl SchemaApiTestSuite {
             upsert_test_data(mt.as_kv_api(), &tbid, data).await?;
             // assert not return out of retention time data
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             assert_eq!(res.len(), 0);
@@ -4658,7 +4658,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4690,7 +4690,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4708,7 +4708,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4735,7 +4735,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4758,7 +4758,7 @@ impl SchemaApiTestSuite {
             assert!(res.table_id >= 1, "table id >= 1");
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4786,7 +4786,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
                 name: DBIdTableName::new(*db_id, tbl_name).to_string_key(),
@@ -4803,7 +4803,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
 
             calc_and_compare_drop_on_table_result(res, vec![DroponInfo {
@@ -4836,7 +4836,7 @@ impl SchemaApiTestSuite {
             let old_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             let _res = mt.create_table(req.clone()).await?;
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             let cur_db = mt.get_database(Self::req_get_db(&tenant, db_name)).await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
@@ -4875,7 +4875,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {
@@ -4904,7 +4904,7 @@ impl SchemaApiTestSuite {
             assert!(old_db.meta.seq < cur_db.meta.seq);
 
             let res = mt
-                .list_retainable_tables(ListTableReq::new(&tenant, db_id))
+                .list_retainable_tables(false, ListTableReq::new(&tenant, db_id))
                 .await?;
             calc_and_compare_drop_on_table_result(res, vec![
                 DroponInfo {

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -4024,6 +4024,11 @@ impl SchemaApiTestSuite {
                 .await?;
 
             assert_eq!(res.len(), 0);
+
+            let res = mt
+                .list_history_tables(true, ListTableReq::new(&tenant, db_id))
+                .await?;
+            assert_eq!(res.len(), 1);
         }
 
         Ok(())

--- a/src/query/catalog/src/database.rs
+++ b/src/query/catalog/src/database.rs
@@ -109,7 +109,10 @@ pub trait Database: DynClone + Sync + Send {
     }
 
     #[async_backtrace::framed]
-    async fn list_tables_history(&self) -> Result<Vec<Arc<dyn Table>>> {
+    async fn list_tables_history(
+        &self,
+        _include_non_retainable: bool,
+    ) -> Result<Vec<Arc<dyn Table>>> {
         Err(ErrorCode::Unimplemented(format!(
             "UnImplement list_tables_history in {} Database",
             self.name()

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -541,7 +541,7 @@ impl Catalog for MutableCatalog {
         db_name: &str,
     ) -> Result<Vec<Arc<dyn Table>>> {
         let db = self.get_database(tenant, db_name).await?;
-        db.list_tables_history().await
+        db.list_tables_history(false).await
     }
 
     async fn get_drop_table_infos(

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -205,7 +205,7 @@ impl Database for DefaultDatabase {
         let mut dropped = self
             .ctx
             .meta
-            .list_retainable_tables(
+            .list_history_tables(
                 include_non_retainable,
                 ListTableReq::new(self.get_tenant(), self.db_info.database_id),
             )

--- a/src/query/service/src/databases/default/default_database.rs
+++ b/src/query/service/src/databases/default/default_database.rs
@@ -193,7 +193,10 @@ impl Database for DefaultDatabase {
     }
 
     #[async_backtrace::framed]
-    async fn list_tables_history(&self) -> Result<Vec<Arc<dyn Table>>> {
+    async fn list_tables_history(
+        &self,
+        include_non_retainable: bool,
+    ) -> Result<Vec<Arc<dyn Table>>> {
         // `get_table_history` will not fetch the tables that created before the
         // "metasrv time travel functions" is added.
         // thus, only the table-infos of dropped tables are used.
@@ -202,10 +205,10 @@ impl Database for DefaultDatabase {
         let mut dropped = self
             .ctx
             .meta
-            .list_retainable_tables(ListTableReq::new(
-                self.get_tenant(),
-                self.db_info.database_id,
-            ))
+            .list_retainable_tables(
+                include_non_retainable,
+                ListTableReq::new(self.get_tenant(), self.db_info.database_id),
+            )
             .await?
             .into_iter()
             .filter(|i| i.value().drop_on.is_some())

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -143,7 +143,7 @@ impl SimpleArgFunc for FuseTimeTravelSize {
                 }
                 None => {
                     let start = std::time::Instant::now();
-                    let tables = db.list_tables_history().await?;
+                    let tables = db.list_tables_history(true).await?;
                     info!("list_tables cost: {:?}", start.elapsed());
                     tables
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. In the past, fuse_time_travel_size() did not account for tables with a drop time exceeding 24 hours. After this PR, these tables will be included in the count. 
2. This PR will not affect the behavior of other parts of the system.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17164)
<!-- Reviewable:end -->
