### PR TITLE
fix(query): fix lazy columns missed in constant table scan

### DIFF
--- a/src/query/sql/src/executor/physical_plans/physical_constant_table_scan.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_constant_table_scan.rs
@@ -51,14 +51,10 @@ impl PhysicalPlanBuilder {
         required: ColumnSet,
     ) -> Result<PhysicalPlan> {
         // 1. Prune unused Columns.
-        let mut used: ColumnSet = required.intersection(&scan.columns).cloned().collect();
+        let used: ColumnSet = required.intersection(&scan.columns).cloned().collect();
         let (values, fields) = if used == scan.columns {
             (scan.values.clone(), scan.schema.fields().clone())
         } else {
-            for column in self.metadata.read().clone().lazy_columns() {
-                used.insert(*column);
-            }
-
             let new_scan = scan.prune_columns(used);
             (new_scan.values.clone(), new_scan.schema.fields().clone())
         };

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -170,6 +170,10 @@ impl Metadata {
         self.lazy_columns.extend(indices);
     }
 
+    pub fn clear_lazy_columns(&mut self) {
+        self.lazy_columns.clear();
+    }
+
     pub fn add_non_lazy_columns(&mut self, indices: HashSet<usize>) {
         debug_assert!(indices.iter().all(|i| *i < self.columns.len()));
         self.non_lazy_columns.extend(indices);

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/rule_eliminate_filter.rs
@@ -77,6 +77,12 @@ impl Rule for RuleEliminateFilter {
                 .derive_relational_prop(&RelExpr::with_s_expr(s_expr))?
                 .output_columns
                 .clone();
+
+            {
+                let mut metadata = self.metadata.write();
+                metadata.clear_lazy_columns();
+            }
+
             let metadata = self.metadata.read();
             let mut fields = Vec::with_capacity(output_columns.len());
 

--- a/tests/sqllogictests/suites/query/issues/issue_17158.test
+++ b/tests/sqllogictests/suites/query/issues/issue_17158.test
@@ -1,0 +1,8 @@
+statement ok
+create table tt2 (c0 bool, c1 int);
+
+statement ok
+insert into tt2 values(true, 1),(false, 2),(true, 3);
+
+statement ok
+select null, c0, 30, c1 from tt2 where false order by c0 LIMIT 3 OFFSET 0;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The `build_limit` method of `PhysicalPlanBuilder` excludes lazy columns and adds them back in RowFetch, including the row_id_col in the table scan but not in the constant table scan. So, I directly add the lazy columns to the `output_schema` of the constant table scan.

- fixes: #17158 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17258)
<!-- Reviewable:end -->
