### PR TITLE
fix: parquet meta cache key should not use mtime.

### DIFF
--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -67,11 +67,11 @@ impl StageFileInfo {
     }
 
     pub fn dedup_key(&self) -> Option<String> {
+        // should not use last_modified because the accuracy is in seconds for S3.
         if let Some(md5) = &self.md5 {
             Some(md5.clone())
         } else {
-            self.last_modified
-                .map(|t| t.format("%Y%m%d%H%M%S").to_string())
+            self.etag.clone()
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

when query from parquet files, we use a in memory cache for metadata of parquet files.
the original implementation only use file path as key of cache, which may leads to error when file is overwritten （read the metadata of the old file ）.
recently,  I fixed it by using `(path, content_md5/mtime )` as key.

this pr fix the key again: 

1. remove mtime,   because the accuracy of last_modified  is in seconds for S3, not enough to distinguish 2 files.
2. add etag, because in opendal the `content_md5()` is not always set to etag when etag exists.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17589)
<!-- Reviewable:end -->
