### PR TITLE
feat: support specifying columns to include in the "Attach table" statement

### DIFF
--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -265,7 +265,9 @@ impl Display for AttachTableStmt {
         )?;
 
         if let Some(cols) = &self.columns_opt {
+            write!(f, " (")?;
             write_comma_separated_list(f, cols.iter())?;
+            write!(f, ")")?;
         }
 
         write!(f, " {}", self.uri_location)?;

--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -249,6 +249,7 @@ pub struct AttachTableStmt {
     pub catalog: Option<Identifier>,
     pub database: Option<Identifier>,
     pub table: Identifier,
+    pub columns_opt: Option<Vec<Identifier>>,
     pub uri_location: UriLocation,
 }
 
@@ -262,6 +263,10 @@ impl Display for AttachTableStmt {
                 .chain(&self.database)
                 .chain(Some(&self.table)),
         )?;
+
+        if let Some(cols) = &self.columns_opt {
+            write_comma_separated_list(f, cols.iter())?;
+        }
 
         write!(f, " {}", self.uri_location)?;
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -869,13 +869,15 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
 
     let attach_table = map(
         rule! {
-            ATTACH ~ TABLE ~ #dot_separated_idents_1_to_3 ~ #uri_location
+            ATTACH ~ TABLE ~ #dot_separated_idents_1_to_3 ~ ("(" ~ #comma_separated_list1(ident) ~ ")")? ~ #uri_location
         },
-        |(_, _, (catalog, database, table), uri_location)| {
+        |(_, _, (catalog, database, table), columns_opt, uri_location)| {
+            let columns_opt = columns_opt.map(|(_, v, _)| v);
             Statement::AttachTable(AttachTableStmt {
                 catalog,
                 database,
                 table,
+                columns_opt,
                 uri_location,
             })
         },

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -23705,6 +23705,7 @@ AttachTable(
             quote: None,
             ident_type: None,
         },
+        columns_opt: None,
         uri_location: UriLocation {
             protocol: "s3",
             name: "a",

--- a/src/query/ee/src/attach_table/handler.rs
+++ b/src/query/ee/src/attach_table/handler.rs
@@ -142,7 +142,7 @@ impl RealAttachTableHandler {
                 )));
             }
 
-            let new_table_schema = if !field_ids_to_include.is_empty() {
+            let new_table_schema_metadata = if !field_ids_to_include.is_empty() {
                 // If columns to include are specified explicitly, their ids should
                 // be kept in the metadata of TableSchema.
                 let ids = field_ids_to_include
@@ -159,7 +159,7 @@ impl RealAttachTableHandler {
 
             TableSchema {
                 fields: fields_to_attach,
-                metadata: new_table_schema,
+                metadata: new_table_schema_metadata,
                 next_column_id: base_table_schema.next_column_id,
             }
         } else {

--- a/src/query/ee/src/attach_table/handler.rs
+++ b/src/query/ee/src/attach_table/handler.rs
@@ -75,7 +75,7 @@ impl AttachTableHandler for RealAttachTableHandler {
             number_of_blocks: Some(snapshot.summary.block_count),
         };
 
-        let attach_table_schema = Self::extract_schema(&plan, &snapshot)?;
+        let attach_table_schema = Self::gen_schema(&plan, &snapshot)?;
 
         let field_comments = vec!["".to_string(); snapshot.schema.num_fields()];
         let table_meta = TableMeta {
@@ -112,11 +112,7 @@ impl RealAttachTableHandler {
         Ok(())
     }
 
-    // `attach_table_schema` is the initial table schema, which is
-    // - A cloned schema of the table being attached to
-    // - Or a sub-schema of the table being attached to
-    //    if columns to include are explicitly specified in the "ATTACH TABLE" statement.
-    fn extract_schema(
+    fn gen_schema(
         plan: &&CreateTablePlan,
         base_table_snapshot: &Arc<TableSnapshot>,
     ) -> Result<TableSchema> {
@@ -167,6 +163,8 @@ impl RealAttachTableHandler {
                 next_column_id: base_table_schema.next_column_id,
             }
         } else {
+            // If columns are not specified, use all the fields of table being attached to,
+            // in this case, no schema meta of key FUSE_OPT_KEY_ATTACH_COLUMN_IDS will be kept.
             base_table_snapshot.schema.clone()
         };
 

--- a/src/query/ee/tests/it/inverted_index/pruning.rs
+++ b/src/query/ee/tests/it/inverted_index/pruning.rs
@@ -122,6 +122,7 @@ async fn test_block_pruner() -> Result<()> {
         as_select: None,
         cluster_key: None,
         inverted_indexes: None,
+        attached_columns: None,
     };
 
     let interpreter = CreateTableInterpreter::try_create(ctx.clone(), create_table_plan)?;

--- a/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
@@ -306,6 +306,7 @@ async fn create_memory_table_for_cte_scan(
                 cluster_key: None,
                 as_select: None,
                 inverted_indexes: None,
+                attached_columns: None,
             };
             let create_table_interpreter =
                 CreateTableInterpreter::try_create(ctx.clone(), create_table_plan)?;

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -348,6 +348,7 @@ impl TestFixture {
             as_select: None,
             cluster_key: Some("(id)".to_string()),
             inverted_indexes: None,
+            attached_columns: None,
         }
     }
 
@@ -372,6 +373,7 @@ impl TestFixture {
             as_select: None,
             cluster_key: None,
             inverted_indexes: None,
+            attached_columns: None,
         }
     }
 
@@ -407,6 +409,7 @@ impl TestFixture {
             as_select: None,
             cluster_key: None,
             inverted_indexes: None,
+            attached_columns: None,
         }
     }
 
@@ -442,6 +445,7 @@ impl TestFixture {
             as_select: None,
             cluster_key: None,
             inverted_indexes: None,
+            attached_columns: None,
         }
     }
 
@@ -486,6 +490,7 @@ impl TestFixture {
             as_select: None,
             cluster_key: None,
             inverted_indexes: None,
+            attached_columns: None,
         }
     }
 

--- a/src/query/service/tests/it/sql/planner/optimizer/agg_index_query_rewrite.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/agg_index_query_rewrite.rs
@@ -84,6 +84,7 @@ fn create_table_plan(fixture: &TestFixture, format: &str) -> CreateTablePlan {
         as_select: None,
         cluster_key: None,
         inverted_indexes: None,
+        attached_columns: None,
     }
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/clustering.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/clustering.rs
@@ -53,6 +53,7 @@ async fn test_fuse_alter_table_cluster_key() -> databend_common_exception::Resul
         as_select: None,
         cluster_key: None,
         inverted_indexes: None,
+        attached_columns: None,
     };
 
     // create test table

--- a/src/query/service/tests/it/storages/fuse/pruning.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning.rs
@@ -116,6 +116,7 @@ async fn test_block_pruner() -> Result<()> {
         as_select: None,
         cluster_key: None,
         inverted_indexes: None,
+        attached_columns: None,
     };
 
     let interpreter = CreateTableInterpreter::try_create(ctx.clone(), create_table_plan)?;

--- a/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
@@ -174,6 +174,7 @@ async fn test_snapshot_pruner() -> Result<()> {
         as_select: None,
         cluster_key: None,
         inverted_indexes: None,
+        attached_columns: None,
     };
 
     let interpreter = CreateTableInterpreter::try_create(ctx.clone(), create_table_plan)?;

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -724,6 +724,7 @@ impl Binder {
             cluster_key,
             as_select: as_query_plan,
             inverted_indexes,
+            attached_columns: None,
         };
         Ok(Plan::CreateTable(Box::new(plan)))
     }
@@ -789,6 +790,7 @@ impl Binder {
             cluster_key: None,
             as_select: None,
             inverted_indexes: None,
+            attached_columns: stmt.columns_opt.clone(),
         })))
     }
 

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use databend_common_ast::ast::Engine;
+use databend_common_ast::ast::Identifier;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::DataField;
@@ -55,6 +56,8 @@ pub struct CreateTablePlan {
     pub cluster_key: Option<String>,
     pub as_select: Option<Box<Plan>>,
     pub inverted_indexes: Option<BTreeMap<String, TableIndex>>,
+
+    pub attached_columns: Option<Vec<Identifier>>,
 }
 
 impl CreateTablePlan {

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -20,6 +20,8 @@ pub const FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD: &str = "row_avg_depth_threshold"
 
 pub const FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS: &str = "data_retention_period_in_hours";
 
+pub const FUSE_OPT_KEY_ATTACH_COLUMN_IDS: &str = "attach_column_ids";
+
 pub const FUSE_TBL_BLOCK_PREFIX: &str = "_b";
 pub const FUSE_TBL_BLOCK_INDEX_PREFIX: &str = "_i";
 pub const FUSE_TBL_XOR_BLOOM_INDEX_PREFIX: &str = "_i_b_v2";

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -50,6 +50,7 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::BlockThresholds;
 use databend_common_expression::ColumnId;
 use databend_common_expression::RemoteExpr;
+use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::ORIGIN_BLOCK_ID_COL_NAME;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COL_NAME;
@@ -92,6 +93,7 @@ use databend_storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
 use databend_storages_common_table_meta::table::OPT_KEY_TABLE_ATTACHED_DATA_URI;
 use databend_storages_common_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
 use futures_util::TryStreamExt;
+use itertools::Itertools;
 use log::info;
 use log::warn;
 use opendal::Operator;
@@ -115,6 +117,7 @@ use crate::TableStatistics;
 use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::DEFAULT_ROW_PER_PAGE;
 use crate::DEFAULT_ROW_PER_PAGE_FOR_BLOCKING;
+use crate::FUSE_OPT_KEY_ATTACH_COLUMN_IDS;
 use crate::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS;
@@ -562,6 +565,8 @@ impl FuseTable {
             // If table_info options contains key OPT_KEY_SNAPSHOT_LOCATION_FIXED_FLAG,
             // it means that this table info has been tweaked according to the rules of
             // resolving snapshot location from the hint file, it should not be tweaked again.
+            // Otherwise, inconsistent table snapshots may be used while table is being processed in
+            // a distributed manner.
             return Ok(());
         }
 
@@ -584,7 +589,39 @@ impl FuseTable {
                     .options_mut()
                     .insert(OPT_KEY_SNAPSHOT_LOCATION.to_string(), location);
 
-                table_info.meta.schema = Arc::new(schema);
+                if let Some(ids) = table_info
+                    .schema()
+                    .metadata
+                    .get(FUSE_OPT_KEY_ATTACH_COLUMN_IDS)
+                {
+                    // extract ids of column to include
+                    let ids: Vec<ColumnId> = ids
+                        .as_str()
+                        .split(",")
+                        .map(|s| s.parse::<u32>())
+                        .try_collect()?;
+
+                    // retain the columns that are still there
+                    let fields: Vec<TableField> = ids
+                        .iter()
+                        .filter_map(|id| schema.field_of_column_id(*id).ok().cloned())
+                        .collect();
+
+                    if fields.is_empty() {
+                        return Err(ErrorCode::StorageOther(format!(
+                            "no effective columns found in ATTACH table {}",
+                            table_info.desc
+                        )));
+                    }
+
+                    let mut new_schema = table_info.meta.schema.as_ref().clone();
+                    new_schema.metadata = schema.metadata.clone();
+                    new_schema.next_column_id = schema.next_column_id();
+                    new_schema.fields = fields;
+                    table_info.meta.schema = Arc::new(new_schema);
+                } else {
+                    table_info.meta.schema = Arc::new(schema);
+                }
             }
         }
 

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
@@ -55,6 +55,9 @@ attaching base table
 >>>> select * from attach_tbl
 c2	c4
 <<<<
+>>>> show create table attach_tbl
+attach_tbl	ATTACH TABLE (c2,c4) `default`.`attach_tbl` 's3://testbucket/admin/data/1/6208/' CONNECTION = ( connection_name = '******onn' )
+<<<<
 >>>> drop table if exists attach_tbl
 attaching non-exists column
 Error: APIError: QueryFailed: [2004]Columns [c_not_exist] do not exist in the table being attached to

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
@@ -56,7 +56,7 @@ attaching base table
 c2	c4
 <<<<
 >>>> show create table attach_tbl
-attach_tbl	ATTACH TABLE (c2,c4) `default`.`attach_tbl` 's3://testbucket/admin/data/1/6208/' CONNECTION = ( connection_name = '******onn' )
+attach_tbl	ATTACH TABLE (c2,c4) `default`.`attach_tbl` 
 <<<<
 >>>> drop table if exists attach_tbl
 attaching non-exists column

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
@@ -44,6 +44,73 @@ Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'table_to'
 1
 2
 <<<<
+##############################
+# implicitly include columns #
+##############################
+>>>> create or replace table base(c1 string, c2 string, c3 string, c4 string) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900');
+>>>> insert into base values('c1', 'c2', 'c3', 'c4')
+1
+>>>> drop table if exists attach_tbl
+attaching base table
+>>>> select * from attach_tbl
+c2	c4
+<<<<
+>>>> drop table if exists attach_tbl
+attaching non-exists column
+Error: APIError: QueryFailed: [2004]Attached columns do not exist: c_not_exist
+#############################
+## access renamed columns ###
+#############################
+>>>> drop table if exists attach_tbl
+>>>> alter table base RENAME COLUMN c2 to c2_new
+>>>> insert into base values('c1', 'c2_new', 'c3', 'c4')
+1
+select all should work
+>>>> select * from attach_tbl order by c2_new
+c2	c4
+c2_new	c4
+<<<<
+select c2_new should work
+>>>> select c2_new from attach_tbl order by c2_new
+c2
+c2_new
+<<<<
+##################################
+## drop column from base table ###
+##################################
+>>>> alter table base DROP COLUMN c1
+>>>> delete from base
+2
+>>>> insert into base values('c2_new', 'c3', 'c4')
+1
+select all should work
+>>>> select * from attach_tbl
+c2_new	c4
+<<<<
+select c2_new should work
+>>>> select c2_new from attach_tbl order by c2_new
+c2_new
+<<<<
+>>>> alter table base DROP COLUMN c4
+select the dropped column will fail
+>>>> select c4 from attach_tbl
+Error: APIError: QueryFailed: [1065]error: 
+  --> SQL:1:8
+  |
+1 | select c4 from attach_tbl
+  |        ^^ column c4 doesn't exist
+
+
+<<<<
+>>>> select * from attach_tbl order by c2_new
+c2_new
+<<<<
+>>>> alter table base DROP COLUMN c2_new
+but if all the include columns are dropped, select ALL should fail as well
+>>>> select * from attach_tbl
+Error: APIError: QueryFailed: [4000]no effective columns found in ATTACH table 'default'.'attach_tbl'
+<<<<
+>>>> drop table if exists attach_tbl;
 >>>> drop connection my_conn;
 >>>> drop table if exists table_from;
 >>>> drop table if exists table_from2;

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
@@ -57,7 +57,7 @@ c2	c4
 <<<<
 >>>> drop table if exists attach_tbl
 attaching non-exists column
-Error: APIError: QueryFailed: [2004]Attached columns do not exist: c_not_exist
+Error: APIError: QueryFailed: [2004]Columns [c_not_exist] do not exist in the table being attached to
 #############################
 ## access renamed columns ###
 #############################

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -70,7 +70,9 @@ echo "attach table attach_tbl (c2, c4) 's3://testbucket/admin/data/$base_storage
 
 query "select * from attach_tbl"
 
-query "show create table attach_tbl"
+
+# the components after columns, i.e. "'ss://... ' connection = ...." will be cut off
+query "show create table attach_tbl" | cut -d "'" -f 1
 
 stmt "drop table if exists attach_tbl"
 

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -53,6 +53,83 @@ query "select * from table_to order by a;"
 comment "select after deletion with self-defined connection"
 query "select * from table_to2 order by a;"
 
+echo "##############################"
+echo "# implicitly include columns #"
+echo "##############################"
+
+stmt "create or replace table base(c1 string, c2 string, c3 string, c4 string) 's3://testbucket/admin/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');"
+
+stmt "insert into base values('c1', 'c2', 'c3', 'c4')"
+
+base_storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table base" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
+
+stmt "drop table if exists attach_tbl"
+
+echo "attaching base table"
+echo "attach table attach_tbl (c2, c4) 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+
+query "select * from attach_tbl"
+
+stmt "drop table if exists attach_tbl"
+
+# include non-exist column should fail
+echo "attaching non-exists column"
+echo "attach table attach_tbl (c2, c_not_exist) 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+
+
+
+# access modified table
+echo "#############################"
+echo "## access renamed columns ###"
+echo "#############################"
+
+stmt "drop table if exists attach_tbl"
+echo "attach table attach_tbl (c2, c4) 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+
+stmt "alter table base RENAME COLUMN c2 to c2_new"
+stmt "insert into base values('c1', 'c2_new', 'c3', 'c4')"
+
+echo "select all should work"
+query "select * from attach_tbl order by c2_new"
+
+echo "select c2_new should work"
+query "select c2_new from attach_tbl order by c2_new"
+
+echo "##################################"
+echo "## drop column from base table ###"
+echo "##################################"
+
+# CASE: dropping columns which are NOT included in the attach table, should not matter
+stmt "alter table base DROP COLUMN c1"
+stmt "delete from base"
+stmt "insert into base values('c2_new', 'c3', 'c4')"
+echo "select all should work"
+query "select * from attach_tbl"
+
+echo "select c2_new should work"
+query "select c2_new from attach_tbl order by c2_new"
+
+# CASE: dropping columns which are included in the attach table
+stmt "alter table base DROP COLUMN c4"
+
+# if dropped column is accessed, it will fail
+echo "select the dropped column will fail"
+query "select c4 from attach_tbl"
+
+# but select ALL will return the remaining columns
+query "select * from attach_tbl order by c2_new"
+
+
+stmt "alter table base DROP COLUMN c2_new"
+echo "but if all the include columns are dropped, select ALL should fail as well"
+query "select * from attach_tbl"
+
+stmt "drop table if exists attach_tbl;"
+
+
+
+
+
 stmt "drop connection my_conn;"
 
 stmt "drop table if exists table_from;"

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -70,6 +70,8 @@ echo "attach table attach_tbl (c2, c4) 's3://testbucket/admin/data/$base_storage
 
 query "select * from attach_tbl"
 
+query "show create table attach_tbl"
+
 stmt "drop table if exists attach_tbl"
 
 # include non-exist column should fail


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Allow optionally specifying which columns to include in the 'Attach table' statement.

e.g.

To create a table named `test_tbl` that attaches to the path 's3://databend-toronto/1/556/' and includes only the columns `col1` and `col2`, you can use the following SQL statement:

~~~
ATTACH TABLE `test_tbl`  (col1, col2) 's3://databend-toronto/1/556/';
~~~

------

Suppose the table `base` is being attached:

~~~

create or replace table base(c1 string, c2 string, c3 string, c4 string) ...

~~~


-  Try Including columns which do not exist in the `base` table will fail

  e.g.   `attach table attach_tbl (c2, c_not_exist) ....` will fail


- Dropping non-included columns from `base` does not matter

  e.g.
  ~~~
   -- attach to base table
  attach table attach_tbl (c2, c4) ....; 

  alter table base drop column c1;
  
  -- should still work
  select * from attach_tbl;
  ~~~

- Renaming included columns of `base` does not matter

  e.g.
  ~~~
   -- attach to base table
  attach table attach_tbl (c2, c4) ....; 

  alter table base rename column c2 to c2_new;
  
  -- should still work
  select * from attach_tbl;
  select c2_new from attach_tbl;
  
  -- but the old column name is NO longer available
  select c2 from attach_tbl; -- this will fail
  ~~~


- Column that have been dropped from `base` table will be inaccessible

  e.g.
  ~~~
   -- attach to base table
  attach table attach_tbl (c2_new, c4) ....; 

  alter table base drop column c4;
  
  -- this will fail
  select c4 from attach_tbl;
  
  -- but this should work
  select c2_new from attach_tbl;
  ~~~

  `select *` should still work, as long as there is at least one column left:

  ~~~
   -- should still work
  select * from attach_tbl;
  ~~~
  
  
  if all the attached columns have been dropped from the `base` table, `attach_tbl` can no longer be scanned:
  
  ~~~
  -- remove c4 from base
  alter table base drop column c4;

  -- this will fail
  select * from attach_tbl; 
  ~~~



- fixes: #17439


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17442)
<!-- Reviewable:end -->
