### PR TITLE
refactor(meta): simplify map key handling and improve naming consistency

### DIFF
--- a/src/meta/raft-store/src/leveled_store/db_map_api_ro_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/db_map_api_ro_impl.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::io;
 use std::ops::RangeBounds;
 
@@ -23,6 +22,7 @@ use rotbl::v001::SeqMarked;
 use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapApiRO;
 use crate::leveled_store::map_api::MapKey;
+use crate::leveled_store::map_api::MapKeyDecode;
 use crate::leveled_store::map_api::MapKeyEncode;
 use crate::leveled_store::rotbl_codec::RotblCodec;
 use crate::marked::Marked;
@@ -31,14 +31,11 @@ use crate::marked::Marked;
 impl<K> MapApiRO<K> for DB
 where
     K: MapKey,
+    K: MapKeyEncode,
+    K: MapKeyDecode,
     Marked<K::V>: TryFrom<SeqMarked, Error = io::Error>,
 {
-    async fn get<Q>(&self, key: &Q) -> Result<Marked<K::V>, io::Error>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        Q: MapKeyEncode,
-    {
+    async fn get(&self, key: &K) -> Result<Marked<K::V>, io::Error> {
         let key = RotblCodec::encode_key(key)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 

--- a/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
+++ b/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
@@ -69,18 +69,18 @@ async fn test_db_map_api_ro() -> anyhow::Result<()> {
     let smap = db.str_map();
     assert_eq!(
         Marked::new_with_meta(4, b("a1"), Some(KVMeta::new(Some(15)))),
-        smap.get("a").await?
+        smap.get(&s("a")).await?
     );
     assert_eq!(
         Marked::empty(),
-        smap.get("b").await?,
+        smap.get(&s("b")).await?,
         "no tombstone is stored"
     );
     assert_eq!(
         Marked::new_with_meta(3, b("c0"), Some(KVMeta::new(Some(20)))),
-        smap.get("c").await?
+        smap.get(&s("c")).await?
     );
-    assert_eq!(Marked::empty(), smap.get("d").await?);
+    assert_eq!(Marked::empty(), smap.get(&s("d")).await?);
 
     let got = smap.range(..).await?.try_collect::<Vec<_>>().await?;
     assert_eq!(

--- a/src/meta/raft-store/src/leveled_store/immutable.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable.rs
@@ -27,7 +27,6 @@ use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapApiRO;
 use crate::leveled_store::map_api::MapKV;
 use crate::leveled_store::map_api::MapKey;
-use crate::leveled_store::map_api::MapKeyEncode;
 use crate::leveled_store::map_api::MarkedOf;
 use crate::marked::Marked;
 use crate::state_machine::ExpireKey;
@@ -119,12 +118,7 @@ impl Immutable {
 
 #[async_trait::async_trait]
 impl MapApiRO<String> for Immutable {
-    async fn get<Q>(&self, key: &Q) -> Result<Marked<<String as MapKey>::V>, io::Error>
-    where
-        String: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        Q: MapKeyEncode,
-    {
+    async fn get(&self, key: &String) -> Result<Marked<<String as MapKey>::V>, io::Error> {
         // get() is just delegated
         self.as_ref().str_map().get(key).await
     }
@@ -138,12 +132,7 @@ impl MapApiRO<String> for Immutable {
 
 #[async_trait::async_trait]
 impl MapApiRO<ExpireKey> for Immutable {
-    async fn get<Q>(&self, key: &Q) -> Result<MarkedOf<ExpireKey>, io::Error>
-    where
-        ExpireKey: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-        Q: MapKeyEncode,
-    {
+    async fn get(&self, key: &ExpireKey) -> Result<MarkedOf<ExpireKey>, io::Error> {
         // get() is just delegated
         self.as_ref().expire_map().get(key).await
     }

--- a/src/meta/raft-store/src/leveled_store/key_spaces_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/key_spaces_impl.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::io::Error;
 
 use crate::leveled_store::map_api::MapKey;
+use crate::leveled_store::map_api::MapKeyDecode;
 use crate::leveled_store::map_api::MapKeyEncode;
 use crate::state_machine::ExpireKey;
 
@@ -30,12 +31,14 @@ impl MapKeyEncode for String {
     }
 }
 
-impl MapKey for String {
-    type V = Vec<u8>;
-
+impl MapKeyDecode for String {
     fn decode(buf: &str) -> Result<Self, Error> {
         Ok(buf.to_string())
     }
+}
+
+impl MapKey for String {
+    type V = Vec<u8>;
 }
 
 impl MapKeyEncode for str {
@@ -56,9 +59,7 @@ impl MapKeyEncode for ExpireKey {
     }
 }
 
-impl MapKey for ExpireKey {
-    type V = String;
-
+impl MapKeyDecode for ExpireKey {
     fn decode(buf: &str) -> Result<Self, Error> {
         if buf.len() != 41 {
             return Err(Error::new(
@@ -120,6 +121,10 @@ impl MapKey for ExpireKey {
 
         Ok(Self::new(time_ms, seq))
     }
+}
+
+impl MapKey for ExpireKey {
+    type V = String;
 }
 
 #[cfg(test)]

--- a/src/meta/raft-store/src/leveled_store/key_spaces_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/key_spaces_impl.rs
@@ -41,14 +41,6 @@ impl MapKey for String {
     type V = Vec<u8>;
 }
 
-impl MapKeyEncode for str {
-    const PREFIX: &'static str = "kv--";
-
-    fn encode<W: fmt::Write>(&self, mut w: W) -> Result<(), fmt::Error> {
-        w.write_str(self)
-    }
-}
-
 impl MapKeyEncode for ExpireKey {
     const PREFIX: &'static str = "exp-";
 
@@ -130,14 +122,6 @@ impl MapKey for ExpireKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_str_encode() {
-        let key = "key";
-        let mut buf: String = String::new();
-        key.encode(&mut buf).unwrap();
-        assert_eq!(key, buf);
-    }
 
     #[test]
     fn test_string_encode_decode() {

--- a/src/meta/raft-store/src/leveled_store/level.rs
+++ b/src/meta/raft-store/src/leveled_store/level.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::io;
 use std::ops::RangeBounds;
@@ -82,11 +81,7 @@ impl Level {
 
 #[async_trait::async_trait]
 impl MapApiRO<String> for Level {
-    async fn get<Q>(&self, key: &Q) -> Result<Marked<<String as MapKey>::V>, io::Error>
-    where
-        String: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-    {
+    async fn get(&self, key: &String) -> Result<Marked<<String as MapKey>::V>, io::Error> {
         let got = self.kv.get(key).cloned().unwrap_or(Marked::empty());
         Ok(got)
     }
@@ -139,11 +134,7 @@ impl MapApi<String> for Level {
 
 #[async_trait::async_trait]
 impl MapApiRO<ExpireKey> for Level {
-    async fn get<Q>(&self, key: &Q) -> Result<MarkedOf<ExpireKey>, io::Error>
-    where
-        ExpireKey: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-    {
+    async fn get(&self, key: &ExpireKey) -> Result<MarkedOf<ExpireKey>, io::Error> {
         let got = self.expire.get(key).cloned().unwrap_or(Marked::empty());
         Ok(got)
     }

--- a/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
@@ -116,10 +116,10 @@ async fn test_single_level() -> anyhow::Result<()> {
     ]);
 
     // Get
-    let got = l.str_map().get("a2").await?;
+    let got = l.str_map().get(&s("a2")).await?;
     assert_eq!(got, Marked::new_with_meta(2, b("b2"), None));
 
-    let got = l.str_map().get("a3").await?;
+    let got = l.str_map().get(&s("a3")).await?;
     assert_eq!(got, Marked::new_tombstone(6));
     Ok(())
 }
@@ -182,13 +182,13 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     // Get
 
-    let got = l.str_map().get("a1").await?;
+    let got = l.str_map().get(&s("a1")).await?;
     assert_eq!(got, Marked::new_with_meta(7, b("b5"), None));
 
-    let got = l.str_map().get("a2").await?;
+    let got = l.str_map().get(&s("a2")).await?;
     assert_eq!(got, Marked::new_with_meta(6, b("b4"), None));
 
-    let got = l.str_map().get("w1").await?;
+    let got = l.str_map().get(&s("w1")).await?;
     assert_eq!(got, Marked::new_tombstone(0));
 
     // Check base level
@@ -241,22 +241,22 @@ async fn build_3_levels() -> anyhow::Result<LeveledMap> {
 async fn test_three_levels_get_range() -> anyhow::Result<()> {
     let l = build_3_levels().await?;
 
-    let got = l.str_map().get("a").await?;
+    let got = l.str_map().get(&s("a")).await?;
     assert_eq!(got, Marked::new_with_meta(1, b("a0"), None));
 
-    let got = l.str_map().get("b").await?;
+    let got = l.str_map().get(&s("b")).await?;
     assert_eq!(got, Marked::new_tombstone(4));
 
-    let got = l.str_map().get("c").await?;
+    let got = l.str_map().get(&s("c")).await?;
     assert_eq!(got, Marked::new_tombstone(6));
 
-    let got = l.str_map().get("d").await?;
+    let got = l.str_map().get(&s("d")).await?;
     assert_eq!(got, Marked::new_with_meta(7, b("d2"), None));
 
-    let got = l.str_map().get("e").await?;
+    let got = l.str_map().get(&s("e")).await?;
     assert_eq!(got, Marked::new_with_meta(6, b("e1"), None));
 
-    let got = l.str_map().get("f").await?;
+    let got = l.str_map().get(&s("f")).await?;
     assert_eq!(got, Marked::new_tombstone(0));
 
     let got = l
@@ -462,7 +462,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
         );
 
-        let got = l.str_map().get("a").await?;
+        let got = l.str_map().get(&s("a")).await?;
         assert_eq!(
             got,
             Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
@@ -483,7 +483,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
             Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
         );
 
-        let got = l.str_map().get("b").await?;
+        let got = l.str_map().get(&s("b")).await?;
         assert_eq!(
             got,
             Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
@@ -498,7 +498,7 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         assert_eq!(prev, Marked::new_tombstone(0));
         assert_eq!(result, Marked::new_with_meta(6, b("d1"), None));
 
-        let got = l.str_map().get("d").await?;
+        let got = l.str_map().get(&s("d")).await?;
         assert_eq!(got, Marked::new_with_meta(6, b("d1"), None));
     }
 
@@ -522,7 +522,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
         );
 
-        let got = l.str_map().get("a").await?;
+        let got = l.str_map().get(&s("a")).await?;
         assert_eq!(
             got,
             Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
@@ -540,7 +540,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         );
         assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
 
-        let got = l.str_map().get("b").await?;
+        let got = l.str_map().get(&s("b")).await?;
         assert_eq!(got, Marked::new_with_meta(6, b("b1"), None));
     }
 
@@ -556,7 +556,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
             Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
         );
 
-        let got = l.str_map().get("c").await?;
+        let got = l.str_map().get(&s("c")).await?;
         assert_eq!(
             got,
             Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
@@ -572,7 +572,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         assert_eq!(prev, Marked::new_tombstone(0));
         assert_eq!(result, Marked::new_tombstone(0));
 
-        let got = l.str_map().get("d").await?;
+        let got = l.str_map().get(&s("d")).await?;
         assert_eq!(got, Marked::new_tombstone(0));
     }
 

--- a/src/meta/raft-store/src/leveled_store/map_api/map_api_ro_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/map_api/map_api_ro_impl.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::io::Error;
 use std::ops::RangeBounds;
 
@@ -29,11 +28,7 @@ use crate::marked::Marked;
 impl<K> MapApiRO<K> for ()
 where K: MapKey
 {
-    async fn get<Q>(&self, _key: &Q) -> Result<Marked<K::V>, Error>
-    where
-        K: Borrow<Q>,
-        Q: Ord + Send + Sync + ?Sized,
-    {
+    async fn get(&self, _key: &K) -> Result<Marked<K::V>, Error> {
         Ok(Marked::empty())
     }
 

--- a/src/meta/raft-store/src/mem_meta.rs
+++ b/src/meta/raft-store/src/mem_meta.rs
@@ -86,7 +86,7 @@ impl KVApi for MemMeta {
         let sm = self.sm.lock().await;
 
         for k in keys {
-            let got = sm.get_maybe_expired_kv(k.as_str()).await?;
+            let got = sm.get_maybe_expired_kv(k).await?;
             let v = Self::non_expired(got, local_now_ms);
             items.push(Ok(StreamItem::from((k.clone(), v))));
         }

--- a/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
@@ -67,10 +67,10 @@ async fn test_leveled_query_with_db() -> anyhow::Result<()> {
     ]);
 
     assert_eq!(
-        lm.str_map().get("a").await?,
+        lm.str_map().get(&s("a")).await?,
         Marked::new_with_meta(1, b("a0"), None)
     );
-    assert_eq!(lm.str_map().get("b").await?, Marked::new_tombstone(4));
+    assert_eq!(lm.str_map().get(&s("b")).await?, Marked::new_tombstone(4));
 
     let got = lm
         .expire_map()

--- a/src/meta/raft-store/src/sm_v003/sm_v003_kv_api.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003_kv_api.rs
@@ -49,7 +49,7 @@ impl kvapi::KVApi for SMV003KVApi<'_> {
         let mut items = Vec::with_capacity(keys.len());
 
         for k in keys {
-            let got = self.sm.get_maybe_expired_kv(k.as_str()).await?;
+            let got = self.sm.get_maybe_expired_kv(k).await?;
             let v = Self::non_expired(got, local_now_ms);
             items.push(Ok(StreamItem::from((k.clone(), v))));
         }

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -198,7 +198,7 @@ pub trait StateMachineApiExt: StateMachineApi {
     /// Get a cloned value by key.
     ///
     /// It does not check expiration of the returned entry.
-    async fn get_maybe_expired_kv(&self, key: &str) -> Result<Option<SeqV>, io::Error> {
+    async fn get_maybe_expired_kv(&self, key: &String) -> Result<Option<SeqV>, io::Error> {
         let got = self.map_ref().str_map().get(key).await?;
         let seqv = Into::<Option<SeqV>>::into(got);
         Ok(seqv)

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -69,7 +69,7 @@ pub trait StateMachineApiExt: StateMachineApi {
             }
         };
 
-        let expire_ms = kv_meta.expiry_ms();
+        let expire_ms = kv_meta.expires_at_ms();
         if expire_ms < self.get_expire_cursor().time_ms {
             // The record has expired, delete it at once.
             //
@@ -136,13 +136,13 @@ pub trait StateMachineApiExt: StateMachineApi {
 
         // Remove previous expiration index, add a new one.
 
-        if let Some(exp_ms) = removed.get_expire_at_ms() {
+        if let Some(exp_ms) = removed.expires_at_ms_opt() {
             self.map_mut()
                 .set(ExpireKey::new(exp_ms, removed.order_key().seq()), None)
                 .await?;
         }
 
-        if let Some(exp_ms) = added.get_expire_at_ms() {
+        if let Some(exp_ms) = added.expires_at_ms_opt() {
             let k = ExpireKey::new(exp_ms, added.order_key().seq());
             let v = key.to_string();
             self.map_mut().set(k, Some((v, None))).await?;

--- a/src/meta/types/src/eval_expire_time.rs
+++ b/src/meta/types/src/eval_expire_time.rs
@@ -17,21 +17,21 @@ pub trait Expirable {
     /// Evaluates and returns the absolute expiration time in milliseconds since the Unix epoch (January 1, 1970).
     ///
     /// If there is no expiration time, it returns `u64::MAX`.
-    fn expiry_ms(&self) -> u64;
+    fn expires_at_ms(&self) -> u64;
 }
 
 impl<T> Expirable for &T
 where T: Expirable
 {
-    fn expiry_ms(&self) -> u64 {
-        Expirable::expiry_ms(*self)
+    fn expires_at_ms(&self) -> u64 {
+        Expirable::expires_at_ms(*self)
     }
 }
 
 impl<T> Expirable for Option<T>
 where T: Expirable
 {
-    fn expiry_ms(&self) -> u64 {
-        self.as_ref().map(|m| m.expiry_ms()).unwrap_or(u64::MAX)
+    fn expires_at_ms(&self) -> u64 {
+        self.as_ref().map(|m| m.expires_at_ms()).unwrap_or(u64::MAX)
     }
 }

--- a/src/meta/types/src/seq_value/kv_meta.rs
+++ b/src/meta/types/src/seq_value/kv_meta.rs
@@ -44,7 +44,7 @@ impl KVMeta {
 }
 
 impl Expirable for KVMeta {
-    fn expiry_ms(&self) -> u64 {
+    fn expires_at_ms(&self) -> u64 {
         match self.expire_at {
             None => u64::MAX,
             Some(exp_at_sec) => exp_at_sec * 1000,

--- a/src/meta/types/src/seq_value/seq_value_trait.rs
+++ b/src/meta/types/src/seq_value/seq_value_trait.rs
@@ -26,22 +26,19 @@ pub trait SeqValue<V = Vec<u8>> {
         (self.seq(), self.into_value())
     }
 
-    /// Return the expire time in millisecond since 1970.
-    fn get_expire_at_ms(&self) -> Option<u64> {
-        if let Some(meta) = self.meta() {
-            meta.get_expire_at_ms()
-        } else {
-            None
-        }
+    /// Return the expiry time in millisecond since 1970.
+    fn expires_at_ms_opt(&self) -> Option<u64> {
+        let meta = self.meta()?;
+        meta.get_expire_at_ms()
     }
 
     /// Evaluate and returns the absolute expire time in millisecond since 1970.
-    fn expiry_ms(&self) -> u64 {
-        self.meta().expiry_ms()
+    fn expires_at_ms(&self) -> u64 {
+        self.meta().expires_at_ms()
     }
 
     /// Return true if the record is expired.
     fn is_expired(&self, now_ms: u64) -> bool {
-        self.expiry_ms() < now_ms
+        self.expires_at_ms() < now_ms
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore(meta): remove unused impl MapKeyEncode for &str


##### refactor(meta): separate map key behavior from key encoding

This commit refactors the handling of map keys and their encoding/decoding:

- **`MapKey` Trait**:
  The `MapKey` trait, which already existed, now strictly defines the
  behavior of a map key without requiring codec-related logic.
- **New Traits**:
  Introduced `MapKeyEncode` and `MapKeyDecode` traits to encapsulate
  encoding and decoding behavior separately from the `MapKey` trait.

### Changes:

- Refactored `MapApiRO` and `MapApi` traits:
  - These traits no longer depend on encoding/decoding logic, focusing
    solely on map key behavior.
- Removed `K: Borrow<Q>` from the `get<Q>()` method:
  - While `Q` was intended to allow flexible borrowing (e.g., `&str` as
    a borrowed type of `String`), it added unnecessary complexity when
    handling `MapKey` and `MapKeyEncode`.
  - This feature was removed to simplify the interface.
- Updated method calls to use reference-wrapped keys (`&K`) instead of
  relying on borrowed types like `&str`.
- Adjusted test cases to align with the refined interface.


##### chore: Rename `expiry_ms` to `expires_at_ms` for clarity

Renamed `expiry_ms` to `expires_at_ms` across the codebase for improved
clarity and consistency in expiration-related APIs. Updates include:

- `Expirable` trait: `expiry_ms` → `expires_at_ms`.
- `KVMeta`: Updated method and related logic.
- `SeqValue`:
  - `get_expire_at_ms` → `expires_at_ms_opt`.
  - `expiry_ms` → `expires_at_ms`.

This is a non-functional change to improve readability and naming
consistency.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17545)
<!-- Reviewable:end -->
