### PR TITLE
fix: persistent log table may loss records when shutdown

### DIFF
--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -49,6 +49,7 @@ pub use crate::panic_hook::log_panic;
 pub use crate::panic_hook::set_panic_hook;
 pub use crate::remote_log::convert_to_batch;
 pub use crate::remote_log::LogBuffer as RemoteLogBuffer;
+pub use crate::remote_log::LogMessage;
 pub use crate::remote_log::RemoteLog;
 pub use crate::remote_log::RemoteLogElement;
 pub use crate::remote_log::RemoteLogGuard;

--- a/src/common/tracing/src/remote_log.rs
+++ b/src/common/tracing/src/remote_log.rs
@@ -175,9 +175,7 @@ impl RemoteLog {
         }
 
         let op = GlobalLogger::instance().get_operator().await;
-        if op.is_none() {
-            return None;
-        }
+        op.as_ref()?;
 
         let path = format!(
             "stage/internal/{}/{}.parquet",

--- a/src/common/tracing/src/remote_log.rs
+++ b/src/common/tracing/src/remote_log.rs
@@ -91,7 +91,7 @@ pub struct RemoteLogGuard {
     buffer: Arc<LogBuffer>,
 }
 
-enum LogMessage {
+pub enum LogMessage {
     Flush(Vec<RemoteLogElement>),
     ForceFlush(Vec<RemoteLogElement>, mpsc::Sender<Result<()>>),
 }

--- a/src/common/tracing/tests/it/remote_log.rs
+++ b/src/common/tracing/tests/it/remote_log.rs
@@ -21,6 +21,7 @@ use databend_common_base::base::tokio;
 use databend_common_exception::Result;
 use databend_common_tracing::convert_to_batch;
 use databend_common_tracing::Config;
+use databend_common_tracing::LogMessage;
 use databend_common_tracing::RemoteLog;
 use databend_common_tracing::RemoteLogBuffer;
 use databend_common_tracing::RemoteLogElement;
@@ -96,7 +97,9 @@ async fn test_buffer_flush_with_buffer_limit() -> Result<()> {
         buffer.log(get_remote_log_elements())?
     }
     let res = rx.recv().await.unwrap();
-    assert_eq!(res.len(), 5000);
+    if let LogMessage::Flush(elements) = res {
+        assert_eq!(elements.len(), 5000);
+    }
     Ok(())
 }
 
@@ -111,7 +114,9 @@ async fn test_buffer_flush_with_buffer_interval() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(1)).await;
     buffer.log(get_remote_log_elements())?;
     let res = rx.recv().await.unwrap();
-    assert_eq!(res.len(), 6);
+    if let LogMessage::Flush(elements) = res {
+        assert_eq!(elements.len(), 6);
+    }
     Ok(())
 }
 
@@ -126,7 +131,9 @@ async fn test_buffer_flush_with_force_collect() -> Result<()> {
     }
     buffer.collect()?;
     let res = rx.recv().await.unwrap();
-    assert_eq!(res.len(), 500);
+    if let LogMessage::Flush(elements) = res {
+        assert_eq!(elements.len(), 500);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

follow up: #17598

Add force collect to fix log data loss.

```
root@localhost:8000/default> select * from persistent_system.query_log order by timestamp desc limit 1;
-[ RECORD 1 ]-----------------------------------
   timestamp: 2025-04-02 13:11:22.354154
        path: databend_query::entry: entry.rs:426
      target: databend_query::entry
   log_level: INFO
  cluster_id: test_cluster
     node_id: TR5fixys6tAWEot24JEZ61
warehouse_id: NULL
    query_id: NULL
     message: Shutdown server.
      fields: {}

1 row read in 0.097 sec. Processed 705 row, 5.59 KiB (7.26 thousand row/s, 57.62 KiB/s)
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Last PR covered


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17695)
<!-- Reviewable:end -->
