### PR TITLE
fix(query): procedure support string type

### DIFF
--- a/src/query/service/src/interpreters/interpreter_procedure_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_procedure_drop.rs
@@ -64,7 +64,7 @@ impl Interpreter for DropProcedureInterpreter {
         if dropped.is_none() && !self.plan.if_exists {
             return Err(ErrorCode::UnknownProcedure(format!(
                 "Unknown procedure '{}' while drop procedure",
-                drop_procedure_req.name_ident
+                drop_procedure_req.name_ident.procedure_name()
             )));
         }
 

--- a/src/query/service/src/interpreters/interpreter_procedure_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_procedure_drop.rs
@@ -62,10 +62,22 @@ impl Interpreter for DropProcedureInterpreter {
             .drop_procedure(&drop_procedure_req.name_ident)
             .await?;
         if dropped.is_none() && !self.plan.if_exists {
-            return Err(ErrorCode::UnknownProcedure(format!(
-                "Unknown procedure '{}' while drop procedure",
-                drop_procedure_req.name_ident.procedure_name()
-            )));
+            {
+                // try drop old name:
+                let old_drop_procedure_req = DropProcedureReq {
+                    name_ident: self.plan.old_name.clone(),
+                };
+                let dropped = UserApiProvider::instance()
+                    .procedure_api(&tenant)
+                    .drop_procedure(&old_drop_procedure_req.name_ident)
+                    .await?;
+                if dropped.is_none() {
+                    return Err(ErrorCode::UnknownProcedure(format!(
+                        "Unknown procedure '{}' while drop procedure",
+                        drop_procedure_req.name_ident.procedure_name()
+                    )));
+                }
+            }
         }
 
         Ok(PipelineBuildResult::create())

--- a/src/query/sql/src/planner/plans/ddl/procedure.rs
+++ b/src/query/sql/src/planner/plans/ddl/procedure.rs
@@ -66,6 +66,7 @@ pub struct DropProcedurePlan {
     pub if_exists: bool,
     pub tenant: Tenant,
     pub name: ProcedureNameIdent,
+    pub old_name: ProcedureNameIdent,
 }
 
 impl From<DropProcedurePlan> for DropProcedureReq {

--- a/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
@@ -156,4 +156,19 @@ statement ok
 drop procedure sum_even_numbers(Int, Int);
 
 statement ok
+CREATE PROCEDURE if not exists p2(x STRING) RETURNS Int32 NOT NULL LANGUAGE SQL  COMMENT='test' AS $$
+BEGIN
+    RETURN x;
+END;
+$$;
+
+query T
+call procedure p2('x');
+----
+'x'
+
+statement ok
+drop procedure p2(string);
+
+statement ok
 unset global enable_experimental_procedure;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

in call procedure binder, will parse arg's datatype.

in create procedure will store the arg typename.

If not Standardize the type's display, may cause confusing.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17325)
<!-- Reviewable:end -->
