### PR TITLE
chore: optimize building bloom index for null

### DIFF
--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -756,6 +756,62 @@ impl ScalarRef<'_> {
             },
         }
     }
+
+    /// Estimates the memory size of a scalar value if it were repeated `n` times,
+    /// without actually converting it into a column. This avoids unnecessary allocations
+    /// and provides a direct calculation based on the scalar type and its associated DataType.
+    ///
+    /// # Parameters:
+    /// - `scalar`: The scalar value to estimate memory size for.
+    /// - `n`: The number of times the scalar is hypothetically repeated.
+    /// - `data_type`: The data type of the scalar, used for correct size calculations.
+    ///
+    /// # Returns:
+    /// The estimated memory size (in bytes) that `n` repetitions of `scalar` would occupy.
+    pub fn estimated_scalar_repeat_size(&self, n: usize, data_type: &DataType) -> usize {
+        if !self.is_null() {
+            if let DataType::Nullable(ty) = data_type {
+                return self.estimated_scalar_repeat_size(n, ty) + (n + 7) / 8;
+            }
+        }
+
+        match self {
+            ScalarRef::Null => match data_type {
+                DataType::Null => std::mem::size_of::<usize>(),
+                DataType::Nullable(_) => {
+                    // For `Nullable` columns with no valid values,
+                    // only the size of the validity bitmap is counted.
+                    (n + 7) / 8
+                }
+                _ => unreachable!(),
+            },
+            ScalarRef::EmptyArray | ScalarRef::EmptyMap => std::mem::size_of::<usize>(),
+            ScalarRef::Number(_) => n * self.memory_size(),
+            ScalarRef::Decimal(_) => n * self.memory_size(),
+            ScalarRef::Boolean(_) => (n + 7) / 8,
+            ScalarRef::Binary(s) => s.len() * n + (n + 1) * 8,
+            ScalarRef::String(s) => s.len() * n + n * 12,
+            ScalarRef::Timestamp(_) => n * 8,
+            ScalarRef::Date(_) => n * 4,
+            ScalarRef::Interval(_) => n * 16,
+            ScalarRef::Array(col) => col.memory_size() * n + (n + 1) * 8,
+            ScalarRef::Map(col) => col.memory_size() * n + (n + 1) * 8,
+            ScalarRef::Bitmap(b) => b.len() * n + (n + 1) * 8,
+            ScalarRef::Tuple(fields) => {
+                let DataType::Tuple(fields_ty) = data_type else {
+                    unreachable!()
+                };
+                fields
+                    .iter()
+                    .zip(fields_ty.iter())
+                    .map(|(v, ty)| v.estimated_scalar_repeat_size(n, ty))
+                    .sum()
+            }
+            ScalarRef::Variant(s) => s.len() * n + (n + 1) * 8,
+            ScalarRef::Geometry(s) => s.len() * n + (n + 1) * 8,
+            ScalarRef::Geography(s) => s.0.len() * n + (n + 1) * 8,
+        }
+    }
 }
 
 impl PartialOrd for Scalar {
@@ -1708,9 +1764,8 @@ impl ColumnBuilder {
             ScalarRef::Map(col) => ColumnBuilder::Map(Box::new(ArrayColumnBuilder::repeat(col, n))),
             ScalarRef::Bitmap(b) => ColumnBuilder::Bitmap(BinaryColumnBuilder::repeat(b, n)),
             ScalarRef::Tuple(fields) => {
-                let fields_ty = match data_type {
-                    DataType::Tuple(fields_ty) => fields_ty,
-                    _ => unreachable!(),
+                let DataType::Tuple(fields_ty) = data_type else {
+                    unreachable!()
                 };
                 ColumnBuilder::Tuple(
                     fields

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -644,6 +644,15 @@ fn test_builder() {
     assert_eq!(r1, r2)
 }
 
+fn assert_estimated_scalar_repeat_size(scalar: ScalarRef, num_rows: usize, ty: DataType) {
+    let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+    let col = builder.build();
+    assert_eq!(
+        scalar.estimated_scalar_repeat_size(num_rows, &ty),
+        col.memory_size()
+    );
+}
+
 #[test]
 fn test_estimated_scalar_repeat_size() {
     let num_rows = 108;
@@ -652,12 +661,7 @@ fn test_estimated_scalar_repeat_size() {
     {
         let scalar = ScalarRef::Null;
         let ty = DataType::Null;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // nullable
@@ -677,12 +681,7 @@ fn test_estimated_scalar_repeat_size() {
     {
         let scalar = ScalarRef::Number(NumberScalar::Float32(OrderedFloat(2.33)));
         let ty = DataType::Nullable(Box::new(DataType::Number(NumberDataType::Float32)));
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // decimal
@@ -695,84 +694,49 @@ fn test_estimated_scalar_repeat_size() {
             precision: 46,
             scale: 6,
         }));
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // string
     {
         let scalar = ScalarRef::String("abc");
         let ty = DataType::String;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // string
     {
         let scalar = ScalarRef::String("abcdefghijklmn123");
         let ty = DataType::String;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // binary
     {
         let scalar = ScalarRef::Binary(&[1, 133, 244, 123]);
         let ty = DataType::Binary;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // boolean
     {
         let scalar = ScalarRef::Boolean(true);
         let ty = DataType::Boolean;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // bitmap
     {
         let scalar = ScalarRef::Bitmap(&[1, 133, 244, 123]);
         let ty = DataType::Bitmap;
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // array
     {
         let scalar = ScalarRef::Array(StringType::from_data(vec!["abc", "abcdefghijklmn123"]));
         let ty = DataType::Array(Box::new(DataType::String));
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 
     // map
@@ -785,11 +749,6 @@ fn test_estimated_scalar_repeat_size() {
             DataType::Number(NumberDataType::UInt8),
             DataType::String,
         ])));
-        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
-        let col = builder.build();
-        assert_eq!(
-            scalar.estimated_scalar_repeat_size(num_rows, &ty),
-            col.memory_size()
-        );
+        assert_estimated_scalar_repeat_size(scalar, num_rows, ty);
     }
 }

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -14,11 +14,17 @@
 
 use core::ops::Range;
 
+use databend_common_base::base::OrderedFloat;
 use databend_common_column::bitmap::Bitmap;
 use databend_common_expression::block_debug::assert_block_value_eq;
 use databend_common_expression::types::number::*;
 use databend_common_expression::types::AnyType;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalDataType;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
+use databend_common_expression::types::IntervalType;
+use databend_common_expression::types::NullableType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::ValueType;
@@ -31,6 +37,7 @@ use databend_common_expression::FilterVisitor;
 use databend_common_expression::FromData;
 use databend_common_expression::IterationStrategy;
 use databend_common_expression::Scalar;
+use databend_common_expression::ScalarRef;
 use databend_common_expression::Value;
 use goldenfile::Mint;
 
@@ -635,4 +642,154 @@ fn test_builder() {
     let r2 = builder2.build();
 
     assert_eq!(r1, r2)
+}
+
+#[test]
+fn test_estimated_scalar_repeat_size() {
+    let num_rows = 108;
+
+    // null
+    {
+        let scalar = ScalarRef::Null;
+        let ty = DataType::Null;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // nullable
+    {
+        let scalar = ScalarRef::Null;
+        let ty = DataType::Nullable(Box::new(DataType::Interval));
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        let col = NullableType::<IntervalType>::try_downcast_column(&col).unwrap();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.validity.as_slice().0.len()
+        );
+    }
+
+    // nullable(float32)
+    {
+        let scalar = ScalarRef::Number(NumberScalar::Float32(OrderedFloat(2.33)));
+        let ty = DataType::Nullable(Box::new(DataType::Number(NumberDataType::Float32)));
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // decimal
+    {
+        let scalar = ScalarRef::Decimal(DecimalScalar::Decimal128(233, DecimalSize {
+            precision: 46,
+            scale: 6,
+        }));
+        let ty = DataType::Decimal(DecimalDataType::Decimal256(DecimalSize {
+            precision: 46,
+            scale: 6,
+        }));
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // string
+    {
+        let scalar = ScalarRef::String("abc");
+        let ty = DataType::String;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // string
+    {
+        let scalar = ScalarRef::String("abcdefghijklmn123");
+        let ty = DataType::String;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // binary
+    {
+        let scalar = ScalarRef::Binary(&[1, 133, 244, 123]);
+        let ty = DataType::Binary;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // boolean
+    {
+        let scalar = ScalarRef::Boolean(true);
+        let ty = DataType::Boolean;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // bitmap
+    {
+        let scalar = ScalarRef::Bitmap(&[1, 133, 244, 123]);
+        let ty = DataType::Bitmap;
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // array
+    {
+        let scalar = ScalarRef::Array(StringType::from_data(vec!["abc", "abcdefghijklmn123"]));
+        let ty = DataType::Array(Box::new(DataType::String));
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
+
+    // map
+    {
+        let scalar = ScalarRef::Map(Column::Tuple(vec![
+            UInt8Type::from_data(vec![1, 2]),
+            StringType::from_data(vec!["a", "b"]),
+        ]));
+        let ty = DataType::Map(Box::new(DataType::Tuple(vec![
+            DataType::Number(NumberDataType::UInt8),
+            DataType::String,
+        ])));
+        let builder = ColumnBuilder::repeat(&scalar, num_rows, &ty);
+        let col = builder.build();
+        assert_eq!(
+            scalar.estimated_scalar_repeat_size(num_rows, &ty),
+            col.memory_size()
+        );
+    }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
@@ -12,56 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
-use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
-use databend_common_pipeline_core::processors::InputPort;
-use databend_common_pipeline_core::processors::OutputPort;
-use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_pipeline_core::Pipeline;
 
 use crate::processors::AccumulatingTransform;
 use crate::processors::BlockCompactMeta;
 use crate::processors::TransformCompactBlock;
 use crate::processors::TransformPipelineHelper;
-use crate::Transform;
-use crate::Transformer;
 
 pub fn build_compact_block_pipeline(
     pipeline: &mut Pipeline,
     thresholds: BlockThresholds,
 ) -> Result<()> {
     let output_len = pipeline.output_len();
-    pipeline.add_transform(ConvertToFullTransform::create)?;
     pipeline.try_resize(1)?;
     pipeline.add_accumulating_transformer(|| BlockCompactBuilder::new(thresholds));
     pipeline.try_resize(output_len)?;
     pipeline.add_block_meta_transformer(TransformCompactBlock::default);
     Ok(())
-}
-
-pub(crate) struct ConvertToFullTransform;
-
-impl ConvertToFullTransform {
-    pub(crate) fn create(input: Arc<InputPort>, output: Arc<OutputPort>) -> Result<ProcessorPtr> {
-        Ok(ProcessorPtr::create(Transformer::create(
-            input,
-            output,
-            ConvertToFullTransform {},
-        )))
-    }
-}
-
-impl Transform for ConvertToFullTransform {
-    const NAME: &'static str = "ConvertToFullTransform";
-
-    fn transform(&mut self, data: DataBlock) -> Result<DataBlock> {
-        Ok(data.consume_convert_to_full())
-    }
 }
 
 pub struct BlockCompactBuilder {
@@ -93,7 +63,7 @@ impl AccumulatingTransform for BlockCompactBuilder {
 
     fn transform(&mut self, data: DataBlock) -> Result<Vec<DataBlock>> {
         let num_rows = data.num_rows();
-        let num_bytes = memory_size(&data);
+        let num_bytes = data.estimate_block_size();
 
         if !self.thresholds.check_for_compact(num_rows, num_bytes) {
             // holding slices of blocks to merge later may lead to oom, so
@@ -141,19 +111,4 @@ impl AccumulatingTransform for BlockCompactBuilder {
             ))]),
         }
     }
-}
-
-pub fn memory_size(data_block: &DataBlock) -> usize {
-    data_block
-        .columns()
-        .iter()
-        .map(|entry| match &entry.value {
-            Value::Column(Column::Nullable(col)) if col.validity.true_count() == 0 => {
-                // For `Nullable` columns with no valid values,
-                // only the size of the validity bitmap is counted.
-                col.validity.as_slice().0.len()
-            }
-            _ => entry.memory_size(),
-        })
-        .sum()
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_no_split_builder.rs
@@ -79,7 +79,7 @@ impl AccumulatingTransform for BlockCompactNoSplitBuilder {
 
     fn transform(&mut self, data: DataBlock) -> Result<Vec<DataBlock>> {
         self.accumulated_rows += data.num_rows();
-        self.accumulated_bytes += crate::processors::memory_size(&data);
+        self.accumulated_bytes += data.estimate_block_size();
         if !self
             .thresholds
             .check_large_enough(self.accumulated_rows, self.accumulated_bytes)

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
@@ -17,7 +17,6 @@ use databend_common_expression::BlockThresholds;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
-use databend_common_pipeline_transforms::memory_size;
 use databend_common_pipeline_transforms::sort_merge;
 use databend_common_settings::Settings;
 
@@ -56,7 +55,7 @@ impl DataProcessorStrategy for CompactStrategy {
         let mut result = Vec::with_capacity(blocks_num);
         for block in data_blocks {
             accumulated_rows += block.num_rows();
-            accumulated_bytes += memory_size(&block);
+            accumulated_bytes += block.estimate_block_size();
             if !self
                 .thresholds
                 .check_large_enough(accumulated_rows, accumulated_bytes)

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -563,7 +563,7 @@ impl TestFixture {
         num_of_blocks: usize,
         start: i32,
     ) -> (TableSchemaRef, Vec<Result<DataBlock>>) {
-        Self::gen_sample_blocks_ex(num_of_blocks, 3, start)
+        Self::gen_sample_blocks_ex(num_of_blocks, 2, start)
     }
 
     pub fn gen_sample_blocks_ex(

--- a/src/query/service/src/test_kits/fuse.rs
+++ b/src/query/service/src/test_kits/fuse.rs
@@ -177,7 +177,7 @@ async fn generate_blocks(
     let mut block_metas = vec![];
 
     // does not matter in this suite
-    let rows_per_block = 1;
+    let rows_per_block = 2;
     let value_start_from = 1;
 
     let stream =

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -41,7 +41,6 @@ use databend_common_metrics::storage::metrics_inc_block_inverted_index_write_num
 use databend_common_metrics::storage::metrics_inc_block_write_milliseconds;
 use databend_common_metrics::storage::metrics_inc_block_write_nums;
 use databend_common_native::write::NativeWriter;
-use databend_common_pipeline_transforms::memory_size;
 use databend_storages_common_blocks::blocks_to_parquet;
 use databend_storages_common_index::BloomIndex;
 use databend_storages_common_io::ReadSettings;
@@ -384,8 +383,7 @@ impl BlockBuilder {
             gen_columns_statistics(&data_block, column_distinct_count, &self.source_schema)?;
 
         let mut buffer = Vec::with_capacity(DEFAULT_BLOCK_BUFFER_SIZE);
-        let data_block = data_block.consume_convert_to_full();
-        let block_size = memory_size(&data_block) as u64;
+        let block_size = data_block.estimate_block_size() as u64;
         let col_metas = serialize_block(
             &self.write_settings,
             &self.source_schema,

--- a/tests/sqllogictests/scripts/prepare_iceberg_tpch_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_tpch_data.py
@@ -157,7 +157,7 @@ for table_name, (schema, file_path) in tables.items():
 
     create_table = f"""
     CREATE OR REPLACE TABLE {full_table_name} (
-        {', '.join([f'{field.name} {field.dataType.simpleString()}' for field in schema.fields])}
+        {", ".join([f"{field.name} {field.dataType.simpleString()}" for field in schema.fields])}
     ) USING iceberg;
     """
     print(create_table)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0006_func_fuse_history.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0006_func_fuse_history.test
@@ -18,10 +18,10 @@ select count(1) from fuse_block('db_09_0006', 't')
 statement ok
 insert into t values (1)
 
-query II
-select block_count, row_count from fuse_snapshot('db_09_0006', 't') order by row_count desc limit 1
+query III
+select block_count, row_count, index_size from fuse_snapshot('db_09_0006', 't') order by row_count desc limit 1
 ----
-1 1
+1 1 0
 
 query I
 select count(1) from fuse_block('db_09_0006', 't')
@@ -31,10 +31,10 @@ select count(1) from fuse_block('db_09_0006', 't')
 statement ok
 insert into t values (2),(3)
 
-query II
-select block_count, row_count from fuse_snapshot('db_09_0006', 't') order by row_count desc limit 1
+query III
+select block_count, row_count, index_size from fuse_snapshot('db_09_0006', 't') order by row_count desc limit 1
 ----
-2 3
+2 3 425
 
 query II
 select block_count, row_count from fuse_snapshot('db_09_0006', 't') order by row_count;
@@ -47,6 +47,12 @@ select block_size from fuse_block('db_09_0006', 't') order by block_size
 ----
 8
 16
+
+query I
+select bloom_filter_size from fuse_block('db_09_0006', 't') order by bloom_filter_size
+----
+0
+425
 
 statement ok
 create table t1(a int not null) row_per_block=3

--- a/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.py
+++ b/tests/suites/1_stateful/09_http_handler/09_0010_heartbeat.py
@@ -8,19 +8,19 @@ auth = ("root", "")
 STICKY_HEADER = "X-DATABEND-STICKY-NODE"
 
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s %(levelname)s %(message)s")
-session = {
-    "settings": {
-        "http_handler_result_timeout_secs": "3",
-        "max_threads": "32"
-    }
-}
+session = {"settings": {"http_handler_result_timeout_secs": "3", "max_threads": "32"}}
+
 
 def do_query(query, port=8000):
     url = f"http://localhost:{port}/v1/query"
     query_payload = {
         "sql": query,
-        "pagination": {"wait_time_secs": 2, "max_rows_per_page": 4, "max_rows_in_buffer": 3},
-        "session": session
+        "pagination": {
+            "wait_time_secs": 2,
+            "max_rows_per_page": 4,
+            "max_rows_in_buffer": 3,
+        },
+        "session": session,
     }
     headers = {
         "Content-Type": "application/json",
@@ -43,7 +43,7 @@ def test_heartbeat(port):
     m = {}
     m.setdefault(resp1.get("node_id"), []).append(resp1.get("id"))
     m.setdefault(resp2.get("node_id"), []).append(resp2.get("id"))
-    payload = { "node_to_queries": m }
+    payload = {"node_to_queries": m}
     headers = {
         "Content-Type": "application/json",
     }
@@ -53,13 +53,11 @@ def test_heartbeat(port):
         assert len(response.get("queries_to_remove")) == 0
         time.sleep(1)
 
-    for (i, r) in enumerate([resp1, resp2]):
+    for i, r in enumerate([resp1, resp2]):
         print(f"continue fetch {i}")
-        headers = {
-            STICKY_HEADER: r.get("node_id")
-        }
+        headers = {STICKY_HEADER: r.get("node_id")}
         next_uri = f"http://localhost:8000/{r.get('next_uri')}?"
-        response = requests.get(next_uri, headers=headers ,auth=auth)
+        response = requests.get(next_uri, headers=headers, auth=auth)
         assert response.status_code == 200, f"{response.status_code} {response.text}"
         assert len(response.json().get("data")) > 0
     print("end")

--- a/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
@@ -119,7 +119,7 @@ echo "select * from test_vacuum_drop_4.b"  | $BENDSQL_CLIENT_CONNECT
 
 ## test vacuum table output
 echo "create table test_vacuum_drop_4.c(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_4.c VALUES (1)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "INSERT INTO test_vacuum_drop_4.c VALUES (1),(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
 count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c" | $BENDSQL_CLIENT_CONNECT | awk '{print $9}')
 if [[ "$count" != "4" ]]; then
   echo "vacuum table, count:$count"

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.result
@@ -1,11 +1,11 @@
 >>>> create or replace database test_vacuum_table_only_orphans
 >>>> create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'
->>>> insert into test_vacuum_table_only_orphans.a values (1)
-1
->>>> insert into test_vacuum_table_only_orphans.a values (2)
-1
->>>> insert into test_vacuum_table_only_orphans.a values (3)
-1
+>>>> insert into test_vacuum_table_only_orphans.a values (1),(2)
+2
+>>>> insert into test_vacuum_table_only_orphans.a values (2),(3)
+2
+>>>> insert into test_vacuum_table_only_orphans.a values (3),(4)
+2
 before purge
 4
 4

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
@@ -10,9 +10,9 @@ mkdir -p /tmp/test_vacuum_table_only_orphans/
 stmt "create or replace table test_vacuum_table_only_orphans.a(c int) 'fs:///tmp/test_vacuum_table_only_orphans/'"
 
 
-stmt "insert into test_vacuum_table_only_orphans.a values (1)"
-stmt "insert into test_vacuum_table_only_orphans.a values (2)"
-stmt "insert into test_vacuum_table_only_orphans.a values (3)"
+stmt "insert into test_vacuum_table_only_orphans.a values (1),(2)"
+stmt "insert into test_vacuum_table_only_orphans.a values (2),(3)"
+stmt "insert into test_vacuum_table_only_orphans.a values (3),(4)"
 
 SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_table_only_orphans','a') limit 1" | $BENDSQL_CLIENT_CONNECT)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. optimization to the Bloom index construction process. Specifically, it skips building a Bloom index for columns that contain only a single unique value or are entirely composed of NULL values. Because we donot need to generate bloom index, it will never be used since range index is checked first.
2. Calculate the block's memory without convert to full column.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17625)
<!-- Reviewable:end -->
