### PR TITLE
fix: flaky hybrid cache test

### DIFF
--- a/src/query/storages/common/cache/src/providers/hybrid_cache.rs
+++ b/src/query/storages/common/cache/src/providers/hybrid_cache.rs
@@ -478,7 +478,7 @@ mod tests {
             value: "does not matter".to_string(),
         });
 
-        // Since the on-disk cache is populated asynchronously, but items queued in the populate-queue
+        // Although the on-disk cache is populated asynchronously, items queued in the populate-queue
         // are processed one by one. To ensure that key "test_key" has been processed, we could wait
         // until the populate-queue is empty. At that time, at least the first key `test_key`
         // should have been written into the on-disk cache.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix the following flaky test:

~~~
running 1 test
test providers::hybrid_cache::tests::test_hybrid_cache_evict ... FAILED

failures:

failures:
    providers::hybrid_cache::tests::test_hybrid_cache_evict

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.01s
~~~

In test case `test_hybrid_cache_evict`, we should also wait until the disk cache item being tested stabilized.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17735)
<!-- Reviewable:end -->
