### PR TITLE
chore: refine some fuse_time_travel_size related logs

### DIFF
--- a/src/query/storages/common/table_meta/src/table/table_prefix.rs
+++ b/src/query/storages/common/table_meta/src/table/table_prefix.rs
@@ -14,12 +14,12 @@
 
 use std::fmt::Display;
 
-/// Constructs the prefix path which covers all the data of of a give table identity
+/// Constructs the prefix path which covers all the data of a give table identity
 pub fn table_storage_prefix(database_id: impl Display, table_id: impl Display) -> String {
     format!("{}/{}", database_id, table_id)
 }
 
-/// Constructs the prefix path which covers all the data of of a give table identity
+/// Constructs the prefix path which covers all the data of a give database identity
 pub fn database_storage_prefix(database_id: impl Display) -> String {
     format!("{}", database_id)
 }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -565,6 +565,12 @@ impl FuseTable {
             return Ok(());
         }
 
+        info!(
+            "extracting snapshot location of table {} with id {:?} from the last snapshot hint file.",
+            table_info.desc,
+            table_info.ident
+        );
+
         let snapshot_hint =
             Self::refresh_schema_from_hint(operator, storage_prefix, &table_info.desc)?;
 

--- a/src/query/storages/fuse/src/operations/snapshot_hint.rs
+++ b/src/query/storages/fuse/src/operations/snapshot_hint.rs
@@ -102,7 +102,12 @@ async fn try_read_legacy_hint(
     let begin_load_hint = Instant::now();
     let maybe_hint_content = operator.read(&hint_file_path).await;
     info!(
-        "loaded last snapshot hint file [{}], time used {:?}",
+        "{} load last snapshot hint file [{}], time used {:?}",
+        if maybe_hint_content.is_ok() {
+            "successfully"
+        } else {
+            "failed to"
+        },
         hint_file_path,
         begin_load_hint.elapsed()
     );

--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -134,9 +134,12 @@ impl SimpleArgFunc for FuseTimeTravelSize {
             if db.name() == "system" || db.name() == "information_schema" {
                 continue;
             }
+
+            info!("loading tables from database : {}", db.name());
             let tables = match &args.table_name {
                 Some(table_name) => {
                     let start = std::time::Instant::now();
+                    info!("loading table {}", table_name);
                     let table = db.get_table(table_name.as_str()).await?;
                     info!("get_table cost: {:?}", start.elapsed());
                     vec![table]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Refining some `fuse_time_travel_size` related logs, tracking the name of db/table being processed.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - refine logs only

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17515)
<!-- Reviewable:end -->
