### PR TITLE
fix: impl hive disable_table_info_refresh for hive to avoid error when show table status from

### DIFF
--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -105,7 +105,6 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::VirtualColumnMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_store::MetaStore;
-use databend_common_meta_types::anyerror::func_name;
 use databend_common_meta_types::MetaId;
 use databend_common_meta_types::SeqV;
 use databend_storages_common_session::SessionState;
@@ -141,23 +140,20 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     // Get the info of the catalog.
     fn info(&self) -> Arc<CatalogInfo>;
 
-    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
-        Err(ErrorCode::Unimplemented(format!(
-            "{} not implemented",
-            func_name!()
-        )))
-    }
+    // This is used to return a new catalog; in the new catalog, the table info is not refreshed
+    // This is used for attached table, if we attach many tables each is to read from s3, query system.tables it will be very slow.
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>>;
 
     // Get the database by name.
     async fn get_database(&self, tenant: &Tenant, db_name: &str) -> Result<Arc<dyn Database>>;
 
-    // List all databases history
+    // List all database history
     async fn list_databases_history(&self, tenant: &Tenant) -> Result<Vec<Arc<dyn Database>>>;
 
     // Get all the databases.
     async fn list_databases(&self, tenant: &Tenant) -> Result<Vec<Arc<dyn Database>>>;
 
-    // Operation with database.
+    // Operation with a database.
     async fn create_database(&self, req: CreateDatabaseReq) -> Result<CreateDatabaseReply>;
 
     async fn drop_database(&self, req: DropDatabaseReq) -> Result<DropDatabaseReply>;

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -234,6 +234,10 @@ impl Catalog for MutableCatalog {
         CatalogInfo::default().into()
     }
 
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
+        Ok(self)
+    }
+
     #[async_backtrace::framed]
     async fn get_database(&self, tenant: &Tenant, db_name: &str) -> Result<Arc<dyn Database>> {
         let db_info = self

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -146,6 +146,10 @@ impl Catalog for SessionCatalog {
         self.inner.info()
     }
 
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
+        Ok(self)
+    }
+
     // Get the database by name.
     async fn get_database(&self, tenant: &Tenant, db_name: &str) -> Result<Arc<dyn Database>> {
         self.inner.get_database(tenant, db_name).await
@@ -681,7 +685,7 @@ impl Catalog for SessionCatalog {
                     } else {
                         self.get_table_by_info(&stream.source)
                     }
-                    })
+                })
                 .transpose()
         } else {
             Ok(None)

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -167,6 +167,10 @@ impl Catalog for FakedCatalog {
         self.cat.info()
     }
 
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
+        todo!()
+    }
+
     async fn get_database(&self, _tenant: &Tenant, _db_name: &str) -> Result<Arc<dyn Database>> {
         todo!()
     }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -908,6 +908,10 @@ impl Catalog for FakedCatalog {
         self.cat.info()
     }
 
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
+        todo!()
+    }
+
     async fn get_database(&self, _tenant: &Tenant, _db_name: &str) -> Result<Arc<dyn Database>> {
         todo!()
     }

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -278,6 +278,10 @@ impl Catalog for HiveCatalog {
         self.info.clone()
     }
 
+    fn disable_table_info_refresh(self: Arc<Self>) -> Result<Arc<dyn Catalog>> {
+        Ok(self)
+    }
+
     #[fastrace::trace]
     #[async_backtrace::framed]
     async fn get_database(&self, _tenant: &Tenant, db_name: &str) -> Result<Arc<dyn Database>> {

--- a/tests/sqllogictests/suites/base/05_ddl/05_0029_ddl_create_catalog.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0029_ddl_create_catalog.test
@@ -13,6 +13,15 @@ statement error 1001
 CREATE CATALOG ctl TYPE=ICEBERG CONNECTION=(TYPE='REST' ADDRESS='http://127.0.0.1:1000' WAREHOUSE='default' );
 
 statement ok
+CREATE DATABASE db1;
+
+statement ok
+SHOW TABLE STATUS FROM db1;
+
+statement ok
+DROP DATABASE db1;
+
+statement ok
 DROP CATALOG IF EXISTS ctl;
 
 statement error 1001


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If we have a hive catalog, the query will never works:
```
show table status from tpcds_1000; -- fuse engine database
error: APIError: QueryFailed: [1002]disable_table_info_refresh not implemented
```

Root cause is here:
https://github.com/databendlabs/databend/blob/0199277f72264d38657d08544cc89691fd73c383/src/query/catalog/src/catalog/interface.rs#L144-L149

This PR impl the `disable_table_info_refresh ` for hive catalog.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17484)
<!-- Reviewable:end -->
