### PR TITLE
fix(query): aviod building TransformSortMergeLimit with a big number limit 

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
@@ -337,7 +337,7 @@ impl TransformSortMergeBuilder {
             !self.schema.has_field(ORDER_COL_NAME)
         });
 
-        if self.limit.is_some() {
+        if self.limit.map(|limit| limit < 10000).unwrap_or_default() {
             self.build_sort_limit()
         } else {
             self.build_sort()
@@ -400,6 +400,7 @@ impl TransformSortMergeBuilder {
                     self.sort_desc,
                     self.block_size,
                     self.enable_loser_tree,
+                    self.limit,
                 ),
             )?,
         ))

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_limit.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_limit.rs
@@ -127,7 +127,6 @@ impl<R: Rows> CursorOrder<R> for LocalCursorOrder {
 
 impl<R: Rows> TransformSortMergeLimit<R> {
     pub fn create(block_size: usize, limit: usize) -> Self {
-        debug_assert!(limit <= 10000, "Too large sort merge limit: {}", limit);
         TransformSortMergeLimit {
             heap: FixedHeap::new(limit),
             buffer: HashMap::with_capacity(limit),

--- a/src/query/service/tests/it/pipelines/transforms/sort/spill.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/spill.rs
@@ -71,6 +71,7 @@ fn create_sort_spill_pipeline(
                 sort_desc.clone(),
                 block_size,
                 enable_loser_tree,
+                None,
             ),
         )
     })?;

--- a/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by.test
@@ -114,6 +114,18 @@ statement ok
 DROP TABLE t3
 
 query I
+SELECT number FROM numbers(3) ORDER BY number LIMIT 214748364900;
+----
+0
+1
+2
+
+query I
+SELECT number FROM numbers(100000) ORDER BY number LIMIT 1 OFFSET 50000;
+----
+50000
+
+query I
 SELECT number FROM numbers(10000) ORDER BY number LIMIT 3
 ----
 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #17337

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
