### PR TITLE
fix(query): fix lambda function bind column failed

### DIFF
--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -366,13 +366,14 @@ pub fn parse_lambda_expr(
     // The column index may not be consecutive, and the length of columns
     // cannot be used to calculate the column index of the lambda argument.
     // We need to start from the current largest column index.
-    let mut column_index = 0;
-    for column in lambda_context.all_column_bindings().iter().rev() {
-        if column.index >= column_index {
-            column_index = column.index + 1;
-        }
-    }
+    let mut column_index = lambda_context
+        .all_column_bindings()
+        .iter()
+        .map(|c| c.index)
+        .max()
+        .unwrap_or_default();
     for (lambda_column, lambda_column_type) in lambda_columns.iter() {
+        column_index += 1;
         lambda_context.add_column_binding(
             ColumnBindingBuilder::new(
                 lambda_column.clone(),
@@ -382,7 +383,6 @@ pub fn parse_lambda_expr(
             )
             .build(),
         );
-        column_index += 1;
     }
 
     let settings = ctx.get_settings();

--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -356,30 +356,39 @@ pub fn parse_computed_expr_to_string(
 
 pub fn parse_lambda_expr(
     ctx: Arc<dyn TableContext>,
-    mut bind_context: BindContext,
-    columns: &[(String, DataType)],
+    lambda_context: &mut BindContext,
+    lambda_columns: &[(String, DataType)],
     ast: &AExpr,
 ) -> Result<Box<(ScalarExpr, DataType)>> {
     let metadata = Metadata::default();
-    bind_context.set_expr_context(ExprContext::InLambdaFunction);
+    lambda_context.set_expr_context(ExprContext::InLambdaFunction);
 
-    let column_len = bind_context.all_column_bindings().len();
-    for (idx, column) in columns.iter().enumerate() {
-        bind_context.add_column_binding(
+    // The column index may not be consecutive, and the length of columns
+    // cannot be used to calculate the column index of the lambda argument.
+    // We need to start from the current largest column index.
+    let mut column_index = 0;
+    for column in lambda_context.all_column_bindings().iter().rev() {
+        if column.index >= column_index {
+            column_index = column.index + 1;
+        }
+    }
+    for (lambda_column, lambda_column_type) in lambda_columns.iter() {
+        lambda_context.add_column_binding(
             ColumnBindingBuilder::new(
-                column.0.clone(),
-                column_len + idx,
-                Box::new(column.1.clone()),
+                lambda_column.clone(),
+                column_index,
+                Box::new(lambda_column_type.clone()),
                 Visibility::Visible,
             )
             .build(),
         );
+        column_index += 1;
     }
 
     let settings = ctx.get_settings();
     let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
     let mut type_checker = TypeChecker::try_create(
-        &mut bind_context,
+        lambda_context,
         ctx.clone(),
         &name_resolution_ctx,
         Arc::new(RwLock::new(metadata)),

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -438,9 +438,9 @@ statement ok
 INSERT INTO c VALUES(1, true, '[1,2]'),(1, false, '[3,4]'),(2, true, '123');
 
 query IT
-select ids.id, array_filter(array_agg(px.payload), x -> x is not null) as px_payload
-  from u ids left join c px on px.id = ids.id
-  group by ids.id;
+SELECT ids.id, array_filter(array_agg(px.payload), x -> x is not null) AS px_payload
+  FROM u ids LEFT JOIN c px ON px.id = ids.id
+  GROUP BY ids.id ORDER BY ids.id;
 ----
 1 ['[1,2]','[3,4]']
 2 ['123']

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -419,6 +419,32 @@ SELECT arrays_zip(col1, col2) FROM t3;
 [(NULL,4)]
 [(7,5),(8,5)]
 
+#issue 16794
+
+statement ok
+CREATE OR REPLACE TABLE u (id VARCHAR NULL);
+
+statement ok
+INSERT INTO u VALUES(1),(2);
+
+statement ok
+CREATE OR REPLACE TABLE c (
+  id VARCHAR NULL,
+  what_fuck BOOLEAN NOT NULL,
+  payload VARIANT NULL
+);
+
+statement ok
+INSERT INTO c VALUES(1, true, '[1,2]'),(1, false, '[3,4]'),(2, true, '123');
+
+query IT
+select ids.id, array_filter(array_agg(px.payload), x -> x is not null) as px_payload
+  from u ids left join c px on px.id = ids.id
+  group by ids.id;
+----
+1 ['[1,2]','[3,4]']
+2 ['123']
+
 statement ok
 USE default
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

We use the number of bound columns as the column index of the lambda column, but since the column index may be discontinuous, e.g. if there is a not null column in the join table, a new nullable wrapper is generated to replace the original column, and a new column index is generated. In this case, the parameter of lambda function will got a wrong column index and cause resolve lambda function fail, this PR fixes this bug.

- fixes: #17400

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17402)
<!-- Reviewable:end -->
