### PR TITLE
feat: UNPIVOT supports AS

### DIFF
--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -900,16 +900,40 @@ fn pivot(i: Input) -> IResult<Pivot> {
     )(i)
 }
 
+fn unpivot_name(i: Input) -> IResult<UnpivotName> {
+    let short_alias = map(
+        rule! {
+            #literal_string
+            ~ #error_hint(
+                rule! { AS },
+                "an alias without `AS` keyword has already been defined before this one, \
+                    please remove one of them"
+            )
+        },
+        |(string, _)| string,
+    );
+    let as_alias = map(
+        rule! {
+            AS ~ #literal_string
+        },
+        |(_, string)| string,
+    );
+    map(
+        rule! {#ident ~ (#short_alias | #as_alias)?},
+        |(ident, alias)| UnpivotName { ident, alias },
+    )(i)
+}
+
 // UNPIVOT(ident for ident IN (ident, ...))
 fn unpivot(i: Input) -> IResult<Unpivot> {
     map(
         rule! {
-            UNPIVOT ~ "(" ~ #ident ~ FOR ~ #ident ~ IN ~ "(" ~ #comma_separated_list1(ident) ~ ")" ~ ")"
+            UNPIVOT ~ "(" ~ #ident ~ FOR ~ #ident ~ IN ~ "(" ~ #comma_separated_list1(unpivot_name) ~ ")" ~ ")"
         },
-        |(_unpivot, _, value_column, _for, column_name, _in, _, names, _, _)| Unpivot {
+        |(_unpivot, _, value_column, _for, unpivot_column, _in, _, column_names, _, _)| Unpivot {
             value_column,
-            column_name,
-            names,
+            unpivot_column,
+            column_names,
         },
     )(i)
 }

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1136,7 +1136,7 @@ fn test_query() {
         r#"select * from (select * from monthly_sales) pivot(sum(amount) for month in ('JAN', 'FEB', 'MAR', 'APR')) order by empid"#,
         r#"select * from monthly_sales pivot(sum(amount) for month in (select distinct month from monthly_sales)) order by empid"#,
         r#"select * from (select * from monthly_sales) pivot(sum(amount) for month in ((select distinct month from monthly_sales))) order by empid"#,
-        r#"select * from monthly_sales_1 unpivot(sales for month in (jan, feb, mar, april)) order by empid"#,
+        r#"select * from monthly_sales_1 unpivot(sales for month in (jan as '1月', feb 'February', mar As 'MARCH', april)) order by empid"#,
         r#"select * from (select * from monthly_sales_1) unpivot(sales for month in (jan, feb, mar, april)) order by empid"#,
         r#"select * from range(1, 2)"#,
         r#"select sum(a) over w from customer window w as (partition by a order by b)"#,

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -7154,19 +7154,19 @@ Query {
 
 
 ---------- Input ----------
-select * from monthly_sales_1 unpivot(sales for month in (jan, feb, mar, april)) order by empid
+select * from monthly_sales_1 unpivot(sales for month in (jan as '1月', feb 'February', mar As 'MARCH', april)) order by empid
 ---------- Output ---------
-SELECT * FROM monthly_sales_1 UNPIVOT(sales FOR month IN (jan, feb, mar, april)) ORDER BY empid
+SELECT * FROM monthly_sales_1 UNPIVOT(sales FOR month IN (jan AS '1月', feb AS 'February', mar AS 'MARCH', april)) ORDER BY empid
 ---------- AST ------------
 Query {
     span: Some(
-        0..80,
+        0..112,
     ),
     with: None,
     body: Select(
         SelectStmt {
             span: Some(
-                0..80,
+                0..112,
             ),
             hints: None,
             distinct: false,
@@ -7186,7 +7186,7 @@ Query {
             from: [
                 Table {
                     span: Some(
-                        14..80,
+                        14..112,
                     ),
                     catalog: None,
                     database: None,
@@ -7212,7 +7212,7 @@ Query {
                                 quote: None,
                                 ident_type: None,
                             },
-                            column_name: Identifier {
+                            unpivot_column: Identifier {
                                 span: Some(
                                     48..53,
                                 ),
@@ -7220,38 +7220,56 @@ Query {
                                 quote: None,
                                 ident_type: None,
                             },
-                            names: [
-                                Identifier {
-                                    span: Some(
-                                        58..61,
+                            column_names: [
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            58..61,
+                                        ),
+                                        name: "jan",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: Some(
+                                        "1月",
                                     ),
-                                    name: "jan",
-                                    quote: None,
-                                    ident_type: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        63..66,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            73..76,
+                                        ),
+                                        name: "feb",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: Some(
+                                        "February",
                                     ),
-                                    name: "feb",
-                                    quote: None,
-                                    ident_type: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        68..71,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            89..92,
+                                        ),
+                                        name: "mar",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: Some(
+                                        "MARCH",
                                     ),
-                                    name: "mar",
-                                    quote: None,
-                                    ident_type: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        73..78,
-                                    ),
-                                    name: "april",
-                                    quote: None,
-                                    ident_type: None,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            105..110,
+                                        ),
+                                        name: "april",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: None,
                                 },
                             ],
                         },
@@ -7270,7 +7288,7 @@ Query {
         OrderByExpr {
             expr: ColumnRef {
                 span: Some(
-                    90..95,
+                    122..127,
                 ),
                 column: ColumnRef {
                     database: None,
@@ -7278,7 +7296,7 @@ Query {
                     column: Name(
                         Identifier {
                             span: Some(
-                                90..95,
+                                122..127,
                             ),
                             name: "empid",
                             quote: None,
@@ -7405,7 +7423,7 @@ Query {
                                 quote: None,
                                 ident_type: None,
                             },
-                            column_name: Identifier {
+                            unpivot_column: Identifier {
                                 span: Some(
                                     64..69,
                                 ),
@@ -7413,38 +7431,50 @@ Query {
                                 quote: None,
                                 ident_type: None,
                             },
-                            names: [
-                                Identifier {
-                                    span: Some(
-                                        74..77,
-                                    ),
-                                    name: "jan",
-                                    quote: None,
-                                    ident_type: None,
+                            column_names: [
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            74..77,
+                                        ),
+                                        name: "jan",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        79..82,
-                                    ),
-                                    name: "feb",
-                                    quote: None,
-                                    ident_type: None,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            79..82,
+                                        ),
+                                        name: "feb",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        84..87,
-                                    ),
-                                    name: "mar",
-                                    quote: None,
-                                    ident_type: None,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            84..87,
+                                        ),
+                                        name: "mar",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: None,
                                 },
-                                Identifier {
-                                    span: Some(
-                                        89..94,
-                                    ),
-                                    name: "april",
-                                    quote: None,
-                                    ident_type: None,
+                                UnpivotName {
+                                    ident: Identifier {
+                                        span: Some(
+                                            89..94,
+                                        ),
+                                        name: "april",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                    alias: None,
                                 },
                             ],
                         },

--- a/tests/sqllogictests/suites/query/unpivot.test
+++ b/tests/sqllogictests/suites/query/unpivot.test
@@ -7,7 +7,7 @@ INSERT INTO monthly_sales_1 VALUES
     (2, 'clothes', 100, 300, 150, 200),
     (3, 'cars', 200, 400, 100, 50);
 
-query IIII
+query ITTI
 SELECT * exclude(Jan,Feb,Mar,April), unnest(['Jan','Feb','Mar','April']) AS month, unnest([Jan,Feb,Mar,April]) AS sales
 FROM monthly_sales_1
 ORDER BY empid;
@@ -25,46 +25,45 @@ ORDER BY empid;
 3	cars	Mar	100
 3	cars	April	50
 
-query IIII
+query ITTI
 SELECT empid,dept,month,sales FROM (
     SELECT * FROM monthly_sales_1
-        UNPIVOT(sales FOR month IN (jan, feb, mar, april))
+        UNPIVOT(sales FOR month IN (jan as 'Jan', feb As '2', mar 'MARCH', april))
         ORDER BY empid
 );
 ----
-1	electronics	jan	100
-1	electronics	feb	200
-1	electronics	mar	300
-1	electronics	april	100
-2	clothes	jan	100
-2	clothes	feb	300
-2	clothes	mar	150
-2	clothes	april	200
-3	cars	jan	200
-3	cars	feb	400
-3	cars	mar	100
-3	cars	april	50
+1 electronics Jan 100
+1 electronics 2 200
+1 electronics MARCH 300
+1 electronics april 100
+2 clothes Jan 100
+2 clothes 2 300
+2 clothes MARCH 150
+2 clothes april 200
+3 cars Jan 200
+3 cars 2 400
+3 cars MARCH 100
+3 cars april 50
 
-query IIII
+query ITTI
 SELECT empid,dept,month,sales FROM (
     SELECT * FROM (SELECT * FROM monthly_sales_1)
-        UNPIVOT(sales FOR month IN (jan, feb, mar, april))
+        UNPIVOT(sales FOR month IN (jan 'Jan', feb, mar, april))
         ORDER BY empid
 );
 ----
-1	electronics	jan	100
-1	electronics	feb	200
-1	electronics	mar	300
-1	electronics	april	100
-2	clothes	jan	100
-2	clothes	feb	300
-2	clothes	mar	150
-2	clothes	april	200
-3	cars	jan	200
-3	cars	feb	400
-3	cars	mar	100
-3	cars	april	50
+1 electronics Jan 100
+1 electronics feb 200
+1 electronics mar 300
+1 electronics april 100
+2 clothes Jan 100
+2 clothes feb 300
+2 clothes mar 150
+2 clothes april 200
+3 cars Jan 200
+3 cars feb 400
+3 cars mar 100
+3 cars april 50
 
 statement ok
 drop table monthly_sales_1;
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

[Snowflake](https://docs.snowflake.com/en/sql-reference/constructs/unpivot) does not support this `UNPIVOT AS` syntax, but [databricks](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-select-unpivot) does.

Example:
```sql
-- Create the unpivoted_monthly_sales table
CREATE TABLE unpivoted_monthly_sales(  empid INT,   jan INT,  feb INT,  mar INT,  apr INT);

-- Insert sales data
INSERT INTO unpivoted_monthly_sales VALUES
  (1, 10400,  8000, 11000, 18000),
  (2, 39500, 90700, 12000,  5300);

SELECT *
FROM unpivoted_monthly_sales
    UNPIVOT (amount
    FOR month IN (jan as 'Jan', feb AS 'F e b', mar 'MARCH', apr));
┌──────────────────────────────────────────────────────┐
│      empid      │       month      │      amount     │
│ Nullable(Int32) │ Nullable(String) │ Nullable(Int32) │
├─────────────────┼──────────────────┼─────────────────┤
│               1 │ Jan              │           10400 │
│               1 │ F e b            │            8000 │
│               1 │ MARCH            │           11000 │
│               1 │ apr              │           18000 │
│               2 │ Jan              │           39500 │
│               2 │ F e b            │           90700 │
│               2 │ MARCH            │           12000 │
│               2 │ apr              │            5300 │
└──────────────────────────────────────────────────────┘
```

- fixes: #17583


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
