### PR TITLE
fix: The update in MERGE INTO was mistakenly optimized as a delete

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -47,6 +47,7 @@ use crate::optimizer::RuleID;
 use crate::optimizer::SExpr;
 use crate::optimizer::DEFAULT_REWRITE_RULES;
 use crate::planner::query_executor::QueryExecutor;
+use crate::plans::ConstantTableScan;
 use crate::plans::CopyIntoLocationPlan;
 use crate::plans::Join;
 use crate::plans::JoinType;
@@ -555,28 +556,36 @@ async fn optimize_mutation(mut opt_ctx: OptimizerContext, s_expr: SExpr) -> Resu
     // the condition is false and the match branch can never be executed.
     // Therefore, the match evaluators can be reset.
     let inner_rel_op = input_s_expr.plan.rel_op();
-    // if !mutation.matched_evaluators.is_empty() {
-    //     match inner_rel_op {
-    //         RelOp::ConstantTableScan => {
-    //             mutation.no_effect = true;
-    //         }
-    //         RelOp::Join => {
-    //             let right_child = input_s_expr.child(1)?;
-    //             let mut right_child_rel = right_child.plan.rel_op();
-    //             if right_child_rel == RelOp::Exchange {
-    //                 right_child_rel = right_child.child(0)?.plan.rel_op();
-    //             }
-    //             if right_child_rel == RelOp::ConstantTableScan {
-    //                 mutation.matched_evaluators = vec![MatchedEvaluator {
-    //                     condition: None,
-    //                     update: None,
-    //                 }];
-    //                 mutation.can_try_update_column_only = false;
-    //             }
-    //         }
-    //         _ => (),
-    //     }
-    // }
+    if !mutation.matched_evaluators.is_empty() {
+        match inner_rel_op {
+            RelOp::ConstantTableScan => {
+                let constant_table_scan = ConstantTableScan::try_from(input_s_expr.plan().clone())?;
+                if constant_table_scan.num_rows == 0 {
+                    mutation.no_effect = true;
+                }
+            }
+            RelOp::Join => {
+                let mut right_child = input_s_expr.child(1)?;
+                let mut right_child_rel = right_child.plan.rel_op();
+                if right_child_rel == RelOp::Exchange {
+                    right_child_rel = right_child.child(0)?.plan.rel_op();
+                    right_child = right_child.child(0)?;
+                }
+                if right_child_rel == RelOp::ConstantTableScan {
+                    let constant_table_scan =
+                        ConstantTableScan::try_from(right_child.plan().clone())?;
+                    if constant_table_scan.num_rows == 0 {
+                        mutation.matched_evaluators = vec![MatchedEvaluator {
+                            condition: None,
+                            update: None,
+                        }];
+                        mutation.can_try_update_column_only = false;
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
 
     input_s_expr = match mutation.mutation_type {
         MutationType::Merge => {

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -555,28 +555,28 @@ async fn optimize_mutation(mut opt_ctx: OptimizerContext, s_expr: SExpr) -> Resu
     // the condition is false and the match branch can never be executed.
     // Therefore, the match evaluators can be reset.
     let inner_rel_op = input_s_expr.plan.rel_op();
-    if !mutation.matched_evaluators.is_empty() {
-        match inner_rel_op {
-            RelOp::ConstantTableScan => {
-                mutation.no_effect = true;
-            }
-            RelOp::Join => {
-                let right_child = input_s_expr.child(1)?;
-                let mut right_child_rel = right_child.plan.rel_op();
-                if right_child_rel == RelOp::Exchange {
-                    right_child_rel = right_child.child(0)?.plan.rel_op();
-                }
-                if right_child_rel == RelOp::ConstantTableScan {
-                    mutation.matched_evaluators = vec![MatchedEvaluator {
-                        condition: None,
-                        update: None,
-                    }];
-                    mutation.can_try_update_column_only = false;
-                }
-            }
-            _ => (),
-        }
-    }
+    // if !mutation.matched_evaluators.is_empty() {
+    //     match inner_rel_op {
+    //         RelOp::ConstantTableScan => {
+    //             mutation.no_effect = true;
+    //         }
+    //         RelOp::Join => {
+    //             let right_child = input_s_expr.child(1)?;
+    //             let mut right_child_rel = right_child.plan.rel_op();
+    //             if right_child_rel == RelOp::Exchange {
+    //                 right_child_rel = right_child.child(0)?.plan.rel_op();
+    //             }
+    //             if right_child_rel == RelOp::ConstantTableScan {
+    //                 mutation.matched_evaluators = vec![MatchedEvaluator {
+    //                     condition: None,
+    //                     update: None,
+    //                 }];
+    //                 mutation.can_try_update_column_only = false;
+    //             }
+    //         }
+    //         _ => (),
+    //     }
+    // }
 
     input_s_expr = match mutation.mutation_type {
         MutationType::Merge => {

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0045_merge_into_issue_16581.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0045_merge_into_issue_16581.test
@@ -1,0 +1,18 @@
+statement ok
+create or replace table test_merge(col1 varchar,col2 varchar,col3 varchar);
+
+statement ok
+insert into test_merge values(2,'abc',2),(3,'abc',3),(4,'abc',4);
+
+query II
+merge into test_merge as tba using (select * from (values('1','add','11'),('4','add','44'))) as tbb("col1","col2","col3") on tba.col1=tbb.col1 WHEN MATCHED THEN update set tba.col1=tbb.col1 ,tba.col2='update',tba.col3=tbb.col3;
+----
+1
+
+query ITI
+select * from test_merge;
+----
+2 abc 2
+3 abc 3
+4 update 44
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

A query like `SELECT * FROM (VALUES ('1', 'add', '11'))` will be optimized into a ConstantTableScan, which may further lead to the UPDATE being optimized into a DELETE by the optimizer.

This PR makes the optimization rule more precise, only rewriting merge into with an empty ConstantScan to delete.
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17571)
<!-- Reviewable:end -->
