### PR TITLE
feat: `string_agg` is compatible with multiple types as arguments instead of just String

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_string_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_string_agg.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::DataType;
@@ -217,16 +218,29 @@ pub fn try_create_aggregate_string_agg_function(
     _sort_descs: Vec<AggregateFunctionSortDesc>,
 ) -> Result<Arc<dyn AggregateFunction>> {
     assert_variadic_arguments(display_name, argument_types.len(), (1, 2))?;
+    let value_type = argument_types[0].remove_nullable();
+    if !matches!(
+        value_type,
+        DataType::Boolean
+            | DataType::String
+            | DataType::Number(_)
+            | DataType::Decimal(_)
+            | DataType::Timestamp
+            | DataType::Date
+            | DataType::Variant
+            | DataType::Interval
+    ) {
+        return Err(ErrorCode::BadDataValueType(format!(
+            "{} does not support type '{:?}'",
+            display_name, value_type
+        )));
+    }
     let delimiter = if params.len() == 1 {
         params[0].as_string().unwrap().clone()
     } else {
         String::new()
     };
-    AggregateStringAggFunction::try_create(
-        display_name,
-        delimiter,
-        argument_types[0].remove_nullable(),
-    )
+    AggregateStringAggFunction::try_create(display_name, delimiter, value_type)
 }
 
 pub fn aggregate_string_agg_function_desc() -> AggregateFunctionDescription {

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1785,6 +1785,7 @@ impl<'a> TypeChecker<'a> {
                 )));
             }
             let _ = arguments.pop();
+            let _ = arg_types.pop();
             let delimiter = delimiter_value.unwrap();
             vec![delimiter.value]
         } else {

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -354,14 +354,14 @@ select group_array_moving_sum(k), group_array_moving_sum(2)(v) from aggr;
 [1,3,5,7,9,11,13,15,17,19,21] [10,20,20,20,30,40,45,55,60,60,60]
 
 statement ok
-create table t3(s string null, x int null, y int null, z int null);
+create table t3(s string null, x int null, y int null, z int null, b boolean null);
 
 statement ok
 insert into t3 values
-    ('abc', 3, 1, 2),
-    ('def', 2, 1, null),
-    (null, 1, 2, 1),
-    ('xyz', 0, 2, 0);
+    ('abc', 3, 1, 2, true),
+    ('def', 2, 1, null, false),
+    (null, 1, 2, 1, null),
+    ('xyz', 0, 2, 0, true);
 
 query T
 select string_agg(s) from t3;
@@ -377,6 +377,16 @@ query T
 select string_agg(s, '|') from t3;
 ----
 abc|def|xyz
+
+query T
+select string_agg(x + 1, '|') from t3;
+----
+4|3|2|1
+
+query T
+select string_agg(b, '|') from t3;
+----
+true|false|true
 
 query T
 select listagg(s) from t3;

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -354,14 +354,14 @@ select group_array_moving_sum(k), group_array_moving_sum(2)(v) from aggr;
 [1,3,5,7,9,11,13,15,17,19,21] [10,20,20,20,30,40,45,55,60,60,60]
 
 statement ok
-create table t3(s string null, x int null, y int null, z int null, b boolean null);
+create table t3(s string null, x int null, y int null, z int null, b boolean null, arr Array(Int32));
 
 statement ok
 insert into t3 values
-    ('abc', 3, 1, 2, true),
-    ('def', 2, 1, null, false),
-    (null, 1, 2, 1, null),
-    ('xyz', 0, 2, 0, true);
+    ('abc', 3, 1, 2, true, [1,2,3]),
+    ('def', 2, 1, null, false, [4,5,6]),
+    (null, 1, 2, 1, null, [7,8,9]),
+    ('xyz', 0, 2, 0, true, [10,11,12]);
 
 query T
 select string_agg(s) from t3;
@@ -387,6 +387,9 @@ query T
 select string_agg(b, '|') from t3;
 ----
 true|false|true
+
+statement error
+select listagg(arr) from t3;
 
 query T
 select listagg(s) from t3;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
`string_agg` will convert argment if it is not of `DataType::String`


```sql
create table t3(x int null, b boolean null);

insert into t3 values
    (3, true),
    (2, false),
    (1, null),
    (0, true);


select string_agg(x + 1, '|') from t3;
----
4|3|2|1

select string_agg(b, '|') from t3;
----
true|false|true

```


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17570)
<!-- Reviewable:end -->
