### PR TITLE
fix: flaky unit test `test_persistent_log_write`

### DIFF
--- a/src/query/service/tests/it/persistent_log/global_persistent_log.rs
+++ b/src/query/service/tests/it/persistent_log/global_persistent_log.rs
@@ -67,6 +67,7 @@ pub async fn test_persistent_log_write() -> Result<()> {
         write_remote_log(&config.log.persistentlog.stage_name).await?;
         tokio::time::sleep(std::time::Duration::from_secs(random_sleep)).await;
     }
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
     let res = fixture
         .execute_query("select count(*) from persistent_system.query_log")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Why flaky: A random time was added to the interval to prevent one node from continuously obtaining the lock, so using a precise interval here might cause flaky tests. Therefore, I added a waiting period to ensure all operations have been completed.

**I rerun this case for 20 times locally, it should be stable now.**

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17701)
<!-- Reviewable:end -->
