### PR TITLE
feat(metrics): display scan rows/bytes, write rows/bytes in global counter metrics

### DIFF
--- a/src/common/base/src/base/mod.rs
+++ b/src/common/base/src/base/mod.rs
@@ -40,6 +40,7 @@ pub use net::get_free_udp_port;
 pub use ordered_float::OrderedFloat;
 pub use profiling::Profiling;
 pub use progress::Progress;
+pub use progress::ProgressHook;
 pub use progress::ProgressValues;
 pub use progress::SpillProgress;
 pub use select::select3;

--- a/src/common/base/src/base/progress.rs
+++ b/src/common/base/src/base/progress.rs
@@ -19,8 +19,6 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::runtime::metrics::Counter;
-
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ProgressValues {
     pub rows: usize,
@@ -31,28 +29,6 @@ pub struct ProgressValues {
 /// whenever the progress is updated.
 pub trait ProgressHook: std::fmt::Debug + Send + Sync {
     fn incr(&self, progress_values: &ProgressValues);
-}
-
-#[derive(Debug)]
-pub struct MetricProgressHook {
-    pub rows_metrics: Arc<Counter>,
-    pub bytes_metrics: Arc<Counter>,
-}
-
-impl MetricProgressHook {
-    pub fn new(rows_metrics: Arc<Counter>, bytes_metrics: Arc<Counter>) -> Self {
-        Self {
-            rows_metrics,
-            bytes_metrics,
-        }
-    }
-}
-
-impl ProgressHook for MetricProgressHook {
-    fn incr(&self, progress_values: &ProgressValues) {
-        self.rows_metrics.inc_by(progress_values.rows as u64);
-        self.bytes_metrics.inc_by(progress_values.bytes as u64);
-    }
 }
 
 #[derive(Debug)]

--- a/src/common/base/src/base/progress.rs
+++ b/src/common/base/src/base/progress.rs
@@ -14,7 +14,6 @@
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/src/common/base/src/base/progress.rs
+++ b/src/common/base/src/base/progress.rs
@@ -14,9 +14,12 @@
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::runtime::metrics::Counter;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ProgressValues {
@@ -28,6 +31,28 @@ pub struct ProgressValues {
 /// whenever the progress is updated.
 pub trait ProgressHook: std::fmt::Debug + Send + Sync {
     fn incr(&self, progress_values: &ProgressValues);
+}
+
+#[derive(Debug)]
+pub struct MetricProgressHook {
+    pub rows_metrics: Arc<Counter>,
+    pub bytes_metrics: Arc<Counter>,
+}
+
+impl MetricProgressHook {
+    pub fn new(rows_metrics: Arc<Counter>, bytes_metrics: Arc<Counter>) -> Self {
+        Self {
+            rows_metrics,
+            bytes_metrics,
+        }
+    }
+}
+
+impl ProgressHook for MetricProgressHook {
+    fn incr(&self, progress_values: &ProgressValues) {
+        self.rows_metrics.inc_by(progress_values.rows as u64);
+        self.bytes_metrics.inc_by(progress_values.bytes as u64);
+    }
 }
 
 #[derive(Debug)]

--- a/src/common/base/src/runtime/metrics/mod.rs
+++ b/src/common/base/src/runtime/metrics/mod.rs
@@ -22,6 +22,9 @@ mod registry;
 mod sample;
 
 pub use counter::Counter;
+pub use family_metrics::FamilyCounter as InnerFamilyCounter;
+pub use family_metrics::FamilyGauge as InnerFamilyGauge;
+pub use family_metrics::FamilyHistogram as InnerFamilyHistogram;
 pub use gauge::Gauge;
 pub use histogram::Histogram;
 pub use histogram::BUCKET_MILLISECONDS;

--- a/src/common/metrics/src/metrics/interpreter.rs
+++ b/src/common/metrics/src/metrics/interpreter.rs
@@ -40,8 +40,8 @@ const METRIC_QUERY_RESULT_ROWS: &str = "query_result_rows";
 const METRIC_QUERY_RESULT_BYTES: &str = "query_result_bytes";
 const METRIC_QUERY_PROGRESS_SCAN_ROWS: &str = "query_progress_scan_rows";
 const METRIC_QUERY_PROGRESS_SCAN_BYTES: &str = "query_progress_scan_bytes";
-const METRIC_QUERY_PROGRSS_WRITE_ROWS: &str = "query_progress_write_rows";
-const METRIC_QUERY_PROGRSS_WRITE_BYTES: &str = "query_progress_write_bytes";
+const METRIC_QUERY_PROGRESS_WRITE_ROWS: &str = "query_progress_write_rows";
+const METRIC_QUERY_PROGRESS_WRITE_BYTES: &str = "query_progress_write_bytes";
 
 pub static QUERY_START: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_START));
@@ -83,6 +83,6 @@ pub static QUERY_PROGRESS_SCAN_ROWS: LazyLock<FamilyCounter<VecLabels>> =
 pub static QUERY_PROGRESS_SCAN_BYTES: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_SCAN_BYTES));
 pub static QUERY_PROGRESS_WRITE_ROWS: LazyLock<FamilyCounter<VecLabels>> =
-    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_ROWS));
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_WRITE_ROWS));
 pub static QUERY_PROGRESS_WRITE_BYTES: LazyLock<FamilyCounter<VecLabels>> =
-    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_BYTES));
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_WRITE_BYTES));

--- a/src/common/metrics/src/metrics/interpreter.rs
+++ b/src/common/metrics/src/metrics/interpreter.rs
@@ -82,7 +82,7 @@ pub static QUERY_PROGRESS_SCAN_ROWS: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_SCAN_ROWS));
 pub static QUERY_PROGRESS_SCAN_BYTES: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_SCAN_BYTES));
-pub static QUERY_PROGRSS_WRITE_ROWS: LazyLock<FamilyCounter<VecLabels>> =
+pub static QUERY_PROGRESS_WRITE_ROWS: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_ROWS));
-pub static QUERY_PROGRSS_WRITE_BYTES: LazyLock<FamilyCounter<VecLabels>> =
+pub static QUERY_PROGRESS_WRITE_BYTES: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_BYTES));

--- a/src/common/metrics/src/metrics/interpreter.rs
+++ b/src/common/metrics/src/metrics/interpreter.rs
@@ -38,6 +38,10 @@ const METRIC_QUERY_SCAN_PARTITIONS: &str = "query_scan_partitions";
 const METRIC_QUERY_TOTAL_PARTITIONS: &str = "query_total_partitions";
 const METRIC_QUERY_RESULT_ROWS: &str = "query_result_rows";
 const METRIC_QUERY_RESULT_BYTES: &str = "query_result_bytes";
+const METRIC_QUERY_PROGRESS_SCAN_ROWS: &str = "query_progress_scan_rows";
+const METRIC_QUERY_PROGRESS_SCAN_BYTES: &str = "query_progress_scan_bytes";
+const METRIC_QUERY_PROGRSS_WRITE_ROWS: &str = "query_progress_write_rows";
+const METRIC_QUERY_PROGRSS_WRITE_BYTES: &str = "query_progress_write_bytes";
 
 pub static QUERY_START: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_START));
@@ -73,3 +77,12 @@ pub static QUERY_RESULT_ROWS: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_RESULT_ROWS));
 pub static QUERY_RESULT_BYTES: LazyLock<FamilyCounter<VecLabels>> =
     LazyLock::new(|| register_counter_family(METRIC_QUERY_RESULT_BYTES));
+
+pub static QUERY_PROGRESS_SCAN_ROWS: LazyLock<FamilyCounter<VecLabels>> =
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_SCAN_ROWS));
+pub static QUERY_PROGRESS_SCAN_BYTES: LazyLock<FamilyCounter<VecLabels>> =
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRESS_SCAN_BYTES));
+pub static QUERY_PROGRSS_WRITE_ROWS: LazyLock<FamilyCounter<VecLabels>> =
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_ROWS));
+pub static QUERY_PROGRSS_WRITE_BYTES: LazyLock<FamilyCounter<VecLabels>> =
+    LazyLock::new(|| register_counter_family(METRIC_QUERY_PROGRSS_WRITE_BYTES));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

currently we've tracked the scan rows/bytes, write rows/bytes progress value in query stats. and collected them into metrics in query_finished.

but this have an issue like, given a COPY statement which executed for 10 hours. this `databend_query_scan_rows` will kept to be zero during the executation, can not reflect the executing progress in metrics.

this pr add a hook on the `Progress` struct to increment the global metrics as well as the local stats.

## Tests

- [x] No Test - simple metrics enhancement

## Type of change

- [x] Other (please describe): observability

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17266)
<!-- Reviewable:end -->
