### PR TITLE
feat: heartbeat to avoid query result timeout. 

### DIFF
--- a/src/query/service/src/servers/http/middleware/mod.rs
+++ b/src/query/service/src/servers/http/middleware/mod.rs
@@ -18,6 +18,7 @@ mod session;
 
 pub(crate) use metrics::MetricsMiddleware;
 pub(crate) use panic_handler::PanicHandler;
+pub(crate) use session::forward_request_with_body;
 pub use session::json_response;
 pub(crate) use session::sanitize_request_headers;
 pub use session::EndpointKind;

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -277,4 +277,19 @@ impl HttpQueryManager {
         }
         Ok(())
     }
+
+    pub(crate) fn on_heartbeat(&self, query_ids: Vec<String>) -> Vec<String> {
+        let mut failed = vec![];
+        for query_id in query_ids {
+            if !self
+                .queries
+                .get(&query_id)
+                .map(|q| q.on_heartbeat())
+                .unwrap_or(false)
+            {
+                failed.push(query_id);
+            }
+        }
+        failed
+    }
 }

--- a/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.py
+++ b/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import requests
+import time
+import logging
+
+auth = ("root", "")
+STICKY_HEADER = "X-DATABEND-STICKY-NODE"
+
+logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
+session = {
+    "settings": {
+        "http_handler_result_timeout_secs": "3",
+        "max_threads": "32"
+    }
+}
+
+def do_query(query, port=8000):
+    url = f"http://localhost:{port}/v1/query"
+    query_payload = {
+        "sql": query,
+        "pagination": {"wait_time_secs": 2, "max_rows_per_page": 4, "max_rows_in_buffer": 3},
+        "session": session
+    }
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    response = requests.post(url, headers=headers, json=query_payload, auth=auth)
+    return response.json()
+
+
+def test_heartbeat(port):
+    resp1 = do_query("select * from numbers(100)")
+    print("started query 0")
+    # print(resp1.get("node_id"), resp1.get("id"))
+    resp2 = do_query("select * from numbers(100)", port=port)
+    print("started query 1")
+    # print(resp1.get("node_id"), resp1.get("id"))
+    # print(resp2.get("node_id"), resp2.get("id"))
+
+    url = f"http://localhost:8000/v1/session/heartbeat"
+    m = {}
+    m.setdefault(resp1.get("node_id"), []).append(resp1.get("id"))
+    m.setdefault(resp2.get("node_id"), []).append(resp2.get("id"))
+    payload = { "node_to_queries": m }
+    headers = {
+        "Content-Type": "application/json",
+    }
+    for i in range(10):
+        print(f"sending heartbeat {i}")
+        response = requests.post(url, headers=headers, json=payload, auth=auth).json()
+        assert len(response.get("queries_to_remove")) == 0
+        time.sleep(1)
+
+    for (i, r) in enumerate([resp1, resp2]):
+        print(f"continue fetch {i}")
+        headers = {
+            STICKY_HEADER: r.get("node_id")
+        }
+        next_uri = f"http://localhost:8000/{r.get('next_uri')}?"
+        response = requests.get(next_uri, headers=headers ,auth=auth)
+        assert response.status_code == 200, f"{response.status_code} {response.text}"
+        assert len(response.json().get("data")) > 0
+    print("end")
+
+
+def main():
+    query_resp = do_query("select count(*) from system.clusters")
+    num_nodes = int(query_resp.get("data")[0][0])
+    if num_nodes == 1:
+        test_heartbeat(8000)
+    else:
+        test_heartbeat(8002)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logging.exception(f"An error occurred: {e}")

--- a/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.result
@@ -1,0 +1,15 @@
+started query 0
+started query 1
+sending heartbeat 0
+sending heartbeat 1
+sending heartbeat 2
+sending heartbeat 3
+sending heartbeat 4
+sending heartbeat 5
+sending heartbeat 6
+sending heartbeat 7
+sending heartbeat 8
+sending heartbeat 9
+continue fetch 0
+continue fetch 1
+end


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Motivation

Each query and its result will be cleared when there is no data pulling request within a certain period of time. However, the data pulling request depends on the consumption of the client users. If there is a long interval in consumption, an unexpected timeout error will be received. 

this pr extend heartbeat api to keep alive of the query result

### solution

1. query return `result_timeout` in response.
2. client is expected to send heartbeat request (in background) when it is about to timeout.
   -  before that, client should check the version of server to make sure heartbeat is supported. 
3.  heartbeat for queries can be batched, and are grouped by node_id,  the server receiving  HB from client is responsible for dispatch them to nodes in cluster in parallel 

related pr：https://github.com/databendlabs/databend-jdbc/pull/306

### other changes made

1.   fix query forward by remove the `HOST` header.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17624)
<!-- Reviewable:end -->
