### PR TITLE
feat: (semi-)sync table/field comments  with  the table being attached

### DIFF
--- a/src/query/service/src/interpreters/interpreter_table_drop_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_drop_column.rs
@@ -19,8 +19,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataSchema;
 use databend_common_meta_app::schema::DatabaseType;
-use databend_common_meta_app::schema::UpdateTableMetaReq;
-use databend_common_meta_types::MatchSeq;
 use databend_common_sql::plans::DropTableColumnPlan;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
@@ -28,7 +26,7 @@ use databend_common_storages_view::view_table::VIEW_ENGINE;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
-use crate::interpreters::interpreter_table_add_column::generate_new_snapshot;
+use crate::interpreters::interpreter_table_add_column::commit_table_meta;
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
@@ -126,18 +124,14 @@ impl Interpreter for DropTableColumnInterpreter {
             }
         }
 
-        let table_id = table_info.ident.table_id;
-        let table_version = table_info.ident.seq;
-
-        generate_new_snapshot(self.ctx.as_ref(), table.as_ref(), &mut new_table_meta).await?;
-
-        let req = UpdateTableMetaReq {
-            table_id,
-            seq: MatchSeq::Exact(table_version),
+        commit_table_meta(
+            &self.ctx,
+            table.as_ref(),
+            table_info,
             new_table_meta,
-        };
-
-        let _resp = catalog.update_single_table_meta(req, table_info).await?;
+            catalog,
+        )
+        .await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -29,6 +29,7 @@ pub const FUSE_TBL_SEGMENT_PREFIX: &str = "_sg";
 pub const FUSE_TBL_SNAPSHOT_PREFIX: &str = "_ss";
 pub const FUSE_TBL_SNAPSHOT_STATISTICS_PREFIX: &str = "_ts";
 pub const FUSE_TBL_LAST_SNAPSHOT_HINT: &str = "last_snapshot_location_hint";
+pub const FUSE_TBL_LAST_SNAPSHOT_HINT_V2: &str = "last_snapshot_location_hint_v2";
 pub const FUSE_TBL_VIRTUAL_BLOCK_PREFIX: &str = "_vb";
 pub const FUSE_TBL_AGG_INDEX_PREFIX: &str = "_i_a";
 pub const FUSE_TBL_INVERTED_INDEX_PREFIX: &str = "_i_i";

--- a/src/query/storages/fuse/src/io/locations.rs
+++ b/src/query/storages/fuse/src/io/locations.rs
@@ -35,7 +35,7 @@ use crate::index::filters::BlockFilter;
 use crate::index::InvertedIndexFile;
 use crate::FUSE_TBL_AGG_INDEX_PREFIX;
 use crate::FUSE_TBL_INVERTED_INDEX_PREFIX;
-use crate::FUSE_TBL_LAST_SNAPSHOT_HINT;
+use crate::FUSE_TBL_LAST_SNAPSHOT_HINT_V2;
 use crate::FUSE_TBL_XOR_BLOOM_INDEX_PREFIX;
 static SNAPSHOT_V0: SnapshotVersion = SnapshotVersion::V0(PhantomData);
 static SNAPSHOT_V1: SnapshotVersion = SnapshotVersion::V1(PhantomData);
@@ -160,7 +160,7 @@ impl TableMetaLocationGenerator {
     }
 
     pub fn gen_last_snapshot_hint_location(&self) -> String {
-        format!("{}/{}", &self.prefix, FUSE_TBL_LAST_SNAPSHOT_HINT)
+        format!("{}/{}", &self.prefix, FUSE_TBL_LAST_SNAPSHOT_HINT_V2)
     }
 
     pub fn gen_virtual_block_location(location: &str) -> String {

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -36,6 +36,8 @@ mod revert;
 mod truncate;
 mod util;
 
+mod snapshot_hint;
+
 pub use agg_index_sink::AggIndexSink;
 pub use analyze::HistogramInfoSink;
 pub use changes::ChangesDesc;
@@ -47,6 +49,7 @@ pub use mutation_source::*;
 pub use read::need_reserve_block_info;
 pub use read::row_fetch_processor;
 pub use replace_into::*;
+pub use snapshot_hint::*;
 pub use util::acquire_task_permit;
 pub use util::column_parquet_metas;
 pub use util::read_block;

--- a/src/query/storages/fuse/src/operations/snapshot_hint.rs
+++ b/src/query/storages/fuse/src/operations/snapshot_hint.rs
@@ -1,0 +1,176 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+use std::io::Write;
+use std::time::Instant;
+
+use bytes::Buf;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
+use databend_common_meta_app::schema::TableMeta;
+use log::info;
+use log::warn;
+use opendal::ErrorKind;
+use opendal::Operator;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::io::TableMetaLocationGenerator;
+use crate::FUSE_TBL_LAST_SNAPSHOT_HINT;
+use crate::FUSE_TBL_LAST_SNAPSHOT_HINT_V2;
+
+pub struct SnapshotHintWriter<'a> {
+    ctx: &'a dyn TableContext,
+    dal: &'a Operator,
+}
+
+impl<'a> SnapshotHintWriter<'a> {
+    pub fn new(ctx: &'a dyn TableContext, dal: &'a Operator) -> Self {
+        SnapshotHintWriter { ctx, dal }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SnapshotHint {
+    pub snapshot_full_path: String,
+    pub entity_comments: EntityComments,
+}
+
+impl SnapshotHint {
+    fn marshall<W: Write>(&self, writer: W) -> Result<()> {
+        serde_json::to_writer(writer, self)?;
+        Ok(())
+    }
+    fn unmarshall<R: Read>(reader: R) -> Result<Self> {
+        let v = serde_json::from_reader(reader)?;
+        Ok(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct EntityComments {
+    pub table_comment: String,
+    pub field_comments: Vec<String>,
+}
+
+impl<'a> From<&'a TableMeta> for EntityComments {
+    fn from(meta: &'a TableMeta) -> Self {
+        EntityComments {
+            table_comment: meta.comment.clone(),
+            field_comments: meta.field_comments.clone(),
+        }
+    }
+}
+
+pub async fn load_last_snapshot_hint(
+    storage_prefix: &str,
+    operator: &Operator,
+) -> Result<Option<SnapshotHint>> {
+    // First, try to load the v2 format hint file
+    let hint_file_path = format!("{}/{}", storage_prefix, FUSE_TBL_LAST_SNAPSHOT_HINT_V2);
+    match operator.read(&hint_file_path).await {
+        Err(e) => {
+            if e.kind() == ErrorKind::NotFound {
+                // if there is no V2 hint file, fallback to read the legacy hint file
+                try_read_legacy_hint(storage_prefix, operator).await
+            } else {
+                Err(e.into())
+            }
+        }
+
+        Ok(buf) => Ok(Some(SnapshotHint::unmarshall(buf.to_bytes().reader())?)),
+    }
+}
+
+async fn try_read_legacy_hint(
+    storage_prefix: &str,
+    operator: &Operator,
+) -> Result<Option<SnapshotHint>> {
+    let hint_file_path = format!("{}/{}", storage_prefix, FUSE_TBL_LAST_SNAPSHOT_HINT);
+    let begin_load_hint = Instant::now();
+    let maybe_hint_content = operator.read(&hint_file_path).await;
+    info!(
+        "loaded last snapshot hint file [{}], time used {:?}",
+        hint_file_path,
+        begin_load_hint.elapsed()
+    );
+    match maybe_hint_content {
+        Ok(buf) => {
+            let hint_content = buf.to_vec();
+            let snapshot_location = String::from_utf8(hint_content)?;
+
+            Ok(Some(SnapshotHint {
+                snapshot_full_path: snapshot_location,
+                entity_comments: EntityComments {
+                    table_comment: "".to_string(),
+                    field_comments: vec![],
+                },
+            }))
+        }
+        Err(e) if e.kind() == opendal::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+impl SnapshotHintWriter<'_> {
+    #[async_backtrace::framed]
+    pub async fn write_last_snapshot_hint(
+        &self,
+        location_generator: &TableMetaLocationGenerator,
+        last_snapshot_path: &str,
+        table_meta: &TableMeta,
+    ) {
+        let ctx = &self.ctx;
+        if let Ok(false) = ctx.get_settings().get_enable_last_snapshot_location_hint() {
+            info!(
+                "Write last_snapshot_location_hint disabled. Snapshot {}",
+                last_snapshot_path
+            );
+            return;
+        }
+
+        let dal = &self.dal;
+
+        // Just try our best to write down the hint file of last snapshot
+        // - will retry in the case of temporary failure
+        // but
+        // - errors are ignored if writing is eventually failed
+        // - errors (if any) will not be propagated to caller
+        // - "data race" ignored
+        //   if multiple different versions of hints are written concurrently
+        //   it is NOT guaranteed that the latest version will be kept
+
+        let hint_path = location_generator.gen_last_snapshot_hint_location();
+        let last_snapshot_path = {
+            let operator_meta_data = dal.info();
+            let storage_prefix = operator_meta_data.root();
+            format!("{}{}", storage_prefix, last_snapshot_path)
+        };
+
+        let hint = SnapshotHint {
+            snapshot_full_path: last_snapshot_path,
+            entity_comments: EntityComments::from(table_meta),
+        };
+
+        let mut bytes = vec![];
+        if let Err(e) = hint.marshall(&mut bytes) {
+            warn!("marshaling last snapshot hint failed. {}", e);
+        } else {
+            dal.write(&hint_path, bytes).await.unwrap_or_else(|e| {
+                warn!("write last snapshot hint failure. {}", e);
+            });
+        }
+    }
+}

--- a/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.result
+++ b/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.result
@@ -1,0 +1,7 @@
+init table
+1
+check table comment
+tbl comment
+check column comment
+c1	c1 comment
+c2	c2 comment

--- a/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+# base table
+echo "drop table if exists comment_base" | $BENDSQL_CLIENT_CONNECT
+echo "create table comment_base (c1 int comment 'c1 comment', c2 int comment 'c2 comment') comment = 'tbl comment'" | $BENDSQL_CLIENT_CONNECT
+
+# empty table is not attachable currently, thus we need to insert some data
+echo "init table"
+echo "insert into comment_base values(1, 2)" | $BENDSQL_CLIENT_CONNECT
+
+storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table comment_base" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
+
+# attach table
+echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+
+
+echo "check table comment"
+echo "select comment from system.tables where name = 'att_comment'" | $BENDSQL_CLIENT_CONNECT
+
+echo "check column comment"
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+
+
+echo "drop table if exists comment_base" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Adjust the format of the snapshot hint file so that during the `attach table` process, the comment information of the attached table and fields can be retrieved.

- **Adjustment to the snapshot hint file format**  
   
  A new version of the hint file format is introduced. In this new version, not only is the path to the latest snapshot recorded, but the comments for tables and fields are also included.  

  The new version of the hint file is named `last_snapshot_location_hint_v2` and is serialized in JSON format.  

- **Adjustment to the `attach table` implementation**  
   
  During the process of attaching the target table, the system will prioritize detecting and using the new version of the hint file. If the new version is not available, it will fall back to the previous behavior.
  
 
 
Versions with and without this PR can be deployed together in a mixed environment, but please note the following issues:

Versions that include this PR will only create and update the new version of the hint file. Therefore, if a node executing `attach table` does not include this PR, the execution of `attach table`:

- Will only read the old version of the hint file, which means:  
   - The table schema/data might be outdated.  
- May fail if the table being attached has never generated an old version of the hint file. 

  
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17478)
<!-- Reviewable:end -->
