### PR TITLE
fix: agg input does not match union output when subquery

### DIFF
--- a/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/decorrelate.rs
@@ -286,7 +286,7 @@ impl SubqueryRewriter {
                 )?;
 
                 let mut join_type = JoinType::LeftSingle;
-                if subquery.contain_agg.unwrap() {
+                if matches!(subquery.contain_agg, Some(true)) {
                     let rel_expr = RelExpr::with_s_expr(&subquery.subquery);
                     let card = rel_expr
                         .derive_cardinality()?
@@ -473,7 +473,9 @@ impl SubqueryRewriter {
                 .table_index(column_entry.table_index())
                 .build(),
             });
-            let derive_column = self.derived_columns.get(correlated_column).unwrap();
+            let Some(derive_column) = self.derived_columns.get(correlated_column) else {
+                continue;
+            };
             let column_entry = metadata.column(*derive_column);
             let left_column = ScalarExpr::BoundColumnRef(BoundColumnRef {
                 span,

--- a/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/decorrelate/flatten_plan.rs
@@ -786,6 +786,9 @@ impl SubqueryRewriter {
             flatten_info,
             need_cross_join,
         )?;
+        self.derived_columns
+            .retain(|_, derived_column| op.output_indexes.contains(derived_column));
+
         Ok(SExpr::create_binary(
             Arc::new(op.clone().into()),
             Arc::new(left_flatten_plan),

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -912,3 +912,33 @@ group by input_date order by input_date;
 
 statement ok
 drop table test_group;
+
+# https://github.com/databendlabs/databend/issues/17476
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+DROP TABLE IF EXISTS t2;
+
+statement ok
+CREATE TABLE t1 (i1 INT);
+
+statement ok
+CREATE TABLE t2 (i1 INT);
+
+statement ok
+insert into t1 values (0);
+
+statement ok
+insert into t2 values (0);
+
+query I
+SELECT 1 FROM t1
+WHERE t1.i1 = (
+  SELECT t1.i1
+    FROM t2 UNION
+  SELECT dt1.i1
+    FROM (t1 AS dt1)
+);
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: https://github.com/databendlabs/databend/issues/17476

```sql
insert into t1 values (0);
insert into t2 values (0);

SELECT 1 FROM t1
WHERE t1.i1 = (
  SELECT t1.i1
    FROM t2 UNION
  SELECT dt1.i1
    FROM (t1 AS dt1)
);

┌───────┐
│   1   │
│ UInt8 │
├───────┤
│     1 │
└───────┘

explain SELECT 1 FROM t1
WHERE t1.i1 = (
  SELECT t1.i1
    FROM t2 UNION
  SELECT dt1.i1
    FROM (t1 AS dt1)
);

-[ EXPLAIN ]-----------------------------------
EvalScalar
├── output columns: [1 (#4)]
├── expressions: [1]
├── estimated rows: 2.00
└── HashJoin
    ├── output columns: []
    ├── join type: INNER
    ├── build keys: [t1.i1 (#0)]
    ├── probe keys: [scalar_subquery_3 (#3)]
    ├── keys is null equal: [false]
    ├── filters: []
    ├── estimated rows: 2.00
    ├── TableScan(Build)
    │   ├── table: default.default.t1
    │   ├── output columns: [i1 (#0)]
    │   ├── read rows: 1
    │   ├── read size: < 1 KiB
    │   ├── partitions total: 1
    │   ├── partitions scanned: 1
    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
    │   ├── push downs: [filters: [], limit: NONE]
    │   └── estimated rows: 1.00
    └── AggregateFinal(Probe)
        ├── output columns: [i1 (#3)]
        ├── group by: [i1]
        ├── aggregate functions: []
        ├── estimated rows: 2.00
        └── AggregatePartial
            ├── group by: [i1]
            ├── aggregate functions: []
            ├── estimated rows: 2.00
            └── UnionAll
                ├── output columns: [i1 (#3)]
                ├── estimated rows: 2.00
                ├── EvalScalar
                │   ├── output columns: [t1.i1 (#0)]
                │   ├── expressions: [i1 (#5)]
                │   ├── estimated rows: 1.00
                │   └── HashJoin
                │       ├── output columns: [i1 (#5)]
                │       ├── join type: CROSS
                │       ├── build keys: []
                │       ├── probe keys: []
                │       ├── keys is null equal: []
                │       ├── filters: []
                │       ├── estimated rows: 1.00
                │       ├── TableScan(Build)
                │       │   ├── table: default.default.t2
                │       │   ├── output columns: []
                │       │   ├── read rows: 1
                │       │   ├── read size: 0
                │       │   ├── partitions total: 1
                │       │   ├── partitions scanned: 1
                │       │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                │       │   ├── push downs: [filters: [], limit: NONE]
                │       │   └── estimated rows: 1.00
                │       └── AggregateFinal(Probe)
                │           ├── output columns: [i1 (#5)]
                │           ├── group by: [i1]
                │           ├── aggregate functions: []
                │           ├── estimated rows: 1.00
                │           └── AggregatePartial
                │               ├── group by: [i1]
                │               ├── aggregate functions: []
                │               ├── estimated rows: 1.00
                │               └── TableScan
                │                   ├── table: default.default.t1
                │                   ├── output columns: [i1 (#5)]
                │                   ├── read rows: 1
                │                   ├── read size: < 1 KiB
                │                   ├── partitions total: 1
                │                   ├── partitions scanned: 1
                │                   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                │                   ├── push downs: [filters: [], limit: NONE]
                │                   └── estimated rows: 1.00
                └── HashJoin
                    ├── output columns: [dt1.i1 (#2)]
                    ├── join type: CROSS
                    ├── build keys: []
                    ├── probe keys: []
                    ├── keys is null equal: []
                    ├── filters: []
                    ├── estimated rows: 1.00
                    ├── TableScan(Build)
                    │   ├── table: default.default.t1
                    │   ├── output columns: [i1 (#2)]
                    │   ├── read rows: 1
                    │   ├── read size: < 1 KiB
                    │   ├── partitions total: 1
                    │   ├── partitions scanned: 1
                    │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                    │   ├── push downs: [filters: [], limit: NONE]
                    │   └── estimated rows: 1.00
                    └── AggregateFinal(Probe)
                        ├── output columns: [i1 (#6)]
                        ├── group by: [i1]
                        ├── aggregate functions: []
                        ├── estimated rows: 1.00
                        └── AggregatePartial
                            ├── group by: [i1]
                            ├── aggregate functions: []
                            ├── estimated rows: 1.00
                            └── TableScan
                                ├── table: default.default.t1
                                ├── output columns: [i1 (#6)]
                                ├── read rows: 1
                                ├── read size: < 1 KiB
                                ├── partitions total: 1
                                ├── partitions scanned: 1
                                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
                                ├── push downs: [filters: [], limit: NONE]
                                └── estimated rows: 1.00

```

## Todo: 

MySQL can directly determine that this subquery does not need to be executed. Databend currently seems to still need to execute this subquery (for join)
![img_v3_02k3_ae19626b-8cca-4dc5-8c3d-d4dfdc49d78g](https://github.com/user-attachments/assets/0da521f3-2902-4684-94a9-baf0f3af37e2)



## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17552)
<!-- Reviewable:end -->
