### PR TITLE
chore: enable sort spill in recluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,7 +4160,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "siphasher",
- "sys-info",
  "tantivy",
  "tantivy-common",
  "tantivy-fst",

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
@@ -79,7 +79,7 @@ impl AccumulatingTransform for BlockCompactNoSplitBuilder {
 
     fn transform(&mut self, data: DataBlock) -> Result<Vec<DataBlock>> {
         self.accumulated_rows += data.num_rows();
-        self.accumulated_bytes += data.memory_size();
+        self.accumulated_bytes += crate::processors::memory_size(&data);
         if !self
             .thresholds
             .check_large_enough(self.accumulated_rows, self.accumulated_bytes)

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_dummy.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_dummy.rs
@@ -27,7 +27,6 @@ use crate::processors::transforms::Transformer;
 pub struct TransformDummy;
 
 impl TransformDummy {
-    #[allow(dead_code)]
     pub fn create(input: Arc<InputPort>, output: Arc<OutputPort>) -> ProcessorPtr {
         ProcessorPtr::create(Transformer::create(input, output, TransformDummy {}))
     }

--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -203,6 +203,7 @@ async fn compact_table(
                     &compact_target.database,
                     &compact_target.table,
                 )?;
+                ctx.set_enable_sort_spill(false);
                 let recluster = RelOperator::Recluster(Recluster {
                     catalog: compact_target.catalog,
                     database: compact_target.database,

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -154,7 +154,6 @@ impl PipelineBuilder {
                 let sort_block_size =
                     block_thresholds.calc_rows_per_block(task.total_bytes, task.total_rows);
 
-                self.ctx.set_enable_sort_spill(false);
                 let sort_pipeline_builder =
                     SortPipelineBuilder::create(self.ctx.clone(), schema, Arc::new(sort_descs))?
                         .with_block_size_hit(sort_block_size)

--- a/src/query/sql/src/executor/physical_plan.rs
+++ b/src/query/sql/src/executor/physical_plan.rs
@@ -584,8 +584,8 @@ impl PhysicalPlan {
             | PhysicalPlan::CompactSource(_)
             | PhysicalPlan::ReplaceAsyncSourcer(_)
             | PhysicalPlan::Recluster(_)
-            | PhysicalPlan::HilbertSerialize(_)
             | PhysicalPlan::RecursiveCteScan(_) => Box::new(std::iter::empty()),
+            PhysicalPlan::HilbertSerialize(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::Filter(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::EvalScalar(plan) => Box::new(std::iter::once(plan.input.as_ref())),
             PhysicalPlan::AggregateExpand(plan) => Box::new(std::iter::once(plan.input.as_ref())),

--- a/src/query/sql/src/executor/physical_plan_visitor.rs
+++ b/src/query/sql/src/executor/physical_plan_visitor.rs
@@ -128,7 +128,12 @@ pub trait PhysicalPlanReplacer {
     }
 
     fn replace_hilbert_serialize(&mut self, plan: &HilbertSerialize) -> Result<PhysicalPlan> {
-        Ok(PhysicalPlan::HilbertSerialize(Box::new(plan.clone())))
+        let input = self.replace(&plan.input)?;
+        Ok(PhysicalPlan::HilbertSerialize(Box::new(HilbertSerialize {
+            plan_id: plan.plan_id,
+            input: Box::new(input),
+            table_info: plan.table_info.clone(),
+        })))
     }
 
     fn replace_table_scan(&mut self, plan: &TableScan) -> Result<PhysicalPlan> {

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -67,7 +67,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 siphasher = { workspace = true }
-sys-info = { workspace = true }
 tantivy = { workspace = true }
 tantivy-common = { workspace = true }
 tantivy-fst = { workspace = true }

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -185,7 +185,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
 
                 let mut handlers = Vec::new();
                 for table in tables {
-                    // If db1 is visible, do not means db1.table1 is visible. An user may have a grant about db1.table2, so db1 is visible
+                    // If db1 is visible, do not mean db1.table1 is visible. A user may have a grant about db1.table2, so db1 is visible
                     // for her, but db1.table1 may be not visible. So we need an extra check about table here after db visibility check.
                     let t_id = table.get_id();
                     if visibility_checker.check_table_visibility(

--- a/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.result
@@ -1,7 +1,7 @@
 sample.csv
 Succeeded
 96
-125
+192
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China

--- a/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.result
@@ -1,6 +1,6 @@
 sample.csv
 96
-125
+192
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China

--- a/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.result
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.result
@@ -1,6 +1,6 @@
 sample.csv
 96
-125
+192
 null
 1	'Beijing'	100	China
 2	'Shanghai'	80	China


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. enable sort spill in alter recluster to avoid oom. hook compact keep disable spill.
2. fix hilbert clustering with quoted key bug.
3. Adjusts the Transform Compact operator to exclude null columns when calculating block memory size.
4. FIx hilbert clustering in cluster mode.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17236)
<!-- Reviewable:end -->
