### PR TITLE
feat(raft-log): enhance raft-log reliability and add compatibility tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,9 +2214,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "codeq"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a9092f38f07d18434ac49a148db55fdd887b8b852a4655bece6e2f347a8490"
+checksum = "7dc658ab6515a8d5ef40bf5267796fa065d6376eb508d8362eaf533755b4008f"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -11832,9 +11832,9 @@ dependencies = [
 
 [[package]]
 name = "raft-log"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f53e45db5ca60e7ce71737cdd12cd6c466d694eebfe9040de66f09f7bf0682"
+checksum = "30779291e2ee1156b741c964a709da7fa17e47c28613513e668fe9724d3e340f"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,7 +421,7 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 prost = { version = "0.13" }
 prost-build = { version = "0.13" }
 prqlc = "0.11.3"
-raft-log = { version = "0.2.6" }
+raft-log = { version = "0.2.7" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
 rayon = "1.9.0"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(raft-log): enhance raft-log reliability and add compatibility tests

Bump raft-log crate version to 0.2.7

Features:

- Reuse last healthy closed chunk when reopening raft-log;
  In order to avoid too many chunk if it reopen too many times.

- Add compatibility test for raft log format v0.2.6
  - Generate sample data for current version
  - Verify reading existing v0.2.6 data
  - Validate file contents and naming consistency

raft-log crate changes: https://github.com/drmingdrmer/raft-log/compare/v0.2.6...v0.2.7

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17510)
<!-- Reviewable:end -->
