### PR TITLE
fix(query): fix variant get string function auto cast null to SQL NULL

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -394,8 +394,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                 }
                 match get_by_name(val, name, false) {
                     Some(v) => {
-                        let json_str = cast_to_string(&v);
-                        output.push(&json_str);
+                        if is_null(&v) {
+                            output.push_null();
+                        } else {
+                            let json_str = cast_to_string(&v);
+                            output.push(&json_str);
+                        }
                     }
                     None => output.push_null(),
                 }
@@ -419,8 +423,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                 } else {
                     match get_by_index(val, idx as usize) {
                         Some(v) => {
-                            let json_str = cast_to_string(&v);
-                            output.push(&json_str);
+                            if is_null(&v) {
+                                output.push_null();
+                            } else {
+                                let json_str = cast_to_string(&v);
+                                output.push(&json_str);
+                            }
                         }
                         None => {
                             output.push_null();
@@ -632,7 +640,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 let mut out_offsets = Vec::new();
                                 match get_by_path(&buf, json_path, &mut out_buf, &mut out_offsets) {
                                     Ok(()) => {
-                                        if out_offsets.is_empty() {
+                                        if out_offsets.is_empty() || is_null(&out_buf) {
                                             output.push_null();
                                         } else {
                                             let json_str = cast_to_string(&out_buf);

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -900,6 +900,15 @@ output domain  : {"{\"b\":2}"..="{\"b\":2}"}
 output         : '{"b":2}'
 
 
+ast            : json_extract_path_text('{"a":null}', 'a')
+raw expr       : json_extract_path_text('{"a":null}', 'a')
+checked expr   : json_extract_path_text<String, String>("{\"a\":null}", "a")
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+
 ast            : json_extract_path_text(s, k)
 raw expr       : json_extract_path_text(s::String, k::String)
 checked expr   : json_extract_path_text<String, String>(s, k)
@@ -3277,6 +3286,15 @@ output         : 'v'
 ast            : parse_json('{"k":"v"}')->>'x'
 raw expr       : get_string(parse_json('{"k":"v"}'), 'x')
 checked expr   : get_string<Variant, String>(parse_json<String>("{\"k\":\"v\"}"), "x")
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : parse_json('{"k":null}')->>'k'
+raw expr       : get_string(parse_json('{"k":null}'), 'k')
+checked expr   : get_string<Variant, String>(parse_json<String>("{\"k\":null}"), "k")
 optimized expr : NULL
 output type    : String NULL
 output domain  : {NULL}

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -326,6 +326,7 @@ fn test_get_string_arrow_op(file: &mut impl Write) {
     run_ast(file, "parse_json('[1,2,3,4]')->>(2+3)", &[]);
     run_ast(file, "parse_json('{\"k\":\"v\"}')->>'k'", &[]);
     run_ast(file, "parse_json('{\"k\":\"v\"}')->>'x'", &[]);
+    run_ast(file, "parse_json('{\"k\":null}')->>'k'", &[]);
     run_ast(file, "CAST(('a', 'b') AS VARIANT)->>'2'", &[]);
 
     run_ast(file, "parse_json(s)->>i", &[
@@ -471,6 +472,7 @@ fn test_json_extract_path_text(file: &mut impl Write) {
     );
     run_ast(file, "json_extract_path_text('{\"a\":{\"b\":2}}', 'a')", &[
     ]);
+    run_ast(file, "json_extract_path_text('{\"a\":null}', 'a')", &[]);
 
     run_ast(file, "json_extract_path_text(s, k)", &[
         (

--- a/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
+++ b/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
@@ -92,10 +92,15 @@ NULL
 query T
 select parse_json('{"aa": null, "aA": 2, "Aa": 3}')->>'aa'
 ----
-null
+NULL
 
 query T
 select parse_json(null)->>'aa'
+----
+NULL
+
+query T
+select parse_json('{"key1":null}')->>'key1'
 ----
 NULL
 
@@ -201,6 +206,10 @@ select json_extract_path_text('{"customer":{"id": 1, "name":"databend", "extras"
 ----
 {"customer":{"extras":["ext","test"],"id":1,"name":"databend"}}
 
+query T
+select json_extract_path_text('{"attr":null}', 'attr')
+----
+NULL
 
 query T
 select NULL#>'{0}'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Variant get string function automatically converts json null to SQL NULL to avoid cast failures caused by null values.
for example:
```sql
root@0.0.0.0:48000/default> select cast(parse_json('{"key1":null}')->>'key1' as integer);
┌───────────────────────────────────────────────────────┐
│ CAST(parse_json('{"key1":null}') ->> 'key1' AS Int32) │
│                    Nullable(Int32)                    │
├───────────────────────────────────────────────────────┤
│                                                  NULL │
└───────────────────────────────────────────────────────┘
1 row read in 0.024 sec. Processed 1 row, 1 B (41.67 rows/s, 41 B/s)
```

- fixes: #17433

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17466)
<!-- Reviewable:end -->
