### PR TITLE
chore: increase the concurrency of fuse_time_travel_size

### DIFF
--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -113,6 +113,7 @@ impl SimpleArgFunc for FuseTimeTravelSize {
         let mut latest_snapshot_sizes = Vec::new();
         let mut data_retention_period_in_hours = Vec::new();
         let mut errors = Vec::new();
+        let mut tasks = Vec::new();
         let catalog = ctx.get_default_catalog()?;
         let dbs = match &args.database_name {
             Some(db_name) => {
@@ -160,7 +161,13 @@ impl SimpleArgFunc for FuseTimeTravelSize {
                 if FuseTable::is_table_attached(&tbl.get_table_info().meta.options) {
                     continue;
                 }
-                let (time_travel_size, latest_snapshot_size) = calc_tbl_size(fuse_table).await?;
+                let table_clone = tbl.clone();
+                tasks.push(async move {
+                    let fuse_table = FuseTable::try_from_table(table_clone.as_ref()).unwrap();
+                    let (time_travel_size, latest_snapshot_size) =
+                        calc_tbl_size(fuse_table).await?;
+                    Ok::<_, ErrorCode>((time_travel_size, latest_snapshot_size))
+                });
                 let data_retention_period_in_hour = fuse_table
                     .table_info
                     .meta
@@ -172,17 +179,23 @@ impl SimpleArgFunc for FuseTimeTravelSize {
                 database_names.push(db.name().to_string());
                 table_names.push(tbl.name().to_string());
                 is_droppeds.push(is_dropped);
-                sizes.push(time_travel_size);
                 data_retention_period_in_hours.push(data_retention_period_in_hour);
-                match latest_snapshot_size {
-                    Ok(size) => {
-                        latest_snapshot_sizes.push(Some(size));
-                        errors.push(None);
-                    }
-                    Err(e) => {
-                        latest_snapshot_sizes.push(None);
-                        errors.push(Some(e.to_string()));
-                    }
+            }
+        }
+
+        // if use execute_futures_in_parallel(), will get error: `implementation of `std::ops::FnOnce` is not general enough`
+        let results = futures::future::try_join_all(tasks).await?;
+        for result in results {
+            let (time_travel_size, latest_snapshot_size) = result;
+            sizes.push(time_travel_size);
+            match latest_snapshot_size {
+                Ok(size) => {
+                    latest_snapshot_sizes.push(Some(size));
+                    errors.push(None);
+                }
+                Err(e) => {
+                    latest_snapshot_sizes.push(None);
+                    errors.push(Some(e.to_string()));
                 }
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Tested in an environment where the storage backend is S3:
```SQL
select * from fuse_time_travel_size('tpcds_sf100');
```
1.940s -> 0.343s

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17745)
<!-- Reviewable:end -->
