### PR TITLE
feat: auto vacuum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-users",
  "databend-enterprise-fail-safe",
+ "databend-enterprise-vacuum-handler",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -4824,7 +4825,6 @@ dependencies = [
  "databend-common-base",
  "databend-common-catalog",
  "databend-common-exception",
- "databend-common-storages-fuse",
 ]
 
 [[package]]

--- a/src/common/io/src/constants.rs
+++ b/src/common/io/src/constants.rs
@@ -36,4 +36,4 @@ pub const DEFAULT_BLOCK_MIN_ROWS: usize = 800 * 1000;
 pub const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;
 
 // The min values of table option data_retention_period_in_hours
-pub const DEFAULT_MIN_TABLE_LEVEL_DATA_RETENTION_PERIOD_IN_HOURS: u64 = 1;
+pub const DEFAULT_MIN_TABLE_LEVEL_DATA_RETENTION_PERIOD_IN_HOURS: u64 = 0;

--- a/src/query/ee/src/storages/fuse/operations/handler.rs
+++ b/src/query/ee/src/storages/fuse/operations/handler.rs
@@ -21,7 +21,6 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::AbortChecker;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_storages_fuse::FuseTable;
 use databend_enterprise_vacuum_handler::vacuum_handler::VacuumDropTablesResult;
 use databend_enterprise_vacuum_handler::vacuum_handler::VacuumTempOptions;
 use databend_enterprise_vacuum_handler::VacuumHandler;
@@ -37,21 +36,21 @@ pub struct RealVacuumHandler {}
 impl VacuumHandler for RealVacuumHandler {
     async fn do_vacuum(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         retention_time: DateTime<Utc>,
         dry_run: bool,
     ) -> Result<Option<Vec<String>>> {
-        do_vacuum(fuse_table, ctx, retention_time, dry_run).await
+        do_vacuum(table, ctx, retention_time, dry_run).await
     }
 
     async fn do_vacuum2(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         respect_flash_back: bool,
     ) -> Result<Vec<String>> {
-        do_vacuum2(fuse_table, ctx, respect_flash_back).await
+        do_vacuum2(table, ctx, respect_flash_back).await
     }
 
     async fn do_vacuum_drop_tables(

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table.rs
@@ -356,11 +356,12 @@ pub async fn do_dry_run_orphan_files(
 
 #[async_backtrace::framed]
 pub async fn do_vacuum(
-    fuse_table: &FuseTable,
+    table: &dyn Table,
     ctx: Arc<dyn TableContext>,
     retention_time: DateTime<Utc>,
     dry_run: bool,
 ) -> Result<Option<Vec<String>>> {
+    let fuse_table = FuseTable::try_from_table(table)?;
     let start = Instant::now();
     // First, do purge
     let instant = Some(NavigationPoint::TimePoint(retention_time));

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -82,10 +82,11 @@ use uuid::Version;
 const ASSUMPTION_MAX_TXN_DURATION: Duration = Duration::days(3);
 #[async_backtrace::framed]
 pub async fn do_vacuum2(
-    fuse_table: &FuseTable,
+    table: &dyn Table,
     ctx: Arc<dyn TableContext>,
     respect_flash_back: bool,
 ) -> Result<Vec<String>> {
+    let fuse_table = FuseTable::try_from_table(table)?;
     let start = std::time::Instant::now();
     let retention_period_in_days = ctx.get_settings().get_data_retention_time_in_days()?;
     let is_vacuum_all = retention_period_in_days == 0;

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -88,7 +88,13 @@ pub async fn do_vacuum2(
 ) -> Result<Vec<String>> {
     let fuse_table = FuseTable::try_from_table(table)?;
     let start = std::time::Instant::now();
-    let retention_period_in_days = ctx.get_settings().get_data_retention_time_in_days()?;
+
+    let retention_period_in_days = if fuse_table.is_transient() {
+        0
+    } else {
+        ctx.get_settings().get_data_retention_time_in_days()?
+    };
+
     let is_vacuum_all = retention_period_in_days == 0;
 
     let Some(lvt) = set_lvt(fuse_table, ctx.as_ref(), retention_period_in_days).await? else {

--- a/src/query/ee_features/vacuum_handler/Cargo.toml
+++ b/src/query/ee_features/vacuum_handler/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-catalog = { workspace = true }
 databend-common-exception = { workspace = true }
-databend-common-storages-fuse = { workspace = true }
 
 [build-dependencies]
 

--- a/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
+++ b/src/query/ee_features/vacuum_handler/src/vacuum_handler.rs
@@ -23,7 +23,6 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::AbortChecker;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_storages_fuse::FuseTable;
 // (TableName, file, file size)
 pub type VacuumDropFileInfo = (String, String, u64);
 
@@ -34,7 +33,7 @@ pub type VacuumDropTablesResult = Result<(Option<Vec<VacuumDropFileInfo>>, HashS
 pub trait VacuumHandler: Sync + Send {
     async fn do_vacuum(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         retention_time: DateTime<Utc>,
         dry_run: bool,
@@ -42,7 +41,7 @@ pub trait VacuumHandler: Sync + Send {
 
     async fn do_vacuum2(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         respect_flash_back: bool,
     ) -> Result<Vec<String>>;
@@ -82,25 +81,25 @@ impl VacuumHandlerWrapper {
     #[async_backtrace::framed]
     pub async fn do_vacuum(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         retention_time: DateTime<Utc>,
         dry_run: bool,
     ) -> Result<Option<Vec<String>>> {
         self.handler
-            .do_vacuum(fuse_table, ctx, retention_time, dry_run)
+            .do_vacuum(table, ctx, retention_time, dry_run)
             .await
     }
 
     #[async_backtrace::framed]
     pub async fn do_vacuum2(
         &self,
-        fuse_table: &FuseTable,
+        table: &dyn Table,
         ctx: Arc<dyn TableContext>,
         respect_flash_back: bool,
     ) -> Result<Vec<String>> {
         self.handler
-            .do_vacuum2(fuse_table, ctx, respect_flash_back)
+            .do_vacuum2(table, ctx, respect_flash_back)
             .await
     }
 

--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -21,7 +21,6 @@ use databend_common_ast::ast::Engine;
 use databend_common_exception::ErrorCode;
 use databend_common_expression::TableSchemaRef;
 use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
-use databend_common_io::constants::DEFAULT_MIN_TABLE_LEVEL_DATA_RETENTION_PERIOD_IN_HOURS;
 use databend_common_settings::Settings;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
@@ -165,16 +164,9 @@ pub fn is_valid_data_retention_period(
     if let Some(value) = options.get(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS) {
         let new_duration_in_hours = value.parse::<u64>()?;
 
-        if new_duration_in_hours < DEFAULT_MIN_TABLE_LEVEL_DATA_RETENTION_PERIOD_IN_HOURS {
-            return Err(ErrorCode::TableOptionInvalid(format!(
-                "Invalid data_retention_period_in_hours {:?}, it should not be lesser than {:?}",
-                new_duration_in_hours, DEFAULT_MIN_TABLE_LEVEL_DATA_RETENTION_PERIOD_IN_HOURS
-            )));
-        }
-
         let default_max_period_in_days = Settings::get_max_data_retention_period_in_days();
-
         let default_max_duration = Duration::days(default_max_period_in_days as i64);
+
         let new_duration = Duration::hours(new_duration_in_hours as i64);
 
         if new_duration > default_max_duration {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -1493,19 +1493,23 @@ impl TableContext for QueryContext {
             Some(ts) => Ok(ts),
             None => {
                 let delta = {
-                    let settings = &self.query_settings;
-                    let max_exec_time_secs = settings.get_max_execute_time_in_seconds()?;
-                    let duration = if max_exec_time_secs != 0 {
-                        Duration::from_secs(max_exec_time_secs)
+                    let fuse_table = FuseTable::try_from_table(table)?;
+                    let duration = if fuse_table.is_transient() {
+                        Duration::from_secs(0)
                     } else {
-                        // no limit, use retention period as delta
-                        let fuse_table = FuseTable::try_from_table(table)?;
-                        // prefer table-level retention setting.
-                        match fuse_table.get_table_retention_period() {
-                            None => {
-                                Duration::from_days(settings.get_data_retention_time_in_days()?)
+                        let settings = &self.query_settings;
+                        let max_exec_time_secs = settings.get_max_execute_time_in_seconds()?;
+                        if max_exec_time_secs != 0 {
+                            Duration::from_secs(max_exec_time_secs)
+                        } else {
+                            // no limit, use retention period as delta
+                            // prefer table-level retention setting.
+                            match fuse_table.get_table_retention_period() {
+                                None => {
+                                    Duration::from_days(settings.get_data_retention_time_in_days()?)
+                                }
+                                Some(v) => v,
                             }
-                            Some(v) => v,
                         }
                     };
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1228,6 +1228,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("use_vacuum2_to_purge_transient_table_data", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Experimental flag which indicates if use vacuum2 to purge transient table data",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
             ]);
 
             Ok(Arc::new(DefaultSettings {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1221,6 +1221,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_auto_vacuum", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Whether to automatically trigger VACUUM operations on tables (using vacuum2)",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
             ]);
 
             Ok(Arc::new(DefaultSettings {

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -912,4 +912,8 @@ impl Settings {
     pub fn get_force_aggregate_data_spill(&self) -> Result<bool> {
         Ok(self.try_get_u64("force_aggregate_data_spill")? == 1)
     }
+
+    pub fn get_enable_auto_vacuum(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_auto_vacuum")? == 1)
+    }
 }

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -916,4 +916,8 @@ impl Settings {
     pub fn get_enable_auto_vacuum(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_auto_vacuum")? == 1)
     }
+
+    pub fn get_enable_use_vacuum2_to_purge_transient_table_data(&self) -> Result<bool> {
+        Ok(self.try_get_u64("use_vacuum2_to_purge_transient_table_data")? == 1)
+    }
 }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -32,6 +32,7 @@ databend-common-sql = { workspace = true }
 databend-common-storage = { workspace = true }
 databend-common-users = { workspace = true }
 databend-enterprise-fail-safe = { workspace = true }
+databend-enterprise-vacuum-handler = { workspace = true }
 databend-storages-common-blocks = { workspace = true }
 databend-storages-common-cache = { workspace = true }
 databend-storages-common-index = { workspace = true }

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -117,7 +117,9 @@ where F: SnapshotGenerator + Send + 'static
         deduplicated_label: Option<String>,
         table_meta_timestamps: TableMetaTimestamps,
     ) -> Result<ProcessorPtr> {
-        let purge = Self::need_purge(table, &snapshot_gen);
+        let purge = Self::need_purge(table, &snapshot_gen)
+            || ctx.get_settings().get_enable_auto_vacuum()?;
+
         Ok(ProcessorPtr::create(Box::new(CommitSink {
             state: State::None,
             ctx,

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -115,7 +115,7 @@ where F: SnapshotGenerator + Send + 'static
         deduplicated_label: Option<String>,
         table_meta_timestamps: TableMetaTimestamps,
     ) -> Result<ProcessorPtr> {
-        let purge = Self::do_purge(table, &snapshot_gen);
+        let purge = Self::need_purge(table, &snapshot_gen);
         Ok(ProcessorPtr::create(Box::new(CommitSink {
             state: State::None,
             ctx,
@@ -187,7 +187,7 @@ where F: SnapshotGenerator + Send + 'static
         Ok(Event::Async)
     }
 
-    fn do_purge(table: &FuseTable, snapshot_gen: &F) -> bool {
+    fn need_purge(table: &FuseTable, snapshot_gen: &F) -> bool {
         if table.is_transient() {
             return true;
         }

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
@@ -601,11 +601,6 @@ alter table t_opt_retention  set options(data_retention_period_in_hours = 'abc')
 statement error 1301
 alter table t_opt_retention  set options(data_retention_period_in_hours = 3000);
 
-# invalid value (lesser than default min: 1 hour )
-statement error 1301
-alter table t_opt_retention  set options(data_retention_period_in_hours = 0);
-
-
 statement ok
 alter table t_opt_retention  set options(data_retention_period_in_hours = 2);
 

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0003_vacuum2.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0003_vacuum2.test
@@ -80,6 +80,7 @@ select count() from list_stage(location=> '@stage_v') where name like '%_ss%';
 4
 
 # vacuum historical data
+# `call system$fuse_vacuum2(...)` also works, but we need to ignore the result
 statement ok
 select * from fuse_vacuum2('vacuum2', 't') ignore_result;
 

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
@@ -44,18 +44,21 @@ statement ok
 create or replace stage stage_av url = 'fs:///tmp/auto_vacuum/';
 
 # expect there are 3 segments/blocks/snapshots
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
 ----
 3
 
 # expect 3 block
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
 ----
 3
 
 # expect 1 snapshot, since historical snapshots are removed immediately
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 ----
@@ -69,21 +72,25 @@ optimize table t compact;
 
 # expects that historical data will be vacuumed immediately
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
 ----
 1
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
 ----
 1
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 ----
 1
 
+onlyif http
 query I
 select c from t order by c;
 ----
@@ -120,16 +127,19 @@ insert into t values(3);
 statement ok
 optimize table t compact;
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
 ----
 1
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
 ----
 1
 
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 ----

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
@@ -1,0 +1,150 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+create or replace database auto_vacuum;
+
+statement ok
+use auto_vacuum;
+
+# If set retention period to zero, and enabled auto vacuum, historical table data will
+# be cleaned immediately.
+
+statement ok
+set data_retention_time_in_days = 0;
+
+statement ok
+set enable_auto_vacuum = 1;
+
+statement ok
+create or replace table t (c int) 'fs:///tmp/auto_vacuum/';
+
+# prepare data
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(2);
+
+statement ok
+insert into t values(3);
+
+statement ok
+create or replace stage stage_av url = 'fs:///tmp/auto_vacuum/';
+
+# expect there are 3 segments/blocks/snapshots
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
+----
+3
+
+# expect 3 block
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
+----
+3
+
+# expect 1 snapshot, since historical snapshots are removed immediately
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
+----
+1
+
+# compact previously inserted data:
+# - 3 blocks will be compacted into 1 block
+# - 3 segments will be compacted into 1 segment
+statement ok
+optimize table t compact;
+
+# expects that historical data will be vacuumed immediately
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
+----
+1
+
+query I
+select c from t order by c;
+----
+1
+2
+3
+
+statement ok
+drop table t;
+
+# ---------------------------------------------
+
+
+# Check that table retention period option has a higher priority
+
+statement ok
+set data_retention_time_in_days = 1;
+
+statement ok
+create or replace table t (c int) 'fs:///tmp/auto_vacuum_case2/';
+
+statement ok
+alter table t set options(data_retention_period_in_hours = 0);
+
+statement ok
+create or replace stage stage_av url = 'fs:///tmp/auto_vacuum_case2/';
+
+statement ok
+insert into t values(1);
+statement ok
+insert into t values(2);
+statement ok
+insert into t values(3);
+statement ok
+optimize table t compact;
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
+----
+1
+
+# ---------------------------------------------
+
+# We do not check default retention period works as expected, i.e. by default table historical data
+# will be cleaned according to the retention period settings. As tests of streams will check it implicitly
+
+
+
+statement ok
+remove @stage_av;
+
+statement ok
+drop stage stage_av;
+

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0005_vacuum_transient.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0005_vacuum_transient.test
@@ -1,0 +1,94 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+create or replace database vaccum_transient;
+
+statement ok
+use vaccum_transient;
+
+statement ok
+set use_vacuum2_to_purge_transient_table_data = 1;
+
+statement ok
+create or replace transient table t (c int) 'fs:///tmp/vaccum_transient/';
+
+# prepare data
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(2);
+
+statement ok
+insert into t values(3);
+
+statement ok
+create or replace stage stage_vacuum_transient url = 'fs:///tmp/vaccum_transient/';
+
+# expect there are 3 segments/blocks/snapshots
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%_sg%';
+----
+3
+
+# expect 3 block
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%\/_b\/%';
+----
+3
+
+# expect 1 snapshot, since historical snapshots are removed immediately
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%_ss%';
+----
+1
+
+# compact previously inserted data:
+# - 3 blocks will be compacted into 1 block
+# - 3 segments will be compacted into 1 segment
+statement ok
+optimize table t compact;
+
+# expects that historical data will be vacuumed immediately
+
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%_sg%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%\/_b\/%';
+----
+1
+
+query I
+select count() from list_stage(location=> '@stage_vacuum_transient') where name like '%_ss%';
+----
+1
+
+query I
+select c from t order by c;
+----
+1
+2
+3
+
+
+statement ok
+remove @stage_vacuum_transient;
+
+statement ok
+drop stage stage_vacuum_transient;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### 1. New Setting: `enable_auto_vacuum`
- **Purpose**: When enabled, automatically vacuums historical table objects (metadata and data) based on retention period settings immediately after a new table version is committed.
- **Behavior**: Operates on a best-effort basis—vacuum errors, if any, are ignored.
- **Default**: Disabled.
- **Example**:
  ```sql
  SET enable_auto_vacuum = 1;

  -- After this insert commits, historical data in table 't' is vacuumed per retention settings.
  INSERT INTO t VALUES (...);

Notes:
- Only functional in auto-commit mode. Support for explicit transactions will be added later.
- Retention period considerations:
Small retention periods are safe but may impact dependent features
   - Streams relying on historical versions could malfunction with aggressive settings (e.g., 0).
   - Early vacuuming of table objects may cause failures in highly concurrent transactions (though data integrity remains intact).

### 2. New Setting: `use_vacuum2_to_purge_transient_table_data`
- **Purpose**: When enabled, uses `vacuum2` to clean historical data of transient tables.
- **Default**: Disabled.

Notes:
 This setting may impact the `purge` phase of `DROP TABLE ALL`, if enabled, it cleans up table objects based on retention settings (or table options) instead of just deleting everything.
Since the `ALL` option of `DROP TABLE` statement isn’t officially supported and will be dropped eventually, this difference isn’t a big deal.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17579)
<!-- Reviewable:end -->
