### PR TITLE
refactor: try drop old udf - DON'T MERGE

### DIFF
--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -27,6 +27,7 @@ use databend_common_meta_kvapi::kvapi::DirName;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::MetaError;
+use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
 use futures::TryStreamExt;
 
@@ -155,14 +156,24 @@ impl UdfMgr {
         seq: MatchSeq,
     ) -> Result<Option<SeqV<UserDefinedFunction>>, MetaError> {
         let key = UdfIdent::new(&self.tenant, udf_name);
-        let req = UpsertPB::delete(key).with(seq);
-        let res = self.kv_api.upsert_pb(&req).await?;
-
-        if res.is_changed() {
-            Ok(res.prev)
+        let req = UpsertPB::delete(key.clone()).with(seq);
+        if let Ok(res) = self.kv_api.upsert_pb(&req).await {
+            if res.is_changed() {
+                Ok(res.prev)
+            } else {
+                Ok(None)
+            }
         } else {
+            self.try_drop_old_udf(&key).await?;
             Ok(None)
         }
+    }
+
+    #[async_backtrace::framed]
+    #[fastrace::trace]
+    pub async fn try_drop_old_udf(&self, key: &UdfIdent) -> Result<(), MetaError> {
+        let _res = self.kv_api.upsert_kv(UpsertKV::delete(key)).await?;
+        Ok(())
     }
 
     fn ensure_non_builtin(&self, name: &str) -> Result<(), UdfError> {

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -832,9 +832,9 @@ impl AccessChecker for PrivilegeAccess {
             }
             Plan::DropUDF(plan) => {
                 let udf_name = &plan.udf;
-                if !UserApiProvider::instance().exists_udf(&tenant, udf_name).await? && plan.if_exists {
+                /*if !UserApiProvider::instance().exists_udf(&tenant, udf_name).await? && plan.if_exists {
                     return Ok(());
-                }
+                }*/
                 if enable_experimental_rbac_check {
                     let udf = HashSet::from([udf_name]);
                     self.validate_udf_access(udf).await?;

--- a/src/query/service/src/interpreters/interpreter_user_udf_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_user_udf_drop.rs
@@ -15,10 +15,10 @@
 use std::sync::Arc;
 
 use databend_common_exception::Result;
-use databend_common_management::RoleApi;
-use databend_common_meta_app::principal::OwnershipObject;
+// use databend_common_management::RoleApi;
+// use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_sql::plans::DropUDFPlan;
-use databend_common_users::RoleCacheManager;
+// use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
 use log::debug;
 
@@ -57,21 +57,20 @@ impl Interpreter for DropUserUDFScript {
         let plan = self.plan.clone();
         let tenant = self.ctx.get_tenant();
 
-        // we should do `drop ownership` after actually drop udf, and udf maybe not exists.
+        // // we should do `drop ownership` after actually drop udf, and udf maybe not exists.
         // drop the ownership
-        if UserApiProvider::instance()
-            .exists_udf(&tenant, &self.plan.udf)
-            .await?
-        {
-            let role_api = UserApiProvider::instance().role_api(&tenant);
-            let owner_object = OwnershipObject::UDF {
-                name: self.plan.udf.clone(),
-            };
-
-            role_api.revoke_ownership(&owner_object).await?;
-            RoleCacheManager::instance().invalidate_cache(&tenant);
-        }
-
+        // if UserApiProvider::instance()
+        // .exists_udf(&tenant, &self.plan.udf)
+        // .await?
+        // {
+        // let role_api = UserApiProvider::instance().role_api(&tenant);
+        // let owner_object = OwnershipObject::UDF {
+        // name: self.plan.udf.clone(),
+        // };
+        //
+        // role_api.revoke_ownership(&owner_object).await?;
+        // RoleCacheManager::instance().invalidate_cache(&tenant);
+        // }
         // TODO: if it is appropriate to return an ErrorCode that contains either meta-service error and UdfNotFound error?
 
         UserApiProvider::instance()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In earlier version, udf serialize as json. In the current version, we can not drop/list these udfs.

```
show user functions;
2001=>InvalidReply: source:(PbDecodeError: failed to decode Protobuf message: buffer underflow; when:(decode value of __fd_udfs/tn3ftqihs/plusp)) while list UDFs

drop function IF EXISTS plusp;
2001=>InvalidReply: source:(PbDecodeError: failed to decode Protobuf message: buffer underflow; when:(decode value of __fd_udfs/tn3ftqihs/plusp))

```

So if drop udf return err, we directly drop the kv.

- fixes: https://github.com/databendlabs/databend/issues/17174


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17264)
<!-- Reviewable:end -->
