### PR TITLE
fix(query): unsupport datetime format item should not return panic error

### DIFF
--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -15,6 +15,7 @@
 use std::io::Write;
 
 use chrono::format::parse_and_remainder;
+use chrono::format::Item;
 use chrono::format::Parsed;
 use chrono::format::StrftimeItems;
 use chrono::prelude::*;
@@ -700,18 +701,22 @@ fn register_to_string(registry: &mut FunctionRegistry) {
                 if format.is_empty() {
                     output.push_null();
                 } else {
-                    // Can't use `tz.timestamp_nanos(self.as_() * 1000)` directly, is may cause multiply with overflow.
-                    let (mut secs, mut nanos) =
-                        (micros / MICROS_PER_SEC, (micros % MICROS_PER_SEC) * 1_000);
-                    if nanos < 0 {
-                        secs -= 1;
-                        nanos += 1_000_000_000;
+                    let items = StrftimeItems::new(format);
+                    if items.clone().any(|item| matches!(item, Item::Error)) {
+                        ctx.set_error(output.len(), "Invalid format string".to_string());
+                        output.push_null();
+                    } else {
+                        // Can't use `tz.timestamp_nanos(self.as_() * 1000)` directly, is may cause multiply with overflow.
+                        let (mut secs, mut nanos) =
+                            (micros / MICROS_PER_SEC, (micros % MICROS_PER_SEC) * 1_000);
+                        if nanos < 0 {
+                            secs -= 1;
+                            nanos += 1_000_000_000;
+                        }
+                        let ts = ctx.func_ctx.tz.timestamp_opt(secs, nanos as u32).unwrap();
+                        let res = ts.format(format).to_string();
+                        output.push(&res);
                     }
-                    let ts = ctx.func_ctx.tz.timestamp_opt(secs, nanos as u32).unwrap();
-                    // https://github.com/BurntSushi/jiff/issues/155
-                    // ASCII is currently required in jiff crate
-                    let res = ts.format(format).to_string();
-                    output.push(&res);
                 }
             },
         ),

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1367,6 +1367,10 @@ select to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的%Y�
 ----
 2022-02-02
 
+
+statement error 1006
+select date_format('2022-2-04T03:58:59', '%i');
+
 statement error 1006
 select date_format('', '');
 
@@ -1486,3 +1490,5 @@ query T
 SELECT add_hours(to_timestamp(710455), 2147483647);
 ----
 1000-01-01 00:00:00.000000
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

unsupport datetime format item should not return panic error

- fix #17318

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17323)
<!-- Reviewable:end -->
