### PR TITLE
refactor: add defensive checks during datablock construction

### DIFF
--- a/src/common/storage/src/copy.rs
+++ b/src/common/storage/src/copy.rs
@@ -45,7 +45,7 @@ impl CopyStatus {
     }
 }
 
-#[derive(Default, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct FileStatus {
     pub num_rows_loaded: usize,
     pub error: Option<FileErrorsInfo>,
@@ -79,7 +79,7 @@ impl FileStatus {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct FileErrorsInfo {
     pub num_errors: usize,
     pub first_error: FileErrorInfo,
@@ -94,7 +94,7 @@ impl FileErrorsInfo {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct FileErrorInfo {
     pub error: FileParseError,
     pub line: usize,

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -20,6 +20,7 @@ use std::ops::Range;
 use arrow_array::ArrayRef;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use itertools::Itertools;
 
 use crate::schema::DataSchema;
 use crate::types::AnyType;
@@ -184,8 +185,11 @@ impl DataBlock {
         }
         let num_rows = columns[0].len();
         if !columns.iter().all(|c| c.len() == num_rows) {
+            let num_rows_of_columns = columns.iter().map(|c| c.len()).join(",");
             return Err(ErrorCode::Internal(
-                "Building DataBlock with columns that have different number of rows is not expected",
+                format!(
+                 "Building DataBlock with columns that have different number of rows is not expected. \n\
+                  Number of rows of each column are: {}", num_rows_of_columns),
             ));
         }
         Ok(DataBlock::new_from_columns_internal(columns, num_rows))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Adjust `DataBlock::new_from_columns`
  Enabled assertions for column row consistency checks in release mode.
- Add `DataBlock::try_new_from_columns`
    Returns an Err when column row count mismatches are detected.
- Update `BlockBuilder::flush_block`
   Uses `try_new_from_columns` in `databend_common_storages_stage::read::row_based::processors::block_builder::BlockBuilder::flush_block` to build DataBlock. 
   Collects additional context information on failure.



## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - covered by existing test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17705)
<!-- Reviewable:end -->
