### PR TITLE
fix: disk cache failed to build on macOS

### DIFF
--- a/src/query/storages/common/cache/benches/read_cache_content.rs
+++ b/src/query/storages/common/cache/benches/read_cache_content.rs
@@ -39,7 +39,7 @@ fn bench_read_cache_content(c: &mut Criterion) {
     let large_file_path = create_test_file(&temp_dir, "large.bin", 1024 * 1024); // 1MB
 
     // Benchmark Unix specific implementation (open with O_NOATIME, read with libc::read without stat / seek)
-    #[cfg(linux)]
+    #[cfg(target_os = "linux")]
     {
         let mut group = c.benchmark_group("read_cache_content_linux_specific_impl");
 

--- a/src/query/storages/common/cache/benches/read_cache_content.rs
+++ b/src/query/storages/common/cache/benches/read_cache_content.rs
@@ -39,9 +39,9 @@ fn bench_read_cache_content(c: &mut Criterion) {
     let large_file_path = create_test_file(&temp_dir, "large.bin", 1024 * 1024); // 1MB
 
     // Benchmark Unix specific implementation (open with O_NOATIME, read with libc::read without stat / seek)
-    #[cfg(unix)]
+    #[cfg(linux)]
     {
-        let mut group = c.benchmark_group("read_cache_content_unix_specific_impl");
+        let mut group = c.benchmark_group("read_cache_content_linux_specific_impl");
 
         group.bench_function("small_file_4KB", |b| {
             b.iter(|| {

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
@@ -177,7 +177,7 @@ impl LruDiskCacheBuilder {
     }
 }
 
-#[cfg(not(linux))]
+#[cfg(not(target_os = "linux"))]
 pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>> {
     use std::fs::File;
     use std::io::Read;
@@ -188,11 +188,12 @@ pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>
     Ok(v)
 }
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>> {
     linux_read::read_cache_content_with_syscall(path, size, linux_read::LibcRead)
 }
 
+#[cfg(target_os = "linux")]
 mod linux_read {
 
     #[cfg(test)]
@@ -223,7 +224,6 @@ mod linux_read {
         }
     }
 
-    #[cfg(linux)]
     pub(super) fn read_cache_content_with_syscall<R: CallRead>(
         path: PathBuf,
         size: usize,

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
@@ -177,7 +177,7 @@ impl LruDiskCacheBuilder {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(linux))]
 pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>> {
     use std::fs::File;
     use std::io::Read;
@@ -188,12 +188,12 @@ pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>
     Ok(v)
 }
 
-#[cfg(unix)]
+#[cfg(linux)]
 pub fn read_cache_content(path: PathBuf, size: usize) -> std::io::Result<Vec<u8>> {
-    unix_read::read_cache_content_with_syscall(path, size, unix_read::LibcRead)
+    linux_read::read_cache_content_with_syscall(path, size, linux_read::LibcRead)
 }
 
-mod unix_read {
+mod linux_read {
 
     #[cfg(test)]
     use mockall::automock;
@@ -223,7 +223,7 @@ mod unix_read {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(linux)]
     pub(super) fn read_cache_content_with_syscall<R: CallRead>(
         path: PathBuf,
         size: usize,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Disk cache failed to build on macOS.

No `O_NOATIME` on macOS, let's focus on Linux for now.



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Adjust `cfg`, covered by existing cases

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17643)
<!-- Reviewable:end -->
