### PR TITLE
fix(ddl): fix modify column data type null to not null failed

### DIFF
--- a/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.result
+++ b/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.result
@@ -41,3 +41,22 @@ Error: APIError: QueryFailed: [1006]null value in column `a` of table `f` violat
 	2
 a	VARCHAR	NO	''	
 b	INT	NO	0	
+begin test modify column NULL to not NULL
+1
+1	1
+a	1
+b	NULL
+NULL	3
+d	4
+1
+a	1
+b	NULL
+	3
+d	4
+1
+a	1
+b	0
+	3
+d	4
+a	VARCHAR	NO	''	
+b	INT	NO	0	

--- a/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.result
+++ b/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.result
@@ -42,18 +42,15 @@ Error: APIError: QueryFailed: [1006]null value in column `a` of table `f` violat
 a	VARCHAR	NO	''	
 b	INT	NO	0	
 begin test modify column NULL to not NULL
-1
-1	1
+4
 a	1
 b	NULL
 NULL	3
 d	4
-1
 a	1
 b	NULL
 	3
 d	4
-1
 a	1
 b	0
 	3

--- a/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
@@ -59,4 +59,14 @@ echo "INSERT INTO test_modify_column_type.f (a,b) values('',2)"  | $BENDSQL_CLIE
 echo "SELECT a,b from test_modify_column_type.f order by b"  | $BENDSQL_CLIENT_CONNECT
 echo "DESC test_modify_column_type.f"  | $BENDSQL_CLIENT_CONNECT
 
+echo "begin test modify column NULL to not NULL"
+echo "CREATE table test_modify_column_type.g(a STRING NULL, b INT NULL)"  | $BENDSQL_CLIENT_CONNECT
+echo "INSERT INTO test_modify_column_type.g VALUES('a',1),('b',NULL),(NULL,3),('d',4)"  | $BENDSQL_CLIENT_CONNECT
+echo "SELECT a,b from test_modify_column_type.g" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER TABLE test_modify_column_type.g MODIFY COLUMN a STRING NOT NULL"  | $BENDSQL_CLIENT_CONNECT
+echo "SELECT a,b from test_modify_column_type.g" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER TABLE test_modify_column_type.g MODIFY COLUMN b INT NOT NULL"  | $BENDSQL_CLIENT_CONNECT
+echo "SELECT a,b from test_modify_column_type.g" | $BENDSQL_CLIENT_CONNECT
+echo "DESC test_modify_column_type.g"  | $BENDSQL_CLIENT_CONNECT
+
 echo "DROP DATABASE IF EXISTS test_modify_column_type" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
@@ -60,7 +60,7 @@ echo "SELECT a,b from test_modify_column_type.f order by b"  | $BENDSQL_CLIENT_C
 echo "DESC test_modify_column_type.f"  | $BENDSQL_CLIENT_CONNECT
 
 echo "begin test modify column NULL to not NULL"
-echo "CREATE table test_modify_column_type.g(a STRING NULL, b INT NULL)"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE TABLE test_modify_column_type.g(a STRING NULL, b INT NULL) STORAGE_FORMAT='native'"  | $BENDSQL_CLIENT_CONNECT
 echo "INSERT INTO test_modify_column_type.g VALUES('a',1),('b',NULL),(NULL,3),('d',4)"  | $BENDSQL_CLIENT_CONNECT
 echo "SELECT a,b from test_modify_column_type.g" | $BENDSQL_CLIENT_CONNECT
 echo "ALTER TABLE test_modify_column_type.g MODIFY COLUMN a STRING NOT NULL"  | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. fix modify column data type null to not null failed, using `remove_nullable` function to remove null value from the original column.
2. nullable random column values remove unused underlaying values.

- fixes: https://github.com/databendlabs/databend/issues/17648

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17650)
<!-- Reviewable:end -->
