### PR TITLE
feat(query): support DATE_TRUNC('WEEK', EXPR)->DATE

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3004,6 +3004,16 @@ impl<'a> TypeChecker<'a> {
                     &[date],
                 )
             }
+            ASTIntervalKind::Week => {
+                self.resolve_function(
+                    span,
+                    "to_start_of_week", vec![],
+                    &[date, &Expr::Literal {
+                        span: None,
+                        value: Literal::UInt64(1)
+                    }],
+                )
+            }
             ASTIntervalKind::Day => {
                 self.resolve_function(
                     span,

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -272,6 +272,16 @@ SELECT max(MONTHS_BETWEEN(mine_date, birth_date))/12 as demo_age FROM t GROUP BY
 statement ok
 drop table if exists t;
 
+query T
+select date_trunc('month', '2025-02-05 00:01:00');
+----
+2025-02-01
+
+query T
+select date_trunc('week', '2025-02-05 00:01:00');
+----
+2025-02-03
+
 query FF
 SELECT
     MONTHS_BETWEEN('2019-03-15'::DATE,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

:) select date_trunc('week', '2025-02-05 00:01:00');

select
  date_trunc('week', '2025-02-05 00:01:00')

┌─────────────────────────────────────────┐
│ DATE_TRUNC(WEEK, '2025-02-05 00:01:00') │
│                   Date                  │
├─────────────────────────────────────────┤
│ 2025-02-03                              │
└─────────────────────────────────────────┘

- fixes: #17404


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17407)
<!-- Reviewable:end -->
