### PR TITLE
fix: correct state type for Decimal256 AVG aggregation 

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_avg.rs
+++ b/src/query/functions/src/aggregates/aggregate_avg.rs
@@ -27,7 +27,6 @@ use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::Scalar;
 use num_traits::AsPrimitive;
 
-use super::aggregate_sum::DecimalSumState;
 use super::AggregateUnaryFunction;
 use super::FunctionData;
 use super::UnaryState;
@@ -283,7 +282,7 @@ pub fn try_create_aggregate_avg_function(
                 Ok(Arc::new(func))
             } else {
                 let func = AggregateUnaryFunction::<
-                    DecimalSumState<false, Decimal256Type>,
+                    DecimalAvgState<false, Decimal256Type>,
                     Decimal256Type,
                     Decimal256Type,
                 >::try_create(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixed a typo in the AVG aggregation function where DecimalSumState was incorrectly used instead of DecimalAvgState.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17774)
<!-- Reviewable:end -->
