### PR TITLE
fix(query): stick the created_by infos in parquet writer

### DIFF
--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -14,6 +14,7 @@
 
 use std::any::Any;
 use std::collections::VecDeque;
+use std::fmt::format;
 use std::mem;
 use std::sync::Arc;
 
@@ -87,8 +88,9 @@ fn create_writer(
         DATABEND_SEMVER.pre.as_str()
     );
 
-    if create_by.len() > CREATE_BY_LEN {
-        create_by.truncate(CREATE_BY_LEN);
+    if create_by.len() != CREATE_BY_LEN {
+        create_by = format!("{:.<24}", create_by);
+        create_by.truncate(24);
     }
 
     let props = WriterProperties::builder()

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -71,7 +71,7 @@ pub struct ParquetFileWriter {
 const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
 // this is number of rows, not size
 const MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
-const VERSION_LEN: usize = 15; // "1.2.333-nightly".len();
+const CREATE_BY_LEN: usize = 24; // "Databend 1.2.333-nightly".len();
 
 fn create_writer(
     arrow_schema: Arc<Schema>,
@@ -87,8 +87,8 @@ fn create_writer(
         DATABEND_SEMVER.pre.as_str()
     );
 
-    if create_by.len() != VERSION_LEN {
-        create_by = format!("{:.<15}", create_by);
+    if create_by.len() != CREATE_BY_LEN {
+        create_by = format!("{:.<24}", create_by);
     }
 
     let props = WriterProperties::builder()

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -71,11 +71,26 @@ pub struct ParquetFileWriter {
 const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
 // this is number of rows, not size
 const MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
+const VERSION_LEN: usize = 15; // "1.2.333-nightly".len();
 
 fn create_writer(
     arrow_schema: Arc<Schema>,
     targe_file_size: Option<usize>,
 ) -> Result<ArrowWriter<Vec<u8>>> {
+    // example:  1.2.333-nightly
+    // tags may contain other items like `1.2.680-p2`, we will fill it with `1.2.680-p2.....`
+    let mut create_by = format!(
+        "Databend {}.{}.{}-{:.<7}",
+        DATABEND_SEMVER.major,
+        DATABEND_SEMVER.minor,
+        DATABEND_SEMVER.patch,
+        DATABEND_SEMVER.pre.as_str()
+    );
+
+    if create_by.len() != VERSION_LEN {
+        create_by = format!("{:.<15}", create_by);
+    }
+
     let props = WriterProperties::builder()
         .set_compression(TableCompression::Zstd.into())
         .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
@@ -83,7 +98,7 @@ fn create_writer(
         .set_dictionary_enabled(false)
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_bloom_filter_enabled(false)
-        .set_created_by(format!("Databend {}", *DATABEND_SEMVER))
+        .set_created_by(create_by)
         .build();
     let buf_size = match targe_file_size {
         Some(n) if n < MAX_BUFFER_SIZE => n,

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -87,8 +87,8 @@ fn create_writer(
         DATABEND_SEMVER.pre.as_str()
     );
 
-    if create_by.len() != CREATE_BY_LEN {
-        create_by = format!("{:.<24}", create_by);
+    if create_by.len() > CREATE_BY_LEN {
+        create_by.truncate(CREATE_BY_LEN);
     }
 
     let props = WriterProperties::builder()

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -14,7 +14,6 @@
 
 use std::any::Any;
 use std::collections::VecDeque;
-use std::fmt::format;
 use std::mem;
 use std::sync::Arc;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): stick the created_by infos in parquet writer

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17220)
<!-- Reviewable:end -->
