### PR TITLE
chore(ci): add ci test_stateless_cluster_linux timeout minute to 18

### DIFF
--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -170,7 +170,7 @@ jobs:
           runner_provider: ${{ inputs.runner_provider }}
           type: ${{ inputs.license_type }}
       - uses: ./.github/actions/test_stateless_cluster_linux
-        timeout-minutes: 15
+        timeout-minutes: 18
 
   test_stateful_standalone:
     runs-on: [self-hosted, X64, Linux, 2c8g, "${{ inputs.runner_provider }}"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


https://github.com/databendlabs/databend/actions/runs/14541941648/job/40805342069?pr=17812

Rerun 3 times, but report action timeout
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17813)
<!-- Reviewable:end -->
