### PR TITLE
fix: with recursive bind table panic

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
@@ -290,7 +290,7 @@ async fn create_memory_table_for_cte_scan(
             let schema = TableSchemaRefExt::create(table_fields);
 
             let create_table_plan = CreateTablePlan {
-                create_option: CreateOption::Create,
+                create_option: CreateOption::CreateIfNotExists,
                 tenant: Tenant {
                     tenant: ctx.get_tenant().tenant,
                 },

--- a/src/query/sql/src/planner/binder/bind_query/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind.rs
@@ -55,7 +55,7 @@ impl Binder {
 
         // Bind query body.
         let (mut s_expr, mut bind_context) =
-            self.bind_set_expr(bind_context, &query.body, &query.order_by, limit)?;
+            self.bind_set_expr(bind_context, &query.body, &query.order_by, limit, None)?;
 
         // Bind order by for `SetOperation` and `Values`.
         s_expr = self.bind_query_order_by(&mut bind_context, query, s_expr)?;

--- a/src/query/sql/src/planner/binder/bind_query/bind_set_expr.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_set_expr.rs
@@ -27,6 +27,7 @@ impl Binder {
         set_expr: &SetExpr,
         order_by: &[OrderByExpr],
         limit: Option<usize>,
+        cte_name: Option<String>,
     ) -> Result<(SExpr, BindContext)> {
         match set_expr {
             SetExpr::Select(stmt) => self.bind_select(bind_context, stmt, order_by, limit),
@@ -37,7 +38,7 @@ impl Binder {
                 &set_operation.right,
                 &set_operation.op,
                 &set_operation.all,
-                None,
+                cte_name,
             ),
             SetExpr::Values { span, values } => self.bind_values(bind_context, *span, values),
         }

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -119,7 +119,8 @@ impl Binder {
         all: &bool,
         cte_name: Option<String>,
     ) -> Result<(SExpr, BindContext)> {
-        let (left_expr, left_bind_context) = self.bind_set_expr(bind_context, left, &[], None)?;
+        let (left_expr, left_bind_context) =
+            self.bind_set_expr(bind_context, left, &[], None, cte_name.clone())?;
         if let Some(cte_name) = cte_name.as_ref() {
             if !all {
                 return Err(ErrorCode::Internal(
@@ -147,7 +148,7 @@ impl Binder {
             .cte_context
             .merge(left_bind_context.cte_context.clone());
         let (right_expr, right_bind_context) =
-            self.bind_set_expr(bind_context, right, &[], None)?;
+            self.bind_set_expr(bind_context, right, &[], None, None)?;
 
         if left_bind_context.columns.len() != right_bind_context.columns.len() {
             return Err(ErrorCode::SemanticError(

--- a/tests/sqllogictests/suites/query/cte/cte.test
+++ b/tests/sqllogictests/suites/query/cte/cte.test
@@ -575,3 +575,19 @@ with t(tt) as (select number as tt from numbers(10)),  t2(tt) AS MATERIALIZED (S
 7
 8
 9
+
+# https://github.com/databendlabs/databend/issues/17295
+statement ok
+create table t1(a int);
+
+statement ok
+create table t2(a int);
+
+query I
+WITH RECURSIVE
+closure(x) AS (VALUES(1)
+UNION all SELECT a from t1, closure where t1.a = closure.x
+UNION all SELECT a from t2, closure where t2.a = closure.x
+) SELECT x FROM closure;
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: https://github.com/databendlabs/databend/issues/17295

```sql
WITH RECURSIVE
closure(x) AS (VALUES(1)
UNION all SELECT a from t1, closure where t1.a = closure.x
UNION all SELECT a from t2, closure where t2.a = closure.x
) SELECT x FROM closure;

┌────────┐
│    x   │
│ UInt64 │
├────────┤
│      1 │
└────────┘

```
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17554)
<!-- Reviewable:end -->
