### PR TITLE
chore: calc rows per block for recluster

### DIFF
--- a/src/common/io/src/constants.rs
+++ b/src/common/io/src/constants.rs
@@ -25,15 +25,13 @@ pub const INF_BYTES_LOWER: &str = "inf";
 pub const INF_BYTES_LONG: &str = "Infinity";
 
 // The size of the I/O read/write block buffer by default.
-pub const DEFAULT_BLOCK_BUFFER_SIZE: usize = 100 * 1024 * 1024;
+pub const DEFAULT_BLOCK_BUFFER_SIZE: usize = 125 * 1024 * 1024;
 // The size of the block compressed by default.
 pub const DEFAULT_BLOCK_COMPRESSED_SIZE: usize = 16 * 1024 * 1024;
 // The size of the I/O read/write block index buffer by default.
 pub const DEFAULT_BLOCK_INDEX_BUFFER_SIZE: usize = 300 * 1024;
 // The max number of a block by default.
-pub const DEFAULT_BLOCK_MAX_ROWS: usize = 1000 * 1000;
-// The min number of a block by default.
-pub const DEFAULT_BLOCK_MIN_ROWS: usize = 800 * 1000;
+pub const DEFAULT_BLOCK_ROW_COUNT: usize = 1000 * 1000;
 // The number of blocks in a segment by default.
 pub const DEFAULT_BLOCK_PER_SEGMENT: usize = 1000;
 /// The number of bytes read at the end of the file on first read

--- a/src/common/io/src/constants.rs
+++ b/src/common/io/src/constants.rs
@@ -27,7 +27,7 @@ pub const INF_BYTES_LONG: &str = "Infinity";
 // The size of the I/O read/write block buffer by default.
 pub const DEFAULT_BLOCK_BUFFER_SIZE: usize = 100 * 1024 * 1024;
 // The size of the block compressed by default.
-pub const DEFAULT_BLOCK_COMPRESSED_SIZE: usize = 10 * 1024 * 1024;
+pub const DEFAULT_BLOCK_COMPRESSED_SIZE: usize = 16 * 1024 * 1024;
 // The size of the I/O read/write block index buffer by default.
 pub const DEFAULT_BLOCK_INDEX_BUFFER_SIZE: usize = 300 * 1024;
 // The max number of a block by default.

--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -28,11 +28,6 @@ use databend_common_expression::BlockThresholds;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchema;
-use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
-use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
-use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
-use databend_common_io::constants::DEFAULT_BLOCK_MIN_ROWS;
-use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::UnknownTableId;
 use databend_common_meta_app::schema::TableIdent;
@@ -382,13 +377,7 @@ pub trait Table: Sync + Send {
     }
 
     fn get_block_thresholds(&self) -> BlockThresholds {
-        BlockThresholds {
-            max_rows_per_block: DEFAULT_BLOCK_MAX_ROWS,
-            min_rows_per_block: DEFAULT_BLOCK_MIN_ROWS,
-            max_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE,
-            max_bytes_per_file: DEFAULT_BLOCK_COMPRESSED_SIZE,
-            block_per_segment: DEFAULT_BLOCK_PER_SEGMENT,
-        }
+        BlockThresholds::default()
     }
 
     #[async_backtrace::framed]

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -14,26 +14,32 @@
 
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
-use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
-use databend_common_io::constants::DEFAULT_BLOCK_MIN_ROWS;
 use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
+use databend_common_io::constants::DEFAULT_BLOCK_ROW_COUNT;
 
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 pub struct BlockThresholds {
     pub max_rows_per_block: usize,
     pub min_rows_per_block: usize,
+
     pub max_bytes_per_block: usize,
-    pub max_bytes_per_file: usize,
+    pub min_bytes_per_block: usize,
+
+    pub max_compressed_per_block: usize,
+    pub min_compressed_per_block: usize,
+
     pub block_per_segment: usize,
 }
 
 impl Default for BlockThresholds {
     fn default() -> BlockThresholds {
         BlockThresholds {
-            max_rows_per_block: DEFAULT_BLOCK_MAX_ROWS,
-            min_rows_per_block: DEFAULT_BLOCK_MIN_ROWS,
+            max_rows_per_block: DEFAULT_BLOCK_ROW_COUNT,
+            min_rows_per_block: (DEFAULT_BLOCK_ROW_COUNT * 4).div_ceil(5),
             max_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE,
-            max_bytes_per_file: DEFAULT_BLOCK_COMPRESSED_SIZE,
+            min_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE * 4 / 5,
+            max_compressed_per_block: DEFAULT_BLOCK_COMPRESSED_SIZE,
+            min_compressed_per_block: (DEFAULT_BLOCK_COMPRESSED_SIZE * 4).div_ceil(5),
             block_per_segment: DEFAULT_BLOCK_PER_SEGMENT,
         }
     }
@@ -42,16 +48,17 @@ impl Default for BlockThresholds {
 impl BlockThresholds {
     pub fn new(
         max_rows_per_block: usize,
-        min_rows_per_block: usize,
         max_bytes_per_block: usize,
-        max_bytes_per_file: usize,
+        max_compressed_per_block: usize,
         block_per_segment: usize,
     ) -> Self {
         BlockThresholds {
             max_rows_per_block,
-            min_rows_per_block,
+            min_rows_per_block: (max_rows_per_block * 4).div_ceil(5),
             max_bytes_per_block,
-            max_bytes_per_file,
+            min_bytes_per_block: (max_bytes_per_block * 4).div_ceil(5),
+            max_compressed_per_block,
+            min_compressed_per_block: (max_compressed_per_block * 4).div_ceil(5),
             block_per_segment,
         }
     }
@@ -64,8 +71,8 @@ impl BlockThresholds {
         file_size: usize,
     ) -> bool {
         row_count >= self.min_rows_per_block
-            || block_size >= self.max_bytes_per_block
-            || file_size >= self.max_bytes_per_file
+            || block_size >= self.min_bytes_per_block
+            || file_size >= self.min_compressed_per_block
     }
 
     #[inline]
@@ -78,25 +85,25 @@ impl BlockThresholds {
     ) -> bool {
         total_blocks >= self.block_per_segment
             && (total_rows >= self.min_rows_per_block * self.block_per_segment
-                || total_bytes >= self.max_bytes_per_block * self.block_per_segment
-                || total_compressed >= self.max_bytes_per_file * self.block_per_segment)
+                || total_bytes >= self.min_bytes_per_block * self.block_per_segment
+                || total_compressed >= self.min_compressed_per_block * self.block_per_segment)
     }
 
     #[inline]
     pub fn check_large_enough(&self, row_count: usize, block_size: usize) -> bool {
-        row_count >= self.min_rows_per_block || block_size >= self.max_bytes_per_block
+        row_count >= self.min_rows_per_block || block_size >= self.min_bytes_per_block
     }
 
     #[inline]
     pub fn check_for_compact(&self, row_count: usize, block_size: usize) -> bool {
-        row_count < 2 * self.min_rows_per_block && block_size < 2 * self.max_bytes_per_block
+        row_count < 2 * self.min_rows_per_block && block_size < 2 * self.min_bytes_per_block
     }
 
     #[inline]
     pub fn check_too_small(&self, row_count: usize, block_size: usize, file_size: usize) -> bool {
         row_count < self.min_rows_per_block / 2
-            && block_size < self.max_bytes_per_block / 2
-            && file_size <= self.max_bytes_per_file / 2
+            && block_size < self.min_bytes_per_block / 2
+            && file_size < self.min_compressed_per_block / 2
     }
 
     #[inline]
@@ -106,18 +113,11 @@ impl BlockThresholds {
         }
 
         let block_num_by_rows = std::cmp::max(total_rows / self.min_rows_per_block, 1);
-        let block_num_by_size = total_bytes / self.max_bytes_per_block;
+        let block_num_by_size = total_bytes / self.min_bytes_per_block;
         if block_num_by_rows >= block_num_by_size {
             return self.max_rows_per_block;
         }
-
-        let mut rows_per_block = total_rows.div_ceil(block_num_by_size);
-        if rows_per_block < self.max_rows_per_block / 2 {
-            // If block rows < 500_000, max_bytes_per_block set to 125M
-            let block_num_by_size = (4 * block_num_by_size / 5).max(1);
-            rows_per_block = total_rows.div_ceil(block_num_by_size);
-        }
-        rows_per_block
+        total_rows.div_ceil(block_num_by_size)
     }
 
     /// Calculates the optimal number of rows per block based on total data size and row count.
@@ -142,7 +142,7 @@ impl BlockThresholds {
         }
 
         let block_num_by_rows = std::cmp::max(total_rows / self.min_rows_per_block, 1);
-        let block_num_by_compressed = total_compressed.div_ceil(self.max_bytes_per_file);
+        let block_num_by_compressed = total_compressed.div_ceil(self.max_compressed_per_block);
         // If row-based block count exceeds compressed-based block count, use max rows per block.
         if block_num_by_rows >= block_num_by_compressed {
             return self.max_rows_per_block;
@@ -150,12 +150,14 @@ impl BlockThresholds {
 
         let bytes_per_block = total_bytes.div_ceil(block_num_by_compressed);
         // Adjust the number of blocks based on block size thresholds.
-        let block_nums = if bytes_per_block > 4 * self.max_bytes_per_block {
+        let max_bytes_per_block = (4 * self.min_bytes_per_block).min(400 * 1024 * 1024);
+        let min_bytes_per_block = (self.min_bytes_per_block / 2).min(50 * 1024 * 1024);
+        let block_nums = if bytes_per_block > max_bytes_per_block {
             // Case 1: If the block size exceeds 400MB
-            total_bytes.div_ceil(4 * self.max_bytes_per_block)
-        } else if bytes_per_block < self.max_bytes_per_block / 2 {
+            total_bytes.div_ceil(max_bytes_per_block)
+        } else if bytes_per_block < min_bytes_per_block {
             // Case 2: If the block size is smaller than 50MB
-            total_bytes * 2 / self.max_bytes_per_block
+            total_bytes / min_bytes_per_block
         } else {
             // Case 3: Otherwise, use the compressed-based block count.
             block_num_by_compressed

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -37,7 +37,7 @@ impl Default for BlockThresholds {
             max_rows_per_block: DEFAULT_BLOCK_ROW_COUNT,
             min_rows_per_block: (DEFAULT_BLOCK_ROW_COUNT * 4).div_ceil(5),
             max_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE,
-            min_bytes_per_block: DEFAULT_BLOCK_BUFFER_SIZE * 4 / 5,
+            min_bytes_per_block: (DEFAULT_BLOCK_BUFFER_SIZE * 4).div_ceil(5),
             max_compressed_per_block: DEFAULT_BLOCK_COMPRESSED_SIZE,
             min_compressed_per_block: (DEFAULT_BLOCK_COMPRESSED_SIZE * 4).div_ceil(5),
             block_per_segment: DEFAULT_BLOCK_PER_SEGMENT,
@@ -150,10 +150,10 @@ impl BlockThresholds {
 
         let bytes_per_block = total_bytes.div_ceil(block_num_by_compressed);
         // Adjust the number of blocks based on block size thresholds.
-        let max_bytes_per_block = (4 * self.min_bytes_per_block).min(400 * 1024 * 1024);
+        let max_bytes_per_block = (4 * self.min_bytes_per_block).min(500 * 1024 * 1024);
         let min_bytes_per_block = (self.min_bytes_per_block / 2).min(50 * 1024 * 1024);
         let block_nums = if bytes_per_block > max_bytes_per_block {
-            // Case 1: If the block size exceeds 400MB
+            // Case 1: If the block size exceeds 500MB
             total_bytes.div_ceil(max_bytes_per_block)
         } else if bytes_per_block < min_bytes_per_block {
             // Case 2: If the block size is smaller than 50MB

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -142,7 +142,7 @@ impl BlockThresholds {
         }
 
         let block_num_by_rows = std::cmp::max(total_rows / self.min_rows_per_block, 1);
-        let block_num_by_compressed = total_compressed / self.max_bytes_per_file;
+        let block_num_by_compressed = total_compressed.div_ceil(self.max_bytes_per_file);
         // If row-based block count exceeds compressed-based block count, use max rows per block.
         if block_num_by_rows >= block_num_by_compressed {
             return self.max_rows_per_block;
@@ -152,7 +152,7 @@ impl BlockThresholds {
         // Adjust the number of blocks based on block size thresholds.
         let block_nums = if bytes_per_block > 4 * self.max_bytes_per_block {
             // Case 1: If the block size exceeds 400MB
-            total_bytes / (4 * self.max_bytes_per_block)
+            total_bytes.div_ceil(4 * self.max_bytes_per_block)
         } else if bytes_per_block < self.max_bytes_per_block / 2 {
             // Case 2: If the block size is smaller than 50MB
             total_bytes * 2 / self.max_bytes_per_block

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -150,10 +150,10 @@ impl BlockThresholds {
 
         let bytes_per_block = total_bytes.div_ceil(block_num_by_compressed);
         // Adjust the number of blocks based on block size thresholds.
-        let max_bytes_per_block = (4 * self.min_bytes_per_block).min(500 * 1024 * 1024);
+        let max_bytes_per_block = (4 * self.min_bytes_per_block).min(400 * 1024 * 1024);
         let min_bytes_per_block = (self.min_bytes_per_block / 2).min(50 * 1024 * 1024);
         let block_nums = if bytes_per_block > max_bytes_per_block {
-            // Case 1: If the block size exceeds 500MB
+            // Case 1: If the block size exceeds 400MB
             total_bytes.div_ceil(max_bytes_per_block)
         } else if bytes_per_block < min_bytes_per_block {
             // Case 2: If the block size is smaller than 50MB

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -132,12 +132,14 @@ impl BlockThresholds {
     #[inline]
     pub fn calc_rows_for_recluster(
         &self,
-        total_bytes: usize,
         total_rows: usize,
+        total_bytes: usize,
         total_compressed: usize,
     ) -> usize {
         // Check if the data is compact enough to skip further calculations.
-        if self.check_for_compact(total_rows, total_bytes) {
+        if self.check_for_compact(total_rows, total_bytes)
+            && total_compressed < 2 * self.min_compressed_per_block
+        {
             return total_rows;
         }
 
@@ -153,10 +155,10 @@ impl BlockThresholds {
         let max_bytes_per_block = (4 * self.min_bytes_per_block).min(400 * 1024 * 1024);
         let min_bytes_per_block = (self.min_bytes_per_block / 2).min(50 * 1024 * 1024);
         let block_nums = if bytes_per_block > max_bytes_per_block {
-            // Case 1: If the block size exceeds 400MB
+            // Case 1: If the block size is too bigger.
             total_bytes.div_ceil(max_bytes_per_block)
         } else if bytes_per_block < min_bytes_per_block {
-            // Case 2: If the block size is smaller than 50MB
+            // Case 2: If the block size is too smaller.
             total_bytes / min_bytes_per_block
         } else {
             // Case 3: Otherwise, use the compressed-based block count.

--- a/src/query/expression/tests/it/block.rs
+++ b/src/query/expression/tests/it/block.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use databend_common_column::buffer::Buffer;
 use databend_common_expression::block_debug::box_render;
 use databend_common_expression::types::number::NumberScalar;

--- a/src/query/expression/tests/it/block_thresholds.rs
+++ b/src/query/expression/tests/it/block_thresholds.rs
@@ -1,0 +1,114 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_expression::BlockThresholds;
+
+fn default_thresholds() -> BlockThresholds {
+    BlockThresholds::new(1000, 1_000_000, 100_000, 4)
+}
+
+#[test]
+fn test_check_perfect_block() {
+    let t = default_thresholds();
+
+    // All below threshold
+    assert!(!t.check_perfect_block(100, 1000, 1000));
+
+    // Any one above threshold
+    assert!(t.check_perfect_block(800, 1000, 1000));
+    assert!(t.check_perfect_block(100, 800_000, 1000));
+    assert!(t.check_perfect_block(100, 1000, 80_000));
+}
+
+#[test]
+fn test_check_perfect_segment() {
+    let t = default_thresholds();
+    let total_blocks = 4;
+
+    // Below threshold
+    assert!(!t.check_perfect_segment(total_blocks, 100, 1000, 1000));
+
+    // One condition meets threshold
+    assert!(t.check_perfect_segment(total_blocks, 4000, 1000, 1000));
+    assert!(t.check_perfect_segment(total_blocks, 100, 4_000_000, 1000));
+    assert!(t.check_perfect_segment(total_blocks, 100, 1000, 320_000));
+}
+
+#[test]
+fn test_check_large_enough() {
+    let t = default_thresholds();
+
+    assert!(!t.check_large_enough(100, 1000));
+    assert!(t.check_large_enough(800, 1000));
+    assert!(t.check_large_enough(100, 800_000));
+}
+
+#[test]
+fn test_check_for_compact() {
+    let t = default_thresholds();
+
+    assert!(t.check_for_compact(1500, 1_500_000)); // just under 2x min
+    assert!(!t.check_for_compact(3000, 3_000_000)); // too large
+}
+
+#[test]
+fn test_check_too_small() {
+    let t = default_thresholds();
+
+    assert!(t.check_too_small(50, 10_000, 10_000)); // All very small
+    assert!(!t.check_too_small(800, 10_000, 10_000)); // Row count not too small
+    assert!(!t.check_too_small(50, 800_000, 10_000)); // Block size not too small
+}
+
+#[test]
+fn test_calc_rows_for_compact() {
+    let t = default_thresholds();
+
+    assert_eq!(t.calc_rows_for_compact(500_000, 1000), 1000);
+
+    // Block number by rows wins → max_rows_per_block
+    assert_eq!(
+        t.calc_rows_for_compact(2_000_000, 10_000),
+        t.max_rows_per_block
+    );
+
+    // Size-based block number wins
+    assert_eq!(t.calc_rows_for_compact(4_000_000, 2000), 400);
+}
+
+#[test]
+fn test_calc_rows_for_recluster() {
+    let t = default_thresholds();
+
+    // compact enough to skip further calculations
+    assert_eq!(t.calc_rows_for_recluster(1000, 500_000, 100_000), 1000);
+
+    // row-based block count exceeds compressed-based block count, use max rows per block.
+    assert_eq!(
+        t.calc_rows_for_recluster(10_000, 2_000_000, 100_000),
+        t.max_rows_per_block
+    );
+
+    // Case 1: If the block size is too bigger.
+    let result = t.calc_rows_for_recluster(4_000, 30_000_000, 600_000);
+    assert_eq!(result, 400);
+
+    // Case 2: If the block size is too smaller.
+    let result = t.calc_rows_for_recluster(4_000, 2_000_000, 600_000);
+    assert_eq!(result, 800);
+
+    // Case 3: use the compressed-based block count.
+    let result = t.calc_rows_for_recluster(4_000, 10_000_000, 600_000);
+    assert_eq!(result, 667);
+}

--- a/src/query/expression/tests/it/main.rs
+++ b/src/query/expression/tests/it/main.rs
@@ -26,6 +26,7 @@ extern crate core;
 
 mod arrow;
 mod block;
+mod block_thresholds;
 mod common;
 mod decimal;
 mod fill_field_default_value;

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
@@ -69,7 +69,7 @@ impl AccumulatingTransform for BlockCompactBuilder {
             // holding slices of blocks to merge later may lead to oom, so
             // 1. we expect blocks from file formats are not slice.
             // 2. if block is split here, cut evenly and emit them at once.
-            let rows_per_block = self.thresholds.calc_rows_per_block(num_bytes, num_rows, 0);
+            let rows_per_block = self.thresholds.calc_rows_for_compact(num_bytes, num_rows);
             Ok(vec![DataBlock::empty_with_meta(Box::new(
                 BlockCompactMeta::Split {
                     block: data,

--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -20,7 +20,7 @@ use chrono::Duration;
 use databend_common_ast::ast::Engine;
 use databend_common_exception::ErrorCode;
 use databend_common_expression::TableSchemaRef;
-use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
+use databend_common_io::constants::DEFAULT_BLOCK_ROW_COUNT;
 use databend_common_settings::Settings;
 use databend_common_sql::BloomIndexColumns;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
@@ -154,7 +154,7 @@ pub fn is_valid_row_per_block(
         let row_per_block = value.parse::<u64>()?;
         let error_str = "invalid row_per_block option, can't be over 1000000";
 
-        if row_per_block > DEFAULT_BLOCK_MAX_ROWS as u64 {
+        if row_per_block > DEFAULT_BLOCK_ROW_COUNT as u64 {
             error!("{}", error_str);
             return Err(ErrorCode::TableOptionInvalid(error_str));
         }

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -321,7 +321,7 @@ impl ReclusterTableInterpreter {
 
         // Determine rows per block based on data size and compression ratio
         let rows_per_block =
-            block_thresholds.calc_rows_for_recluster(total_bytes, total_rows, total_compressed);
+            block_thresholds.calc_rows_for_recluster(total_rows, total_bytes, total_compressed);
 
         // Calculate initial partition count based on data volume and block size
         let mut total_partitions = std::cmp::max(total_rows / rows_per_block, 1);

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -321,7 +321,7 @@ impl ReclusterTableInterpreter {
 
         // Determine rows per block based on data size and compression ratio
         let rows_per_block =
-            block_thresholds.calc_rows_per_block(total_bytes, total_rows, total_compressed);
+            block_thresholds.calc_rows_for_recluster(total_bytes, total_rows, total_compressed);
 
         // Calculate initial partition count based on data volume and block size
         let mut total_partitions = std::cmp::max(total_rows / rows_per_block, 1);

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -472,6 +472,7 @@ impl ReclusterTableInterpreter {
             table_info: table_info.clone(),
             num_partitions: total_partitions,
             table_meta_timestamps,
+            rows_per_block,
         }));
 
         // Finally, commit the newly clustered table

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -151,7 +151,7 @@ impl PipelineBuilder {
                     .collect();
 
                 // merge sort
-                let sort_block_size = block_thresholds.calc_rows_per_block(
+                let sort_block_size = block_thresholds.calc_rows_for_recluster(
                     task.total_bytes,
                     task.total_rows,
                     task.total_compressed,

--- a/src/query/service/src/pipelines/builders/builder_recluster.rs
+++ b/src/query/service/src/pipelines/builders/builder_recluster.rs
@@ -152,8 +152,8 @@ impl PipelineBuilder {
 
                 // merge sort
                 let sort_block_size = block_thresholds.calc_rows_for_recluster(
-                    task.total_bytes,
                     task.total_rows,
+                    task.total_bytes,
                     task.total_compressed,
                 );
 

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
-use databend_common_expression::BlockThresholds;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
@@ -26,16 +25,24 @@ pub trait DataProcessorStrategy: Send + Sync + 'static {
 }
 
 pub struct CompactStrategy {
-    thresholds: BlockThresholds,
+    max_bytes_per_block: usize,
+    max_rows_per_block: usize,
 }
 
 impl CompactStrategy {
-    pub fn new(thresholds: BlockThresholds) -> Self {
-        Self { thresholds }
+    pub fn new(max_rows_per_block: usize, max_bytes_per_block: usize) -> Self {
+        Self {
+            max_bytes_per_block,
+            max_rows_per_block,
+        }
     }
 
     fn concat_blocks(blocks: Vec<DataBlock>) -> Result<DataBlock> {
         DataBlock::concat(&blocks)
+    }
+
+    fn check_large_enough(&self, rows: usize, bytes: usize) -> bool {
+        rows >= self.max_rows_per_block || bytes >= self.max_bytes_per_block
     }
 }
 
@@ -56,29 +63,14 @@ impl DataProcessorStrategy for CompactStrategy {
         for block in data_blocks {
             accumulated_rows += block.num_rows();
             accumulated_bytes += block.estimate_block_size();
-            if !self
-                .thresholds
-                .check_large_enough(accumulated_rows, accumulated_bytes)
-            {
-                pending_blocks.push(block);
+            pending_blocks.push(block);
+            if !self.check_large_enough(accumulated_rows, accumulated_bytes) {
                 continue;
             }
-
             if !staged_blocks.is_empty() {
                 result.push(Self::concat_blocks(std::mem::take(&mut staged_blocks))?);
             }
-
-            if pending_blocks.is_empty()
-                || self
-                    .thresholds
-                    .check_for_compact(accumulated_rows, accumulated_bytes)
-            {
-                std::mem::swap(&mut staged_blocks, &mut pending_blocks);
-            } else {
-                result.push(Self::concat_blocks(std::mem::take(&mut pending_blocks))?);
-            }
-
-            staged_blocks.push(block);
+            std::mem::swap(&mut staged_blocks, &mut pending_blocks);
             accumulated_rows = 0;
             accumulated_bytes = 0;
         }

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -173,13 +173,7 @@ async fn test_safety() -> Result<()> {
     settings.set_max_threads(2)?;
     settings.set_max_storage_io_requests(4)?;
 
-    let threshold = BlockThresholds {
-        max_rows_per_block: 5,
-        min_rows_per_block: 4,
-        max_bytes_per_block: 1024,
-        max_bytes_per_file: 100,
-        block_per_segment: 5,
-    };
+    let threshold = BlockThresholds::new(5, 1024, 100, 10);
 
     let schema = TestFixture::default_table_schema();
     let mut rand = thread_rng();

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -182,13 +182,7 @@ async fn test_safety_for_recluster() -> Result<()> {
         .set_recluster_block_size(recluster_block_size as u64)?;
 
     let cluster_key_id = 0;
-    let threshold = BlockThresholds {
-        max_rows_per_block: 5,
-        min_rows_per_block: 4,
-        max_bytes_per_block: 1024,
-        max_bytes_per_file: 100,
-        block_per_segment: 5,
-    };
+    let threshold = BlockThresholds::new(5, 1024, 100, 5);
 
     let data_accessor = operator.clone();
     let schema = TestFixture::default_table_schema();

--- a/src/query/service/tests/it/storages/fuse/statistics.rs
+++ b/src/query/service/tests/it/storages/fuse/statistics.rs
@@ -351,13 +351,8 @@ async fn test_ft_cluster_stats_with_stats() -> databend_common_exception::Result
         None,
     ));
 
-    let block_compactor = BlockThresholds::new(
-        1_000_000,
-        800_000,
-        100 * 1024 * 1024,
-        10 * 1024 * 1024,
-        1000,
-    );
+    let block_compactor =
+        BlockThresholds::new(1_000_000, 125 * 1024 * 1024, 16 * 1024 * 1024, 1000);
     let stats_gen = ClusterStatsGenerator::new(
         0,
         vec![0],

--- a/src/query/sql/src/executor/physical_plans/physical_recluster.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_recluster.rs
@@ -33,4 +33,5 @@ pub struct HilbertPartition {
     pub table_info: TableInfo,
     pub num_partitions: usize,
     pub table_meta_timestamps: TableMetaTimestamps,
+    pub rows_per_block: usize,
 }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -58,8 +58,8 @@ use databend_common_expression::ROW_VERSION_COL_NAME;
 use databend_common_expression::SEARCH_SCORE_COLUMN_ID;
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
-use databend_common_io::constants::DEFAULT_BLOCK_MAX_ROWS;
 use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
+use databend_common_io::constants::DEFAULT_BLOCK_ROW_COUNT;
 use databend_common_meta_app::schema::DatabaseType;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
@@ -1044,8 +1044,7 @@ impl Table for FuseTable {
 
     fn get_block_thresholds(&self) -> BlockThresholds {
         let max_rows_per_block =
-            self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_BLOCK_MAX_ROWS);
-        let min_rows_per_block = (max_rows_per_block * 4).div_ceil(5);
+            self.get_option(FUSE_OPT_KEY_ROW_PER_BLOCK, DEFAULT_BLOCK_ROW_COUNT);
         let max_bytes_per_block = self.get_option(
             FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD,
             DEFAULT_BLOCK_BUFFER_SIZE,
@@ -1055,7 +1054,6 @@ impl Table for FuseTable {
             self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
         BlockThresholds::new(
             max_rows_per_block,
-            min_rows_per_block,
             max_bytes_per_block,
             max_file_size,
             block_per_segment,

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -108,10 +108,7 @@ impl BlockCompactMutator {
             self.operator.clone(),
             Arc::new(self.compact_params.base_snapshot.schema.clone()),
         );
-        let mut checker = SegmentCompactChecker::new(
-            self.compact_params.block_per_seg as u64,
-            self.cluster_key_id,
-        );
+        let mut checker = SegmentCompactChecker::new(self.thresholds, self.cluster_key_id);
 
         let mut segment_idx = 0;
         let mut is_end = false;
@@ -144,7 +141,7 @@ impl BlockCompactMutator {
             }
 
             // Check the segment to be compacted.
-            // Size of compacted segment should be in range R == [threshold, 2 * threshold)
+            // Size of compacted segment should be in range R == [threshold, 2 * threshold]
             for (segment_idx, compact_segment) in segment_infos.into_iter() {
                 let segments_vec = checker.add(segment_idx, compact_segment);
                 for segments in segments_vec {
@@ -294,9 +291,9 @@ impl BlockCompactMutator {
 }
 
 pub struct SegmentCompactChecker {
+    thresholds: BlockThresholds,
     segments: Vec<(SegmentIndex, Arc<CompactSegmentInfo>)>,
     total_block_count: u64,
-    block_threshold: u64,
     cluster_key_id: Option<u32>,
 
     compacted_segment_cnt: usize,
@@ -304,15 +301,40 @@ pub struct SegmentCompactChecker {
 }
 
 impl SegmentCompactChecker {
-    pub fn new(block_threshold: u64, cluster_key_id: Option<u32>) -> Self {
+    pub fn new(thresholds: BlockThresholds, cluster_key_id: Option<u32>) -> Self {
         Self {
             segments: vec![],
             total_block_count: 0,
-            block_threshold,
+            thresholds,
             cluster_key_id,
             compacted_block_cnt: 0,
             compacted_segment_cnt: 0,
         }
+    }
+
+    fn check_not_need_compact(&self, summary: &Statistics) -> bool {
+        let cluster_match = match (self.cluster_key_id, summary.cluster_stats.as_ref()) {
+            (Some(id), Some(stats)) => id == stats.cluster_key_id,
+            (None, _) => true,
+            _ => false,
+        };
+
+        if !cluster_match {
+            return false;
+        }
+
+        if summary.block_count == 1 {
+            return true;
+        }
+
+        let avg_rows = (summary.row_count / summary.block_count) as usize;
+        let avg_uncompressed = (summary.uncompressed_byte_size / summary.block_count) as usize;
+        let avg_compressed = (summary.compressed_byte_size / summary.block_count) as usize;
+
+        summary.perfect_block_count == summary.block_count
+            && self
+                .thresholds
+                .check_perfect_block(avg_rows, avg_uncompressed, avg_compressed)
     }
 
     fn check_for_compact(&mut self, segments: &[(SegmentIndex, Arc<CompactSegmentInfo>)]) -> bool {
@@ -320,21 +342,15 @@ impl SegmentCompactChecker {
             return false;
         }
 
-        if segments.len() == 1 {
-            let summary = &segments[0].1.summary;
-            if (summary.block_count == 1 || summary.perfect_block_count == summary.block_count)
-                && (self.cluster_key_id.is_none()
-                    || self.cluster_key_id
-                        == summary.cluster_stats.as_ref().map(|v| v.cluster_key_id))
-            {
-                return false;
-            }
+        if segments.len() == 1 && self.check_not_need_compact(&segments[0].1.summary) {
+            return false;
         }
 
         self.compacted_segment_cnt += segments.len();
         self.compacted_block_cnt += segments
             .iter()
-            .fold(0, |acc, x| acc + x.1.summary.block_count);
+            .map(|(_, info)| info.summary.block_count)
+            .sum::<u64>();
         true
     }
 
@@ -343,25 +359,28 @@ impl SegmentCompactChecker {
         idx: SegmentIndex,
         segment: Arc<CompactSegmentInfo>,
     ) -> Vec<Vec<(SegmentIndex, Arc<CompactSegmentInfo>)>> {
+        let block_per_segment = self.thresholds.block_per_segment as u64;
+
         self.total_block_count += segment.summary.block_count;
-        if self.total_block_count < self.block_threshold {
-            self.segments.push((idx, segment));
+        self.segments.push((idx, segment));
+
+        if self.total_block_count < block_per_segment {
             return vec![];
         }
 
-        if self.total_block_count >= 2 * self.block_threshold {
-            self.total_block_count = 0;
-            let trivial = vec![(idx, segment)];
+        let output = if self.total_block_count >= 2 * block_per_segment {
+            let trivial = vec![self.segments.pop().unwrap()];
             if self.segments.is_empty() {
-                return vec![trivial];
+                vec![trivial]
             } else {
-                return vec![std::mem::take(&mut self.segments), trivial];
+                vec![std::mem::take(&mut self.segments), trivial]
             }
-        }
+        } else {
+            vec![std::mem::take(&mut self.segments)]
+        };
 
         self.total_block_count = 0;
-        self.segments.push((idx, segment));
-        vec![std::mem::take(&mut self.segments)]
+        output
     }
 
     pub fn generate_part(
@@ -370,15 +389,11 @@ impl SegmentCompactChecker {
         parts: &mut Vec<PartInfoPtr>,
     ) {
         if !segments.is_empty() && self.check_for_compact(&segments) {
-            let mut segment_indices = Vec::with_capacity(segments.len());
-            let mut compact_segments = Vec::with_capacity(segments.len());
-            for (idx, segment) in segments.into_iter() {
-                segment_indices.push(idx);
-                compact_segments.push(segment);
-            }
-
-            let lazy_part = CompactLazyPartInfo::create(segment_indices, compact_segments);
-            parts.push(lazy_part);
+            let (segment_indices, compact_segments) = segments.into_iter().unzip();
+            parts.push(CompactLazyPartInfo::create(
+                segment_indices,
+                compact_segments,
+            ));
         }
     }
 
@@ -389,10 +404,11 @@ impl SegmentCompactChecker {
 
     pub fn is_limit_reached(&self, num_segment_limit: usize, num_block_limit: usize) -> bool {
         let residual_segment_cnt = self.segments.len();
-        let residual_block_cnt = self
+        let residual_block_cnt: u64 = self
             .segments
             .iter()
-            .fold(0, |acc, e| acc + e.1.summary.block_count);
+            .map(|(_, info)| info.summary.block_count)
+            .sum();
         self.compacted_segment_cnt + residual_segment_cnt >= num_segment_limit
             || self.compacted_block_cnt + residual_block_cnt >= num_block_limit as u64
     }
@@ -438,16 +454,6 @@ impl CompactTaskBuilder {
     }
 
     fn add(&mut self, block: &Arc<BlockMeta>) -> (bool, bool) {
-        if let Some(default_cluster_key) = self.cluster_key_id {
-            if block
-                .cluster_stats
-                .as_ref()
-                .is_some_and(|v| v.level != 0 && v.cluster_key_id == default_cluster_key)
-            {
-                return (true, !self.blocks.is_empty());
-            }
-        }
-
         let total_rows = self.total_rows + block.row_count as usize;
         let total_size = self.total_size + block.block_size as usize;
         let total_compressed = self.total_compressed + block.file_size as usize;
@@ -464,7 +470,7 @@ impl CompactTaskBuilder {
             (false, true)
         } else {
             // blocks >= 2N
-            (true, !self.blocks.is_empty())
+            (true, !self.is_empty())
         }
     }
 
@@ -475,7 +481,7 @@ impl CompactTaskBuilder {
         total_compressed: usize,
     ) -> bool {
         self.thresholds.check_large_enough(total_rows, total_size)
-            || total_compressed >= self.thresholds.max_bytes_per_file
+            || total_compressed >= self.thresholds.min_compressed_per_block
     }
 
     fn check_for_compact(
@@ -485,7 +491,7 @@ impl CompactTaskBuilder {
         total_compressed: usize,
     ) -> bool {
         self.thresholds.check_for_compact(total_rows, total_size)
-            && total_compressed < 2 * self.thresholds.max_bytes_per_file
+            && total_compressed < 2 * self.thresholds.min_compressed_per_block
     }
 
     fn build_task(
@@ -495,14 +501,13 @@ impl CompactTaskBuilder {
         block_idx: BlockIndex,
         blocks: Vec<Arc<BlockMeta>>,
     ) -> bool {
-        let mut flag = false;
         if blocks.len() == 1 && !self.check_compact(&blocks[0]) {
             unchanged_blocks.push((block_idx, blocks[0].clone()));
-            flag = true;
+            true
         } else {
             tasks.push_back((block_idx, blocks));
+            false
         }
-        flag
     }
 
     fn check_compact(&self, block: &Arc<BlockMeta>) -> bool {

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -387,10 +387,8 @@ impl ReclusterMutator {
         let mut recluster_blocks_count = 0;
 
         let mut parts = Vec::new();
-        let mut checker = SegmentCompactChecker::new(
-            self.block_thresholds.block_per_segment as u64,
-            Some(self.cluster_key_id),
-        );
+        let mut checker =
+            SegmentCompactChecker::new(self.block_thresholds, Some(self.cluster_key_id));
 
         for (loc, compact_segment) in compact_segments.into_iter() {
             recluster_blocks_count += compact_segment.summary.block_count;

--- a/src/query/storages/stage/src/read/block_builder_state.rs
+++ b/src/query/storages/stage/src/read/block_builder_state.rs
@@ -164,7 +164,7 @@ impl BlockBuilderState {
             self.num_rows, mem
         );
         if self.num_rows >= ctx.block_compact_thresholds.min_rows_per_block
-            || mem > ctx.block_compact_thresholds.max_bytes_per_block
+            || mem > ctx.block_compact_thresholds.min_bytes_per_block
         {
             self.flush_block(false)
         } else {

--- a/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
@@ -62,7 +62,7 @@ impl BlockBuilder {
             self.state.num_rows, mem
         );
         if self.state.num_rows >= self.ctx.block_compact_thresholds.min_rows_per_block
-            || mem > self.ctx.block_compact_thresholds.max_bytes_per_block
+            || mem > self.ctx.block_compact_thresholds.min_bytes_per_block
         {
             self.flush_block(false)
         } else {

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -524,7 +524,7 @@ optimize table t9 compact
 query II
 select segment_count, block_count from fuse_snapshot('db_09_0008', 't9') limit 2
 ----
-1 2
+1 1
 2 2
 
 statement ok
@@ -536,8 +536,8 @@ optimize table t9 compact
 query II
 select segment_count, block_count from fuse_snapshot('db_09_0008', 't9') limit 2
 ----
-1 2
-2 3
+1 1
+2 2
 
 query I
 select a from t9 order by a

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -11,6 +11,9 @@ statement ok
 create table t(a int) cluster by(a) change_tracking = false
 
 statement ok
+set enable_compact_after_write = 0;
+
+statement ok
 insert into t values(1),(2)
 
 statement error 1065
@@ -94,7 +97,7 @@ statement ok
 insert into t2 values(0),(2),(1)
 
 statement ok
-set enable_experimental_merge_into = 1
+set enable_compact_after_write = 1;
 
 query TTT
 merge into t using t2 on t.a = t2.a when matched and t2.a = 1 then update set t.a = 8 when matched and t2.a = 2 then delete when not matched then insert *
@@ -180,8 +183,6 @@ merge into t3 using t4 on t3.a = t4.a when matched and t4.a = 4 then delete when
 ----
 1 1 1
 
-statement ok
-set enable_compact_after_write = 0;
 
 query IIBBII
 select a, b, _row_version from t3 order by a
@@ -227,9 +228,6 @@ drop table test_select all
 ######################
 # end of issue 15412 #
 ######################
-
-statement ok
-set enable_experimental_merge_into = 0
 
 statement ok
 drop table t all


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
1. **Dynamically calculate optimal rows per block**  
   Introduced logic to compute the optimal number of rows per block based on total data size, row count, and compressed size. This ensures that generated blocks meet both performance and storage efficiency thresholds.

2. **Fix potential fragmentation in Hilbert recluster**  
   Resolved an issue where Hilbert-based reclustering could result in fragmented small blocks, affecting downstream compaction and performance.

3. **Enable effective compaction after modifying `block_size_thresholds`**  
   Adjustments to `BlockThresholds` now properly propagate into the block compaction logic, ensuring compact operations behave as expected after threshold changes.

4. Update default configuration: `file_size` = `16MB`, `block_size_thresholds` = `125MB`

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17639)
<!-- Reviewable:end -->
