### PR TITLE
chore: use Box::leak() to ensure logging guard lives for the program's lifetime

### DIFF
--- a/src/meta/binaries/meta/entry.rs
+++ b/src/meta/binaries/meta/entry.rs
@@ -71,7 +71,8 @@ pub async fn entry(conf: Config) -> anyhow::Result<()> {
         "cluster_name".to_string(),
         conf.raft_config.cluster_name.clone(),
     );
-    let _guards = init_logging(&app_name_shuffle, &conf.log, log_labels);
+    let guards = init_logging(&app_name_shuffle, &conf.log, log_labels);
+    Box::new(guards).leak();
 
     info!("Databend Meta version: {}", METASRV_COMMIT_VERSION.as_str());
     info!(

--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -375,7 +375,8 @@ async fn main() -> anyhow::Result<()> {
         },
         ..Default::default()
     };
-    let _guards = init_logging("metactl", &log_config, BTreeMap::new());
+    let guards = init_logging("metactl", &log_config, BTreeMap::new());
+    Box::new(guards).leak();
 
     match app.command {
         Some(ref cmd) => match cmd {

--- a/src/meta/binaries/metaverifier/main.rs
+++ b/src/meta/binaries/metaverifier/main.rs
@@ -94,7 +94,8 @@ async fn main() -> Result<()> {
         ..Default::default()
     };
 
-    let _guards = init_logging("databend-metaverifier", &log_config, BTreeMap::new());
+    let guards = init_logging("databend-metaverifier", &log_config, BTreeMap::new());
+    Box::new(guards).leak();
 
     println!("config: {:?}", config);
     if config.grpc_api_address.is_empty() {

--- a/src/meta/process/src/examples.rs
+++ b/src/meta/process/src/examples.rs
@@ -61,11 +61,12 @@ impl Default for RaftConfig {
 async fn upgrade_09() -> anyhow::Result<()> {
     let config = Config::parse();
 
-    let _guards = init_logging(
+    let guards = init_logging(
         "databend-meta-upgrade-09",
         &LogConfig::default(),
         BTreeMap::new(),
     );
+    Box::new(guards).leak();
 
     eprintln!("config: {}", pretty(&config)?);
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: use `Box::leak()` to ensure logging guard lives for the program's lifetime

Previously, the logging guard was held with `let _guard = ...`, which
caused it to be dropped when the `main` function returned. This could
lead to an error when other threads, still running and depending on the
logging guard for log output, attempt to log after the guard has been
dropped.

By using `Box::leak()`, the logging guard is ensured to remain valid for
the entire lifetime of the program, preventing such errors.

- Fix: #16676

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17425)
<!-- Reviewable:end -->
