### PR TITLE
chore: add more log info(like temp dir) for the vacuum temp files hook

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
@@ -247,12 +247,13 @@ async fn vacuum_by_meta_buffer(
     *removed_total += cur_removed;
     // Log for the current batch
     info!(
-            "Total progress: {} files removed, now vacuum removed {} temp files from meta: {}(elapsed: {} seconds)",
-            *removed_total,
-            cur_removed,
-            meta_file_path,
-            start_time.elapsed().as_secs(),
-        );
+        "Vacuum temporary files progress(by meta file): Total removed: {}, Current batch: {} (from '{}'), Dir: '{}', Time: {} sec",
+        *removed_total,
+        cur_removed,
+        meta_file_path,
+        temporary_dir,
+        start_time.elapsed().as_secs(),
+    );
 
     Ok(cur_removed)
 }
@@ -298,14 +299,14 @@ async fn vacuum_by_list_dir(
     let _ = operator.delete_iter(batches.into_iter().take(limit)).await;
 
     *removed_total += cur_removed;
-    // Log for the current batch
+    // Log progress for the current batch
     info!(
-            "Total progress: {} files removed, now vacuum removed {} temp files from list query dir: {}(elapsed: {} seconds)",
-            *removed_total,
-            cur_removed,
-            dir_path,
-            start_time.elapsed().as_secs(),
-        );
+        "Vacuum temporary files progress(by list dir): Total removed: {}, Current batch: {} (from '{}'), Time: {} sec",
+        *removed_total,
+        cur_removed,
+        dir_path,
+        start_time.elapsed().as_secs(),
+    );
 
     Ok(cur_removed)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Restructure log messages for better readability and consistency
- Add clear labels for vacuum methods (by meta file/by list dir)
- Standardize progress information format across different vacuum operations"

old:
```
Total progress: {} files removed, now vacuum removed {} temp files from meta: {}(elapsed: {} seconds)
```

now:
```
Vacuum temporary files progress(by meta file): Total removed: {}, Current batch: {} (from '{}'), Dir: '{}', Time: {} sec
```


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): **only change the log info, make the it more readable.**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17494)
<!-- Reviewable:end -->
