### PR TITLE
feat(query): support query iceberg table by version

### DIFF
--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1084,6 +1084,8 @@ fn test_query() {
         r#"select * from customer at(offset => -10 * 30)"#,
         r#"select * from customer changes(information => default) at (stream => s) order by a, b"#,
         r#"select * from customer with consume as s"#,
+        r#"select * from t12_0004 at (TIMESTAMP => 'xxxx') as t"#,
+        r#"select count(t.c) from t12_0004 at (snapshot => 'xxxx') as t"#,
         r#"select * from customer inner join orders"#,
         r#"select * from customer cross join orders"#,
         r#"select * from customer inner join orders on (a = b)"#,

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -766,6 +766,226 @@ Query {
 
 
 ---------- Input ----------
+select * from t12_0004 at (TIMESTAMP => 'xxxx') as t
+---------- Output ---------
+SELECT * FROM t12_0004 AT (TIMESTAMP => 'xxxx') AS t
+---------- AST ------------
+Query {
+    span: Some(
+        0..52,
+    ),
+    with: None,
+    body: Select(
+        SelectStmt {
+            span: Some(
+                0..52,
+            ),
+            hints: None,
+            distinct: false,
+            top_n: None,
+            select_list: [
+                StarColumns {
+                    qualified: [
+                        Star(
+                            Some(
+                                7..8,
+                            ),
+                        ),
+                    ],
+                    column_filter: None,
+                },
+            ],
+            from: [
+                Table {
+                    span: Some(
+                        14..52,
+                    ),
+                    catalog: None,
+                    database: None,
+                    table: Identifier {
+                        span: Some(
+                            14..22,
+                        ),
+                        name: "t12_0004",
+                        quote: None,
+                        ident_type: None,
+                    },
+                    alias: Some(
+                        TableAlias {
+                            name: Identifier {
+                                span: Some(
+                                    51..52,
+                                ),
+                                name: "t",
+                                quote: None,
+                                ident_type: None,
+                            },
+                            columns: [],
+                        },
+                    ),
+                    temporal: Some(
+                        TimeTravel(
+                            Timestamp(
+                                Literal {
+                                    span: Some(
+                                        40..46,
+                                    ),
+                                    value: String(
+                                        "xxxx",
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    with_options: None,
+                    pivot: None,
+                    unpivot: None,
+                    sample: None,
+                },
+            ],
+            selection: None,
+            group_by: None,
+            having: None,
+            window_list: None,
+            qualify: None,
+        },
+    ),
+    order_by: [],
+    limit: [],
+    offset: None,
+    ignore_result: false,
+}
+
+
+---------- Input ----------
+select count(t.c) from t12_0004 at (snapshot => 'xxxx') as t
+---------- Output ---------
+SELECT count(t.c) FROM t12_0004 AT (SNAPSHOT => 'xxxx') AS t
+---------- AST ------------
+Query {
+    span: Some(
+        0..60,
+    ),
+    with: None,
+    body: Select(
+        SelectStmt {
+            span: Some(
+                0..60,
+            ),
+            hints: None,
+            distinct: false,
+            top_n: None,
+            select_list: [
+                AliasedExpr {
+                    expr: FunctionCall {
+                        span: Some(
+                            7..17,
+                        ),
+                        func: FunctionCall {
+                            distinct: false,
+                            name: Identifier {
+                                span: Some(
+                                    7..12,
+                                ),
+                                name: "count",
+                                quote: None,
+                                ident_type: None,
+                            },
+                            args: [
+                                ColumnRef {
+                                    span: Some(
+                                        13..14,
+                                    ),
+                                    column: ColumnRef {
+                                        database: None,
+                                        table: Some(
+                                            Identifier {
+                                                span: Some(
+                                                    13..14,
+                                                ),
+                                                name: "t",
+                                                quote: None,
+                                                ident_type: None,
+                                            },
+                                        ),
+                                        column: Name(
+                                            Identifier {
+                                                span: Some(
+                                                    15..16,
+                                                ),
+                                                name: "c",
+                                                quote: None,
+                                                ident_type: None,
+                                            },
+                                        ),
+                                    },
+                                },
+                            ],
+                            params: [],
+                            order_by: [],
+                            window: None,
+                            lambda: None,
+                        },
+                    },
+                    alias: None,
+                },
+            ],
+            from: [
+                Table {
+                    span: Some(
+                        23..60,
+                    ),
+                    catalog: None,
+                    database: None,
+                    table: Identifier {
+                        span: Some(
+                            23..31,
+                        ),
+                        name: "t12_0004",
+                        quote: None,
+                        ident_type: None,
+                    },
+                    alias: Some(
+                        TableAlias {
+                            name: Identifier {
+                                span: Some(
+                                    59..60,
+                                ),
+                                name: "t",
+                                quote: None,
+                                ident_type: None,
+                            },
+                            columns: [],
+                        },
+                    ),
+                    temporal: Some(
+                        TimeTravel(
+                            Snapshot(
+                                "xxxx",
+                            ),
+                        ),
+                    ),
+                    with_options: None,
+                    pivot: None,
+                    unpivot: None,
+                    sample: None,
+                },
+            ],
+            selection: None,
+            group_by: None,
+            having: None,
+            window_list: None,
+            qualify: None,
+        },
+    ),
+    order_by: [],
+    limit: [],
+    offset: None,
+    ignore_result: false,
+}
+
+
+---------- Input ----------
 select * from customer inner join orders
 ---------- Output ---------
 SELECT * FROM customer INNER JOIN orders

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -462,6 +462,11 @@ impl Table for IcebergTable {
             }
         };
 
+        if snapshot_id.is_none() {
+            return Err(ErrorCode::TableHistoricalDataNotFound(
+                "No historical data found at given point",
+            ));
+        }
         let (table, statistics) = Self::parse_engine_options(&self.info.meta.engine_options)?;
         Ok(Arc::new(IcebergTable {
             info: self.info.clone(),

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -29,9 +29,12 @@ use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table::ColumnStatisticsProvider;
 use databend_common_catalog::table::DistributionLevel;
+use databend_common_catalog::table::NavigationPoint;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableStatistics;
+use databend_common_catalog::table::TimeNavigation;
 use databend_common_catalog::table_args::TableArgs;
+use databend_common_catalog::table_context::AbortChecker;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -61,6 +64,8 @@ pub struct IcebergTable {
     info: TableInfo,
 
     pub table: iceberg::table::Table,
+    // None means current_snapshot_id
+    pub snapshot_id: Option<i64>,
     statistics: IcebergStatistics,
 }
 
@@ -71,6 +76,7 @@ impl IcebergTable {
         Ok(Box::new(Self {
             info,
             table,
+            snapshot_id: None,
             statistics,
         }))
     }
@@ -246,6 +252,7 @@ impl IcebergTable {
         Ok(Self {
             info,
             table,
+            snapshot_id: None,
             statistics,
         })
     }
@@ -276,7 +283,13 @@ impl IcebergTable {
         _: Arc<dyn TableContext>,
         push_downs: Option<PushDownInfo>,
     ) -> Result<(PartStatistics, Partitions)> {
-        let mut scan = self.table.scan();
+        // Some means navigate is valid
+        let mut scan = if let Some(snapshot_id) = self.snapshot_id {
+            let scan = self.table.scan();
+            scan.snapshot_id(snapshot_id)
+        } else {
+            self.table.scan()
+        };
 
         if let Some(push_downs) = &push_downs {
             if let Some(projection) = &push_downs.projection {
@@ -404,5 +417,57 @@ impl Table for IcebergTable {
 
     fn has_exact_total_row_count(&self) -> bool {
         true
+    }
+
+    #[async_backtrace::framed]
+    async fn navigate_to(
+        &self,
+        navigation: &TimeNavigation,
+        _abort_checker: AbortChecker,
+    ) -> Result<Arc<dyn Table>> {
+        let snapshot_id = match navigation {
+            TimeNavigation::TimeTravel(np) => match np {
+                NavigationPoint::SnapshotID(sid) => {
+                    let sid = sid.parse::<i64>()?;
+                    if self.table.metadata().snapshot_by_id(sid).is_some() {
+                        Some(sid)
+                    } else {
+                        None
+                    }
+                }
+                NavigationPoint::TimePoint(dt) => {
+                    let ts = dt.timestamp_millis();
+                    self.table
+                        .metadata()
+                        .history()
+                        .iter()
+                        .filter(|log| log.timestamp_ms < ts)
+                        .max_by_key(|log| log.timestamp_ms)
+                        .map(|s| s.snapshot_id)
+                }
+                _ => {
+                    return Err(ErrorCode::Unimplemented(format!(
+                            "Time travel operation is not supported for the table '{}', which uses the '{}' engine.",
+                            self.name(),
+                            self.get_table_info().engine(),
+                        )));
+                }
+            },
+            _ => {
+                return Err(ErrorCode::Unimplemented(format!(
+                    "Time travel operation is not supported for the table '{}', which uses the '{}' engine.",
+                    self.name(),
+                    self.get_table_info().engine(),
+                )));
+            }
+        };
+
+        let (table, statistics) = Self::parse_engine_options(&self.info.meta.engine_options)?;
+        Ok(Arc::new(IcebergTable {
+            info: self.info.clone(),
+            table,
+            snapshot_id,
+            statistics,
+        }))
     }
 }

--- a/tests/sqllogictests/suites/tpch_iceberg/table_function.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/table_function.test
@@ -28,7 +28,10 @@ statement ok
 select sum(summary['total-records']::Int64), count() from iceberg_snapshot('tpch', 'lineitem') where operation = 'append';
 
 statement ok
-select * from tpch.lineitem at (timestamp=>'2025-03-12 23:18:22.665000'::Timestamp) limit 1;
+select * from tpch.lineitem at (timestamp=>'2099-03-12 23:18:22.665000'::Timestamp) limit 1;
 
-statement ok
+statement error 2013
+select * from tpch.lineitem at (timestamp=>'2000-03-12 23:18:22.665000'::Timestamp) limit 1;
+
+statement error 2013
 select * from tpch.lineitem at (snapshot=>'4524280171191816067') limit 1;

--- a/tests/sqllogictests/suites/tpch_iceberg/table_function.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/table_function.test
@@ -26,3 +26,9 @@ select sum(added_data_files_count) from iceberg_manifest('tpch', 'lineitem');
 
 statement ok
 select sum(summary['total-records']::Int64), count() from iceberg_snapshot('tpch', 'lineitem') where operation = 'append';
+
+statement ok
+select * from tpch.lineitem at (timestamp=>'2025-03-12 23:18:22.665000'::Timestamp) limit 1;
+
+statement ok
+select * from tpch.lineitem at (snapshot=>'4524280171191816067') limit 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


```sql
select * from lineitem at (timestamp=>'2025-03-12 23:18:22.665000'::Timestamp) limit 1;

select * from lineitem at (snapshot=>'4524280171191816067') limit 1;
```

Note:

If timestamp is less or bigger than min snapshot ts will return error.

If snapshot id is not exists will return error.

Fix: #17563 
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17693)
<!-- Reviewable:end -->
