### PR TITLE
fix(query): tpcds q69 fail

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -24,6 +24,7 @@ use databend_common_hashtable::RowPtr;
 use super::desc::MARKER_KIND_FALSE;
 use crate::sql::plans::JoinType;
 
+#[derive(Debug)]
 pub struct ProcessState {
     pub input: DataBlock,
     pub keys_state: KeysState,

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -1427,6 +1427,7 @@ fn hash_join_to_format_tree(
         .map(|scalar| scalar.as_expr(&BUILTIN_FUNCTIONS).sql_display())
         .collect::<Vec<_>>()
         .join(", ");
+    let is_null_equal = plan.is_null_equal.iter().map(|b| format!("{b}")).join(", ");
     let filters = plan
         .non_equi_conditions
         .iter()
@@ -1448,6 +1449,7 @@ fn hash_join_to_format_tree(
         FormatTreeNode::new(format!("join type: {}", plan.join_type)),
         FormatTreeNode::new(format!("build keys: [{build_keys}]")),
         FormatTreeNode::new(format!("probe keys: [{probe_keys}]")),
+        FormatTreeNode::new(format!("keys is null equal: [{is_null_equal}]")),
         FormatTreeNode::new(format!("filters: [{filters}]")),
     ];
 

--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -342,6 +342,16 @@ impl SubqueryRewriter {
                     &mut left_conditions,
                     &mut right_conditions,
                 )?;
+                let mut is_null_equal = Vec::new();
+                for (i, (l, r)) in left_conditions
+                    .iter()
+                    .zip(right_conditions.iter())
+                    .enumerate()
+                {
+                    if l.data_type()?.is_nullable() || r.data_type()?.is_nullable() {
+                        is_null_equal.push(i);
+                    }
+                }
 
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
@@ -356,7 +366,7 @@ impl SubqueryRewriter {
                     equi_conditions: JoinEquiCondition::new_conditions(
                         right_conditions,
                         left_conditions,
-                        vec![],
+                        is_null_equal,
                     ),
                     non_equi_conditions: vec![],
                     join_type: JoinType::RightMark,

--- a/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
@@ -376,7 +376,12 @@ impl SubqueryRewriter {
                         span: subquery.span,
                         func_name: "not".to_string(),
                         params: vec![],
-                        arguments: vec![column_ref],
+                        arguments: vec![ScalarExpr::FunctionCall(FunctionCall {
+                            span: subquery.span,
+                            func_name: "is_true".to_string(),
+                            params: vec![],
+                            arguments: vec![column_ref],
+                        })],
                     })
                 } else {
                     column_ref

--- a/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/mark_join_to_semi_join.rs
+++ b/src/query/sql/src/planner/optimizer/rule/rewrite/push_down_filter_join/mark_join_to_semi_join.rs
@@ -37,22 +37,19 @@ pub fn convert_mark_to_semi_join(s_expr: &SExpr) -> Result<(SExpr, bool)> {
 
     // remove mark index filter
     for (idx, predicate) in filter.predicates.iter().enumerate() {
-        match predicate {
-            ScalarExpr::BoundColumnRef(col) if col.column.index == mark_index => {
+        if !predicate.used_columns().contains(&mark_index) {
+            continue;
+        }
+
+        if let ScalarExpr::BoundColumnRef(col) = predicate {
+            if col.column.index == mark_index {
                 find_mark_index = true;
                 filter.predicates.remove(idx);
                 break;
             }
-            ScalarExpr::FunctionCall(func) if func.func_name == "not" => {
-                // Check if the argument is mark index, if so, we won't convert it to semi join
-                if let ScalarExpr::BoundColumnRef(col) = &func.arguments[0] {
-                    if col.column.index == mark_index {
-                        return Ok((s_expr.clone(), false));
-                    }
-                }
-            }
-            _ => (),
         }
+        // Check if the predicate used mark, if so, we won't convert it to semi join
+        return Ok((s_expr.clone(), false));
     }
 
     if !find_mark_index {

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -55,9 +55,11 @@ pub enum JoinType {
     LeftAnti,
     RightAnti,
     /// Mark Join is a special case of join that is used to process Any subquery and correlated Exists subquery.
-    /// Left Mark Join use subquery as probe side, it's blocked at `mark_join_blocks`
+    /// Left Mark output build fields and marker
+    /// Left Mark Join use subquery as probe(left) side, it's blocked at `mark_join_blocks`
     LeftMark,
-    /// Right Mark Join use subquery as build side, it's executed by streaming.
+    /// Right Mark output probe fields and marker
+    /// Right Mark Join use subquery as build(right) side, it's executed by streaming.
     RightMark,
     /// Single Join is a special kind of join that is used to process correlated scalar subquery.
     LeftSingle,

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -9,6 +9,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t1.number (#1)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -44,6 +45,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t2.number (#2)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 6.00
     ├── Exchange(Build)
@@ -54,6 +56,7 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [t.number (#0)]
     │       ├── probe keys: [t1.number (#1)]
+    |       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
@@ -98,6 +101,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.b (#1)]
     ├── probe keys: [t2.number (#3)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 6.00
     ├── Exchange(Build)
@@ -108,6 +112,7 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [t.a (#0)]
     │       ├── probe keys: [t1.number (#2)]
+    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
@@ -156,6 +161,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#1)]
     ├── probe keys: [CAST(t1.number (#2) AS UInt64 NULL)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -240,6 +246,7 @@ Fragment 2:
         ├── join type: INNER
         ├── build keys: [t.number (#1)]
         ├── probe keys: [CAST(t1.number (#2) AS UInt64 NULL)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── ExchangeSource(Build)
@@ -294,6 +301,7 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
+            |   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)
@@ -322,6 +330,7 @@ AggregateFinal
                 ├── join type: INNER
                 ├── build keys: [t3.a (#3)]
                 ├── probe keys: [t1.a (#2)]
+                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 100.00
                 ├── Exchange(Build)
@@ -379,6 +388,7 @@ AggregateFinal
         │       ├── join type: INNER
         │       ├── build keys: [t1.a (#0)]
         │       ├── probe keys: [t2.a (#1)]
+        │       ├── keys is null equal: [false]
         │       ├── filters: []
         │       ├── estimated rows: 10000.00
         │       ├── Exchange(Build)
@@ -419,6 +429,7 @@ AggregateFinal
                         ├── join type: INNER
                         ├── build keys: [t3.a (#3)]
                         ├── probe keys: [t1.a (#2)]
+                        ├── keys is null equal: [false]
                         ├── filters: []
                         ├── estimated rows: 100.00
                         ├── Exchange(Build)
@@ -475,6 +486,7 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
+            |   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)
@@ -524,6 +536,7 @@ Exchange
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 100000.00
     ├── Exchange(Build)
@@ -543,6 +556,7 @@ Exchange
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 10000.00
         ├── Exchange(Build)
@@ -581,6 +595,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.number (#1)]
     ├── probe keys: [t1.number (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 200.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -56,7 +56,7 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [t.number (#0)]
     │       ├── probe keys: [t1.number (#1)]
-    |       ├── keys is null equal: [false]
+    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
@@ -301,7 +301,7 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
-            |   ├── keys is null equal: [false]
+            │   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)
@@ -486,7 +486,7 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
-            |   ├── keys is null equal: [false]
+            │   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -132,7 +132,6 @@ EvalScalar
     └── Join(Cross)
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── other filters: []
         ├── Scan
         │   ├── table: default.t1
@@ -153,7 +152,6 @@ EvalScalar
 └── Join(Inner)
     ├── build keys: [t2.a (#2), t2.b (#3)]
     ├── probe keys: [t1.a (#0), t1.b (#1)]
-    ├── keys is null equal: [false, false]
     ├── other filters: []
     ├── Filter
     │   ├── filters: [gt(t1.a (#0), 2)]

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -49,6 +49,7 @@ Exchange
         ├── join type: INNER
         ├── build keys: [t2.a (#2)]
         ├── probe keys: [t1.a (#0)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 99.92
         ├── Exchange(Build)
@@ -94,6 +95,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 100.00
     ├── Exchange(Build)
@@ -130,6 +132,7 @@ EvalScalar
     └── Join(Cross)
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── other filters: []
         ├── Scan
         │   ├── table: default.t1
@@ -150,6 +153,7 @@ EvalScalar
 └── Join(Inner)
     ├── build keys: [t2.a (#2), t2.b (#3)]
     ├── probe keys: [t1.a (#0), t1.b (#1)]
+    ├── keys is null equal: [false, false]
     ├── other filters: []
     ├── Filter
     │   ├── filters: [gt(t1.a (#0), 2)]
@@ -218,6 +222,7 @@ Limit
                     ├── join type: INNER
                     ├── build keys: [t2.a (#2)]
                     ├── probe keys: [t1.a (#0)]
+                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 100.00
                     ├── Exchange(Build)
@@ -258,6 +263,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 100.00
     ├── Exchange(Build)
@@ -336,6 +342,7 @@ AggregateFinal
             ├── join type: RIGHT OUTER
             ├── build keys: [CAST(y.a (#1) AS UInt64 NULL)]
             ├── probe keys: [x.a (#2)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 50.00
             ├── Exchange(Build)
@@ -393,6 +400,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [CAST(CAST(subquery_2 (#2) AS UInt8 NULL) AS Int32 NULL)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -435,6 +443,7 @@ Exchange
     ├── join type: LEFT OUTER
     ├── build keys: [b.query_node (#63)]
     ├── probe keys: [CAST(a.cluster_node (#0) AS String NULL)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
+++ b/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
@@ -100,7 +100,7 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [table2.value (#1)]
     │       ├── probe keys: [table3.value (#2)]
-    |       ├── keys is null equal: [false]
+    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 250.00
     │       ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
+++ b/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
@@ -43,6 +43,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)
@@ -88,6 +89,7 @@ Exchange
     ├── join type: INNER
     ├── build keys: [table3.value (#2)]
     ├── probe keys: [table1.value (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 200.00
     ├── Exchange(Build)
@@ -98,6 +100,7 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [table2.value (#1)]
     │       ├── probe keys: [table3.value (#2)]
+    |       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 250.00
     │       ├── Exchange(Build)
@@ -158,6 +161,7 @@ Exchange
     ├── join type: LEFT SEMI
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)
@@ -203,6 +207,7 @@ Exchange
     ├── join type: RIGHT SEMI
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -160,6 +160,7 @@ CommitSink
         ├── join type: RIGHT OUTER
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: [t1.a (#1) < t2.a (#0)]
         ├── estimated rows: 15.00
         ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -72,6 +72,7 @@ CommitSink
                 ├── join type: LEFT OUTER
                 ├── build keys: []
                 ├── probe keys: []
+                ├── keys is null equal: []
                 ├── filters: []
                 ├── estimated rows: 1.00
                 ├── Exchange(Build)
@@ -121,6 +122,7 @@ CommitSink
         ├── join type: RIGHT OUTER
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: [t1.a (#1) > t.a (#0)]
         ├── estimated rows: 15.00
         ├── TableScan(Build)
@@ -255,6 +257,7 @@ CommitSink
                 ├── join type: RIGHT OUTER
                 ├── build keys: [CAST(t2.a (#0) AS Int64 NULL)]
                 ├── probe keys: [CAST(t1.a (#1) AS Int64 NULL)]
+                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 0.00
                 ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle.test
@@ -35,6 +35,7 @@ Sort
             ├── join type: RIGHT OUTER
             ├── build keys: [t2.number (#1)]
             ├── probe keys: [t1.number (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.01
             ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -96,6 +96,7 @@ Exchange
                 ├── join type: INNER
                 ├── build keys: [d.department_id (#4)]
                 ├── probe keys: [e.department_id (#2)]
+                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 8.00
                 ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -161,6 +161,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_5 (#5), b (#4)]
 ├── probe keys: [SUM(a) (#2), b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
@@ -13,7 +13,7 @@ INSERT INTO test_linear VALUES(2, 1), (2, 2);
 statement ok
 ALTER TABLE test_linear RECLUSTER FINAL;
 
-query TTIIFFT
+query TTIIRRT
 select * exclude(timestamp) from clustering_information('default','test_linear')
 ----
 (a, b) linear 2 0 0.0 1.0 {"00001":2}

--- a/tests/sqllogictests/suites/mode/standalone/explain/delete.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/delete.test
@@ -35,6 +35,7 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)
@@ -77,6 +78,7 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -18,6 +18,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -49,6 +50,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -80,6 +82,7 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -111,6 +114,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -150,6 +154,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -189,6 +194,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -228,6 +234,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -267,6 +274,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -306,6 +314,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
@@ -345,6 +354,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 8.00
 ├── Filter(Build)
@@ -384,6 +394,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
@@ -423,6 +434,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 9.00
 ├── Filter(Build)
@@ -462,6 +474,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 9.00
 ├── Filter(Build)
@@ -501,6 +514,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── Filter(Build)
@@ -545,6 +559,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -580,6 +595,7 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 8.40
     ├── Filter(Build)
@@ -623,6 +639,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -657,6 +674,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -52,6 +52,7 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -91,6 +92,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -325,6 +327,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.40
     ├── Filter(Build)
@@ -368,6 +371,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 5.00
     ├── Filter(Build)
@@ -409,6 +413,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
@@ -416,6 +421,7 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
+│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 5.00
 │   ├── TableScan(Build)
@@ -457,6 +463,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 28.16
 ├── Filter(Build)
@@ -468,6 +475,7 @@ HashJoin
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
+│       ├── keys is null equal: []
 │       ├── filters: []
 │       ├── estimated rows: 4.40
 │       ├── Filter(Build)
@@ -534,6 +542,7 @@ Limit
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
+            ├── keys is null equal: []
             ├── filters: []
             ├── estimated rows: 4.40
             ├── Filter(Build)
@@ -573,6 +582,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 5.00
 ├── Filter(Build)
@@ -804,6 +814,7 @@ Limit
     ├── join type: INNER
     ├── build keys: [a.id (#0)]
     ├── probe keys: [b.id (#2)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── Filter(Build)
@@ -857,6 +868,7 @@ Sort
     ├── join type: INNER
     ├── build keys: [b.register_at (#3), numbers.number (#2)]
     ├── probe keys: [a.pt (#1), a.number (#0)]
+    ├── keys is null equal: [false, false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── EvalScalar(Build)
@@ -922,6 +934,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_2 (#2), id (#2)]
 ├── probe keys: [a.id (#0), a.id (#0)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.40
 ├── Filter(Build)
@@ -969,6 +982,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 3.00
 ├── TableScan(Build)
@@ -1006,6 +1020,7 @@ Filter
     ├── join type: LEFT MARK
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── TableScan(Build)
@@ -1064,6 +1079,7 @@ Sort
     ├── join type: LEFT OUTER
     ├── build keys: [t2.k (#2)]
     ├── probe keys: [t1.i (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── EmptyResultScan(Build)
@@ -1276,6 +1292,7 @@ EvalScalar
     ├── join type: LEFT OUTER
     ├── build keys: [t2.b (#1)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -1327,6 +1344,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#3)]
 ├── probe keys: [a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
 ├── Sort(Build)
@@ -1373,6 +1391,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#3)]
 ├── probe keys: [a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
 ├── Sort(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_table_function_obfuscate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_table_function_obfuscate.test
@@ -13,6 +13,7 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1)]
 ├── probe keys: [v1.c1 (#3), b (#5)]
+├── keys is null equal: [false, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1]
@@ -63,6 +64,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1), c (#2)]
 ├── probe keys: [v1.c1 (#3), b (#5), c (#6)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -103,6 +105,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -147,6 +150,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
@@ -156,6 +160,7 @@ HashJoin
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]
@@ -217,6 +222,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t1.a (#0) AS Int64 NULL), b (#1), c1 (#3)]
 ├── probe keys: [v2.c2 (#9), b (#11), c1 (#13)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 3]
@@ -226,6 +232,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -518,6 +518,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -556,6 +557,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -563,6 +565,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── Filter(Build)
@@ -696,6 +699,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -703,6 +707,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -770,6 +775,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.id (#1) AS Int64 NULL)]
 ├── probe keys: [CAST(t1.id (#0) AS Int64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0)]
 ├── probe keys: [t1.number (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -55,6 +56,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0), t.number (#0)]
 ├── probe keys: [t1.number (#1), t1.number (#1) + 1]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -90,6 +92,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -133,6 +136,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -165,6 +169,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t2.number (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -172,6 +177,7 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
+│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── Filter(Build)
@@ -237,6 +243,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── Filter(Build)
@@ -276,6 +283,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.33
 ├── Filter(Build)
@@ -315,6 +323,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── Filter(Build)
@@ -360,6 +369,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── TableScan(Build)
@@ -391,6 +401,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.67
 ├── Filter(Build)
@@ -445,6 +456,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -482,6 +494,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -515,6 +528,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -552,6 +566,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -589,6 +604,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -627,6 +643,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t1.b (#1) > t2.b (#3)]
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -740,6 +757,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.x (#1)]
 ├── probe keys: [o.x (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.33
 ├── Filter(Build)
@@ -786,6 +804,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.number (#1)]
 ├── probe keys: [t1.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 200.00
 ├── TableScan(Build)
@@ -831,6 +850,7 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -872,6 +892,7 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -913,6 +934,7 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)
@@ -961,6 +983,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t1.a (#0) >= CAST(scalar_subquery_2 (#2) AS Int32 NULL)]
 ├── estimated rows: 4.00
 ├── EvalScalar(Build)
@@ -987,6 +1010,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t1.a (#0) >= scalar_subquery_1 (#1)]
 ├── estimated rows: 4.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -36,6 +36,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -43,6 +44,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -84,6 +86,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -91,6 +94,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -132,6 +136,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -139,6 +144,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -180,6 +186,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -187,6 +194,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -228,6 +236,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -235,6 +244,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -276,6 +286,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -283,6 +294,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -324,6 +336,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -359,6 +372,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── EvalScalar(Build)
@@ -394,6 +408,7 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -425,6 +440,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -456,6 +472,7 @@ HashJoin
 ├── join type: RIGHT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -487,6 +504,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -31,6 +32,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -72,6 +74,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -79,6 +82,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -120,6 +124,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -127,6 +132,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -168,6 +174,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -175,6 +182,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -216,6 +224,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -223,6 +232,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -264,6 +274,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -271,6 +282,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -6,6 +6,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [subquery_1 (#1)]
 ├── probe keys: [numbers.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10000.00
 ├── TableScan(Build)
@@ -35,6 +36,7 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [numbers.number (#0)]
 ├── probe keys: [subquery_1 (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -89,6 +91,7 @@ EvalScalar
     ├── join type: LEFT SINGLE
     ├── build keys: [c (#8)]
     ├── probe keys: [c (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)
@@ -100,6 +103,7 @@ EvalScalar
     │       ├── join type: RIGHT MARK
     │       ├── build keys: [a (#2)]
     │       ├── probe keys: [c (#8)]
+    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 4.00
     │       ├── Filter(Build)
@@ -121,6 +125,7 @@ EvalScalar
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
+    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 4.00
     │           ├── DummyTableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -31,6 +32,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -72,6 +74,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -79,6 +82,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -120,6 +124,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -127,6 +132,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -168,6 +174,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -175,6 +182,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -216,6 +224,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -223,6 +232,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -264,6 +274,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -271,6 +282,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
@@ -6,6 +6,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#1)]
 ├── probe keys: [number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)
@@ -35,6 +36,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#0)]
 ├── probe keys: [number (#3)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -55,6 +57,7 @@ HashJoin
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 100.00
         ├── TableScan(Build)
@@ -93,6 +96,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL), CAST(number (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.b (#3), number (#4)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -117,6 +121,7 @@ HashJoin
             ├── join type: INNER
             ├── build keys: [t1.a (#1)]
             ├── probe keys: [number (#4)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 100.00
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -104,6 +104,7 @@ Limit
                     ├── join type: LEFT OUTER
                     ├── build keys: [number (#2)]
                     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
+                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 1.00
                     ├── AggregateFinal(Build)
@@ -120,6 +121,7 @@ Limit
                     │           ├── join type: CROSS
                     │           ├── build keys: []
                     │           ├── probe keys: []
+                    │           ├── keys is null equal: []
                     │           ├── filters: []
                     │           ├── estimated rows: 1.00
                     │           ├── TableScan(Build)
@@ -145,6 +147,7 @@ Limit
                         ├── join type: CROSS
                         ├── build keys: []
                         ├── probe keys: []
+                        ├── keys is null equal: []
                         ├── filters: []
                         ├── estimated rows: 1.00
                         ├── TableScan(Build)
@@ -183,6 +186,7 @@ Limit
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
         ├── probe keys: [t4.c (#4)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
@@ -6,6 +6,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#1)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)
@@ -35,6 +36,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#1)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -38,6 +38,7 @@ CommitSink
         ├── join type: LEFT OUTER
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 4.00
         ├── EmptyResultScan(Build)
@@ -78,6 +79,7 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [salaries2.employee_id (#3)]
             ├── probe keys: [employees2.employee_id (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -121,6 +123,7 @@ CommitSink
             ├── join type: RIGHT OUTER
             ├── build keys: [employees2.employee_id (#0)]
             ├── probe keys: [salaries2.employee_id (#3)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -160,6 +163,7 @@ CommitSink
             ├── join type: RIGHT OUTER
             ├── build keys: [employees2.employee_id (#0)]
             ├── probe keys: [salaries2.employee_id (#3)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -215,6 +219,7 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -236,7 +241,7 @@ CommitSink
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 0.00
 
-query T
+query ok
 explain MERGE INTO column_only_optimization_target as t1 using column_only_optimization_source as t2
 on t1.a = t2.a when matched then update * when not matched then insert *;
 ----
@@ -253,6 +258,7 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -294,6 +300,7 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -332,6 +339,7 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -241,7 +241,7 @@ CommitSink
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 0.00
 
-query ok
+query T
 explain MERGE INTO column_only_optimization_target as t1 using column_only_optimization_source as t2
 on t1.a = t2.a when matched then update * when not matched then insert *;
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
@@ -19,6 +19,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -66,6 +67,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -112,6 +114,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -158,6 +161,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -139,6 +139,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.a (#3) AS UInt64 NULL)]
 ├── probe keys: [CAST(t1.a (#2) AS UInt64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 450.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -77,6 +77,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#2)]
 ├── probe keys: [t2.b (#7)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── EvalScalar(Build)
@@ -118,6 +119,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_12 (#12)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── AggregateFinal(Build)
@@ -134,6 +136,7 @@ HashJoin
 │           ├── join type: INNER
 │           ├── build keys: [t2.b (#5)]
 │           ├── probe keys: [t3.b (#10)]
+│           ├── keys is null equal: [false]
 │           ├── filters: []
 │           ├── estimated rows: 0.20
 │           ├── EvalScalar(Build)
@@ -205,6 +208,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
@@ -77,6 +77,7 @@ AggregateFinal
         │           ├── join type: LEFT OUTER
         │           ├── build keys: [tb.sid (#1)]
         │           ├── probe keys: [t.id (#0)]
+        │           ├── keys is null equal: [false]
         │           ├── filters: []
         │           ├── estimated rows: 0.00
         │           ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -66,6 +67,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -106,6 +108,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -142,6 +145,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -178,6 +182,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -218,6 +223,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -258,6 +264,7 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t2.a (#2) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -70,6 +71,7 @@ Filter
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.56
     ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -66,6 +67,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t1.a (#0) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -98,6 +100,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -134,6 +137,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -174,6 +178,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -228,6 +233,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -280,6 +286,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -66,6 +67,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -16,6 +16,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b2.a (#2)]
 ├── probe keys: [b1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [d.b (#1) < d.b (#3)]
 ├── estimated rows: 400.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -136,6 +136,7 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#0)]
     ├── probe keys: [t1.a (#1)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)
@@ -177,6 +178,7 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#1)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -10,6 +10,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [number (#2)]
     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── AggregateFinal(Build)
@@ -26,6 +27,7 @@ Filter
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
+    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 1.00
     │           ├── TableScan(Build)
@@ -51,6 +53,7 @@ Filter
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 1.00
         ├── TableScan(Build)
@@ -84,6 +87,7 @@ Filter
     ├── join type: RIGHT MARK
     ├── build keys: [number (#1)]
     ├── probe keys: [number (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -113,6 +117,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -164,6 +169,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_1 (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -197,6 +203,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -226,6 +233,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -255,6 +263,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -284,6 +293,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -321,6 +331,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: [t.number (#0) < numbers.number (#1)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -350,6 +361,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -379,6 +391,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#2)]
 ├── probe keys: [number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── HashJoin(Build)
@@ -386,6 +399,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [number (#2)]
 │   ├── probe keys: [t1.number (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.20
 │   ├── Filter(Build)
@@ -437,6 +451,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t.number (#0) < t1.number (#2)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -453,6 +468,7 @@ HashJoin
     ├── join type: LEFT SEMI
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: [t.number (#0) > t1.number (#1)]
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -512,6 +528,7 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/update.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/update.test
@@ -31,6 +31,7 @@ CommitSink
             ├── join type: LEFT SEMI
             ├── build keys: [subquery_2 (#2)]
             ├── probe keys: [t1.a (#0)]
+            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 2.00
             ├── TableScan(Build)
@@ -73,6 +74,7 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)
@@ -145,6 +147,7 @@ CommitSink
             ├── join type: INNER
             ├── build keys: [p.c_code (#9), p.id (#8), p.me_id (#10)]
             ├── probe keys: [c.c_code (#1), c.id (#0), c.me_id (#2)]
+            ├── keys is null equal: [false, false, false]
             ├── filters: []
             ├── estimated rows: 3.20
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -36,6 +36,7 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)
@@ -67,6 +68,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -100,6 +102,7 @@ EvalScalar
     └── Join(Cross)
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── other filters: []
         ├── Scan
         │   ├── table: default.t1
@@ -120,6 +123,7 @@ EvalScalar
 └── Join(Inner)
     ├── build keys: [t2.a (#2), t2.b (#3)]
     ├── probe keys: [t1.a (#0), t1.b (#1)]
+    ├── keys is null equal: [false, false]
     ├── other filters: []
     ├── Filter
     │   ├── filters: [gt(t1.a (#0), 2)]
@@ -301,6 +305,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.40
     ├── TableScan(Build)
@@ -336,6 +341,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 5.00
     ├── TableScan(Build)
@@ -373,6 +379,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
@@ -380,6 +387,7 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
+│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 5.00
 │   ├── TableScan(Build)
@@ -421,6 +429,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 28.16
 ├── Filter(Build)
@@ -432,6 +441,7 @@ HashJoin
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
+│       ├── keys is null equal: []
 │       ├── filters: []
 │       ├── estimated rows: 4.40
 │       ├── TableScan(Build)
@@ -486,6 +496,7 @@ Limit
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
+            ├── keys is null equal: []
             ├── filters: []
             ├── estimated rows: 4.40
             ├── TableScan(Build)
@@ -517,6 +528,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 5.00
 ├── TableScan(Build)
@@ -727,6 +739,7 @@ Sort
     ├── join type: LEFT OUTER
     ├── build keys: [t2.k (#2)]
     ├── probe keys: [t1.i (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── EmptyResultScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -102,7 +102,6 @@ EvalScalar
     └── Join(Cross)
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── other filters: []
         ├── Scan
         │   ├── table: default.t1
@@ -123,7 +122,6 @@ EvalScalar
 └── Join(Inner)
     ├── build keys: [t2.a (#2), t2.b (#3)]
     ├── probe keys: [t1.a (#0), t1.b (#1)]
-    ├── keys is null equal: [false, false]
     ├── other filters: []
     ├── Filter
     │   ├── filters: [gt(t1.a (#0), 2)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1)]
 ├── probe keys: [v1.c1 (#3), b (#5)]
+├── keys is null equal: [false, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1]
@@ -64,6 +65,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1), c (#2)]
 ├── probe keys: [v1.c1 (#3), b (#5), c (#6)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -104,6 +106,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -148,6 +151,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
@@ -157,6 +161,7 @@ HashJoin
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]
@@ -218,6 +223,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t1.a (#0) AS Int64 NULL), b (#1), c1 (#3)]
 ├── probe keys: [v2.c2 (#9), b (#11), c1 (#13)]
+├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 3]
@@ -227,6 +233,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
+│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -418,6 +418,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -448,6 +449,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -455,6 +457,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -564,6 +567,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -571,6 +575,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -637,6 +642,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.id (#1) AS Int64 NULL)]
 ├── probe keys: [CAST(t1.id (#0) AS Int64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0)]
 ├── probe keys: [t1.number (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -55,6 +56,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0), t.number (#0)]
 ├── probe keys: [t1.number (#1), t1.number (#1) + 1]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -86,6 +88,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -121,6 +124,7 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -153,6 +157,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t2.number (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -160,6 +165,7 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
+│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -221,6 +227,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── TableScan(Build)
@@ -252,6 +259,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.33
 ├── TableScan(Build)
@@ -283,6 +291,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── TableScan(Build)
@@ -320,6 +329,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── TableScan(Build)
@@ -351,6 +361,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.67
 ├── TableScan(Build)
@@ -397,6 +408,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -426,6 +438,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -455,6 +468,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -484,6 +498,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -513,6 +528,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
+├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -542,6 +558,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t1.b (#1) > t2.b (#3)]
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -655,6 +672,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t1.a (#0) >= CAST(scalar_subquery_2 (#2) AS Int32 NULL)]
 ├── estimated rows: 4.00
 ├── EvalScalar(Build)
@@ -681,6 +699,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t1.a (#0) >= scalar_subquery_1 (#1)]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
@@ -33,6 +33,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -40,6 +41,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -81,6 +83,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -88,6 +91,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -129,6 +133,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -136,6 +141,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -177,6 +183,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -184,6 +191,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -225,6 +233,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -232,6 +241,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -273,6 +283,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -280,6 +291,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -321,6 +333,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -356,6 +369,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── EvalScalar(Build)
@@ -391,6 +405,7 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -422,6 +437,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -453,6 +469,7 @@ HashJoin
 ├── join type: RIGHT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -484,6 +501,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -31,6 +32,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -72,6 +74,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -79,6 +82,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -120,6 +124,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -127,6 +132,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -168,6 +174,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -175,6 +182,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -216,6 +224,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -223,6 +232,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -264,6 +274,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -271,6 +282,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
@@ -6,6 +6,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [subquery_1 (#1)]
 ├── probe keys: [numbers.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10000.00
 ├── TableScan(Build)
@@ -35,6 +36,7 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [numbers.number (#0)]
 ├── probe keys: [subquery_1 (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
@@ -24,6 +24,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -31,6 +32,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -72,6 +74,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -79,6 +82,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -120,6 +124,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -127,6 +132,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -168,6 +174,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -175,6 +182,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -216,6 +224,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -223,6 +232,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -264,6 +274,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -271,6 +282,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -104,6 +104,7 @@ Limit
                     ├── join type: LEFT OUTER
                     ├── build keys: [number (#2)]
                     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
+                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 1.00
                     ├── AggregateFinal(Build)
@@ -120,6 +121,7 @@ Limit
                     │           ├── join type: CROSS
                     │           ├── build keys: []
                     │           ├── probe keys: []
+                    │           ├── keys is null equal: []
                     │           ├── filters: []
                     │           ├── estimated rows: 1.00
                     │           ├── TableScan(Build)
@@ -145,6 +147,7 @@ Limit
                         ├── join type: CROSS
                         ├── build keys: []
                         ├── probe keys: []
+                        ├── keys is null equal: []
                         ├── filters: []
                         ├── estimated rows: 1.00
                         ├── TableScan(Build)
@@ -183,6 +186,7 @@ Limit
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
         ├── probe keys: [t4.c (#4)]
+        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
@@ -91,6 +91,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.a (#3) AS UInt64 NULL)]
 ├── probe keys: [CAST(t1.a (#2) AS UInt64 NULL)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 450.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
@@ -77,6 +77,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#2)]
 ├── probe keys: [t2.b (#7)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── EvalScalar(Build)
@@ -118,6 +119,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_12 (#12)]
 ├── probe keys: [t1.a (#1)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── AggregateFinal(Build)
@@ -134,6 +136,7 @@ HashJoin
 │           ├── join type: INNER
 │           ├── build keys: [t2.b (#5)]
 │           ├── probe keys: [t3.b (#10)]
+│           ├── keys is null equal: [false]
 │           ├── filters: []
 │           ├── estimated rows: 0.20
 │           ├── EvalScalar(Build)
@@ -205,6 +208,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
@@ -77,6 +77,7 @@ AggregateFinal
         │           ├── join type: LEFT OUTER
         │           ├── build keys: [tb.sid (#1)]
         │           ├── probe keys: [t.id (#0)]
+        │           ├── keys is null equal: [false]
         │           ├── filters: []
         │           ├── estimated rows: 0.00
         │           ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -58,6 +59,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -90,6 +92,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -122,6 +125,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -154,6 +158,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -186,6 +191,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -218,6 +224,7 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t2.a (#2) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -62,6 +63,7 @@ Filter
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.56
     ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -58,6 +59,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: [t1.a (#0) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -90,6 +92,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -122,6 +125,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -154,6 +158,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -204,6 +209,7 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -252,6 +258,7 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#0)]
 ├── probe keys: [t1.a (#2)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -26,6 +26,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -58,6 +59,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
@@ -136,6 +136,7 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#0)]
     ├── probe keys: [t1.a (#1)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)
@@ -177,6 +178,7 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#1)]
     ├── probe keys: [t1.a (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -10,6 +10,7 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [number (#2)]
     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── AggregateFinal(Build)
@@ -26,6 +27,7 @@ Filter
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
+    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 1.00
     │           ├── TableScan(Build)
@@ -51,6 +53,7 @@ Filter
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
+        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 1.00
         ├── TableScan(Build)
@@ -84,6 +87,7 @@ Filter
     ├── join type: RIGHT MARK
     ├── build keys: [number (#1)]
     ├── probe keys: [number (#0)]
+    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -113,6 +117,7 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -164,6 +169,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_1 (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -197,6 +203,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -226,6 +233,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -255,6 +263,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -284,6 +293,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -321,6 +331,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: [t.number (#0) < numbers.number (#1)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -350,6 +361,7 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -379,6 +391,7 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#2)]
 ├── probe keys: [number (#0)]
+├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── HashJoin(Build)
@@ -386,6 +399,7 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [number (#2)]
 │   ├── probe keys: [t1.number (#1)]
+│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.20
 │   ├── Filter(Build)
@@ -437,6 +451,7 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: []
 ├── probe keys: []
+├── keys is null equal: []
 ├── filters: [t.number (#0) < t1.number (#2)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -453,6 +468,7 @@ HashJoin
     ├── join type: LEFT SEMI
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: [t.number (#0) > t1.number (#1)]
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -495,6 +511,7 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
+    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/tpcds/queries.test
+++ b/tests/sqllogictests/suites/tpcds/queries.test
@@ -11306,7 +11306,6 @@ Adams John Marion Oak Ridge 206733 32377.89 1224.72 72590.31
 
 
 # Q69
-onlyif todo
 query I
 SELECT cd_gender,
        cd_marital_status,
@@ -11360,6 +11359,107 @@ ORDER BY cd_gender,
          cd_credit_rating
 LIMIT 100;
 ----
+F	D	2 yr Degree	1	2500	1	Low Risk	1
+F	D	2 yr Degree	1	4500	1	Good	1
+F	D	2 yr Degree	2	4500	2	Low Risk	2
+F	D	2 yr Degree	1	9000	1	Good	1
+F	D	2 yr Degree	1	9500	1	Good	1
+F	D	4 yr Degree	1	1000	1	Low Risk	1
+F	D	4 yr Degree	1	1500	1	Low Risk	1
+F	D	4 yr Degree	1	1500	1	Unknown	1
+F	D	4 yr Degree	1	2000	1	Good	1
+F	D	4 yr Degree	1	2500	1	Unknown	1
+F	D	4 yr Degree	1	4000	1	Unknown	1
+F	D	4 yr Degree	1	5500	1	Good	1
+F	D	4 yr Degree	1	7000	1	Good	1
+F	D	4 yr Degree	1	7000	1	High Risk	1
+F	D	4 yr Degree	1	8000	1	High Risk	1
+F	D	4 yr Degree	1	8500	1	Unknown	1
+F	D	Advanced Degree	1	1000	1	Good	1
+F	D	Advanced Degree	1	3500	1	Good	1
+F	D	Advanced Degree	1	3500	1	High Risk	1
+F	D	Advanced Degree	1	4000	1	Good	1
+F	D	Advanced Degree	1	4000	1	High Risk	1
+F	D	Advanced Degree	1	5000	1	High Risk	1
+F	D	Advanced Degree	1	5500	1	Good	1
+F	D	Advanced Degree	1	5500	1	Low Risk	1
+F	D	Advanced Degree	1	6500	1	Low Risk	1
+F	D	Advanced Degree	1	7000	1	High Risk	1
+F	D	Advanced Degree	1	8000	1	Low Risk	1
+F	D	Advanced Degree	1	8500	1	High Risk	1
+F	D	Advanced Degree	1	9500	1	Low Risk	1
+F	D	Advanced Degree	1	9500	1	Unknown	1
+F	D	Advanced Degree	1	10000	1	Low Risk	1
+F	D	College	1	1500	1	Low Risk	1
+F	D	College	1	2500	1	Good	1
+F	D	College	1	4000	1	High Risk	1
+F	D	College	1	6000	1	Good	1
+F	D	College	1	6000	1	High Risk	1
+F	D	College	1	9000	1	High Risk	1
+F	D	Primary	1	3000	1	High Risk	1
+F	D	Primary	1	4000	1	Low Risk	1
+F	D	Primary	1	4000	1	Unknown	1
+F	D	Primary	1	4500	1	Unknown	1
+F	D	Primary	1	5000	1	High Risk	1
+F	D	Primary	1	5000	1	Unknown	1
+F	D	Primary	1	6000	1	Good	1
+F	D	Primary	1	6000	1	Unknown	1
+F	D	Primary	1	8500	1	Unknown	1
+F	D	Primary	1	9000	1	Unknown	1
+F	D	Primary	1	9500	1	High Risk	1
+F	D	Primary	1	9500	1	Unknown	1
+F	D	Primary	1	10000	1	Good	1
+F	D	Primary	2	10000	2	Low Risk	2
+F	D	Secondary	1	 500	1	Low Risk	1
+F	D	Secondary	1	1000	1	High Risk	1
+F	D	Secondary	1	3000	1	Good	1
+F	D	Secondary	1	3500	1	Good	1
+F	D	Secondary	1	6000	1	Low Risk	1
+F	D	Secondary	1	6500	1	Unknown	1
+F	D	Secondary	1	8500	1	High Risk	1
+F	D	Secondary	1	10000	1	Low Risk	1
+F	D	Unknown	1	1500	1	High Risk	1
+F	D	Unknown	1	3000	1	Good	1
+F	D	Unknown	1	3000	1	High Risk	1
+F	D	Unknown	1	6000	1	Good	1
+F	D	Unknown	1	6500	1	High Risk	1
+F	D	Unknown	2	8000	2	Low Risk	2
+F	D	Unknown	1	10000	1	Unknown	1
+F	M	2 yr Degree	1	2500	1	Low Risk	1
+F	M	2 yr Degree	3	4000	3	Unknown	3
+F	M	2 yr Degree	1	4500	1	Low Risk	1
+F	M	2 yr Degree	1	8500	1	High Risk	1
+F	M	4 yr Degree	1	1000	1	Good	1
+F	M	4 yr Degree	1	1500	1	Good	1
+F	M	4 yr Degree	1	4000	1	Low Risk	1
+F	M	4 yr Degree	1	4000	1	Unknown	1
+F	M	4 yr Degree	1	5000	1	Unknown	1
+F	M	4 yr Degree	1	5500	1	Low Risk	1
+F	M	4 yr Degree	1	6000	1	Good	1
+F	M	4 yr Degree	1	8000	1	High Risk	1
+F	M	Advanced Degree	1	 500	1	Low Risk	1
+F	M	Advanced Degree	1	 500	1	Unknown	1
+F	M	Advanced Degree	1	2500	1	Good	1
+F	M	Advanced Degree	1	3500	1	High Risk	1
+F	M	Advanced Degree	2	5500	2	Unknown	2
+F	M	Advanced Degree	1	6500	1	Good	1
+F	M	Advanced Degree	1	6500	1	Unknown	1
+F	M	Advanced Degree	1	8000	1	Low Risk	1
+F	M	Advanced Degree	1	9500	1	Good	1
+F	M	Advanced Degree	1	10000	1	Low Risk	1
+F	M	College	1	1000	1	Unknown	1
+F	M	College	1	3000	1	Good	1
+F	M	College	2	5000	2	High Risk	2
+F	M	College	1	6000	1	Low Risk	1
+F	M	College	1	7000	1	High Risk	1
+F	M	College	1	8000	1	Good	1
+F	M	College	1	9000	1	Good	1
+F	M	College	2	9000	2	High Risk	2
+F	M	College	1	10000	1	High Risk	1
+F	M	Primary	1	1000	1	Low Risk	1
+F	M	Primary	1	1500	1	High Risk	1
+F	M	Primary	1	7000	1	Good	1
+
 
 
 # Q70


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. The `JoinEquiCondition` for mark join needs to account for `is_null_equal`.
2. In the logical plan explained, the `HashJoin` node displays `JoinEquiCondition.is_null_equal`.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17516)
<!-- Reviewable:end -->
