### PR TITLE
refactor: s3 region auto detect error add timeout/endpoint

### DIFF
--- a/src/meta/app/src/storage/storage_params.rs
+++ b/src/meta/app/src/storage/storage_params.rs
@@ -145,9 +145,7 @@ impl StorageParams {
                 .map_err(|e| {
                     ErrorCode::StorageOther(format!(
                         "detect region timeout: {}s, endpoint: {}, elapsed: {}",
-                        DEFAULT_DETECT_REGION_TIMEOUT_SEC,
-                        endpoint,
-                        e
+                        DEFAULT_DETECT_REGION_TIMEOUT_SEC, endpoint, e
                     ))
                 })?
                 .unwrap_or_default();

--- a/src/meta/app/src/storage/storage_params.rs
+++ b/src/meta/app/src/storage/storage_params.rs
@@ -24,6 +24,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 const DEFAULT_DETECT_REGION_TIMEOUT_SEC: u64 = 10;
+
 /// Storage params which contains the detailed storage info.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -142,7 +143,12 @@ impl StorageParams {
                 )
                 .await
                 .map_err(|e| {
-                    ErrorCode::StorageOther(format!("detect region timeout, time used {}", e))
+                    ErrorCode::StorageOther(format!(
+                        "detect region timeout: {}s, endpoint: {}, elapsed: {}",
+                        DEFAULT_DETECT_REGION_TIMEOUT_SEC,
+                        endpoint,
+                        e
+                    ))
                 })?
                 .unwrap_or_default();
 
@@ -260,6 +266,7 @@ impl Default for StorageFsConfig {
 }
 
 pub const STORAGE_FTP_DEFAULT_ENDPOINT: &str = "ftps://127.0.0.1";
+
 /// Config for FTP and FTPS data source
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageFtpConfig {
@@ -419,6 +426,7 @@ pub struct StorageHttpConfig {
 }
 
 pub const STORAGE_IPFS_DEFAULT_ENDPOINT: &str = "https://ipfs.io";
+
 /// Config for IPFS storage backend
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageIpfsConfig {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `DEFAULT_DETECT_REGION_TIMEOUT_SEC`, `endpoint` to the error message when s3 region detection:
```
                    ErrorCode::StorageOther(format!(
                        "detect region timeout: {}s, endpoint: {}, elapsed: {}",
                        DEFAULT_DETECT_REGION_TIMEOUT_SEC,
                        endpoint,
                        e
                    ))
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Error message improvment

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17482)
<!-- Reviewable:end -->
