### PR TITLE
chore: show file path when copy meet invalid parquet file.

### DIFF
--- a/src/query/storages/orc/src/table.rs
+++ b/src/query/storages/orc/src/table.rs
@@ -44,6 +44,7 @@ use orc_rust::ArrowReaderBuilder;
 
 use crate::chunk_reader_impl::OrcChunkReader;
 use crate::read_partition::read_partitions_simple;
+use crate::utils::map_orc_error;
 
 pub struct OrcTable {
     pub(super) stage_table_info: StageTableInfo,
@@ -107,11 +108,11 @@ impl OrcTable {
         let file = OrcChunkReader {
             operator,
             size: file_info.size,
-            path: file_info.path,
+            path: file_info.path.clone(),
         };
         let builder = ArrowReaderBuilder::try_new_async(file)
             .await
-            .map_err(|e| ErrorCode::StorageOther(e.to_string()))?;
+            .map_err(|e| map_orc_error(e, &file_info.path))?;
         let arrow_schema = builder.build_async().schema();
         Ok(arrow_schema)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

enable user to find the invalid file.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17716)
<!-- Reviewable:end -->
