### PR TITLE
chore(query): continue the vacuum query hook even aborted

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
@@ -173,8 +173,10 @@ async fn vacuum_by_duration(
     Ok(removed_total)
 }
 
+// Vacuum temporary files by query hook
+// If query was killed, we still need to clean up the temporary files
 async fn vacuum_query_hook(
-    abort_checker: AbortChecker,
+    _abort_checker: AbortChecker,
     temporary_dir: &str,
     nodes: &[usize],
     query_id: &str,
@@ -198,7 +200,6 @@ async fn vacuum_query_hook(
         .filter_map(|x| x.is_ok().then(|| x.unwrap()));
 
     for (meta_file_path, buffer) in metas {
-        abort_checker.try_check_aborting()?;
         let removed = vacuum_by_meta_buffer(
             &meta_file_path,
             temporary_dir,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -401,6 +401,7 @@ impl QueryContext {
     pub fn get_spill_file_stats(&self, node_id: Option<String>) -> SpillProgress {
         let r = self.shared.cluster_spill_progress.read();
         let node_id = node_id.unwrap_or(self.get_cluster().local_id());
+
         r.get(&node_id).cloned().unwrap_or(SpillProgress::default())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): continue the vacuum query hook even aborted

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
