### PR TITLE
chore: reorganize meta service watcher module

### DIFF
--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -73,7 +73,8 @@ where SM: StateMachineApi + 'static
     pub(crate) cmd_ctx: CmdContext,
 
     /// The changes have been made by the applying one log entry
-    changes: Vec<Change<Vec<u8>, String>>,
+    /// `(key, prev, result)`.
+    changes: Vec<(String, Option<SeqV>, Option<SeqV>)>,
 }
 
 impl<'a, SM> Applier<'a, SM>
@@ -586,8 +587,7 @@ where SM: StateMachineApi + 'static
             return;
         }
 
-        self.changes
-            .push(Change::new(prev, result).with_id(key.to_string()))
+        self.changes.push((key.to_string(), prev, result))
     }
 
     /// Retrieve the proposing time from a raft-log.

--- a/src/meta/raft-store/src/state_machine_api.rs
+++ b/src/meta/raft-store/src/state_machine_api.rs
@@ -16,7 +16,6 @@ use std::fmt::Debug;
 
 use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::sys_data::SysData;
-use databend_common_meta_types::Change;
 use databend_common_meta_types::SeqV;
 use tokio::sync::mpsc;
 use tonic::Status;
@@ -27,7 +26,7 @@ use crate::state_machine::ExpireKey;
 
 /// Send a key-value change event to subscribers.
 pub trait SMEventSender: Debug + Sync + Send {
-    fn send(&self, change: Change<Vec<u8>, String>);
+    fn send(&self, change: (String, Option<SeqV>, Option<SeqV>));
 
     /// Inform to send all items in `strm` to `tx`.
     ///
@@ -39,21 +38,51 @@ pub trait SMEventSender: Debug + Sync + Send {
     );
 }
 
-/// The API a state machine implements
+/// The API a state machine implements.
+///
+/// The state machine is responsible for managing the application's persistent state,
+/// including application kv data and expired key data.
 pub trait StateMachineApi: Send + Sync {
     type Map: MapApi<String> + MapApi<ExpireKey> + 'static;
 
+    /// Returns the current expire key cursor position.
+    ///
+    /// The expiry key cursor marks a boundary in the key space:
+    /// - All keys before this cursor (exclusive) have already been processed and deleted
+    /// - This cursor position is used to track progress when incrementally cleaning up expired keys
     fn get_expire_cursor(&self) -> ExpireKey;
 
+    /// Updates the expiry key cursor position.
+    ///
+    /// This method is called after a batch of expired keys have been processed and deleted.
+    /// The new cursor position indicates that all keys before it (exclusive) have been
+    /// successfully cleaned up.
     fn set_expire_cursor(&mut self, cursor: ExpireKey);
 
-    /// Return a reference to the map that stores app data.
+    /// Returns a reference to the map that stores application data.
+    ///
+    /// This method provides read-only access to the underlying key-value store
+    /// that contains the application's persistent state, including application kv data and expired key data.
     fn map_ref(&self) -> &Self::Map;
 
-    /// Return a mutable reference to the map that stores app data.
+    /// Returns a mutable reference to the map that stores application data.
+    ///
+    /// This method provides read-write access to the underlying key-value store
+    /// that contains the application's persistent state, including application kv data and expired key data.
+    /// Changes made through this reference will be persisted according to the state machine's replication
+    /// protocol.
     fn map_mut(&mut self) -> &mut Self::Map;
 
+    /// Returns a mutable reference to the system data.
+    ///
+    /// This method provides read-write access to the system data, which includes
+    /// metadata about the state machine and its configuration.
     fn sys_data_mut(&mut self) -> &mut SysData;
 
+    /// Returns an optional reference to the event sender.
+    ///
+    /// This method returns an event sender that can be used to send state change events to subscribers.
+    ///
+    /// The implementation could just return `None` if the state machine does not support subscribing.
     fn event_sender(&self) -> Option<&dyn SMEventSender>;
 }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -78,7 +78,7 @@ use crate::version::from_digit_ver;
 use crate::version::to_digit_ver;
 use crate::version::METASRV_SEMVER;
 use crate::version::MIN_METACLI_SEMVER;
-use crate::watcher::WatchStream;
+use crate::watcher::watch_stream::WatchStream;
 
 pub struct MetaServiceImpl {
     token: GrpcToken,
@@ -396,7 +396,7 @@ impl MetaService for MetaServiceImpl {
         let mn = &self.meta_node;
 
         let sender = mn.add_watcher(watch, tx.clone()).await?;
-        let stream = WatchStream::new(rx, sender, mn.subscriber_handle.clone());
+        let stream = WatchStream::new(rx, sender, mn.dispatcher_handle.clone());
 
         if flush {
             let sm = mn.raft_store.state_machine.clone();

--- a/src/meta/service/src/watcher/dispatch/dispatcher.rs
+++ b/src/meta/service/src/watcher/dispatch/dispatcher.rs
@@ -33,43 +33,54 @@ use tonic::Status;
 
 use crate::metrics::network_metrics;
 use crate::metrics::server_metrics;
-use crate::watcher::command::Command;
-use crate::watcher::id::WatcherId;
-use crate::watcher::subscriber_handle::SubscriberHandle;
-use crate::watcher::StreamSender;
+use crate::watcher::dispatch::command::Command;
+use crate::watcher::dispatch::dispatcher_handle::DispatcherHandle;
+use crate::watcher::dispatch::Update;
+use crate::watcher::watch_stream::WatchStreamSender;
 use crate::watcher::WatchDesc;
+use crate::watcher::WatcherId;
 
-/// Receives events from event sources(such as raft state machine),
-/// dispatches them to interested watchers.
-pub struct EventSubscriber {
+/// Receives events from event sources via `rx` and dispatches them to interested watchers.
+///
+/// The [`Dispatcher`] acts as a central hub for the watch system, managing
+/// subscriptions and ensuring that each watcher receives only the events
+/// they have registered interest in. It maintains a mapping of watchers
+/// and their watch descriptors to efficiently route events.
+pub struct Dispatcher {
     rx: mpsc::UnboundedReceiver<Command>,
 
-    watchers: SpanMap<String, Arc<StreamSender>>,
+    watchers: SpanMap<String, Arc<WatchStreamSender>>,
 
     current_watcher_id: WatcherId,
 }
 
-impl EventSubscriber {
+impl Dispatcher {
     /// Spawn a dispatcher loop task.
-    pub(crate) fn spawn() -> SubscriberHandle {
+    ///
+    /// Creates a new [`Dispatcher`] instance and spawns it as an asynchronous task.
+    /// The dispatcher will process incoming commands and route watch events to the
+    /// appropriate subscribers.
+    ///
+    /// Returns a handle that can be used to send commands to the dispatcher.
+    pub(crate) fn spawn() -> DispatcherHandle {
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let subscriber = EventSubscriber {
+        let dispatcher = Dispatcher {
             rx,
             watchers: SpanMap::new(),
             current_watcher_id: 1,
         };
 
-        let _h = databend_common_base::runtime::spawn(subscriber.main());
+        let _h = databend_common_base::runtime::spawn(dispatcher.main());
 
-        SubscriberHandle::new(tx)
+        DispatcherHandle::new(tx)
     }
 
     #[fastrace::trace]
     async fn main(mut self) {
         while let Some(event) = self.rx.recv().await {
             match event {
-                Command::KVChange(kv_change) => {
+                Command::Update(kv_change) => {
                     self.dispatch(kv_change).await;
                 }
                 Command::Request { req } => req(&mut self),
@@ -77,12 +88,20 @@ impl EventSubscriber {
             }
         }
 
-        info!("EventDispatcher: all event senders are closed. quit.");
+        info!("watch-event-Dispatcher: all event senders are closed. quit.");
     }
 
-    /// Send a stream of kv changes to a watcher.
+    /// Creates a future that streams key-value changes to a watcher.
+    ///
+    /// This method constructs a future that will process each item in the stream and
+    /// forward it to the watcher via `tx` as a [`WatchResponse`]. The future terminates
+    /// if the stream ends or if sending to the watcher fails.
+    ///
+    /// # Parameters
+    /// * `to_tx` - The sender channel connected to a watcher client
+    /// * `strm` - A stream of key-value pairs with sequence versions
     pub fn send_stream(
-        tx: mpsc::Sender<Result<WatchResponse, Status>>,
+        to_tx: mpsc::Sender<Result<WatchResponse, Status>>,
         mut strm: BoxStream<'static, Result<(String, SeqV), io::Error>>,
     ) -> BoxFuture<'static, ()> {
         let fu = async move {
@@ -90,8 +109,11 @@ impl EventSubscriber {
                 let (key, seq_v) = match res {
                     Ok((key, seq)) => (key, seq),
                     Err(err) => {
-                        warn!("EventSubscriber: recv error from kv stream: {}", err);
-                        tx.send(Err(Status::internal(err.to_string()))).await.ok();
+                        warn!("watch-event-Dispatcher: recv error from kv stream: {}", err);
+                        to_tx
+                            .send(Err(Status::internal(err.to_string())))
+                            .await
+                            .ok();
                         break;
                     }
                 };
@@ -100,8 +122,8 @@ impl EventSubscriber {
                     WatchResponse::new(&Change::new(None, Some(seq_v)).with_id(key)).unwrap();
                 let resp_size = resp.encoded_len() as u64;
 
-                if let Err(_err) = tx.send(Ok(resp)).await {
-                    warn!("EventSubscriber: fail to send to watcher; close this stream");
+                if let Err(_err) = to_tx.send(Ok(resp)).await {
+                    warn!("watch-event-Dispatcher: fail to send to watcher; close this stream");
                     break;
                 } else {
                     network_metrics::incr_sent_bytes(resp_size);
@@ -112,20 +134,19 @@ impl EventSubscriber {
     }
 
     /// Dispatch a kv change event to interested watchers.
-    async fn dispatch(&mut self, change: Change<Vec<u8>, String>) {
-        let Some(key) = change.ident.clone() else {
-            warn!("EventSubscriber: change event without key; ignore it");
-            return;
-        };
+    async fn dispatch(&mut self, update: Update) {
+        let is_delete = update.after.is_none();
 
-        let is_delete = change.result.is_none();
-
-        let resp = WatchResponse::new(&change).unwrap();
+        let resp = WatchResponse::new3(
+            update.key.clone(),
+            update.before.clone(),
+            update.after.clone(),
+        );
         let resp_size = resp.encoded_len() as u64;
 
         let mut removed = vec![];
 
-        for sender in self.watchers.get(&key) {
+        for sender in self.watchers.get(&update.key) {
             let interested = sender.desc.interested;
 
             match interested {
@@ -144,7 +165,7 @@ impl EventSubscriber {
 
             if let Err(_err) = sender.send(resp.clone()).await {
                 warn!(
-                    "EventSubscriber: fail to send to watcher {}; close this stream",
+                    "watch-event-Dispatcher: fail to send to watcher {}; close this stream",
                     sender.desc.watcher_id
                 );
                 removed.push(sender.clone());
@@ -163,13 +184,13 @@ impl EventSubscriber {
         &mut self,
         req: WatchRequest,
         tx: mpsc::Sender<Result<WatchResponse, Status>>,
-    ) -> Result<Arc<StreamSender>, &'static str> {
-        info!("EventSubscriber::add_watcher: {:?}", req);
+    ) -> Result<Arc<WatchStreamSender>, &'static str> {
+        info!("watch-event-Dispatcher::add_watcher: {:?}", req);
 
         let interested = req.filter_type();
         let desc = self.new_watch_desc(req.key, req.key_end, interested)?;
 
-        let stream_sender = Arc::new(StreamSender::new(desc, tx));
+        let stream_sender = Arc::new(WatchStreamSender::new(desc, tx));
 
         self.watchers
             .insert(stream_sender.desc.key_range.clone(), stream_sender.clone());
@@ -195,15 +216,18 @@ impl EventSubscriber {
     }
 
     #[fastrace::trace]
-    pub fn remove_watcher(&mut self, stream_sender: Arc<StreamSender>) {
-        info!("EventSubscriber::remove_watcher: {:?}", stream_sender);
+    pub fn remove_watcher(&mut self, stream_sender: Arc<WatchStreamSender>) {
+        info!(
+            "watch-event-Dispatcher::remove_watcher: {:?}",
+            stream_sender
+        );
 
         self.watchers.remove(.., stream_sender);
 
         server_metrics::incr_watchers(-1);
     }
 
-    pub fn watch_senders(&self) -> BTreeSet<&Arc<StreamSender>> {
+    pub fn watch_senders(&self) -> BTreeSet<&Arc<WatchStreamSender>> {
         self.watchers.values(..)
     }
 }

--- a/src/meta/service/src/watcher/dispatch/mod.rs
+++ b/src/meta/service/src/watcher/dispatch/mod.rs
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The client watch a key range and get notified when the key range changes.
+//! Subscribe events and dispatch them to watchers.
 
-mod desc;
-pub mod dispatch;
-mod id;
-pub mod watch_stream;
+mod command;
+mod dispatcher;
+mod dispatcher_handle;
 
-use std::collections::Bound;
-
-pub use desc::WatchDesc;
-pub use id::WatcherId;
-
-pub(crate) type KeyRange = (Bound<String>, Bound<String>);
+pub use command::Command;
+pub use command::Update;
+pub use dispatcher::Dispatcher;
+pub use dispatcher_handle::DispatcherHandle;

--- a/src/meta/service/src/watcher/watch_stream/mod.rs
+++ b/src/meta/service/src/watcher/watch_stream/mod.rs
@@ -12,16 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The client watch a key range and get notified when the key range changes.
+mod sender;
+mod stream;
 
-mod desc;
-pub mod dispatch;
-mod id;
-pub mod watch_stream;
-
-use std::collections::Bound;
-
-pub use desc::WatchDesc;
-pub use id::WatcherId;
-
-pub(crate) type KeyRange = (Bound<String>, Bound<String>);
+pub use sender::WatchStreamSender;
+pub use stream::WatchStream;

--- a/src/meta/service/src/watcher/watch_stream/sender.rs
+++ b/src/meta/service/src/watcher/watch_stream/sender.rs
@@ -21,44 +21,48 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
 use tonic::Status;
 
-use crate::watcher::desc::WatchDesc;
+use crate::watcher::WatchDesc;
 
-/// A handle of a watching stream, for feeding messages to the stream.
+/// A handle to a watching stream that feeds messages to connected watchers.
+///
+/// The stream sender is responsible for sending watch events through the stream
+/// to the client-side watcher. It encapsulates the communication channel between
+/// the server's event source and the client's watch request.
 #[derive(Clone)]
-pub struct StreamSender {
+pub struct WatchStreamSender {
     pub desc: WatchDesc,
     tx: mpsc::Sender<Result<WatchResponse, Status>>,
 }
 
-impl fmt::Debug for StreamSender {
+impl fmt::Debug for WatchStreamSender {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "WatchStreamSender({:?})", self.desc)
     }
 }
 
-impl PartialEq for StreamSender {
+impl PartialEq for WatchStreamSender {
     fn eq(&self, other: &Self) -> bool {
         self.desc.watcher_id == other.desc.watcher_id
     }
 }
 
-impl Eq for StreamSender {}
+impl Eq for WatchStreamSender {}
 
-impl PartialOrd for StreamSender {
+impl PartialOrd for WatchStreamSender {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for StreamSender {
+impl Ord for WatchStreamSender {
     fn cmp(&self, other: &Self) -> Ordering {
         self.desc.watcher_id.cmp(&other.desc.watcher_id)
     }
 }
 
-impl StreamSender {
+impl WatchStreamSender {
     pub fn new(desc: WatchDesc, tx: mpsc::Sender<Result<WatchResponse, Status>>) -> Self {
-        StreamSender { desc, tx }
+        WatchStreamSender { desc, tx }
     }
 
     pub async fn send(

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -570,7 +570,7 @@ async fn test_watch_stream_count() -> anyhow::Result<()> {
     info!("one watcher");
     {
         let got = mn
-            .subscriber_handle
+            .dispatcher_handle
             .request_blocking(move |d| d.watch_senders().len())
             .await?;
 
@@ -583,7 +583,7 @@ async fn test_watch_stream_count() -> anyhow::Result<()> {
         let _watch_stream2 = client2.request(watch_req()).await?;
 
         let got = mn
-            .subscriber_handle
+            .dispatcher_handle
             .request_blocking(move |d| d.watch_senders().len())
             .await?;
 
@@ -596,7 +596,7 @@ async fn test_watch_stream_count() -> anyhow::Result<()> {
     info!("second watcher is removed");
     {
         let got = mn
-            .subscriber_handle
+            .dispatcher_handle
             .request_blocking(move |d| d.watch_senders().len())
             .await?;
 

--- a/src/meta/types/src/proto_ext/watch_ext.rs
+++ b/src/meta/types/src/proto_ext/watch_ext.rs
@@ -19,6 +19,7 @@ use crate::protobuf::watch_request::FilterType;
 use crate::protobuf::WatchRequest;
 use crate::protobuf::WatchResponse;
 use crate::Change;
+use crate::SeqV;
 
 impl WatchRequest {
     /// Build a key range from a `key` and an optional `key_end`.
@@ -59,6 +60,17 @@ impl WatchRequest {
 }
 
 impl WatchResponse {
+    /// Create a new `WatchResponse` with `key`, `prev` and `current` values.
+    pub fn new3(key: String, prev: Option<SeqV>, current: Option<SeqV>) -> Self {
+        let ev = pb::Event {
+            key,
+            prev: prev.map(pb::SeqV::from),
+            current: current.map(pb::SeqV::from),
+        };
+
+        WatchResponse { event: Some(ev) }
+    }
+
     pub fn new(change: &Change<Vec<u8>, String>) -> Option<Self> {
         let ev = pb::Event {
             key: change.ident.clone()?,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: reorganize meta service watcher module

- Split watcher module into three main components:
  - Dispatcher: receives and dispatches events to watchers
  - Stream: handles sending events to clients
  - Data types: defines core structures and interfaces

- Reduce dependency on `databend_common_meta_types` crate, to make it
  easier to become a standalone crate.

- Introduce dedicated `Update` struct for key-value events

- Refine doc for StateMachineApi

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17557)
<!-- Reviewable:end -->
