### PR TITLE
fix(query): user/role name not support \b and \f

### DIFF
--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -408,7 +408,7 @@ impl<'a> Binder {
             } => {
                 if illegal_ident_name(role_name) {
                     return Err(ErrorCode::IllegalRole(
-                        format!("Illegal Role Name: Illegal role name [{}], not support username contain ' or \"", role_name),
+                        format!("Illegal Role Name: Illegal role name [{}], not support username contain ' or \" or \\b or \\f", role_name),
                     ));
                 }
                 Plan::CreateRole(Box::new(CreateRolePlan {

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -265,7 +265,7 @@ impl Binder {
         } = stmt;
         if illegal_ident_name(&user.username) {
             return Err(ErrorCode::IllegalUser(format!(
-                "Illegal Username: Illegal user name [{}], not support username contain ' or \"",
+                "Illegal Username: Illegal user name [{}], not support username contain ' or \" \\b or \\f",
                 user.username
             )));
         }

--- a/src/query/sql/src/planner/binder/util.rs
+++ b/src/query/sql/src/planner/binder/util.rs
@@ -33,7 +33,9 @@ use crate::NameResolutionSuggest;
 /// Ident name can not contain ' or "
 /// Forbidden ' or " in UserName and RoleName, to prevent Meta injection problem
 pub fn illegal_ident_name(ident_name: &str) -> bool {
-    ident_name.chars().any(|c| c == '\'' || c == '\"')
+    ident_name
+        .chars()
+        .any(|c| c == '\'' || c == '\"' || c == '\u{000C}' || c == '\u{0008}')
 }
 
 impl Binder {

--- a/tests/sqllogictests/suites/base/05_ddl/05_0004_ddl_create_user.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0004_ddl_create_user.test
@@ -90,3 +90,15 @@ create user `a"a` identified by '123'
 
 statement error 2218
 create user `a'a` identified by '123'
+
+statement error 2218
+CREATE user 'a\b' identified by '123'
+
+statement error 2218
+CREATE user 'a\f' identified by '123'
+
+statement ok
+drop user if exists 'a\b';
+
+statement ok
+drop user if exists 'a\f';

--- a/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
@@ -7,6 +7,18 @@ CREATE ROLE `test-a`
 statement error 2216
 CREATE ROLE `test-a`
 
+statement error 2217
+CREATE ROLE 'a\b'
+
+statement error 2217
+CREATE ROLE 'a\f'
+
+statement ok
+drop role if exists 'a\b';
+
+statement ok
+drop role if exists 'a\f';
+
 statement ok
 CREATE ROLE IF NOT EXISTS `test-a`
 
@@ -32,7 +44,7 @@ statement error 2217
 create role 'public'
 
 statement error 2217
-create role `a"a`
+create role 'a"a'
 
 statement error 2217
-create role `a'a`
+create role "a'a"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Not support:
```sql
create user/role 'a\b';
create user/role 'a\f';
```
Because \b and \f will be rewrite as \u{0008} and \u{000C}.

The show result will be strange.


in  main:

```sql
:)  create role  'a"b';
error: APIError: QueryFailed: [2217]Illegal Role Name: Illegal role name [a"b], not support username contain ' or "
:)  create role  "a'b";
error: APIError: QueryFailed: [2217]Illegal Role Name: Illegal role name [a'b], not support username contain ' or "
:)  create user  "a'b" identified by '123';
error: APIError: QueryFailed: [2218]Illegal Username: Illegal user name [a'b], not support username contain ' or "
:)  create user  'a"b' identified by '123';
error: APIError: QueryFailed: [2218]Illegal Username: Illegal user name [a"b], not support username contain ' or "
:) create role 'a\b';


0 row written in 0.028 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)

:) show roles;

show roles

┌──────────────────────────────────────────────────────────────────────────────────┐
│      name     │ inherited_roles │ inherited_roles_name │ is_current │ is_default │
│     String    │      UInt64     │        String        │   Boolean  │   Boolean  │
├───────────────┼─────────────────┼──────────────────────┼────────────┼────────────┤
│              │               0 │                      │ false      │ false      │
│ a\eqb         │               0 │                      │ false      │ false      │
│ account_admin │               0 │                      │ true       │ true       │
│ public        │               0 │                      │ false      │ false      │
└──────────────────────────────────────────────────────────────────────────────────┘
4 rows read in 0.024 sec. Processed 4 rows, 143 B (166.67 rows/s, 5.82 KiB/s)
```

in pr we add this limit:

```sql
:) create role 'a\f';
error: APIError: QueryFailed: [2217]Illegal Role Name: Illegal role name [a
                                                                           ], not support username contain ' or " or \b or \f
:) create role 'a\b';
error: APIError: QueryFailed: [2217]Illegal Role Name: Illegal role name [], not support username contain ' or " or \b or \f

:) create user 'a\b' identified by '123';
error: APIError: QueryFailed: [2218]Illegal Username: Illegal user name [], not support username contain ' or " \b or \f
:) create user 'a\f' identified by '123';
error: APIError: QueryFailed: [2218]Illegal Username: Illegal user name [a
                                                                          ], not support username contain ' or " \b or \f
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17530)
<!-- Reviewable:end -->
