### PR TITLE
fix(query): disallow push down filters that use columns in window order by columns or function argument columns

### DIFF
--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -72,23 +72,20 @@ impl Window {
 
         used_columns.insert(self.index);
         used_columns.extend(self.function.used_columns());
-
-        for arg in self.arguments.iter() {
-            used_columns.insert(arg.index);
-            used_columns.extend(arg.scalar.used_columns())
-        }
-
-        for part in self.partition_by.iter() {
-            used_columns.insert(part.index);
-            used_columns.extend(part.scalar.used_columns())
-        }
-
-        for sort in self.order_by.iter() {
-            used_columns.insert(sort.order_by_item.index);
-            used_columns.extend(sort.order_by_item.scalar.used_columns())
-        }
+        used_columns.extend(self.arguments_columns()?);
+        used_columns.extend(self.partition_by_columns()?);
+        used_columns.extend(self.order_by_columns()?);
 
         Ok(used_columns)
+    }
+
+    pub fn arguments_columns(&self) -> Result<ColumnSet> {
+        let mut col_set = ColumnSet::new();
+        for arg in self.arguments.iter() {
+            col_set.insert(arg.index);
+            col_set.extend(arg.scalar.used_columns())
+        }
+        Ok(col_set)
     }
 
     // `Window.partition_by_columns` used in `RulePushDownFilterWindow` only consider `partition_by` field,
@@ -98,6 +95,15 @@ impl Window {
         for part in self.partition_by.iter() {
             col_set.insert(part.index);
             col_set.extend(part.scalar.used_columns())
+        }
+        Ok(col_set)
+    }
+
+    pub fn order_by_columns(&self) -> Result<ColumnSet> {
+        let mut col_set = ColumnSet::new();
+        for sort in self.order_by.iter() {
+            col_set.insert(sort.order_by_item.index);
+            col_set.extend(sort.order_by_item.scalar.used_columns())
         }
         Ok(col_set)
     }

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -733,5 +733,80 @@ Window
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 50.00
 
+query T
+explain with test as ( select number % 10 as id, number as full_matched, max(number) OVER ( PARTITION BY id ) max from numbers(1000)) select * from test where full_matched = 3;
+----
+EvalScalar
+├── output columns: [numbers.number (#0), max(number) OVER (PARTITION BY id) (#2), id (#3)]
+├── expressions: [numbers.number (#0) % 10]
+├── estimated rows: 0.40
+└── Filter
+    ├── output columns: [numbers.number (#0), max(number) OVER (PARTITION BY id) (#2)]
+    ├── filters: [numbers.number (#0) = 3]
+    ├── estimated rows: 0.40
+    └── Window
+        ├── output columns: [numbers.number (#0), max_part_0 (#1), max(number) OVER (PARTITION BY id) (#2)]
+        ├── aggregate function: [max(number)]
+        ├── partition by: [max_part_0]
+        ├── order by: []
+        ├── frame: [Range: Preceding(None) ~ Following(None)]
+        └── WindowPartition
+            ├── output columns: [numbers.number (#0), max_part_0 (#1)]
+            ├── hash keys: [max_part_0]
+            ├── estimated rows: 1000.00
+            └── EvalScalar
+                ├── output columns: [numbers.number (#0), max_part_0 (#1)]
+                ├── expressions: [numbers.number (#0) % 10]
+                ├── estimated rows: 1000.00
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── output columns: [number (#0)]
+                    ├── read rows: 1000
+                    ├── read size: 7.81 KiB
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 1000.00
+
+query T
+explain with test as (select number % 10 as id, number as full_matched from numbers(1000) QUALIFY row_number() OVER (PARTITION BY id ORDER BY  number DESC)=1) select full_matched, count() from test group by full_matched having full_matched = 3;
+----
+AggregateFinal
+├── output columns: [count() (#3), numbers.number (#0)]
+├── group by: [number]
+├── aggregate functions: [count()]
+├── estimated rows: 0.40
+└── AggregatePartial
+    ├── group by: [number]
+    ├── aggregate functions: [count()]
+    ├── estimated rows: 0.40
+    └── Filter
+        ├── output columns: [numbers.number (#0)]
+        ├── filters: [numbers.number (#0) = 3, row_number() OVER (PARTITION BY id ORDER BY number DESC) (#2) = 1]
+        ├── estimated rows: 0.40
+        └── Window
+            ├── output columns: [numbers.number (#0), id (#1), row_number() OVER (PARTITION BY id ORDER BY number DESC) (#2)]
+            ├── aggregate function: [row_number]
+            ├── partition by: [id]
+            ├── order by: [number]
+            ├── frame: [Range: Preceding(None) ~ CurrentRow]
+            └── WindowPartition
+                ├── output columns: [numbers.number (#0), id (#1)]
+                ├── hash keys: [id]
+                ├── estimated rows: 1000.00
+                └── EvalScalar
+                    ├── output columns: [numbers.number (#0), id (#1)]
+                    ├── expressions: [numbers.number (#0) % 10]
+                    ├── estimated rows: 1000.00
+                    └── TableScan
+                        ├── table: default.system.numbers
+                        ├── output columns: [number (#0)]
+                        ├── read rows: 1000
+                        ├── read size: 7.81 KiB
+                        ├── partitions total: 1
+                        ├── partitions scanned: 1
+                        ├── push downs: [filters: [], limit: NONE]
+                        └── estimated rows: 1000.00
+
 statement ok
 DROP DATABASE test_explain_window;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #17338

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17353)
<!-- Reviewable:end -->
