### PR TITLE
fix(metrics): remove high cardinality labels in metrics

### DIFF
--- a/src/common/metrics/src/metrics/lock.rs
+++ b/src/common/metrics/src/metrics/lock.rs
@@ -38,19 +38,13 @@ static SHUTDOWN_LOCK_HOLDER_NUMS: LazyLock<Counter> =
 const LABEL_TYPE: &str = "type";
 const LABEL_TABLE_ID: &str = "table_id";
 
-pub fn record_created_lock_nums(lock_type: String, table_id: u64, num: u64) {
-    let labels = &vec![
-        (LABEL_TYPE, lock_type),
-        (LABEL_TABLE_ID, table_id.to_string()),
-    ];
+pub fn record_created_lock_nums(lock_type: String, num: u64) {
+    let labels = &vec![(LABEL_TYPE, lock_type)];
     CREATED_LOCK_NUMS.get_or_create(labels).inc_by(num);
 }
 
-pub fn record_acquired_lock_nums(lock_type: String, table_id: u64, num: u64) {
-    let labels = &vec![
-        (LABEL_TYPE, lock_type),
-        (LABEL_TABLE_ID, table_id.to_string()),
-    ];
+pub fn record_acquired_lock_nums(lock_type: String, num: u64) {
+    let labels = &vec![(LABEL_TYPE, lock_type)];
     ACQUIRED_LOCK_NUMS.get_or_create(labels).inc_by(num);
 }
 

--- a/src/common/storage/src/metrics_layer.rs
+++ b/src/common/storage/src/metrics_layer.rs
@@ -242,7 +242,6 @@ impl EncodeLabelSet for OperationLabels {
     fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), fmt::Error> {
         (observe::LABEL_SCHEME, self.0.scheme.into_static()).encode(encoder.encode_label())?;
         (observe::LABEL_NAMESPACE, self.0.namespace.as_ref()).encode(encoder.encode_label())?;
-        (observe::LABEL_ROOT, self.0.root.as_ref()).encode(encoder.encode_label())?;
         (observe::LABEL_OPERATION, self.0.operation).encode(encoder.encode_label())?;
 
         if let Some(error) = &self.0.error {

--- a/src/query/service/src/locks/lock_holder.rs
+++ b/src/query/service/src/locks/lock_holder.rs
@@ -103,7 +103,7 @@ impl LockHolder {
 
                 catalog.extend_lock_revision(extend_table_lock_req).await?;
                 // metrics.
-                record_acquired_lock_nums(lock_type, table_id, 1);
+                record_acquired_lock_nums(lock_type, 1);
                 break;
             }
 
@@ -174,7 +174,7 @@ impl LockHolder {
         let res = catalog.create_lock_revision(req).await?;
         let revision = res.revision;
         // metrics.
-        record_created_lock_nums(lock_key.lock_type().to_string(), lock_key.get_table_id(), 1);
+        record_created_lock_nums(lock_key.lock_type().to_string(), 1);
         log::debug!("create table lock success, revision={}", revision);
 
         let delete_table_lock_req = DeleteLockRevReq::new(lock_key.clone(), revision);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

prometheus hates labels with high cardinalities.

this pr removes two high cardinality labels:

1. `table_id` label in the table locks metrics, users may have thousands of tables
2. `root` label in opendal access metrics, users may have thousands of stages

## Tests

- [x] No Test - improve metrics

## Type of change

- [x] Other (please describe): metrics enhancement
