### PR TITLE
chore: Fix warning for backtrace while compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,10 @@ async-stream = "0.3.3"
 async-trait = { version = "0.1.77" }
 backoff = "0.4" # FIXME: use backon to replace this.
 backon = "1"
-backtrace = "0.3.73"
+backtrace = { version = "0.3.73", features = [
+    "std",
+    "serialize-serde",
+] }
 base64 = "0.22"
 bincode = { version = "2.0.0-rc.3", features = ["serde", "std", "alloc"] }
 bincode_v1 = { package = "bincode", version = "1.3.3" }
@@ -631,10 +634,7 @@ arrow-udf-python = { git = "https://github.com/arrow-udf/arrow-udf", rev = "ade8
 arrow-udf-wasm = { git = "https://github.com/arrow-udf/arrow-udf", rev = "ade868f" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
-backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be", features = [
-    "std",
-    "serialize-serde",
-] }
+backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "3038c145" }
 ethnum = { git = "https://github.com/datafuse-extras/ethnum-rs", rev = "4cb05f1" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

As title.

Fix the following warning:

```
warning: patch for `backtrace` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Not needed.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17204)
<!-- Reviewable:end -->
