### PR TITLE
fix: Upload to stage in streaming way instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.3"
 source = "git+https://github.com/datafuse-extras/async-compression?rev=dc81082#dc8108229e3a0288ee9097c986b89a90788fe9f6"
@@ -4979,6 +4992,7 @@ dependencies = [
  "arrow-udf-wasm",
  "async-backtrace",
  "async-channel 1.9.0",
+ "async-compat",
  "async-recursion",
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,7 @@ async-compression = { git = "https://github.com/datafuse-extras/async-compressio
 async-recursion = "1.1.1"
 async-stream = "0.3.3"
 async-trait = { version = "0.1.77" }
+async-compat = { version = "0.2" }
 backoff = "0.4" # FIXME: use backon to replace this.
 backon = "1"
 backtrace = { version = "0.3.73", features = [

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -41,6 +41,7 @@ async-channel = { workspace = true }
 async-recursion = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+async-compat = { workspace = true }
 backoff = { workspace = true, features = ["futures", "tokio"] }
 backon = { workspace = true }
 base64 = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Part of https://github.com/databendlabs/databend/issues/17218

We used to load the entire file into memory which could lead to oom or unexpected timeout. This PR will fix it.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
