### PR TITLE
fix: check table mutability in `copy into`

### DIFF
--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
@@ -60,3 +60,5 @@ undrop table should work
 0	c2
 show create attach table
 attach_read_only	ATTACH TABLE `default`.`attach_read_only` 'sPLACE_HOLDER://testbucket/admin/PLACE_HOLDER/PLACE_HOLDER/' CONNECTION = ( access_key_id = '******min', endpoint_url = '******PLACE_HOLDER', secret_access_key = '******min' )
+copy into attached table should fail
+Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.

--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
@@ -113,5 +113,11 @@ echo "show create attach table"
 # e.g. s3://testbucket/admin/data/1/401/ to s3://testbucket/admin/data/PLACE_HOLDER/PLACE_HOLDER/
 echo "show create table attach_read_only" | $BENDSQL_CLIENT_CONNECT | sed -E 's/[0-9]+/PLACE_HOLDER/g'
 
+# 4.2 copy into
+echo "copy into attached table should fail"
+echo "CREATE OR REPLACE STAGE test_attach_source;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into attach_read_only from @test_attach_source" | $BENDSQL_CLIENT_CONNECT
+
+
 echo "drop table if exists base" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists attach_read_only" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Check table mutability in `copy into`:

If table is created with `ATTACH` stmt, copy into it will fail with message like `Modification not permitted: Table 'attach_read_only' is READ ONLY ...`

- fixes: #17479


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17480)
<!-- Reviewable:end -->
