### PR TITLE
chore: bump jsonb 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "jsonb"
 version = "0.4.4"
-source = "git+https://github.com/databendlabs/jsonb?rev=1a53512#1a535124f0f57b18b57377437fe486d9bd680980"
+source = "git+https://github.com/b41sh/jsonb?rev=52e46f0f50225011d7aba38a53b1f046411e3a13#52e46f0f50225011d7aba38a53b1f046411e3a13"
 dependencies = [
  "byteorder",
  "fast-float2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -639,7 +639,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "c149502" }
 ethnum = { git = "https://github.com/datafuse-extras/ethnum-rs", rev = "4cb05f1" }
-jsonb = { git = "https://github.com/databendlabs/jsonb", rev = "1a53512" }
+jsonb = { git = "https://github.com/b41sh/jsonb", rev = "52e46f0f50225011d7aba38a53b1f046411e3a13" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.2.3" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.9" }

--- a/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
+++ b/tests/sqllogictests/suites/query/functions/02_0051_function_semi_structureds_get.test
@@ -383,7 +383,7 @@ statement ok
 CREATE TABLE IF NOT EXISTS t5(id Int null, obj Variant null) Engine = Fuse
 
 statement ok
-insert into t5 values(1, '{"car_no":10,"测试\\"\\uD83D\\uDC8E":"a"}'), (2, '{"car_no":20}')
+insert into t5 values(1, '{"car_no":10,"测试\\"\\uD83D\\uDC8E":"a","nums":[2,3,4],"obj":{"a":{"b":[1,2]},"c":1}}'), (2, '{"car_no":20,"nums":[-10,-11],"obj":{"x":"y"}}')
 
 query T
 select get(arr, 0) from t1
@@ -550,6 +550,11 @@ select id, json_path_query(arr, '$[*]?(@ > 1 && @ <= 3)') from t1
 1 3
 
 query IT
+select id, json_path_query(arr, '$[3][*]?(@ starts with "a")') from t1
+----
+1 "a"
+
+query IT
 select id, json_path_query(arr, '$[*][1]') from t1
 ----
 1 "b"
@@ -703,6 +708,85 @@ select json_path_query_first(obj, '$.测试\\"\\uD83D\\uDC8E') from t5
 ----
 "a"
 NULL
+
+query IT
+select id, json_path_query(obj, '$.obj.**') from t5
+----
+1 {"a":{"b":[1,2]},"c":1}
+1 {"b":[1,2]}
+1 [1,2]
+1 1
+1 2
+1 1
+2 {"x":"y"}
+2 "y"
+
+query IT
+select id, json_path_query(obj, '$.obj.**{2 to last}') from t5
+----
+1 [1,2]
+1 1
+1 2
+
+query IT
+select id, json_path_query(obj, '$.obj.**{1}') from t5
+----
+1 {"b":[1,2]}
+1 1
+2 "y"
+
+query IT
+select id, json_path_query(obj, '$.obj.**{1}.b') from t5
+---
+1 [1,2]
+
+query IT
+select id, json_path_query(obj, '+$.nums') from t5
+----
+1 2
+1 3
+1 4
+2 -10
+2 -11
+
+query IT
+select id, json_path_query(obj, '-$.nums') from t5
+----
+1 -2
+1 -3
+1 -4
+2 10
+2 11
+
+query IT
+select id, json_path_query(obj, '$.nums[0] + 3') from t5
+----
+1 5
+2 -7
+
+query IT
+select id, json_path_query(obj, '7 - $.nums[0]') from t5
+----
+1 5
+2 17
+
+query IT
+select id, json_path_query(obj, '2 * $.nums[1]') from t5
+----
+1 6
+2 -22
+
+query IT
+select id, json_path_query(obj, '$.nums[1] / 2') from t5
+----
+1 1.5
+2 -5.5
+
+query IT
+select id, json_path_query(obj, '$.nums[1] % 2') from t5
+----
+1 1
+2 -1
 
 statement ok
 set max_block_size = 65535;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

bump jsonb 0.5.0

jsonpath support some new syntax:
1. recursive wildcard member accessor `.**`.
2. number caculate operators
    - `number + number → number`
    - `number - number → number`
    - `number * number → number`
    - `number / number → number`
    - `number % number → number`
    - `+ number → number`
    - `- number → number`
3. `starts with` check whether the second operand is an initial substring of the first operand, for example `$[*] ? (@ starts with "Test")`

- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
