### PR TITLE
fix(query): return semantic error for SRFs in WHERE and HAVING clauses

### DIFF
--- a/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
+++ b/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
@@ -572,6 +572,12 @@ select id, json_path_query(obj, '$.b?(@.c > 2)') from t2
 statement error 1006
 select id, json_path_query(obj, '--') from t2
 
+statement error 1065
+select id from t2 where json_path_query(obj, '$.a') = 1
+
+statement error 1065
+select id from t2 having json_path_query(obj, '$.a') = 1
+
 query IT
 select id, json_path_query_array(arr, '$[2, 1 to last -1]') from t1
 ----

--- a/tests/sqllogictests/suites/query/functions/02_0062_function_unnest.test
+++ b/tests/sqllogictests/suites/query/functions/02_0062_function_unnest.test
@@ -512,6 +512,12 @@ b
 statement error 1065
 select unnest(first_value('aa') OVER (PARTITION BY 'bb'))
 
+statement error 1065
+select * from numbers(10) where unnest([1,2,3])::BOOLEAN;
+
+statement error 1065
+select * from numbers(10) having unnest([1,2,3])::BOOLEAN;
+
 statement ok
 set max_block_size = 65535;
 

--- a/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
+++ b/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
@@ -370,6 +370,12 @@ b [1,2,3]
 c true
 d {"k1":1,"k2":2}
 
+statement error 1065
+SELECT * FROM json_each(parse_json('{"a": true}')) WHERE json_each(parse_json('{"a": true}'))
+
+statement error 1065
+SELECT * FROM json_each(parse_json('{"a": true}')) HAVING json_each(parse_json('{"a": true}'))
+
 query T
 SELECT json_array_elements(NULL)
 ----
@@ -419,6 +425,12 @@ SELECT * FROM json_array_elements(parse_json('[1, [1,2,3], true, {"k1": 1, "k2":
 [1,2,3]
 true
 {"k1":1,"k2":2}
+
+statement error 1065
+SELECT * FROM json_array_elements(parse_json('[true]')) WHERE json_array_elements(parse_json('[true]'))
+
+statement error 1065
+SELECT * FROM json_array_elements(parse_json('[true]')) HAVING json_array_elements(parse_json('[true]'))
 
 query T
 select parse_json('["1","2","3"]') ? NULL
@@ -1106,6 +1118,12 @@ ORDER BY jq:key;
 1 {"key":"scores","value":"[85,90,78]"}
 2 {"key":"scores","value":"[92,88,95]"}
 3 {"key":"scores","value":"[76,80,82]"}
+
+statement error 1065
+SELECT * FROM test_data WHERE jq('.scores | min', json_data) > 85
+
+statement error 1065
+SELECT * FROM test_data HAVING jq('.scores | min', json_data) > 85
 
 statement ok
 DROP TABLE test_data;

--- a/tests/sqllogictests/suites/query/functions/02_0068_function_flatten.test
+++ b/tests/sqllogictests/suites/query/functions/02_0068_function_flatten.test
@@ -47,9 +47,3 @@ select * from flatten(input => parse_json('{"a":1, "b":[77,88], "c": {"d":"X"}}'
 query ITTTTT
 select * from flatten(input => parse_json('{"a":1, "b":[77,88], "c": {"d":"X"}}'), recursive => true, mode => 'array')
 ----
-
-statement error 1005
-select * from numbers(10) where flatten(input => parse_json('[1]'))
-
-statement error 1005
-select * from numbers(10) having flatten(input => parse_json('[1]'))

--- a/tests/sqllogictests/suites/query/functions/02_0068_function_flatten.test
+++ b/tests/sqllogictests/suites/query/functions/02_0068_function_flatten.test
@@ -47,3 +47,9 @@ select * from flatten(input => parse_json('{"a":1, "b":[77,88], "c": {"d":"X"}}'
 query ITTTTT
 select * from flatten(input => parse_json('{"a":1, "b":[77,88], "c": {"d":"X"}}'), recursive => true, mode => 'array')
 ----
+
+statement error 1005
+select * from numbers(10) where flatten(input => parse_json('[1]'))
+
+statement error 1005
+select * from numbers(10) having flatten(input => parse_json('[1]'))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #17154
- This PR changed behavior to return a semantic error instead of panic for SRFs in WHERE and HAVING clauses.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17167)
<!-- Reviewable:end -->
