### PR TITLE
chore: rename `EvalExpireTime` to `Expirable` for better semantics

### DIFF
--- a/src/meta/raft-store/src/leveled_store/leveled_map/map_api_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/map_api_impl.rs
@@ -81,7 +81,7 @@ where
         let prev = self.get(&key).await?.clone();
 
         // No such entry at all, no need to create a tombstone for delete
-        if prev.not_found() && value.is_none() {
+        if prev.is_not_found() && value.is_none() {
             return Ok((prev, Marked::new_tombstone(0)));
         }
 

--- a/src/meta/raft-store/src/marked/marked_test.rs
+++ b/src/meta/raft-store/src/marked/marked_test.rs
@@ -16,8 +16,8 @@ use databend_common_meta_types::seq_value::KVMeta;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
 
-use crate::marked::InternalSeq;
 use crate::marked::Marked;
+use crate::marked::SeqTombstone;
 use crate::state_machine::ExpireValue;
 
 #[test]
@@ -62,10 +62,10 @@ fn test_empty() -> anyhow::Result<()> {
 #[test]
 fn test_order_key() -> anyhow::Result<()> {
     let m = Marked::new_with_meta(1, 2, None);
-    assert_eq!(m.order_key(), InternalSeq::normal(1));
+    assert_eq!(m.order_key(), SeqTombstone::normal(1));
 
     let m: Marked<u64> = Marked::new_tombstone(1);
-    assert_eq!(m.order_key(), InternalSeq::tombstone(1));
+    assert_eq!(m.order_key(), SeqTombstone::tombstone(1));
 
     Ok(())
 }

--- a/src/meta/raft-store/src/marked/mod.rs
+++ b/src/meta/raft-store/src/marked/mod.rs
@@ -15,14 +15,14 @@
 #[cfg(test)]
 mod marked_test;
 
-mod internal_seq;
+mod seq_tombstone;
 
 mod marked_impl;
 
 use databend_common_meta_types::seq_value::KVMeta;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::seq_value::SeqValue;
-pub(crate) use internal_seq::InternalSeq;
+pub(crate) use seq_tombstone::SeqTombstone;
 
 use crate::state_machine::ExpireValue;
 
@@ -108,12 +108,12 @@ impl<T> Marked<T> {
     }
 
     /// Return a key to determine which one of the values of the same key are the last inserted.
-    pub(crate) fn order_key(&self) -> InternalSeq {
+    pub(crate) fn order_key(&self) -> SeqTombstone {
         match self {
-            Marked::TombStone { internal_seq: seq } => InternalSeq::tombstone(*seq),
+            Marked::TombStone { internal_seq: seq } => SeqTombstone::tombstone(*seq),
             Marked::Normal {
                 internal_seq: seq, ..
-            } => InternalSeq::normal(*seq),
+            } => SeqTombstone::normal(*seq),
         }
     }
 
@@ -199,7 +199,7 @@ impl<T> Marked<T> {
     }
 
     /// Return if the entry is neither a normal entry nor a tombstone.
-    pub fn not_found(&self) -> bool {
+    pub fn is_not_found(&self) -> bool {
         matches!(self, Marked::TombStone { internal_seq: 0 })
     }
 

--- a/src/meta/raft-store/src/marked/seq_tombstone.rs
+++ b/src/meta/raft-store/src/marked/seq_tombstone.rs
@@ -28,12 +28,12 @@
 ///
 /// With such a design, the system seq increases only when a new normal record is inserted, ensuring compatibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct InternalSeq {
+pub(crate) struct SeqTombstone {
     pub(crate) seq: u64,
     pub(crate) tombstone: bool,
 }
 
-impl InternalSeq {
+impl SeqTombstone {
     pub fn normal(seq: u64) -> Self {
         Self {
             seq,
@@ -59,16 +59,16 @@ impl InternalSeq {
 
 #[cfg(test)]
 mod tests {
-    use super::InternalSeq;
+    use super::SeqTombstone;
 
     #[test]
     fn test_ord() -> Result<(), anyhow::Error> {
-        assert!(InternalSeq::normal(5) < InternalSeq::normal(6));
-        assert!(InternalSeq::normal(7) > InternalSeq::normal(6));
-        assert!(InternalSeq::normal(6) == InternalSeq::normal(6));
+        assert!(SeqTombstone::normal(5) < SeqTombstone::normal(6));
+        assert!(SeqTombstone::normal(7) > SeqTombstone::normal(6));
+        assert!(SeqTombstone::normal(6) == SeqTombstone::normal(6));
 
-        assert!(InternalSeq::normal(6) < InternalSeq::tombstone(6));
-        assert!(InternalSeq::normal(6) > InternalSeq::tombstone(5));
+        assert!(SeqTombstone::normal(6) < SeqTombstone::tombstone(6));
+        assert!(SeqTombstone::normal(6) > SeqTombstone::tombstone(5));
 
         Ok(())
     }

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::ops::RangeBounds;
 
 use databend_common_meta_types::CmdContext;
-use databend_common_meta_types::EvalExpireTime;
+use databend_common_meta_types::Expirable;
 use databend_common_meta_types::MatchSeqExt;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::SeqV;
@@ -69,7 +69,7 @@ pub trait StateMachineApiExt: StateMachineApi {
             }
         };
 
-        let expire_ms = kv_meta.eval_expire_at_ms();
+        let expire_ms = kv_meta.expiry_ms();
         if expire_ms < self.get_expire_cursor().time_ms {
             // The record has expired, delete it at once.
             //

--- a/src/meta/types/src/eval_expire_time.rs
+++ b/src/meta/types/src/eval_expire_time.rs
@@ -12,28 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Evaluate and returns the absolute expire time.
-pub trait EvalExpireTime {
-    /// Evaluate and returns the absolute expire time in millisecond since 1970.
+/// A trait for evaluating and returning the absolute expiration time.
+pub trait Expirable {
+    /// Evaluates and returns the absolute expiration time in milliseconds since the Unix epoch (January 1, 1970).
     ///
-    /// If there is no expire time, return u64::MAX.
-    fn eval_expire_at_ms(&self) -> u64;
+    /// If there is no expiration time, it returns `u64::MAX`.
+    fn expiry_ms(&self) -> u64;
 }
 
-impl<T> EvalExpireTime for &T
-where T: EvalExpireTime
+impl<T> Expirable for &T
+where T: Expirable
 {
-    fn eval_expire_at_ms(&self) -> u64 {
-        EvalExpireTime::eval_expire_at_ms(*self)
+    fn expiry_ms(&self) -> u64 {
+        Expirable::expiry_ms(*self)
     }
 }
 
-impl<T> EvalExpireTime for Option<T>
-where T: EvalExpireTime
+impl<T> Expirable for Option<T>
+where T: Expirable
 {
-    fn eval_expire_at_ms(&self) -> u64 {
-        self.as_ref()
-            .map(|m| m.eval_expire_at_ms())
-            .unwrap_or(u64::MAX)
+    fn expiry_ms(&self) -> u64 {
+        self.as_ref().map(|m| m.expiry_ms()).unwrap_or(u64::MAX)
     }
 }

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -80,7 +80,7 @@ pub use errors::meta_network_errors::MetaNetworkError;
 pub use errors::meta_network_errors::MetaNetworkResult;
 pub use errors::meta_startup_errors::MetaStartupError;
 pub use errors::rpc_errors::ForwardRPCError;
-pub use eval_expire_time::EvalExpireTime;
+pub use eval_expire_time::Expirable;
 pub use grpc_config::GrpcConfig;
 pub use log_entry::LogEntry;
 pub use match_seq::MatchSeq;

--- a/src/meta/types/src/seq_value/kv_meta.rs
+++ b/src/meta/types/src/seq_value/kv_meta.rs
@@ -15,7 +15,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::EvalExpireTime;
+use crate::Expirable;
 
 /// The meta data of a record in kv
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
@@ -43,8 +43,8 @@ impl KVMeta {
     }
 }
 
-impl EvalExpireTime for KVMeta {
-    fn eval_expire_at_ms(&self) -> u64 {
+impl Expirable for KVMeta {
+    fn expiry_ms(&self) -> u64 {
         match self.expire_at {
             None => u64::MAX,
             Some(exp_at_sec) => exp_at_sec * 1000,

--- a/src/meta/types/src/seq_value/seq_value_trait.rs
+++ b/src/meta/types/src/seq_value/seq_value_trait.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::seq_value::kv_meta::KVMeta;
-use crate::EvalExpireTime;
+use crate::Expirable;
 
 pub trait SeqValue<V = Vec<u8>> {
     fn seq(&self) -> u64;
@@ -36,12 +36,12 @@ pub trait SeqValue<V = Vec<u8>> {
     }
 
     /// Evaluate and returns the absolute expire time in millisecond since 1970.
-    fn eval_expire_at_ms(&self) -> u64 {
-        self.meta().eval_expire_at_ms()
+    fn expiry_ms(&self) -> u64 {
+        self.meta().expiry_ms()
     }
 
     /// Return true if the record is expired.
     fn is_expired(&self, now_ms: u64) -> bool {
-        self.eval_expire_at_ms() < now_ms
+        self.expiry_ms() < now_ms
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: rename `EvalExpireTime` to `Expirable` for better semantics

This change renames the `EvalExpireTime` trait to `Expirable` and its method
`eval_expire_at_ms()` to `expiry_ms()` for improved clarity and consistency.


##### rename InternalSeq to SeqTombstone

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17540)
<!-- Reviewable:end -->
