### PR TITLE
chore(storage): add block file size

### DIFF
--- a/src/common/io/src/constants.rs
+++ b/src/common/io/src/constants.rs
@@ -26,12 +26,16 @@ pub const INF_BYTES_LONG: &str = "Infinity";
 
 // The size of the I/O read/write block buffer by default.
 pub const DEFAULT_BLOCK_BUFFER_SIZE: usize = 100 * 1024 * 1024;
+// The size of the block compressed by default.
+pub const DEFAULT_BLOCK_COMPRESSED_SIZE: usize = 10 * 1024 * 1024;
 // The size of the I/O read/write block index buffer by default.
 pub const DEFAULT_BLOCK_INDEX_BUFFER_SIZE: usize = 300 * 1024;
 // The max number of a block by default.
 pub const DEFAULT_BLOCK_MAX_ROWS: usize = 1000 * 1000;
 // The min number of a block by default.
 pub const DEFAULT_BLOCK_MIN_ROWS: usize = 800 * 1000;
+// The number of blocks in a segment by default.
+pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 /// The number of bytes read at the end of the file on first read
 pub const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;
 

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -342,6 +342,7 @@ pub struct ReclusterTask {
     pub stats: PartStatistics,
     pub total_rows: usize,
     pub total_bytes: usize,
+    pub total_compressed: usize,
     pub level: i32,
 }
 

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -29,8 +29,10 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchema;
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
+use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
 use databend_common_io::constants::DEFAULT_BLOCK_MIN_ROWS;
+use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::UnknownTableId;
 use databend_common_meta_app::schema::TableIdent;
@@ -384,6 +386,8 @@ pub trait Table: Sync + Send {
             max_rows_per_block: DEFAULT_BLOCK_MAX_ROWS,
             min_rows_per_block: DEFAULT_BLOCK_MIN_ROWS,
             max_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE,
+            max_bytes_per_file: DEFAULT_BLOCK_COMPRESSED_SIZE,
+            block_per_segment: DEFAULT_BLOCK_PER_SEGMENT,
         }
     }
 

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -93,8 +93,10 @@ impl BlockThresholds {
     }
 
     #[inline]
-    pub fn check_too_small(&self, row_count: usize, block_size: usize) -> bool {
-        row_count < self.min_rows_per_block / 2 && block_size < self.max_bytes_per_block / 2
+    pub fn check_too_small(&self, row_count: usize, block_size: usize, file_size: usize) -> bool {
+        row_count < self.min_rows_per_block / 2
+            && block_size < self.max_bytes_per_block / 2
+            && file_size <= self.max_bytes_per_file / 2
     }
 
     #[inline]

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
@@ -99,7 +99,7 @@ impl AccumulatingTransform for BlockCompactBuilder {
             // holding slices of blocks to merge later may lead to oom, so
             // 1. we expect blocks from file formats are not slice.
             // 2. if block is split here, cut evenly and emit them at once.
-            let rows_per_block = self.thresholds.calc_rows_per_block(num_bytes, num_rows);
+            let rows_per_block = self.thresholds.calc_rows_per_block(num_bytes, num_rows, 0);
             Ok(vec![DataBlock::empty_with_meta(Box::new(
                 BlockCompactMeta::Split {
                     block: data,

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
@@ -98,7 +98,7 @@ impl AccumulatingTransform for BlockCompactNoSplitBuilder {
             // N <= blocks < 2N
             std::mem::swap(&mut self.staged_blocks, &mut self.pending_blocks);
         } else {
-            // blocks > 2N
+            // blocks >= 2N
             res.push(Self::create_output_data(&mut self.pending_blocks));
         }
         self.staged_blocks.push(data);

--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -27,6 +27,7 @@ use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use databend_common_storages_fuse::FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS;
+use databend_common_storages_fuse::FUSE_OPT_KEY_FILE_SIZE;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ROW_PER_BLOCK;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ROW_PER_PAGE;
@@ -56,6 +57,7 @@ pub static CREATE_FUSE_OPTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(
     r.insert(FUSE_OPT_KEY_BLOCK_PER_SEGMENT);
     r.insert(FUSE_OPT_KEY_ROW_PER_BLOCK);
     r.insert(FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD);
+    r.insert(FUSE_OPT_KEY_FILE_SIZE);
     r.insert(FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
 
@@ -110,6 +112,7 @@ pub static UNSET_TABLE_OPTIONS_WHITE_LIST: LazyLock<HashSet<&'static str>> = Laz
     r.insert(FUSE_OPT_KEY_ROW_PER_BLOCK);
     r.insert(FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD);
     r.insert(FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD);
+    r.insert(FUSE_OPT_KEY_FILE_SIZE);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
     r.insert(OPT_KEY_ENABLE_COPY_DEDUP_FULL_PATH);
     r

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -151,8 +151,11 @@ impl PipelineBuilder {
                     .collect();
 
                 // merge sort
-                let sort_block_size =
-                    block_thresholds.calc_rows_per_block(task.total_bytes, task.total_rows);
+                let sort_block_size = block_thresholds.calc_rows_per_block(
+                    task.total_bytes,
+                    task.total_rows,
+                    task.total_compressed,
+                );
 
                 let sort_pipeline_builder =
                     SortPipelineBuilder::create(self.ctx.clone(), schema, Arc::new(sort_descs))?

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -177,6 +177,8 @@ async fn test_safety() -> Result<()> {
         max_rows_per_block: 5,
         min_rows_per_block: 4,
         max_bytes_per_block: 1024,
+        max_bytes_per_file: 100,
+        block_per_segment: 5,
     };
 
     let schema = TestFixture::default_table_schema();
@@ -217,7 +219,6 @@ async fn test_safety() -> Result<()> {
             rows_per_blocks,
             threshold,
             cluster_key_id,
-            5,
             false,
         )
         .await?;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -154,7 +154,6 @@ async fn test_recluster_mutator_block_select() -> Result<()> {
         BlockThresholds::default(),
         cluster_key_id,
         1,
-        1000,
         column_ids,
     );
     let (_, parts) = mutator
@@ -183,11 +182,12 @@ async fn test_safety_for_recluster() -> Result<()> {
         .set_recluster_block_size(recluster_block_size as u64)?;
 
     let cluster_key_id = 0;
-    let block_per_seg = 5;
     let threshold = BlockThresholds {
         max_rows_per_block: 5,
         min_rows_per_block: 4,
         max_bytes_per_block: 1024,
+        max_bytes_per_file: 100,
+        block_per_segment: 5,
     };
 
     let data_accessor = operator.clone();
@@ -235,7 +235,6 @@ async fn test_safety_for_recluster() -> Result<()> {
             rows_per_blocks,
             threshold,
             Some(cluster_key_id),
-            block_per_seg,
             unclustered,
         )
         .await?;
@@ -286,7 +285,6 @@ async fn test_safety_for_recluster() -> Result<()> {
             threshold,
             cluster_key_id,
             max_tasks,
-            block_per_seg,
             column_ids,
         ));
         let (mode, selected_segs) = mutator.select_segments(&compact_segments, 8)?;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -192,7 +192,7 @@ async fn test_compact_segment_unresolvable_conflict() -> Result<()> {
         compact_segment(ctx.clone(), &table).await?;
     }
 
-    // the compact operation committed latter should failed
+    // the compact operation committed latter should be failed.
     let r = mutator.try_commit(table.clone()).await;
     assert!(r.is_err());
     assert_eq!(r.err().unwrap().code(), ErrorCode::UNRESOLVABLE_CONFLICT);
@@ -279,10 +279,21 @@ async fn build_mutator(
 async fn test_segment_compactor() -> Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
+    let threshold_10 = BlockThresholds {
+        block_per_segment: 10,
+        ..Default::default()
+    };
+    let threshold_3 = BlockThresholds {
+        block_per_segment: 3,
+        ..Default::default()
+    };
+    let threshold_5 = BlockThresholds {
+        block_per_segment: 5,
+        ..Default::default()
+    };
 
     {
         let case_name = "highly fragmented segments";
-        let threshold = 10;
         let case = CompactCase {
             // 3 fragmented segments
             // - each of them have number blocks lesser than `threshold`
@@ -303,12 +314,11 @@ async fn test_segment_compactor() -> Result<()> {
         //   - blocks and the order of them are not changed
         //   - statistics are as expected
         //   - the output segments could not be compacted further
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         let case_name = "greedy compact, but not too greedy(1), right assoc";
-        let threshold = 10;
         let case = CompactCase {
             // - 4 segments
             blocks_number_of_input_segments: vec![1, 8, 2, 8],
@@ -327,12 +337,11 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
         // run & verify
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         let case_name = "greedy compact, but not too greedy (2), right-assoc";
-        let threshold = 10;
         let case = CompactCase {
             // 4 segments
             blocks_number_of_input_segments: vec![5, 2, 3, 6],
@@ -353,14 +362,13 @@ async fn test_segment_compactor() -> Result<()> {
         };
 
         // run & verify
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         // case: fragmented segments, with barrier
 
         let case_name = "barrier(1), right-assoc";
-        let threshold = 10;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![5, 6, 11, 2, 10],
@@ -372,68 +380,64 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         // case: fragmented segments, with barrier
 
         let case_name = "barrier(2)";
-        let threshold = 10;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![10, 10, 1, 2, 10],
             // these segments should be compacted into
             // (10), (10), (1 + 2 + 10)
             expected_number_of_output_segments: 3,
-            expected_block_number_of_new_segments: vec![(1 + 2 + 10)],
+            expected_block_number_of_new_segments: vec![1 + 2 + 10],
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         // case: fragmented segments, with barrier
 
         let case_name = "barrier(3)";
-        let threshold = 10;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![1, 19, 5, 6],
             // these segments should be compacted into
             // (1), (19), (5, 6)
             expected_number_of_output_segments: 3,
-            expected_block_number_of_new_segments: vec![(5 + 6)],
+            expected_block_number_of_new_segments: vec![5 + 6],
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         // edge case: empty segments should be dropped
 
         let case_name = "empty segments should be dropped";
-        let threshold = 10;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![0, 1, 0, 19, 0, 5, 0, 6, 0],
             // these segments should be compacted into
             // (1), (19), (5, 6)
             expected_number_of_output_segments: 3,
-            expected_block_number_of_new_segments: vec![(5 + 6)],
+            expected_block_number_of_new_segments: vec![5 + 6],
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         // edge case: single jumbo block
 
         let case_name = "single jumbo block";
-        let threshold = 3;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![10],
@@ -442,12 +446,11 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_3, None).await?;
     }
 
     {
         let case_name = "jumbo block with single fragment";
-        let threshold = 3;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![7, 2],
@@ -458,12 +461,11 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_3, None).await?;
     }
 
     {
         let case_name = "right assoc";
-        let threshold = 10;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![8, 5, 7],
@@ -475,12 +477,11 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, None).await?;
+        case.run_and_verify(&ctx, threshold_10, None).await?;
     }
 
     {
         let case_name = "limit (normal case)";
-        let threshold = 5;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![1, 2, 3, 2, 3],
@@ -489,12 +490,11 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, Some(2)).await?;
+        case.run_and_verify(&ctx, threshold_5, Some(2)).await?;
     }
 
     {
         let case_name = "limit (auto adjust limit)";
-        let threshold = 5;
         let case = CompactCase {
             // input segments
             blocks_number_of_input_segments: vec![1, 2, 3, 2, 3],
@@ -503,15 +503,14 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        // if limit is specified as 1, it will be adjust to 2 during execution
+        // if limit is specified as 1, it will be adjusted to 2 during execution
         // since at least two fragmented segments are needed for compaction
         let limit = Some(1);
-        case.run_and_verify(&ctx, threshold, limit).await?;
+        case.run_and_verify(&ctx, threshold_5, limit).await?;
     }
 
     {
         let case_name = "limit (abundant limit)";
-        let threshold = 5;
         let limit = Some(5);
         let case = CompactCase {
             // input segments
@@ -521,7 +520,7 @@ async fn test_segment_compactor() -> Result<()> {
             case_name,
         };
 
-        case.run_and_verify(&ctx, threshold, limit).await?;
+        case.run_and_verify(&ctx, threshold_5, limit).await?;
     }
 
     {
@@ -620,7 +619,7 @@ async fn test_segment_compactor() -> Result<()> {
                 case_name,
             };
 
-            case.run_and_verify(&ctx, threshold as u64, None).await?;
+            case.run_and_verify(&ctx, threshold_3, None).await?;
         }
     }
 
@@ -628,7 +627,7 @@ async fn test_segment_compactor() -> Result<()> {
 }
 
 pub struct CompactSegmentTestFixture {
-    threshold: u64,
+    threshold: BlockThresholds,
     ctx: Arc<dyn TableContext>,
     data_accessor: DataOperator,
     location_gen: TableMetaLocationGenerator,
@@ -637,12 +636,12 @@ pub struct CompactSegmentTestFixture {
 }
 
 impl CompactSegmentTestFixture {
-    fn try_new(ctx: &Arc<QueryContext>, block_per_seg: u64) -> Result<Self> {
+    fn try_new(ctx: &Arc<QueryContext>, threshold: BlockThresholds) -> Result<Self> {
         let location_gen = TableMetaLocationGenerator::new("test/".to_owned());
         let data_accessor = ctx.get_application_level_data_operator()?;
         Ok(Self {
             ctx: ctx.clone(),
-            threshold: block_per_seg,
+            threshold,
             data_accessor,
             location_gen,
             input_blocks: vec![],
@@ -655,18 +654,17 @@ impl CompactSegmentTestFixture {
         limit: Option<usize>,
         cluster_key_id: Option<u32>,
     ) -> Result<(SegmentCompactionState, Statistics)> {
-        let block_per_seg = self.threshold;
         let data_accessor = &self.data_accessor.operator();
         let location_gen = &self.location_gen;
 
         let schema = TestFixture::default_table_schema();
         let fuse_segment_io = SegmentsIO::create(self.ctx.clone(), data_accessor.clone(), schema);
-        let max_theads = self.ctx.get_settings().get_max_threads()? as usize;
+        let max_threads = self.ctx.get_settings().get_max_threads()? as usize;
 
         let seg_acc = SegmentCompactor::new(
-            block_per_seg,
+            self.threshold.block_per_segment as u64,
             cluster_key_id,
-            max_theads,
+            max_threads,
             &fuse_segment_io,
             data_accessor,
             location_gen,
@@ -677,9 +675,8 @@ impl CompactSegmentTestFixture {
             self.ctx.clone(),
             num_block_of_segments.to_owned(),
             rows_per_block,
-            BlockThresholds::default(),
+            self.threshold,
             cluster_key_id,
-            block_per_seg as usize,
             false,
         )
         .await?;
@@ -703,7 +700,6 @@ impl CompactSegmentTestFixture {
         rows_per_blocks: Vec<usize>,
         thresholds: BlockThresholds,
         cluster_key_id: Option<u32>,
-        block_per_seg: usize,
         unclustered: bool,
     ) -> Result<(Vec<Location>, Vec<BlockMeta>, Vec<SegmentInfo>)> {
         let location_gen = TableMetaLocationGenerator::new("test/".to_owned());
@@ -738,7 +734,9 @@ impl CompactSegmentTestFixture {
                             let right =
                                 vec![unsafe { val.value.index_unchecked(val.value.len() - 1) }
                                     .to_owned()];
-                            let level = if left.eq(&right) && block.num_rows() >= block_per_seg {
+                            let level = if left.eq(&right)
+                                && block.num_rows() >= thresholds.block_per_segment
+                            {
                                 -1
                             } else {
                                 0
@@ -850,7 +848,7 @@ impl CompactCase {
     async fn run_and_verify(
         &self,
         ctx: &Arc<QueryContext>,
-        block_per_segment: u64,
+        threshold: BlockThresholds,
         limit: Option<usize>,
     ) -> Result<()> {
         // setup & run
@@ -858,7 +856,7 @@ impl CompactCase {
             ctx.get_application_level_data_operator()?.operator(),
             TestFixture::default_table_schema(),
         );
-        let mut case_fixture = CompactSegmentTestFixture::try_new(ctx, block_per_segment)?;
+        let mut case_fixture = CompactSegmentTestFixture::try_new(ctx, threshold)?;
         let (r, summary) = case_fixture
             .run(&self.blocks_number_of_input_segments, limit, None)
             .await?;
@@ -933,7 +931,7 @@ impl CompactCase {
 
         // 6. the output segments can not be compacted further, if (no limit)
         if limit.is_none() {
-            let mut case_fixture = CompactSegmentTestFixture::try_new(ctx, block_per_segment)?;
+            let mut case_fixture = CompactSegmentTestFixture::try_new(ctx, threshold)?;
             let (r, _) = case_fixture
                 .run(&block_num_of_output_segments, None, None)
                 .await?;
@@ -958,9 +956,12 @@ impl CompactCase {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compact_segment_with_cluster() -> Result<()> {
-    let block_per_seg = 5;
     let cluster_key_id = 0;
     let chunk_size = 6;
+    let threshold = BlockThresholds {
+        block_per_segment: 5,
+        ..Default::default()
+    };
 
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
@@ -1007,9 +1008,8 @@ async fn test_compact_segment_with_cluster() -> Result<()> {
             ctx.clone(),
             block_number_of_segments,
             rows_per_block,
-            BlockThresholds::default(),
+            threshold,
             Some(cluster_key_id),
-            block_per_seg as usize,
             false,
         )
         .await?;
@@ -1020,7 +1020,7 @@ async fn test_compact_segment_with_cluster() -> Result<()> {
 
         eprintln!("running compact, limit {}", limit);
         let seg_acc = SegmentCompactor::new(
-            block_per_seg,
+            threshold.block_per_segment as u64,
             Some(cluster_key_id),
             chunk_size,
             &fuse_segment_io,

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -351,7 +351,13 @@ async fn test_ft_cluster_stats_with_stats() -> databend_common_exception::Result
         None,
     ));
 
-    let block_compactor = BlockThresholds::new(1_000_000, 800_000, 100 * 1024 * 1024);
+    let block_compactor = BlockThresholds::new(
+        1_000_000,
+        800_000,
+        100 * 1024 * 1024,
+        10 * 1024 * 1024,
+        1000,
+    );
     let stats_gen = ClusterStatsGenerator::new(
         0,
         vec![0],

--- a/src/query/storages/common/table_meta/src/meta/utils.rs
+++ b/src/query/storages/common/table_meta/src/meta/utils.rs
@@ -74,8 +74,8 @@ pub fn monotonically_increased_timestamp(
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Copy)]
 pub struct TableMetaTimestamps {
-    pub segment_block_timestamp: chrono::DateTime<chrono::Utc>,
-    pub snapshot_timestamp: chrono::DateTime<chrono::Utc>,
+    pub segment_block_timestamp: DateTime<Utc>,
+    pub snapshot_timestamp: DateTime<Utc>,
 }
 
 impl TableMetaTimestamps {

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -17,6 +17,7 @@ pub const FUSE_OPT_KEY_BLOCK_PER_SEGMENT: &str = "block_per_segment";
 pub const FUSE_OPT_KEY_ROW_PER_BLOCK: &str = "row_per_block";
 pub const FUSE_OPT_KEY_ROW_PER_PAGE: &str = "row_per_page";
 pub const FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD: &str = "row_avg_depth_threshold";
+pub const FUSE_OPT_KEY_FILE_SIZE: &str = "file_size";
 
 pub const FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS: &str = "data_retention_period_in_hours";
 
@@ -34,7 +35,6 @@ pub const FUSE_TBL_VIRTUAL_BLOCK_PREFIX: &str = "_vb";
 pub const FUSE_TBL_AGG_INDEX_PREFIX: &str = "_i_a";
 pub const FUSE_TBL_INVERTED_INDEX_PREFIX: &str = "_i_i";
 
-pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 pub const DEFAULT_ROW_PER_PAGE: usize = 131072;
 pub const DEFAULT_ROW_PER_PAGE_FOR_BLOCKING: usize = 2048;
 pub const DEFAULT_ROW_PER_INDEX: usize = 100000;

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -57,7 +57,9 @@ use databend_common_expression::ORIGIN_VERSION_COL_NAME;
 use databend_common_expression::ROW_VERSION_COL_NAME;
 use databend_common_expression::SEARCH_SCORE_COLUMN_ID;
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
+use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
+use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_common_meta_app::schema::DatabaseType;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
@@ -116,13 +118,13 @@ use crate::FuseStorageFormat;
 use crate::NavigationPoint;
 use crate::Table;
 use crate::TableStatistics;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::DEFAULT_ROW_PER_PAGE;
 use crate::DEFAULT_ROW_PER_PAGE_FOR_BLOCKING;
 use crate::FUSE_OPT_KEY_ATTACH_COLUMN_IDS;
 use crate::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS;
+use crate::FUSE_OPT_KEY_FILE_SIZE;
 use crate::FUSE_OPT_KEY_ROW_PER_BLOCK;
 use crate::FUSE_OPT_KEY_ROW_PER_PAGE;
 
@@ -1048,7 +1050,16 @@ impl Table for FuseTable {
             FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
             DEFAULT_BLOCK_BUFFER_SIZE,
         );
-        BlockThresholds::new(max_rows_per_block, min_rows_per_block, max_bytes_per_block)
+        let max_file_size = self.get_option(FUSE_OPT_KEY_FILE_SIZE, DEFAULT_BLOCK_COMPRESSED_SIZE);
+        let block_per_segment =
+            self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
+        BlockThresholds::new(
+            max_rows_per_block,
+            min_rows_per_block,
+            max_bytes_per_block,
+            max_file_size,
+            block_per_segment,
+        )
     }
 
     #[async_backtrace::framed]

--- a/src/query/storages/fuse/src/io/read/meta/meta_readers.rs
+++ b/src/query/storages/fuse/src/io/read/meta/meta_readers.rs
@@ -273,9 +273,6 @@ mod thrift_file_meta_read {
     const FOOTER_SIZE: u64 = 8;
     const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
 
-    /// The number of bytes read at the end of the parquet file on first read
-    const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;
-
     #[async_backtrace::framed]
     async fn stream_len(
         seek: &mut (impl AsyncSeek + std::marker::Unpin),

--- a/src/query/storages/fuse/src/io/write/write_settings.rs
+++ b/src/query/storages/fuse/src/io/write/write_settings.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_storages_common_table_meta::table::TableCompression;
 
 use crate::FuseStorageFormat;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::DEFAULT_ROW_PER_PAGE;
 
 #[derive(Clone, Debug)]

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -58,8 +58,6 @@ use crate::statistics::reducers::merge_statistics_mut;
 use crate::statistics::reducers::reduce_block_metas;
 use crate::statistics::sort_by_cluster_stats;
 use crate::FuseTable;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
-use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 
 pub struct TableMutationAggregator {
     ctx: Arc<dyn TableContext>,
@@ -68,7 +66,6 @@ pub struct TableMutationAggregator {
     dal: Operator,
     location_gen: TableMetaLocationGenerator,
     thresholds: BlockThresholds,
-    block_per_seg: usize,
 
     default_cluster_key_id: Option<u32>,
     base_segments: Vec<Location>,
@@ -158,8 +155,6 @@ impl TableMutationAggregator {
             thresholds: table.get_block_thresholds(),
             default_cluster_key_id: table.cluster_key_id(),
             set_hilbert_level,
-            block_per_seg: table
-                .get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT),
             mutations: HashMap::new(),
             appended_segments: vec![],
             base_segments,
@@ -272,11 +267,10 @@ impl TableMutationAggregator {
 
         let mut tasks = Vec::new();
         let merged_blocks = std::mem::take(&mut self.recluster_merged_blocks);
-        let segments_num = (merged_blocks.len() / self.block_per_seg).max(1);
+        let segments_num = (merged_blocks.len() / self.thresholds.block_per_segment).max(1);
         let chunk_size = merged_blocks.len().div_ceil(segments_num);
         let default_cluster_key = Some(default_cluster_key_id);
         let thresholds = self.thresholds;
-        let block_per_seg = self.block_per_seg;
         let set_hilbert_level = self.set_hilbert_level;
         let kind = self.kind;
         for chunk in &merged_blocks.into_iter().chunks(chunk_size) {
@@ -294,7 +288,6 @@ impl TableMutationAggregator {
                     thresholds,
                     default_cluster_key,
                     all_perfect,
-                    block_per_seg,
                     kind,
                     set_hilbert_level,
                     table_meta_timestamps,
@@ -431,7 +424,6 @@ impl TableMutationAggregator {
     ) -> Result<Vec<SegmentLite>> {
         let thresholds = self.thresholds;
         let default_cluster_key_id = self.default_cluster_key_id;
-        let block_per_seg = self.block_per_seg;
         let kind = self.kind;
         let set_hilbert_level = self.set_hilbert_level;
         let mut tasks = Vec::with_capacity(segment_indices.len());
@@ -504,7 +496,6 @@ impl TableMutationAggregator {
                     thresholds,
                     default_cluster_key_id,
                     all_perfect,
-                    block_per_seg,
                     kind,
                     set_level,
                     table_meta_timestamps,
@@ -579,7 +570,6 @@ async fn write_segment(
     thresholds: BlockThresholds,
     default_cluster_key: Option<u32>,
     all_perfect: bool,
-    block_per_seg: usize,
     kind: MutationKind,
     set_hilbert_level: bool,
     table_meta_timestamps: TableMetaTimestamps,
@@ -598,11 +588,12 @@ async fn write_segment(
     }
     if set_hilbert_level {
         debug_assert!(new_summary.cluster_stats.is_none());
-        let level = if new_summary.block_count >= block_per_seg as u64
-            && (new_summary.row_count as usize >= block_per_seg * thresholds.min_rows_per_block
-                || new_summary.uncompressed_byte_size as usize
-                    >= block_per_seg * thresholds.max_bytes_per_block)
-        {
+        let level = if thresholds.check_perfect_segment(
+            new_summary.block_count as usize,
+            new_summary.row_count as usize,
+            new_summary.uncompressed_byte_size as usize,
+            new_summary.compressed_byte_size as usize,
+        ) {
             -1
         } else {
             0

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -19,6 +19,7 @@ use databend_common_catalog::table::CompactionLimits;
 use databend_common_exception::Result;
 use databend_common_expression::ComputedExpr;
 use databend_common_expression::FieldIndex;
+use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 
 use crate::operations::mutation::BlockCompactMutator;
@@ -26,7 +27,6 @@ use crate::operations::mutation::SegmentCompactMutator;
 use crate::FuseTable;
 use crate::Table;
 use crate::TableContext;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 
 #[derive(Clone)]

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -587,7 +587,7 @@ impl CompactTaskBuilder {
                     blocks.extend(tail);
                     self.build_task(&mut tasks, &mut unchanged_blocks, block_idx, blocks);
                 } else {
-                    // blocks > 2N
+                    // blocks >= 2N
                     self.build_task(&mut tasks, &mut unchanged_blocks, block_idx, blocks);
                     self.build_task(&mut tasks, &mut unchanged_blocks, block_idx + 1, tail);
                 }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -406,6 +406,7 @@ struct CompactTaskBuilder {
     blocks: Vec<Arc<BlockMeta>>,
     total_rows: usize,
     total_size: usize,
+    total_compressed: usize,
 }
 
 impl CompactTaskBuilder {
@@ -421,6 +422,7 @@ impl CompactTaskBuilder {
             blocks: vec![],
             total_rows: 0,
             total_size: 0,
+            total_compressed: 0,
         }
     }
 
@@ -431,10 +433,11 @@ impl CompactTaskBuilder {
     fn take_blocks(&mut self) -> Vec<Arc<BlockMeta>> {
         self.total_rows = 0;
         self.total_size = 0;
+        self.total_compressed = 0;
         std::mem::take(&mut self.blocks)
     }
 
-    fn add(&mut self, block: &Arc<BlockMeta>, thresholds: BlockThresholds) -> (bool, bool) {
+    fn add(&mut self, block: &Arc<BlockMeta>) -> (bool, bool) {
         if let Some(default_cluster_key) = self.cluster_key_id {
             if block
                 .cluster_stats
@@ -447,13 +450,15 @@ impl CompactTaskBuilder {
 
         let total_rows = self.total_rows + block.row_count as usize;
         let total_size = self.total_size + block.block_size as usize;
-        if !thresholds.check_large_enough(total_rows, total_size) {
+        let total_compressed = self.total_compressed + block.file_size as usize;
+        if !self.check_large_enough(total_rows, total_size, total_compressed) {
             // blocks < N
             self.blocks.push(block.clone());
             self.total_rows = total_rows;
             self.total_size = total_size;
+            self.total_compressed = total_compressed;
             (false, false)
-        } else if thresholds.check_for_compact(total_rows, total_size) {
+        } else if self.check_for_compact(total_rows, total_size, total_compressed) {
             // N <= blocks < 2N
             self.blocks.push(block.clone());
             (false, true)
@@ -461,6 +466,26 @@ impl CompactTaskBuilder {
             // blocks >= 2N
             (true, !self.blocks.is_empty())
         }
+    }
+
+    fn check_large_enough(
+        &self,
+        total_rows: usize,
+        total_size: usize,
+        total_compressed: usize,
+    ) -> bool {
+        self.thresholds.check_large_enough(total_rows, total_size)
+            || total_compressed >= self.thresholds.max_bytes_per_file
+    }
+
+    fn check_for_compact(
+        &self,
+        total_rows: usize,
+        total_size: usize,
+        total_compressed: usize,
+    ) -> bool {
+        self.thresholds.check_for_compact(total_rows, total_size)
+            && total_compressed < 2 * self.thresholds.max_bytes_per_file
     }
 
     fn build_task(
@@ -552,7 +577,7 @@ impl CompactTaskBuilder {
 
         let mut tasks = VecDeque::new();
         for block in blocks.iter() {
-            let (unchanged, need_take) = self.add(block, self.thresholds);
+            let (unchanged, need_take) = self.add(block);
             if need_take {
                 let blocks = self.take_blocks();
                 latest_flag = self.build_task(&mut tasks, &mut unchanged_blocks, block_idx, blocks);
@@ -577,13 +602,16 @@ impl CompactTaskBuilder {
                     tasks.pop_back().map_or(vec![], |(_, v)| v)
                 };
 
-                let (total_rows, total_size) =
-                    blocks.iter().chain(tail.iter()).fold((0, 0), |mut acc, x| {
+                let (total_rows, total_size, total_compressed) = blocks
+                    .iter()
+                    .chain(tail.iter())
+                    .fold((0, 0, 0), |mut acc, x| {
                         acc.0 += x.row_count as usize;
                         acc.1 += x.block_size as usize;
+                        acc.2 += x.file_size as usize;
                         acc
                     });
-                if self.thresholds.check_for_compact(total_rows, total_size) {
+                if self.check_for_compact(total_rows, total_size, total_compressed) {
                     blocks.extend(tail);
                     self.build_task(&mut tasks, &mut unchanged_blocks, block_idx, blocks);
                 } else {

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -55,8 +55,6 @@ use crate::statistics::sort_by_cluster_stats;
 use crate::FuseTable;
 use crate::SegmentLocation;
 use crate::DEFAULT_AVG_DEPTH_THRESHOLD;
-use crate::DEFAULT_BLOCK_PER_SEGMENT;
-use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD;
 
 pub enum ReclusterMode {
@@ -72,7 +70,6 @@ pub struct ReclusterMutator {
     pub(crate) cluster_key_id: u32,
     pub(crate) schema: TableSchemaRef,
     pub(crate) max_tasks: usize,
-    pub(crate) block_per_seg: usize,
     pub(crate) cluster_key_types: Vec<DataType>,
     pub(crate) column_ids: HashSet<u32>,
 }
@@ -86,8 +83,6 @@ impl ReclusterMutator {
         let schema = table.schema_with_stream();
         let cluster_key_id = table.cluster_key_meta.clone().unwrap().0;
         let block_thresholds = table.get_block_thresholds();
-        let block_per_seg =
-            table.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
 
         let avg_depth_threshold = table.get_option(
             FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD,
@@ -114,7 +109,6 @@ impl ReclusterMutator {
             block_thresholds,
             cluster_key_id,
             max_tasks,
-            block_per_seg,
             cluster_key_types,
             column_ids,
         })
@@ -130,7 +124,6 @@ impl ReclusterMutator {
         block_thresholds: BlockThresholds,
         cluster_key_id: u32,
         max_tasks: usize,
-        block_per_seg: usize,
         column_ids: HashSet<u32>,
     ) -> Self {
         Self {
@@ -140,7 +133,6 @@ impl ReclusterMutator {
             block_thresholds,
             cluster_key_id,
             max_tasks,
-            block_per_seg,
             cluster_key_types,
             column_ids,
         }
@@ -221,6 +213,7 @@ impl ReclusterMutator {
 
             let mut total_rows = 0;
             let mut total_bytes = 0;
+            let mut total_compressed = 0;
             let mut small_blocks = IndexSet::new();
             let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
 
@@ -242,6 +235,7 @@ impl ReclusterMutator {
 
                 total_rows += block.row_count;
                 total_bytes += block.block_size;
+                total_compressed += block.file_size;
             }
 
             // If total rows and bytes are too small, compact the blocks into one
@@ -262,6 +256,7 @@ impl ReclusterMutator {
                     &column_nodes,
                     total_rows as usize,
                     total_bytes as usize,
+                    total_compressed as usize,
                     level,
                 ));
                 break;
@@ -280,6 +275,7 @@ impl ReclusterMutator {
             // Process selected blocks into recluster tasks based on memory threshold
             let mut task_bytes = 0;
             let mut task_rows = 0;
+            let mut task_compressed = 0;
             let mut task_indices = Vec::new();
             let mut selected_blocks = Vec::new();
             for idx in selected_idx {
@@ -296,11 +292,13 @@ impl ReclusterMutator {
                         &column_nodes,
                         task_rows,
                         task_bytes,
+                        task_compressed,
                         level,
                     ));
 
                     task_rows = 0;
                     task_bytes = 0;
+                    task_compressed = 0;
                     selected_blocks.clear();
 
                     // Break if maximum task limit is reached
@@ -311,6 +309,7 @@ impl ReclusterMutator {
 
                 task_rows += row_count;
                 task_bytes += block_size;
+                task_compressed += block.file_size as usize;
                 task_indices.push(idx);
                 selected_blocks.push((None, block));
             }
@@ -323,6 +322,7 @@ impl ReclusterMutator {
                     &column_nodes,
                     task_rows,
                     task_bytes,
+                    task_compressed,
                     level,
                 ));
             }
@@ -340,7 +340,8 @@ impl ReclusterMutator {
                     ) == Ordering::Greater
                 })
             };
-            (selected_segs_idx.len() > 1 && blocks.len() <= self.block_per_seg) || unordered()
+            (selected_segs_idx.len() > 1 && blocks.len() <= self.block_thresholds.block_per_segment)
+                || unordered()
         } else {
             true
         };
@@ -385,8 +386,10 @@ impl ReclusterMutator {
         let mut recluster_blocks_count = 0;
 
         let mut parts = Vec::new();
-        let mut checker =
-            SegmentCompactChecker::new(self.block_per_seg as u64, Some(self.cluster_key_id));
+        let mut checker = SegmentCompactChecker::new(
+            self.block_thresholds.block_per_segment as u64,
+            Some(self.cluster_key_id),
+        );
 
         for (loc, compact_segment) in compact_segments.into_iter() {
             recluster_blocks_count += compact_segment.summary.block_count;
@@ -442,6 +445,7 @@ impl ReclusterMutator {
         column_nodes: &ColumnNodes,
         total_rows: usize,
         total_bytes: usize,
+        total_compressed: usize,
         level: i32,
     ) -> ReclusterTask {
         if log::log_enabled!(log::Level::Debug) {
@@ -462,6 +466,7 @@ impl ReclusterMutator {
             stats,
             total_rows,
             total_bytes,
+            total_compressed,
             level,
         }
     }
@@ -501,7 +506,10 @@ impl ReclusterMutator {
             }
 
             // Skip if segment has more blocks than required and no reclustering is needed
-            if level < 0 && compact_segment.summary.block_count as usize >= self.block_per_seg {
+            if level < 0
+                && compact_segment.summary.block_count as usize
+                    >= self.block_thresholds.block_per_segment
+            {
                 continue;
             }
 
@@ -509,7 +517,7 @@ impl ReclusterMutator {
             if let Some(stats) = &compact_segment.summary.cluster_stats {
                 blocks_num += compact_segment.summary.block_count as usize;
                 // Track small segments for special handling later
-                if blocks_num < self.block_per_seg {
+                if blocks_num < self.block_thresholds.block_per_segment {
                     small_segments.insert(i);
                 }
                 // Add to indices for potential reclustering
@@ -531,17 +539,18 @@ impl ReclusterMutator {
             return Ok((ReclusterMode::Compact, unclustered_segments));
         }
 
-        let selected_segments = if indices.len() > 1 && blocks_num > self.block_per_seg {
-            let selected = self.fetch_max_depth(points_map, 1.0, max_len)?;
-            if selected.is_empty() && small_segments.len() > 1 {
-                // If no segments were selected but small segments exist, use those.
-                small_segments
+        let selected_segments =
+            if indices.len() > 1 && blocks_num > self.block_thresholds.block_per_segment {
+                let selected = self.fetch_max_depth(points_map, 1.0, max_len)?;
+                if selected.is_empty() && small_segments.len() > 1 {
+                    // If no segments were selected but small segments exist, use those.
+                    small_segments
+                } else {
+                    selected
+                }
             } else {
-                selected
-            }
-        } else {
-            indices
-        };
+                indices
+            };
 
         Ok((ReclusterMode::Recluster, selected_segments))
     }
@@ -549,7 +558,8 @@ impl ReclusterMutator {
     pub fn segment_can_recluster(&self, summary: &Statistics) -> bool {
         if let Some(stats) = &summary.cluster_stats {
             stats.cluster_key_id == self.cluster_key_id
-                && (stats.level >= 0 || (summary.block_count as usize) < self.block_per_seg)
+                && (stats.level >= 0
+                    || (summary.block_count as usize) < self.block_thresholds.block_per_segment)
         } else {
             false
         }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -227,10 +227,11 @@ impl ReclusterMutator {
                 }
 
                 // Track small blocks for potential compaction
-                if self
-                    .block_thresholds
-                    .check_too_small(block.row_count as usize, block.block_size as usize)
-                {
+                if self.block_thresholds.check_too_small(
+                    block.row_count as usize,
+                    block.block_size as usize,
+                    block.file_size as usize,
+                ) {
                     small_blocks.insert(i);
                 }
 

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -198,6 +198,7 @@ impl ReclusterMutator {
         // specify a rather small value, so that `recluster_block_size` might be tuned to lower value.
         let max_blocks_num =
             (memory_threshold / self.block_thresholds.max_bytes_per_block).max(2) * self.max_tasks;
+        let block_per_seg = self.block_thresholds.block_per_segment;
 
         // Prepare task generation parameters
         let arrow_schema = self.schema.as_ref().into();
@@ -340,8 +341,7 @@ impl ReclusterMutator {
                     ) == Ordering::Greater
                 })
             };
-            (selected_segs_idx.len() > 1 && blocks.len() <= self.block_thresholds.block_per_segment)
-                || unordered()
+            (selected_segs_idx.len() > 1 && blocks.len() <= block_per_seg) || unordered()
         } else {
             true
         };
@@ -481,6 +481,7 @@ impl ReclusterMutator {
         let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
         let mut unclustered_segments = IndexSet::new();
         let mut small_segments = IndexSet::new();
+        let block_per_seg = self.block_thresholds.block_per_segment;
 
         // Iterate over all segments
         for (i, (loc, compact_segment)) in compact_segments.iter().enumerate() {
@@ -506,10 +507,7 @@ impl ReclusterMutator {
             }
 
             // Skip if segment has more blocks than required and no reclustering is needed
-            if level < 0
-                && compact_segment.summary.block_count as usize
-                    >= self.block_thresholds.block_per_segment
-            {
+            if level < 0 && compact_segment.summary.block_count as usize >= block_per_seg {
                 continue;
             }
 
@@ -517,7 +515,7 @@ impl ReclusterMutator {
             if let Some(stats) = &compact_segment.summary.cluster_stats {
                 blocks_num += compact_segment.summary.block_count as usize;
                 // Track small segments for special handling later
-                if blocks_num < self.block_thresholds.block_per_segment {
+                if blocks_num < block_per_seg {
                     small_segments.insert(i);
                 }
                 // Add to indices for potential reclustering
@@ -539,18 +537,17 @@ impl ReclusterMutator {
             return Ok((ReclusterMode::Compact, unclustered_segments));
         }
 
-        let selected_segments =
-            if indices.len() > 1 && blocks_num > self.block_thresholds.block_per_segment {
-                let selected = self.fetch_max_depth(points_map, 1.0, max_len)?;
-                if selected.is_empty() && small_segments.len() > 1 {
-                    // If no segments were selected but small segments exist, use those.
-                    small_segments
-                } else {
-                    selected
-                }
+        let selected_segments = if indices.len() > 1 && blocks_num > block_per_seg {
+            let selected = self.fetch_max_depth(points_map, 1.0, max_len)?;
+            if selected.is_empty() && small_segments.len() > 1 {
+                // If no segments were selected but small segments exist, use those.
+                small_segments
             } else {
-                indices
-            };
+                selected
+            }
+        } else {
+            indices
+        };
 
         Ok((ReclusterMode::Recluster, selected_segments))
     }

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -182,11 +182,7 @@ impl BlockMetaTransform<CompactSourceMeta> for CompactTransform {
                     .collect::<Result<Vec<_>>>()?;
 
                 // concat blocks.
-                let block = if blocks.len() == 1 {
-                    blocks[0].convert_to_full()
-                } else {
-                    DataBlock::concat(&blocks)?
-                };
+                let block = DataBlock::concat(&blocks)?;
 
                 let meta = Box::new(SerializeDataMeta::SerializeBlock(SerializeBlock::create(
                     index,

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -182,7 +182,11 @@ impl BlockMetaTransform<CompactSourceMeta> for CompactTransform {
                     .collect::<Result<Vec<_>>>()?;
 
                 // concat blocks.
-                let block = DataBlock::concat(&blocks)?;
+                let block = if blocks.len() == 1 {
+                    blocks[0].convert_to_full()
+                } else {
+                    DataBlock::concat(&blocks)?
+                };
 
                 let meta = Box::new(SerializeDataMeta::SerializeBlock(SerializeBlock::create(
                     index,

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -189,7 +189,7 @@ impl FuseTable {
 
             block_count += compact_segment.1.summary.block_count as usize;
             selected_segs.push(compact_segment);
-            if block_count >= mutator.block_per_seg || idx == latest {
+            if block_count >= mutator.block_thresholds.block_per_segment || idx == latest {
                 let selected_segs = std::mem::take(&mut selected_segs);
                 let mutator_clone = mutator.clone();
                 let tx_clone = tx.clone();

--- a/src/query/storages/fuse/src/statistics/reducers.rs
+++ b/src/query/storages/fuse/src/statistics/reducers.rs
@@ -211,8 +211,11 @@ pub fn reduce_block_metas<T: Borrow<BlockMeta>>(
         compressed_byte_size += b.file_size;
         index_size += b.bloom_filter_index_size;
         index_size += b.inverted_index_size.unwrap_or_default();
-        if thresholds.check_large_enough(b.row_count as usize, b.block_size as usize)
-            || b.cluster_stats.as_ref().is_some_and(|v| v.level != 0)
+        if thresholds.check_perfect_block(
+            b.row_count as usize,
+            b.block_size as usize,
+            b.file_size as usize,
+        ) || b.cluster_stats.as_ref().is_some_and(|v| v.level != 0)
         {
             perfect_block_count += 1;
         }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -838,6 +838,38 @@ select cluster_key, type, average_overlaps, average_depth from clustering_inform
 ----
 (abs(a)) linear 0.0 1.0
 
+statement ok
+create table t16(a int, b int) file_size = 500;
+
+statement ok
+insert into t16 values(1, 1), (3, 3);
+
+statement ok
+insert into t16 values(2, 2), (4, 4);
+
+statement ok
+optimize table t16 compact;
+
+statement ok
+alter table t16 set options(file_size = 10485760);
+
+statement ok
+insert into t16 values(5, 5);
+
+statement ok
+optimize table t16 compact;
+
+query III
+select segment_count, block_count, row_count from fuse_snapshot('db_09_0008','t16');
+----
+1 1 5
+2 3 5
+1 2 4
+2 2 4
+1 1 2
+
+statement ok
+drop table t16 all;
 
 statement ok
 DROP DATABASE db_09_0008

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -839,7 +839,7 @@ select cluster_key, type, average_overlaps, average_depth from clustering_inform
 (abs(a)) linear 0.0 1.0
 
 statement ok
-create table t16(a int, b int) file_size = 500;
+create table t16(a int, b int) file_size = 100;
 
 statement ok
 insert into t16 values(1, 1), (3, 3);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Introduces a new option, `file_size`, which allows to specify the desired size of Parquet files when blocks are written. The default value is set to `10M`. This option is primarily used during the `recluster` operation to control the size of the resulting blocks.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17580)
<!-- Reviewable:end -->
