### PR TITLE
fix: use full path as cache key for parquet meta.

### DIFF
--- a/src/query/storages/parquet/src/parquet_rs/meta.rs
+++ b/src/query/storages/parquet/src/parquet_rs/meta.rs
@@ -37,9 +37,11 @@ pub async fn read_metadata_async_cached(
     operator: &Operator,
     file_size: Option<u64>,
 ) -> Result<Arc<ParquetMetaData>> {
-    let reader = MetaReader::meta_data_reader(operator.clone());
+    let info = operator.info();
+    let location = format!("{}/{}/{}", info.name(), info.root(), path);
+    let reader = MetaReader::meta_data_reader(operator.clone(), location.len() - path.len());
     let load_params = LoadParams {
-        location: path.to_owned(),
+        location,
         len_hint: file_size,
         ver: 0,
         put_cache: true,
@@ -246,15 +248,15 @@ fn check_memory_usage(max_memory_usage: u64) -> Result<()> {
     Ok(())
 }
 
-pub struct LoaderWrapper<T>(T);
+pub struct LoaderWrapper<T>(T, usize);
 pub type ParquetMetaReader = InMemoryItemCacheReader<ParquetMetaData, LoaderWrapper<Operator>>;
 
 pub struct MetaReader;
 impl MetaReader {
-    pub fn meta_data_reader(dal: Operator) -> ParquetMetaReader {
+    pub fn meta_data_reader(dal: Operator, prefix_len: usize) -> ParquetMetaReader {
         ParquetMetaReader::new(
             CacheManager::instance().get_parquet_meta_data_cache(),
-            LoaderWrapper(dal),
+            LoaderWrapper(dal, prefix_len),
         )
     }
 }
@@ -263,15 +265,12 @@ impl MetaReader {
 impl Loader<ParquetMetaData> for LoaderWrapper<Operator> {
     #[async_backtrace::framed]
     async fn load(&self, params: &LoadParams) -> Result<ParquetMetaData> {
+        let location = &params.location[self.1..];
         let size = match params.len_hint {
             Some(v) => v,
-            None => self.0.stat(&params.location).await?.content_length(),
+            None => self.0.stat(location).await?.content_length(),
         };
-        databend_common_storage::parquet_rs::read_metadata_async(
-            &params.location,
-            &self.0,
-            Some(size),
-        )
-        .await
+        databend_common_storage::parquet_rs::read_metadata_async(location, &self.0, Some(size))
+            .await
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: https://github.com/databendlabs/databend/issues/17312 and https://github.com/databendlabs/databend/issues/17284
 
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17313)
<!-- Reviewable:end -->
