### PR TITLE
fix(query): Align TRIM functions semantically with Snowflake

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -964,12 +964,23 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
             ~ #subexpr(0) ~ ("," ~ #subexpr(0))?
             ~ ^")"
         },
-        |(_, _, expr, trim_str, _)| {
+        |(name, _, expr, trim_str, _)| {
             if let Some(trim_str) = trim_str {
                 let trim_str = trim_str.1;
-                ExprElement::Trim {
-                    expr: Box::new(expr),
-                    trim_where: Some((TrimWhere::Both, Box::new(trim_str))),
+                ExprElement::FunctionCall {
+                    func: FunctionCall {
+                        distinct: false,
+                        name: Identifier {
+                            span: Some(name.span),
+                            name: name.text().to_owned(),
+                            quote: None,
+                            ident_type: IdentifierType::None,
+                        },
+                        args: vec![expr, trim_str],
+                        params: vec![],
+                        window: None,
+                        lambda: None,
+                    },
                 }
             } else {
                 ExprElement::Trim {

--- a/src/query/functions/src/scalars/string.rs
+++ b/src/query/functions/src/scalars/string.rs
@@ -410,7 +410,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "ltrim",
         |_, _| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<StringType, StringType>(|val, output, _| {
-            output.put_and_commit(val.trim_start());
+            output.put_and_commit(val.trim_start_matches(' '));
         }),
     );
 
@@ -418,7 +418,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "rtrim",
         |_, _| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<StringType, StringType>(|val, output, _| {
-            output.put_and_commit(val.trim_end());
+            output.put_and_commit(val.trim_end_matches(' '));
         }),
     );
 
@@ -426,7 +426,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         "trim",
         |_, _| FunctionDomain::Full,
         vectorize_with_builder_1_arg::<StringType, StringType>(|val, output, _| {
-            output.put_and_commit(val.trim());
+            output.put_and_commit(val.trim_matches(' '));
         }),
     );
 
@@ -440,7 +440,8 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
 
-                output.put_and_commit(val.trim_start_matches(trim_str));
+                let p: Vec<_> = trim_str.chars().collect();
+                output.put_and_commit(val.trim_start_matches(p.as_slice()));
             },
         ),
     );
@@ -470,7 +471,8 @@ pub fn register(registry: &mut FunctionRegistry) {
                     return;
                 }
 
-                output.put_and_commit(val.trim_end_matches(trim_str));
+                let p: Vec<_> = trim_str.chars().collect();
+                output.put_and_commit(val.trim_end_matches(p.as_slice()));
             },
         ),
     );
@@ -510,6 +512,22 @@ pub fn register(registry: &mut FunctionRegistry) {
                 }
 
                 output.put_and_commit(res);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<StringType, StringType, StringType, _, _>(
+        "trim",
+        |_, _, _| FunctionDomain::Full,
+        vectorize_with_builder_2_arg::<StringType, StringType, StringType>(
+            |val, trim_str, output, _| {
+                if trim_str.is_empty() {
+                    output.put_and_commit(val);
+                    return;
+                }
+
+                let p: Vec<_> = trim_str.chars().collect();
+                output.put_and_commit(val.trim_matches(p.as_slice()));
             },
         ),
     );

--- a/src/query/functions/tests/it/scalars/string.rs
+++ b/src/query/functions/tests/it/scalars/string.rs
@@ -183,6 +183,9 @@ fn test_ltrim(file: &mut impl Write) {
         "a",
         StringType::from_data(vec!["abc", "   abc", "   abc   ", "abc   "]),
     )]);
+    run_ast(file, "ltrim(' aa','')", &[]);
+    run_ast(file, "ltrim('\\taa')", &[]);
+    run_ast(file, "ltrim('#000000123','0#')", &[]);
 }
 
 fn test_rtrim(file: &mut impl Write) {
@@ -197,6 +200,9 @@ fn test_rtrim(file: &mut impl Write) {
         "a",
         StringType::from_data(vec!["abc", "   abc", "   abc   ", "abc   "]),
     )]);
+    run_ast(file, "rtrim('aa ','')", &[]);
+    run_ast(file, "rtrim('aa\\t')", &[]);
+    run_ast(file, "rtrim('$125.00','0.')", &[]);
 }
 
 fn test_trim_leading(file: &mut impl Write) {
@@ -357,6 +363,8 @@ fn test_trim(file: &mut impl Write) {
         "a",
         StringType::from_data(vec!["abc", "   abc", "   abc   ", "abc   "]),
     )]);
+    run_ast(file, "trim('\\ta\\t')", &[]);
+    run_ast(file, "trim('*-*ABC-*-','*-')", &[]);    
 
     // TRIM([[BOTH | LEADING | TRAILING] <expr> FROM] <expr>)
     test_trim_with_from(file, "both");

--- a/src/query/functions/tests/it/scalars/string.rs
+++ b/src/query/functions/tests/it/scalars/string.rs
@@ -364,7 +364,7 @@ fn test_trim(file: &mut impl Write) {
         StringType::from_data(vec!["abc", "   abc", "   abc   ", "abc   "]),
     )]);
     run_ast(file, "trim('\\ta\\t')", &[]);
-    run_ast(file, "trim('*-*ABC-*-','*-')", &[]);    
+    run_ast(file, "trim('*-*ABC-*-','*-')", &[]);
 
     // TRIM([[BOTH | LEADING | TRAILING] <expr> FROM] <expr>)
     test_trim_with_from(file, "both");

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -4086,6 +4086,8 @@ Functions overloads:
 1 translate(String NULL, String NULL, String NULL) :: String NULL
 0 trim(String) :: String
 1 trim(String NULL) :: String NULL
+2 trim(String, String) :: String
+3 trim(String NULL, String NULL) :: String NULL
 0 trim_both(String, String) :: String
 1 trim_both(String NULL, String NULL) :: String NULL
 0 trim_leading(String, String) :: String

--- a/src/query/functions/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions/tests/it/scalars/testdata/string.txt
@@ -742,6 +742,33 @@ evaluation (internal):
 +--------+----------------------------------------------+
 
 
+ast            : ltrim(' aa','')
+raw expr       : ltrim(' aa', '')
+checked expr   : ltrim<String, String>(" aa", "")
+optimized expr : " aa"
+output type    : String
+output domain  : {" aa"..=" aa"}
+output         : ' aa'
+
+
+ast            : ltrim('\taa')
+raw expr       : ltrim('	aa')
+checked expr   : ltrim<String>("\taa")
+optimized expr : "\taa"
+output type    : String
+output domain  : {"\taa"..="\taa"}
+output         : '	aa'
+
+
+ast            : ltrim('#000000123','0#')
+raw expr       : ltrim('#000000123', '0#')
+checked expr   : ltrim<String, String>("#000000123", "0#")
+optimized expr : "123"
+output type    : String
+output domain  : {"123"..="123"}
+output         : '123'
+
+
 ast            : rtrim('   abc   ')
 raw expr       : rtrim('   abc   ')
 checked expr   : rtrim<String>("   abc   ")
@@ -817,6 +844,33 @@ evaluation (internal):
 | a      | StringColumn[abc,    abc,    abc   , abc   ] |
 | Output | StringColumn[abc,    abc,    abc, abc]       |
 +--------+----------------------------------------------+
+
+
+ast            : rtrim('aa ','')
+raw expr       : rtrim('aa ', '')
+checked expr   : rtrim<String, String>("aa ", "")
+optimized expr : "aa "
+output type    : String
+output domain  : {"aa "..="aa "}
+output         : 'aa '
+
+
+ast            : rtrim('aa\t')
+raw expr       : rtrim('aa	')
+checked expr   : rtrim<String>("aa\t")
+optimized expr : "aa\t"
+output type    : String
+output domain  : {"aa\t"..="aa\t"}
+output         : 'aa	'
+
+
+ast            : rtrim('$125.00','0.')
+raw expr       : rtrim('$125.00', '0.')
+checked expr   : rtrim<String, String>("$125.00", "0.")
+optimized expr : "$125"
+output type    : String
+output domain  : {"$125"..="$125"}
+output         : '$125'
 
 
 ast            : trim_leading('aaabbaaa', 'a')
@@ -1356,6 +1410,24 @@ evaluation (internal):
 | a      | StringColumn[abc,    abc,    abc   , abc   ] |
 | Output | StringColumn[abc, abc, abc, abc]             |
 +--------+----------------------------------------------+
+
+
+ast            : trim('\ta\t')
+raw expr       : trim('	a	')
+checked expr   : trim<String>("\ta\t")
+optimized expr : "\ta\t"
+output type    : String
+output domain  : {"\ta\t"..="\ta\t"}
+output         : '	a	'
+
+
+ast            : trim('*-*ABC-*-','*-')
+raw expr       : trim('*-*ABC-*-', '*-')
+checked expr   : trim<String, String>("*-*ABC-*-", "*-")
+optimized expr : "ABC"
+output type    : String
+output domain  : {"ABC"..="ABC"}
+output         : 'ABC'
 
 
 ast            : trim(both 'a' from 'aaabbaaa')

--- a/tests/sqllogictests/suites/query/functions/02_0020_function_strings_ltrim.test
+++ b/tests/sqllogictests/suites/query/functions/02_0020_function_strings_ltrim.test
@@ -16,3 +16,7 @@ select ltrim(null)
 ----
 NULL
 
+query T
+select ltrim('aaabbaaa', 'aa')
+----
+bbaaa

--- a/tests/sqllogictests/suites/query/functions/02_0021_function_strings_rtrim.test
+++ b/tests/sqllogictests/suites/query/functions/02_0021_function_strings_rtrim.test
@@ -16,3 +16,7 @@ select rtrim(null)
 ----
 NULL
 
+query T
+select rtrim('aaabbaaa', 'aa')
+----
+aaabb

--- a/tests/sqllogictests/suites/query/functions/02_0055_function_strings_trim.test
+++ b/tests/sqllogictests/suites/query/functions/02_0055_function_strings_trim.test
@@ -32,17 +32,7 @@ select trim_leading('aaabbaaa', '')
 aaabbaaa
 
 query T
-select ltrim('aaabbaaa', 'aa')
-----
-abbaaa
-
-query T
 select trim_trailing('aaabbaaa', 'aa')
-----
-aaabba
-
-query T
-select rtrim('aaabbaaa', 'aa')
 ----
 aaabba
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://docs.snowflake.com/en/sql-reference/functions/trim#examples

- fixes: #16798

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17375)
<!-- Reviewable:end -->
