### PR TITLE
feat(auth): auto retry on jwks key not found

### DIFF
--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -128,6 +128,7 @@ impl JwtAuthenticator {
             Some(_) => Ok(c),
         }
     }
+
     #[async_backtrace::framed]
     pub async fn parse_jwt_claims(&self, token: &str) -> Result<JWTClaims<CustomClaims>> {
         let mut combined_code = ErrorCode::AuthenticateFailure(

--- a/src/query/users/src/jwt/authenticator.rs
+++ b/src/query/users/src/jwt/authenticator.rs
@@ -115,7 +115,15 @@ impl JwtAuthenticator {
     ) -> Result<JWTClaims<CustomClaims>> {
         let metadata = Token::decode_metadata(token);
         let key_id = metadata.map_or(None, |e| e.key_id().map(|s| s.to_string()));
-        let pub_key = key_store.get_key(key_id).await?;
+        let pub_key = match key_store.get_key(&key_id).await? {
+            None => {
+                return Err(ErrorCode::AuthenticateFailure(format!(
+                    "key id {} not found in jwk store",
+                    key_id.unwrap_or_default()
+                )));
+            }
+            Some(pk) => pk,
+        };
         let r = match &pub_key {
             PubKey::RSA256(pk) => pk.verify_token::<CustomClaims>(token, None),
             PubKey::ES256(pk) => pk.verify_token::<CustomClaims>(token, None),

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -175,9 +175,11 @@ impl JwkKeyStore {
             .map_err(|e| {
                 ErrorCode::InvalidConfig(format!("Failed to create jwks client: {}", e))
             })?;
-        let response = client.get(&self.url).send().await.map_err(|e| {
-            ErrorCode::AuthenticateFailure(format!("Could not download JWKS: {}", e))
-        })?;
+        let response = client
+            .get(&self.url)
+            .send()
+            .await
+            .map_err(|e| ErrorCode::Internal(format!("Could not download JWKS: {}", e)))?;
         let jwk_keys: JwkKeys = response
             .json()
             .await

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -96,12 +96,12 @@ pub struct JwkKeys {
 }
 
 pub struct JwkKeyStore {
-    pub(crate) url: String,
+    url: String,
     cached_keys: Arc<RwLock<HashMap<String, PubKey>>>,
-    pub(crate) last_refreshed_at: RwLock<Option<Instant>>,
-    pub(crate) refresh_interval: Duration,
-    pub(crate) refresh_timeout: Duration,
-    pub(crate) load_keys_func: Option<Arc<dyn Fn() -> HashMap<String, PubKey> + Send + Sync>>,
+    last_refreshed_at: RwLock<Option<Instant>>,
+    refresh_interval: Duration,
+    refresh_timeout: Duration,
+    load_keys_func: Option<Arc<dyn Fn() -> HashMap<String, PubKey> + Send + Sync>>,
 }
 
 impl JwkKeyStore {

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -99,14 +99,14 @@ pub struct JwkKeys {
 /// [`JwkKeyStore`] is a store for JWKS keys, it will cache the keys for a while and refresh the
 /// keys periodically. When the keys are refreshed, the older keys will still be kept for a while.
 ///
-/// When the keys rorated in the client side first, the server will respond a 401 Authorization Failure
+/// When the keys rotated in the client side first, the server will respond a 401 Authorization Failure
 /// error, as the key is not found in the cache. We'll try to refresh the keys and try again.
 pub struct JwkKeyStore {
     url: String,
     recent_cached_maps: Arc<RwLock<VecDeque<HashMap<String, PubKey>>>>,
-    max_recent_cached_maps: usize,
     last_refreshed_time: RwLock<Option<Instant>>,
     last_retry_time: RwLock<Option<Instant>>,
+    max_recent_cached_maps: usize,
     refresh_interval: Duration,
     refresh_timeout: Duration,
     retry_interval: Duration,

--- a/src/query/users/src/jwt/jwk.rs
+++ b/src/query/users/src/jwt/jwk.rs
@@ -235,10 +235,12 @@ impl JwkKeyStore {
         info!("JWKS keys changed.");
 
         // append the new keys to the end of recent_cached_maps
-        let mut recent_cached_maps = self.recent_cached_maps.write();
-        recent_cached_maps.push_back(new_keys);
-        if recent_cached_maps.len() > self.max_recent_cached_maps {
-            recent_cached_maps.pop_front();
+        {
+            let mut recent_cached_maps = self.recent_cached_maps.write();
+            recent_cached_maps.push_back(new_keys);
+            if recent_cached_maps.len() > self.max_recent_cached_maps {
+                recent_cached_maps.pop_front();
+            }
         }
         self.last_refreshed_time.write().replace(Instant::now());
         Ok(())

--- a/src/query/users/tests/it/jwt/jwk.rs
+++ b/src/query/users/tests/it/jwt/jwk.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use databend_common_base::base::tokio;
+use databend_common_exception::Result;
+use databend_common_users::JwkKeyStore;
+use databend_common_users::PubKey;
+use jwt_simple::prelude::*;
+use parking_lot::Mutex;
+
+struct MockJwksLoader {
+    keys: Mutex<HashMap<String, PubKey>>,
+}
+
+impl MockJwksLoader {
+    fn new() -> Self {
+        Self {
+            keys: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn reset_keys(&self, key_names: &[&'static str]) {
+        let mut keys = self.keys.lock();
+        for key_name in key_names {
+            keys.insert(
+                key_name.to_string(),
+                PubKey::RSA256(Box::new(RS256KeyPair::generate(2048).unwrap().public_key())),
+            );
+        }
+    }
+
+    fn load_keys(&self) -> HashMap<String, PubKey> {
+        self.keys.lock().clone()
+    }
+}
+
+#[tokio::test]
+async fn test_jwk_store_with_random_keys() -> Result<()> {
+    let mock_jwks_loader = Arc::new(MockJwksLoader::new());
+    mock_jwks_loader.reset_keys(&["key1", "key2"]);
+
+    let jwk_store = JwkKeyStore::new("jwks_key".to_string())
+        .with_load_keys_func(Arc::new(move || mock_jwks_loader.load_keys()));
+    let key = jwk_store.get_key(Some("key1".to_string())).await?;
+    Ok(())
+}

--- a/src/query/users/tests/it/jwt/jwk.rs
+++ b/src/query/users/tests/it/jwt/jwk.rs
@@ -21,6 +21,7 @@ impl MockJwksLoader {
 
     fn reset_keys(&self, key_names: &[&'static str]) {
         let mut keys = self.keys.lock();
+        keys.clear();
         for key_name in key_names {
             keys.insert(
                 key_name.to_string(),
@@ -37,10 +38,36 @@ impl MockJwksLoader {
 #[tokio::test]
 async fn test_jwk_store_with_random_keys() -> Result<()> {
     let mock_jwks_loader = Arc::new(MockJwksLoader::new());
-    mock_jwks_loader.reset_keys(&["key1", "key2"]);
-
+    let mock_jwks_loader_cloned = mock_jwks_loader.clone();
     let jwk_store = JwkKeyStore::new("jwks_key".to_string())
-        .with_load_keys_func(Arc::new(move || mock_jwks_loader.load_keys()));
-    let key = jwk_store.get_key(Some("key1".to_string())).await?;
+        .with_load_keys_func(Arc::new(move || mock_jwks_loader_cloned.load_keys()))
+        .with_max_recent_cached_maps(2)
+        .with_retry_interval(0);
+
+    mock_jwks_loader.reset_keys(&["key1", "key2"]);
+    let key = jwk_store.get_key(&None).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key1".to_string())).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key3".to_string())).await?;
+    assert!(key.is_none());
+
+    mock_jwks_loader.reset_keys(&["key3", "key4"]);
+    let key = jwk_store.get_key(&Some("key3".to_string())).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key4".to_string())).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key5".to_string())).await?;
+    assert!(key.is_none());
+    let key = jwk_store.get_key(&Some("key1".to_string())).await?;
+    assert!(key.is_some());
+
+    mock_jwks_loader.reset_keys(&["key5", "key6"]);
+    let key = jwk_store.get_key(&Some("key5".to_string())).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key6".to_string())).await?;
+    assert!(key.is_some());
+    let key = jwk_store.get_key(&Some("key1".to_string())).await?;
+    assert!(key.is_none());
     Ok(())
 }

--- a/src/query/users/tests/it/jwt/mod.rs
+++ b/src/query/users/tests/it/jwt/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 mod authenticator;
+mod jwk;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

currently, we maintain a cache for the jwks keys, and use the cache to validate the jwt authentications.

however, the jwks endpoint may rotate at any time. if the client rotated with the latest jwt, we may get a key not found 401 error on jwt authentication until the next jwks refresh (by default, it's 30s).

this error can be auto-recovered after 30s, but we want to go a step further about this to make it not noticeable for users with retry.

this pr added a retry for refreshing the jwks endpoint after a key not found error. and to avoid flooding the jwks endpoint, it limited a retry_interval.

there's also a risk that the server rotates the jwks first, but the client still uses the older jwt. to mitigate this risk, this pr also buffered the earlier jwks keys in memory.

## Tests

- [x] Unit Test

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17410)
<!-- Reviewable:end -->
