### PR TITLE
fix(query): fix order by derived column with limit return wrong values

### DIFF
--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -520,6 +520,18 @@ impl Binder {
             return Ok(());
         }
 
+        for order_by_item in order_by {
+            let column = metadata.column(order_by_item.index);
+            // If order by contains derived column or virtual column,
+            // limit can't be pushed down, so there's no need row fetcher.
+            if matches!(
+                column,
+                ColumnEntry::DerivedColumn(_) | ColumnEntry::VirtualColumn(_)
+            ) {
+                return Ok(());
+            }
+        }
+
         // As we don't if this is subquery, we need add required cols to metadata's non_lazy_columns,
         // so if the inner query not match the lazy materialized but outer query matched, we can prevent
         // the cols that inner query required not be pruned when analyze outer query.

--- a/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0004_select_order_by.test
@@ -60,6 +60,16 @@ select * from t1 order by id desc limit 3,3
 4
 
 statement ok
+insert into t1 select number as id from numbers(10)
+
+query I
+select * from t1 order by id::string desc limit 3
+----
+9
+9
+8
+
+statement ok
 drop table t1
 
 query IT

--- a/tests/sqllogictests/suites/mode/standalone/explain/sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/sort.test
@@ -64,6 +64,32 @@ Sort
         ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
         └── estimated rows: 0.00
 
+query T
+explain select a from t1 order by a::string limit 1;
+----
+Limit
+├── output columns: [t1.a (#0), a::STRING (#2)]
+├── limit: 1
+├── offset: 0
+├── estimated rows: 0.00
+└── Sort
+    ├── output columns: [t1.a (#0), a::STRING (#2)]
+    ├── sort keys: [a::STRING ASC NULLS LAST]
+    ├── estimated rows: 0.00
+    └── EvalScalar
+        ├── output columns: [t1.a (#0), a::STRING (#2)]
+        ├── expressions: [CAST(t1.a (#0) AS String NULL)]
+        ├── estimated rows: 0.00
+        └── TableScan
+            ├── table: default.default.t1
+            ├── output columns: [a (#0)]
+            ├── read rows: 0
+            ├── read size: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
+
 statement ok
 set max_threads = 4;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If `order by` contains derived columns, set the `limit` for push down to None, because limit pruner will ignore some blocks, which will lead to incorrect result. Also, if `order by` contains derived columns, do not generate a `RowFetch` plan, because not pushing down the `limit` will make the `RowFetch` optimisation meaningless.

for example, create a table and insert some values to two blocks.

```sql
root@0.0.0.0:48000/default> create table t1(id int);
0 row written in 0.237 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

root@0.0.0.0:48000/default> insert into t1 select number as id from numbers(10);
┌─────────────────────────┐
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                      10 │
└─────────────────────────┘
10 rows written in 0.204 sec. Processed 10 rows, 42 B (49.02 rows/s, 205 B/s)

root@0.0.0.0:48000/default> insert into t1 select number as id from numbers(10);
┌─────────────────────────┐
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                      10 │
└─────────────────────────┘
10 rows written in 0.221 sec. Processed 10 rows, 42 B (45.25 rows/s, 190 B/s)
```

main
```sql
root@0.0.0.0:48000/default> select * from t1 order by id::string desc limit 3;
┌─────────────────┐
│        id       │
│ Nullable(Int32) │
├─────────────────┤
│               9 │
│               8 │
│               7 │
└─────────────────┘
3 rows read in 0.058 sec. Processed 10 rows, 42 B (172.41 rows/s, 724 B/s)

root@0.0.0.0:48000/default> explain select * from t1 order by id::string desc limit 3;
-[ EXPLAIN ]-----------------------------------
Limit
├── output columns: [t1.id (#0), id::STRING (#1)]
├── limit: 3
├── offset: 0
├── estimated rows: 3.00
└── Sort
    ├── output columns: [t1.id (#0), id::STRING (#1)]
    ├── sort keys: [id::STRING DESC NULLS LAST]
    ├── estimated rows: 20.00
    └── EvalScalar
        ├── output columns: [t1.id (#0), id::STRING (#1)]
        ├── expressions: [CAST(t1.id (#0) AS String NULL)]
        ├── estimated rows: 20.00
        └── TableScan
            ├── table: default.default.t1
            ├── output columns: [id (#0)]
            ├── read rows: 10
            ├── read size: < 1 KiB
            ├── partitions total: 2
            ├── partitions scanned: 1
            ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 1>]
            ├── push downs: [filters: [], limit: 3]
            └── estimated rows: 20.00

23 rows explain in 0.030 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)
```

this PR
```sql
root@0.0.0.0:48000/default> select * from t1 order by id::string desc limit 3;
┌─────────────────┐
│        id       │
│ Nullable(Int32) │
├─────────────────┤
│               9 │
│               9 │
│               8 │
└─────────────────┘
3 rows read in 0.163 sec. Processed 20 rows, 84 B (122.7 rows/s, 515 B/s)

root@0.0.0.0:48000/default> explain select * from t1 order by id::string desc limit 3;
-[ EXPLAIN ]-----------------------------------
Limit
├── output columns: [t1.id (#0), id::STRING (#1)]
├── limit: 3
├── offset: 0
├── estimated rows: 3.00
└── Sort
    ├── output columns: [t1.id (#0), id::STRING (#1)]
    ├── sort keys: [id::STRING DESC NULLS LAST]
    ├── estimated rows: 20.00
    └── EvalScalar
        ├── output columns: [t1.id (#0), id::STRING (#1)]
        ├── expressions: [CAST(t1.id (#0) AS String NULL)]
        ├── estimated rows: 20.00
        └── TableScan
            ├── table: default.default.t1
            ├── output columns: [id (#0)]
            ├── read rows: 20
            ├── read size: < 1 KiB
            ├── partitions total: 2
            ├── partitions scanned: 2
            ├── pruning stats: [segments: <range pruning: 2 to 2>, blocks: <range pruning: 2 to 2>]
            ├── push downs: [filters: [], limit: NONE]
            └── estimated rows: 20.00

23 rows explain in 0.108 sec. Processed 0 rows, 0 B (0 row/s, 0 B/s)
```

- fixes: #17451 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17457)
<!-- Reviewable:end -->
