### PR TITLE
fix(binder): AggregateRewriter should skip the rewrite of Pivot.aggregate

### DIFF
--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -458,7 +458,10 @@ impl<'a> SelectRewriter<'a> {
         if let Some(star) = new_select_list.iter_mut().find(|target| target.is_star()) {
             let mut exclude_columns: Vec<_> = aggregate_columns
                 .iter()
-                .map(|c| Identifier::from_name(stmt.span, c.column.name()))
+                .map(|c| match &c.column {
+                    ColumnID::Name(name) => name.clone(),
+                    ColumnID::Position(pos) => Identifier::from_name(pos.span, pos.name),
+                })
                 .collect();
             exclude_columns.push(pivot.value_column.clone());
             star.exclude(exclude_columns);

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -421,20 +421,23 @@ impl<'a> SelectRewriter<'a> {
         }
         let pivot = stmt.from[0].pivot().unwrap();
         let (aggregate_name, aggregate_args) = Self::parse_aggregate_function(&pivot.aggregate)?;
-        let aggregate_columns = aggregate_args
+        let aggregate_args_names = aggregate_args
             .iter()
             .map(|expr| match expr {
-                Expr::ColumnRef { column, .. } => Ok(column.clone()),
+                Expr::ColumnRef {
+                    column:
+                        ColumnRef {
+                            column: ColumnID::Name(ident),
+                            ..
+                        },
+                    ..
+                } => Ok(ident.clone()),
                 _ => Err(ErrorCode::SyntaxException(
                     "The aggregate function of pivot only support column_name",
                 )
                 .set_span(expr.span())),
             })
             .collect::<Result<Vec<_>>>()?;
-        let aggregate_column_names = aggregate_columns
-            .iter()
-            .map(|col| col.column.name())
-            .collect::<Vec<_>>();
         let new_group_by = stmt.group_by.clone().unwrap_or_else(|| {
             GroupBy::Normal(
                 self.column_binding
@@ -442,9 +445,9 @@ impl<'a> SelectRewriter<'a> {
                     .filter(|col_bind| {
                         !self
                             .compare_unquoted_ident(&col_bind.column_name, &pivot.value_column.name)
-                            && !aggregate_column_names
-                                .iter()
-                                .any(|col| self.compare_unquoted_ident(col, &col_bind.column_name))
+                            && !aggregate_args_names.iter().any(|col| {
+                                self.compare_unquoted_ident(&col.name, &col_bind.column_name)
+                            })
                     })
                     .map(|col| Expr::Literal {
                         span: Span::default(),
@@ -456,13 +459,7 @@ impl<'a> SelectRewriter<'a> {
 
         let mut new_select_list = stmt.select_list.clone();
         if let Some(star) = new_select_list.iter_mut().find(|target| target.is_star()) {
-            let mut exclude_columns: Vec<_> = aggregate_columns
-                .iter()
-                .map(|c| match &c.column {
-                    ColumnID::Name(name) => name.clone(),
-                    ColumnID::Position(pos) => Identifier::from_name(pos.span, pos.name),
-                })
-                .collect();
+            let mut exclude_columns = aggregate_args_names;
             exclude_columns.push(pivot.value_column.clone());
             star.exclude(exclude_columns);
         };

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -315,7 +315,7 @@ impl Planner {
         variable_normalizer.render_error()?;
 
         stmt.drive_mut(&mut DistinctToGroupBy::default());
-        stmt.drive_mut(&mut AggregateRewriter);
+        stmt.drive_mut(&mut AggregateRewriter::default());
         let mut set_ops_counter = CountSetOps::default();
         stmt.drive_mut(&mut set_ops_counter);
         let max_set_ops = self.ctx.get_settings().get_max_set_operator_count()?;

--- a/src/query/sql/src/planner/semantic/aggregate_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/aggregate_rewriter.rs
@@ -24,7 +24,7 @@ use derive_visitor::VisitorMut;
 #[visitor(Expr(exit), Pivot(enter))]
 pub struct AggregateRewriter {
     // aggr_expr_ptr is used for skipping the rewrite of Pivot.aggregate.
-    // It only skips the aggregate itself, while the arguments of the aggregate will still be rewritten. 
+    // It only skips the aggregate itself, while the arguments of the aggregate will still be rewritten.
     // Here, it is assumed that the arguments of the aggregate do not contain nested Pivot.
     aggr_expr_ptr: *const Expr,
 }

--- a/tests/sqllogictests/suites/query/pivot.test
+++ b/tests/sqllogictests/suites/query/pivot.test
@@ -105,4 +105,18 @@ SELECT empid,jan,feb,mar,apr FROM (
 );
 
 statement ok
-drop table if exists monthly_sales;
+CREATE OR REPLACE TABLE test_table ("DATA_TIME" timestamp, "METRIC_CODE" string, "VALUE" decimal(16,4));
+
+statement ok
+insert into test_table values ('2024-09-30 14:09:36.000', '0101', 3.5128);
+
+query TR
+SELECT * FROM test_table PIVOT(avg("VALUE") FOR "METRIC_CODE" IN ('0101'));
+----
+2024-09-30 14:09:36.000000	3.5128
+
+statement ok
+drop table monthly_sales;
+
+statement ok
+drop table test_table;

--- a/tests/sqllogictests/suites/query/pivot.test
+++ b/tests/sqllogictests/suites/query/pivot.test
@@ -1,5 +1,5 @@
 statement ok
-CREATE TABLE monthly_sales(empid INT, amount INT, month TEXT);
+CREATE OR REPLACE TABLE monthly_sales(empid INT, amount INT, month TEXT);
 
 statement ok
 INSERT INTO monthly_sales VALUES
@@ -20,8 +20,6 @@ INSERT INTO monthly_sales VALUES
     (2, 800, 'APR'),
     (2, 4500, 'APR');
 
-
-
 query IIIII
 SELECT empid,jan,feb,mar,apr FROM (
     SELECT *
@@ -32,6 +30,17 @@ SELECT empid,jan,feb,mar,apr FROM (
 ----
 1	10400	8000	11000	18000
 2	39500	90700	12000	5300
+
+query IRRRR
+SELECT empid,jan,feb,mar,apr FROM (
+    SELECT *
+        FROM monthly_sales
+            PIVOT(AVG(amount) FOR MONTH IN ('JAN', 'FEB', 'MAR', 'APR'))
+        ORDER BY EMPID
+);
+----
+1	5200.0	4000.0	5500.0	9000.0
+2	19750.0	45350.0	6000.0	2650.0
 
 query IIIII
 SELECT EMPID,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #16557

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17483)
<!-- Reviewable:end -->
