### PR TITLE
feat: `SHOW CREATE TABLE` add quote for ident

### DIFF
--- a/src/query/ast/src/ast/quote.rs
+++ b/src/query/ast/src/ast/quote.rs
@@ -50,10 +50,16 @@ pub fn ident_needs_quote(ident: &str) -> bool {
     false
 }
 
-pub fn display_ident(name: &str, quoted_ident_case_sensitive: bool, dialect: Dialect) -> String {
+pub fn display_ident(
+    name: &str,
+    force_quoted_ident: bool,
+    quoted_ident_case_sensitive: bool,
+    dialect: Dialect,
+) -> String {
     // Db-s -> "Db-s" ; dbs -> dbs
     if name.chars().any(|c| c.is_ascii_uppercase()) && quoted_ident_case_sensitive
         || ident_needs_quote(name)
+        || force_quoted_ident
     {
         QuotedIdent(name, dialect.default_ident_quote()).to_string()
     } else {

--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -73,6 +73,7 @@ pub struct ShowCreateTableStmt {
     pub catalog: Option<Identifier>,
     pub database: Option<Identifier>,
     pub table: Identifier,
+    pub with_quoted_ident: bool,
 }
 
 impl Display for ShowCreateTableStmt {
@@ -84,7 +85,11 @@ impl Display for ShowCreateTableStmt {
                 .iter()
                 .chain(&self.database)
                 .chain(Some(&self.table)),
-        )
+        )?;
+        if self.with_quoted_ident {
+            write!(f, " WITH QUOTED_IDENTIFIERS")?
+        }
+        Ok(())
     }
 }
 

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -823,13 +823,14 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
     );
     let show_create_table = map(
         rule! {
-            SHOW ~ CREATE ~ TABLE ~ #dot_separated_idents_1_to_3
+            SHOW ~ CREATE ~ TABLE ~ #dot_separated_idents_1_to_3 ~ ( WITH ~ ^QUOTED_IDENTIFIERS )?
         },
-        |(_, _, _, (catalog, database, table))| {
+        |(_, _, _, (catalog, database, table), comment_opt)| {
             Statement::ShowCreateTable(ShowCreateTableStmt {
                 catalog,
                 database,
                 table,
+                with_quoted_ident: comment_opt.is_some(),
             })
         },
     );

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -942,6 +942,8 @@ pub enum TokenKind {
     QUERY,
     #[token("QUOTE", ignore(ascii_case))]
     QUOTE,
+    #[token("QUOTED_IDENTIFIERS", ignore(ascii_case))]
+    QUOTED_IDENTIFIERS,
     #[token("RANGE", ignore(ascii_case))]
     RANGE,
     #[token("RAWDEFLATE", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -107,6 +107,7 @@ fn test_statement() {
         r#"show processlist like 't%' limit 2;"#,
         r#"show processlist where database='default' limit 2;"#,
         r#"show create table a.b;"#,
+        r#"show create table a.b with quoted_identifiers;"#,
         r#"show create table a.b format TabSeparatedWithNamesAndTypes;"#,
         r#"replace into test on(c) select sum(c) as c from source group by v;"#,
         r#"explain pipeline select a from b;"#,

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -505,6 +505,38 @@ ShowCreateTable(
             quote: None,
             ident_type: None,
         },
+        with_quoted_ident: false,
+    },
+)
+
+
+---------- Input ----------
+show create table a.b with quoted_identifiers;
+---------- Output ---------
+SHOW CREATE TABLE a.b WITH QUOTED_IDENTIFIERS
+---------- AST ------------
+ShowCreateTable(
+    ShowCreateTableStmt {
+        catalog: None,
+        database: Some(
+            Identifier {
+                span: Some(
+                    18..19,
+                ),
+                name: "a",
+                quote: None,
+                ident_type: None,
+            },
+        ),
+        table: Identifier {
+            span: Some(
+                20..21,
+            ),
+            name: "b",
+            quote: None,
+            ident_type: None,
+        },
+        with_quoted_ident: true,
     },
 )
 
@@ -535,6 +567,7 @@ ShowCreateTable(
             quote: None,
             ident_type: None,
         },
+        with_quoted_ident: false,
     },
 )
 

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -1077,5 +1077,5 @@ fn display_f64(num: f64) -> String {
 
 /// Display a tuple field name, if it contains uppercase letters or special characters, add quotes.
 pub fn display_tuple_field_name(field_name: &str) -> String {
-    display_ident(field_name, true, Dialect::PostgreSQL)
+    display_ident(field_name, false, true, Dialect::PostgreSQL)
 }

--- a/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
@@ -119,7 +119,7 @@ impl ShowCreateDictionaryInterpreter {
 
         let mut dict_create_sql = format!(
             "CREATE DICTIONARY {}\n(\n",
-            display_ident(dict_name, quoted_ident_case_sensitive, sql_dialect)
+            display_ident(dict_name, false, quoted_ident_case_sensitive, sql_dialect)
         );
 
         // Append columns and indexes.
@@ -132,7 +132,12 @@ impl ShowCreateDictionaryInterpreter {
                     .and_then(|c| format!(" COMMENT '{}'", c).into())
                     .unwrap_or_default();
 
-                let ident = display_ident(field.name(), quoted_ident_case_sensitive, sql_dialect);
+                let ident = display_ident(
+                    field.name(),
+                    false,
+                    quoted_ident_case_sensitive,
+                    sql_dialect,
+                );
                 let data_type = field.data_type().sql_name_explicit_null();
                 let column_str = format!("  {ident} {data_type}{comment}",);
 

--- a/src/query/service/src/servers/admin/v1/tenant_tables.rs
+++ b/src/query/service/src/servers/admin/v1/tenant_tables.rs
@@ -66,6 +66,7 @@ async fn load_tenant_tables(tenant: &Tenant) -> Result<TenantTablesResponse> {
 
     let settings = ShowCreateQuerySettings {
         sql_dialect: Dialect::PostgreSQL,
+        force_quoted_ident: false,
         quoted_ident_case_sensitive: true,
         hide_options_in_show_create_table: false,
     };

--- a/src/query/sql/src/planner/binder/copy_into_location.rs
+++ b/src/query/sql/src/planner/binder/copy_into_location.rs
@@ -69,9 +69,24 @@ impl Binder {
                     self.ctx.get_settings().get_quoted_ident_case_sensitive()?;
                 let subquery = format!(
                     "SELECT * FROM {}.{}.{}{with_options_str}",
-                    display_ident(&catalog_name, quoted_ident_case_sensitive, self.dialect),
-                    display_ident(&database_name, quoted_ident_case_sensitive, self.dialect),
-                    display_ident(&table_name, quoted_ident_case_sensitive, self.dialect),
+                    display_ident(
+                        &catalog_name,
+                        false,
+                        quoted_ident_case_sensitive,
+                        self.dialect
+                    ),
+                    display_ident(
+                        &database_name,
+                        false,
+                        quoted_ident_case_sensitive,
+                        self.dialect
+                    ),
+                    display_ident(
+                        &table_name,
+                        false,
+                        quoted_ident_case_sensitive,
+                        self.dialect
+                    ),
                 );
                 let tokens = tokenize_sql(&subquery)?;
                 let sub_stmt_msg = parse_sql(&tokens, self.dialect)?;

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -252,6 +252,7 @@ impl Binder {
             catalog,
             database,
             table,
+            with_quoted_ident,
         } = stmt;
 
         let (catalog, database, table) =
@@ -266,6 +267,7 @@ impl Binder {
             database,
             table,
             schema,
+            with_quoted_ident: *with_quoted_ident,
         })))
     }
 

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -383,6 +383,7 @@ pub struct ShowCreateTablePlan {
     pub table: String,
     /// The table schema
     pub schema: DataSchemaRef,
+    pub with_quoted_ident: bool,
 }
 
 impl ShowCreateTablePlan {

--- a/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0001_show_create_table.test
@@ -12,6 +12,11 @@ SHOW CREATE TABLE `test`.`a`
 ----
 a CREATE TABLE a ( a BIGINT NOT NULL, b INT NOT NULL DEFAULT 3, c VARCHAR NOT NULL DEFAULT 'x', d SMALLINT NULL, e DATE NOT NULL ) ENGINE=NULL
 
+query TT
+SHOW CREATE TABLE `test`.`a` WITH QUOTED_IDENTIFIERS
+----
+a CREATE TABLE "a" ( "a" BIGINT NOT NULL, "b" INT NOT NULL DEFAULT 3, "c" VARCHAR NOT NULL DEFAULT 'x', "d" SMALLINT NULL, "e" DATE NOT NULL ) ENGINE=NULL
+
 statement ok
 CREATE TABLE `test`.`b` ( a bigint not null, b int null default null, c varchar(255) not null, d smallint unsigned null) Engine = Null COMMENT = 'test b'
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
https://github.com/databendlabs/databend/issues/17256

```shell
CREATE TABLE `t1`(a int not null, b int not null, c int not null) bloom_index_columns='a,b,c' COMPRESSION='zstd' STORAGE_FORMAT='native';

SHOW CREATE TABLE `t1` WITH QUOTED_IDENTIFIERS

*************************** 1. row ***************************
       Table: t1
Create Table: CREATE TABLE "t1" (
  "a" INT NOT NULL,
  "b" INT NOT NULL,
  "c" INT NOT NULL
) ENGINE=FUSE

1 row showcreate in 0.053 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

```

## Tests

- [x] Unit Test
- [x] Logic Test

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17505)
<!-- Reviewable:end -->
