### PR TITLE
chore: Bump rust toolchain

### DIFF
--- a/scripts/setup/rust-toolchain.toml
+++ b/scripts/setup/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-11-28"
+channel = "nightly-2025-04-04"
 components = ["rustfmt", "clippy", "rust-src", "miri", "rust-analyzer"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Databend's toolchain is too old to build some new deps.

```shell
error[E0658]: use of unstable library feature `ptr_fn_addr_eq`
  --> /home/xuanwo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.24.1/src/internal_tricks.rs:53:9
   |
53 |         std::ptr::fn_addr_eq(f, g)
   |         ^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #129322 <https://github.com/rust-lang/rust/issues/129322> for more information
   = help: add `#![feature(ptr_fn_addr_eq)]` to the crate attributes to enable
   = note: this compiler was built on 2024-11-27; consider upgrading it if it is out of date
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17751)
<!-- Reviewable:end -->
