### PR TITLE
feat: impl function `strip_null_value` for Variant

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -1869,6 +1869,19 @@ pub fn register(registry: &mut FunctionRegistry) {
             },
         }))
     });
+
+    registry.register_1_arg_core::<NullableType<VariantType>, NullableType<VariantType>, _, _>(
+        "strip_null_value",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<NullableType<VariantType>, NullableType<VariantType>>(|val, _| {
+            val.and_then(|v| {
+                if matches!(RawJsonb::new(v).is_null(), Ok(true)) {
+                    return None;
+                }
+                Some(v.to_vec())
+            })
+        }),
+    );
 }
 
 fn json_array_fn(args: &[Value<AnyType>], ctx: &mut EvalContext) -> Value<AnyType> {

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3449,6 +3449,7 @@ Functions overloads:
 1 strcmp(String NULL, String NULL) :: Int8 NULL
 0 string_to_h3(String) :: UInt64
 1 string_to_h3(String NULL) :: UInt64 NULL
+0 strip_null_value(Variant NULL) :: Variant NULL
 0 sub_bitmap(Bitmap, UInt64, UInt64) :: Bitmap
 1 sub_bitmap(Bitmap NULL, UInt64 NULL, UInt64 NULL) :: Bitmap NULL
 0 substr(String, Int64) :: String

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -5815,3 +5815,75 @@ evaluation (internal):
 +--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
+ast            : strip_null_value(parse_json('1234'))
+raw expr       : strip_null_value(parse_json('1234'))
+checked expr   : strip_null_value<Variant NULL>(CAST(parse_json<String>("1234") AS Variant NULL))
+optimized expr : 0x20000000200000035004d2
+output type    : Variant NULL
+output domain  : Undefined
+output         : '1234'
+
+
+ast            : strip_null_value(parse_json('null'))
+raw expr       : strip_null_value(parse_json('null'))
+checked expr   : strip_null_value<Variant NULL>(CAST(parse_json<String>("null") AS Variant NULL))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : strip_null_value(null)
+raw expr       : strip_null_value(NULL)
+checked expr   : strip_null_value<Variant NULL>(CAST(NULL AS Variant NULL))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : strip_null_value(parse_json(s))
+raw expr       : strip_null_value(parse_json(s::String))
+checked expr   : strip_null_value<Variant NULL>(CAST(parse_json<String>(s) AS Variant NULL))
+evaluation:
++--------+-------------------------------------------------------+--------------------+
+|        | s                                                     | Output             |
++--------+-------------------------------------------------------+--------------------+
+| Type   | String                                                | Variant NULL       |
+| Domain | {"[\"a\",\"b\",\"c\"]"..="{ \"a\": 1, \"b\": null }"} | Unknown            |
+| Row 0  | '{ "a": 1, "b": null }'                               | '{"a":1,"b":null}' |
+| Row 1  | 'null'                                                | NULL               |
+| Row 2  | '["a","b","c"]'                                       | '["a","b","c"]'    |
++--------+-------------------------------------------------------+--------------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                         |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn[{ "a": 1, "b": null }, null, ["a","b","c"]]                                                                                                                                     |
+| Output | NullableColumn { column: BinaryColumn { data: 0x40000002100000011000000120000002000000006162500180000003100000011000000110000001616263, offsets: [0, 24, 24, 43] }, validity: [0b_____101] } |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : strip_null_value(parse_json(s))
+raw expr       : strip_null_value(parse_json(s::String NULL))
+checked expr   : strip_null_value<Variant NULL>(parse_json<String NULL>(s))
+evaluation:
++--------+----------------------------------------------------------------+--------------------+
+|        | s                                                              | Output             |
++--------+----------------------------------------------------------------+--------------------+
+| Type   | String NULL                                                    | Variant NULL       |
+| Domain | {"[\"a\",\"b\",\"c\"]"..="{ \"a\": 1, \"b\": null }"} ∪ {NULL} | Unknown            |
+| Row 0  | '{ "a": 1, "b": null }'                                        | '{"a":1,"b":null}' |
+| Row 1  | 'null'                                                         | NULL               |
+| Row 2  | NULL                                                           | NULL               |
+| Row 3  | '["a","b","c"]'                                                | '["a","b","c"]'    |
++--------+----------------------------------------------------------------+--------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                             |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | NullableColumn { column: StringColumn[{ "a": 1, "b": null }, null, , ["a","b","c"]], validity: [0b____1011] }                                                                                    |
+| Output | NullableColumn { column: BinaryColumn { data: 0x40000002100000011000000120000002000000006162500180000003100000011000000110000001616263, offsets: [0, 24, 24, 24, 43] }, validity: [0b____1001] } |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -72,6 +72,7 @@ fn test_variant() {
     test_json_object_insert(file);
     test_json_object_delete(file);
     test_json_object_pick(file);
+    test_strip_null_value(file);
 }
 
 fn test_parse_json(file: &mut impl Write) {
@@ -2126,6 +2127,34 @@ fn test_json_object_pick(file: &mut impl Write) {
                 r#"{"m":"n"}"#,
                 "",
                 r#"{"a":"b","c":"d","y":"z"}"#,
+            ],
+            vec![true, true, false, true],
+        ),
+    )]);
+}
+
+fn test_strip_null_value(file: &mut impl Write) {
+    run_ast(file, "strip_null_value(parse_json('1234'))", &[]);
+    run_ast(file, "strip_null_value(parse_json('null'))", &[]);
+    run_ast(file, "strip_null_value(null)", &[]);
+
+    run_ast(file, "strip_null_value(parse_json(s))", &[(
+        "s",
+        StringType::from_data(vec![
+            r#"{ "a": 1, "b": null }"#,
+            "null",
+            "[\"a\",\"b\",\"c\"]",
+        ]),
+    )]);
+
+    run_ast(file, "strip_null_value(parse_json(s))", &[(
+        "s",
+        StringType::from_data_with_validity(
+            vec![
+                r#"{ "a": 1, "b": null }"#,
+                "null",
+                "",
+                "[\"a\",\"b\",\"c\"]",
             ],
             vec![true, true, false, true],
         ),

--- a/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
+++ b/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
@@ -1504,3 +1504,23 @@ SELECT id, json_object_pick(v1, 'a', 'k1') from t5
 
 statement ok
 DROP TABLE IF EXISTS t5
+
+statement ok
+CREATE OR REPLACE TABLE t6 (id INT, data VARIANT);
+
+statement ok
+INSERT INTO t6 VALUES
+(1, '{"name": "Alice", "age": 30, "address": null}'),
+(2, '{"name": "Bob", "age": null, "address": {"city": "New York", "zip": null}}'),
+(3, '{"name": "Charlie", "age": 25, "address": {"city": "San Francisco", "zip": "94107"}}');
+
+query II
+SELECT id, data:address, data:address:zip, STRIP_NULL_VALUE(data:address), STRIP_NULL_VALUE(data:address:zip) FROM t6;
+----
+1 null NULL NULL NULL
+2 {"city":"New York","zip":null} null {"city":"New York","zip":null} NULL
+3 {"city":"San Francisco","zip":"94107"} "94107" {"city":"San Francisco","zip":"94107"} "94107"
+
+
+statement ok
+DROP TABLE IF EXISTS t6


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

close https://github.com/databendlabs/databend/issues/17627

```sql
-- Create a simple table with JSON data
CREATE TABLE users (user_data VARIANT);

-- Insert two records: one with a null phone number, one with a value
INSERT INTO users 
  SELECT PARSE_JSON('{"name": "Alice", "phone": null}');
  
INSERT INTO users 
  SELECT PARSE_JSON('{"name": "Bob", "phone": "555-1234"}');

-- Compare regular access vs using STRIP_NULL_VALUE
SELECT 
  user_data:name AS name,
  user_data:phone AS original_phone,      -- JSON null appears as 'null'
  STRIP_NULL_VALUE(user_data:phone) AS phone_number  -- Converts JSON null to SQL NULL
FROM users;

-- Result:
-- +----------+----------------+--------------+
-- | NAME     | ORIGINAL_PHONE | PHONE_NUMBER |
-- +----------+----------------+--------------+
-- | "Alice"  | null           | NULL         |
-- | "Bob"    | "555-1234"     | "555-1234"   |
-- +----------+----------------+--------------+
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17640)
<!-- Reviewable:end -->
