### PR TITLE
fix(query): to_date(9999-12-31, format_string) should success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4896,6 +4896,7 @@ dependencies = [
 name = "databend-functions-scalar-datetime"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "databend-common-column",
  "databend-common-exception",
  "databend-common-expression",

--- a/src/query/functions/src/scalars/timestamp/Cargo.toml
+++ b/src/query/functions/src/scalars/timestamp/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = { workspace = true }
 databend-common-column = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-expression = { workspace = true }

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -1123,17 +1123,38 @@ statement ok
 set timezone='Asia/Shanghai';
 
 query T
-select to_date('2024-03-01-1','%Y-%m-%d');
+select to_date('2024-03-01','%Y-%m-%d');
 ----
 2024-03-01
+
+query T
+select to_date('9999/12/31','%Y/%m/%d');
+----
+9999-12-31
+
+query T
+select to_date('9999-12-31','%Y-%m-%d');
+----
+9999-12-31
+
 
 statement ok
 set timezone='America/Los_Angeles';
 
 query T
-select to_date('2024-03-01-1','%Y-%m-%d');
+select to_date('2024-03-01','%Y-%m-%d');
 ----
 2024-03-01
+
+query T
+select to_date('9999-12-31','%Y-%m-%d');
+----
+9999-12-31
+
+query T
+select to_date('9999/12/31','%Y/%m/%d');
+----
+9999-12-31
 
 statement ok
 unset timezone;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

in main :

set timezone='Asia/Shanghai'

select to_date('9999-12-31', '%Y-%m-%d') will return error.


Because jiff crate in Asia/Shanghai only support Max timestamp 9999-12-30 16:00:00

And this function append time part combain a new datetime.

In pr: backport to chrono crate.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17652)
<!-- Reviewable:end -->
