### PR TITLE
refactor: re-generate hint file after alter table operations

### DIFF
--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.result
@@ -66,6 +66,14 @@ Error: APIError: QueryFailed: [2004]Columns [c_not_exist] do not exist in the ta
 #############################
 >>>> drop table if exists attach_tbl
 >>>> alter table base RENAME COLUMN c2 to c2_new
+'ATTACH' after 'ALTER TABLE RENAME COLUMN' should see the new name of column
+>>>> drop table if exists attach_tbl2
+>>>> desc attach_tbl2
+c1	VARCHAR	YES	NULL	
+c2_new	VARCHAR	YES	NULL	
+c3	VARCHAR	YES	NULL	
+c4	VARCHAR	YES	NULL	
+<<<<
 >>>> insert into base values('c1', 'c2_new', 'c3', 'c4')
 1
 select all should work

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -91,6 +91,13 @@ stmt "drop table if exists attach_tbl"
 echo "attach table attach_tbl (c2, c4) 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
 
 stmt "alter table base RENAME COLUMN c2 to c2_new"
+
+echo "'ATTACH' after 'ALTER TABLE RENAME COLUMN' should see the new name of column"
+stmt "drop table if exists attach_tbl2"
+echo "attach table attach_tbl2 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+query "desc attach_tbl2"
+
+
 stmt "insert into base values('c1', 'c2_new', 'c3', 'c4')"
 
 echo "select all should work"
@@ -98,6 +105,8 @@ query "select * from attach_tbl order by c2_new"
 
 echo "select c2_new should work"
 query "select c2_new from attach_tbl order by c2_new"
+
+
 
 echo "##################################"
 echo "## drop column from base table ###"

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -97,7 +97,6 @@ stmt "drop table if exists attach_tbl2"
 echo "attach table attach_tbl2 's3://testbucket/admin/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
 query "desc attach_tbl2"
 
-
 stmt "insert into base values('c1', 'c2_new', 'c3', 'c4')"
 
 echo "select all should work"
@@ -105,8 +104,6 @@ query "select * from attach_tbl order by c2_new"
 
 echo "select c2_new should work"
 query "select c2_new from attach_tbl order by c2_new"
-
-
 
 echo "##################################"
 echo "## drop column from base table ###"

--- a/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.result
+++ b/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.result
@@ -5,3 +5,12 @@ tbl comment
 check column comment
 c1	c1 comment
 c2	c2 comment
+>>>> alter table comment_base rename column c1 to c1_new
+c1_new	c1 comment
+c2	c2 comment
+>>>> alter table comment_base comment = 'new tbl comment'
+>>>> select comment from system.tables where name = 'att_comment'
+new tbl comment
+>>>> ALTER TABLE comment_base MODIFY COLUMN c1_new int comment 'new comment of c1_new'
+c1_new	new comment of c1_new
+c2	c2 comment

--- a/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
@@ -25,5 +25,23 @@ echo "check column comment"
 echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
 
 
+# alter table rename column should generate new hint file
+stmt "alter table comment_base rename column c1 to c1_new"
+echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+
+# alter table rename comment should generate new hint file
+stmt "alter table comment_base comment = 'new tbl comment'"
+echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+stmt "select comment from system.tables where name = 'att_comment'"
+
+# alter table modify column comment should generate new hint file
+stmt "ALTER TABLE comment_base MODIFY COLUMN c1_new int comment 'new comment of c1_new'"
+echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+
 echo "drop table if exists comment_base" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Re-generates last-snapshot-hint file during the following `alter table` operations:

- alter table rename column
- alter table modify table / column comments


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17511)
<!-- Reviewable:end -->
