### PR TITLE
refactor: add helper methods to trait `LicenseManager`

### DIFF
--- a/src/common/license/src/license.rs
+++ b/src/common/license/src/license.rs
@@ -175,7 +175,7 @@ impl Feature {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct LicenseInfo {
     #[serde(rename = "type")]
     pub r#type: Option<String>,

--- a/src/common/license/src/license_manager.rs
+++ b/src/common/license/src/license_manager.rs
@@ -55,7 +55,7 @@ pub trait LicenseManager: Sync + Send {
     fn parse_license(&self, raw: &str) -> Result<JWTClaims<LicenseInfo>>;
 
     fn is_license_valid(&self, license_key: String) -> bool {
-        self.parse_license(&license_key).is_ok()
+        self.check_license(license_key).is_ok()
     }
 
     fn check_license(&self, license_key: String) -> Result<()> {
@@ -127,13 +127,50 @@ mod tests {
 
     use super::*;
 
-    // Constants for testing
-    const VALID_LICENSE_KEY: &str = "valid-license-key";
-    const INVALID_LICENSE_KEY: &str = "invalid-license-key";
-
     // A mock LicenseManager implementation for testing
     struct MockLicenseManager {
-        valid_license: bool,
+        license_claim: std::result::Result<JWTClaims<LicenseInfo>, ErrorCode>,
+    }
+
+    struct MockLicenseManagerBuilder;
+    impl MockLicenseManagerBuilder {
+        fn invalid() -> MockLicenseManager {
+            MockLicenseManager {
+                license_claim: Err(ErrorCode::LicenceDenied("")),
+            }
+        }
+
+        fn valid_but_expired() -> MockLicenseManager {
+            MockLicenseManager {
+                license_claim: Err(ErrorCode::LicenseKeyExpired("")),
+            }
+        }
+
+        fn valid_and_active() -> MockLicenseManager {
+            let claim = new_license_claim();
+            MockLicenseManager {
+                license_claim: Ok(claim),
+            }
+        }
+    }
+
+    fn new_license_claim() -> JWTClaims<LicenseInfo> {
+        JWTClaims {
+            issued_at: None,
+            expires_at: None,
+            invalid_before: None,
+            issuer: None,
+            subject: None,
+            audiences: None,
+            jwt_id: None,
+            nonce: None,
+            custom: LicenseInfo {
+                r#type: None,
+                org: None,
+                tenants: None,
+                features: None,
+            },
+        }
     }
 
     impl LicenseManager for MockLicenseManager {
@@ -149,29 +186,8 @@ mod tests {
             unimplemented!()
         }
 
-        fn parse_license(&self, raw: &str) -> Result<JWTClaims<LicenseInfo>> {
-            if self.valid_license && raw == VALID_LICENSE_KEY {
-                // We do not care about the claims
-                Ok(JWTClaims {
-                    issued_at: None,
-                    expires_at: None,
-                    invalid_before: None,
-                    issuer: None,
-                    subject: None,
-                    audiences: None,
-                    jwt_id: None,
-                    nonce: None,
-                    custom: LicenseInfo {
-                        r#type: None,
-                        org: None,
-                        tenants: None,
-                        features: None,
-                    },
-                })
-            } else {
-                // Simulate an invalid license
-                Err(ErrorCode::LicenceDenied("Invalid cert".to_string()))
-            }
+        fn parse_license(&self, _raw: &str) -> Result<JWTClaims<LicenseInfo>> {
+            self.license_claim.clone()
         }
 
         fn get_storage_quota(&self, _license_key: String) -> Result<StorageQuota> {
@@ -181,52 +197,30 @@ mod tests {
 
     #[test]
     fn test_is_license_valid() {
-        // Create a MockLicenseManager that accepts the VALID_LICENSE_KEY
-        let valid_manager = MockLicenseManager {
-            valid_license: true,
-        };
+        let valid_and_active = MockLicenseManagerBuilder::valid_and_active();
+        assert!(valid_and_active.is_license_valid("".to_string()));
 
-        // Test with a valid license key
-        assert!(valid_manager.is_license_valid(VALID_LICENSE_KEY.to_string()));
+        let invalid = MockLicenseManagerBuilder::invalid();
+        assert!(!invalid.is_license_valid("".to_string()));
 
-        // Test with an invalid license key
-        assert!(!valid_manager.is_license_valid(INVALID_LICENSE_KEY.to_string()));
-
-        // Create a MockLicenseManager that denies all the keys
-        let invalid_manager = MockLicenseManager {
-            valid_license: false,
-        };
-
-        // All license keys should be considered invalid
-        assert!(!invalid_manager.is_license_valid(VALID_LICENSE_KEY.to_string()));
-        assert!(!invalid_manager.is_license_valid(INVALID_LICENSE_KEY.to_string()));
+        let used_to_be_valid_but_expired_now = MockLicenseManagerBuilder::valid_but_expired();
+        assert!(!used_to_be_valid_but_expired_now.is_license_valid("".to_string()));
     }
 
     #[test]
     fn test_check_license() {
-        // Create a MockLicenseManager that accepts the VALID_LICENSE_KEY
-        let valid_manager = MockLicenseManager {
-            valid_license: true,
-        };
-
-        // Test with a valid license key
-        let result = valid_manager.check_license(VALID_LICENSE_KEY.to_string());
+        let valid_and_active = MockLicenseManagerBuilder::valid_and_active();
+        let result = valid_and_active.check_license("".to_string());
         assert!(result.is_ok());
 
-        // Test with an invalid license key
-        let result = valid_manager.check_license(INVALID_LICENSE_KEY.to_string());
+        let used_to_be_valid_but_expired_now = MockLicenseManagerBuilder::valid_but_expired();
+        let result = used_to_be_valid_but_expired_now.check_license("".to_string());
         assert!(result.is_err());
-
         let e = result.unwrap_err();
-        assert_eq!(ErrorCode::LICENCE_DENIED, e.code());
+        assert_eq!(ErrorCode::LICENSE_KEY_EXPIRED, e.code());
 
-        // Create a MockLicenseManager that denies all the keys
-        let invalid_manager = MockLicenseManager {
-            valid_license: false,
-        };
-
-        // All license keys should be considered invalid
-        let result = invalid_manager.check_license(VALID_LICENSE_KEY.to_string());
+        let invalid = MockLicenseManagerBuilder::invalid();
+        let result = invalid.check_license("".to_string());
         assert!(result.is_err());
         let e = result.unwrap_err();
         assert_eq!(ErrorCode::LICENCE_DENIED, e.code());

--- a/src/common/license/src/license_manager.rs
+++ b/src/common/license/src/license_manager.rs
@@ -130,7 +130,6 @@ mod tests {
     // Constants for testing
     const VALID_LICENSE_KEY: &str = "valid-license-key";
     const INVALID_LICENSE_KEY: &str = "invalid-license-key";
-    const INVALID_LICENSE_MSG: &str = "Invalid license key";
 
     // A mock LicenseManager implementation for testing
     struct MockLicenseManager {
@@ -152,6 +151,7 @@ mod tests {
 
         fn parse_license(&self, raw: &str) -> Result<JWTClaims<LicenseInfo>> {
             if self.valid_license && raw == VALID_LICENSE_KEY {
+                // We do not care about the claims
                 Ok(JWTClaims {
                     issued_at: None,
                     expires_at: None,
@@ -170,7 +170,7 @@ mod tests {
                 })
             } else {
                 // Simulate an invalid license
-                Err(ErrorCode::LicenceDenied(INVALID_LICENSE_MSG.to_string()))
+                Err(ErrorCode::LicenceDenied("Invalid cert".to_string()))
             }
         }
 
@@ -192,7 +192,7 @@ mod tests {
         // Test with an invalid license key
         assert!(!valid_manager.is_license_valid(INVALID_LICENSE_KEY.to_string()));
 
-        // Create a MockLicenseManager that denied all the keys
+        // Create a MockLicenseManager that denies all the keys
         let invalid_manager = MockLicenseManager {
             valid_license: false,
         };
@@ -220,12 +220,12 @@ mod tests {
         let e = result.unwrap_err();
         assert_eq!(ErrorCode::LICENCE_DENIED, e.code());
 
-        // Create a MockLicenseManager that denied all the keys
+        // Create a MockLicenseManager that denies all the keys
         let invalid_manager = MockLicenseManager {
             valid_license: false,
         };
 
-        // All license keys should return an error
+        // All license keys should be considered invalid
         let result = invalid_manager.check_license(VALID_LICENSE_KEY.to_string());
         assert!(result.is_err());
         let e = result.unwrap_err();

--- a/src/common/license/src/license_manager.rs
+++ b/src/common/license/src/license_manager.rs
@@ -124,12 +124,13 @@ mod tests {
     use std::sync::Arc;
 
     use databend_common_exception::ErrorCode;
+    use databend_common_exception::Result;
 
     use super::*;
 
     // A mock LicenseManager implementation for testing
     struct MockLicenseManager {
-        license_claim: std::result::Result<JWTClaims<LicenseInfo>, ErrorCode>,
+        license_claim: Result<JWTClaims<LicenseInfo>>,
     }
 
     struct MockLicenseManagerBuilder;

--- a/src/query/ee/src/license/license_mgr.rs
+++ b/src/query/ee/src/license/license_mgr.rs
@@ -29,6 +29,7 @@ use jwt_simple::claims::JWTClaims;
 use jwt_simple::prelude::Clock;
 use jwt_simple::prelude::ECDSAP256PublicKeyLike;
 use jwt_simple::JWTError;
+use log::info;
 
 const LICENSE_PUBLIC_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGsKCbhXU7j56VKZ7piDlLXGhud0a
@@ -109,6 +110,7 @@ impl LicenseManager for RealLicenseManager {
                 Ok(v) => Ok(v),
                 Err(cause) => match cause.downcast_ref::<JWTError>() {
                     Some(JWTError::TokenHasExpired) => {
+                        info!("License expired");
                         Err(ErrorCode::LicenseKeyExpired("license key is expired."))
                     }
                     Some(JWTError::InvalidSignature) => {

--- a/src/query/ee/src/license/license_mgr.rs
+++ b/src/query/ee/src/license/license_mgr.rs
@@ -133,6 +133,7 @@ impl LicenseManager for RealLicenseManager {
             // Previously cached valid license might be expired
             let claim = v.value();
             if Self::verify_license_expired(claim)? {
+                warn!("Cached License expired");
                 Err(ErrorCode::LicenseKeyExpired("license key is expired."))
             } else {
                 Ok((*claim).clone())

--- a/src/query/ee/src/license/license_mgr.rs
+++ b/src/query/ee/src/license/license_mgr.rs
@@ -29,7 +29,7 @@ use jwt_simple::claims::JWTClaims;
 use jwt_simple::prelude::Clock;
 use jwt_simple::prelude::ECDSAP256PublicKeyLike;
 use jwt_simple::JWTError;
-use log::info;
+use log::warn;
 
 const LICENSE_PUBLIC_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGsKCbhXU7j56VKZ7piDlLXGhud0a
@@ -110,7 +110,7 @@ impl LicenseManager for RealLicenseManager {
                 Ok(v) => Ok(v),
                 Err(cause) => match cause.downcast_ref::<JWTError>() {
                     Some(JWTError::TokenHasExpired) => {
-                        info!("License expired");
+                        warn!("License expired");
                         Err(ErrorCode::LicenseKeyExpired("license key is expired."))
                     }
                     Some(JWTError::InvalidSignature) => {

--- a/src/query/ee/src/license/license_mgr.rs
+++ b/src/query/ee/src/license/license_mgr.rs
@@ -416,14 +416,5 @@ mod tests {
 
         // Verify failed validation doesn't add to cache
         assert!(!manager.is_in_cache(&token));
-
-        if let Err(e) = result {
-            assert!(matches!(
-                e.code(),
-                ErrorCode::LICENSE_KEY_PARSE_ERROR | ErrorCode::LICENCE_DENIED
-            ));
-        } else {
-            panic!("Expected error but got Ok result");
-        }
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add helper methods to trait `LicenseManager`

- `is_license_valid`
   Returns `true` if `self.parse_license` return OK(_), otherwise `false`
- `check_license`
  Returns `Err(e)` if `self.parse_license` return Err(e), otherwise `Ok(())`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17761)
<!-- Reviewable:end -->
