### PR TITLE
chore: use default encoding of parquet columns instead of plain.

### DIFF
--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -34,10 +34,10 @@ use databend_common_pipeline_core::processors::ProcessorPtr;
 use opendal::Operator;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
-use parquet::basic::Encoding;
 use parquet::basic::ZstdLevel;
 use parquet::file::properties::EnabledStatistics;
 use parquet::file::properties::WriterProperties;
+use parquet::file::properties::WriterVersion;
 
 use super::block_batch::BlockBatch;
 use crate::append::output::DataSummary;
@@ -98,13 +98,13 @@ fn create_writer(
     }
 
     let props = WriterProperties::builder()
+        .set_writer_version(WriterVersion::PARQUET_2_0)
         .set_compression(compression)
-        .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
-        .set_encoding(Encoding::PLAIN)
-        .set_dictionary_enabled(false)
-        .set_statistics_enabled(EnabledStatistics::Chunk)
-        .set_bloom_filter_enabled(false)
         .set_created_by(create_by)
+        .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
+        .set_statistics_enabled(EnabledStatistics::Chunk)
+        .set_dictionary_enabled(true)
+        .set_bloom_filter_enabled(false)
         .build();
     let buf_size = match targe_file_size {
         Some(n) if n < MAX_BUFFER_SIZE => n,

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
@@ -25,7 +25,7 @@ select * from t_uuid
 query
 copy into @data/parquet/unload/uuid/ from (select 1 as a)  file_format = (type = parquet)
 ----
-1 1 374
+1 1 408
 
 statement ok
 truncate table t_uuid

--- a/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.result
+++ b/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.result
@@ -1,4 +1,4 @@
 >>>> create or replace connection c_00_0005 storage_type='s3' access_key_id = 'minioadmin'  endpoint_url = 'http://127.0.0.1:9900' secret_access_key = 'minioadmin'
 >>>> copy into 's3://testbucket/c_00_0005/ab de/f' connection=(connection_name='c_00_0005') from (select 1) detailed_output=true use_raw_path=true single=true overwrite=true
-c_00_0005/ab de/f	374	1
+c_00_0005/ab de/f	408	1
 <<<<

--- a/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
+++ b/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
@@ -9,8 +9,8 @@ stmt "create stage s1;"
 # one file when #row is small even though multi-threads
 echo "copy into @s1/ from (select * from numbers(6000000)) max_file_size=64000000 detailed_output=true" | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
 
-# two files, the larger is about 63569025
-echo "copy /*+ set_var(max_threads=1) */ into @s1/ from (select * from numbers(70000000)) max_file_size=64000000 detailed_output=true;"  | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
+# two files, the larger is 24960476
+echo "copy /*+ set_var(max_threads=1) */ into @s1/ from (select * from numbers(70000000)) max_file_size=25000000 detailed_output=true;"  | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
 
 # one file
 echo "copy /*+ set_var(max_threads=1) */ into @s1/ from (select * from numbers(60000000)) max_file_size=64000000 detailed_output=true;"  | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'

--- a/tests/suites/1_stateful/00_stage/00_0019_sequence_as_default.result
+++ b/tests/suites/1_stateful/00_stage/00_0019_sequence_as_default.result
@@ -42,9 +42,9 @@
 >>>> create or replace sequence seq
 >>>> create or replace table dest(seq int default nextval(seq), a int)
 >>>> copy INTO @sequence_as_default/src1/ from src1 file_format=(type=parquet);
-2	9	397
+2	9	430
 >>>> copy INTO @sequence_as_default/src2/ from src2 file_format=(type=parquet);
-2	18	594
+2	18	660
 >>>> copy INTO dest(a) from @sequence_as_default/src1 file_format=(type=parquet) return_failed_only=true;
 >>>> copy INTO dest from @sequence_as_default/src2 file_format=(type=parquet) return_failed_only=true;
 >>>> select * from dest order by seq


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


1.  encoding is not specified, Arrow Parquet will automatically select a suitable encoding for the physical type.
2. enable dictionary encoding, which is the default behavior of Arrow Parquet and generally makes the file smaller.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17688)
<!-- Reviewable:end -->
