### PR TITLE
refactor(meta-client): Improve `MetaHandshakeError`

### DIFF
--- a/src/common/exception/src/exception_backtrace.rs
+++ b/src/common/exception/src/exception_backtrace.rs
@@ -112,7 +112,7 @@ impl PartialEq for StackFrame {
         {
             let StackFrame::Backtrace(addr) = &self;
             let StackFrame::Backtrace(other_addr) = &other;
-            addr.ip() == other_addr.ip()
+            std::ptr::eq(addr.ip(), other_addr.ip())
         }
     }
 }

--- a/src/common/grpc/src/dns_resolver.rs
+++ b/src/common/grpc/src/dns_resolver.rs
@@ -33,8 +33,6 @@ use hyper::Uri;
 use hyper_util::client::legacy::connect::dns::Name;
 use hyper_util::client::legacy::connect::HttpConnector;
 use log::info;
-use serde::Deserialize;
-use serde::Serialize;
 use tonic::transport::Certificate;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
@@ -223,7 +221,7 @@ impl ConnectionFactory {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum GrpcConnectionError {
     #[error("invalid uri: {uri}, error: {source}")]
     InvalidUri {

--- a/src/common/grpc/src/grpc_token.rs
+++ b/src/common/grpc/src/grpc_token.rs
@@ -17,7 +17,7 @@ use databend_common_exception::Result;
 use databend_common_exception::ToErrorCode;
 use jwt_simple::prelude::*;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct GrpcClaim {
     pub username: String,
 }

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -129,7 +129,7 @@ pub enum Response {
     StreamList(Result<BoxStream<StreamItem>, MetaError>),
     Upsert(Result<UpsertKVReply, MetaError>),
     Txn(Result<TxnReply, MetaError>),
-    Watch(Result<tonic::codec::Streaming<WatchResponse>, MetaError>),
+    Watch(Result<tonic::codec::Streaming<WatchResponse>, MetaClientError>),
     Export(Result<tonic::codec::Streaming<ExportedChunk>, MetaError>),
     MakeEstablishedClient(Result<EstablishedClient, MetaClientError>),
     GetEndpoints(Result<Vec<String>, MetaError>),

--- a/src/meta/client/tests/it/grpc_client.rs
+++ b/src/meta/client/tests/it/grpc_client.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use databend_common_base::base::tokio;
-use databend_common_exception::ErrorCode;
 use databend_common_grpc::ConnectionFactory;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaChannelManager;
@@ -25,7 +24,6 @@ use databend_common_meta_client::Streamed;
 use databend_common_meta_client::MIN_METASRV_SEMVER;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_types::protobuf::StreamItem;
-use databend_common_meta_types::MetaClientError;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::UpsertKV;
 use futures::StreamExt;
@@ -85,10 +83,10 @@ async fn test_grpc_client_handshake_timeout() {
         .await;
 
         let got = res.unwrap_err();
-        let got =
-            ErrorCode::from(MetaError::ClientError(MetaClientError::HandshakeError(got))).message();
-        let expect = "failed to handshake with meta-service: when sending handshake rpc, cause: tonic::status::Status: status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }; source: transport error; source: Timeout expired";
-        assert_eq!(got, expect);
+        let expect =
+            "HandshakeError with databend-meta: Connection Failure; cause: tonic::status::Status: status: Cancelled, message: \"Timeout expired\", details: [], metadata: MetadataMap { headers: {} }; source: transport error; source: Timeout expired";
+
+        assert_eq!(got.to_string(), expect);
     }
 
     // handshake success

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_handshake.rs
@@ -95,14 +95,14 @@ async fn test_metasrv_handshake() -> anyhow::Result<()> {
         let e = res.unwrap_err();
 
         let want = format!(
-            "metasrv protocol_version({}) < meta-client min-compatible({})",
+            "Invalid: server protocol_version({}) < client min-compatible({})",
             // strip `nightly` from 0.7.57-nightly
             from_digit_ver(to_digit_ver(METACLI_COMMIT_SEMVER.deref(),)),
             min_srv_ver,
         );
         assert!(
             e.to_string().contains(&want),
-            "handshake err: {:?} contains: {}",
+            "handshake err: {} contains: {}",
             e,
             want
         );

--- a/src/meta/types/src/errors/meta_client_errors.rs
+++ b/src/meta/types/src/errors/meta_client_errors.rs
@@ -15,6 +15,7 @@
 use std::io;
 
 use anyerror::AnyError;
+use tonic::Status;
 
 use crate::MetaHandshakeError;
 use crate::MetaNetworkError;
@@ -43,6 +44,12 @@ impl MetaClientError {
             MetaClientError::NetworkError(err) => err.name(),
             MetaClientError::HandshakeError(_) => "MetaHandshakeError",
         }
+    }
+}
+
+impl From<Status> for MetaClientError {
+    fn from(status: Status) -> Self {
+        Self::NetworkError(status.into())
     }
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-client): Improve `MetaHandshakeError`

`MetaHandshakeError` does not have to contain a source error if its not
caused by other error.

Now `watch()` returns `MetaHandshakeError` if the protocol does support
a watch request.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17755)
<!-- Reviewable:end -->
