### PR TITLE
refactor: include key information in errors when listing meta-service key-values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "anyerror"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aaeb671913f64cfbe528d9f2236832902c7f32db31b9ec3790f675fceb937c6"
+checksum = "71add24cc141a1e8326f249b74c41cfd217aeb2a67c9c6cf9134d175469afd49"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ databend-storages-common-table-meta = { path = "src/query/storages/common/table_
 # Crates.io dependencies
 ahash = "0.8"
 aho-corasick = { version = "1.0.1" } #
-anyerror = { version = "=0.1.10" }
+anyerror = { version = "=0.1.13" }
 anyhow = { version = "1.0.65" }
 approx = "0.5.1"
 arrow = { version = "53" }

--- a/src/meta/api/src/kv_pb_api/codec.rs
+++ b/src/meta/api/src/kv_pb_api/codec.rs
@@ -43,25 +43,53 @@ where T: FromToProto {
 }
 
 /// Decode Change<Vec<u8>> into Change<T>, with FromToProto.
-pub fn decode_transition<T>(seqv: Change<Vec<u8>>) -> Result<Change<T>, PbDecodeError>
+pub fn decode_transition<T>(transition: Change<Vec<u8>>) -> Result<Change<T>, PbDecodeError>
 where T: FromToProto {
+    let prev = transition
+        .prev
+        .map(|seqv| {
+            decode_seqv::<T>(seqv, || {
+                format!("decode `prev` value of {:?}", transition.ident)
+            })
+        })
+        .transpose()?;
+
+    let result = transition
+        .result
+        .map(|seqv| {
+            decode_seqv::<T>(seqv, || {
+                format!("decode `result` value of {:?}", transition.ident)
+            })
+        })
+        .transpose()?;
+
     let c = Change {
-        ident: seqv.ident,
-        prev: seqv.prev.map(decode_seqv::<T>).transpose()?,
-        result: seqv.result.map(decode_seqv::<T>).transpose()?,
+        ident: transition.ident,
+        prev,
+        result,
     };
 
     Ok(c)
 }
 
 /// Deserialize SeqV<Vec<u8>> into SeqV<T>, with FromToProto.
-pub fn decode_seqv<T>(seqv: SeqV) -> Result<SeqV<T>, PbDecodeError>
-where T: FromToProto {
+///
+/// A context function is used to provide a context for error messages, when decoding fails.
+pub fn decode_seqv<T>(
+    seqv: SeqV,
+    context: impl FnOnce() -> String,
+) -> Result<SeqV<T>, PbDecodeError>
+where
+    T: FromToProto,
+{
     let buf = &seqv.data;
-    let p: T::PB = prost::Message::decode(buf.as_ref())?;
-    let v: T = FromToProto::from_pb(p)?;
+    let x: Result<_, PbDecodeError> = try {
+        let p: T::PB = prost::Message::decode(buf.as_ref())?;
+        let v: T = FromToProto::from_pb(p)?;
+        SeqV::with_meta(seqv.seq, seqv.meta, v)
+    };
 
-    Ok(SeqV::with_meta(seqv.seq, seqv.meta, v))
+    x.map_err(|e| e.with_context(context()))
 }
 
 /// Decode key and protobuf encoded value from `StreamItem`.
@@ -79,7 +107,9 @@ where
             let k = K::from_str_key(&item.key)?;
 
             let raw = item.value.ok_or_else(|| NoneValue::new(item.key))?;
-            let v = decode_seqv::<K::ValueType>(SeqV::from(raw))?;
+            let v = decode_seqv::<K::ValueType>(SeqV::from(raw), || {
+                format!("decode value of {}", k.to_string_key())
+            })?;
 
             Ok(NonEmptyItem::new(k, v))
         }

--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::diverging_sub_expression)]
 #![allow(clippy::type_complexity)]
+#![feature(try_blocks)]
 
 extern crate databend_common_meta_types;
 

--- a/src/meta/client/tests/it/grpc_client.rs
+++ b/src/meta/client/tests/it/grpc_client.rs
@@ -87,7 +87,7 @@ async fn test_grpc_client_handshake_timeout() {
         let got = res.unwrap_err();
         let got =
             ErrorCode::from(MetaError::ClientError(MetaClientError::HandshakeError(got))).message();
-        let expect = "failed to handshake with meta-service: when sending handshake rpc, cause: tonic::status::Status: status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} } source: transport error source: Timeout expired";
+        let expect = "failed to handshake with meta-service: when sending handshake rpc, cause: tonic::status::Status: status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }; source: transport error; source: Timeout expired";
         assert_eq!(got, expect);
     }
 

--- a/src/meta/proto-conv/src/background_job_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/background_job_from_to_protobuf_impl.rs
@@ -46,9 +46,8 @@ impl FromToProto for mt::background::BackgroundJobInfo {
             job_status: p
                 .job_status
                 .and_then(|t| BackgroundJobStatus::from_pb(t).ok()),
-            task_type: FromPrimitive::from_i32(p.task_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid TaskType: {}", p.task_type),
-            })?,
+            task_type: FromPrimitive::from_i32(p.task_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid TaskType: {}", p.task_type)))?,
 
             last_updated: p
                 .last_updated
@@ -89,9 +88,8 @@ impl FromToProto for mt::background::BackgroundJobParams {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {
-            job_type: FromPrimitive::from_i32(p.job_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid job type: {}", p.job_type),
-            })?,
+            job_type: FromPrimitive::from_i32(p.job_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid job type: {}", p.job_type)))?,
             scheduled_job_interval: std::time::Duration::from_secs(
                 p.scheduled_job_interval_seconds,
             ),
@@ -99,9 +97,8 @@ impl FromToProto for mt::background::BackgroundJobParams {
             scheduled_job_timezone: p
                 .scheduled_job_timezone
                 .map(|t| {
-                    chrono_tz::Tz::from_str(&t).map_err(|e| Incompatible {
-                        reason: format!("invalid timezone: {}", e),
-                    })
+                    chrono_tz::Tz::from_str(&t)
+                        .map_err(|e| Incompatible::new(format!("invalid timezone: {}", e)))
                 })
                 .transpose()?,
             manual_trigger_params: p
@@ -138,9 +135,8 @@ impl FromToProto for BackgroundJobStatus {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         Ok(Self {
-            job_state: FromPrimitive::from_i32(p.job_state).ok_or_else(|| Incompatible {
-                reason: format!("invalid JobState: {}", p.job_state),
-            })?,
+            job_state: FromPrimitive::from_i32(p.job_state)
+                .ok_or_else(|| Incompatible::new(format!("invalid JobState: {}", p.job_state)))?,
             last_task_id: p.last_task_id,
             last_task_run_at: p
                 .last_task_run_at
@@ -200,11 +196,10 @@ impl FromToProto for mt::background::ManualTriggerParams {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         Ok(Self {
             id: p.id,
-            trigger: mt::principal::UserIdentity::from_pb(p.trigger.ok_or_else(|| {
-                Incompatible {
-                    reason: "trigger is required".to_string(),
-                }
-            })?)?,
+            trigger: mt::principal::UserIdentity::from_pb(
+                p.trigger
+                    .ok_or_else(|| Incompatible::new("trigger is required".to_string()))?,
+            )?,
             triggered_at: DateTime::<Utc>::from_pb(p.triggered_at)?,
         })
     }

--- a/src/meta/proto-conv/src/background_task_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/background_task_from_to_protobuf_impl.rs
@@ -42,12 +42,10 @@ impl FromToProto for mt::background::BackgroundTaskInfo {
             last_updated: p
                 .last_updated
                 .and_then(|t| DateTime::<Utc>::from_pb(t).ok()),
-            task_type: FromPrimitive::from_i32(p.task_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid TaskType: {}", p.task_type),
-            })?,
-            task_state: FromPrimitive::from_i32(p.task_state).ok_or_else(|| Incompatible {
-                reason: format!("invalid TaskState: {}", p.task_state),
-            })?,
+            task_type: FromPrimitive::from_i32(p.task_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid TaskType: {}", p.task_type)))?,
+            task_state: FromPrimitive::from_i32(p.task_state)
+                .ok_or_else(|| Incompatible::new(format!("invalid TaskState: {}", p.task_state)))?,
             message: p.message,
             compaction_task_stats: p
                 .compaction_task_stats

--- a/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/catalog_from_to_protobuf_impl.rs
@@ -37,9 +37,9 @@ impl FromToProto for mt::CatalogMeta {
     fn from_pb(p: pb::CatalogMeta) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let option = p.option.ok_or_else(|| Incompatible {
-            reason: "CatalogMeta.option is None".to_string(),
-        })?;
+        let option = p
+            .option
+            .ok_or_else(|| Incompatible::new("CatalogMeta.option is None".to_string()))?;
 
         let v = Self {
             catalog_option: mt::CatalogOption::from_pb(option)?,
@@ -115,9 +115,9 @@ impl FromToProto for mt::IcebergCatalogOption {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let option = p.iceberg_catalog_option.ok_or_else(|| Incompatible {
-            reason: "IcebergCatalogOption.option is None".to_string(),
-        })?;
+        let option = p
+            .iceberg_catalog_option
+            .ok_or_else(|| Incompatible::new("IcebergCatalogOption.option is None".to_string()))?;
 
         Ok(match option {
             pb::iceberg_catalog_option::IcebergCatalogOption::RestCatalog(v) => {

--- a/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/config_from_to_protobuf_impl.rs
@@ -66,9 +66,9 @@ impl FromToProto for mt::storage::StorageParams {
                     mt::storage::StorageHuggingfaceConfig::from_pb(s)?,
                 ))
             }
-            None => Err(Incompatible {
-                reason: "StageStorage.storage cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new(
+                "StageStorage.storage cannot be None".to_string(),
+            )),
         }
     }
 
@@ -101,9 +101,10 @@ impl FromToProto for mt::storage::StorageParams {
             mt::storage::StorageParams::Huggingface(v) => Ok(pb::StorageConfig {
                 storage: Some(pb::storage_config::Storage::Huggingface(v.to_pb()?)),
             }),
-            others => Err(Incompatible {
-                reason: format!("stage type: {} not supported", others),
-            }),
+            others => Err(Incompatible::new(format!(
+                "stage type: {} not supported",
+                others
+            ))),
         }
     }
 }

--- a/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/database_from_to_protobuf_impl.rs
@@ -87,9 +87,7 @@ impl FromToProto for mt::ShareDbId {
             Some(pb::share_db_id::DbId::Reference(reference)) => {
                 Ok(mt::ShareDbId::Reference(reference.id))
             }
-            None => Err(Incompatible {
-                reason: "ShareDbId cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new("ShareDbId cannot be None".to_string())),
         }
     }
 

--- a/src/meta/proto-conv/src/datetime_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/datetime_from_to_protobuf_impl.rs
@@ -30,9 +30,8 @@ impl FromToProto for DateTime<Utc> {
     }
 
     fn from_pb(p: String) -> Result<Self, Incompatible> {
-        let v = DateTime::<Utc>::from_str(&p).map_err(|e| Incompatible {
-            reason: format!("DateTime error: {}", e),
-        })?;
+        let v = DateTime::<Utc>::from_str(&p)
+            .map_err(|e| Incompatible::new(format!("DateTime error: {}", e)))?;
         Ok(v)
     }
 

--- a/src/meta/proto-conv/src/dictionary_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/dictionary_from_to_protobuf_impl.rs
@@ -34,8 +34,8 @@ impl FromToProto for mt::DictionaryMeta {
     fn from_pb(p: pb::DictionaryMeta) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        let schema = p.schema.ok_or_else(|| Incompatible {
-            reason: "DictionaryMeta.schema can not be None".to_string(),
+        let schema = p.schema.ok_or_else(|| {
+            Incompatible::new("DictionaryMeta.schema can not be None".to_string())
         })?;
         let v = Self {
             source: p.source,

--- a/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/file_format_from_to_protobuf_impl.rs
@@ -57,9 +57,9 @@ impl FromToProtoEnum for mt::principal::StageFileFormatType {
             mt::principal::StageFileFormatType::Orc => Ok(pb::StageFileFormatType::Orc),
             mt::principal::StageFileFormatType::Parquet => Ok(pb::StageFileFormatType::Parquet),
             mt::principal::StageFileFormatType::Xml => Ok(pb::StageFileFormatType::Xml),
-            mt::principal::StageFileFormatType::None => Err(Incompatible {
-                reason: "StageFileFormatType::None cannot be converted to protobuf".to_string(),
-            }),
+            mt::principal::StageFileFormatType::None => Err(Incompatible::new(
+                "StageFileFormatType::None cannot be converted to protobuf".to_string(),
+            )),
         }
     }
 }
@@ -114,14 +114,14 @@ impl FromToProto for mt::principal::FileFormatOptions {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let format = mt::principal::StageFileFormatType::from_pb_enum(
-            FromPrimitive::from_i32(p.format).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileFormatType: {}", p.format),
+            FromPrimitive::from_i32(p.format).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileFormatType: {}", p.format))
             })?,
         )?;
 
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
 
@@ -176,13 +176,11 @@ impl FromToProto for mt::principal::UserDefinedFileFormat {
 
         let file_format_params =
             mt::principal::FileFormatParams::from_pb(p.file_format_params.ok_or_else(|| {
-                Incompatible {
-                    reason: "StageInfo.file_format_params cannot be None".to_string(),
-                }
+                Incompatible::new("StageInfo.file_format_params cannot be None".to_string())
             })?)?;
         let creator =
-            mt::principal::UserIdentity::from_pb(p.creator.ok_or_else(|| Incompatible {
-                reason: "StageInfo.creator cannot be None".to_string(),
+            mt::principal::UserIdentity::from_pb(p.creator.ok_or_else(|| {
+                Incompatible::new("StageInfo.creator cannot be None".to_string())
             })?)?;
 
         Ok(mt::principal::UserDefinedFileFormat {
@@ -249,9 +247,9 @@ impl FromToProto for mt::principal::FileFormatParams {
                     mt::principal::XmlFileFormatParams::from_pb(p)?,
                 ))
             }
-            None => Err(Incompatible {
-                reason: "FileFormatParams.format cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new(
+                "FileFormatParams.format cannot be None".to_string(),
+            )),
         }
     }
 
@@ -305,11 +303,8 @@ impl FromToProto for mt::principal::OrcFileFormatParams {
     fn from_pb(p: pb::OrcFileFormatParams) -> Result<Self, Incompatible>
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
-        mt::principal::OrcFileFormatParams::try_create(p.missing_field_as.as_deref()).map_err(|e| {
-            Incompatible {
-                reason: format!("{e}"),
-            }
-        })
+        mt::principal::OrcFileFormatParams::try_create(p.missing_field_as.as_deref())
+            .map_err(|e| Incompatible::new(format!("{e}")))
     }
 
     fn to_pb(&self) -> Result<pb::OrcFileFormatParams, Incompatible> {
@@ -331,9 +326,7 @@ impl FromToProto for mt::principal::ParquetFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         mt::principal::ParquetFileFormatParams::try_create(p.missing_field_as.as_deref(), p.null_if)
-            .map_err(|e| Incompatible {
-                reason: format!("{e}"),
-            })
+            .map_err(|e| Incompatible::new(format!("{e}")))
     }
 
     fn to_pb(&self) -> Result<pb::ParquetFileFormatParams, Incompatible> {
@@ -356,8 +349,8 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
 
@@ -367,9 +360,7 @@ impl FromToProto for mt::principal::NdJsonFileFormatParams {
             p.null_field_as.as_deref(),
             p.null_if,
         )
-        .map_err(|e| Incompatible {
-            reason: format!("{e}"),
-        })
+        .map_err(|e| Incompatible::new(format!("{e}")))
     }
 
     fn to_pb(&self) -> Result<pb::NdJsonFileFormatParams, Incompatible> {
@@ -396,8 +387,8 @@ impl FromToProto for mt::principal::JsonFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
         Ok(Self { compression })
@@ -424,8 +415,8 @@ impl FromToProto for mt::principal::XmlFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
         Ok(Self {
@@ -456,8 +447,8 @@ impl FromToProto for mt::principal::CsvFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
         let null_display = if p.null_display.is_empty() {
@@ -468,11 +459,7 @@ impl FromToProto for mt::principal::CsvFileFormatParams {
 
         let empty_field_as = p
             .empty_field_as
-            .map(|s| {
-                EmptyFieldAs::from_str(&s).map_err(|e| Incompatible {
-                    reason: format!("{:?}", e),
-                })
-            })
+            .map(|s| EmptyFieldAs::from_str(&s).map_err(|e| Incompatible::new(format!("{:?}", e))))
             .transpose()?
             .unwrap_or_default();
 
@@ -480,17 +467,13 @@ impl FromToProto for mt::principal::CsvFileFormatParams {
             .binary_format
             .map(|s| BinaryFormat::from_str(&s))
             .transpose()
-            .map_err(|e| Incompatible {
-                reason: format!("{:?}", e),
-            })?
+            .map_err(|e| Incompatible::new(format!("{:?}", e)))?
             .unwrap_or_default();
         let geometry_format = p
             .geometry_format
             .map(|s| GeometryDataType::from_str(&s))
             .transpose()
-            .map_err(|e| Incompatible {
-                reason: format!("{:?}", e),
-            })?
+            .map_err(|e| Incompatible::new(format!("{:?}", e)))?
             .unwrap_or_default();
 
         Ok(Self {
@@ -543,8 +526,8 @@ impl FromToProto for mt::principal::TsvFileFormatParams {
     where Self: Sized {
         reader_check_msg(p.ver, p.min_reader_ver)?;
         let compression = mt::principal::StageFileCompression::from_pb_enum(
-            FromPrimitive::from_i32(p.compression).ok_or_else(|| Incompatible {
-                reason: format!("invalid StageFileCompression: {}", p.compression),
+            FromPrimitive::from_i32(p.compression).ok_or_else(|| {
+                Incompatible::new(format!("invalid StageFileCompression: {}", p.compression))
             })?,
         )?;
         Ok(Self {

--- a/src/meta/proto-conv/src/from_to_protobuf.rs
+++ b/src/meta/proto-conv/src/from_to_protobuf.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::sync::Arc;
 
 /// Defines API to convert from/to protobuf meta type.
@@ -44,16 +45,34 @@ pub trait FromToProtoEnum {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("Incompatible: {reason}")]
 pub struct Incompatible {
+    pub context: String,
     pub reason: String,
+}
+
+impl fmt::Display for Incompatible {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.reason)?;
+
+        if !self.context.is_empty() {
+            write!(f, "; when:({})", self.context)?;
+        }
+        Ok(())
+    }
 }
 
 impl Incompatible {
     pub fn new(reason: impl Into<String>) -> Self {
         Self {
+            context: "".into(),
             reason: reason.into(),
         }
+    }
+
+    /// Set the context of the error.
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context = context.into();
+        self
     }
 }
 

--- a/src/meta/proto-conv/src/index_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/index_from_to_protobuf_impl.rs
@@ -40,9 +40,8 @@ impl FromToProto for mt::IndexMeta {
 
         let v = Self {
             table_id: p.table_id,
-            index_type: FromPrimitive::from_i32(p.index_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid IndexType: {}", p.index_type),
-            })?,
+            index_type: FromPrimitive::from_i32(p.index_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid IndexType: {}", p.index_type)))?,
             created_on: DateTime::<Utc>::from_pb(p.created_on)?,
             dropped_on: match p.dropped_on {
                 Some(drop_on) => Some(DateTime::<Utc>::from_pb(drop_on)?),

--- a/src/meta/proto-conv/src/lock_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/lock_from_to_protobuf_impl.rs
@@ -47,9 +47,7 @@ impl FromToProto for mt::LockKey {
                 let tenant = Tenant::new_nonempty(non_empty);
                 Ok(mt::LockKey::Table { tenant, table_id })
             }
-            None => Err(Incompatible {
-                reason: "LockKey cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new("LockKey cannot be None".to_string())),
         }
     }
 
@@ -88,9 +86,8 @@ impl FromToProto for mt::LockMeta {
                 Some(acquired_on) => Some(DateTime::<Utc>::from_pb(acquired_on)?),
                 None => None,
             },
-            lock_type: FromPrimitive::from_i32(p.lock_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid LockType: {}", p.lock_type),
-            })?,
+            lock_type: FromPrimitive::from_i32(p.lock_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid LockType: {}", p.lock_type)))?,
             extra_info: p.extra_info,
         };
 

--- a/src/meta/proto-conv/src/ownership_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/ownership_from_to_protobuf_impl.rs
@@ -36,9 +36,7 @@ impl FromToProto for mt::principal::OwnershipInfo {
         Ok(mt::principal::OwnershipInfo {
             role: p.role.clone(),
             object: mt::principal::OwnershipObject::from_pb(p.object.ok_or_else(|| {
-                Incompatible {
-                    reason: format!("ROLE {}: Object can not be None", &p.role),
-                }
+                Incompatible::new(format!("ROLE {}: Object can not be None", &p.role))
             })?)?,
         })
     }
@@ -63,9 +61,9 @@ impl FromToProto for mt::principal::OwnershipObject {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let Some(object) = p.object else {
-            return Err(Incompatible {
-                reason: "OwnershipObject cannot be None".to_string(),
-            });
+            return Err(Incompatible::new(
+                "OwnershipObject cannot be None".to_string(),
+            ));
         };
 
         match object {

--- a/src/meta/proto-conv/src/procedure_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/procedure_from_to_protobuf_impl.rs
@@ -84,8 +84,11 @@ impl FromToProto for mt::principal::ProcedureMeta {
         let mut return_types = Vec::with_capacity(self.return_types.len());
         for arg_type in self.return_types.iter() {
             let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| Incompatible {
-                    reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+                .map_err(|e| {
+                    Incompatible::new(format!(
+                        "Convert DataType to TableDataType failed: {}",
+                        e.message()
+                    ))
                 })?
                 .to_pb()?;
             return_types.push(arg_type);

--- a/src/meta/proto-conv/src/schema_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/schema_from_to_protobuf_impl.rs
@@ -78,8 +78,8 @@ impl FromToProto for ex::TableField {
 
         let v = ex::TableField::new_from_column_id(
             &p.name,
-            ex::TableDataType::from_pb(p.data_type.ok_or_else(|| Incompatible {
-                reason: "DataField.data_type can not be None".to_string(),
+            ex::TableDataType::from_pb(p.data_type.ok_or_else(|| {
+                Incompatible::new("DataField.data_type can not be None".to_string())
             })?)?,
             p.column_id,
         )
@@ -116,8 +116,8 @@ impl FromToProto for ex::ComputedExpr {
     fn from_pb(p: pb::ComputedExpr) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let computed_expr = p.computed_expr.ok_or_else(|| Incompatible {
-            reason: "Invalid ComputedExpr: .computed_expr can not be None".to_string(),
+        let computed_expr = p.computed_expr.ok_or_else(|| {
+            Incompatible::new("Invalid ComputedExpr: .computed_expr can not be None".to_string())
         })?;
 
         let x = match computed_expr {
@@ -153,9 +153,9 @@ impl FromToProto for ex::TableDataType {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         match (&p.dt, &p.dt24) {
-            (None, None) => Err(Incompatible {
-                reason: "DataType .dt and .dt24 are both None".to_string(),
-            }),
+            (None, None) => Err(Incompatible::new(
+                "DataType .dt and .dt24 are both None".to_string(),
+            )),
             (Some(_), None) => {
                 // Convert from version 23 or lower:
                 let x = match p.dt.unwrap() {
@@ -165,8 +165,8 @@ impl FromToProto for ex::TableDataType {
                         reader_check_msg(nullable_type.ver, nullable_type.min_reader_ver)?;
 
                         let inner = Box::into_inner(nullable_type).inner;
-                        let inner = inner.ok_or_else(|| Incompatible {
-                            reason: "NullableType.inner can not be None".to_string(),
+                        let inner = inner.ok_or_else(|| {
+                            Incompatible::new("NullableType.inner can not be None".to_string())
                         })?;
                         let inner = Box::into_inner(inner);
                         ex::TableDataType::Nullable(Box::new(ex::TableDataType::from_pb(inner)?))
@@ -203,8 +203,8 @@ impl FromToProto for ex::TableDataType {
                         reader_check_msg(a.ver, a.min_reader_ver)?;
 
                         let inner = Box::into_inner(a).inner;
-                        let inner = inner.ok_or_else(|| Incompatible {
-                            reason: "Array.inner can not be None".to_string(),
+                        let inner = inner.ok_or_else(|| {
+                            Incompatible::new("Array.inner can not be None".to_string())
                         })?;
                         let inner = Box::into_inner(inner);
                         ex::TableDataType::Array(Box::new(ex::TableDataType::from_pb(inner)?))
@@ -267,10 +267,9 @@ impl FromToProto for ex::TableDataType {
                 };
                 Ok(x)
             }
-            (Some(_), Some(_)) => Err(Incompatible {
-                reason: "Invalid DataType: at most only one of .dt and .dt23 can be Some"
-                    .to_string(),
-            }),
+            (Some(_), Some(_)) => Err(Incompatible::new(
+                "Invalid DataType: at most only one of .dt and .dt23 can be Some".to_string(),
+            )),
         }
     }
 
@@ -343,9 +342,9 @@ impl FromToProto for ex::types::NumberDataType {
     fn from_pb(p: pb::Number) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let num = p.num.ok_or_else(|| Incompatible {
-            reason: "Invalid Number: .num can not be None".to_string(),
-        })?;
+        let num = p
+            .num
+            .ok_or_else(|| Incompatible::new("Invalid Number: .num can not be None".to_string()))?;
 
         let x = match num {
             Num::Uint8Type(_) => Self::UInt8,
@@ -394,8 +393,8 @@ impl FromToProto for ex::types::DecimalDataType {
     fn from_pb(p: pb::Decimal) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let num = p.decimal.ok_or_else(|| Incompatible {
-            reason: "Invalid Decimal: .decimal can not be None".to_string(),
+        let num = p.decimal.ok_or_else(|| {
+            Incompatible::new("Invalid Decimal: .decimal can not be None".to_string())
         })?;
 
         let x = match num {

--- a/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/stage_from_to_protobuf_impl.rs
@@ -40,9 +40,7 @@ impl FromToProto for mt::principal::StageParams {
     where Self: Sized {
         Ok(mt::principal::StageParams {
             storage: mt::storage::StorageParams::from_pb(p.storage.ok_or_else(|| {
-                Incompatible {
-                    reason: "pb::stage_info::StageParams.storage cannot be None".to_string(),
-                }
+                Incompatible::new("pb::stage_info::StageParams.storage cannot be None".to_string())
             })?)?,
         })
     }
@@ -78,9 +76,9 @@ impl FromToProto for mt::principal::OnErrorMode {
             Some(pb::stage_info::on_error_mode::Mode::AbortNum(n)) => {
                 Ok(mt::principal::OnErrorMode::AbortNum(n))
             }
-            None => Err(Incompatible {
-                reason: "OnErrorMode.mode cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new(
+                "OnErrorMode.mode cannot be None".to_string(),
+            )),
         }
     }
 
@@ -106,25 +104,33 @@ impl FromToProto for mt::principal::CopyOptions {
     }
     fn from_pb(p: pb::stage_info::CopyOptions) -> Result<Self, Incompatible>
     where Self: Sized {
-        let on_error =
-            mt::principal::OnErrorMode::from_pb(p.on_error.ok_or_else(|| Incompatible {
-                reason: "CopyOptions.on_error cannot be None".to_string(),
-            })?)?;
-        let size_limit = usize::try_from(p.size_limit).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.size_limit cannot be convert to usize: {}", err),
+        let on_error = mt::principal::OnErrorMode::from_pb(p.on_error.ok_or_else(|| {
+            Incompatible::new("CopyOptions.on_error cannot be None".to_string())
+        })?)?;
+        let size_limit = usize::try_from(p.size_limit).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.size_limit cannot be convert to usize: {}",
+                err
+            ))
         })?;
-        let max_files = usize::try_from(p.max_files).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.max_files cannot be convert to usize: {}", err),
+        let max_files = usize::try_from(p.max_files).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.max_files cannot be convert to usize: {}",
+                err
+            ))
         })?;
-        let split_size = usize::try_from(p.split_size).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.split_size cannot be convert to usize: {}", err),
+        let split_size = usize::try_from(p.split_size).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.split_size cannot be convert to usize: {}",
+                err
+            ))
         })?;
 
-        let max_file_size = usize::try_from(p.max_file_size).map_err(|err| Incompatible {
-            reason: format!(
+        let max_file_size = usize::try_from(p.max_file_size).map_err(|err| {
+            Incompatible::new(format!(
                 "CopyOptions.max_file_size cannot be convert to usize: {}",
                 err
-            ),
+            ))
         })?;
         Ok(mt::principal::CopyOptions {
             on_error,
@@ -142,20 +148,29 @@ impl FromToProto for mt::principal::CopyOptions {
 
     fn to_pb(&self) -> Result<pb::stage_info::CopyOptions, Incompatible> {
         let on_error = mt::principal::OnErrorMode::to_pb(&self.on_error)?;
-        let size_limit = u64::try_from(self.size_limit).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.size_limit cannot be convert to u64: {}", err),
+        let size_limit = u64::try_from(self.size_limit).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.size_limit cannot be convert to u64: {}",
+                err
+            ))
         })?;
-        let max_files = u64::try_from(self.max_files).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.max_files cannot be convert to u64: {}", err),
+        let max_files = u64::try_from(self.max_files).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.max_files cannot be convert to u64: {}",
+                err
+            ))
         })?;
-        let split_size = u64::try_from(self.split_size).map_err(|err| Incompatible {
-            reason: format!("CopyOptions.split_size cannot be convert to u64: {}", err),
+        let split_size = u64::try_from(self.split_size).map_err(|err| {
+            Incompatible::new(format!(
+                "CopyOptions.split_size cannot be convert to u64: {}",
+                err
+            ))
         })?;
-        let max_file_size = u64::try_from(self.max_file_size).map_err(|err| Incompatible {
-            reason: format!(
+        let max_file_size = u64::try_from(self.max_file_size).map_err(|err| {
+            Incompatible::new(format!(
                 "CopyOptions.max_file_size cannot be convert to u64: {}",
                 err
-            ),
+            ))
         })?;
         Ok(pb::stage_info::CopyOptions {
             on_error: Some(on_error),
@@ -186,35 +201,25 @@ impl FromToProto for mt::principal::StageInfo {
             (None, Some(p)) => {
                 let options = mt::principal::FileFormatOptions::from_pb(p)?;
                 let reader = FileFormatOptionsReader::from_map(options.to_map());
-                mt::principal::FileFormatParams::try_from_reader(reader, true).map_err(|e| Incompatible {
-                    reason: format!("fail to convert StageInfo.file_format_options to StageInfo.file_format_params: {e:?}"),
-                })?
+                mt::principal::FileFormatParams::try_from_reader(reader, true).map_err(|e| Incompatible::new(format!("fail to convert StageInfo.file_format_options to StageInfo.file_format_params: {e:?}")))?
             },
-            (None, None) => Err(Incompatible {
-                reason: "StageInfo.file_format_params and StageInfo.file_format_options cannot be both None".to_string(),
-            })?,
-            (Some(_), Some(_)) => Err(Incompatible {
-                reason: "StageInfo.file_format_params and StageInfo.file_format_options cannot be both set".to_string(),
-            })?,
+            (None, None) => Err(Incompatible::new("StageInfo.file_format_params and StageInfo.file_format_options cannot be both None".to_string()))?,
+            (Some(_), Some(_)) => Err(Incompatible::new("StageInfo.file_format_params and StageInfo.file_format_options cannot be both set".to_string()))?,
         };
         Ok(mt::principal::StageInfo {
             stage_name: p.stage_name.clone(),
             stage_type: mt::principal::StageType::from_pb_enum(
-                FromPrimitive::from_i32(p.stage_type).ok_or_else(|| Incompatible {
-                    reason: format!("invalid StageType: {}", p.stage_type),
+                FromPrimitive::from_i32(p.stage_type).ok_or_else(|| {
+                    Incompatible::new(format!("invalid StageType: {}", p.stage_type))
                 })?,
             )?,
             stage_params: mt::principal::StageParams::from_pb(p.stage_params.ok_or_else(
-                || Incompatible {
-                    reason: "StageInfo.stage_params cannot be None".to_string(),
-                },
+                || Incompatible::new("StageInfo.stage_params cannot be None".to_string()),
             )?)?,
             is_temporary: false,
             file_format_params,
             copy_options: mt::principal::CopyOptions::from_pb(p.copy_options.ok_or_else(
-                || Incompatible {
-                    reason: "StageInfo.copy_options cannot be None".to_string(),
-                },
+                || Incompatible::new("StageInfo.copy_options cannot be None".to_string()),
             )?)?,
             comment: p.comment,
             number_of_files: p.number_of_files,

--- a/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/table_from_to_protobuf_impl.rs
@@ -183,9 +183,9 @@ impl FromToProto for mt::TableMeta {
     fn from_pb(p: pb::TableMeta) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
-        let schema = p.schema.ok_or_else(|| Incompatible {
-            reason: "TableMeta.schema can not be None".to_string(),
-        })?;
+        let schema = p
+            .schema
+            .ok_or_else(|| Incompatible::new("TableMeta.schema can not be None".to_string()))?;
 
         let mut indexes = BTreeMap::new();
         for (name, index) in p.indexes {

--- a/src/meta/proto-conv/src/token_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/token_from_to_protobuf_impl.rs
@@ -37,9 +37,8 @@ impl FromToProto for mt::QueryTokenInfo {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let v = Self {
-            token_type: FromPrimitive::from_i32(p.token_type).ok_or_else(|| Incompatible {
-                reason: format!("invalid TokenType: {}", p.token_type),
-            })?,
+            token_type: FromPrimitive::from_i32(p.token_type)
+                .ok_or_else(|| Incompatible::new(format!("invalid TokenType: {}", p.token_type)))?,
             parent: p.parent,
         };
         Ok(v)

--- a/src/meta/proto-conv/src/udf_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/udf_from_to_protobuf_impl.rs
@@ -65,9 +65,7 @@ impl FromToProto for mt::UDFServer {
             arg_types.push(arg_type);
         }
         let return_type = DataType::from(&TableDataType::from_pb(p.return_type.ok_or_else(
-            || Incompatible {
-                reason: "UdfServer.return_type can not be None".to_string(),
-            },
+            || Incompatible::new("UdfServer.return_type can not be None".to_string()),
         )?)?);
 
         Ok(mt::UDFServer {
@@ -83,15 +81,21 @@ impl FromToProto for mt::UDFServer {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
             let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| Incompatible {
-                    reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+                .map_err(|e| {
+                    Incompatible::new(format!(
+                        "Convert DataType to TableDataType failed: {}",
+                        e.message()
+                    ))
                 })?
                 .to_pb()?;
             arg_types.push(arg_type);
         }
         let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| Incompatible {
-                reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+            .map_err(|e| {
+                Incompatible::new(format!(
+                    "Convert DataType to TableDataType failed: {}",
+                    e.message()
+                ))
             })?
             .to_pb()?;
 
@@ -121,9 +125,7 @@ impl FromToProto for mt::UDFScript {
             arg_types.push(arg_type);
         }
         let return_type = DataType::from(&TableDataType::from_pb(p.return_type.ok_or_else(
-            || Incompatible {
-                reason: "UDFScript.return_type can not be None".to_string(),
-            },
+            || Incompatible::new("UDFScript.return_type can not be None".to_string()),
         )?)?);
 
         Ok(mt::UDFScript {
@@ -140,15 +142,21 @@ impl FromToProto for mt::UDFScript {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
             let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| Incompatible {
-                    reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+                .map_err(|e| {
+                    Incompatible::new(format!(
+                        "Convert DataType to TableDataType failed: {}",
+                        e.message()
+                    ))
                 })?
                 .to_pb()?;
             arg_types.push(arg_type);
         }
         let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| Incompatible {
-                reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+            .map_err(|e| {
+                Incompatible::new(format!(
+                    "Convert DataType to TableDataType failed: {}",
+                    e.message()
+                ))
             })?
             .to_pb()?;
 
@@ -185,11 +193,10 @@ impl FromToProto for mt::UDAFScript {
             .map(|field| TableField::from_pb(field).map(|field| (&field).into()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let return_type =
-            (&TableDataType::from_pb(p.return_type.ok_or_else(|| Incompatible {
-                reason: "UDAFScript.return_type can not be None".to_string(),
-            })?)?)
-                .into();
+        let return_type = (&TableDataType::from_pb(p.return_type.ok_or_else(|| {
+            Incompatible::new("UDAFScript.return_type can not be None".to_string())
+        })?)?)
+            .into();
 
         Ok(mt::UDAFScript {
             code: p.code,
@@ -205,8 +212,11 @@ impl FromToProto for mt::UDAFScript {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
             let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| Incompatible {
-                    reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+                .map_err(|e| {
+                    Incompatible::new(format!(
+                        "Convert DataType to TableDataType failed: {}",
+                        e.message()
+                    ))
                 })?
                 .to_pb()?;
             arg_types.push(arg_type);
@@ -218,11 +228,11 @@ impl FromToProto for mt::UDAFScript {
             .map(|field| {
                 TableField::new(
                     field.name(),
-                    infer_schema_type(field.data_type()).map_err(|e| Incompatible {
-                        reason: format!(
+                    infer_schema_type(field.data_type()).map_err(|e| {
+                        Incompatible::new(format!(
                             "Convert DataType to TableDataType failed: {}",
                             e.message()
-                        ),
+                        ))
                     })?,
                 )
                 .to_pb()
@@ -230,8 +240,11 @@ impl FromToProto for mt::UDAFScript {
             .collect::<Result<_, _>>()?;
 
         let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| Incompatible {
-                reason: format!("Convert DataType to TableDataType failed: {}", e.message()),
+            .map_err(|e| {
+                Incompatible::new(format!(
+                    "Convert DataType to TableDataType failed: {}",
+                    e.message()
+                ))
             })?
             .to_pb()?;
 
@@ -269,9 +282,9 @@ impl FromToProto for mt::UserDefinedFunction {
                 mt::UDFDefinition::UDAFScript(mt::UDAFScript::from_pb(udaf_script)?)
             }
             None => {
-                return Err(Incompatible {
-                    reason: "UserDefinedFunction.definition cannot be None".to_string(),
-                });
+                return Err(Incompatible::new(
+                    "UserDefinedFunction.definition cannot be None".to_string(),
+                ));
             }
         };
 

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -53,14 +53,12 @@ impl FromToProto for mt::principal::AuthInfo {
                 need_change,
             })) => Ok(mt::principal::AuthInfo::Password {
                 hash_value,
-                hash_method: FromPrimitive::from_i32(hash_method).ok_or_else(|| Incompatible {
-                    reason: format!("invalid PasswordHashMethod: {}", hash_method),
+                hash_method: FromPrimitive::from_i32(hash_method).ok_or_else(|| {
+                    Incompatible::new(format!("invalid PasswordHashMethod: {}", hash_method))
                 })?,
                 need_change: need_change.unwrap_or_default(),
             }),
-            None => Err(Incompatible {
-                reason: "AuthInfo cannot be None".to_string(),
-            }),
+            None => Err(Incompatible::new("AuthInfo cannot be None".to_string())),
         }
     }
 
@@ -160,9 +158,7 @@ impl FromToProto for mt::principal::GrantObject {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let Some(object) = p.object else {
-            return Err(Incompatible {
-                reason: "GrantObject cannot be None".to_string(),
-            });
+            return Err(Incompatible::new("GrantObject cannot be None".to_string()));
         };
 
         match object {
@@ -269,8 +265,8 @@ impl FromToProto for mt::principal::GrantEntry {
         let privileges =
             BitFlags::<mt::principal::UserPrivilegeType, u64>::from_bits_truncate(p.privileges);
         Ok(mt::principal::GrantEntry::new(
-            mt::principal::GrantObject::from_pb(p.object.ok_or_else(|| Incompatible {
-                reason: "GrantEntry.object can not be None".to_string(),
+            mt::principal::GrantObject::from_pb(p.object.ok_or_else(|| {
+                Incompatible::new("GrantEntry.object can not be None".to_string())
             })?)?,
             privileges,
         ))
@@ -339,20 +335,19 @@ impl FromToProto for mt::principal::UserInfo {
             name: p.name.clone(),
             hostname: p.hostname.clone(),
             auth_info: mt::principal::AuthInfo::from_pb(p.auth_info.ok_or_else(|| {
-                Incompatible {
-                    reason: format!("USER {}: UserInfo.auth_info cannot be None", &p.name),
-                }
+                Incompatible::new(format!(
+                    "USER {}: UserInfo.auth_info cannot be None",
+                    &p.name
+                ))
             })?)?,
             grants: mt::principal::UserGrantSet::from_pb(p.grants.ok_or_else(|| {
-                Incompatible {
-                    reason: format!("user {}: UserInfo.grants cannot be None", &p.name),
-                }
+                Incompatible::new(format!("user {}: UserInfo.grants cannot be None", &p.name))
             })?)?,
-            quota: mt::principal::UserQuota::from_pb(p.quota.ok_or_else(|| Incompatible {
-                reason: format!("user {}: UserInfo.quota cannot be None", &p.name),
+            quota: mt::principal::UserQuota::from_pb(p.quota.ok_or_else(|| {
+                Incompatible::new(format!("user {}: UserInfo.quota cannot be None", &p.name))
             })?)?,
-            option: mt::principal::UserOption::from_pb(p.option.ok_or_else(|| Incompatible {
-                reason: format!("user {}: UserInfo.option cannot be None", &p.name),
+            option: mt::principal::UserOption::from_pb(p.option.ok_or_else(|| {
+                Incompatible::new(format!("user {}: UserInfo.option cannot be None", &p.name))
             })?)?,
             history_auth_infos: p
                 .history_auth_infos

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -168,27 +168,25 @@ pub const MIN_MSG_VER: u64 = 1;
 pub fn reader_check_msg(msg_ver: u64, msg_min_reader_ver: u64) -> Result<(), Incompatible> {
     // The reader version must be big enough
     if VER < msg_min_reader_ver {
-        return Err(Incompatible {
-            reason: format!(
+        return Err(Incompatible::new(
+            format!(
                 "executable ver={} is smaller than the min reader version({}) that can read this message",
                 VER, msg_min_reader_ver
             ),
-        });
+        ));
     }
 
     // The message version must be big enough
     if msg_ver < MIN_MSG_VER {
-        return Err(Incompatible {
-            reason: format!(
-                "message ver={} is smaller than executable MIN_MSG_VER({}) that this program can read",
-                msg_ver, MIN_MSG_VER
-            ),
-        });
+        return Err(Incompatible::new(format!(
+            "message ver={} is smaller than executable MIN_MSG_VER({}) that this program can read",
+            msg_ver, MIN_MSG_VER
+        )));
     }
     Ok(())
 }
 
 pub fn missing(reason: impl ToString) -> impl FnOnce() -> Incompatible {
     let s = reason.to_string();
-    move || Incompatible { reason: s }
+    move || Incompatible::new(s)
 }

--- a/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/virtual_column_from_to_protobuf_impl.rs
@@ -49,13 +49,11 @@ impl FromToProto for mt::VirtualColumnMeta {
                 .collect()
         } else {
             if p.virtual_columns.len() != p.data_types.len() {
-                return Err(Incompatible {
-                    reason: format!(
-                        "Incompatible virtual columns length is {}, but data types length is {}",
-                        p.virtual_columns.len(),
-                        p.data_types.len()
-                    ),
-                });
+                return Err(Incompatible::new(format!(
+                    "Incompatible virtual columns length is {}, but data types length is {}",
+                    p.virtual_columns.len(),
+                    p.data_types.len()
+                )));
             }
             let mut virtual_columns = Vec::new();
             for (v, ty) in p.virtual_columns.iter().zip(p.data_types.iter()) {

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -299,13 +299,13 @@ fn test_incompatible() -> anyhow::Result<()> {
 
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
-        Incompatible {
-            reason: format!(
+        Incompatible::new(
+            format!(
                 "executable ver={} is smaller than the min reader version({}) that can read this message",
                 VER,
                 VER + 1
             )
-        },
+        ),
         res.unwrap_err()
     );
 
@@ -316,11 +316,9 @@ fn test_incompatible() -> anyhow::Result<()> {
 
     let res = mt::DatabaseMeta::from_pb(p);
     assert_eq!(
-        Incompatible {
-            reason: s(
-                "message ver=0 is smaller than executable MIN_MSG_VER(1) that this program can read"
-            )
-        },
+        Incompatible::new(s(
+            "message ver=0 is smaller than executable MIN_MSG_VER(1) that this program can read"
+        )),
         res.unwrap_err()
     );
 

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -464,13 +464,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::UserInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         );
     }
@@ -483,13 +483,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageFile::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         )
     }
@@ -502,13 +502,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         )
     }
@@ -521,13 +521,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         );
     }
@@ -540,13 +540,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         );
     }
@@ -559,13 +559,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         );
     }
@@ -578,13 +578,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         )
     }
@@ -597,13 +597,13 @@ fn test_user_incompatible() -> anyhow::Result<()> {
 
         let res = mt::principal::StageInfo::from_pb(p);
         assert_eq!(
-            Incompatible {
-                reason: format!(
+            Incompatible::new(
+                format!(
                     "executable ver={} is smaller than the min reader version({}) that can read this message",
                     VER,
                     VER + 1
                 )
-            },
+            ),
             res.unwrap_err()
         )
     }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -24,6 +24,7 @@ use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_types::UpsertKV;
 use log::info;
 use test_harness::test;
+use tokio::time::sleep;
 
 use crate::testing::meta_service_test_harness;
 use crate::tests::service::start_metasrv_cluster;
@@ -85,6 +86,9 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
         }
         stopped_tcs
     };
+
+    // Sleep to make sure the previous nodes are completely stopped.
+    sleep(Duration::from_secs(1)).await;
 
     info!("--- restart the cluster");
     let tcs = {

--- a/src/meta/types/src/errors/meta_network_errors.rs
+++ b/src/meta/types/src/errors/meta_network_errors.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::fmt::Display;
 
 use anyerror::AnyError;
@@ -119,7 +120,6 @@ impl InvalidArgument {
 }
 
 #[derive(thiserror::Error, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
-#[error("InvalidReply: {msg}; source: {source}")]
 pub struct InvalidReply {
     msg: String,
     #[source]
@@ -130,13 +130,23 @@ impl InvalidReply {
     pub fn new(msg: impl Display, source: &(impl std::error::Error + 'static)) -> Self {
         Self {
             msg: msg.to_string(),
-            source: AnyError::new(source),
+            source: AnyError::new(source).with_type(None::<String>),
         }
     }
 
     pub fn add_context(mut self, context: impl Display) -> Self {
         self.msg = format!("{}: {}", self.msg, context);
         self
+    }
+}
+
+impl Display for InvalidReply {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InvalidReply: ")?;
+        if !self.msg.is_empty() {
+            write!(f, "{}; ", self.msg)?;
+        }
+        write!(f, "source:({})", self.source)
     }
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: include key information in errors when listing meta-service key-values

When a malformed value is encountered (e.g., decoding a JSON-encoded
value with Protobuf), it results in a `PbDecodeError`. This commit
enhances debugging by including the key (as a string) of the value that
failed to decode.

This improvement is applied to all `KVPbApi::list_pb_*` methods.

Additionally, a test has been added to verify that the error message
includes the expected key information.


##### chore: add sleep to make sure nodes are completely stopped for meta-service test

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17192)
<!-- Reviewable:end -->
