### PR TITLE
feat: support query metadata from parquet.

### DIFF
--- a/src/query/service/tests/it/parquet_rs/prune_row_groups.rs
+++ b/src/query/service/tests/it/parquet_rs/prune_row_groups.rs
@@ -63,7 +63,7 @@ async fn test_impl_batch(args: &[(Scenario, &str, Vec<usize>)], prune: bool) {
         )
         .unwrap();
 
-        let (rgs, _) = pruner.prune_row_groups(&parquet_meta, None, None).unwrap();
+        let (rgs, _, _) = pruner.prune_row_groups(&parquet_meta, None, None).unwrap();
 
         assert_eq!(
             expected_rgs.to_vec(),

--- a/src/query/storages/delta/src/table.rs
+++ b/src/query/storages/delta/src/table.rs
@@ -254,7 +254,7 @@ impl DeltaTable {
                 .with_pruner(Some(pruner))
                 .with_partition_columns(self.meta.partition_columns.clone());
 
-        let parquet_reader = Arc::new(builder.build_full_reader()?);
+        let parquet_reader = Arc::new(builder.build_full_reader(false)?);
 
         let output_schema = Arc::new(DataSchema::from(plan.schema()));
         pipeline.add_source(

--- a/src/query/storages/hive/hive/src/hive_table.rs
+++ b/src/query/storages/hive/hive/src/hive_table.rs
@@ -195,7 +195,7 @@ impl HiveTable {
                 .with_pruner(Some(pruner))
                 .with_partition_columns(partition_keys);
 
-        let parquet_reader = Arc::new(builder.build_full_reader()?);
+        let parquet_reader = Arc::new(builder.build_full_reader(false)?);
 
         let output_schema = Arc::new(DataSchema::from(plan.schema()));
         pipeline.add_source(

--- a/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/copy_into_table/table.rs
@@ -85,9 +85,11 @@ impl ParquetTableForCopy {
                 num_rows_loaded: num_rows,
                 error: None,
             });
+            let mut start_row = 0;
             for rg in meta.meta.row_groups() {
                 let part = ParquetRSRowGroupPart {
                     location: meta.location.clone(),
+                    start_row,
                     meta: rg.clone(),
                     schema_index,
                     uncompressed_size: rg.total_byte_size() as u64,
@@ -97,6 +99,7 @@ impl ParquetTableForCopy {
                     page_locations: None,
                     selectors: None,
                 };
+                start_row += rg.num_rows() as u64;
                 parts.push(part);
             }
         }

--- a/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/full_reader.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_reader/reader/full_reader.rs
@@ -105,7 +105,7 @@ impl ParquetRSFullReader {
 
         // Prune row groups.
         if let Some(pruner) = &self.pruner {
-            let (selected_row_groups, omits) =
+            let (selected_row_groups, omits, _) =
                 pruner.prune_row_groups(&file_meta, None, partition_values_map.as_ref())?;
             all_pruned = omits.iter().all(|x| *x);
             builder = builder.with_row_groups(selected_row_groups.clone());
@@ -193,7 +193,8 @@ impl ParquetRSFullReader {
 
         let mut full_match = false;
         if let Some(pruner) = &self.pruner {
-            let (selected_row_groups, omits) = pruner.prune_row_groups(&file_meta, None, None)?;
+            let (selected_row_groups, omits, _) =
+                pruner.prune_row_groups(&file_meta, None, None)?;
 
             full_match = omits.iter().all(|x| *x);
             builder = builder.with_row_groups(selected_row_groups.clone());

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/partition.rs
@@ -357,7 +357,8 @@ fn prune_and_generate_partitions(
             ..
         } = meta.as_ref();
         part_stats.partitions_total += meta.num_row_groups();
-        let (rgs, omits) = pruner.prune_row_groups(meta, row_group_level_stats.as_deref(), None)?;
+        let (rgs, omits, start_rows) =
+            pruner.prune_row_groups(meta, row_group_level_stats.as_deref(), None)?;
         let mut row_selections = if omits.iter().all(|x| *x) {
             None
         } else {
@@ -366,7 +367,7 @@ fn prune_and_generate_partitions(
 
         let mut rows_read = 0; // Rows read in current file.
 
-        for (rg, omit) in rgs.into_iter().zip(omits.into_iter()) {
+        for ((rg, omit), start_row) in rgs.into_iter().zip(omits.into_iter()).zip(start_rows) {
             let rg_meta = meta.row_group(rg);
             let num_rows = rg_meta.num_rows() as usize;
             // Split rows belonging to current row group.
@@ -417,6 +418,7 @@ fn prune_and_generate_partitions(
 
             parts.push(ParquetRSRowGroupPart {
                 location: location.clone(),
+                start_row,
                 selectors: serde_selection,
                 meta: rg_meta.clone(),
                 page_locations,

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
@@ -36,8 +36,11 @@ use databend_common_catalog::table::TableStatistics;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ColumnId;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
+use databend_common_expression::FILENAME_COLUMN_ID;
+use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
@@ -210,6 +213,10 @@ impl Table for ParquetRSTable {
 
     fn support_column_projection(&self) -> bool {
         true
+    }
+
+    fn supported_internal_column(&self, column_id: ColumnId) -> bool {
+        (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
     }
 
     fn support_prewhere(&self) -> bool {

--- a/src/query/storages/parquet/src/parquet_rs/partition.rs
+++ b/src/query/storages/parquet/src/parquet_rs/partition.rs
@@ -89,6 +89,7 @@ impl From<&SerdePageLocation> for PageLocation {
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct ParquetRSRowGroupPart {
     pub location: String,
+    pub start_row: u64,
     #[serde(
         serialize_with = "ser_row_group_meta",
         deserialize_with = "deser_row_group_meta"

--- a/src/query/storages/result_cache/src/table_function/table.rs
+++ b/src/query/storages/result_cache/src/table_function/table.rs
@@ -154,8 +154,8 @@ impl Table for ResultScan {
             self.schema.clone(),
         )?
         .with_options(read_options);
-        let row_group_reader = Arc::new(builder.build_row_group_reader()?);
-        let full_file_reader = Some(Arc::new(builder.build_full_reader()?));
+        let row_group_reader = Arc::new(builder.build_row_group_reader(false)?);
+        let full_file_reader = Some(Arc::new(builder.build_full_reader(false)?));
 
         pipeline.add_source(
             |output| {
@@ -165,6 +165,7 @@ impl Table for ResultScan {
                     row_group_reader.clone(),
                     full_file_reader.clone(),
                     Arc::new(None),
+                    vec![],
                 )
             },
             1,

--- a/tests/sqllogictests/suites/stage/formats/parquet/parquet_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/parquet_metadata.test
@@ -1,0 +1,35 @@
+query ok
+select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/parquet/ii/ order by metadata$filename, $2 limit 3;
+----
+parquet/ii/f1.parquet 1 0 1
+parquet/ii/f1.parquet 2 1 2
+parquet/ii/f2.parquet 3 0 3
+
+
+query ok
+select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/parquet/ii/ where metadata$file_row_number = 0 and $1 > 1;
+----
+parquet/ii/f2.parquet 3 0 3
+parquet/ii/f3.parquet 5 0 5
+
+
+statement ok
+create or replace table t(file_name string, id string,  row int)
+
+query ok
+copy into t from (select metadata$filename, $2, metadata$file_row_number + 1 from @data_s3/parquet/ii/)
+----
+parquet/ii/f1.parquet 2 0 NULL NULL
+parquet/ii/f2.parquet 2 0 NULL NULL
+parquet/ii/f3.parquet 2 0 NULL NULL
+
+query ok
+select * from t order by $1,$2
+----
+parquet/ii/f1.parquet 1 1
+parquet/ii/f1.parquet 2 2
+parquet/ii/f2.parquet 3 1
+parquet/ii/f2.parquet 4 2
+parquet/ii/f3.parquet 5 1
+parquet/ii/f3.parquet 6 2
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

continuation of https://github.com/databendlabs/databend/pull/17512

limited by the interface of arrow parquet reader, if filter is used,  we cannot get the `file_row_number`.
so this pr simply abandoned the filter and topk pushdown when the `file_row_number` is queried.
but the filter of rowgroup partitions still work.
this does not affect copy  since filter and topk is not allowed in copy.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17527)
<!-- Reviewable:end -->
