### PR TITLE
feat: support specifying compression when unloading to parquet.

### DIFF
--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -109,7 +109,7 @@ impl FileFormatParams {
             FileFormatParams::NdJson(v) => v.compression,
             FileFormatParams::Json(v) => v.compression,
             FileFormatParams::Xml(v) => v.compression,
-            FileFormatParams::Parquet(_) => StageFileCompression::None,
+            FileFormatParams::Parquet(v) => v.compression,
             FileFormatParams::Orc(_) => StageFileCompression::None,
             FileFormatParams::Avro(_) => StageFileCompression::None,
         }
@@ -153,18 +153,18 @@ impl FileFormatParams {
             StageFileFormatType::Xml => {
                 let default = XmlFileFormatParams::default();
                 let row_tag = reader.take_string(OPT_ROW_TAG, default.row_tag);
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 FileFormatParams::Xml(XmlFileFormatParams {
                     compression,
                     row_tag,
                 })
             }
             StageFileFormatType::Json => {
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 FileFormatParams::Json(JsonFileFormatParams { compression })
             }
             StageFileFormatType::NdJson => {
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 let missing_field_as = reader.options.remove(MISSING_FIELD_AS);
                 let null_field_as = reader.options.remove(NULL_FIELD_AS);
                 let null_if = parse_null_if(reader.options.remove(NULL_IF))?;
@@ -176,7 +176,7 @@ impl FileFormatParams {
                 )?)
             }
             StageFileFormatType::Avro => {
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 let missing_field_as = reader.options.remove(MISSING_FIELD_AS);
                 let null_if = parse_null_if(reader.options.remove(NULL_IF))?;
                 FileFormatParams::Avro(AvroFileFormatParams::try_create(
@@ -186,9 +186,11 @@ impl FileFormatParams {
                 )?)
             }
             StageFileFormatType::Parquet => {
+                let compression = reader.take_compression(StageFileCompression::Zstd)?;
                 let missing_field_as = reader.options.remove(MISSING_FIELD_AS);
                 let null_if = parse_null_if(reader.options.remove(NULL_IF))?;
                 FileFormatParams::Parquet(ParquetFileFormatParams::try_create(
+                    compression,
                     missing_field_as.as_deref(),
                     null_if,
                 )?)
@@ -201,7 +203,7 @@ impl FileFormatParams {
             }
             StageFileFormatType::Csv => {
                 let default = CsvFileFormatParams::default();
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 let headers = reader.take_u64(OPT_SKIP_HEADER, default.headers)?;
                 let field_delimiter =
                     reader.take_string(OPT_FIELD_DELIMITER, default.field_delimiter);
@@ -246,7 +248,7 @@ impl FileFormatParams {
             }
             StageFileFormatType::Tsv => {
                 let default = TsvFileFormatParams::default();
-                let compression = reader.take_compression()?;
+                let compression = reader.take_compression_default_none()?;
                 let headers = reader.take_u64(OPT_SKIP_HEADER, default.headers)?;
                 let field_delimiter =
                     reader.take_string(OPT_FIELD_DELIMITER, default.field_delimiter);
@@ -329,6 +331,7 @@ impl FileFormatParams {
 impl Default for FileFormatParams {
     fn default() -> Self {
         FileFormatParams::Parquet(ParquetFileFormatParams {
+            compression: StageFileCompression::Zstd,
             missing_field_as: NullAs::Error,
             null_if: vec![],
         })
@@ -384,10 +387,13 @@ impl FileFormatOptionsReader {
         }
     }
 
-    fn take_compression(&mut self) -> Result<StageFileCompression> {
+    fn take_compression_default_none(&mut self) -> Result<StageFileCompression> {
+        self.take_compression(StageFileCompression::None)
+    }
+    fn take_compression(&mut self, default: StageFileCompression) -> Result<StageFileCompression> {
         match self.options.remove("compression") {
             Some(c) => StageFileCompression::from_str(&c).map_err(ErrorCode::IllegalFileFormat),
-            None => Ok(StageFileCompression::None),
+            None => Ok(default),
         }
     }
 
@@ -752,16 +758,41 @@ impl AvroFileFormatParams {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParquetFileFormatParams {
+    // used only for unload
+    pub compression: StageFileCompression,
     pub missing_field_as: NullAs,
     pub null_if: Vec<String>,
 }
 
+impl Default for ParquetFileFormatParams {
+    fn default() -> Self {
+        Self {
+            compression: StageFileCompression::Zstd,
+            missing_field_as: Default::default(),
+            null_if: Default::default(),
+        }
+    }
+}
+
 impl ParquetFileFormatParams {
-    pub fn try_create(missing_field_as: Option<&str>, null_if: Vec<String>) -> Result<Self> {
+    pub fn try_create(
+        compression: StageFileCompression,
+        missing_field_as: Option<&str>,
+        null_if: Vec<String>,
+    ) -> Result<Self> {
+        if !matches!(
+            compression,
+            StageFileCompression::Zstd | StageFileCompression::Snappy
+        ) {
+            return Err(ErrorCode::InvalidArgument(format!(
+                "compression algorithm {compression} not supported, only support Zstd and Snappy."
+            )));
+        }
         let missing_field_as = NullAs::parse(missing_field_as, MISSING_FIELD_AS, NullAs::Error)?;
         Ok(Self {
+            compression,
             missing_field_as,
             null_if,
         })

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -152,6 +152,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (120, "2025-02-11: Add: Add new UserPrivilege CreateWarehouse and new OwnershipObject::Warehouse"),
     (121, "2025-03-03: Add: Add new FileFormat AvroFileFormatParams"),
     (122, "2025-03-11: Add: table_meta and virtual_data_schema"),
+    (123, "2025-03-27: Add: add compression in user.proto/ParquetFileFormatParam"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -117,3 +117,4 @@ mod v119_virtual_column;
 mod v120_warehouse_ownershipobject;
 mod v121_avro_format_params;
 mod v122_virtual_schema;
+mod v123_parquet_format_params;

--- a/src/meta/proto-conv/tests/it/v032_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v032_file_format_params.rs
@@ -138,6 +138,7 @@ fn test_decode_v32_parquet_file_format_params() -> anyhow::Result<()> {
 
     let want = || {
         mt::principal::FileFormatParams::Parquet(ParquetFileFormatParams {
+            compression: StageFileCompression::Zstd,
             missing_field_as: Default::default(),
             null_if: vec![],
         })

--- a/src/meta/proto-conv/tests/it/v066_stage_create_on.rs
+++ b/src/meta/proto-conv/tests/it/v066_stage_create_on.rs
@@ -15,6 +15,7 @@
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_meta_app as mt;
+use databend_common_meta_app::principal::StageFileCompression;
 use databend_common_meta_app::principal::UserIdentity;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::storage::StorageS3Config;
@@ -55,6 +56,7 @@ fn test_decode_v66_stage() -> anyhow::Result<()> {
         is_temporary: false,
         file_format_params: mt::principal::FileFormatParams::Parquet(
             mt::principal::ParquetFileFormatParams {
+                compression: StageFileCompression::Zstd,
                 missing_field_as: Default::default(),
                 null_if: vec![],
             },

--- a/src/meta/proto-conv/tests/it/v093_parquet_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v093_parquet_format_params.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_meta_app::principal::ParquetFileFormatParams;
+use databend_common_meta_app::principal::StageFileCompression;
 use fastrace::func_name;
 
 use crate::common;
@@ -31,6 +32,7 @@ use crate::common;
 fn test_decode_v93_parquet_file_format_params() -> anyhow::Result<()> {
     let parquet_file_format_params_v93 = vec![34, 0, 34, 1, 97, 160, 6, 93, 168, 6, 24];
     let want = || ParquetFileFormatParams {
+        compression: StageFileCompression::Zstd,
         missing_field_as: Default::default(),
         null_if: vec!["".to_string(), "a".to_string()],
     };

--- a/src/meta/proto-conv/tests/it/v123_parquet_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v123_parquet_format_params.rs
@@ -30,20 +30,21 @@ use crate::common;
 // *************************************************************
 //
 #[test]
-fn test_decode_v99_parquet_file_format_params() -> anyhow::Result<()> {
-    let parquet_file_format_params_v99 = vec![
-        10, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 34, 0, 34, 1, 97, 160, 6, 99,
-        168, 6, 24,
+fn test_decode_v123_parquet_file_format_params() -> anyhow::Result<()> {
+    let parquet_file_format_params_v123 = vec![
+        10, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 16, 8, 34, 0, 34, 1, 97, 160,
+        6, 123, 168, 6, 24,
     ];
+
     let want = || ParquetFileFormatParams {
-        compression: StageFileCompression::Zstd,
+        compression: StageFileCompression::Snappy,
         missing_field_as: NullAs::FieldDefault,
         null_if: vec!["".to_string(), "a".to_string()],
     };
     common::test_load_old(
         func_name!(),
-        parquet_file_format_params_v99.as_slice(),
-        99,
+        parquet_file_format_params_v123.as_slice(),
+        123,
         want(),
     )?;
     common::test_pb_from_to(func_name!(), want())?;

--- a/src/meta/protos/proto/file_format.proto
+++ b/src/meta/protos/proto/file_format.proto
@@ -93,6 +93,7 @@ message ParquetFileFormatParams {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
   optional string missing_field_as = 1;
+  StageFileCompression compression = 2;
   repeated string null_if = 4;
 }
 

--- a/src/query/ast/src/parser/stage.rs
+++ b/src/query/ast/src/parser/stage.rs
@@ -103,7 +103,7 @@ pub fn format_options(i: Input) -> IResult<FileFormatOptions> {
 
     let option_compression = map(
         rule! {
-            COMPRESSION ~ "=" ~ ( AUTO | NONE | GZIP | BZ2 | BROTLI | ZSTD | DEFLATE | RAWDEFLATE | XZ )
+            COMPRESSION ~ "=" ~ ( AUTO | NONE | GZIP | BZ2 | BROTLI | ZSTD | DEFLATE | RAWDEFLATE | XZ | SNAPPY)
         },
         |(_, _, v)| {
             (

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_compression.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_compression.test
@@ -1,0 +1,24 @@
+statement ok
+create or replace file format parquet_snappy type=parquet compression=snappy
+
+statement ok
+remove @data/unload/parquet_compression/snappy.parquet
+
+statement ok
+copy into @data/unload/parquet_compression/snappy.parquet from (select * from numbers(3)) file_format=(format_name='parquet_snappy')
+
+statement ok
+copy into @data/unload/parquet_compression/zstd.parquet from (select * from numbers(3))
+
+query
+select * from @data/unload/parquet_compression/snappy.parquet
+----
+0
+1
+2
+
+statement ok
+remove @data/unload/parquet_compression/snappy.parquet
+
+statement ok
+remove @data/unload/parquet_compression/zstd.parquet

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/select_options.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/select_options.test
@@ -1,4 +1,4 @@
-query 
+query
 select $1 from @data/parquet/ (files => ('alltypes_plain.parquet')) a;
 ----
 4


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

before this pr，zstd is used for unloading to parquet files.

this pr add a file format option ` compression = zstd | snappy`  to file format parquet.

unlike the `compression` option of other formats(ndjson/csv):
1. it is used only when unloading, instead of both load and unload
2. is it used for compression of internal block of file, instead of the whole file
3. the default is zstd instead of none


for example

```
copy into @data/unload/ from (select * from numbers(3)) file_format=(type = parquet compression=snappy)
```






## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17664)
<!-- Reviewable:end -->
