### PR TITLE
feat: orc support fill missing tuple field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10532,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "orc-rust"
 version = "0.5.0"
-source = "git+https://github.com/datafusion-contrib/orc-rust?rev=dfb1ede#dfb1ede8f875566372568346ad47b359e1a9c92a"
+source = "git+https://github.com/youngsofun/orc-rust?rev=6c5ac57#6c5ac578d8790e3f79bde4764ccea7e5e76a0f0d"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -639,7 +639,7 @@ deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "3038c145" }
 ethnum = { git = "https://github.com/datafuse-extras/ethnum-rs", rev = "4cb05f1" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.7" }
-orc-rust = { git = "https://github.com/datafusion-contrib/orc-rust", rev = "dfb1ede" }
+orc-rust = { git = "https://github.com/youngsofun/orc-rust", rev = "6c5ac57" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "6af35a1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370" }

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -67,9 +67,6 @@ impl BlockOperator {
                         None => Ok(input),
                     }
                 } else {
-                    // for (i, c) in input.columns().iter().enumerate() {
-                    //     println!("{i}: {} = {:?}",c.data_type, c.value.index(0))
-                    // }
                     for expr in exprs {
                         let evaluator = Evaluator::new(&input, func_ctx, &BUILTIN_FUNCTIONS);
                         let result = evaluator.run(expr)?;

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -67,6 +67,9 @@ impl BlockOperator {
                         None => Ok(input),
                     }
                 } else {
+                    // for (i, c) in input.columns().iter().enumerate() {
+                    //     println!("{i}: {} = {:?}",c.data_type, c.value.index(0))
+                    // }
                     for expr in exprs {
                         let evaluator = Evaluator::new(&input, func_ctx, &BUILTIN_FUNCTIONS);
                         let result = evaluator.run(expr)?;

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -182,15 +182,12 @@ impl Binder {
             files: stmt.files.clone(),
             pattern,
         };
-        let required_values_schema: DataSchemaRef = Arc::new(
-            match &stmt.dst_columns {
-                Some(cols) => self.schema_project(&table.schema(), cols)?,
-                None => self.schema_project(&table.schema(), &[])?,
-            }
-            .into(),
-        );
+        let stage_schema = match &stmt.dst_columns {
+            Some(cols) => self.schema_project(&table.schema(), cols)?,
+            None => self.schema_project(&table.schema(), &[])?,
+        };
 
-        let stage_schema = infer_table_schema(&required_values_schema)?;
+        let required_values_schema: DataSchemaRef = Arc::new(stage_schema.clone().into());
 
         let default_values = if stage_info.file_format_params.need_field_default() {
             Some(

--- a/src/query/storages/common/stage/src/read/columnar/projection.rs
+++ b/src/query/storages/common/stage/src/read/columnar/projection.rs
@@ -14,9 +14,13 @@
 
 use databend_common_exception::ErrorCode;
 use databend_common_expression::type_check::check_cast;
+use databend_common_expression::type_check::check_function;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberScalar;
 use databend_common_expression::Expr;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
 use databend_common_expression::TableSchemaRef;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::principal::NullAs;
@@ -82,13 +86,126 @@ pub fn project_columnar(
                             &BUILTIN_FUNCTIONS,
                         )?
                     } else {
-                        return Err(ErrorCode::BadDataValueType(format!(
-                            "fail to load file {}: Cannot cast column {} from {:?} to {:?}",
-                            location,
-                            field_name,
-                            from_field.data_type(),
-                            to_field.data_type()
-                        )));
+                        // special cast for tuple type, fill in default values for the missing fields.
+                        match (
+                            from_field.data_type.remove_nullable(),
+                            to_field.data_type.remove_nullable(),
+                        ) {
+                            (
+                                TableDataType::Tuple {
+                                    fields_name: from_fields_name,
+                                    fields_type: from_fields_type,
+                                },
+                                TableDataType::Tuple {
+                                    fields_name: to_fields_name,
+                                    fields_type: to_fields_type,
+                                },
+                            ) => {
+                                println!("tuple: {from_fields_name:?} {from_fields_type:?} to {to_fields_name:?} {to_fields_type:?}");
+                                let mut inner_columns = Vec::with_capacity(to_fields_name.len());
+
+                                for (to_field_name, to_field_type) in
+                                    to_fields_name.iter().zip(to_fields_type.iter())
+                                {
+                                    let inner_column = match from_fields_name
+                                        .iter()
+                                        .position(|k| k == to_field_name)
+                                    {
+                                        Some(idx) => {
+                                            let from_field_type =
+                                                from_fields_type.get(idx).unwrap();
+                                            let tuple_idx = Scalar::Number(NumberScalar::Int64(
+                                                (idx + 1) as i64,
+                                            ));
+                                            let inner_column = check_function(
+                                                None,
+                                                "get",
+                                                &[tuple_idx],
+                                                &[expr.clone()],
+                                                &BUILTIN_FUNCTIONS,
+                                            )?;
+                                            if from_field_type != to_field_type {
+                                                check_cast(
+                                                    None,
+                                                    false,
+                                                    inner_column,
+                                                    &to_field_type.into(),
+                                                    &BUILTIN_FUNCTIONS,
+                                                )?
+                                            } else {
+                                                inner_column
+                                            }
+                                        }
+                                        None => {
+                                            // if inner field not exists, fill default value.
+                                            let data_type: DataType = to_field_type.into();
+                                            let scalar = Scalar::default_value(&data_type);
+                                            Expr::Constant {
+                                                span: None,
+                                                scalar,
+                                                data_type,
+                                            }
+                                        }
+                                    };
+                                    inner_columns.push(inner_column);
+                                }
+                                let tuple_column = check_function(
+                                    None,
+                                    "tuple",
+                                    &[],
+                                    &inner_columns,
+                                    &BUILTIN_FUNCTIONS,
+                                )?;
+                                let tuple_column = if from_field.data_type != to_field.data_type {
+                                    let dest_ty: DataType = (&to_field.data_type).into();
+                                    check_cast(
+                                        None,
+                                        false,
+                                        tuple_column,
+                                        &dest_ty,
+                                        &BUILTIN_FUNCTIONS,
+                                    )?
+                                } else {
+                                    tuple_column
+                                };
+
+                                if from_field.data_type.is_nullable()
+                                    && to_field.data_type.is_nullable()
+                                {
+                                    // add if function to cast null value
+                                    let is_not_null = check_function(
+                                        None,
+                                        "is_not_null",
+                                        &[],
+                                        &[expr.clone()],
+                                        &BUILTIN_FUNCTIONS,
+                                    )?;
+                                    let null_scalar = Expr::Constant {
+                                        span: None,
+                                        scalar: Scalar::Null,
+                                        data_type: DataType::Null,
+                                    };
+                                    check_function(
+                                        None,
+                                        "if",
+                                        &[],
+                                        &[is_not_null, tuple_column, null_scalar],
+                                        &BUILTIN_FUNCTIONS,
+                                    )?
+                                } else {
+                                    tuple_column
+                                }
+                            }
+                            (_, _) => {
+                                return Err(ErrorCode::BadDataValueType(format!(
+                                    "fail to load file {}: Cannot cast column {} from {:?} to {:?}",
+                                    location,
+                                    field_name,
+                                    from_field.data_type(),
+                                    to_field.data_type()
+                                )));
+                            }
+                        }
                     }
                 }
             }

--- a/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
+++ b/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
@@ -106,7 +106,7 @@ impl StripeDecoderForCopy {
                 display_name, id, ..
             } = expr
             {
-                if display_name.starts_with("#!") {
+                if let Some(display_name) = display_name.strip_prefix("#!") {
                     let typs = match field.data_type() {
                         DataType::Nullable(box DataType::Array(box DataType::Nullable(
                             box DataType::Tuple(v),
@@ -116,7 +116,7 @@ impl StripeDecoderForCopy {
                             unreachable!("expect value: array of tuple")
                         }
                     };
-                    let positions = display_name[2..]
+                    let positions = display_name
                         .split(',')
                         .map(|s| s.parse::<i32>().unwrap())
                         .collect::<Vec<i32>>();

--- a/src/query/storages/orc/src/copy_into_table/projection.rs
+++ b/src/query/storages/orc/src/copy_into_table/projection.rs
@@ -19,6 +19,7 @@ use databend_common_expression::Expr;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_app::principal::NullAs;
+use databend_common_meta_app::principal::StageFileFormatType;
 use databend_storages_common_stage::project_columnar;
 
 use crate::hashable_schema::HashableSchema;
@@ -56,6 +57,7 @@ impl ProjectionFactory {
                 &self.default_values,
                 location,
                 false,
+                StageFileFormatType::Orc,
             )?
             .0;
             self.projections.insert(schema.clone(), v.clone());

--- a/src/query/storages/parquet/src/parquet_rs/copy_into_table/reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/copy_into_table/reader.rs
@@ -23,6 +23,7 @@ use databend_common_expression::Expr;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_app::principal::NullAs;
+use databend_common_meta_app::principal::StageFileFormatType;
 use databend_common_storage::parquet_rs::infer_schema_with_extension;
 use databend_storages_common_stage::project_columnar;
 use opendal::Operator;
@@ -88,6 +89,7 @@ impl RowGroupReaderForCopy {
             &default_values,
             location,
             case_sensitive,
+            StageFileFormatType::Parquet,
         )?;
         pushdown_columns.sort();
         let mapping = pushdown_columns

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
@@ -579,6 +579,12 @@ create table t(a int) cluster by (a+rand())
 statement error 1081.*is not deterministic
 create table t(a string) cluster by (a+uuid())
 
+statement ok
+create table tt(a tuple(x int, y int), b string, c int) cluster by (b);
+
+statement ok
+insert into tt(b,c) values ('1',2);
+
 ##################################################
 # table option  `data_retention_period_in_hours` #
 ##################################################


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. temp orc support fill missing tuple field, including `tuple and array(tuple)`
2. speed up orc load by reading each stripe in one IO.
3. fix cluster key bug https://github.com/databendlabs/databend/issues/17251

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17247)
<!-- Reviewable:end -->
