### PR TITLE
refactor: rename components of the `replace into` impl

### DIFF
--- a/src/query/storages/fuse/src/operations/replace.rs
+++ b/src/query/storages/fuse/src/operations/replace.rs
@@ -29,7 +29,7 @@ use rand::prelude::SliceRandom;
 
 use crate::io::BlockBuilder;
 use crate::operations::mutation::SegmentIndex;
-use crate::operations::replace_into::MergeIntoOperationAggregator;
+use crate::operations::replace_into::ReplaceIntoOperationAggregator;
 use crate::FuseTable;
 
 impl FuseTable {
@@ -102,7 +102,7 @@ impl FuseTable {
         let read_settings = ReadSettings::from_ctx(&ctx)?;
         let mut items = Vec::with_capacity(num_partition);
         for chunk_of_segment_locations in chunks {
-            let item = MergeIntoOperationAggregator::try_create(
+            let item = ReplaceIntoOperationAggregator::try_create(
                 ctx.clone(),
                 on_conflicts.clone(),
                 bloom_filter_column_indexes.clone(),

--- a/src/query/storages/fuse/src/operations/replace_into/meta/mod.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/meta/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod merge_into_operation_meta;
+mod replace_into_operation_meta;
 
-pub use merge_into_operation_meta::*;
+pub use replace_into_operation_meta::*;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/mod.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/mod.rs
@@ -14,11 +14,11 @@
 
 mod column_hash;
 mod deletion_accumulator;
-mod merge_into_mutator;
-mod mutator_replace_into;
+mod replace_into_mutator;
+mod replace_into_operation_agg;
 
 pub use column_hash::row_hash_of_columns;
 pub use deletion_accumulator::BlockDeletionKeys;
 pub use deletion_accumulator::DeletionAccumulator;
-pub use merge_into_mutator::MergeIntoOperationAggregator;
-pub use mutator_replace_into::ReplaceIntoMutator;
+pub use replace_into_mutator::ReplaceIntoMutator;
+pub use replace_into_operation_agg::ReplaceIntoOperationAggregator;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -72,7 +72,7 @@ use crate::operations::mutation::BlockIndex;
 use crate::operations::mutation::SegmentIndex;
 use crate::operations::read_block;
 use crate::operations::replace_into::meta::DeletionByColumn;
-use crate::operations::replace_into::meta::MergeIntoOperation;
+use crate::operations::replace_into::meta::ReplaceIntoOperation;
 use crate::operations::replace_into::meta::UniqueKeyDigest;
 use crate::operations::replace_into::mutator::row_hash_of_columns;
 use crate::operations::replace_into::mutator::DeletionAccumulator;
@@ -103,12 +103,12 @@ struct AggregationContext {
 }
 
 // Apply MergeIntoOperations to segments
-pub struct MergeIntoOperationAggregator {
+pub struct ReplaceIntoOperationAggregator {
     deletion_accumulator: DeletionAccumulator,
     aggregation_ctx: Arc<AggregationContext>,
 }
 
-impl MergeIntoOperationAggregator {
+impl ReplaceIntoOperationAggregator {
     #[allow(clippy::too_many_arguments)] // TODO fix this
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
@@ -215,15 +215,15 @@ impl MergeIntoOperationAggregator {
 }
 
 // aggregate mutations (currently, deletion only)
-impl MergeIntoOperationAggregator {
+impl ReplaceIntoOperationAggregator {
     #[async_backtrace::framed]
-    pub async fn accumulate(&mut self, merge_into_operation: MergeIntoOperation) -> Result<()> {
+    pub async fn accumulate(&mut self, replace_into_operation: ReplaceIntoOperation) -> Result<()> {
         let aggregation_ctx = &self.aggregation_ctx;
         metrics_inc_replace_number_accumulated_merge_action();
 
         let start = Instant::now();
-        match merge_into_operation {
-            MergeIntoOperation::Delete(partitions) => {
+        match replace_into_operation {
+            ReplaceIntoOperation::Delete(partitions) => {
                 for (segment_index, (path, ver)) in &aggregation_ctx.segment_locations {
                     // segment level
                     let load_param = LoadParams {
@@ -279,7 +279,7 @@ impl MergeIntoOperationAggregator {
                     }
                 }
             }
-            MergeIntoOperation::None => {}
+            ReplaceIntoOperation::None => {}
         }
 
         metrics_inc_replace_accumulated_merge_action_time_ms(start.elapsed().as_millis() as u64);
@@ -288,7 +288,7 @@ impl MergeIntoOperationAggregator {
 }
 
 // apply the mutations and generate mutation log
-impl MergeIntoOperationAggregator {
+impl ReplaceIntoOperationAggregator {
     #[async_backtrace::framed]
     pub async fn apply(&mut self) -> Result<Option<MutationLogs>> {
         metrics_inc_replace_number_apply_deletion();

--- a/src/query/storages/fuse/src/operations/replace_into/processors/mod.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/processors/mod.rs
@@ -17,7 +17,7 @@
 mod processor_broadcast;
 mod processor_replace_into;
 mod processor_unbranched_replace_into;
-mod transform_merge_into_mutation_aggregator;
+mod transform_replace_into_mutation_aggregator;
 
 pub use processor_broadcast::BroadcastProcessor;
 pub use processor_replace_into::ReplaceIntoProcessor;

--- a/src/query/storages/fuse/src/operations/replace_into/processors/transform_replace_into_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/processors/transform_replace_into_mutation_aggregator.rs
@@ -21,18 +21,18 @@ use databend_common_pipeline_core::PipeItem;
 use databend_common_pipeline_transforms::processors::AsyncAccumulatingTransform;
 use databend_common_pipeline_transforms::processors::AsyncAccumulatingTransformer;
 
-use crate::operations::replace_into::meta::MergeIntoOperation;
-use crate::operations::replace_into::mutator::MergeIntoOperationAggregator;
+use crate::operations::replace_into::meta::ReplaceIntoOperation;
+use crate::operations::replace_into::mutator::ReplaceIntoOperationAggregator;
 
 #[async_trait::async_trait]
-impl AsyncAccumulatingTransform for MergeIntoOperationAggregator {
-    const NAME: &'static str = "MergeIntoMutationAggregator";
+impl AsyncAccumulatingTransform for ReplaceIntoOperationAggregator {
+    const NAME: &'static str = "ReplaceIntoMutationAggregator";
 
     #[async_backtrace::framed]
     async fn transform(&mut self, data: DataBlock) -> Result<Option<DataBlock>> {
         // accumulate mutations
-        let merge_into_operation = MergeIntoOperation::try_from(data)?;
-        self.accumulate(merge_into_operation).await?;
+        let replace_into_operation = ReplaceIntoOperation::try_from(data)?;
+        self.accumulate(replace_into_operation).await?;
         // no partial output
         Ok(None)
     }
@@ -45,7 +45,7 @@ impl AsyncAccumulatingTransform for MergeIntoOperationAggregator {
     }
 }
 
-impl MergeIntoOperationAggregator {
+impl ReplaceIntoOperationAggregator {
     pub fn into_pipe_item(self) -> PipeItem {
         let input = InputPort::create();
         let output = OutputPort::create();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Initially, `REPLACE INTO` was designed as a simplified implementation of `MERGE INTO`, with the expectation that it would gradually evolve into a full-fledged implementation of `MERGE INTO`, as a result, many `MERGE INTO` related terms exist in the components of `REPLACE INTO` impl.

However, `MERGE INTO` now has its own independent impl, the remaining `MERGE INTO` related terms in the impl of `REPLACE INTO` can be misleading.

Therefore, in this PR, we have renamed all `MERGE INTO` related terms in the impl of `REPLACE INTO` to avoid confusion.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - renaming things, use existing cases

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17355)
<!-- Reviewable:end -->
