### PR TITLE
chore: bring back function `set_cache_capacity`

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -150,6 +150,9 @@ data_path = "./.databend/stateless_test_data"
 # use "disk" to enabled disk cache
 data_cache_storage = "none"
 
+
+table_meta_snapshot_count = 1
+
 [cache.disk]
 # cache path
 path = "./.databend/_cache"

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -150,9 +150,6 @@ data_path = "./.databend/stateless_test_data"
 # use "disk" to enabled disk cache
 data_cache_storage = "none"
 
-
-table_meta_snapshot_count = 1
-
 [cache.disk]
 # cache path
 path = "./.databend/_cache"

--- a/src/common/cache/src/cache.rs
+++ b/src/common/cache/src/cache.rs
@@ -72,6 +72,10 @@ pub trait Cache<K: Eq + Hash + MemSized, V: MemSized> {
 
     fn items_capacity(&self) -> u64;
 
+    fn set_bytes_capacity(&mut self, capacity: u64);
+
+    fn set_items_capacity(&mut self, capacity: u64);
+
     /// Returns the bytes size of all the key-value pairs in the cache.
     fn bytes_size(&self) -> u64;
 

--- a/src/common/cache/src/cache.rs
+++ b/src/common/cache/src/cache.rs
@@ -72,9 +72,9 @@ pub trait Cache<K: Eq + Hash + MemSized, V: MemSized> {
 
     fn items_capacity(&self) -> u64;
 
-    fn set_bytes_capacity(&mut self, capacity: u64);
+    fn set_bytes_capacity(&mut self, capacity: usize);
 
-    fn set_items_capacity(&mut self, capacity: u64);
+    fn set_items_capacity(&mut self, capacity: usize);
 
     /// Returns the bytes size of all the key-value pairs in the cache.
     fn bytes_size(&self) -> u64;

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -301,6 +301,21 @@ impl<K: Eq + Hash + MemSized, V: MemSized> Cache<K, V> for LruCache<K, V> {
         self.max_items as u64
     }
 
+    fn set_bytes_capacity(&mut self, capacity: u64) {
+        // TODO refine this
+        while self.bytes > self.max_bytes || self.map.len() > self.max_items {
+            self.pop_by_policy();
+        }
+        self.max_bytes = capacity as usize;
+    }
+
+    fn set_items_capacity(&mut self, capacity: u64) {
+        while self.bytes > self.max_bytes || self.map.len() > self.max_items {
+            self.pop_by_policy();
+        }
+        self.max_items = capacity as usize;
+    }
+
     /// Returns the bytes size of all the key-value pairs in the cache.
     fn bytes_size(&self) -> u64 {
         self.bytes as u64

--- a/src/common/cache/src/cache/lru.rs
+++ b/src/common/cache/src/cache/lru.rs
@@ -301,19 +301,18 @@ impl<K: Eq + Hash + MemSized, V: MemSized> Cache<K, V> for LruCache<K, V> {
         self.max_items as u64
     }
 
-    fn set_bytes_capacity(&mut self, capacity: u64) {
-        // TODO refine this
-        while self.bytes > self.max_bytes || self.map.len() > self.max_items {
+    fn set_bytes_capacity(&mut self, max_bytes: usize) {
+        while self.bytes > max_bytes || self.map.len() > self.max_items {
             self.pop_by_policy();
         }
-        self.max_bytes = capacity as usize;
+        self.max_bytes = max_bytes;
     }
 
-    fn set_items_capacity(&mut self, capacity: u64) {
-        while self.bytes > self.max_bytes || self.map.len() > self.max_items {
+    fn set_items_capacity(&mut self, max_items: usize) {
+        while self.bytes > self.max_bytes || self.map.len() > max_items {
             self.pop_by_policy();
         }
-        self.max_items = capacity as usize;
+        self.max_items = max_items;
     }
 
     /// Returns the bytes size of all the key-value pairs in the cache.

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -60,7 +60,7 @@ enum ObjectId {
 }
 
 // table functions that need `Super` privilege
-const SYSTEM_TABLE_FUNCTIONS: [&str; 1] = ["fuse_amend"];
+const SYSTEM_TABLE_FUNCTIONS: [&str; 2] = ["fuse_amend", "set_cache_capacity"];
 
 impl PrivilegeAccess {
     pub fn create(ctx: Arc<QueryContext>) -> Box<dyn AccessChecker> {

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -27,6 +27,7 @@ use databend_common_storages_fuse::table_functions::FuseEncodingFunc;
 use databend_common_storages_fuse::table_functions::FuseStatisticsFunc;
 use databend_common_storages_fuse::table_functions::FuseTimeTravelSizeFunc;
 use databend_common_storages_fuse::table_functions::FuseVacuumTemporaryTable;
+use databend_common_storages_fuse::table_functions::SetCacheCapacity;
 use databend_common_storages_fuse::table_functions::TableFunctionTemplate;
 use databend_common_storages_stream::stream_status_table_func::StreamStatusTable;
 use databend_storages_common_table_meta::table_id_ranges::SYS_TBL_FUC_ID_END;
@@ -135,6 +136,14 @@ impl TableFunctionFactory {
             (
                 next_id(),
                 Arc::new(TableFunctionTemplate::<FuseAmendTable>::create),
+            ),
+        );
+
+        creators.insert(
+            "set_cache_capacity".to_string(),
+            (
+                next_id(),
+                Arc::new(TableFunctionTemplate::<SetCacheCapacity>::create),
             ),
         );
 

--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -135,7 +135,7 @@ impl CacheManager {
 
         // Cache of deserialized table data
         let in_memory_table_data_cache =
-            Self::new_named_bytes_cache_slot(MEMORY_CACHE_TABLE_DATA, memory_cache_capacity);
+            Self::new_bytes_cache_slot(MEMORY_CACHE_TABLE_DATA, memory_cache_capacity);
 
         // setup in-memory table meta cache
         if !config.enable_table_meta_cache {
@@ -154,29 +154,29 @@ impl CacheManager {
                 block_meta_cache: CacheSlot::new(None),
             }));
         } else {
-            let table_snapshot_cache = Self::new_named_items_cache_slot(
-                config.table_meta_snapshot_count as usize,
+            let table_snapshot_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_TABLE_SNAPSHOT,
+                config.table_meta_snapshot_count as usize,
             );
-            let table_statistic_cache = Self::new_named_items_cache_slot(
-                config.table_meta_statistic_count as usize,
+            let table_statistic_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_TABLE_STATISTICS,
+                config.table_meta_statistic_count as usize,
             );
-            let compact_segment_info_cache = Self::new_named_bytes_cache_slot(
+            let compact_segment_info_cache = Self::new_bytes_cache_slot(
                 MEMORY_CACHE_COMPACT_SEGMENT_INFO,
                 config.table_meta_segment_bytes as usize,
             );
-            let bloom_index_filter_cache = Self::new_named_bytes_cache_slot(
+            let bloom_index_filter_cache = Self::new_bytes_cache_slot(
                 MEMORY_CACHE_BLOOM_INDEX_FILTER,
                 config.table_bloom_index_filter_size as usize,
             );
-            let bloom_index_meta_cache = Self::new_named_items_cache_slot(
-                config.table_bloom_index_meta_count as usize,
+            let bloom_index_meta_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_BLOOM_INDEX_FILE_META_DATA,
+                config.table_bloom_index_meta_count as usize,
             );
-            let inverted_index_meta_cache = Self::new_named_items_cache_slot(
-                config.inverted_index_meta_count as usize,
+            let inverted_index_meta_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_INVERTED_INDEX_FILE_META_DATA,
+                config.inverted_index_meta_count as usize,
             );
 
             // setup in-memory inverted index filter cache
@@ -187,23 +187,23 @@ impl CacheManager {
             } else {
                 config.inverted_index_filter_size as usize
             };
-            let inverted_index_file_cache = Self::new_named_bytes_cache_slot(
+            let inverted_index_file_cache = Self::new_bytes_cache_slot(
                 MEMORY_CACHE_INVERTED_INDEX_FILE,
                 inverted_index_file_size,
             );
-            let prune_partitions_cache = Self::new_named_items_cache_slot(
-                config.table_prune_partitions_count as usize,
+            let prune_partitions_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_PRUNE_PARTITIONS,
+                config.table_prune_partitions_count as usize,
             );
 
-            let parquet_meta_data_cache = Self::new_named_items_cache_slot(
-                DEFAULT_PARQUET_META_DATA_CACHE_ITEMS,
+            let parquet_meta_data_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_PARQUET_META_DATA,
+                DEFAULT_PARQUET_META_DATA_CACHE_ITEMS,
             );
 
-            let block_meta_cache = Self::new_named_items_cache_slot(
-                config.block_meta_count as usize,
+            let block_meta_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_BLOCK_META,
+                config.block_meta_count as usize,
             );
 
             GlobalInstance::set(Arc::new(Self {
@@ -237,61 +237,41 @@ impl CacheManager {
         match name {
             MEMORY_CACHE_TABLE_DATA => {
                 let cache = &self.in_memory_table_data_cache;
-                Self::set_named_cache_bytes_capacity(cache, new_capacity, name);
+                Self::set_bytes_capacity(cache, new_capacity, name);
             }
             MEMORY_CACHE_PARQUET_META_DATA => {
                 let cache = &self.parquet_meta_data_cache;
-                Self::set_named_cache_items_capacity(cache, new_capacity, name)
+                Self::set_items_capacity(cache, new_capacity, name)
             }
             MEMORY_CACHE_PRUNE_PARTITIONS => {
                 let cache = &self.prune_partitions_cache;
-                Self::set_named_cache_items_capacity(cache, new_capacity, name)
+                Self::set_items_capacity(cache, new_capacity, name)
             }
             MEMORY_CACHE_INVERTED_INDEX_FILE => {
                 let cache = &self.inverted_index_file_cache;
-                Self::set_named_cache_bytes_capacity(cache, new_capacity, name);
+                Self::set_bytes_capacity(cache, new_capacity, name);
             }
             MEMORY_CACHE_INVERTED_INDEX_FILE_META_DATA => {
                 let cache = &self.inverted_index_meta_cache;
-                Self::set_named_cache_items_capacity(cache, new_capacity, name);
+                Self::set_items_capacity(cache, new_capacity, name);
             }
             MEMORY_CACHE_BLOOM_INDEX_FILE_META_DATA => {
-                Self::set_named_cache_items_capacity(
-                    &self.bloom_index_meta_cache,
-                    new_capacity,
-                    name,
-                );
+                Self::set_items_capacity(&self.bloom_index_meta_cache, new_capacity, name);
             }
             MEMORY_CACHE_BLOOM_INDEX_FILTER => {
-                Self::set_named_cache_bytes_capacity(
-                    &self.bloom_index_filter_cache,
-                    new_capacity,
-                    name,
-                );
+                Self::set_bytes_capacity(&self.bloom_index_filter_cache, new_capacity, name);
             }
             MEMORY_CACHE_COMPACT_SEGMENT_INFO => {
-                Self::set_named_cache_bytes_capacity(
-                    &self.compact_segment_info_cache,
-                    new_capacity,
-                    name,
-                );
+                Self::set_bytes_capacity(&self.compact_segment_info_cache, new_capacity, name);
             }
             MEMORY_CACHE_TABLE_STATISTICS => {
-                Self::set_named_cache_items_capacity(
-                    &self.table_statistic_cache,
-                    new_capacity,
-                    name,
-                );
+                Self::set_items_capacity(&self.table_statistic_cache, new_capacity, name);
             }
             MEMORY_CACHE_TABLE_SNAPSHOT => {
-                Self::set_named_cache_items_capacity(
-                    &self.table_snapshot_cache,
-                    new_capacity,
-                    name,
-                );
+                Self::set_items_capacity(&self.table_snapshot_cache, new_capacity, name);
             }
             MEMORY_CACHE_BLOCK_META => {
-                Self::set_named_cache_items_capacity(&self.block_meta_cache, new_capacity, name);
+                Self::set_items_capacity(&self.block_meta_cache, new_capacity, name);
             }
 
             crate::DISK_TABLE_DATA_CACHE_NAME => {
@@ -305,7 +285,7 @@ impl CacheManager {
         Ok(())
     }
 
-    fn set_named_cache_bytes_capacity<T: Into<CacheValue<T>>>(
+    fn set_bytes_capacity<T: Into<CacheValue<T>>>(
         cache: &CacheSlot<InMemoryLruCache<T>>,
         new_capacity: u64,
         name: impl Into<String>,
@@ -313,12 +293,12 @@ impl CacheManager {
         if let Some(v) = cache.get() {
             v.set_bytes_capacity(new_capacity as usize);
         } else {
-            let new_cache = Self::new_named_bytes_cache(name, new_capacity as usize);
+            let new_cache = Self::new_bytes_cache(name, new_capacity as usize);
             cache.set(new_cache)
         }
     }
 
-    fn set_named_cache_items_capacity<T: Into<CacheValue<T>>>(
+    fn set_items_capacity<T: Into<CacheValue<T>>>(
         cache: &CacheSlot<InMemoryLruCache<T>>,
         new_capacity: u64,
         name: impl Into<String>,
@@ -326,7 +306,7 @@ impl CacheManager {
         if let Some(v) = cache.get() {
             v.set_items_capacity(new_capacity as usize);
         } else {
-            let new_cache = Self::new_named_items_cache(new_capacity as usize, name);
+            let new_cache = Self::new_items_cache(name, new_capacity as usize);
             cache.set(new_cache)
         }
     }
@@ -375,16 +355,16 @@ impl CacheManager {
         self.in_memory_table_data_cache.get()
     }
 
-    fn new_named_items_cache_slot<V: Into<CacheValue<V>>>(
-        capacity: usize,
+    fn new_items_cache_slot<V: Into<CacheValue<V>>>(
         name: impl Into<String>,
+        capacity: usize,
     ) -> CacheSlot<InMemoryLruCache<V>> {
-        CacheSlot::new(Self::new_named_items_cache(capacity, name))
+        CacheSlot::new(Self::new_items_cache(name, capacity))
     }
 
-    fn new_named_items_cache<V: Into<CacheValue<V>>>(
-        capacity: usize,
+    fn new_items_cache<V: Into<CacheValue<V>>>(
         name: impl Into<String>,
+        capacity: usize,
     ) -> Option<InMemoryLruCache<V>> {
         match capacity {
             0 => None,
@@ -392,14 +372,14 @@ impl CacheManager {
         }
     }
 
-    fn new_named_bytes_cache_slot<V: Into<CacheValue<V>>>(
+    fn new_bytes_cache_slot<V: Into<CacheValue<V>>>(
         name: impl Into<String>,
         bytes_capacity: usize,
     ) -> CacheSlot<InMemoryLruCache<V>> {
-        CacheSlot::new(Self::new_named_bytes_cache(name, bytes_capacity))
+        CacheSlot::new(Self::new_bytes_cache(name, bytes_capacity))
     }
 
-    fn new_named_bytes_cache<V: Into<CacheValue<V>>>(
+    fn new_bytes_cache<V: Into<CacheValue<V>>>(
         name: impl Into<String>,
         bytes_capacity: usize,
     ) -> Option<InMemoryLruCache<V>> {

--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -256,7 +256,7 @@ impl CacheManager {
                 Self::set_named_cache_items_capacity(cache, new_capacity, name);
             }
             MEMORY_CACHE_BLOOM_INDEX_FILE_META_DATA => {
-                Self::set_named_cache_bytes_capacity(
+                Self::set_named_cache_items_capacity(
                     &self.bloom_index_meta_cache,
                     new_capacity,
                     name,

--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -19,8 +19,10 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_config::CacheConfig;
 use databend_common_config::CacheStorageTypeInnerConfig;
 use databend_common_config::DiskCacheKeyReloadPolicy;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use log::info;
+use parking_lot::RwLock;
 
 use crate::caches::BlockMetaCache;
 use crate::caches::BloomIndexFilterCache;
@@ -40,20 +42,43 @@ use crate::TableDataCacheBuilder;
 
 static DEFAULT_PARQUET_META_DATA_CACHE_ITEMS: usize = 3000;
 
+struct CacheSlot<T> {
+    cache: RwLock<Option<T>>,
+}
+
+impl<T> CacheSlot<T> {
+    fn new(t: Option<T>) -> CacheSlot<T> {
+        CacheSlot {
+            cache: RwLock::new(t),
+        }
+    }
+
+    fn set(&self, t: Option<T>) {
+        let mut guard = self.cache.write();
+        *guard = t
+    }
+}
+
+impl<T: Clone> CacheSlot<T> {
+    fn get(&self) -> Option<T> {
+        self.cache.read().clone()
+    }
+}
+
 /// Where all the caches reside
 pub struct CacheManager {
-    table_snapshot_cache: Option<TableSnapshotCache>,
-    table_statistic_cache: Option<TableSnapshotStatisticCache>,
-    compact_segment_info_cache: Option<CompactSegmentInfoCache>,
-    bloom_index_filter_cache: Option<BloomIndexFilterCache>,
-    bloom_index_meta_cache: Option<BloomIndexMetaCache>,
-    inverted_index_meta_cache: Option<InvertedIndexMetaCache>,
-    inverted_index_file_cache: Option<InvertedIndexFileCache>,
-    prune_partitions_cache: Option<PrunePartitionsCache>,
-    parquet_meta_data_cache: Option<ParquetMetaDataCache>,
-    table_data_cache: Option<TableDataCache>,
-    in_memory_table_data_cache: Option<ColumnArrayCache>,
-    block_meta_cache: Option<BlockMetaCache>,
+    table_snapshot_cache: CacheSlot<TableSnapshotCache>,
+    table_statistic_cache: CacheSlot<TableSnapshotStatisticCache>,
+    compact_segment_info_cache: CacheSlot<CompactSegmentInfoCache>,
+    bloom_index_filter_cache: CacheSlot<BloomIndexFilterCache>,
+    bloom_index_meta_cache: CacheSlot<BloomIndexMetaCache>,
+    inverted_index_meta_cache: CacheSlot<InvertedIndexMetaCache>,
+    inverted_index_file_cache: CacheSlot<InvertedIndexFileCache>,
+    prune_partitions_cache: CacheSlot<PrunePartitionsCache>,
+    parquet_meta_data_cache: CacheSlot<ParquetMetaDataCache>,
+    table_data_cache: CacheSlot<TableDataCache>,
+    in_memory_table_data_cache: CacheSlot<ColumnArrayCache>,
+    block_meta_cache: CacheSlot<BlockMetaCache>,
 }
 
 impl CacheManager {
@@ -66,7 +91,7 @@ impl CacheManager {
         // setup table data cache
         let table_data_cache = {
             match config.data_cache_storage {
-                CacheStorageTypeInnerConfig::None => None,
+                CacheStorageTypeInnerConfig::None => CacheSlot::new(None),
                 CacheStorageTypeInnerConfig::Disk => {
                     let real_disk_cache_root = PathBuf::from(&config.disk_cache_config.path)
                         .join(tenant_id.into())
@@ -110,46 +135,46 @@ impl CacheManager {
 
         // Cache of deserialized table data
         let in_memory_table_data_cache =
-            Self::new_named_bytes_cache(MEMORY_CACHE_TABLE_DATA, memory_cache_capacity);
+            Self::new_named_bytes_cache_slot(MEMORY_CACHE_TABLE_DATA, memory_cache_capacity);
 
         // setup in-memory table meta cache
         if !config.enable_table_meta_cache {
             GlobalInstance::set(Arc::new(Self {
-                table_snapshot_cache: None,
-                compact_segment_info_cache: None,
-                bloom_index_filter_cache: None,
-                bloom_index_meta_cache: None,
-                inverted_index_meta_cache: None,
-                inverted_index_file_cache: None,
-                prune_partitions_cache: None,
-                parquet_meta_data_cache: None,
-                table_statistic_cache: None,
+                table_snapshot_cache: CacheSlot::new(None),
+                compact_segment_info_cache: CacheSlot::new(None),
+                bloom_index_filter_cache: CacheSlot::new(None),
+                bloom_index_meta_cache: CacheSlot::new(None),
+                inverted_index_meta_cache: CacheSlot::new(None),
+                inverted_index_file_cache: CacheSlot::new(None),
+                prune_partitions_cache: CacheSlot::new(None),
+                parquet_meta_data_cache: CacheSlot::new(None),
+                table_statistic_cache: CacheSlot::new(None),
                 table_data_cache,
                 in_memory_table_data_cache,
-                block_meta_cache: None,
+                block_meta_cache: CacheSlot::new(None),
             }));
         } else {
-            let table_snapshot_cache = Self::new_named_items_cache(
+            let table_snapshot_cache = Self::new_named_items_cache_slot(
                 config.table_meta_snapshot_count as usize,
                 MEMORY_CACHE_TABLE_SNAPSHOT,
             );
-            let table_statistic_cache = Self::new_named_items_cache(
+            let table_statistic_cache = Self::new_named_items_cache_slot(
                 config.table_meta_statistic_count as usize,
                 MEMORY_CACHE_TABLE_STATISTICS,
             );
-            let compact_segment_info_cache = Self::new_named_bytes_cache(
+            let compact_segment_info_cache = Self::new_named_bytes_cache_slot(
                 MEMORY_CACHE_COMPACT_SEGMENT_INFO,
                 config.table_meta_segment_bytes as usize,
             );
-            let bloom_index_filter_cache = Self::new_named_bytes_cache(
+            let bloom_index_filter_cache = Self::new_named_bytes_cache_slot(
                 MEMORY_CACHE_BLOOM_INDEX_FILTER,
                 config.table_bloom_index_filter_size as usize,
             );
-            let bloom_index_meta_cache = Self::new_named_items_cache(
+            let bloom_index_meta_cache = Self::new_named_items_cache_slot(
                 config.table_bloom_index_meta_count as usize,
                 MEMORY_CACHE_BLOOM_INDEX_FILE_META_DATA,
             );
-            let inverted_index_meta_cache = Self::new_named_items_cache(
+            let inverted_index_meta_cache = Self::new_named_items_cache_slot(
                 config.inverted_index_meta_count as usize,
                 MEMORY_CACHE_INVERTED_INDEX_FILE_META_DATA,
             );
@@ -162,21 +187,21 @@ impl CacheManager {
             } else {
                 config.inverted_index_filter_size as usize
             };
-            let inverted_index_file_cache = Self::new_named_bytes_cache(
+            let inverted_index_file_cache = Self::new_named_bytes_cache_slot(
                 MEMORY_CACHE_INVERTED_INDEX_FILE,
                 inverted_index_file_size,
             );
-            let prune_partitions_cache = Self::new_named_items_cache(
+            let prune_partitions_cache = Self::new_named_items_cache_slot(
                 config.table_prune_partitions_count as usize,
                 MEMORY_CACHE_PRUNE_PARTITIONS,
             );
 
-            let parquet_meta_data_cache = Self::new_named_items_cache(
+            let parquet_meta_data_cache = Self::new_named_items_cache_slot(
                 DEFAULT_PARQUET_META_DATA_CACHE_ITEMS,
                 MEMORY_CACHE_PARQUET_META_DATA,
             );
 
-            let block_meta_cache = Self::new_named_items_cache(
+            let block_meta_cache = Self::new_named_items_cache_slot(
                 config.block_meta_count as usize,
                 MEMORY_CACHE_BLOCK_META,
             );
@@ -205,54 +230,159 @@ impl CacheManager {
     }
 
     pub fn get_table_snapshot_cache(&self) -> Option<TableSnapshotCache> {
-        self.table_snapshot_cache.clone()
+        self.table_snapshot_cache.get()
+    }
+
+    pub fn set_cache_capacity(&self, name: &str, new_capacity: u64) -> Result<()> {
+        match name {
+            MEMORY_CACHE_TABLE_DATA => {
+                let cache = &self.in_memory_table_data_cache;
+                Self::set_named_cache_bytes_capacity(cache, new_capacity, name);
+            }
+            MEMORY_CACHE_PARQUET_META_DATA => {
+                let cache = &self.parquet_meta_data_cache;
+                Self::set_named_cache_items_capacity(cache, new_capacity, name)
+            }
+            MEMORY_CACHE_PRUNE_PARTITIONS => {
+                let cache = &self.prune_partitions_cache;
+                Self::set_named_cache_items_capacity(cache, new_capacity, name)
+            }
+            MEMORY_CACHE_INVERTED_INDEX_FILE => {
+                let cache = &self.inverted_index_file_cache;
+                Self::set_named_cache_bytes_capacity(cache, new_capacity, name);
+            }
+            MEMORY_CACHE_INVERTED_INDEX_FILE_META_DATA => {
+                let cache = &self.inverted_index_meta_cache;
+                Self::set_named_cache_items_capacity(cache, new_capacity, name);
+            }
+            MEMORY_CACHE_BLOOM_INDEX_FILE_META_DATA => {
+                Self::set_named_cache_bytes_capacity(
+                    &self.bloom_index_meta_cache,
+                    new_capacity,
+                    name,
+                );
+            }
+            MEMORY_CACHE_BLOOM_INDEX_FILTER => {
+                Self::set_named_cache_bytes_capacity(
+                    &self.bloom_index_filter_cache,
+                    new_capacity,
+                    name,
+                );
+            }
+            MEMORY_CACHE_COMPACT_SEGMENT_INFO => {
+                Self::set_named_cache_bytes_capacity(
+                    &self.compact_segment_info_cache,
+                    new_capacity,
+                    name,
+                );
+            }
+            MEMORY_CACHE_TABLE_STATISTICS => {
+                Self::set_named_cache_items_capacity(
+                    &self.table_statistic_cache,
+                    new_capacity,
+                    name,
+                );
+            }
+            MEMORY_CACHE_TABLE_SNAPSHOT => {
+                Self::set_named_cache_items_capacity(
+                    &self.table_snapshot_cache,
+                    new_capacity,
+                    name,
+                );
+            }
+            MEMORY_CACHE_BLOCK_META => {
+                Self::set_named_cache_items_capacity(&self.block_meta_cache, new_capacity, name);
+            }
+
+            crate::DISK_TABLE_DATA_CACHE_NAME => {
+                return Err(ErrorCode::BadArguments(format!(
+                    "set capacity of cache {} is not allowed",
+                    name
+                )));
+            }
+            _ => return Err(ErrorCode::BadArguments(format!("cache {} not found", name))),
+        }
+        Ok(())
+    }
+
+    fn set_named_cache_bytes_capacity<T: Into<CacheValue<T>>>(
+        cache: &CacheSlot<InMemoryLruCache<T>>,
+        new_capacity: u64,
+        name: impl Into<String>,
+    ) {
+        if let Some(v) = cache.get() {
+            v.set_bytes_capacity(new_capacity as usize);
+        } else {
+            let new_cache = Self::new_named_bytes_cache(name, new_capacity as usize);
+            cache.set(new_cache)
+        }
+    }
+
+    fn set_named_cache_items_capacity<T: Into<CacheValue<T>>>(
+        cache: &CacheSlot<InMemoryLruCache<T>>,
+        new_capacity: u64,
+        name: impl Into<String>,
+    ) {
+        if let Some(v) = cache.get() {
+            v.set_items_capacity(new_capacity as usize);
+        } else {
+            let new_cache = Self::new_named_items_cache(new_capacity as usize, name);
+            cache.set(new_cache)
+        }
     }
 
     pub fn get_block_meta_cache(&self) -> Option<BlockMetaCache> {
-        self.block_meta_cache.clone()
+        self.block_meta_cache.get()
     }
 
     pub fn get_table_snapshot_statistics_cache(&self) -> Option<TableSnapshotStatisticCache> {
-        self.table_statistic_cache.clone()
+        self.table_statistic_cache.get()
     }
 
     pub fn get_table_segment_cache(&self) -> Option<CompactSegmentInfoCache> {
-        self.compact_segment_info_cache.clone()
+        self.compact_segment_info_cache.get()
     }
 
     pub fn get_bloom_index_filter_cache(&self) -> Option<BloomIndexFilterCache> {
-        self.bloom_index_filter_cache.clone()
+        self.bloom_index_filter_cache.get()
     }
 
     pub fn get_bloom_index_meta_cache(&self) -> Option<BloomIndexMetaCache> {
-        self.bloom_index_meta_cache.clone()
+        self.bloom_index_meta_cache.get()
     }
 
     pub fn get_inverted_index_meta_cache(&self) -> Option<InvertedIndexMetaCache> {
-        self.inverted_index_meta_cache.clone()
+        self.inverted_index_meta_cache.get()
     }
 
     pub fn get_inverted_index_file_cache(&self) -> Option<InvertedIndexFileCache> {
-        self.inverted_index_file_cache.clone()
+        self.inverted_index_file_cache.get()
     }
 
     pub fn get_prune_partitions_cache(&self) -> Option<PrunePartitionsCache> {
-        self.prune_partitions_cache.clone()
+        self.prune_partitions_cache.get()
     }
 
     pub fn get_parquet_meta_data_cache(&self) -> Option<ParquetMetaDataCache> {
-        self.parquet_meta_data_cache.clone()
+        self.parquet_meta_data_cache.get()
     }
 
     pub fn get_table_data_cache(&self) -> Option<TableDataCache> {
-        self.table_data_cache.clone()
+        self.table_data_cache.get()
     }
 
     pub fn get_table_data_array_cache(&self) -> Option<ColumnArrayCache> {
-        self.in_memory_table_data_cache.clone()
+        self.in_memory_table_data_cache.get()
     }
 
-    pub fn new_named_items_cache<V: Into<CacheValue<V>>>(
+    fn new_named_items_cache_slot<V: Into<CacheValue<V>>>(
+        capacity: usize,
+        name: impl Into<String>,
+    ) -> CacheSlot<InMemoryLruCache<V>> {
+        CacheSlot::new(Self::new_named_items_cache(capacity, name))
+    }
+
+    fn new_named_items_cache<V: Into<CacheValue<V>>>(
         capacity: usize,
         name: impl Into<String>,
     ) -> Option<InMemoryLruCache<V>> {
@@ -260,6 +390,13 @@ impl CacheManager {
             0 => None,
             _ => Some(InMemoryLruCache::with_items_capacity(name.into(), capacity)),
         }
+    }
+
+    fn new_named_bytes_cache_slot<V: Into<CacheValue<V>>>(
+        name: impl Into<String>,
+        bytes_capacity: usize,
+    ) -> CacheSlot<InMemoryLruCache<V>> {
+        CacheSlot::new(Self::new_named_bytes_cache(name, bytes_capacity))
     }
 
     fn new_named_bytes_cache<V: Into<CacheValue<V>>>(
@@ -281,7 +418,7 @@ impl CacheManager {
         disk_cache_bytes_size: usize,
         disk_cache_key_reload_policy: DiskCacheKeyReloadPolicy,
         sync_data: bool,
-    ) -> Result<Option<TableDataCache>> {
+    ) -> Result<CacheSlot<TableDataCache>> {
         if disk_cache_bytes_size > 0 {
             let cache_holder = TableDataCacheBuilder::new_table_data_disk_cache(
                 path,
@@ -290,9 +427,9 @@ impl CacheManager {
                 disk_cache_key_reload_policy,
                 sync_data,
             )?;
-            Ok(Some(cache_holder))
+            Ok(CacheSlot::new(Some(cache_holder)))
         } else {
-            Ok(None)
+            Ok(CacheSlot::new(None))
         }
     }
 }

--- a/src/query/storages/common/cache/src/providers/memory_cache.rs
+++ b/src/query/storages/common/cache/src/providers/memory_cache.rs
@@ -30,14 +30,12 @@ pub struct InMemoryLruCache<V: Into<CacheValue<V>>> {
 impl<V: Into<CacheValue<V>>> InMemoryLruCache<V> {
     pub fn set_bytes_capacity(&self, capacity: usize) {
         let mut cache = self.inner.write();
-        // TODO no as please
-        cache.set_bytes_capacity(capacity as u64);
+        cache.set_bytes_capacity(capacity);
     }
 
     pub fn set_items_capacity(&self, capacity: usize) {
         let mut cache = self.inner.write();
-        // TODO no as please
-        cache.set_items_capacity(capacity as u64);
+        cache.set_items_capacity(capacity);
     }
 }
 

--- a/src/query/storages/common/cache/src/providers/memory_cache.rs
+++ b/src/query/storages/common/cache/src/providers/memory_cache.rs
@@ -27,6 +27,20 @@ pub struct InMemoryLruCache<V: Into<CacheValue<V>>> {
     inner: Arc<RwLock<LruCache<String, CacheValue<V>>>>,
 }
 
+impl<V: Into<CacheValue<V>>> InMemoryLruCache<V> {
+    pub fn set_bytes_capacity(&self, capacity: usize) {
+        let mut cache = self.inner.write();
+        // TODO no as please
+        cache.set_bytes_capacity(capacity as u64);
+    }
+
+    pub fn set_items_capacity(&self, capacity: usize) {
+        let mut cache = self.inner.write();
+        // TODO no as please
+        cache.set_items_capacity(capacity as u64);
+    }
+}
+
 impl<V: Into<CacheValue<V>>> Clone for InMemoryLruCache<V> {
     fn clone(&self) -> Self {
         Self {
@@ -84,10 +98,12 @@ mod impls {
             let mut guard = self.inner.write();
             match guard.get(k.as_ref()) {
                 None => {
+                    // TODO move these out lock
                     metrics_inc_cache_miss_count(1, &self.name);
                     None
                 }
                 Some(cached_value) => {
+                    // TODO move these out of lock
                     metrics_inc_cache_hit_count(1, &self.name);
                     Some(cached_value.get_inner())
                 }

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -26,6 +26,8 @@ mod fuse_time_travel_size;
 mod fuse_vacuum_temporary_table;
 mod table_args;
 
+mod set_cache_capacity;
+
 pub use clustering_information::ClusteringInformationFunc;
 pub use clustering_statistics::ClusteringStatisticsFunc;
 use databend_common_catalog::table_args::TableArgs;

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -45,4 +45,5 @@ pub use fuse_statistic::FuseStatisticsFunc;
 pub use fuse_time_travel_size::FuseTimeTravelSize;
 pub use fuse_time_travel_size::FuseTimeTravelSizeFunc;
 pub use fuse_vacuum_temporary_table::FuseVacuumTemporaryTable;
+pub use set_cache_capacity::SetCacheCapacity;
 pub use table_args::*;

--- a/src/query/storages/fuse/src/table_functions/set_cache_capacity.rs
+++ b/src/query/storages/fuse/src/table_functions/set_cache_capacity.rs
@@ -1,0 +1,100 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
+use databend_common_expression::types::StringType;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchemaRef;
+use databend_common_expression::TableSchemaRefExt;
+use databend_storages_common_cache::CacheManager;
+
+use crate::table_functions::string_literal;
+use crate::table_functions::string_value;
+use crate::table_functions::SimpleTableFunc;
+use crate::table_functions::TableArgs;
+
+#[derive(Clone)]
+pub struct SetCapacity {
+    cache_name: String,
+    capacity: u64,
+}
+
+impl From<&SetCapacity> for TableArgs {
+    fn from(value: &SetCapacity) -> Self {
+        TableArgs::new_positioned(vec![
+            string_literal(&value.cache_name),
+            string_literal(&value.capacity.to_string()),
+        ])
+    }
+}
+
+pub struct SetCacheCapacity {
+    operation: SetCapacity,
+}
+#[async_trait::async_trait]
+impl SimpleTableFunc for SetCacheCapacity {
+    fn table_args(&self) -> Option<TableArgs> {
+        Some((&self.operation).into())
+    }
+
+    fn schema(&self) -> TableSchemaRef {
+        TableSchemaRefExt::create(vec![
+            TableField::new("node", TableDataType::String),
+            TableField::new("result", TableDataType::String),
+        ])
+    }
+
+    fn is_local_func(&self) -> bool {
+        // cache operation needs to be broadcast to all nodes
+        false
+    }
+
+    async fn apply(
+        &self,
+        ctx: &Arc<dyn TableContext>,
+        _plan: &DataSourcePlan,
+    ) -> Result<Option<DataBlock>> {
+        let cache_mgr = CacheManager::instance();
+        let op = &self.operation;
+        cache_mgr.set_cache_capacity(&op.cache_name, op.capacity)?;
+
+        let node = vec![ctx.get_cluster().local_id.clone()];
+        let res = vec!["Ok".to_owned()];
+
+        Ok(Some(DataBlock::new_from_columns(vec![
+            StringType::from_data(node),
+            StringType::from_data(res),
+        ])))
+    }
+
+    fn create(_func_name: &str, table_args: TableArgs) -> Result<Self>
+    where Self: Sized {
+        let args = table_args.expect_all_positioned("", Some(2))?;
+        let cache_name = string_value(&args[0])?;
+        let capacity = string_value(&args[1])?.parse::<u64>()?;
+
+        let operation = SetCapacity {
+            cache_name,
+            capacity,
+        };
+        Ok(Self { operation })
+    }
+}

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0043_set_cache_cap.sql 
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0043_set_cache_cap.sql 
@@ -1,0 +1,17 @@
+statement ok
+create or replace database db_09_0041;
+
+statement ok
+use db_09_0041;
+
+# By default, memory_cache_block_meta is disabled,
+# let's enable it by setting a non-zero capacity
+statement ok
+call system$set_cache_capacity('memory_cache_block_meta', 1000);
+
+# check cache "memory_cache_block_meta" exists
+
+query II
+select count()>=1 from system.caches where name = 'memory_cache_block_meta' and capacity = 1000;
+----
+1

--- a/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.result
+++ b/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.result
@@ -1,0 +1,2 @@
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]
+Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]

--- a/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.result
+++ b/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.result
@@ -1,2 +1,2 @@
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]
-Error: APIError: ResponseError with 1063: Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]
+Error: APIError: QueryFailed: [1063]Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]
+Error: APIError: QueryFailed: [1063]Permission denied: privilege [Super] is required to invoke table function [set_cache_capacity] for user 'test'@'%' with roles [public]

--- a/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.sh
+++ b/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+echo "create user if not exists test identified by 'test'"|$BENDSQL_CLIENT_CONNECT
+
+export TEST_NON_PRIVILEGED_USER_CONNECT="bendsql --user=test --password=test --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
+
+echo "call system\$set_cache_capacity('memory_cache_block_meta', 100)" | $TEST_NON_PRIVILEGED_USER_CONNECT
+
+echo "select * from set_cache_capacity('memory_cache_block_meta', '100')" | $TEST_NON_PRIVILEGED_USER_CONNECT
+
+# CI will check $? of this script, and think it is [FAIL] if $? is non-zero,
+exit 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

bring back function `system$set_cache_capacity`  (https://github.com/databendlabs/databend/pull/16016)

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17196)
<!-- Reviewable:end -->
