### PR TITLE
fix(query): unsupport datetime format item should not return panic error

### DIFF
--- a/src/query/functions/src/scalars/timestamp/src/lib.rs
+++ b/src/query/functions/src/scalars/timestamp/src/lib.rs
@@ -23,6 +23,8 @@
 #![feature(try_blocks)]
 #![feature(downcast_unchecked)]
 #![feature(str_internals)]
+#![feature(fmt_internals)]
+extern crate core;
 
 pub mod datetime;
 pub mod interval;

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1440,8 +1440,11 @@ select date_format('2022-02-04T03:58:59', '%x'), strftime('2022-02-04T03:58:59',
 ----
 2022-02-04 03:58:59 2022-02-04 03:58:59
 
-statement error 1006
+statement error (?s)1006.*%i
 select date_format('2022-2-04T03:58:59', '%i');
+
+statement error (?s)1006.*%Y
+select date_format(now(), '%Y-%m-%d %H.%i.%s');
 
 statement error 1006
 select date_format('', '');


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

unsupport datetime format item should not return panic error

fix: https://github.com/databendlabs/databend/issues/17318

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17490)
<!-- Reviewable:end -->
