### PR TITLE
chore(query): revert 17516

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -24,7 +24,6 @@ use databend_common_hashtable::RowPtr;
 use super::desc::MARKER_KIND_FALSE;
 use crate::sql::plans::JoinType;
 
-#[derive(Debug)]
 pub struct ProcessState {
     pub input: DataBlock,
     pub keys_state: KeysState,

--- a/src/query/sql/src/executor/format.rs
+++ b/src/query/sql/src/executor/format.rs
@@ -1427,7 +1427,6 @@ fn hash_join_to_format_tree(
         .map(|scalar| scalar.as_expr(&BUILTIN_FUNCTIONS).sql_display())
         .collect::<Vec<_>>()
         .join(", ");
-    let is_null_equal = plan.is_null_equal.iter().map(|b| format!("{b}")).join(", ");
     let filters = plan
         .non_equi_conditions
         .iter()
@@ -1449,7 +1448,6 @@ fn hash_join_to_format_tree(
         FormatTreeNode::new(format!("join type: {}", plan.join_type)),
         FormatTreeNode::new(format!("build keys: [{build_keys}]")),
         FormatTreeNode::new(format!("probe keys: [{probe_keys}]")),
-        FormatTreeNode::new(format!("keys is null equal: [{is_null_equal}]")),
         FormatTreeNode::new(format!("filters: [{filters}]")),
     ];
 

--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -342,16 +342,6 @@ impl SubqueryRewriter {
                     &mut left_conditions,
                     &mut right_conditions,
                 )?;
-                let mut is_null_equal = Vec::new();
-                for (i, (l, r)) in left_conditions
-                    .iter()
-                    .zip(right_conditions.iter())
-                    .enumerate()
-                {
-                    if l.data_type()?.is_nullable() || r.data_type()?.is_nullable() {
-                        is_null_equal.push(i);
-                    }
-                }
 
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
@@ -366,7 +356,7 @@ impl SubqueryRewriter {
                     equi_conditions: JoinEquiCondition::new_conditions(
                         right_conditions,
                         left_conditions,
-                        is_null_equal,
+                        vec![],
                     ),
                     non_equi_conditions: vec![],
                     join_type: JoinType::RightMark,

--- a/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/subquery_rewriter.rs
@@ -376,12 +376,7 @@ impl SubqueryRewriter {
                         span: subquery.span,
                         func_name: "not".to_string(),
                         params: vec![],
-                        arguments: vec![ScalarExpr::FunctionCall(FunctionCall {
-                            span: subquery.span,
-                            func_name: "is_true".to_string(),
-                            params: vec![],
-                            arguments: vec![column_ref],
-                        })],
+                        arguments: vec![column_ref],
                     })
                 } else {
                     column_ref

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -55,11 +55,9 @@ pub enum JoinType {
     LeftAnti,
     RightAnti,
     /// Mark Join is a special case of join that is used to process Any subquery and correlated Exists subquery.
-    /// Left Mark output build fields and marker
-    /// Left Mark Join use subquery as probe(left) side, it's blocked at `mark_join_blocks`
+    /// Left Mark Join use subquery as probe side, it's blocked at `mark_join_blocks`
     LeftMark,
-    /// Right Mark output probe fields and marker
-    /// Right Mark Join use subquery as build(right) side, it's executed by streaming.
+    /// Right Mark Join use subquery as build side, it's executed by streaming.
     RightMark,
     /// Single Join is a special kind of join that is used to process correlated scalar subquery.
     LeftSingle,

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -9,7 +9,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t1.number (#1)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -45,7 +44,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#0)]
     ├── probe keys: [t2.number (#2)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 6.00
     ├── Exchange(Build)
@@ -56,7 +54,6 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [t.number (#0)]
     │       ├── probe keys: [t1.number (#1)]
-    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
@@ -101,7 +98,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.b (#1)]
     ├── probe keys: [t2.number (#3)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 6.00
     ├── Exchange(Build)
@@ -112,7 +108,6 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [t.a (#0)]
     │       ├── probe keys: [t1.number (#2)]
-    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 2.00
     │       ├── Exchange(Build)
@@ -161,7 +156,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t.number (#1)]
     ├── probe keys: [CAST(t1.number (#2) AS UInt64 NULL)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -246,7 +240,6 @@ Fragment 2:
         ├── join type: INNER
         ├── build keys: [t.number (#1)]
         ├── probe keys: [CAST(t1.number (#2) AS UInt64 NULL)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── ExchangeSource(Build)
@@ -301,7 +294,6 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
-            │   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)
@@ -330,7 +322,6 @@ AggregateFinal
                 ├── join type: INNER
                 ├── build keys: [t3.a (#3)]
                 ├── probe keys: [t1.a (#2)]
-                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 100.00
                 ├── Exchange(Build)
@@ -388,7 +379,6 @@ AggregateFinal
         │       ├── join type: INNER
         │       ├── build keys: [t1.a (#0)]
         │       ├── probe keys: [t2.a (#1)]
-        │       ├── keys is null equal: [false]
         │       ├── filters: []
         │       ├── estimated rows: 10000.00
         │       ├── Exchange(Build)
@@ -429,7 +419,6 @@ AggregateFinal
                         ├── join type: INNER
                         ├── build keys: [t3.a (#3)]
                         ├── probe keys: [t1.a (#2)]
-                        ├── keys is null equal: [false]
                         ├── filters: []
                         ├── estimated rows: 100.00
                         ├── Exchange(Build)
@@ -486,7 +475,6 @@ AggregateFinal
             │   ├── join type: INNER
             │   ├── build keys: [t1.a (#0)]
             │   ├── probe keys: [t2.a (#1)]
-            │   ├── keys is null equal: [false]
             │   ├── filters: []
             │   ├── estimated rows: 10000.00
             │   ├── Exchange(Build)
@@ -536,7 +524,6 @@ Exchange
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 100000.00
     ├── Exchange(Build)
@@ -556,7 +543,6 @@ Exchange
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 10000.00
         ├── Exchange(Build)
@@ -595,7 +581,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.number (#1)]
     ├── probe keys: [t1.number (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 200.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -49,7 +49,6 @@ Exchange
         ├── join type: INNER
         ├── build keys: [t2.a (#2)]
         ├── probe keys: [t1.a (#0)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 99.92
         ├── Exchange(Build)
@@ -95,7 +94,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 100.00
     ├── Exchange(Build)
@@ -220,7 +218,6 @@ Limit
                     ├── join type: INNER
                     ├── build keys: [t2.a (#2)]
                     ├── probe keys: [t1.a (#0)]
-                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 100.00
                     ├── Exchange(Build)
@@ -261,7 +258,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 100.00
     ├── Exchange(Build)
@@ -340,7 +336,6 @@ AggregateFinal
             ├── join type: RIGHT OUTER
             ├── build keys: [CAST(y.a (#1) AS UInt64 NULL)]
             ├── probe keys: [x.a (#2)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 50.00
             ├── Exchange(Build)
@@ -398,7 +393,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [CAST(CAST(subquery_2 (#2) AS UInt8 NULL) AS Int32 NULL)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Exchange(Build)
@@ -441,7 +435,6 @@ Exchange
     ├── join type: LEFT OUTER
     ├── build keys: [b.query_node (#63)]
     ├── probe keys: [CAST(a.cluster_node (#0) AS String NULL)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
+++ b/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
@@ -43,7 +43,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)
@@ -89,7 +88,6 @@ Exchange
     ├── join type: INNER
     ├── build keys: [table3.value (#2)]
     ├── probe keys: [table1.value (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 200.00
     ├── Exchange(Build)
@@ -100,7 +98,6 @@ Exchange
     │       ├── join type: INNER
     │       ├── build keys: [table2.value (#1)]
     │       ├── probe keys: [table3.value (#2)]
-    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 250.00
     │       ├── Exchange(Build)
@@ -161,7 +158,6 @@ Exchange
     ├── join type: LEFT SEMI
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)
@@ -207,7 +203,6 @@ Exchange
     ├── join type: RIGHT SEMI
     ├── build keys: [table2.value (#1)]
     ├── probe keys: [table1.value (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 250.00
     ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -72,7 +72,6 @@ CommitSink
                 ├── join type: LEFT OUTER
                 ├── build keys: []
                 ├── probe keys: []
-                ├── keys is null equal: []
                 ├── filters: []
                 ├── estimated rows: 1.00
                 ├── Exchange(Build)
@@ -122,7 +121,6 @@ CommitSink
         ├── join type: RIGHT OUTER
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: [t1.a (#1) > t.a (#0)]
         ├── estimated rows: 15.00
         ├── TableScan(Build)
@@ -160,7 +158,6 @@ CommitSink
         ├── join type: RIGHT OUTER
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: [t1.a (#1) < t2.a (#0)]
         ├── estimated rows: 15.00
         ├── TableScan(Build)
@@ -258,7 +255,6 @@ CommitSink
                 ├── join type: RIGHT OUTER
                 ├── build keys: [CAST(t2.a (#0) AS Int64 NULL)]
                 ├── probe keys: [CAST(t1.a (#1) AS Int64 NULL)]
-                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 0.00
                 ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/cluster/shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle.test
@@ -35,7 +35,6 @@ Sort
             ├── join type: RIGHT OUTER
             ├── build keys: [t2.number (#1)]
             ├── probe keys: [t1.number (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.01
             ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -96,7 +96,6 @@ Exchange
                 ├── join type: INNER
                 ├── build keys: [d.department_id (#4)]
                 ├── probe keys: [e.department_id (#2)]
-                ├── keys is null equal: [false]
                 ├── filters: []
                 ├── estimated rows: 8.00
                 ├── Exchange(Build)

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_agg_index.test
@@ -161,7 +161,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_5 (#5), b (#4)]
 ├── probe keys: [SUM(a) (#2), b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
@@ -13,7 +13,7 @@ INSERT INTO test_linear VALUES(2, 1), (2, 2);
 statement ok
 ALTER TABLE test_linear RECLUSTER FINAL;
 
-query TTIIRRT
+query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','test_linear')
 ----
 (a, b) linear 2 0 0.0 1.0 {"00001":2}

--- a/tests/sqllogictests/suites/mode/standalone/explain/delete.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/delete.test
@@ -35,7 +35,6 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)
@@ -78,7 +77,6 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -18,7 +18,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -50,7 +49,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -82,7 +80,6 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -114,7 +111,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -154,7 +150,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -194,7 +189,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -234,7 +228,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -274,7 +267,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)
@@ -314,7 +306,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
@@ -354,7 +345,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 8.00
 ├── Filter(Build)
@@ -394,7 +384,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)
@@ -434,7 +423,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 9.00
 ├── Filter(Build)
@@ -474,7 +462,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 9.00
 ├── Filter(Build)
@@ -514,7 +501,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── Filter(Build)
@@ -559,7 +545,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -595,7 +580,6 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 8.40
     ├── Filter(Build)
@@ -639,7 +623,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [t1.a (#1)]
     ├── probe keys: [t.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -674,7 +657,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#1)]
 ├── probe keys: [t.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -52,7 +52,6 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -92,7 +91,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -327,7 +325,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.40
     ├── Filter(Build)
@@ -371,7 +368,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 5.00
     ├── Filter(Build)
@@ -413,7 +409,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
@@ -421,7 +416,6 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
-│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 5.00
 │   ├── TableScan(Build)
@@ -463,7 +457,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 28.16
 ├── Filter(Build)
@@ -475,7 +468,6 @@ HashJoin
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
-│       ├── keys is null equal: []
 │       ├── filters: []
 │       ├── estimated rows: 4.40
 │       ├── Filter(Build)
@@ -542,7 +534,6 @@ Limit
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
-            ├── keys is null equal: []
             ├── filters: []
             ├── estimated rows: 4.40
             ├── Filter(Build)
@@ -582,7 +573,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 5.00
 ├── Filter(Build)
@@ -814,7 +804,6 @@ Limit
     ├── join type: INNER
     ├── build keys: [a.id (#0)]
     ├── probe keys: [b.id (#2)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── Filter(Build)
@@ -868,7 +857,6 @@ Sort
     ├── join type: INNER
     ├── build keys: [b.register_at (#3), numbers.number (#2)]
     ├── probe keys: [a.pt (#1), a.number (#0)]
-    ├── keys is null equal: [false, false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── EvalScalar(Build)
@@ -934,7 +922,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_2 (#2), id (#2)]
 ├── probe keys: [a.id (#0), a.id (#0)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.40
 ├── Filter(Build)
@@ -982,7 +969,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 3.00
 ├── TableScan(Build)
@@ -1020,7 +1006,6 @@ Filter
     ├── join type: LEFT MARK
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [CAST(CAST(subquery_2 (#2) AS UInt16 NULL) AS Int32 NULL)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── TableScan(Build)
@@ -1079,7 +1064,6 @@ Sort
     ├── join type: LEFT OUTER
     ├── build keys: [t2.k (#2)]
     ├── probe keys: [t1.i (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── EmptyResultScan(Build)
@@ -1292,7 +1276,6 @@ EvalScalar
     ├── join type: LEFT OUTER
     ├── build keys: [t2.b (#1)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -1344,7 +1327,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#3)]
 ├── probe keys: [a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
 ├── Sort(Build)
@@ -1391,7 +1373,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#3)]
 ├── probe keys: [a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── estimated rows: 0.00
 ├── Sort(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_table_function_obfuscate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_table_function_obfuscate.test
@@ -13,7 +13,6 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1)]
 ├── probe keys: [v1.c1 (#3), b (#5)]
-├── keys is null equal: [false, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1]
@@ -64,7 +63,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1), c (#2)]
 ├── probe keys: [v1.c1 (#3), b (#5), c (#6)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -105,7 +103,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -150,7 +147,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
@@ -160,7 +156,6 @@ HashJoin
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]
@@ -222,7 +217,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t1.a (#0) AS Int64 NULL), b (#1), c1 (#3)]
 ├── probe keys: [v2.c2 (#9), b (#11), c1 (#13)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 3]
@@ -232,7 +226,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -518,7 +518,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -557,7 +556,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -565,7 +563,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── Filter(Build)
@@ -699,7 +696,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -707,7 +703,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -775,7 +770,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.id (#1) AS Int64 NULL)]
 ├── probe keys: [CAST(t1.id (#0) AS Int64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0)]
 ├── probe keys: [t1.number (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -56,7 +55,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0), t.number (#0)]
 ├── probe keys: [t1.number (#1), t1.number (#1) + 1]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -92,7 +90,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -136,7 +133,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -169,7 +165,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t2.number (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -177,7 +172,6 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
-│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── Filter(Build)
@@ -243,7 +237,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── Filter(Build)
@@ -283,7 +276,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.33
 ├── Filter(Build)
@@ -323,7 +315,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── Filter(Build)
@@ -369,7 +360,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── TableScan(Build)
@@ -401,7 +391,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.67
 ├── Filter(Build)
@@ -456,7 +445,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -494,7 +482,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -528,7 +515,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -566,7 +552,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -604,7 +589,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -643,7 +627,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t1.b (#1) > t2.b (#3)]
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -757,7 +740,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.x (#1)]
 ├── probe keys: [o.x (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.33
 ├── Filter(Build)
@@ -804,7 +786,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.number (#1)]
 ├── probe keys: [t1.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 200.00
 ├── TableScan(Build)
@@ -850,7 +831,6 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -892,7 +872,6 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── Filter(Build)
@@ -934,7 +913,6 @@ EvalScalar
     ├── join type: INNER
     ├── build keys: [t6.wms_id (#4)]
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)
@@ -983,7 +961,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t1.a (#0) >= CAST(scalar_subquery_2 (#2) AS Int32 NULL)]
 ├── estimated rows: 4.00
 ├── EvalScalar(Build)
@@ -1010,7 +987,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t1.a (#0) >= scalar_subquery_1 (#1)]
 ├── estimated rows: 4.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -36,7 +36,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -44,7 +43,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -86,7 +84,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -94,7 +91,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -136,7 +132,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -144,7 +139,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -186,7 +180,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -194,7 +187,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -236,7 +228,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -244,7 +235,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -286,7 +276,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -294,7 +283,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -336,7 +324,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -372,7 +359,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── EvalScalar(Build)
@@ -408,7 +394,6 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -440,7 +425,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -472,7 +456,6 @@ HashJoin
 ├── join type: RIGHT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -504,7 +487,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -32,7 +31,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -74,7 +72,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -82,7 +79,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -124,7 +120,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -132,7 +127,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -174,7 +168,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -182,7 +175,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -224,7 +216,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -232,7 +223,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -274,7 +264,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -282,7 +271,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -6,7 +6,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [subquery_1 (#1)]
 ├── probe keys: [numbers.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10000.00
 ├── TableScan(Build)
@@ -36,7 +35,6 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [numbers.number (#0)]
 ├── probe keys: [subquery_1 (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -91,7 +89,6 @@ EvalScalar
     ├── join type: LEFT SINGLE
     ├── build keys: [c (#8)]
     ├── probe keys: [c (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)
@@ -103,7 +100,6 @@ EvalScalar
     │       ├── join type: RIGHT MARK
     │       ├── build keys: [a (#2)]
     │       ├── probe keys: [c (#8)]
-    │       ├── keys is null equal: [false]
     │       ├── filters: []
     │       ├── estimated rows: 4.00
     │       ├── Filter(Build)
@@ -125,7 +121,6 @@ EvalScalar
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
-    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 4.00
     │           ├── DummyTableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -32,7 +31,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -74,7 +72,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -82,7 +79,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -124,7 +120,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -132,7 +127,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -174,7 +168,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -182,7 +175,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -224,7 +216,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -232,7 +223,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -274,7 +264,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -282,7 +271,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lateral.test
@@ -6,7 +6,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#1)]
 ├── probe keys: [number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)
@@ -36,7 +35,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#0)]
 ├── probe keys: [number (#3)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -57,7 +55,6 @@ HashJoin
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 100.00
         ├── TableScan(Build)
@@ -96,7 +93,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL), CAST(number (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.b (#3), number (#4)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)
@@ -121,7 +117,6 @@ HashJoin
             ├── join type: INNER
             ├── build keys: [t1.a (#1)]
             ├── probe keys: [number (#4)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 100.00
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -104,7 +104,6 @@ Limit
                     ├── join type: LEFT OUTER
                     ├── build keys: [number (#2)]
                     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
-                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 1.00
                     ├── AggregateFinal(Build)
@@ -121,7 +120,6 @@ Limit
                     │           ├── join type: CROSS
                     │           ├── build keys: []
                     │           ├── probe keys: []
-                    │           ├── keys is null equal: []
                     │           ├── filters: []
                     │           ├── estimated rows: 1.00
                     │           ├── TableScan(Build)
@@ -147,7 +145,6 @@ Limit
                         ├── join type: CROSS
                         ├── build keys: []
                         ├── probe keys: []
-                        ├── keys is null equal: []
                         ├── filters: []
                         ├── estimated rows: 1.00
                         ├── TableScan(Build)
@@ -186,7 +183,6 @@ Limit
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
         ├── probe keys: [t4.c (#4)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
@@ -6,7 +6,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#1)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)
@@ -36,7 +35,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#1)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 100.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -38,7 +38,6 @@ CommitSink
         ├── join type: LEFT OUTER
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 4.00
         ├── EmptyResultScan(Build)
@@ -79,7 +78,6 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [salaries2.employee_id (#3)]
             ├── probe keys: [employees2.employee_id (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -123,7 +121,6 @@ CommitSink
             ├── join type: RIGHT OUTER
             ├── build keys: [employees2.employee_id (#0)]
             ├── probe keys: [salaries2.employee_id (#3)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -163,7 +160,6 @@ CommitSink
             ├── join type: RIGHT OUTER
             ├── build keys: [employees2.employee_id (#0)]
             ├── probe keys: [salaries2.employee_id (#3)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 4.00
             ├── TableScan(Build)
@@ -219,7 +215,6 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -258,7 +253,6 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -300,7 +294,6 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)
@@ -339,7 +332,6 @@ CommitSink
             ├── join type: LEFT OUTER
             ├── build keys: [t1.a (#2)]
             ├── probe keys: [t2.a (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 0.00
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/outer_to_inner.test
@@ -19,7 +19,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -67,7 +66,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -114,7 +112,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -161,7 +158,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.b (#3)]
 ├── probe keys: [t1.b (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -139,7 +139,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.a (#3) AS UInt64 NULL)]
 ├── probe keys: [CAST(t1.a (#2) AS UInt64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 450.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -77,7 +77,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#2)]
 ├── probe keys: [t2.b (#7)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── EvalScalar(Build)
@@ -119,7 +118,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_12 (#12)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── AggregateFinal(Build)
@@ -136,7 +134,6 @@ HashJoin
 │           ├── join type: INNER
 │           ├── build keys: [t2.b (#5)]
 │           ├── probe keys: [t3.b (#10)]
-│           ├── keys is null equal: [false]
 │           ├── filters: []
 │           ├── estimated rows: 0.20
 │           ├── EvalScalar(Build)
@@ -208,7 +205,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_eval_scalar.test
@@ -77,7 +77,6 @@ AggregateFinal
         │           ├── join type: LEFT OUTER
         │           ├── build keys: [tb.sid (#1)]
         │           ├── probe keys: [t.id (#0)]
-        │           ├── keys is null equal: [false]
         │           ├── filters: []
         │           ├── estimated rows: 0.00
         │           ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -67,7 +66,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -108,7 +106,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -145,7 +142,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -182,7 +178,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -223,7 +218,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -264,7 +258,6 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t2.a (#2) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -71,7 +70,6 @@ Filter
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.56
     ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -67,7 +66,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t1.a (#0) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -100,7 +98,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -137,7 +134,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -178,7 +174,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── Filter(Build)
@@ -233,7 +228,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -286,7 +280,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -67,7 +66,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -16,7 +16,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b2.a (#2)]
 ├── probe keys: [b1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [d.b (#1) < d.b (#3)]
 ├── estimated rows: 400.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -136,7 +136,6 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#0)]
     ├── probe keys: [t1.a (#1)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)
@@ -178,7 +177,6 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#1)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -10,7 +10,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [number (#2)]
     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── AggregateFinal(Build)
@@ -27,7 +26,6 @@ Filter
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
-    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 1.00
     │           ├── TableScan(Build)
@@ -53,7 +51,6 @@ Filter
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 1.00
         ├── TableScan(Build)
@@ -87,7 +84,6 @@ Filter
     ├── join type: RIGHT MARK
     ├── build keys: [number (#1)]
     ├── probe keys: [number (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -117,7 +113,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -169,7 +164,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_1 (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -203,7 +197,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -233,7 +226,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -263,7 +255,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -293,7 +284,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -331,7 +321,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: [t.number (#0) < numbers.number (#1)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -361,7 +350,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -391,7 +379,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#2)]
 ├── probe keys: [number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── HashJoin(Build)
@@ -399,7 +386,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [number (#2)]
 │   ├── probe keys: [t1.number (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.20
 │   ├── Filter(Build)
@@ -451,7 +437,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t.number (#0) < t1.number (#2)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -468,7 +453,6 @@ HashJoin
     ├── join type: LEFT SEMI
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: [t.number (#0) > t1.number (#1)]
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -528,7 +512,6 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain/update.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/update.test
@@ -31,7 +31,6 @@ CommitSink
             ├── join type: LEFT SEMI
             ├── build keys: [subquery_2 (#2)]
             ├── probe keys: [t1.a (#0)]
-            ├── keys is null equal: [false]
             ├── filters: []
             ├── estimated rows: 2.00
             ├── TableScan(Build)
@@ -74,7 +73,6 @@ CommitSink
         ├── join type: LEFT SEMI
         ├── build keys: [subquery_2 (#2)]
         ├── probe keys: [t1.a (#0)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── TableScan(Build)
@@ -147,7 +145,6 @@ CommitSink
             ├── join type: INNER
             ├── build keys: [p.c_code (#9), p.id (#8), p.me_id (#10)]
             ├── probe keys: [c.c_code (#1), c.id (#0), c.me_id (#2)]
-            ├── keys is null equal: [false, false, false]
             ├── filters: []
             ├── estimated rows: 3.20
             ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -36,7 +36,6 @@ Filter
     ├── join type: INNER
     ├── build keys: [t1.a (#0)]
     ├── probe keys: [t2.a (#2)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 0.00
     ├── TableScan(Build)
@@ -68,7 +67,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -303,7 +301,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.40
     ├── TableScan(Build)
@@ -339,7 +336,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 5.00
     ├── TableScan(Build)
@@ -377,7 +373,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
@@ -385,7 +380,6 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
-│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 5.00
 │   ├── TableScan(Build)
@@ -427,7 +421,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 28.16
 ├── Filter(Build)
@@ -439,7 +432,6 @@ HashJoin
 │       ├── join type: CROSS
 │       ├── build keys: []
 │       ├── probe keys: []
-│       ├── keys is null equal: []
 │       ├── filters: []
 │       ├── estimated rows: 4.40
 │       ├── TableScan(Build)
@@ -494,7 +486,6 @@ Limit
             ├── join type: CROSS
             ├── build keys: []
             ├── probe keys: []
-            ├── keys is null equal: []
             ├── filters: []
             ├── estimated rows: 4.40
             ├── TableScan(Build)
@@ -526,7 +517,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 5.00
 ├── TableScan(Build)
@@ -737,7 +727,6 @@ Sort
     ├── join type: LEFT OUTER
     ├── build keys: [t2.k (#2)]
     ├── probe keys: [t1.i (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.00
     ├── EmptyResultScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/expression_scan.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1)]
 ├── probe keys: [v1.c1 (#3), b (#5)]
-├── keys is null equal: [false, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1]
@@ -65,7 +64,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#1), b (#1), c (#2)]
 ├── probe keys: [v1.c1 (#3), b (#5), c (#6)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -106,7 +104,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 0
 ├── cache columns: [1, 2]
@@ -151,7 +148,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t1.a (#0), b (#1), c (#2)]
 ├── probe keys: [v2.c2 (#10), b (#12), c (#13)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 2]
@@ -161,7 +157,6 @@ HashJoin
 │   ├── join type: RIGHT OUTER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]
@@ -223,7 +218,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t1.a (#0) AS Int64 NULL), b (#1), c1 (#3)]
 ├── probe keys: [v2.c2 (#9), b (#11), c1 (#13)]
-├── keys is null equal: [false, true, true]
 ├── filters: []
 ├── cache index: 1
 ├── cache columns: [1, 3]
@@ -233,7 +227,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t1.a (#0), b (#1), c (#2)]
 │   ├── probe keys: [v1.c2 (#4), b (#6), c (#7)]
-│   ├── keys is null equal: [false, true, true]
 │   ├── filters: []
 │   ├── cache index: 0
 │   ├── cache columns: [1, 2]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -418,7 +418,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -449,7 +448,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -457,7 +455,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -567,7 +564,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t3.a (#4)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -575,7 +571,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t3.a (#4)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -642,7 +637,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.id (#1) AS Int64 NULL)]
 ├── probe keys: [CAST(t1.id (#0) AS Int64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0)]
 ├── probe keys: [t1.number (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -56,7 +55,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.number (#0), t.number (#0)]
 ├── probe keys: [t1.number (#1), t1.number (#1) + 1]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -88,7 +86,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -124,7 +121,6 @@ Filter
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 10.00
     ├── TableScan(Build)
@@ -157,7 +153,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.number (#1)]
 ├── probe keys: [t2.number (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── HashJoin(Build)
@@ -165,7 +160,6 @@ HashJoin
 │   ├── join type: CROSS
 │   ├── build keys: []
 │   ├── probe keys: []
-│   ├── keys is null equal: []
 │   ├── filters: []
 │   ├── estimated rows: 0.00
 │   ├── TableScan(Build)
@@ -227,7 +221,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── TableScan(Build)
@@ -259,7 +252,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.33
 ├── TableScan(Build)
@@ -291,7 +283,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [b.x (#1)]
 ├── probe keys: [a.x (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.37
 ├── TableScan(Build)
@@ -329,7 +320,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [b.x (#1)]
     ├── probe keys: [a.x (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── TableScan(Build)
@@ -361,7 +351,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [a.x (#0)]
 ├── probe keys: [b.x (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.67
 ├── TableScan(Build)
@@ -408,7 +397,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -438,7 +426,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -468,7 +455,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -498,7 +484,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -528,7 +513,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2), t2.b (#3)]
 ├── probe keys: [t1.a (#0), t1.b (#1)]
-├── keys is null equal: [false, false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -558,7 +542,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t1.b (#1) > t2.b (#3)]
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -672,7 +655,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t1.a (#0) >= CAST(scalar_subquery_2 (#2) AS Int32 NULL)]
 ├── estimated rows: 4.00
 ├── EvalScalar(Build)
@@ -699,7 +681,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t1.a (#0) >= scalar_subquery_1 (#1)]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/chain.test
@@ -33,7 +33,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -41,7 +40,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -83,7 +81,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -91,7 +88,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -133,7 +129,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -141,7 +136,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -183,7 +177,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -191,7 +184,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -233,7 +225,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -241,7 +232,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -283,7 +273,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -291,7 +280,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -333,7 +321,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [CAST(t.a (#0) AS UInt64 NULL)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)
@@ -369,7 +356,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [CAST(t1.a (#1) AS UInt64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── EvalScalar(Build)
@@ -405,7 +391,6 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -437,7 +422,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -469,7 +453,6 @@ HashJoin
 ├── join type: RIGHT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -501,7 +484,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/cycles.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -32,7 +31,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -74,7 +72,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -82,7 +79,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -124,7 +120,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -132,7 +127,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -174,7 +168,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -182,7 +175,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -224,7 +216,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -232,7 +223,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -274,7 +264,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -282,7 +271,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/mark.test
@@ -6,7 +6,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [subquery_1 (#1)]
 ├── probe keys: [numbers.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 10000.00
 ├── TableScan(Build)
@@ -36,7 +35,6 @@ HashJoin
 ├── join type: RIGHT SEMI
 ├── build keys: [numbers.number (#0)]
 ├── probe keys: [subquery_1 (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1000.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/join_reorder/star.test
@@ -24,7 +24,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t2.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -32,7 +31,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -74,7 +72,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -82,7 +79,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -124,7 +120,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -132,7 +127,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t2.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -174,7 +168,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -182,7 +175,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t2.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -224,7 +216,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -232,7 +223,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
 │   ├── probe keys: [t1.a (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
@@ -274,7 +264,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.a (#2)]
 ├── probe keys: [t2.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
@@ -282,7 +271,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
 │   ├── probe keys: [t1.a (#2)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/limit.test
@@ -104,7 +104,6 @@ Limit
                     ├── join type: LEFT OUTER
                     ├── build keys: [number (#2)]
                     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
-                    ├── keys is null equal: [false]
                     ├── filters: []
                     ├── estimated rows: 1.00
                     ├── AggregateFinal(Build)
@@ -121,7 +120,6 @@ Limit
                     │           ├── join type: CROSS
                     │           ├── build keys: []
                     │           ├── probe keys: []
-                    │           ├── keys is null equal: []
                     │           ├── filters: []
                     │           ├── estimated rows: 1.00
                     │           ├── TableScan(Build)
@@ -147,7 +145,6 @@ Limit
                         ├── join type: CROSS
                         ├── build keys: []
                         ├── probe keys: []
-                        ├── keys is null equal: []
                         ├── filters: []
                         ├── estimated rows: 1.00
                         ├── TableScan(Build)
@@ -186,7 +183,6 @@ Limit
         ├── join type: RIGHT OUTER
         ├── build keys: [CAST(t3.c1 (#1) AS UInt64 NULL)]
         ├── probe keys: [t4.c (#4)]
-        ├── keys is null equal: [false]
         ├── filters: []
         ├── estimated rows: 2.00
         ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/project_set.test
@@ -91,7 +91,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [CAST(t2.a (#3) AS UInt64 NULL)]
 ├── probe keys: [CAST(t1.a (#2) AS UInt64 NULL)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 450.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/prune_column.test
@@ -77,7 +77,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t1.b (#2)]
 ├── probe keys: [t2.b (#7)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── EvalScalar(Build)
@@ -119,7 +118,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_12 (#12)]
 ├── probe keys: [t1.a (#1)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 2.00
 ├── AggregateFinal(Build)
@@ -136,7 +134,6 @@ HashJoin
 │           ├── join type: INNER
 │           ├── build keys: [t2.b (#5)]
 │           ├── probe keys: [t3.b (#10)]
-│           ├── keys is null equal: [false]
 │           ├── filters: []
 │           ├── estimated rows: 0.20
 │           ├── EvalScalar(Build)
@@ -208,7 +205,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 10.00
 ├── Filter(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_eval_scalar.test
@@ -77,7 +77,6 @@ AggregateFinal
         │           ├── join type: LEFT OUTER
         │           ├── build keys: [tb.sid (#1)]
         │           ├── probe keys: [t.id (#0)]
-        │           ├── keys is null equal: [false]
         │           ├── filters: []
         │           ├── estimated rows: 0.00
         │           ├── AggregateFinal(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -59,7 +58,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -92,7 +90,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -125,7 +122,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -158,7 +154,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -191,7 +186,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -224,7 +218,6 @@ HashJoin
 ├── join type: FULL OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t2.a (#2) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -63,7 +62,6 @@ Filter
     ├── join type: INNER
     ├── build keys: [t2.a (#2)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 3.56
     ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -59,7 +58,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: [t1.a (#0) > 0]
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -92,7 +90,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -125,7 +122,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -158,7 +154,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 4.00
 ├── TableScan(Build)
@@ -209,7 +204,6 @@ HashJoin
 ├── join type: LEFT OUTER
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -258,7 +252,6 @@ HashJoin
 ├── join type: RIGHT OUTER
 ├── build keys: [t2.a (#0)]
 ├── probe keys: [t1.a (#2)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -26,7 +26,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)
@@ -59,7 +58,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [t2.a (#2)]
 ├── probe keys: [t1.a (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── TableScan(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
@@ -136,7 +136,6 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#0)]
     ├── probe keys: [t1.a (#1)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)
@@ -178,7 +177,6 @@ Limit
     ├── join type: RIGHT OUTER
     ├── build keys: [t.a (#1)]
     ├── probe keys: [t1.a (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 2.00
     ├── Limit(Build)

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/subquery.test
@@ -10,7 +10,6 @@ Filter
     ├── join type: LEFT OUTER
     ├── build keys: [number (#2)]
     ├── probe keys: [CAST(number (#0) AS UInt64 NULL)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── AggregateFinal(Build)
@@ -27,7 +26,6 @@ Filter
     │           ├── join type: CROSS
     │           ├── build keys: []
     │           ├── probe keys: []
-    │           ├── keys is null equal: []
     │           ├── filters: []
     │           ├── estimated rows: 1.00
     │           ├── TableScan(Build)
@@ -53,7 +51,6 @@ Filter
         ├── join type: CROSS
         ├── build keys: []
         ├── probe keys: []
-        ├── keys is null equal: []
         ├── filters: []
         ├── estimated rows: 1.00
         ├── TableScan(Build)
@@ -87,7 +84,6 @@ Filter
     ├── join type: RIGHT MARK
     ├── build keys: [number (#1)]
     ├── probe keys: [number (#0)]
-    ├── keys is null equal: [false]
     ├── filters: []
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -117,7 +113,6 @@ HashJoin
 ├── join type: CROSS
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -169,7 +164,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [scalar_subquery_1 (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -203,7 +197,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -233,7 +226,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -263,7 +255,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -293,7 +284,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.00
 ├── Filter(Build)
@@ -331,7 +321,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: [t.number (#0) < numbers.number (#1)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -361,7 +350,6 @@ HashJoin
 ├── join type: LEFT SEMI
 ├── build keys: [numbers.number (#1)]
 ├── probe keys: [t.number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -391,7 +379,6 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [number (#2)]
 ├── probe keys: [number (#0)]
-├── keys is null equal: [false]
 ├── filters: []
 ├── estimated rows: 0.20
 ├── HashJoin(Build)
@@ -399,7 +386,6 @@ HashJoin
 │   ├── join type: INNER
 │   ├── build keys: [number (#2)]
 │   ├── probe keys: [t1.number (#1)]
-│   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── estimated rows: 0.20
 │   ├── Filter(Build)
@@ -451,7 +437,6 @@ HashJoin
 ├── join type: LEFT ANTI
 ├── build keys: []
 ├── probe keys: []
-├── keys is null equal: []
 ├── filters: [t.number (#0) < t1.number (#2)]
 ├── estimated rows: 1.00
 ├── TableScan(Build)
@@ -468,7 +453,6 @@ HashJoin
     ├── join type: LEFT SEMI
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: [t.number (#0) > t1.number (#1)]
     ├── estimated rows: 1.00
     ├── TableScan(Build)
@@ -511,7 +495,6 @@ EvalScalar
     ├── join type: CROSS
     ├── build keys: []
     ├── probe keys: []
-    ├── keys is null equal: []
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/tpcds/queries.test
+++ b/tests/sqllogictests/suites/tpcds/queries.test
@@ -11306,6 +11306,7 @@ Adams John Marion Oak Ridge 206733 32377.89 1224.72 72590.31
 
 
 # Q69
+onlyif todo
 query I
 SELECT cd_gender,
        cd_marital_status,
@@ -11359,107 +11360,6 @@ ORDER BY cd_gender,
          cd_credit_rating
 LIMIT 100;
 ----
-F	D	2 yr Degree	1	2500	1	Low Risk	1
-F	D	2 yr Degree	1	4500	1	Good	1
-F	D	2 yr Degree	2	4500	2	Low Risk	2
-F	D	2 yr Degree	1	9000	1	Good	1
-F	D	2 yr Degree	1	9500	1	Good	1
-F	D	4 yr Degree	1	1000	1	Low Risk	1
-F	D	4 yr Degree	1	1500	1	Low Risk	1
-F	D	4 yr Degree	1	1500	1	Unknown	1
-F	D	4 yr Degree	1	2000	1	Good	1
-F	D	4 yr Degree	1	2500	1	Unknown	1
-F	D	4 yr Degree	1	4000	1	Unknown	1
-F	D	4 yr Degree	1	5500	1	Good	1
-F	D	4 yr Degree	1	7000	1	Good	1
-F	D	4 yr Degree	1	7000	1	High Risk	1
-F	D	4 yr Degree	1	8000	1	High Risk	1
-F	D	4 yr Degree	1	8500	1	Unknown	1
-F	D	Advanced Degree	1	1000	1	Good	1
-F	D	Advanced Degree	1	3500	1	Good	1
-F	D	Advanced Degree	1	3500	1	High Risk	1
-F	D	Advanced Degree	1	4000	1	Good	1
-F	D	Advanced Degree	1	4000	1	High Risk	1
-F	D	Advanced Degree	1	5000	1	High Risk	1
-F	D	Advanced Degree	1	5500	1	Good	1
-F	D	Advanced Degree	1	5500	1	Low Risk	1
-F	D	Advanced Degree	1	6500	1	Low Risk	1
-F	D	Advanced Degree	1	7000	1	High Risk	1
-F	D	Advanced Degree	1	8000	1	Low Risk	1
-F	D	Advanced Degree	1	8500	1	High Risk	1
-F	D	Advanced Degree	1	9500	1	Low Risk	1
-F	D	Advanced Degree	1	9500	1	Unknown	1
-F	D	Advanced Degree	1	10000	1	Low Risk	1
-F	D	College	1	1500	1	Low Risk	1
-F	D	College	1	2500	1	Good	1
-F	D	College	1	4000	1	High Risk	1
-F	D	College	1	6000	1	Good	1
-F	D	College	1	6000	1	High Risk	1
-F	D	College	1	9000	1	High Risk	1
-F	D	Primary	1	3000	1	High Risk	1
-F	D	Primary	1	4000	1	Low Risk	1
-F	D	Primary	1	4000	1	Unknown	1
-F	D	Primary	1	4500	1	Unknown	1
-F	D	Primary	1	5000	1	High Risk	1
-F	D	Primary	1	5000	1	Unknown	1
-F	D	Primary	1	6000	1	Good	1
-F	D	Primary	1	6000	1	Unknown	1
-F	D	Primary	1	8500	1	Unknown	1
-F	D	Primary	1	9000	1	Unknown	1
-F	D	Primary	1	9500	1	High Risk	1
-F	D	Primary	1	9500	1	Unknown	1
-F	D	Primary	1	10000	1	Good	1
-F	D	Primary	2	10000	2	Low Risk	2
-F	D	Secondary	1	 500	1	Low Risk	1
-F	D	Secondary	1	1000	1	High Risk	1
-F	D	Secondary	1	3000	1	Good	1
-F	D	Secondary	1	3500	1	Good	1
-F	D	Secondary	1	6000	1	Low Risk	1
-F	D	Secondary	1	6500	1	Unknown	1
-F	D	Secondary	1	8500	1	High Risk	1
-F	D	Secondary	1	10000	1	Low Risk	1
-F	D	Unknown	1	1500	1	High Risk	1
-F	D	Unknown	1	3000	1	Good	1
-F	D	Unknown	1	3000	1	High Risk	1
-F	D	Unknown	1	6000	1	Good	1
-F	D	Unknown	1	6500	1	High Risk	1
-F	D	Unknown	2	8000	2	Low Risk	2
-F	D	Unknown	1	10000	1	Unknown	1
-F	M	2 yr Degree	1	2500	1	Low Risk	1
-F	M	2 yr Degree	3	4000	3	Unknown	3
-F	M	2 yr Degree	1	4500	1	Low Risk	1
-F	M	2 yr Degree	1	8500	1	High Risk	1
-F	M	4 yr Degree	1	1000	1	Good	1
-F	M	4 yr Degree	1	1500	1	Good	1
-F	M	4 yr Degree	1	4000	1	Low Risk	1
-F	M	4 yr Degree	1	4000	1	Unknown	1
-F	M	4 yr Degree	1	5000	1	Unknown	1
-F	M	4 yr Degree	1	5500	1	Low Risk	1
-F	M	4 yr Degree	1	6000	1	Good	1
-F	M	4 yr Degree	1	8000	1	High Risk	1
-F	M	Advanced Degree	1	 500	1	Low Risk	1
-F	M	Advanced Degree	1	 500	1	Unknown	1
-F	M	Advanced Degree	1	2500	1	Good	1
-F	M	Advanced Degree	1	3500	1	High Risk	1
-F	M	Advanced Degree	2	5500	2	Unknown	2
-F	M	Advanced Degree	1	6500	1	Good	1
-F	M	Advanced Degree	1	6500	1	Unknown	1
-F	M	Advanced Degree	1	8000	1	Low Risk	1
-F	M	Advanced Degree	1	9500	1	Good	1
-F	M	Advanced Degree	1	10000	1	Low Risk	1
-F	M	College	1	1000	1	Unknown	1
-F	M	College	1	3000	1	Good	1
-F	M	College	2	5000	2	High Risk	2
-F	M	College	1	6000	1	Low Risk	1
-F	M	College	1	7000	1	High Risk	1
-F	M	College	1	8000	1	Good	1
-F	M	College	1	9000	1	Good	1
-F	M	College	2	9000	2	High Risk	2
-F	M	College	1	10000	1	High Risk	1
-F	M	Primary	1	1000	1	Low Risk	1
-F	M	Primary	1	1500	1	High Risk	1
-F	M	Primary	1	7000	1	Good	1
-
 
 
 # Q70


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The PR #https://github.com/databendlabs/databend/pull/17516 is causing memory out-of-bounds issues, let's revert first.  CC: @forsaken628 The Valgrind log is as follows:

```


==402171== Thread 65 PipelineExecuto:
==402171== Invalid write of size 1
==402171==    at 0x1D07B38: write<u8> (mod.rs:1578)
==402171==    by 0x1D07B38: write<u8> (mut_ptr.rs:1484)
==402171==    by 0x1D07B38: databend_common_expression::kernels::group_by_hash::method_fixed_keys::fixed_hash (number.rs:899)
==402171==    by 0x1D069CB: databend_common_expression::kernels::group_by_hash::method_fixed_keys::fixed_hash (method_fixed_keys.rs:434)
==402171==    by 0x1D06627: databend_common_expression::kernels::group_by_hash::method_fixed_keys::build (method_fixed_keys.rs:400)
==402171==    by 0x1D16827: build_keys_vec<u32> (method_fixed_keys.rs:100)
==402171==    by 0x1D16827: <databend_common_expression::kernels::group_by_hash::method_fixed_keys::HashMethodFixedKeys<u32> as databend_common_expression::kernels::group_by_hash::method::HashMethod>::build_keys_state (method_fixed_keys.rs:258)
==402171==    by 0x567C62F: databend_query::pipelines::processors::transforms::hash_join::hash_join_probe_state::HashJoinProbeState::probe_join (hash_join_probe_state.rs:297)
==402171==    by 0x567AA5B: databend_query::pipelines::processors::transforms::hash_join::hash_join_probe_state::HashJoinProbeState::probe (hash_join_probe_state.rs:146)
==402171==    by 0x4EF4D6B: databend_query::pipelines::processors::transforms::hash_join::transform_hash_join_probe::TransformHashJoinProbe::probe_hash_table (transform_hash_join_probe.rs:479)
==402171==    by 0x4F51747: <databend_query::pipelines::processors::transforms::hash_join::transform_hash_join_probe::TransformHashJoinProbe as databend_common_pipeline_core::processors::processor::Processor>::process (transform_hash_join_probe.rs:354)
==402171==    by 0x2976FD7: databend_common_pipeline_core::processors::processor::ProcessorPtr::process (processor.rs:169)
==402171==    by 0x51B4817: execute_sync_task (executor_worker_context.rs:169)
==402171==    by 0x51B4817: databend_query::pipelines::executor::executor_worker_context::ExecutorWorkerContext::execute_task (executor_worker_context.rs:132)
==402171==    by 0x51AF9B3: databend_query::pipelines::executor::query_pipeline_executor::QueryPipelineExecutor::execute_single_thread (query_pipeline_executor.rs:391)
==402171==    by 0x515D073: {closure#0} (query_pipeline_executor.rs:363)
==402171==    by 0x515D073: call_once<core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>, databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}> (unwind_safe.rs:272)
==402171==    by 0x515D073: do_call<core::panic::unwind_safe::AssertUnwindSafe<databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}>, core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>> (panicking.rs:557)
==402171==    by 0x515D073: try<core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>, core::panic::unwind_safe::AssertUnwindSafe<databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}>> (panicking.rs:520)
==402171==    by 0x515D073: std::panic::catch_unwind (panic.rs:358)
==402171==  Address 0xd64e870 is 0 bytes after a block of size 736 alloc'd
==402171==    at 0xC16C0AC: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==402171==    by 0x5CB7BAB: alloc_zeroed (unix.rs:36)
==402171==    by 0x5CB7BAB: alloc_impl (alloc.rs:142)
==402171==    by 0x5CB7BAB: allocate_zeroed (alloc.rs:212)
==402171==    by 0x5CB7BAB: allocate_zeroed (std_.rs:47)
==402171==    by 0x5CB7BAB: allocate_zeroed<databend_common_base::mem_allocator::std_::StdAllocator> (global.rs:75)
==402171==    by 0x5CB7BAB: alloc_zeroed<databend_common_base::mem_allocator::std_::StdAllocator> (global.rs:131)
==402171==    by 0x5CB7BAB: __rust_alloc_zeroed (ee_main.rs:37)
==402171==    by 0xEF6D23: with_capacity_zeroed_in<alloc::alloc::Global> (raw_vec.rs:448)
==402171==    by 0xEF6D23: with_capacity_zeroed_in<u32, alloc::alloc::Global> (raw_vec.rs:216)
==402171==    by 0xEF6D23: from_elem<u32, alloc::alloc::Global> (spec_from_elem.rs:26)
==402171==    by 0xEF6D23: alloc::vec::from_elem (mod.rs:3175)
==402171==    by 0x1D1678F: build_keys_vec<u32> (method_fixed_keys.rs:76)
==402171==    by 0x1D1678F: <databend_common_expression::kernels::group_by_hash::method_fixed_keys::HashMethodFixedKeys<u32> as databend_common_expression::kernels::group_by_hash::method::HashMethod>::build_keys_state (method_fixed_keys.rs:258)
==402171==    by 0x567C62F: databend_query::pipelines::processors::transforms::hash_join::hash_join_probe_state::HashJoinProbeState::probe_join (hash_join_probe_state.rs:297)
==402171==    by 0x567AA5B: databend_query::pipelines::processors::transforms::hash_join::hash_join_probe_state::HashJoinProbeState::probe (hash_join_probe_state.rs:146)
==402171==    by 0x4EF4D6B: databend_query::pipelines::processors::transforms::hash_join::transform_hash_join_probe::TransformHashJoinProbe::probe_hash_table (transform_hash_join_probe.rs:479)
==402171==    by 0x4F51747: <databend_query::pipelines::processors::transforms::hash_join::transform_hash_join_probe::TransformHashJoinProbe as databend_common_pipeline_core::processors::processor::Processor>::process (transform_hash_join_probe.rs:354)
==402171==    by 0x2976FD7: databend_common_pipeline_core::processors::processor::ProcessorPtr::process (processor.rs:169)
==402171==    by 0x51B4817: execute_sync_task (executor_worker_context.rs:169)
==402171==    by 0x51B4817: databend_query::pipelines::executor::executor_worker_context::ExecutorWorkerContext::execute_task (executor_worker_context.rs:132)
==402171==    by 0x51AF9B3: databend_query::pipelines::executor::query_pipeline_executor::QueryPipelineExecutor::execute_single_thread (query_pipeline_executor.rs:391)
==402171==    by 0x515D073: {closure#0} (query_pipeline_executor.rs:363)
==402171==    by 0x515D073: call_once<core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>, databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}> (unwind_safe.rs:272)
==402171==    by 0x515D073: do_call<core::panic::unwind_safe::AssertUnwindSafe<databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}>, core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>> (panicking.rs:557)
==402171==    by 0x515D073: try<core::result::Result<(), databend_common_exception::exception::ErrorCode<()>>, core::panic::unwind_safe::AssertUnwindSafe<databend_query::pipelines::executor::query_pipeline_executor::{impl#0}::execute_threads::{closure#1}::{closure_env#0}>> (panicking.rs:520)
==402171==    by 0x515D073: std::panic::catch_unwind (panic.rs:358)
==402171== 
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):
