### PR TITLE
feat: csv/tsv/ndjson support querying file meta data.

### DIFF
--- a/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
@@ -44,6 +44,7 @@ pub struct StageTableInfo {
     pub is_select: bool,
     pub copy_into_location_options: CopyIntoLocationOptions,
     pub copy_into_table_options: CopyIntoTableOptions,
+    pub stage_root: String,
 }
 
 impl StageTableInfo {

--- a/src/query/catalog/src/plan/datasource/datasource_plan.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_plan.rs
@@ -20,6 +20,7 @@ use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 
 use crate::plan::datasource::datasource_info::DataSourceInfo;
+use crate::plan::InternalColumn;
 use crate::plan::PartStatistics;
 use crate::plan::Partitions;
 use crate::plan::PushDownInfo;
@@ -38,7 +39,7 @@ pub struct DataSourcePlan {
 
     pub tbl_args: Option<TableArgs>,
     pub push_downs: Option<PushDownInfo>,
-    pub query_internal_columns: bool,
+    pub internal_columns: Option<BTreeMap<FieldIndex, InternalColumn>>,
     pub base_block_ids: Option<Scalar>,
     // used for recluster to update stream columns
     pub update_stream_columns: bool,

--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -37,6 +37,8 @@ use databend_common_expression::Value;
 use databend_common_expression::BASE_BLOCK_IDS_COLUMN_ID;
 use databend_common_expression::BASE_ROW_ID_COLUMN_ID;
 use databend_common_expression::BLOCK_NAME_COLUMN_ID;
+use databend_common_expression::FILENAME_COLUMN_ID;
+use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
 use databend_common_expression::ROW_ID_COLUMN_ID;
 use databend_common_expression::SEARCH_MATCHED_COLUMN_ID;
 use databend_common_expression::SEARCH_SCORE_COLUMN_ID;
@@ -141,6 +143,9 @@ pub enum InternalColumnType {
     // search columns
     SearchMatched,
     SearchScore,
+
+    FileName,
+    FileRowNumber,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -176,6 +181,8 @@ impl InternalColumn {
             )),
             InternalColumnType::SearchMatched => TableDataType::Boolean,
             InternalColumnType::SearchScore => TableDataType::Number(NumberDataType::Float32),
+            InternalColumnType::FileName => TableDataType::String,
+            InternalColumnType::FileRowNumber => TableDataType::Number(NumberDataType::UInt64),
         }
     }
 
@@ -198,6 +205,8 @@ impl InternalColumn {
             InternalColumnType::BaseBlockIds => BASE_BLOCK_IDS_COLUMN_ID,
             InternalColumnType::SearchMatched => SEARCH_MATCHED_COLUMN_ID,
             InternalColumnType::SearchScore => SEARCH_SCORE_COLUMN_ID,
+            InternalColumnType::FileName => FILENAME_COLUMN_ID,
+            InternalColumnType::FileRowNumber => FILE_ROW_NUMBER_COLUMN_ID,
         }
     }
 
@@ -314,6 +323,9 @@ impl InternalColumn {
                     DataType::Number(NumberDataType::Float32),
                     Value::Column(Float32Type::from_data(scores)),
                 )
+            }
+            InternalColumnType::FileName | InternalColumnType::FileRowNumber => {
+                todo!("generate_column_values not support for file related")
             }
         }
     }

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -67,11 +67,16 @@ pub const CHANGE_ROW_ID_COL_NAME: &str = "change$row_id";
 
 pub const PREDICATE_COLUMN_NAME: &str = "_predicate";
 
+pub const FILENAME_COLUMN_NAME: &str = "metadata$filename";
+pub const FILE_ROW_NUMBER_COLUMN_NAME: &str = "metadata$file_row_number";
+
 // stream column id.
 pub const ORIGIN_BLOCK_ROW_NUM_COLUMN_ID: u32 = u32::MAX - 10;
 pub const ORIGIN_BLOCK_ID_COLUMN_ID: u32 = u32::MAX - 11;
 pub const ORIGIN_VERSION_COLUMN_ID: u32 = u32::MAX - 12;
 pub const ROW_VERSION_COLUMN_ID: u32 = u32::MAX - 13;
+pub const FILENAME_COLUMN_ID: u32 = u32::MAX - 14;
+pub const FILE_ROW_NUMBER_COLUMN_ID: u32 = u32::MAX - 15;
 // stream column name.
 pub const ORIGIN_VERSION_COL_NAME: &str = "_origin_version";
 pub const ORIGIN_BLOCK_ID_COL_NAME: &str = "_origin_block_id";
@@ -98,12 +103,15 @@ pub static INTERNAL_COLUMNS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| 
         ORIGIN_BLOCK_ID_COL_NAME,
         ORIGIN_BLOCK_ROW_NUM_COL_NAME,
         ROW_VERSION_COL_NAME,
+        FILENAME_COLUMN_NAME,
+        FILE_ROW_NUMBER_COLUMN_NAME,
     ])
 });
 
 #[inline]
 pub fn is_internal_column_id(column_id: ColumnId) -> bool {
     column_id >= SEARCH_SCORE_COLUMN_ID
+        || (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
 }
 
 #[inline]

--- a/src/query/service/src/interpreters/interpreter_copy_into_location.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_location.rs
@@ -113,6 +113,7 @@ impl CopyIntoLocationInterpreter {
                 default_values: None,
                 copy_into_location_options: options.clone(),
                 copy_into_table_options: Default::default(),
+                stage_root: "".to_string(),
             },
         }));
 

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -83,7 +83,7 @@ impl PipelineBuilder {
                     description,
                     tbl_args: table.table_args(),
                     push_downs: None,
-                    query_internal_columns: false,
+                    internal_columns: None,
                     base_block_ids: None,
                     update_stream_columns: table.change_tracking_enabled(),
                     data_mask_policy: None,

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -91,6 +91,7 @@ use databend_common_pipeline_core::InputError;
 use databend_common_pipeline_core::LockGuard;
 use databend_common_settings::Settings;
 use databend_common_sql::IndexType;
+use databend_common_storage::init_stage_operator;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::DataOperator;
 use databend_common_storage::FileStatus;
@@ -1514,6 +1515,14 @@ impl TableContext for QueryContext {
         max_column_position: usize,
         case_sensitive: bool,
     ) -> Result<Arc<dyn Table>> {
+        let operator = init_stage_operator(&stage_info)?;
+        let info = operator.info();
+        let stage_root = format!("{}{}", info.name(), info.root());
+        let stage_root = if stage_root.ends_with('/') {
+            stage_root
+        } else {
+            format!("{}/", stage_root)
+        };
         match stage_info.file_format_params {
             FileFormatParams::Parquet(..) => {
                 let mut read_options = ParquetReadOptions::default();
@@ -1553,6 +1562,7 @@ impl TableContext for QueryContext {
                     default_values: None,
                     copy_into_location_options: Default::default(),
                     copy_into_table_options: Default::default(),
+                    stage_root,
                 };
                 OrcTable::try_create(info).await
             }
@@ -1571,6 +1581,7 @@ impl TableContext for QueryContext {
                     default_values: None,
                     copy_into_location_options: Default::default(),
                     copy_into_table_options: Default::default(),
+                    stage_root,
                 };
                 StageTable::try_create(info)
             }
@@ -1607,6 +1618,7 @@ impl TableContext for QueryContext {
                     default_values: None,
                     copy_into_location_options: Default::default(),
                     copy_into_table_options: Default::default(),
+                    stage_root,
                 };
                 StageTable::try_create(info)
             }

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -272,7 +272,7 @@ impl ToReadDataSourcePlan for dyn Table {
             description,
             tbl_args: self.table_args(),
             push_downs,
-            query_internal_columns: internal_columns.is_some(),
+            internal_columns,
             base_block_ids,
             update_stream_columns,
             data_mask_policy,

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -225,6 +225,7 @@ impl Binder {
                 default_values,
                 copy_into_location_options: Default::default(),
                 copy_into_table_options: stmt.options.clone(),
+                stage_root: "".to_string(),
             },
             values_consts: vec![],
             required_source_schema: required_values_schema.clone(),
@@ -405,6 +406,7 @@ impl Binder {
                 default_values: Some(default_values),
                 copy_into_location_options: Default::default(),
                 copy_into_table_options: options,
+                stage_root: "".to_string(),
             },
             write_mode,
             query: None,
@@ -482,6 +484,7 @@ impl Binder {
 
         // rewrite async function and udf
         s_expr = self.rewrite_udf(&mut from_context, s_expr)?;
+        s_expr = self.add_internal_column_into_expr(&mut from_context, s_expr)?;
 
         let mut output_context = BindContext::new();
         output_context.parent = from_context.parent;

--- a/src/query/sql/src/planner/binder/internal_column_factory.rs
+++ b/src/query/sql/src/planner/binder/internal_column_factory.rs
@@ -20,6 +20,8 @@ use databend_common_catalog::plan::InternalColumnType;
 use databend_common_expression::BASE_BLOCK_IDS_COL_NAME;
 use databend_common_expression::BASE_ROW_ID_COL_NAME;
 use databend_common_expression::BLOCK_NAME_COL_NAME;
+use databend_common_expression::FILENAME_COLUMN_NAME;
+use databend_common_expression::FILE_ROW_NUMBER_COLUMN_NAME;
 use databend_common_expression::ROW_ID_COL_NAME;
 use databend_common_expression::SEARCH_MATCHED_COL_NAME;
 use databend_common_expression::SEARCH_SCORE_COL_NAME;
@@ -75,6 +77,19 @@ impl InternalColumnFactory {
         internal_columns.insert(
             SEARCH_SCORE_COL_NAME.to_string(),
             InternalColumn::new(SEARCH_SCORE_COL_NAME, InternalColumnType::SearchScore),
+        );
+
+        internal_columns.insert(
+            FILENAME_COLUMN_NAME.to_string(),
+            InternalColumn::new(FILENAME_COLUMN_NAME, InternalColumnType::FileName),
+        );
+
+        internal_columns.insert(
+            FILE_ROW_NUMBER_COLUMN_NAME.to_string(),
+            InternalColumn::new(
+                FILE_ROW_NUMBER_COLUMN_NAME,
+                InternalColumnType::FileRowNumber,
+            ),
         );
 
         InternalColumnFactory { internal_columns }

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -76,7 +76,7 @@ impl FuseTable {
                 &self.schema_with_stream(),
                 plan.push_downs.as_ref(),
             ),
-            plan.query_internal_columns,
+            plan.internal_columns.is_some(),
             plan.update_stream_columns,
             put_cache,
         )

--- a/src/query/storages/stage/src/read/row_based/format.rs
+++ b/src/query/storages/stage/src/read/row_based/format.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_expression::Column;
-use databend_common_expression::DataBlock;
 use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_storage::FileStatus;
 
@@ -33,11 +32,8 @@ pub trait SeparatorState: Send + Sync {
 }
 
 pub trait RowDecoder: Send + Sync {
-    fn add(
-        &self,
-        block_builder: &mut BlockBuilderState,
-        batch: RowBatchWithPosition,
-    ) -> Result<Vec<DataBlock>>;
+    fn add(&self, block_builder: &mut BlockBuilderState, batch: RowBatchWithPosition)
+        -> Result<()>;
 
     fn flush(&self, columns: Vec<Column>, _num_rows: usize) -> Vec<Column> {
         columns

--- a/src/query/storages/stage/src/read/row_based/formats/csv/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/csv/block_builder.rs
@@ -19,7 +19,6 @@ use databend_common_expression::types::nullable::NullableColumnBuilder;
 use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
-use databend_common_expression::DataBlock;
 use databend_common_expression::TableDataType;
 use databend_common_formats::SeparatedTextDecoder;
 use databend_common_meta_app::principal::EmptyFieldAs;
@@ -150,18 +149,15 @@ impl CsvDecoder {
 }
 
 impl RowDecoder for CsvDecoder {
-    fn add(
-        &self,
-        state: &mut BlockBuilderState,
-        batch: RowBatchWithPosition,
-    ) -> Result<Vec<DataBlock>> {
+    fn add(&self, state: &mut BlockBuilderState, batch: RowBatchWithPosition) -> Result<()> {
         let data = batch.data.into_csv().unwrap();
-        let columns = &mut state.mutable_columns;
         let mut start = 0usize;
         let mut field_end_idx = 0;
         for (i, end) in data.row_ends.iter().enumerate() {
+            let columns = &mut state.column_builders;
             let num_fields = data.num_fields[i];
             let buf = &data.data[start..*end];
+            let row_id = batch.start_pos.rows + i;
             if let Err(e) = self.read_row(
                 buf,
                 columns,
@@ -172,16 +168,15 @@ impl RowDecoder for CsvDecoder {
                     Some((columns, state.num_rows)),
                     &mut state.file_status,
                     &batch.start_pos.path,
-                    i + batch.start_pos.rows,
+                    row_id,
                 )?
             } else {
-                state.num_rows += 1;
-                state.file_status.num_rows_loaded += 1;
+                state.add_row(row_id);
             }
             start = *end;
             field_end_idx += num_fields;
         }
-        Ok(vec![])
+        Ok(())
     }
 
     fn flush(&self, columns: Vec<Column>, num_rows: usize) -> Vec<Column> {

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use bstr::ByteSlice;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
-use databend_common_expression::DataBlock;
 use databend_common_formats::FieldJsonAstDecoder;
 use databend_common_meta_app::principal::NullAs;
 use databend_common_storage::FileParseError;
@@ -154,12 +153,7 @@ impl NdJsonDecoder {
 }
 
 impl RowDecoder for NdJsonDecoder {
-    fn add(
-        &self,
-        state: &mut BlockBuilderState,
-        batch: RowBatchWithPosition,
-    ) -> Result<Vec<DataBlock>> {
-        let columns = &mut state.mutable_columns;
+    fn add(&self, state: &mut BlockBuilderState, batch: RowBatchWithPosition) -> Result<()> {
         let data = batch.data.into_nd_json().unwrap();
         let null_if = self
             .fmt
@@ -168,9 +162,10 @@ impl RowDecoder for NdJsonDecoder {
             .iter()
             .map(|x| x.as_str())
             .collect::<Vec<_>>();
-
         for (row_id, row) in data.iter().enumerate() {
+            let columns = &mut state.column_builders;
             let row = row.trim();
+            let row_id = batch.start_pos.rows + row_id;
             if !row.is_empty() {
                 if let Err(e) = self.read_row(row, columns, &null_if) {
                     self.load_context.error_handler.on_error(
@@ -178,15 +173,14 @@ impl RowDecoder for NdJsonDecoder {
                         Some((columns, state.num_rows)),
                         &mut state.file_status,
                         &batch.start_pos.path,
-                        batch.start_pos.rows + row_id,
+                        row_id,
                     )?
                 } else {
-                    state.num_rows += 1;
-                    state.file_status.num_rows_loaded += 1;
+                    state.add_row(row_id);
                 }
             }
         }
-        Ok(vec![])
+        Ok(())
     }
 }
 

--- a/src/query/storages/stage/src/read/row_based/read_pipeline.rs
+++ b/src/query/storages/stage/src/read/row_based/read_pipeline.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::StageTableInfo;
@@ -74,6 +75,7 @@ impl RowBasedReadPipelineBuilder<'_> {
         ctx: Arc<dyn TableContext>,
         plan: &DataSourcePlan,
         pipeline: &mut Pipeline,
+        internal_columns: Vec<InternalColumn>,
     ) -> Result<()> {
         if plan.parts.is_empty() {
             // no file match
@@ -105,6 +107,7 @@ impl RowBasedReadPipelineBuilder<'_> {
             self.stage_table_info,
             pos_projection,
             self.compact_threshold,
+            internal_columns,
         )?);
 
         match self

--- a/tests/sqllogictests/scripts/prepare_stage.sh
+++ b/tests/sqllogictests/scripts/prepare_stage.sh
@@ -6,22 +6,24 @@
 # Use "fs" default to make development easier.
 # most of the time, the tests will succeed with with "s3" too.
 # todo: add storage "http"?
+DATADIR="fs://${PWD}/tests/data/"
 echo "drop stage if exists data" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace connection my_conn_s3 storage_type = 's3' access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900'" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace stage data_s3 url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace stage data_fs url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
 if [ -z "$TEST_STAGE_STORAGE" ] || [ "$TEST_STAGE_STORAGE" == "fs" ]; then
-	DATADIR="fs://${PWD}/tests/data/"
-	echo "create stage data url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+	echo "create or replace stage data url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
 elif [ "$TEST_STAGE_STORAGE" == "s3" ]; then
-	echo "create stage data url='s3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900') FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+	echo "create or replace stage data url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
 else
 	echo "unknown TEST_STAGE_STORAGE value: ${TEST_STAGE_STORAGE}"
 	exit 1
 fi
 
-
 echo "drop table if exists ontime" | $BENDSQL_CLIENT_CONNECT
 cat tests/data/ddl/ontime.sql | $BENDSQL_CLIENT_CONNECT
 
-if [ "$TEST_STAGE_DEDUP" = "full_path" ]; then
+if [ -z "$TEST_STAGE_DEDUP" ] || [ "$TEST_STAGE_DEDUP" = "full_path" ]; then
     FULL_PATH=1
 elif [ "$TEST_STAGE_DEDUP" = "sub_path" ]; then
     FULL_PATH=0

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_metadata.test
@@ -1,0 +1,19 @@
+query ok
+select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/csv/it.csv (file_format=>'csv')
+----
+testbucket/data/csv/it.csv b 0 1
+testbucket/data/csv/it.csv d 1 2
+
+statement ok
+create or replace table t(file_name string, c2 string,  row int, c1 int)
+
+query ok
+copy into t from (select metadata$filename, $2, metadata$file_row_number + 1, $1 from @data_s3/csv/it.csv) file_format=(type=csv)
+----
+csv/it.csv 2 0 NULL NULL
+
+query ok
+select * from t
+----
+testbucket/data/csv/it.csv b 1 1
+testbucket/data/csv/it.csv d 2 2

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_metadata.test
@@ -1,0 +1,21 @@
+query ok
+select metadata$filename, $1, metadata$file_row_number  from @data_s3/ndjson/ts.ndjson (file_format=>'ndjson')
+----
+testbucket/data/ndjson/ts.ndjson {"t":1736305864} 0
+testbucket/data/ndjson/ts.ndjson {"t":1736305865000} 1
+testbucket/data/ndjson/ts.ndjson {"t":1736305866000000} 2
+
+statement ok
+create or replace table t(file_name string, value variant,  row int)
+
+query ok
+copy into t from (select metadata$filename, $1, metadata$file_row_number + 1  from @data_s3/ndjson/ts.ndjson) file_format=(type=ndjson)
+----
+ndjson/ts.ndjson 3 0 NULL NULL
+
+query ok
+select * from t
+----
+testbucket/data/ndjson/ts.ndjson {"t":1736305864} 1
+testbucket/data/ndjson/ts.ndjson {"t":1736305865000} 2
+testbucket/data/ndjson/ts.ndjson {"t":1736305866000000} 3

--- a/tests/sqllogictests/suites/stage/formats/tsv/tsv_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/tsv/tsv_metadata.test
@@ -1,0 +1,20 @@
+query ok
+select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/tsv/no_newline.tsv (file_format=>'tsv')
+----
+testbucket/data/tsv/no_newline.tsv 2 0 1
+testbucket/data/tsv/no_newline.tsv 4 1 3
+
+
+statement ok
+create or replace table t(file_name string, c2 string,  row int, c1 int)
+
+query ok
+copy into t from (select metadata$filename, $2, metadata$file_row_number + 1, $1 from @data_s3/tsv/no_newline.tsv) file_format=(type=tsv)
+----
+tsv/no_newline.tsv 2 0 NULL NULL
+
+query ok
+select * from t
+----
+testbucket/data/tsv/no_newline.tsv 2 1 1
+testbucket/data/tsv/no_newline.tsv 4 2 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

this pr only add support of  `metadata$filename` and  `metadata$file_row_number` for csv/tsv/ndjson

e.g. 

```
select metadata$filename, $1, metadata$file_row_number  from @data_s3/ndjson/ts.ndjson (file_format=>'ndjson')

create or replace table t(file_name string, c2 string,  row int, c1 int)
copy into t from (select metadata$filename, $2, metadata$file_row_number + 1, $1 from @data_s3/tsv/no_newline.tsv) file_format=(type=tsv)
```



- fixes: #[Link the issue here]


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17512)
<!-- Reviewable:end -->
