### PR TITLE
fix(parser): allow timestamp as a function name

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -957,39 +957,6 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
         value(TrimWhere::Leading, rule! { LEADING }),
         value(TrimWhere::Trailing, rule! { TRAILING }),
     ));
-    let trim = map(
-        rule! {
-            TRIM
-            ~ "("
-            ~ #subexpr(0) ~ ("," ~ #subexpr(0))?
-            ~ ^")"
-        },
-        |(name, _, expr, trim_str, _)| {
-            if let Some(trim_str) = trim_str {
-                let trim_str = trim_str.1;
-                ExprElement::FunctionCall {
-                    func: FunctionCall {
-                        distinct: false,
-                        name: Identifier {
-                            span: Some(name.span),
-                            name: name.text().to_owned(),
-                            quote: None,
-                            ident_type: IdentifierType::None,
-                        },
-                        args: vec![expr, trim_str],
-                        params: vec![],
-                        window: None,
-                        lambda: None,
-                    },
-                }
-            } else {
-                ExprElement::Trim {
-                    expr: Box::new(expr),
-                    trim_where: None,
-                }
-            }
-        },
-    );
     let trim_from = map(
         rule! {
             TRIM
@@ -1391,7 +1358,6 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
             ),
             rule!(
                 #substring : "`SUBSTRING(... [FROM ...] [FOR ...])`"
-                | #trim : "`TRIM(...)`"
                 | #trim_from : "`TRIM([(BOTH | LEADEING | TRAILING) ... FROM ...)`"
                 | #is_distinct_from: "`... IS [NOT] DISTINCT FROM ...`"
                 | #chain_function_call : "x.function(...)"

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1573,10 +1573,10 @@ impl TokenKind {
             | TokenKind::TABLE
             | TokenKind::THEN
             // | TokenKind::TIME
-            | TokenKind::TIMESTAMP
+            // | TokenKind::TIMESTAMP
             | TokenKind::TRAILING
             // | TokenKind::TREAT
-            | TokenKind::TRIM
+            // | TokenKind::TRIM
             | TokenKind::TRUE
             | TokenKind::TRY_CAST
             // | TokenKind::UNIQUE

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1214,6 +1214,8 @@ fn test_expr() {
         r#"TRY_CAST(col1 AS BIGINT UNSIGNED)"#,
         r#"TRY_CAST(col1 AS TUPLE(BIGINT UNSIGNED NULL, BOOLEAN))"#,
         r#"trim(leading 'abc' from 'def')"#,
+        r#"trim('aa','bb')"#,
+        r#"timestamp()"#, // issue #16628
         r#"extract(year from d)"#,
         r#"date_part(year, d)"#,
         r#"position('a' in str)"#,

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -1656,6 +1656,77 @@ Trim {
 
 
 ---------- Input ----------
+trim('aa','bb')
+---------- Output ---------
+trim('aa', 'bb')
+---------- AST ------------
+FunctionCall {
+    span: Some(
+        0..15,
+    ),
+    func: FunctionCall {
+        distinct: false,
+        name: Identifier {
+            span: Some(
+                0..4,
+            ),
+            name: "trim",
+            quote: None,
+            ident_type: None,
+        },
+        args: [
+            Literal {
+                span: Some(
+                    5..9,
+                ),
+                value: String(
+                    "aa",
+                ),
+            },
+            Literal {
+                span: Some(
+                    10..14,
+                ),
+                value: String(
+                    "bb",
+                ),
+            },
+        ],
+        params: [],
+        window: None,
+        lambda: None,
+    },
+}
+
+
+---------- Input ----------
+timestamp()
+---------- Output ---------
+timestamp()
+---------- AST ------------
+FunctionCall {
+    span: Some(
+        0..11,
+    ),
+    func: FunctionCall {
+        distinct: false,
+        name: Identifier {
+            span: Some(
+                0..9,
+            ),
+            name: "timestamp",
+            quote: None,
+            ident_type: None,
+        },
+        args: [],
+        params: [],
+        window: None,
+        lambda: None,
+    },
+}
+
+
+---------- Input ----------
 extract(year from d)
 ---------- Output ---------
 EXTRACT(YEAR FROM d)

--- a/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
@@ -95,7 +95,7 @@ explain select count(3), type, name, trim(name) as a from system.columns group b
 ----
 EvalScalar
 ├── output columns: [count(3) (#13), columns.name (#0), columns.type (#3), a (#14)]
-├── expressions: [trim_both(columns.name (#0), ' ')]
+├── expressions: [trim(columns.name (#0))]
 ├── estimated rows: 0.00
 └── AggregateFinal
     ├── output columns: [count(3) (#13), columns.name (#0), columns.type (#3)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/aggregate.test
@@ -95,7 +95,7 @@ explain select count(3), type, name, trim(name) as a from system.columns group b
 ----
 EvalScalar
 ├── output columns: [count(3) (#13), columns.name (#0), columns.type (#3), a (#14)]
-├── expressions: [trim_both(columns.name (#0), ' ')]
+├── expressions: [trim(columns.name (#0))]
 ├── estimated rows: 0.00
 └── AggregateFinal
     ├── output columns: [count(3) (#13), columns.name (#0), columns.type (#3)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- fixes: #16628

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17455)
<!-- Reviewable:end -->
