### PR TITLE
fix: vacuum index not work if index is dropped by create or replace

### DIFF
--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -71,6 +71,9 @@ where
     /// Such operations do not have any condition constraints.
     /// For example, a `name -> id` mapping can have a reverse `id -> name` mapping.
     ///
+    /// `mark_delete_records` is used to generate additional key-values for implementing `mark_delete` operation.
+    /// For example, when an index is dropped by `override_exist`,  `__fd_marked_deleted_index/<table_id>/<index_id> -> marked_deleted_index_meta` will be added.
+    ///
     /// If there is already a `name_ident` exists, return the existing id in a `Ok(Err(exist))`.
     /// Otherwise, create `name -> id -> value` and returns the created id in a `Ok(Ok(created))`.
     async fn create_id_value<A, M>(

--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
 use std::future::Future;
 
 use databend_common_meta_app::data_id::DataId;
 use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::primitive::Id;
-use databend_common_meta_app::schema::IndexMeta;
 use databend_common_meta_app::tenant_key::ident::TIdent;
 use databend_common_meta_app::tenant_key::resource::TenantResource;
 use databend_common_meta_app::KeyWithTenant;
@@ -40,7 +38,6 @@ use log::debug;
 use crate::kv_pb_api::KVPbApi;
 use crate::kv_pb_api::UpsertPB;
 use crate::meta_txn_error::MetaTxnError;
-use crate::schema_api_impl::mark_index_as_deleted;
 use crate::txn_backoff::txn_backoff;
 use crate::txn_op_del;
 use crate::util::fetch_id;
@@ -76,15 +73,17 @@ where
     ///
     /// If there is already a `name_ident` exists, return the existing id in a `Ok(Err(exist))`.
     /// Otherwise, create `name -> id -> value` and returns the created id in a `Ok(Ok(created))`.
-    async fn create_id_value<A>(
+    async fn create_id_value<A, M>(
         &self,
         name_ident: &K,
         value: &IdRsc::ValueType,
         override_exist: bool,
         associated_records: A,
+        mark_delete_records: M,
     ) -> Result<Result<DataId<IdRsc>, SeqV<DataId<IdRsc>>>, MetaTxnError>
     where
         A: Fn(DataId<IdRsc>) -> Vec<(String, Vec<u8>)> + Send,
+        M: Fn(DataId<IdRsc>, &IdRsc::ValueType) -> Result<Vec<(String, Vec<u8>)>, MetaError> + Send,
     {
         debug!(name_ident :? =name_ident; "NameIdValueApi: {}", func_name!());
 
@@ -118,13 +117,9 @@ where
                             txn.if_then.push(TxnOp::delete(k));
                         }
 
-                        let index_meta = <dyn Any>::downcast_ref::<IndexMeta>(&seq_meta.data);
-                        if let Some(index_meta) = index_meta {
-                            txn.if_then.push(mark_index_as_deleted(
-                                name_ident.tenant(),
-                                index_meta.table_id,
-                                *seq_id.data,
-                            )?);
+                        let kvs = mark_delete_records(seq_id.data, &seq_meta.data)?;
+                        for (k, v) in kvs {
+                            txn.if_then.push(TxnOp::put(k, v));
                         }
                     } else {
                         return Ok(Err(seq_id));

--- a/src/meta/api/src/schema_api_impl.rs
+++ b/src/meta/api/src/schema_api_impl.rs
@@ -753,12 +753,21 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         let name_ident_raw = serialize_struct(&IndexNameIdentRaw::from(name_ident))?;
 
         let create_res = self
-            .create_id_value(name_ident, meta, overriding, |id| {
-                vec![(
-                    IndexIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
-                    name_ident_raw.clone(),
-                )]
-            })
+            .create_id_value(
+                name_ident,
+                meta,
+                overriding,
+                |id| {
+                    vec![(
+                        IndexIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
+                        name_ident_raw.clone(),
+                    )]
+                },
+                |index_id, value| {
+                    mark_index_as_deleted(name_ident.tenant(), value.table_id, *index_id)
+                        .map(|(k, v)| vec![(k, v)])
+                },
+            )
             .await?;
 
         match create_res {
@@ -802,11 +811,10 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
             txn.if_then.push(TxnOp::delete(
                 IndexIdToNameIdent::new_generic(name_ident.tenant(), seq_id.data).to_string_key(),
             ));
-            txn.if_then.push(mark_index_as_deleted(
-                name_ident.tenant(),
-                seq_meta.data.table_id,
-                *seq_id.data,
-            )?);
+
+            let (key, value) =
+                mark_index_as_deleted(name_ident.tenant(), seq_meta.data.table_id, *seq_id.data)?;
+            txn.if_then.push(TxnOp::put(key, value));
 
             let (succ, _responses) = send_txn(self, txn).await?;
             debug!(key :? =name_ident, id :? =&id_ident,succ = succ; "{}", func_name!());
@@ -2891,12 +2899,18 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         let name_ident_raw = serialize_struct(&CatalogNameIdentRaw::from(name_ident))?;
 
         let res = self
-            .create_id_value(name_ident, meta, false, |id| {
-                vec![(
-                    CatalogIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
-                    name_ident_raw.clone(),
-                )]
-            })
+            .create_id_value(
+                name_ident,
+                meta,
+                false,
+                |id| {
+                    vec![(
+                        CatalogIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
+                        name_ident_raw.clone(),
+                    )]
+                },
+                |_, _| Ok(vec![]),
+            )
             .await?;
 
         Ok(res)
@@ -3010,7 +3024,13 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SchemaApi for KV {
         let name_ident = &req.dictionary_ident;
 
         let create_res = self
-            .create_id_value(name_ident, &req.dictionary_meta, false, |_| vec![])
+            .create_id_value(
+                name_ident,
+                &req.dictionary_meta,
+                false,
+                |_| vec![],
+                |_, _| Ok(vec![]),
+            )
             .await?;
 
         match create_res {
@@ -4173,7 +4193,7 @@ pub fn mark_index_as_deleted(
     tenant: &Tenant,
     table_id: u64,
     index_id: u64,
-) -> Result<TxnOp, MetaError> {
+) -> Result<(String, Vec<u8>), MetaError> {
     let marked_deleted_index_id_ident = MarkedDeletedIndexIdIdent::new_generic(
         tenant,
         MarkedDeletedIndexId::new(table_id, index_id),
@@ -4183,7 +4203,7 @@ pub fn mark_index_as_deleted(
         index_type: MarkedDeletedIndexType::AGGREGATING,
     };
 
-    Ok(TxnOp::put(
+    Ok((
         marked_deleted_index_id_ident.to_string_key(),
         serialize_struct(&marked_deleted_index_meta)?,
     ))

--- a/src/meta/kvapi/src/kvapi/value.rs
+++ b/src/meta/kvapi/src/kvapi/value.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::fmt::Debug;
 
 use crate::kvapi;
 
 /// A value that can be stored in kvapi::KVApi.
-pub trait Value: Debug {
+pub trait Value: Debug + Any {
     type KeyType: kvapi::Key;
 
     /// Return keys this value depends on.

--- a/src/meta/kvapi/src/kvapi/value.rs
+++ b/src/meta/kvapi/src/kvapi/value.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
 use std::fmt::Debug;
 
 use crate::kvapi;
 
 /// A value that can be stored in kvapi::KVApi.
-pub trait Value: Debug + Any {
+pub trait Value: Debug {
     type KeyType: kvapi::Key;
 
     /// Return keys this value depends on.

--- a/src/query/management/src/procedure/procedure_mgr.rs
+++ b/src/query/management/src/procedure/procedure_mgr.rs
@@ -66,12 +66,19 @@ impl ProcedureMgr {
 
         let create_res = self
             .kv_api
-            .create_id_value(name_ident, meta, overriding, |id| {
-                vec![(
-                    ProcedureIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
-                    name_ident_raw.clone(),
-                )]
-            })
+            .create_id_value(
+                name_ident,
+                meta,
+                overriding,
+                |id| {
+                    vec![(
+                        ProcedureIdToNameIdent::new_generic(name_ident.tenant(), id)
+                            .to_string_key(),
+                        name_ident_raw.clone(),
+                    )]
+                },
+                |_, _| Ok(vec![]),
+            )
             .await?;
 
         match create_res {

--- a/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.result
+++ b/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.result
@@ -50,3 +50,4 @@ before vacuum, should be 1 index dir
 >>>> create or replace aggregating index index AS SELECT MIN(a), MAX(b) FROM test_vacuum_drop_aggregating_index.agg;
 after vacuum, should be 0 index dir
 0
+>>>> drop aggregating index index

--- a/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.result
+++ b/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.result
@@ -37,3 +37,16 @@ before vacuum, should be 1 index dir
 after vacuum, should be 0 index dir
 0
 0
+>>>> create or replace database test_vacuum_drop_aggregating_index
+>>>> create or replace table test_vacuum_drop_aggregating_index.agg(a int, b int,c int) 'fs:///tmp/test_vacuum_drop_aggregating_index/'
+>>>> insert into test_vacuum_drop_aggregating_index.agg values (1,1,4), (1,2,1), (1,2,4)
+3
+>>>> CREATE OR REPLACE AGGREGATING INDEX index AS SELECT MIN(a), MAX(b) FROM test_vacuum_drop_aggregating_index.agg;
+>>>> insert into test_vacuum_drop_aggregating_index.agg values (2,2,5)
+1
+>>>> REFRESH AGGREGATING INDEX index;
+before vacuum, should be 1 index dir
+1
+>>>> create or replace aggregating index index AS SELECT MIN(a), MAX(b) FROM test_vacuum_drop_aggregating_index.agg;
+after vacuum, should be 0 index dir
+0

--- a/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
+++ b/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
@@ -118,3 +118,5 @@ stmt "set data_retention_time_in_days=0; select * from fuse_vacuum_drop_aggregat
 
 echo "after vacuum, should be 0 index dir"
 find /tmp/test_vacuum_drop_aggregating_index/"$PREFIX"/_i_a/ -type f | wc -l
+
+stmt "drop aggregating index index"

--- a/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
+++ b/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
@@ -86,3 +86,35 @@ echo "after vacuum, should be 0 index dir"
 
 find /tmp/test_vacuum_drop_aggregating_index/"$PREFIX_1"/_i_a/ -type f | wc -l
 find /tmp/test_vacuum_drop_aggregating_index/"$PREFIX_2"/_i_a/ -type f | wc -l
+
+
+### create or replace index
+
+stmt "create or replace database test_vacuum_drop_aggregating_index"
+
+mkdir -p /tmp/test_vacuum_drop_aggregating_index/
+
+stmt "create or replace table test_vacuum_drop_aggregating_index.agg(a int, b int,c int) 'fs:///tmp/test_vacuum_drop_aggregating_index/'"
+
+
+stmt "insert into test_vacuum_drop_aggregating_index.agg values (1,1,4), (1,2,1), (1,2,4)"
+
+stmt "CREATE OR REPLACE AGGREGATING INDEX index AS SELECT MIN(a), MAX(b) FROM test_vacuum_drop_aggregating_index.agg;"
+
+stmt "insert into test_vacuum_drop_aggregating_index.agg values (2,2,5)"
+
+stmt "REFRESH AGGREGATING INDEX index;"
+
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg') limit 1" | $BENDSQL_CLIENT_CONNECT)
+PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
+
+echo "before vacuum, should be 1 index dir"
+
+ls  /tmp/test_vacuum_drop_aggregating_index/"$PREFIX"/_i_a/ | wc -l
+
+stmt "create or replace aggregating index index AS SELECT MIN(a), MAX(b) FROM test_vacuum_drop_aggregating_index.agg;"
+
+stmt "set data_retention_time_in_days=0; select * from fuse_vacuum_drop_aggregating_index('test_vacuum_drop_aggregating_index','agg')" > /dev/null
+
+echo "after vacuum, should be 0 index dir"
+find /tmp/test_vacuum_drop_aggregating_index/"$PREFIX"/_i_a/ -type f | wc -l


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


The `create or replace index` operation may cause an index to be dropped, and such dropped indexes should also be recorded in `__fd_marked_deleted_index`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17263)
<!-- Reviewable:end -->
