### PR TITLE
feat(query): Supports folding of show grants results for roles and users

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -933,6 +933,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_expand_roles", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Enable expand roles when execute show grants statement(enable by default).",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("create_query_flight_client_with_current_rt", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Turns on (1) or off (0) the use of the current runtime for query operations.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -532,6 +532,10 @@ impl Settings {
         Ok(self.try_get_u64("enable_experimental_rbac_check")? != 0)
     }
 
+    pub fn get_enable_expand_roles(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_expand_roles")? != 0)
+    }
+
     pub fn get_table_lock_expire_secs(&self) -> Result<u64> {
         self.try_get_u64("table_lock_expire_secs")
     }

--- a/tests/sqllogictests/suites/base/06_show/06_0007_show_roles.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0007_show_roles.test
@@ -15,3 +15,121 @@ account_admin 0 (empty) 1 1
 
 statement ok
 DROP ROLE test
+
+statement ok
+drop role if exists a;
+
+statement ok
+drop role if exists b;
+
+statement ok
+drop user if exists a;
+
+statement ok
+create user a identified by '123';
+
+statement ok
+create or replace table t(id int);
+
+statement ok
+create role a;
+
+statement ok
+grant ownership on default.t to role a;
+
+statement ok
+grant select on default.t to role a;
+
+statement ok
+grant insert on *.* to role a;
+
+statement ok
+create or replace table t1(id int);
+
+statement ok
+create role b;
+
+statement ok
+grant ownership on default.t1 to role b;
+
+statement ok
+grant select on *.* to role b;
+
+statement ok
+grant role b to role a;
+
+statement ok
+grant role a to a;
+
+statement ok
+grant create database on *.* to a;
+
+statement ok
+set enable_expand_roles=1;
+
+query T
+select grants from show_grants('role', 'b') order by object_id;
+----
+GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `b`
+GRANT SELECT ON *.* TO ROLE `b`
+
+query T
+select grants from show_grants('role', 'a') order by object_id;
+----
+GRANT SELECT ON 'default'.'default'.'t' TO ROLE `a`
+GRANT OWNERSHIP ON 'default'.'default'.'t' TO ROLE `a`
+GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `a`
+GRANT SELECT,INSERT ON *.* TO ROLE `a`
+
+query T
+select grants from show_grants('user', 'a') order by object_id;
+----
+GRANT SELECT ON 'default'.'default'.'t' TO 'a'@'%'
+GRANT OWNERSHIP ON 'default'.'default'.'t' TO 'a'@'%'
+GRANT OWNERSHIP ON 'default'.'default'.'t1' TO 'a'@'%'
+GRANT SELECT,INSERT,CREATE DATABASE ON *.* TO 'a'@'%'
+
+statement ok
+set enable_expand_roles=0;
+
+query T
+select grants from show_grants('role', 'b') order by object_id;
+----
+GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `b`
+GRANT ROLE public to ROLE `b`
+GRANT SELECT ON *.* TO ROLE `b`
+
+query T
+select grants from show_grants('role', 'a') order by object_id;
+----
+GRANT SELECT ON 'default'.'default'.'t' TO ROLE `a`
+GRANT OWNERSHIP ON 'default'.'default'.'t' TO ROLE `a`
+GRANT ROLE b to ROLE `a`
+GRANT ROLE public to ROLE `a`
+GRANT INSERT ON *.* TO ROLE `a`
+
+query T
+select grants from show_grants('user', 'a') order by object_id;
+----
+GRANT ROLE a to 'a'@'%'
+GRANT ROLE b to 'a'@'%'
+GRANT ROLE public to 'a'@'%'
+GRANT CREATE DATABASE ON *.* TO 'a'@'%'
+
+statement ok
+unset enable_expand_roles;
+
+statement ok
+drop role if exists a;
+
+statement ok
+drop role if exists b;
+
+statement ok
+drop user if exists a;
+
+statement ok
+drop table t;
+
+statement ok
+drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


1. add new setting enable_expand_roles (enable by default)
2. Supports the folding of show grants results for roles and users
3. modify table function show_grants's field grants type. Nullable(String) -> String

e.g.

```sql
drop role if exists a;
drop role if exists b;
drop user if exists a;
create user a identified by '123';

create or replace table t(id int);
create role a;
grant ownership on default.t to role a;
grant select on default.t to role a;
grant insert on *.* to role a;

create or replace table t1(id int);
create role b;
grant ownership on default.t1 to role b;
grant select on *.* to role b;

grant role b to role a;
grant role a to a;
grant create database on *.* to a;
```

In default setting:

```sql
select grants from show_grants('role', 'b') order by object_id;
----
GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `b`
GRANT SELECT ON *.* TO ROLE `b`

select grants from show_grants('role', 'a') order by object_id;
----
GRANT SELECT ON 'default'.'default'.'t' TO ROLE `a`
GRANT OWNERSHIP ON 'default'.'default'.'t' TO ROLE `a`
GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `a`
GRANT SELECT,INSERT ON *.* TO 'a'@'%'

select grants from show_grants('user', 'a') order by object_id;
----
GRANT SELECT ON 'default'.'default'.'t' TO 'a'@'%'
GRANT OWNERSHIP ON 'default'.'default'.'t' TO 'a'@'%'
GRANT OWNERSHIP ON 'default'.'default'.'t1' TO 'a'@'%'
GRANT SELECT,INSERT,CREATE DATABASE ON *.* TO ROLE `a`
```

If disable new setting enable_expand_roles

```sql
-- The role b only display b's owner object and privilege.
select grants from show_grants('role', 'b') order by object_id;
----
GRANT OWNERSHIP ON 'default'.'default'.'t1' TO ROLE `b`
GRANT ROLE public to ROLE b
GRANT SELECT ON *.* TO ROLE `b`

-- The role a only display a's owner object and privilege.
-- But it will display the grant role sql
select grants from show_grants('role', 'a') order by object_id;
----
GRANT SELECT ON 'default'.'default'.'t' TO ROLE `a`
GRANT OWNERSHIP ON 'default'.'default'.'t' TO ROLE `a`
GRANT ROLE b to ROLE a
GRANT ROLE public to ROLE a
GRANT INSERT ON *.* TO ROLE `a`

-- The user a only display user a's privilege.
-- But it will display the grant role sql
select grants from show_grants('user', 'a') order by object_id;
----
GRANT ROLE a to USER a
GRANT ROLE b to USER a
GRANT ROLE public to USER a
GRANT CREATE DATABASE ON *.* TO 'a'@'%'
```



## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17543)
<!-- Reviewable:end -->
