### PR TITLE
fix: parquet meta cache key include md5 or mtime or query_id.

### DIFF
--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -47,7 +47,7 @@ pub struct StageFileInfo {
     pub path: String,
     pub size: u64,
     pub md5: Option<String>,
-    pub last_modified: DateTime<Utc>,
+    pub last_modified: Option<DateTime<Utc>>,
     pub etag: Option<String>,
     pub status: StageFileStatus,
     pub creator: Option<UserIdentity>,
@@ -59,10 +59,19 @@ impl StageFileInfo {
             path,
             size: meta.content_length(),
             md5: meta.content_md5().map(str::to_string),
-            last_modified: meta.last_modified().unwrap_or_default(),
+            last_modified: meta.last_modified(),
             etag: meta.etag().map(str::to_string),
             status: StageFileStatus::NeedCopy,
             creator: None,
+        }
+    }
+
+    pub fn dedup_key(&self) -> Option<String> {
+        if let Some(md5) = &self.md5 {
+            Some(md5.clone())
+        } else {
+            self.last_modified
+                .map(|t| t.format("%Y%m%d%H%M%S").to_string())
         }
     }
 }
@@ -419,7 +428,7 @@ fn stdin_stage_info() -> StageFileInfo {
         path: STDIN_FD.to_string(),
         size: u64::MAX,
         md5: None,
-        last_modified: Utc::now(),
+        last_modified: Some(Utc::now()),
         etag: None,
         status: StageFileStatus::NeedCopy,
         creator: None,

--- a/src/query/service/src/pipelines/builders/builder_copy_into_table.rs
+++ b/src/query/service/src/pipelines/builders/builder_copy_into_table.rs
@@ -214,7 +214,7 @@ impl PipelineBuilder {
             copied_file_tree.insert(path, TableCopiedFileInfo {
                 etag: short_etag,
                 content_length: file.size,
-                last_modified: Some(file.last_modified),
+                last_modified: file.last_modified,
             });
         }
 

--- a/src/query/service/src/table_functions/list_stage/list_stage_table.rs
+++ b/src/query/service/src/table_functions/list_stage/list_stage_table.rs
@@ -225,6 +225,7 @@ fn make_block(files: &[StageFileInfo]) -> DataBlock {
         .iter()
         .map(|file| {
             file.last_modified
+                .unwrap_or_default()
                 .format("%Y-%m-%d %H:%M:%S.%3f %z")
                 .to_string()
         })

--- a/src/query/storages/parquet/src/parquet_rs/meta.rs
+++ b/src/query/storages/parquet/src/parquet_rs/meta.rs
@@ -21,6 +21,7 @@ use databend_common_catalog::plan::FullParquetMeta;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::TableField;
+use databend_common_storage::parquet_rs::read_metadata_async;
 use databend_storages_common_cache::CacheManager;
 use databend_storages_common_cache::InMemoryItemCacheReader;
 use databend_storages_common_cache::LoadParams;
@@ -36,9 +37,12 @@ pub async fn read_metadata_async_cached(
     path: &str,
     operator: &Operator,
     file_size: Option<u64>,
+    query_id: String,
+    dedup_key: Option<String>,
 ) -> Result<Arc<ParquetMetaData>> {
+    let dedup_key = dedup_key.unwrap_or(query_id);
     let info = operator.info();
-    let location = format!("{}/{}/{}", info.name(), info.root(), path);
+    let location = format!("{dedup_key}:{}/{}/{}", info.name(), info.root(), path);
     let reader = MetaReader::meta_data_reader(operator.clone(), location.len() - path.len());
     let load_params = LoadParams {
         location,
@@ -52,11 +56,12 @@ pub async fn read_metadata_async_cached(
 #[async_backtrace::framed]
 pub async fn read_metas_in_parallel(
     op: &Operator,
-    file_infos: &[(String, u64)],
+    file_infos: &[(String, u64, Option<String>)],
     expected: (SchemaDescPtr, String),
     leaf_fields: Arc<Vec<TableField>>,
     num_threads: usize,
     max_memory_usage: u64,
+    use_cache: Option<String>,
 ) -> Result<Vec<Arc<FullParquetMeta>>> {
     if file_infos.is_empty() {
         return Ok(vec![]);
@@ -84,6 +89,7 @@ pub async fn read_metas_in_parallel(
             leaf_fields,
             schema_from,
             max_memory_usage,
+            use_cache.clone(),
         ));
     }
 
@@ -173,8 +179,14 @@ async fn load_and_check_parquet_meta(
     op: Operator,
     expect: &SchemaDescriptor,
     schema_from: &str,
+    use_cache: Option<String>,
+    dedup_key: Option<String>,
 ) -> Result<Arc<ParquetMetaData>> {
-    let metadata = read_metadata_async_cached(file, &op, Some(size)).await?;
+    let metadata = if let Some(query_id) = use_cache {
+        read_metadata_async_cached(file, &op, Some(size), query_id, dedup_key).await?
+    } else {
+        Arc::new(read_metadata_async(file, &op, Some(size)).await?)
+    };
     check_parquet_schema(
         expect,
         metadata.file_metadata().schema_descr(),
@@ -185,17 +197,26 @@ async fn load_and_check_parquet_meta(
 }
 
 pub async fn read_parquet_metas_batch(
-    file_infos: Vec<(String, u64)>,
+    file_infos: Vec<(String, u64, Option<String>)>,
     op: Operator,
     expect: SchemaDescPtr,
     leaf_fields: Arc<Vec<TableField>>,
     schema_from: String,
     max_memory_usage: u64,
+    use_cache: Option<String>,
 ) -> Result<Vec<Arc<FullParquetMeta>>> {
     let mut metas = Vec::with_capacity(file_infos.len());
-    for (location, size) in file_infos {
-        let meta =
-            load_and_check_parquet_meta(&location, size, op.clone(), &expect, &schema_from).await?;
+    for (location, size, dedup_key) in file_infos {
+        let meta = load_and_check_parquet_meta(
+            &location,
+            size,
+            op.clone(),
+            &expect,
+            &schema_from,
+            use_cache.clone(),
+            dedup_key,
+        )
+        .await?;
         if unlikely(meta.file_metadata().num_rows() == 0) {
             // Don't collect empty files
             continue;
@@ -220,7 +241,7 @@ pub async fn read_parquet_metas_batch_for_copy(
 ) -> Result<Vec<Arc<FullParquetMeta>>> {
     let mut metas = Vec::with_capacity(file_infos.len());
     for (location, size) in file_infos {
-        let meta = read_metadata_async_cached(&location, &op, Some(size)).await?;
+        let meta = Arc::new(read_metadata_async(&location, &op, Some(size)).await?);
         if unlikely(meta.file_metadata().num_rows() == 0) {
             // Don't collect empty files
             continue;
@@ -270,7 +291,6 @@ impl Loader<ParquetMetaData> for LoaderWrapper<Operator> {
             Some(v) => v,
             None => self.0.stat(location).await?.content_length(),
         };
-        databend_common_storage::parquet_rs::read_metadata_async(location, &self.0, Some(size))
-            .await
+        read_metadata_async(location, &self.0, Some(size)).await
     }
 }

--- a/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_rs/parquet_table/table.rs
@@ -292,14 +292,14 @@ impl Table for ParquetRSTable {
             Some(files) => files
                 .iter()
                 .filter(|f| f.size > 0)
-                .map(|f| (f.path.clone(), f.size))
+                .map(|f| (f.path.clone(), f.size, f.dedup_key()))
                 .collect::<Vec<_>>(),
             None => self
                 .files_info
                 .list(&self.operator, thread_num, None)
                 .await?
                 .into_iter()
-                .map(|f| (f.path, f.size))
+                .map(|f| (f.path.clone(), f.size, f.dedup_key()))
                 .collect::<Vec<_>>(),
         };
 
@@ -314,6 +314,7 @@ impl Table for ParquetRSTable {
             self.leaf_fields.clone(),
             self.max_threads,
             self.max_memory_usage,
+            Some(ctx.get_id()),
         )
         .await?;
         let elapsed = now.elapsed();

--- a/tests/suites/1_stateful/00_stage/00_0010_parquet_meta_cache.result
+++ b/tests/suites/1_stateful/00_stage/00_0010_parquet_meta_cache.result
@@ -1,0 +1,12 @@
+>>>> DROP STAGE IF EXISTS s1;
+>>>> CREATE STAGE s1;
+>>>> select /*+ set_var(parquet_fast_read_bytes=0) */ * from @s1/parquet_cache.parquet
+1	(1,'a')
+2	(3,'b')
+3	(3,'c')
+<<<<
+>>>> select /*+ set_var(parquet_fast_read_bytes=0) */ * from @s1/parquet_cache.parquet
+1	{"a":11}
+2	"abc"
+<<<<
+>>>> DROP STAGE IF EXISTS s1;

--- a/tests/suites/1_stateful/00_stage/00_0010_parquet_meta_cache.sh
+++ b/tests/suites/1_stateful/00_stage/00_0010_parquet_meta_cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+stmt "DROP STAGE IF EXISTS s1;"
+stmt "CREATE STAGE s1;"
+
+aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/admin/data/parquet/tuple.parquet s3://testbucket/admin/stage/internal/s1/parquet_cache.parquet >/dev/null 2>&1
+query "select /*+ set_var(parquet_fast_read_bytes=0) */ * from @s1/parquet_cache.parquet"
+
+aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/admin/data/parquet/variant.parquet  s3://testbucket/admin/stage/internal/s1/parquet_cache.parquet >/dev/null 2>&1
+query "select /*+ set_var(parquet_fast_read_bytes=0) */ * from @s1/parquet_cache.parquet"
+
+stmt "DROP STAGE IF EXISTS s1;"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. copy from parquet disable cache
2. select from parquet add dedup_key (md5 or mtime or query id) into cache key 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17556)
<!-- Reviewable:end -->
