### PR TITLE
feat: impl function: `regexp_extract` & `regexp_extract_all`

### DIFF
--- a/src/query/functions/tests/it/scalars/regexp.rs
+++ b/src/query/functions/tests/it/scalars/regexp.rs
@@ -762,4 +762,21 @@ fn test_regexp_extract(file: &mut impl Write) {
             ]),
         )],
     );
+
+    // null source
+    run_ast(
+        file,
+        "regexp_extract(null, '(\\d+)-(\\d+)-(\\d+)', ['y', 'm'])",
+        &[],
+    );
+    run_ast(
+        file,
+        "regexp_extract_all(null, 'Order-(\\d+)-(\\d+)', 2)",
+        &[],
+    );
+    run_ast(
+        file,
+        "regexp_extract(null, '([A-Za-z]+) ([A-Za-z]+), Age: (\\d+)', 3)",
+        &[],
+    );
 }

--- a/src/query/functions/tests/it/scalars/regexp.rs
+++ b/src/query/functions/tests/it/scalars/regexp.rs
@@ -31,6 +31,7 @@ fn test_string() {
     test_regexp_replace(regexp_file);
     test_regexp_substr(regexp_file);
     test_glob(regexp_file);
+    test_regexp_extract(regexp_file);
 }
 
 fn test_regexp_instr(file: &mut impl Write) {
@@ -688,5 +689,77 @@ fn test_regexp_substr(file: &mut impl Write) {
         file,
         "regexp_substr(source, pat, pos, occur, mt)",
         match_type_error_five_columns,
+    );
+}
+
+fn test_regexp_extract(file: &mut impl Write) {
+    run_ast(file, "regexp_extract('abc def ghi', '[a-z]+')", &[]);
+    run_ast(file, "regexp_extract('abc def ghi', '[a-z]+', 2)", &[]);
+    run_ast(file, "regexp_extract('abc def ghi', NULL)", &[]);
+    run_ast(file, "regexp_extract('abc def ghi', '')", &[]);
+    run_ast(file, "regexp_extract('', '[a-z]+')", &[]);
+    run_ast(file, "regexp_extract('123 456', '[a-z]+')", &[]);
+    run_ast(
+        file,
+        "regexp_extract('John Doe', '([A-Za-z]+) ([A-Za-z]+)', 1)",
+        &[],
+    );
+
+    run_ast(file, "regexp_extract(s, '([A-Za-z]+) ([A-Za-z]+)', 1)", &[
+        (
+            "s",
+            StringType::from_data(vec!["John Doe", "James Davis", "Lisa Taylor"]),
+        ),
+    ]);
+
+    run_ast(file, "regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])", &[]);
+    run_ast(file, "regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])", &[]);
+    run_ast(
+        file,
+        "regexp_extract('name: John, age: 30', NULL, ['name', 'age'])",
+        &[],
+    );
+    run_ast(
+        file,
+        "regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', [])",
+        &[],
+    );
+    run_ast(file, "regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])", &[]);
+
+    run_ast(
+        file,
+        "regexp_extract(s, 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])",
+        &[(
+            "s",
+            StringType::from_data(vec![
+                "name: John, age: 30",
+                "name: James, age: 25",
+                "name: Lisa, age: 19",
+            ]),
+        )],
+    );
+
+    run_ast(file, "regexp_extract_all('abc def ghi', '[a-z]+')", &[]);
+    run_ast(
+        file,
+        "regexp_extract_all('John Doe, Jane Smith', '([A-Za-z]+) ([A-Za-z]+)', 1)",
+        &[],
+    );
+    run_ast(file, "regexp_extract_all('abc def ghi', NULL)", &[]);
+    run_ast(file, "regexp_extract_all('', '[a-z]+')", &[]);
+    run_ast(file, "regexp_extract_all('123 456', '[a-z]+')", &[]);
+    run_ast(file, "regexp_extract_all('name: John, age: 30; name: Jane, age: 25', 'name: ([A-Za-z]+), age: ([0-9]+)')", &[]);
+
+    run_ast(
+        file,
+        "regexp_extract_all(s, '([A-Za-z]+) ([A-Za-z]+)', 1)",
+        &[(
+            "s",
+            StringType::from_data(vec![
+                "John Doe, Jane Smith",
+                "James Davis, Robert Wilson",
+                "Lisa Taylor, Sarah Williams",
+            ]),
+        )],
     );
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3209,6 +3209,8 @@ Functions overloads:
 1 range_partition_id(T0 NULL, Array(T0) NULL) :: UInt64
 0 regexp(String, String) :: Boolean
 1 regexp(String NULL, String NULL) :: Boolean NULL
+0 regexp_extract FACTORY
+0 regexp_extract_all FACTORY
 0 regexp_instr FACTORY
 0 regexp_like FACTORY
 0 regexp_replace FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3209,8 +3209,16 @@ Functions overloads:
 1 range_partition_id(T0 NULL, Array(T0) NULL) :: UInt64
 0 regexp(String, String) :: Boolean
 1 regexp(String NULL, String NULL) :: Boolean NULL
-0 regexp_extract FACTORY
-0 regexp_extract_all FACTORY
+0 regexp_extract(String, String) :: String
+1 regexp_extract(String NULL, String NULL) :: String NULL
+2 regexp_extract(String, String, UInt32) :: String
+3 regexp_extract(String NULL, String NULL, UInt32 NULL) :: String NULL
+4 regexp_extract(String, String, Array(String)) :: Map(String, String NULL)
+5 regexp_extract(String NULL, String NULL, Array(String) NULL) :: Map(String, String NULL) NULL
+0 regexp_extract_all(String, String) :: Array(String NULL)
+1 regexp_extract_all(String NULL, String NULL) :: Array(String NULL) NULL
+2 regexp_extract_all(String, String, UInt32) :: Array(String NULL)
+3 regexp_extract_all(String NULL, String NULL, UInt32 NULL) :: Array(String NULL) NULL
 0 regexp_instr FACTORY
 0 regexp_like FACTORY
 0 regexp_replace FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3213,12 +3213,12 @@ Functions overloads:
 1 regexp_extract(String NULL, String NULL) :: String NULL
 2 regexp_extract(String, String, UInt32) :: String
 3 regexp_extract(String NULL, String NULL, UInt32 NULL) :: String NULL
-4 regexp_extract(String, String, Array(String)) :: Map(String, String NULL)
-5 regexp_extract(String NULL, String NULL, Array(String) NULL) :: Map(String, String NULL) NULL
-0 regexp_extract_all(String, String) :: Array(String NULL)
-1 regexp_extract_all(String NULL, String NULL) :: Array(String NULL) NULL
-2 regexp_extract_all(String, String, UInt32) :: Array(String NULL)
-3 regexp_extract_all(String NULL, String NULL, UInt32 NULL) :: Array(String NULL) NULL
+4 regexp_extract(String, String, Array(String)) :: Map(String, String)
+5 regexp_extract(String NULL, String NULL, Array(String) NULL) :: Map(String, String) NULL
+0 regexp_extract_all(String, String) :: Array(String)
+1 regexp_extract_all(String NULL, String NULL) :: Array(String) NULL
+2 regexp_extract_all(String, String, UInt32) :: Array(String)
+3 regexp_extract_all(String NULL, String NULL, UInt32 NULL) :: Array(String) NULL
 0 regexp_instr FACTORY
 0 regexp_like FACTORY
 0 regexp_replace FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/regexp.txt
+++ b/src/query/functions/tests/it/scalars/testdata/regexp.txt
@@ -1205,3 +1205,30 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------+
 
 
+ast            : regexp_extract(null, '(\d+)-(\d+)-(\d+)', ['y', 'm'])
+raw expr       : regexp_extract(NULL, '(\d+)-(\d+)-(\d+)', array('y', 'm'))
+checked expr   : regexp_extract<String NULL, String NULL, Array(String) NULL>(CAST(NULL AS String NULL), CAST("(\\d+)-(\\d+)-(\\d+)" AS String NULL), CAST(array<T0=String><T0, T0>("y", "m") AS Array(String) NULL))
+optimized expr : NULL
+output type    : Map(String, String) NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : regexp_extract_all(null, 'Order-(\d+)-(\d+)', 2)
+raw expr       : regexp_extract_all(NULL, 'Order-(\d+)-(\d+)', 2)
+checked expr   : regexp_extract_all<String NULL, String NULL, UInt32 NULL>(CAST(NULL AS String NULL), CAST("Order-(\\d+)-(\\d+)" AS String NULL), CAST(2_u8 AS UInt32 NULL))
+optimized expr : NULL
+output type    : Array(String) NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : regexp_extract(null, '([A-Za-z]+) ([A-Za-z]+), Age: (\d+)', 3)
+raw expr       : regexp_extract(NULL, '([A-Za-z]+) ([A-Za-z]+), Age: (\d+)', 3)
+checked expr   : regexp_extract<String NULL, String NULL, UInt32 NULL>(CAST(NULL AS String NULL), CAST("([A-Za-z]+) ([A-Za-z]+), Age: (\\d+)" AS String NULL), CAST(3_u8 AS UInt32 NULL))
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+

--- a/src/query/functions/tests/it/scalars/testdata/regexp.txt
+++ b/src/query/functions/tests/it/scalars/testdata/regexp.txt
@@ -974,3 +974,234 @@ output domain  : {TRUE}
 output         : true
 
 
+ast            : regexp_extract('abc def ghi', '[a-z]+')
+raw expr       : regexp_extract('abc def ghi', '[a-z]+')
+checked expr   : regexp_extract<String, String>("abc def ghi", "[a-z]+")
+optimized expr : "abc"
+output type    : String
+output domain  : {"abc"..="abc"}
+output         : 'abc'
+
+
+ast            : regexp_extract('abc def ghi', '[a-z]+', 2)
+raw expr       : regexp_extract('abc def ghi', '[a-z]+', 2)
+checked expr   : regexp_extract<String, String, UInt32>("abc def ghi", "[a-z]+", to_uint32<UInt8>(2_u8))
+optimized expr : ""
+output type    : String
+output domain  : {""..=""}
+output         : ''
+
+
+ast            : regexp_extract('abc def ghi', NULL)
+raw expr       : regexp_extract('abc def ghi', NULL)
+checked expr   : regexp_extract<String NULL, String NULL>(CAST("abc def ghi" AS String NULL), CAST(NULL AS String NULL))
+optimized expr : NULL
+output type    : String NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : regexp_extract('abc def ghi', '')
+raw expr       : regexp_extract('abc def ghi', '')
+checked expr   : regexp_extract<String, String>("abc def ghi", "")
+optimized expr : ""
+output type    : String
+output domain  : {""..=""}
+output         : ''
+
+
+ast            : regexp_extract('', '[a-z]+')
+raw expr       : regexp_extract('', '[a-z]+')
+checked expr   : regexp_extract<String, String>("", "[a-z]+")
+optimized expr : ""
+output type    : String
+output domain  : {""..=""}
+output         : ''
+
+
+ast            : regexp_extract('123 456', '[a-z]+')
+raw expr       : regexp_extract('123 456', '[a-z]+')
+checked expr   : regexp_extract<String, String>("123 456", "[a-z]+")
+optimized expr : ""
+output type    : String
+output domain  : {""..=""}
+output         : ''
+
+
+ast            : regexp_extract('John Doe', '([A-Za-z]+) ([A-Za-z]+)', 1)
+raw expr       : regexp_extract('John Doe', '([A-Za-z]+) ([A-Za-z]+)', 1)
+checked expr   : regexp_extract<String, String, UInt32>("John Doe", "([A-Za-z]+) ([A-Za-z]+)", to_uint32<UInt8>(1_u8))
+optimized expr : "John"
+output type    : String
+output domain  : {"John"..="John"}
+output         : 'John'
+
+
+ast            : regexp_extract(s, '([A-Za-z]+) ([A-Za-z]+)', 1)
+raw expr       : regexp_extract(s::String, '([A-Za-z]+) ([A-Za-z]+)', 1)
+checked expr   : regexp_extract<String, String, UInt32>(s, "([A-Za-z]+) ([A-Za-z]+)", to_uint32<UInt8>(1_u8))
+optimized expr : regexp_extract<String, String, UInt32>(s, "([A-Za-z]+) ([A-Za-z]+)", 1_u32)
+evaluation:
++--------+---------------------------------+---------+
+|        | s                               | Output  |
++--------+---------------------------------+---------+
+| Type   | String                          | String  |
+| Domain | {"James Davis"..="Lisa Taylor"} | Unknown |
+| Row 0  | 'John Doe'                      | 'John'  |
+| Row 1  | 'James Davis'                   | 'James' |
+| Row 2  | 'Lisa Taylor'                   | 'Lisa'  |
++--------+---------------------------------+---------+
+evaluation (internal):
++--------+--------------------------------------------------+
+| Column | Data                                             |
++--------+--------------------------------------------------+
+| s      | StringColumn[John Doe, James Davis, Lisa Taylor] |
+| Output | StringColumn[John, James, Lisa]                  |
++--------+--------------------------------------------------+
+
+
+ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])
+raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
+checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
+optimized expr : {"name":"John", "age":"30"}
+output type    : Map(String, String NULL)
+output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
+output         : {'name':'John', 'age':'30'}
+
+
+ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])
+raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
+checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
+optimized expr : {"name":"John", "age":"30"}
+output type    : Map(String, String NULL)
+output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
+output         : {'name':'John', 'age':'30'}
+
+
+ast            : regexp_extract('name: John, age: 30', NULL, ['name', 'age'])
+raw expr       : regexp_extract('name: John, age: 30', NULL, array('name', 'age'))
+checked expr   : regexp_extract<String NULL, String NULL, Array(String) NULL>(CAST("name: John, age: 30" AS String NULL), CAST(NULL AS String NULL), CAST(array<T0=String><T0, T0>("name", "age") AS Array(String) NULL))
+optimized expr : NULL
+output type    : Map(String, String NULL) NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', [])
+raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array())
+checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", CAST(array<>() AS Array(String)))
+optimized expr : {}
+output type    : Map(String, String NULL)
+output domain  : {}
+output         : {}
+
+
+ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])
+raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
+checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
+optimized expr : {"name":"John", "age":"30"}
+output type    : Map(String, String NULL)
+output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
+output         : {'name':'John', 'age':'30'}
+
+
+ast            : regexp_extract(s, 'name: ([A-Za-z]+), age: ([0-9]+)', ['name', 'age'])
+raw expr       : regexp_extract(s::String, 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
+checked expr   : regexp_extract<String, String, Array(String)>(s, "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
+optimized expr : regexp_extract<String, String, Array(String)>(s, "name: ([A-Za-z]+), age: ([0-9]+)", ['name', 'age'])
+evaluation:
++--------+--------------------------------------------------+------------------------------+
+|        | s                                                | Output                       |
++--------+--------------------------------------------------+------------------------------+
+| Type   | String                                           | Map(String, String NULL)     |
+| Domain | {"name: James, age: 25"..="name: Lisa, age: 19"} | Unknown                      |
+| Row 0  | 'name: John, age: 30'                            | {'name':'John', 'age':'30'}  |
+| Row 1  | 'name: James, age: 25'                           | {'name':'James', 'age':'25'} |
+| Row 2  | 'name: Lisa, age: 19'                            | {'name':'Lisa', 'age':'19'}  |
++--------+--------------------------------------------------+------------------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn[name: John, age: 30, name: James, age: 25, name: Lisa, age: 19]                                                                                                                          |
+| Output | ArrayColumn { values: Tuple([StringColumn[name, age, name, age, name, age], NullableColumn { column: StringColumn[John, 30, James, 25, Lisa, 19], validity: [0b__111111] }]), offsets: [0, 2, 4, 6] } |
++--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+ast            : regexp_extract_all('abc def ghi', '[a-z]+')
+raw expr       : regexp_extract_all('abc def ghi', '[a-z]+')
+checked expr   : regexp_extract_all<String, String>("abc def ghi", "[a-z]+")
+optimized expr : ['abc', 'def', 'ghi']
+output type    : Array(String NULL)
+output domain  : [{"abc"..="ghi"}]
+output         : ['abc', 'def', 'ghi']
+
+
+ast            : regexp_extract_all('John Doe, Jane Smith', '([A-Za-z]+) ([A-Za-z]+)', 1)
+raw expr       : regexp_extract_all('John Doe, Jane Smith', '([A-Za-z]+) ([A-Za-z]+)', 1)
+checked expr   : regexp_extract_all<String, String, UInt32>("John Doe, Jane Smith", "([A-Za-z]+) ([A-Za-z]+)", to_uint32<UInt8>(1_u8))
+optimized expr : ['John', 'Jane']
+output type    : Array(String NULL)
+output domain  : [{"Jane"..="John"}]
+output         : ['John', 'Jane']
+
+
+ast            : regexp_extract_all('abc def ghi', NULL)
+raw expr       : regexp_extract_all('abc def ghi', NULL)
+checked expr   : regexp_extract_all<String NULL, String NULL>(CAST("abc def ghi" AS String NULL), CAST(NULL AS String NULL))
+optimized expr : NULL
+output type    : Array(String NULL) NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : regexp_extract_all('', '[a-z]+')
+raw expr       : regexp_extract_all('', '[a-z]+')
+checked expr   : regexp_extract_all<String, String>("", "[a-z]+")
+optimized expr : []
+output type    : Array(String NULL)
+output domain  : []
+output         : []
+
+
+ast            : regexp_extract_all('123 456', '[a-z]+')
+raw expr       : regexp_extract_all('123 456', '[a-z]+')
+checked expr   : regexp_extract_all<String, String>("123 456", "[a-z]+")
+optimized expr : []
+output type    : Array(String NULL)
+output domain  : []
+output         : []
+
+
+ast            : regexp_extract_all('name: John, age: 30; name: Jane, age: 25', 'name: ([A-Za-z]+), age: ([0-9]+)')
+raw expr       : regexp_extract_all('name: John, age: 30; name: Jane, age: 25', 'name: ([A-Za-z]+), age: ([0-9]+)')
+checked expr   : regexp_extract_all<String, String>("name: John, age: 30; name: Jane, age: 25", "name: ([A-Za-z]+), age: ([0-9]+)")
+optimized expr : ['name: John, age: 30', 'name: Jane, age: 25']
+output type    : Array(String NULL)
+output domain  : [{"name: Jane, age: 25"..="name: John, age: 30"}]
+output         : ['name: John, age: 30', 'name: Jane, age: 25']
+
+
+ast            : regexp_extract_all(s, '([A-Za-z]+) ([A-Za-z]+)', 1)
+raw expr       : regexp_extract_all(s::String, '([A-Za-z]+) ([A-Za-z]+)', 1)
+checked expr   : regexp_extract_all<String, String, UInt32>(s, "([A-Za-z]+) ([A-Za-z]+)", to_uint32<UInt8>(1_u8))
+optimized expr : regexp_extract_all<String, String, UInt32>(s, "([A-Za-z]+) ([A-Za-z]+)", 1_u32)
+evaluation:
++--------+----------------------------------------------------------------+---------------------+
+|        | s                                                              | Output              |
++--------+----------------------------------------------------------------+---------------------+
+| Type   | String                                                         | Array(String NULL)  |
+| Domain | {"James Davis, Robert Wilson"..="Lisa Taylor, Sarah Williams"} | Unknown             |
+| Row 0  | 'John Doe, Jane Smith'                                         | ['John', 'Jane']    |
+| Row 1  | 'James Davis, Robert Wilson'                                   | ['James', 'Robert'] |
+| Row 2  | 'Lisa Taylor, Sarah Williams'                                  | ['Lisa', 'Sarah']   |
++--------+----------------------------------------------------------------+---------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                                   |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn[John Doe, Jane Smith, James Davis, Robert Wilson, Lisa Taylor, Sarah Williams]                                                            |
+| Output | ArrayColumn { values: NullableColumn { column: StringColumn[John, Jane, James, Robert, Lisa, Sarah], validity: [0b__111111] }, offsets: [0, 2, 4, 6] } |
++--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+

--- a/src/query/functions/tests/it/scalars/testdata/regexp.txt
+++ b/src/query/functions/tests/it/scalars/testdata/regexp.txt
@@ -1064,7 +1064,7 @@ ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: 
 raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
 checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
 optimized expr : {"name":"John", "age":"30"}
-output type    : Map(String, String NULL)
+output type    : Map(String, String)
 output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
 output         : {'name':'John', 'age':'30'}
 
@@ -1073,7 +1073,7 @@ ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: 
 raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
 checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
 optimized expr : {"name":"John", "age":"30"}
-output type    : Map(String, String NULL)
+output type    : Map(String, String)
 output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
 output         : {'name':'John', 'age':'30'}
 
@@ -1082,7 +1082,7 @@ ast            : regexp_extract('name: John, age: 30', NULL, ['name', 'age'])
 raw expr       : regexp_extract('name: John, age: 30', NULL, array('name', 'age'))
 checked expr   : regexp_extract<String NULL, String NULL, Array(String) NULL>(CAST("name: John, age: 30" AS String NULL), CAST(NULL AS String NULL), CAST(array<T0=String><T0, T0>("name", "age") AS Array(String) NULL))
 optimized expr : NULL
-output type    : Map(String, String NULL) NULL
+output type    : Map(String, String) NULL
 output domain  : {NULL}
 output         : NULL
 
@@ -1091,7 +1091,7 @@ ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: 
 raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array())
 checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", CAST(array<>() AS Array(String)))
 optimized expr : {}
-output type    : Map(String, String NULL)
+output type    : Map(String, String)
 output domain  : {}
 output         : {}
 
@@ -1100,7 +1100,7 @@ ast            : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: 
 raw expr       : regexp_extract('name: John, age: 30', 'name: ([A-Za-z]+), age: ([0-9]+)', array('name', 'age'))
 checked expr   : regexp_extract<String, String, Array(String)>("name: John, age: 30", "name: ([A-Za-z]+), age: ([0-9]+)", array<T0=String><T0, T0>("name", "age"))
 optimized expr : {"name":"John", "age":"30"}
-output type    : Map(String, String NULL)
+output type    : Map(String, String)
 output domain  : {[{"age"..="name"}], [{"30"..="John"}]}
 output         : {'name':'John', 'age':'30'}
 
@@ -1113,26 +1113,26 @@ evaluation:
 +--------+--------------------------------------------------+------------------------------+
 |        | s                                                | Output                       |
 +--------+--------------------------------------------------+------------------------------+
-| Type   | String                                           | Map(String, String NULL)     |
+| Type   | String                                           | Map(String, String)          |
 | Domain | {"name: James, age: 25"..="name: Lisa, age: 19"} | Unknown                      |
 | Row 0  | 'name: John, age: 30'                            | {'name':'John', 'age':'30'}  |
 | Row 1  | 'name: James, age: 25'                           | {'name':'James', 'age':'25'} |
 | Row 2  | 'name: Lisa, age: 19'                            | {'name':'Lisa', 'age':'19'}  |
 +--------+--------------------------------------------------+------------------------------+
 evaluation (internal):
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Column | Data                                                                                                                                                                                                  |
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| s      | StringColumn[name: John, age: 30, name: James, age: 25, name: Lisa, age: 19]                                                                                                                          |
-| Output | ArrayColumn { values: Tuple([StringColumn[name, age, name, age, name, age], NullableColumn { column: StringColumn[John, 30, James, 25, Lisa, 19], validity: [0b__111111] }]), offsets: [0, 2, 4, 6] } |
-+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                               |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| s      | StringColumn[name: John, age: 30, name: James, age: 25, name: Lisa, age: 19]                                                                       |
+| Output | ArrayColumn { values: Tuple([StringColumn[name, age, name, age, name, age], StringColumn[John, 30, James, 25, Lisa, 19]]), offsets: [0, 2, 4, 6] } |
++--------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 ast            : regexp_extract_all('abc def ghi', '[a-z]+')
 raw expr       : regexp_extract_all('abc def ghi', '[a-z]+')
 checked expr   : regexp_extract_all<String, String>("abc def ghi", "[a-z]+")
 optimized expr : ['abc', 'def', 'ghi']
-output type    : Array(String NULL)
+output type    : Array(String)
 output domain  : [{"abc"..="ghi"}]
 output         : ['abc', 'def', 'ghi']
 
@@ -1141,7 +1141,7 @@ ast            : regexp_extract_all('John Doe, Jane Smith', '([A-Za-z]+) ([A-Za-
 raw expr       : regexp_extract_all('John Doe, Jane Smith', '([A-Za-z]+) ([A-Za-z]+)', 1)
 checked expr   : regexp_extract_all<String, String, UInt32>("John Doe, Jane Smith", "([A-Za-z]+) ([A-Za-z]+)", to_uint32<UInt8>(1_u8))
 optimized expr : ['John', 'Jane']
-output type    : Array(String NULL)
+output type    : Array(String)
 output domain  : [{"Jane"..="John"}]
 output         : ['John', 'Jane']
 
@@ -1150,7 +1150,7 @@ ast            : regexp_extract_all('abc def ghi', NULL)
 raw expr       : regexp_extract_all('abc def ghi', NULL)
 checked expr   : regexp_extract_all<String NULL, String NULL>(CAST("abc def ghi" AS String NULL), CAST(NULL AS String NULL))
 optimized expr : NULL
-output type    : Array(String NULL) NULL
+output type    : Array(String) NULL
 output domain  : {NULL}
 output         : NULL
 
@@ -1159,7 +1159,7 @@ ast            : regexp_extract_all('', '[a-z]+')
 raw expr       : regexp_extract_all('', '[a-z]+')
 checked expr   : regexp_extract_all<String, String>("", "[a-z]+")
 optimized expr : []
-output type    : Array(String NULL)
+output type    : Array(String)
 output domain  : []
 output         : []
 
@@ -1168,7 +1168,7 @@ ast            : regexp_extract_all('123 456', '[a-z]+')
 raw expr       : regexp_extract_all('123 456', '[a-z]+')
 checked expr   : regexp_extract_all<String, String>("123 456", "[a-z]+")
 optimized expr : []
-output type    : Array(String NULL)
+output type    : Array(String)
 output domain  : []
 output         : []
 
@@ -1177,7 +1177,7 @@ ast            : regexp_extract_all('name: John, age: 30; name: Jane, age: 25', 
 raw expr       : regexp_extract_all('name: John, age: 30; name: Jane, age: 25', 'name: ([A-Za-z]+), age: ([0-9]+)')
 checked expr   : regexp_extract_all<String, String>("name: John, age: 30; name: Jane, age: 25", "name: ([A-Za-z]+), age: ([0-9]+)")
 optimized expr : ['name: John, age: 30', 'name: Jane, age: 25']
-output type    : Array(String NULL)
+output type    : Array(String)
 output domain  : [{"name: Jane, age: 25"..="name: John, age: 30"}]
 output         : ['name: John, age: 30', 'name: Jane, age: 25']
 
@@ -1190,18 +1190,18 @@ evaluation:
 +--------+----------------------------------------------------------------+---------------------+
 |        | s                                                              | Output              |
 +--------+----------------------------------------------------------------+---------------------+
-| Type   | String                                                         | Array(String NULL)  |
+| Type   | String                                                         | Array(String)       |
 | Domain | {"James Davis, Robert Wilson"..="Lisa Taylor, Sarah Williams"} | Unknown             |
 | Row 0  | 'John Doe, Jane Smith'                                         | ['John', 'Jane']    |
 | Row 1  | 'James Davis, Robert Wilson'                                   | ['James', 'Robert'] |
 | Row 2  | 'Lisa Taylor, Sarah Williams'                                  | ['Lisa', 'Sarah']   |
 +--------+----------------------------------------------------------------+---------------------+
 evaluation (internal):
-+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Column | Data                                                                                                                                                   |
-+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| s      | StringColumn[John Doe, Jane Smith, James Davis, Robert Wilson, Lisa Taylor, Sarah Williams]                                                            |
-| Output | ArrayColumn { values: NullableColumn { column: StringColumn[John, Jane, James, Robert, Lisa, Sarah], validity: [0b__111111] }, offsets: [0, 2, 4, 6] } |
-+--------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
++--------+-----------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                |
++--------+-----------------------------------------------------------------------------------------------------+
+| s      | StringColumn[John Doe, Jane Smith, James Davis, Robert Wilson, Lisa Taylor, Sarah Williams]         |
+| Output | ArrayColumn { values: StringColumn[John, Jane, James, Robert, Lisa, Sarah], offsets: [0, 2, 4, 6] } |
++--------+-----------------------------------------------------------------------------------------------------+
 
 

--- a/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
+++ b/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
@@ -134,3 +134,71 @@ select regexp_extract_all('img.jpg readme', '(\w+)(?:\.(\w+))?', 2)
 
 statement ok
 DROP TABLE regex_test;
+
+# regexp_extract(string, pattern, name_list)
+statement ok
+CREATE OR REPLACE TABLE regex_test_1 (
+    id INTEGER,
+    input_string VARCHAR
+);
+
+statement ok
+INSERT INTO regex_test_1 VALUES (1, '2023-04-15'), (2, '192.168.1.1'), (3, 'hello_world_rust'), (4, 'no-match-here'), (5, '');
+
+query T
+SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd']) AS extracted_date
+FROM regex_test_1 WHERE id = 1;
+----
+1 {"y": "2023", "m": "04", "d": "15"}
+
+query T
+SELECT id, regexp_extract(input_string, '(\d+)\.(\d+)\.(\d+)\.(\d+)', ['octet1', 'octet2', 'octet3', 'octet4']) AS extracted_ip
+FROM regex_test_1 WHERE id = 2;
+----
+2 {"octet1": "192", "octet2": "168", "octet3": "1", "octet4": "1"}
+
+query T
+SELECT id, regexp_extract(input_string, '(\w+)_(\w+)_(\w+)', ['part1', 'part2', 'part3']) AS extracted_parts
+FROM regex_test_1 WHERE id = 3;
+----
+3 {"part1": "hello", "part2": "world", "part3": "rust"}
+
+query T
+SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']) AS no_match
+FROM regex_test_1 WHERE id = 4;
+----
+4 {"x": "", "y": "", "z": ""}
+
+query T
+SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']) AS empty_string_result
+FROM regex_test_1 WHERE id = 5;
+----
+5 {"a": "", "b": "", "c": ""}
+
+query T
+select regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd']);
+----
+{"y": "2023", "m": "04", "d": "15"}
+
+query T
+SELECT regexp_extract('192.168.1.1', '(\d+)\.(\d+)\.(\d+)\.(\d+)', ['octet1', 'octet2', 'octet3', 'octet4']);
+----
+{"octet1": "192", "octet2": "168", "octet3": "1", "octet4": "1"}
+
+query T
+SELECT regexp_extract('hello_world_rust', '(\w+)_([\w]+)_(\w+)', ['part1', 'part2', 'part3']);
+----
+{"part1": "hello", "part2": "world", "part3": "rust"}
+
+query T
+SELECT regexp_extract('no-match-here', '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']);
+----
+{"x": "", "y": "", "z": ""}
+
+query T
+SELECT regexp_extract('', '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']);
+----
+{"a": "", "b": "", "c": ""}
+
+statement ok
+DROP TABLE regex_test_1;

--- a/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
+++ b/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
@@ -1,0 +1,136 @@
+# regexp_extract(string, pattern[, group = 0])
+statement ok
+CREATE OR REPLACE TABLE regex_test (
+    id INT,
+    text_string STRING NOT NULL,
+    pattern STRING NOT NULL,
+    group_index UINT32
+);
+
+statement ok
+INSERT INTO regex_test VALUES
+    (1, 'John Doe, age 30', '[A-Za-z]+', 0),
+    (2, 'Email: test@example.com', '([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+)\\.([A-Za-z]{2,})', 1),
+    (3, 'Phone: +1 (123) 456-7890', '\\+(\\d+)\\s*\\((\\d+)\\)\\s*(\\d+)-(\\d+)', 2),
+    (4, 'Date: 2023-05-15', '(\\d{4})-(\\d{2})-(\\d{2})', 0),
+    (5, 'Color codes: #FF0000, #00FF00, #0000FF', '#([A-Fa-f0-9]{6})', 1),
+    (6, 'No match here', '\\d+', 0);
+
+query I rowsort
+SELECT id, regexp_extract(text_string, pattern, group_index) FROM regex_test;
+----
+1 John
+2 test
+3 123
+4 2023-05-15
+5 FF0000
+6 (empty)
+
+query T
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 0)
+----
+foo-bar-baz
+
+query T
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 1)
+----
+foo
+
+query T
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 2)
+----
+bar
+
+query T
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 3)
+----
+baz
+
+query B
+select regexp_extract('foo-bar-baz', '([0-9]+)', 1) is null
+----
+0
+
+query B
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 4) is null
+----
+0
+
+query B
+select regexp_extract('', '([a-z]*)', 0)
+----
+(empty)
+
+query B
+select regexp_extract('FOO-BAR', '([a-z]+)-([a-z]+)', 1) is null
+----
+0
+
+query T
+select regexp_extract('2023-04-15', '(\d{4})-(\d{2})-(\d{2})', 1)
+----
+2023
+
+query T
+select regexp_extract('John Doe, Age: 30', '([A-Za-z]+) ([A-Za-z]+), Age: (\d+)', 3)
+----
+30
+
+query T
+select regexp_extract('color: #FF0000', 'color: #(?P<red>[0-9A-F]{2})(?P<green>[0-9A-F]{2})(?P<blue>[0-9A-F]{2})', 1)
+----
+FF
+
+# regexp_extract_all(string, regex[, group = 0])
+query T rowsort
+SELECT id, regexp_extract_all(text_string, pattern, group_index) FROM regex_test;
+----
+1 ["John", "Doe", "age"]
+2 ["test"]
+3 ["123"]
+4 ["2023-05-15"]
+5 ["FF0000", "00FF00", "0000FF"]
+6 []
+
+query T
+select regexp_extract_all('2023-04-15 2024-05-20', '(\d{4})-(\d{2})-(\d{2})', 0)
+----
+["2023-04-15", "2024-05-20"]
+
+query T
+select regexp_extract_all('John 30, Jane 25', '(\w+) (\d+)', 1)
+----
+["John", "Jane"]
+
+query T
+select regexp_extract_all('A1 B2 C3', '([A-Z])(\d)', 2)
+----
+["1", "2", "3"]
+
+query T
+select regexp_extract_all('no numbers here', '(\d+)', 0)
+----
+[]
+
+query T
+select regexp_extract_all('2023-04', '(\d{4})-(\d{2})', 3)
+----
+[]
+
+query T
+select regexp_extract_all('', '(\d+)', 0)
+----
+[]
+
+query T
+select regexp_extract_all('Order-123-456 Order-789-012', 'Order-(\d+)-(\d+)', 2)
+----
+["456", "012"]
+
+query T
+select regexp_extract_all('img.jpg readme', '(\w+)(?:\.(\w+))?', 2)
+----
+["jpg"]
+
+statement ok
+DROP TABLE regex_test;

--- a/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
+++ b/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
@@ -128,7 +128,7 @@ select regexp_extract_all('Order-123-456 Order-789-012', 'Order-(\d+)-(\d+)', 2)
 query T
 select regexp_extract_all('img.jpg readme', '(\w+)(?:\.(\w+))?', 2)
 ----
-['jpg',NULL]
+['jpg','']
 
 statement error
 select regexp_extract_all('A1 B2 C3', '([A-Z])(\d)', 3)
@@ -171,13 +171,13 @@ query T
 SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']) AS no_match
 FROM regex_test_1 WHERE id = 4;
 ----
-4 {'x':NULL,'y':NULL,'z':NULL}
+4 {'x':'','y':'','z':''}
 
 query T
 SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']) AS empty_string_result
 FROM regex_test_1 WHERE id = 5;
 ----
-5 {'a':NULL,'b':NULL,'c':NULL}
+5 {'a':'','b':'','c':''}
 
 query T
 select regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd']);
@@ -197,12 +197,12 @@ SELECT regexp_extract('hello_world_rust', '(\w+)_([\w]+)_(\w+)', ['part1', 'part
 query T
 SELECT regexp_extract('no-match-here', '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']);
 ----
-{'x':NULL,'y':NULL,'z':NULL}
+{'x':'','y':'','z':''}
 
 query T
 SELECT regexp_extract('', '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']);
 ----
-{'a':NULL,'b':NULL,'c':NULL}
+{'a':'','b':'','c':''}
 
 query T
 select regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm']);

--- a/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
+++ b/tests/sqllogictests/suites/query/functions/02_0081_function_string_regexp_extract.test
@@ -46,22 +46,17 @@ select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 3)
 ----
 baz
 
-query B
+query T
 select regexp_extract('foo-bar-baz', '([0-9]+)', 1) is null
 ----
 0
 
-query B
-select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 4) is null
-----
-0
-
-query B
+query T
 select regexp_extract('', '([a-z]*)', 0)
 ----
 (empty)
 
-query B
+query T
 select regexp_extract('FOO-BAR', '([a-z]+)-([a-z]+)', 1) is null
 ----
 0
@@ -81,39 +76,42 @@ select regexp_extract('color: #FF0000', 'color: #(?P<red>[0-9A-F]{2})(?P<green>[
 ----
 FF
 
+query T
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 4)
+----
+(empty)
+
+statement error
+select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 10)
+
 # regexp_extract_all(string, regex[, group = 0])
 query T rowsort
 SELECT id, regexp_extract_all(text_string, pattern, group_index) FROM regex_test;
 ----
-1 ["John", "Doe", "age"]
-2 ["test"]
-3 ["123"]
-4 ["2023-05-15"]
-5 ["FF0000", "00FF00", "0000FF"]
+1 ['John','Doe','age']
+2 ['test']
+3 ['123']
+4 ['2023-05-15']
+5 ['FF0000','00FF00','0000FF']
 6 []
 
 query T
 select regexp_extract_all('2023-04-15 2024-05-20', '(\d{4})-(\d{2})-(\d{2})', 0)
 ----
-["2023-04-15", "2024-05-20"]
+['2023-04-15','2024-05-20']
 
 query T
 select regexp_extract_all('John 30, Jane 25', '(\w+) (\d+)', 1)
 ----
-["John", "Jane"]
+['John','Jane']
 
 query T
 select regexp_extract_all('A1 B2 C3', '([A-Z])(\d)', 2)
 ----
-["1", "2", "3"]
+['1','2','3']
 
 query T
 select regexp_extract_all('no numbers here', '(\d+)', 0)
-----
-[]
-
-query T
-select regexp_extract_all('2023-04', '(\d{4})-(\d{2})', 3)
 ----
 []
 
@@ -125,12 +123,18 @@ select regexp_extract_all('', '(\d+)', 0)
 query T
 select regexp_extract_all('Order-123-456 Order-789-012', 'Order-(\d+)-(\d+)', 2)
 ----
-["456", "012"]
+['456','012']
 
 query T
 select regexp_extract_all('img.jpg readme', '(\w+)(?:\.(\w+))?', 2)
 ----
-["jpg"]
+['jpg',NULL]
+
+statement error
+select regexp_extract_all('A1 B2 C3', '([A-Z])(\d)', 3)
+
+statement error
+select regexp_extract_all('A1 B2 C3', '([A-Z])(\d)', 10)
 
 statement ok
 DROP TABLE regex_test;
@@ -149,56 +153,64 @@ query T
 SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd']) AS extracted_date
 FROM regex_test_1 WHERE id = 1;
 ----
-1 {"y": "2023", "m": "04", "d": "15"}
+1 {'y':'2023','m':'04','d':'15'}
 
 query T
 SELECT id, regexp_extract(input_string, '(\d+)\.(\d+)\.(\d+)\.(\d+)', ['octet1', 'octet2', 'octet3', 'octet4']) AS extracted_ip
 FROM regex_test_1 WHERE id = 2;
 ----
-2 {"octet1": "192", "octet2": "168", "octet3": "1", "octet4": "1"}
+2 {'octet1':'192','octet2':'168','octet3':'1','octet4':'1'}
 
 query T
 SELECT id, regexp_extract(input_string, '(\w+)_(\w+)_(\w+)', ['part1', 'part2', 'part3']) AS extracted_parts
 FROM regex_test_1 WHERE id = 3;
 ----
-3 {"part1": "hello", "part2": "world", "part3": "rust"}
+3 {'part1':'hello','part2':'world','part3':'rust'}
 
 query T
 SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']) AS no_match
 FROM regex_test_1 WHERE id = 4;
 ----
-4 {"x": "", "y": "", "z": ""}
+4 {'x':NULL,'y':NULL,'z':NULL}
 
 query T
 SELECT id, regexp_extract(input_string, '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']) AS empty_string_result
 FROM regex_test_1 WHERE id = 5;
 ----
-5 {"a": "", "b": "", "c": ""}
+5 {'a':NULL,'b':NULL,'c':NULL}
 
 query T
 select regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm', 'd']);
 ----
-{"y": "2023", "m": "04", "d": "15"}
+{'y':'2023','m':'04','d':'15'}
 
 query T
 SELECT regexp_extract('192.168.1.1', '(\d+)\.(\d+)\.(\d+)\.(\d+)', ['octet1', 'octet2', 'octet3', 'octet4']);
 ----
-{"octet1": "192", "octet2": "168", "octet3": "1", "octet4": "1"}
+{'octet1':'192','octet2':'168','octet3':'1','octet4':'1'}
 
 query T
 SELECT regexp_extract('hello_world_rust', '(\w+)_([\w]+)_(\w+)', ['part1', 'part2', 'part3']);
 ----
-{"part1": "hello", "part2": "world", "part3": "rust"}
+{'part1':'hello','part2':'world','part3':'rust'}
 
 query T
 SELECT regexp_extract('no-match-here', '(\d+)-(\d+)-(\d+)', ['x', 'y', 'z']);
 ----
-{"x": "", "y": "", "z": ""}
+{'x':NULL,'y':NULL,'z':NULL}
 
 query T
 SELECT regexp_extract('', '(\d+)-(\d+)-(\d+)', ['a', 'b', 'c']);
 ----
-{"a": "", "b": "", "c": ""}
+{'a':NULL,'b':NULL,'c':NULL}
+
+query T
+select regexp_extract('2023-04-15', '(\d+)-(\d+)-(\d+)', ['y', 'm']);
+----
+{'y':'2023','m':'04'}
+
+statement error
+select regexp_extract('2023-04-15', '(\d+)-(\d+)', ['y', 'm', 'd']);
 
 statement ok
 DROP TABLE regex_test_1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
- fixes: https://github.com/databendlabs/databend/issues/17655

```shell
select regexp_extract('foo-bar-baz', '([a-z]+)-([a-z]+)-([a-z]+)', 0)
----
foo-bar-baz

SELECT regexp_extract('hello_world_rust', '(\w+)_([\w]+)_(\w+)', ['part1', 'part2', 'part3']);
----
{"part1": "hello", "part2": "world", "part3": "rust"}


select regexp_extract_all('Order-123-456 Order-789-012', 'Order-(\d+)-(\d+)', 2)
----
["456", "012"]
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17658)
<!-- Reviewable:end -->
