### PR TITLE
feat: subquery to join case 0

### DIFF
--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_table.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_table.rs
@@ -164,7 +164,7 @@ impl Binder {
         {
             let change_type = get_change_type(&table_name_alias);
             if change_type.is_some() {
-                let table_index = self.metadata.write().add_table(
+                let (table_index, source_table_index) = self.metadata.write().add_table(
                     catalog,
                     database.clone(),
                     table_meta,
@@ -178,6 +178,7 @@ impl Binder {
                     bind_context,
                     database.as_str(),
                     table_index,
+                    source_table_index,
                     change_type,
                     sample,
                 )?;
@@ -281,7 +282,7 @@ impl Binder {
                 }
             }
             _ => {
-                let table_index = self.metadata.write().add_table(
+                let (table_index, source_table_index) = self.metadata.write().add_table(
                     catalog.clone(),
                     database.clone(),
                     table_meta.clone(),
@@ -296,6 +297,7 @@ impl Binder {
                     bind_context,
                     database.as_str(),
                     table_index,
+                    source_table_index,
                     None,
                     sample,
                 )?;

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
@@ -143,7 +143,7 @@ impl Binder {
             } else {
                 None
             };
-            let table_index = self.metadata.write().add_table(
+            let (table_index, source_table_index) = self.metadata.write().add_table(
                 CATALOG_DEFAULT.to_string(),
                 "system".to_string(),
                 table.clone(),
@@ -154,8 +154,14 @@ impl Binder {
                 None,
             );
 
-            let (s_expr, mut bind_context) =
-                self.bind_base_table(bind_context, "system", table_index, None, sample)?;
+            let (s_expr, mut bind_context) = self.bind_base_table(
+                bind_context,
+                "system",
+                table_index,
+                source_table_index,
+                None,
+                sample,
+            )?;
             if let Some(alias) = alias {
                 bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
             }
@@ -205,7 +211,7 @@ impl Binder {
                 None
             };
 
-            let table_index = self.metadata.write().add_table(
+            let (table_index, source_table_index) = self.metadata.write().add_table(
                 CATALOG_DEFAULT.to_string(),
                 "system".to_string(),
                 table.clone(),
@@ -216,8 +222,14 @@ impl Binder {
                 None,
             );
 
-            let (s_expr, mut bind_context) =
-                self.bind_base_table(bind_context, "system", table_index, None, &None)?;
+            let (s_expr, mut bind_context) = self.bind_base_table(
+                bind_context,
+                "system",
+                table_index,
+                source_table_index,
+                None,
+                &None,
+            )?;
             if let Some(alias) = alias {
                 bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
             }

--- a/src/query/sql/src/planner/binder/column_binding.rs
+++ b/src/query/sql/src/planner/binder/column_binding.rs
@@ -28,6 +28,8 @@ pub struct ColumnBinding {
     pub column_position: Option<usize>,
     /// Table index of this `ColumnBinding` in current context
     pub table_index: Option<IndexType>,
+    /// Source table index of this `ColumnBinding` in current context
+    pub source_table_index: Option<IndexType>,
     /// Column name of this `ColumnBinding` in current context
     pub column_name: String,
     /// Column index of ColumnBinding
@@ -72,6 +74,7 @@ impl ColumnBinding {
             table_name: None,
             column_position: None,
             table_index: None,
+            source_table_index: None,
             column_name: name,
             index,
             data_type,
@@ -96,6 +99,8 @@ pub struct ColumnBindingBuilder {
     pub column_position: Option<usize>,
     /// Table index of this `ColumnBinding` in current context
     pub table_index: Option<IndexType>,
+    /// Source table index of this `ColumnBinding` in current context
+    pub source_table_index: Option<IndexType>,
     /// Column name of this `ColumnBinding` in current context
     pub column_name: String,
     /// Column index of ColumnBinding
@@ -120,6 +125,7 @@ impl ColumnBindingBuilder {
             table_name: None,
             column_position: None,
             table_index: None,
+            source_table_index: None,
             column_name,
             index,
             data_type,
@@ -148,6 +154,11 @@ impl ColumnBindingBuilder {
         self
     }
 
+    pub fn source_table_index(mut self, index: Option<IndexType>) -> ColumnBindingBuilder {
+        self.source_table_index = index;
+        self
+    }
+
     pub fn virtual_expr(mut self, virtual_expr: Option<String>) -> ColumnBindingBuilder {
         self.virtual_expr = virtual_expr;
         self
@@ -159,6 +170,7 @@ impl ColumnBindingBuilder {
             table_name: self.table_name,
             column_position: self.column_position,
             table_index: self.table_index,
+            source_table_index: self.source_table_index,
             column_name: self.column_name,
             index: self.index,
             data_type: self.data_type,

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -132,7 +132,7 @@ impl Binder {
             None
         };
 
-        let table_index = self.metadata.write().add_table(
+        let (table_index, source_table_index) = self.metadata.write().add_table(
             CATALOG_DEFAULT.to_string(),
             "system".to_string(),
             table.clone(),
@@ -143,8 +143,14 @@ impl Binder {
             None,
         );
 
-        let (s_expr, mut bind_context) =
-            self.bind_base_table(bind_context, "system", table_index, None, &None)?;
+        let (s_expr, mut bind_context) = self.bind_base_table(
+            bind_context,
+            "system",
+            table_index,
+            source_table_index,
+            None,
+            &None,
+        )?;
         if let Some(alias) = alias {
             bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
         }
@@ -353,6 +359,7 @@ impl Binder {
         bind_context: &BindContext,
         database_name: &str,
         table_index: IndexType,
+        source_table_index: Option<IndexType>,
         change_type: Option<ChangeType>,
         sample: &Option<SampleConfig>,
     ) -> Result<(SExpr, BindContext)> {
@@ -388,6 +395,7 @@ impl Binder {
                     .table_name(Some(table_name.to_string()))
                     .database_name(Some(database_name.to_string()))
                     .table_index(Some(*table_index))
+                    .source_table_index(source_table_index)
                     .column_position(*column_position)
                     .virtual_expr(virtual_expr.clone())
                     .build();

--- a/src/query/sql/src/planner/dataframe.rs
+++ b/src/query/sql/src/planner/dataframe.rs
@@ -93,7 +93,7 @@ impl Dataframe {
                 query_ctx.clone().get_abort_checker(),
             )?;
 
-            let table_index = metadata.write().add_table(
+            let (table_index, source_table_index) = metadata.write().add_table(
                 CATALOG_DEFAULT.to_owned(),
                 database.to_string(),
                 table_meta,
@@ -104,7 +104,14 @@ impl Dataframe {
                 None,
             );
 
-            binder.bind_base_table(&bind_context, database, table_index, None, &None)
+            binder.bind_base_table(
+                &bind_context,
+                database,
+                table_index,
+                source_table_index,
+                None,
+                &None,
+            )
         } else {
             binder.bind_table_reference(&mut bind_context, &table)
         }?;

--- a/src/query/sql/src/planner/expression_parser.rs
+++ b/src/query/sql/src/planner/expression_parser.rs
@@ -60,7 +60,7 @@ use crate::Visibility;
 pub fn bind_table(table_meta: Arc<dyn Table>) -> Result<(BindContext, MetadataRef)> {
     let mut bind_context = BindContext::new();
     let metadata = Arc::new(RwLock::new(Metadata::default()));
-    let table_index = metadata.write().add_table(
+    let (table_index, _) = metadata.write().add_table(
         CATALOG_DEFAULT.to_owned(),
         "default".to_string(),
         table_meta,

--- a/src/query/sql/src/planner/metadata.rs
+++ b/src/query/sql/src/planner/metadata.rs
@@ -358,9 +358,10 @@ impl Metadata {
         source_of_index: bool,
         source_of_stage: bool,
         cte_suffix_name: Option<String>,
-    ) -> IndexType {
+    ) -> (IndexType, Option<IndexType>) {
         let table_name = table_meta.name().to_string();
         let table_name = Self::remove_cte_suffix(table_name, cte_suffix_name);
+        let source_table_index = self.get_table_index(Some(database.as_str()), table_name.as_str());
 
         let table_index = self.tables.len();
         // If exists table alias name, use it instead of origin name
@@ -455,7 +456,7 @@ impl Metadata {
             }
         }
 
-        table_index
+        (table_index, source_table_index)
     }
 
     pub fn change_derived_column_alias(&mut self, index: IndexType, alias: String) {

--- a/src/query/sql/src/planner/optimizer/aggregate/normalize_aggregate.rs
+++ b/src/query/sql/src/planner/optimizer/aggregate/normalize_aggregate.rs
@@ -143,6 +143,7 @@ impl RuleNormalizeAggregateOptimizer {
                             column: ColumnBinding {
                                 table_name: None,
                                 table_index: None,
+                                source_table_index: None,
                                 database_name: None,
                                 column_position: None,
                                 index: work_index,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This rule comes from the subquery optimization mentioned in the wetune paper: https://ipads.se.sjtu.edu.cn:1312/opensource/wetune/-/blob/main/wtune_data/issues/issues?ref_type=heads#L8

It can remove the redundant scan of left in the case of in subquery.

```sql
explain
SELECT
  COUNT(topics.id)
FROM
  topics
WHERE
  id IN (
    SELECT
      topic_id
    FROM
      posts AS p
      INNER JOIN topics AS t2 ON t2.id = p.topic_id
    WHERE
      p.deleted_at IS NULL
      AND t2.user_id <> p.user_id
      AND p.user_id = 9627
  )

-[ EXPLAIN ]-----------------------------------
AggregateFinal
├── output columns: [COUNT(topics.id) (#45)]
├── group by: []
├── aggregate functions: [count()]
├── estimated rows: 1.00
└── AggregatePartial
    ├── group by: []
    ├── aggregate functions: [count()]
    ├── estimated rows: 1.00
    └── AggregateFinal
        ├── output columns: [p.topic_id (#48)]
        ├── group by: [topic_id]
        ├── aggregate functions: []
        ├── estimated rows: 0.00
        └── AggregatePartial
            ├── group by: [topic_id]
            ├── aggregate functions: []
            ├── estimated rows: 0.00
            └── HashJoin
                ├── output columns: [p.topic_id (#48)]
                ├── join type: INNER
                ├── build keys: [t2.id (#97)]
                ├── probe keys: [p.topic_id (#48)]
                ├── keys is null equal: [false]
                ├── filters: [t2.user_id (#104) <> p.user_id (#47)]
                ├── estimated rows: 0.00
                ├── TableScan(Build)
                │   ├── table: default.public.topics
                │   ├── output columns: [id (#97), user_id (#104)]
                │   ├── read rows: 0
                │   ├── read size: 0
                │   ├── partitions total: 0
                │   ├── partitions scanned: 0
                │   ├── push downs: [filters: [], limit: NONE]
                │   └── estimated rows: 0.00
                └── Filter(Probe)
                    ├── output columns: [p.user_id (#47), p.topic_id (#48)]
                    ├── filters: [is_true(p.user_id (#47) = 9627), NOT is_not_null(p.deleted_at (#57))]
                    ├── estimated rows: 0.00
                    └── TableScan
                        ├── table: default.public.posts
                        ├── output columns: [user_id (#47), topic_id (#48), deleted_at (#57)]
                        ├── read rows: 0
                        ├── read size: 0
                        ├── partitions total: 0
                        ├── partitions scanned: 0
                        ├── push downs: [filters: [and_filters(posts.user_id (#47) = 9627, NOT is_not_null(posts.deleted_at (#57)))], limit: NONE]
                        └── estimated rows: 0.00

```

There are currently two issues waiting to be resolved for this optimization
1. When the column required by the downstream node is not the child expr of the subquery, a schema mapping error will occur.
```sql
explain SELECT COUNT(topics.user_id)
FROM topics
WHERE id IN (SELECT topic_id
             FROM posts AS p
                      INNER JOIN topics AS t2 ON t2.id = p.topic_id
             WHERE p.deleted_at IS NULL
               AND t2.user_id <> p.user_id
               AND p.user_id = 9627);
```
2. When there are multiple tables in the left or there are complex situations such as limits

Here are some questions about table creation and related sql to help you test(Please manually change txt to sql)
[subquery.txt](https://github.com/user-attachments/files/19304339/subquery.txt)

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17617)
<!-- Reviewable:end -->
