### PR TITLE
feat: function extract, date_part,date_diff support more date part

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -14,6 +14,7 @@
 "flate" = "flate"
 "Tke" = "Tke"
 "typ" = "typ"
+"dows" = "dows"
 
 [files]
 extend-exclude = [

--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -845,6 +845,9 @@ pub enum IntervalKind {
     Dow,
     Epoch,
     MicroSecond,
+    ISODow,
+    YearWeek,
+    Millennium,
 }
 
 impl Display for IntervalKind {
@@ -860,6 +863,9 @@ impl Display for IntervalKind {
             IntervalKind::Second => "SECOND",
             IntervalKind::Doy => "DOY",
             IntervalKind::Dow => "DOW",
+            IntervalKind::ISODow => "ISODOW",
+            IntervalKind::YearWeek => "YEARWEEK",
+            IntervalKind::Millennium => "MILLENNIUM",
             IntervalKind::Week => "WEEK",
             IntervalKind::Epoch => "EPOCH",
             IntervalKind::MicroSecond => "MICROSECOND",

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1853,9 +1853,12 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
     let second = value(IntervalKind::Second, rule! { SECOND });
     let doy = value(IntervalKind::Doy, rule! { DOY });
     let dow = value(IntervalKind::Dow, rule! { DOW });
+    let isodow = value(IntervalKind::ISODow, rule! { ISODOW });
     let week = value(IntervalKind::Week, rule! { WEEK });
     let epoch = value(IntervalKind::Epoch, rule! { EPOCH });
     let microsecond = value(IntervalKind::MicroSecond, rule! { MICROSECOND });
+    let millennium = value(IntervalKind::Millennium, rule! { MILLENNIUM });
+    let yearweek = value(IntervalKind::YearWeek, rule! { YEARWEEK });
 
     let iso_year_str = value(
         IntervalKind::ISOYear,
@@ -1891,15 +1894,19 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
     );
     let doy_str = value(
         IntervalKind::Doy,
-        rule! { #literal_string_eq_ignore_case("DOY")  },
+        rule! { #literal_string_eq_ignore_case("DOY") | #literal_string_eq_ignore_case("DAYOFYEAR")  },
     );
     let dow_str = value(
         IntervalKind::Dow,
-        rule! { #literal_string_eq_ignore_case("DOW")  },
+        rule! { (#literal_string_eq_ignore_case("DOW") | #literal_string_eq_ignore_case("WEEKDAY") | #literal_string_eq_ignore_case("DAYOFWEEK") )  },
+    );
+    let isodow_str = value(
+        IntervalKind::ISODow,
+        rule! { #literal_string_eq_ignore_case("ISODOW")  },
     );
     let week_str = value(
         IntervalKind::Week,
-        rule! { #literal_string_eq_ignore_case("WEEK")  },
+        rule! { (#literal_string_eq_ignore_case("WEEK") | #literal_string_eq_ignore_case("WEEKS") | #literal_string_eq_ignore_case("W"))  },
     );
     let epoch_str = value(
         IntervalKind::Epoch,
@@ -1908,6 +1915,14 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
     let microsecond_str = value(
         IntervalKind::MicroSecond,
         rule! { #literal_string_eq_ignore_case("MICROSECOND")  },
+    );
+    let yearweek_str = value(
+        IntervalKind::YearWeek,
+        rule! { #literal_string_eq_ignore_case("YEARWEEK")  },
+    );
+    let millennium_str = value(
+        IntervalKind::Millennium,
+        rule! { #literal_string_eq_ignore_case("MILLENNIUM")  },
     );
     alt((
         rule!(
@@ -1924,6 +1939,9 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
             | #week
             | #epoch
             | #microsecond
+            | #isodow
+            | #millennium
+            | #yearweek
         ),
         rule!(
             #year_str
@@ -1939,6 +1957,9 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
             | #week_str
             | #epoch_str
             | #microsecond_str
+            | #isodow_str
+            | #yearweek_str
+            | #millennium_str
         ),
     ))(i)
 }

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -591,6 +591,8 @@ pub enum TokenKind {
     ENGINES,
     #[token("EPOCH", ignore(ascii_case))]
     EPOCH,
+    #[token("YEARWEEK", ignore(ascii_case))]
+    YEARWEEK,
     #[token("MICROSECOND", ignore(ascii_case))]
     MICROSECOND,
     #[token("ERROR_ON_COLUMN_COUNT_MISMATCH", ignore(ascii_case))]

--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -1261,6 +1261,115 @@ fn register_diff_functions(registry: &mut FunctionRegistry) {
         ),
     );
 
+    registry.register_passthrough_nullable_2_arg::<DateType, DateType, Int64Type, _, _>(
+        "diff_microseconds",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<DateType, DateType, Int64Type>(
+            |date_end, date_start, builder, _| {
+                let diff_microseconds =
+                    EvalDaysImpl::eval_date_diff(date_start, date_end) as i64 * MICROSECS_PER_DAY;
+                builder.push(diff_microseconds);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<TimestampType, TimestampType, Int64Type, _, _>(
+        "diff_microseconds",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<TimestampType, TimestampType, Int64Type>(
+            |date_end, date_start, builder, _| {
+                builder.push(date_end - date_start);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<DateType, DateType, Int64Type, _, _>(
+        "diff_yearweeks",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<DateType, DateType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff = EvalYearWeeksImpl::eval_date_diff(
+                    date_start,
+                    date_end,
+                    ctx.func_ctx.tz.clone(),
+                );
+                builder.push(diff as i64);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<TimestampType, TimestampType, Int64Type, _, _>(
+        "diff_yearweeks",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<TimestampType, TimestampType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff = EvalYearWeeksImpl::eval_timestamp_diff(
+                    date_start,
+                    date_end,
+                    ctx.func_ctx.tz.clone(),
+                );
+                builder.push(diff);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<DateType, DateType, Int64Type, _, _>(
+        "diff_isoyears",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<DateType, DateType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff =
+                    EvalISOYearsImpl::eval_date_diff(date_start, date_end, ctx.func_ctx.tz.clone());
+                builder.push(diff as i64);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<TimestampType, TimestampType, Int64Type, _, _>(
+        "diff_isoyears",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<TimestampType, TimestampType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff = EvalISOYearsImpl::eval_timestamp_diff(
+                    date_start,
+                    date_end,
+                    ctx.func_ctx.tz.clone(),
+                );
+                builder.push(diff);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<DateType, DateType, Int64Type, _, _>(
+        "diff_millenniums",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<DateType, DateType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff_years =
+                    EvalYearsImpl::eval_date_diff(date_start, date_end, ctx.func_ctx.tz.clone());
+                builder.push((diff_years / 1000) as i64);
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<TimestampType, TimestampType, Int64Type, _, _>(
+        "diff_millenniums",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<TimestampType, TimestampType, Int64Type>(
+            |date_end, date_start, builder, ctx| {
+                let diff_years = EvalYearsImpl::eval_timestamp_diff(
+                    date_start,
+                    date_end,
+                    ctx.func_ctx.tz.clone(),
+                );
+
+                builder.push(diff_years / 1000);
+            },
+        ),
+    );
+    registry.register_aliases("diff_seconds", &["diff_epochs"]);
+    registry.register_aliases("diff_days", &["diff_dows", "diff_isodows", "diff_doys"]);
+
     registry.register_2_arg::<DateType, DateType, Int32Type, _, _>(
         "minus",
         |_, lhs, rhs| {
@@ -1531,6 +1640,45 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
             }
         }),
     );
+    registry.register_passthrough_nullable_1_arg::<DateType, UInt8Type, _, _>(
+        "dayofweek",
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_1_arg::<DateType, UInt8Type>(|val, output, ctx| {
+            match ToNumberImpl::eval_date::<DayOfWeek, _>(val, ctx.func_ctx.tz.clone()) {
+                Ok(t) => output.push(t),
+                Err(e) => {
+                    ctx.set_error(output.len(), format!("cannot parse to type `Date`. {}", e));
+                    output.push(0);
+                }
+            }
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<DateType, UInt32Type, _, _>(
+        "yearweek",
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_1_arg::<DateType, UInt32Type>(|val, output, ctx| {
+            match ToNumberImpl::eval_date::<ToYYYYWW, _>(val, ctx.func_ctx.tz.clone()) {
+                Ok(t) => output.push(t),
+                Err(e) => {
+                    ctx.set_error(output.len(), format!("cannot parse to type `Date`. {}", e));
+                    output.push(0);
+                }
+            }
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<DateType, UInt16Type, _, _>(
+        "millennium",
+        |_, _| FunctionDomain::Full,
+        vectorize_with_builder_1_arg::<DateType, UInt16Type>(|val, output, ctx| {
+            match ToNumberImpl::eval_date::<ToMillennium, _>(val, ctx.func_ctx.tz.clone()) {
+                Ok(t) => output.push(t),
+                Err(e) => {
+                    ctx.set_error(output.len(), format!("cannot parse to type `Date`. {}", e));
+                    output.push(0);
+                }
+            }
+        }),
+    );
     registry.register_passthrough_nullable_1_arg::<DateType, UInt32Type, _, _>(
         "to_week_of_year",
         |_, _| FunctionDomain::Full,
@@ -1620,6 +1768,27 @@ fn register_to_number_functions(registry: &mut FunctionRegistry) {
         |_, _| FunctionDomain::Full,
         vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
             ToNumberImpl::eval_timestamp::<ToDayOfWeek, _>(val, ctx.func_ctx.tz.clone())
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<TimestampType, UInt8Type, _, _>(
+        "dayofweek",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<TimestampType, UInt8Type>(|val, ctx| {
+            ToNumberImpl::eval_timestamp::<DayOfWeek, _>(val, ctx.func_ctx.tz.clone())
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(
+        "yearweek",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<TimestampType, UInt32Type>(|val, ctx| {
+            ToNumberImpl::eval_timestamp::<ToYYYYWW, _>(val, ctx.func_ctx.tz.clone())
+        }),
+    );
+    registry.register_passthrough_nullable_1_arg::<TimestampType, UInt16Type, _, _>(
+        "millennium",
+        |_, _| FunctionDomain::Full,
+        vectorize_1_arg::<TimestampType, UInt16Type>(|val, ctx| {
+            ToNumberImpl::eval_timestamp::<ToMillennium, _>(val, ctx.func_ctx.tz.clone())
         }),
     );
     registry.register_passthrough_nullable_1_arg::<TimestampType, UInt32Type, _, _>(

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -16,6 +16,10 @@ date_format -> to_string
 day -> to_day_of_month
 dayofmonth -> to_day_of_month
 dayofyear -> to_day_of_year
+diff_dows -> diff_days
+diff_doys -> diff_days
+diff_epochs -> diff_seconds
+diff_isodows -> diff_days
 hex -> to_hex
 intdiv -> div
 ipv4_num_to_string -> inet_ntoa
@@ -1239,6 +1243,10 @@ Functions overloads:
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
 1 crc32(String NULL) :: UInt32 NULL
+0 dayofweek(Date) :: UInt8
+1 dayofweek(Date NULL) :: UInt8 NULL
+2 dayofweek(Timestamp) :: UInt8
+3 dayofweek(Timestamp NULL) :: UInt8 NULL
 0 degrees(Float64) :: Float64
 1 degrees(Float64 NULL) :: Float64 NULL
 0 delete_by_keypath FACTORY
@@ -1248,6 +1256,18 @@ Functions overloads:
 3 diff_days(Timestamp NULL, Timestamp NULL) :: Int64 NULL
 0 diff_hours(Timestamp, Timestamp) :: Int64
 1 diff_hours(Timestamp NULL, Timestamp NULL) :: Int64 NULL
+0 diff_isoyears(Date, Date) :: Int64
+1 diff_isoyears(Date NULL, Date NULL) :: Int64 NULL
+2 diff_isoyears(Timestamp, Timestamp) :: Int64
+3 diff_isoyears(Timestamp NULL, Timestamp NULL) :: Int64 NULL
+0 diff_microseconds(Date, Date) :: Int64
+1 diff_microseconds(Date NULL, Date NULL) :: Int64 NULL
+2 diff_microseconds(Timestamp, Timestamp) :: Int64
+3 diff_microseconds(Timestamp NULL, Timestamp NULL) :: Int64 NULL
+0 diff_millenniums(Date, Date) :: Int64
+1 diff_millenniums(Date NULL, Date NULL) :: Int64 NULL
+2 diff_millenniums(Timestamp, Timestamp) :: Int64
+3 diff_millenniums(Timestamp NULL, Timestamp NULL) :: Int64 NULL
 0 diff_minutes(Timestamp, Timestamp) :: Int64
 1 diff_minutes(Timestamp NULL, Timestamp NULL) :: Int64 NULL
 0 diff_months(Date, Date) :: Int64
@@ -1268,6 +1288,10 @@ Functions overloads:
 1 diff_years(Date NULL, Date NULL) :: Int64 NULL
 2 diff_years(Timestamp, Timestamp) :: Int64
 3 diff_years(Timestamp NULL, Timestamp NULL) :: Int64 NULL
+0 diff_yearweeks(Date, Date) :: Int64
+1 diff_yearweeks(Date NULL, Date NULL) :: Int64 NULL
+2 diff_yearweeks(Timestamp, Timestamp) :: Int64
+3 diff_yearweeks(Timestamp NULL, Timestamp NULL) :: Int64 NULL
 0 div(UInt8, UInt8) :: UInt8
 1 div(UInt8 NULL, UInt8 NULL) :: UInt8 NULL
 2 div(UInt8, UInt16) :: UInt16
@@ -2279,6 +2303,10 @@ Functions overloads:
 1 markov_generate(Array(T0) NULL, String NULL, UInt64 NULL, String NULL) :: String NULL
 0 md5(String) :: String
 1 md5(String NULL) :: String NULL
+0 millennium(Date) :: UInt16
+1 millennium(Date NULL) :: UInt16 NULL
+2 millennium(Timestamp) :: UInt16
+3 millennium(Timestamp NULL) :: UInt16 NULL
 0 minus(Variant, Int32) :: Variant
 1 minus(Variant NULL, Int32 NULL) :: Variant NULL
 2 minus(Variant, String) :: Variant
@@ -4627,4 +4655,8 @@ Functions overloads:
 33 xxhash64(Float32 NULL) :: UInt64 NULL
 34 xxhash64(Float64) :: UInt64
 35 xxhash64(Float64 NULL) :: UInt64 NULL
+0 yearweek(Date) :: UInt32
+1 yearweek(Date NULL) :: UInt32 NULL
+2 yearweek(Timestamp) :: UInt32
+3 yearweek(Timestamp NULL) :: UInt32 NULL
 0 yesterday() :: Date

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3116,11 +3116,20 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Minute => self.resolve_function(span, "to_minute", vec![], &[arg]),
             ASTIntervalKind::Second => self.resolve_function(span, "to_second", vec![], &[arg]),
             ASTIntervalKind::Doy => self.resolve_function(span, "to_day_of_year", vec![], &[arg]),
-            ASTIntervalKind::Dow => self.resolve_function(span, "to_day_of_week", vec![], &[arg]),
+            // Day of the week (Sunday = 0, Saturday = 6)
+            ASTIntervalKind::Dow => self.resolve_function(span, "dayofweek", vec![], &[arg]),
             ASTIntervalKind::Week => self.resolve_function(span, "to_week_of_year", vec![], &[arg]),
             ASTIntervalKind::Epoch => self.resolve_function(span, "epoch", vec![], &[arg]),
             ASTIntervalKind::MicroSecond => {
                 self.resolve_function(span, "to_microsecond", vec![], &[arg])
+            }
+            // ISO day of the week (Monday = 1, Sunday = 7)
+            ASTIntervalKind::ISODow => {
+                self.resolve_function(span, "to_day_of_week", vec![], &[arg])
+            }
+            ASTIntervalKind::YearWeek => self.resolve_function(span, "yearweek", vec![], &[arg]),
+            ASTIntervalKind::Millennium => {
+                self.resolve_function(span, "millennium", vec![], &[arg])
             }
         }
     }

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1568,3 +1568,65 @@ SELECT add_hours(to_timestamp(710455), 2147483647);
 
 statement error 1006
 SELECT CAST('2001-04-20 14:42:11.123000000000000000002001-04-20 14:42:11.12300000000000000000' AS TIMESTAMP);
+
+query T
+SELECT extract(isodow from '2025-04-13'::Date);
+----
+7
+
+query T
+SELECT extract(dow from '2025-04-13'::Date);
+----
+0
+
+query T
+select extract(yearweek from '1992-02-15'::Date);
+----
+199207
+
+query T
+select yearweek('1992-02-15'::Date);
+----
+199207
+
+query T
+select extract(yearweek from '1992-02-15'::Date);
+----
+199207
+
+query T
+select extract(millennium from '1992-02-15'::Date);
+----
+2
+
+query T
+select millennium('1992-02-15'::Date);
+----
+2
+
+
+query T
+select date_diff(isoyear, '2022-02-01'::Date, '2023-01-01'::Date); --0
+----
+0
+
+query T
+select date_diff(MILLENNIUM, '2022-02-01'::Date, '2023-01-01'::Date); --0
+----
+0
+
+query T
+select date_diff('yearweek', '2022-02-01'::Date, '2023-01-01'::Date); --47
+----
+47
+
+query T
+select date_diff('dow', '2022-02-01'::Date, '2023-01-01'::Date), date_diff('doy', '2022-02-01'::Date, '2023-01-01'::Date), date_diff('day', '2022-02-01'::Date, '2023-01-01'::Date); --334
+----
+334 334 334
+
+query T
+select date_diff('microsecond', '2022-02-01'::Date, '2023-01-01'::Date) -- 28857600000000
+----
+28857600000000
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add new interval kind:
```
ISODOW, YEARWEEK, MILLENNIUM
```

Extract, date_part and date_diff support more DATE PART.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17759)
<!-- Reviewable:end -->
