### PR TITLE
refactor: start a meta-service as local meta for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,16 +3747,20 @@ dependencies = [
 name = "databend-common-meta-store"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "databend-common-base",
  "databend-common-grpc",
  "databend-common-meta-client",
- "databend-common-meta-embedded",
  "databend-common-meta-kvapi",
  "databend-common-meta-semaphore",
  "databend-common-meta-types",
+ "databend-meta",
  "log",
+ "tempfile",
+ "tokio",
  "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/src/meta/api/src/txn_backoff.rs
+++ b/src/meta/api/src/txn_backoff.rs
@@ -140,7 +140,7 @@ mod tests {
         let _ = trials.next().unwrap().unwrap().await;
         let elapsed = now.elapsed().as_secs_f64();
 
-        assert!(elapsed < 0.010, "{} is expected to be 0", elapsed);
+        assert!(elapsed < 0.100, "{} is expected to be 0", elapsed);
     }
 
     #[tokio::test]

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -11,16 +11,20 @@ edition = { workspace = true }
 io-uring = []
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-grpc = { workspace = true }
 databend-common-meta-client = { workspace = true }
-databend-common-meta-embedded = { workspace = true }
 databend-common-meta-kvapi = { workspace = true }
 databend-common-meta-semaphore = { workspace = true }
 databend-common-meta-types = { workspace = true }
+databend-meta = { workspace = true }
 log = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -12,26 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
+pub(crate) mod local;
+
+use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
-use databend_common_base::base::tokio::sync::Semaphore as TokioSemaphore;
 use databend_common_grpc::RpcClientConf;
 use databend_common_meta_client::errors::CreationError;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
-use databend_common_meta_embedded::MemMeta;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::KVStream;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
 use databend_common_meta_semaphore::acquirer::Permit;
-use databend_common_meta_semaphore::acquirer::SharedAcquirerStat;
 use databend_common_meta_semaphore::errors::AcquireError;
-use databend_common_meta_semaphore::errors::ConnectionClosed;
 use databend_common_meta_semaphore::Semaphore;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
@@ -39,6 +37,7 @@ use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
 use databend_common_meta_types::UpsertKV;
+pub use local::LocalMetaService;
 use log::info;
 use tokio_stream::Stream;
 
@@ -53,11 +52,22 @@ pub struct MetaStoreProvider {
 /// MetaStore is impl with either a local embedded meta store, or a grpc-client of metasrv
 #[derive(Clone)]
 pub enum MetaStore {
-    L(Arc<MemMeta>),
+    L(Arc<LocalMetaService>),
     R(Arc<ClientHandle>),
 }
 
 impl MetaStore {
+    /// Create a local meta service for testing.
+    ///
+    /// It is required to assign a base port as the port number range.
+    pub async fn new_local_testing() -> Self {
+        MetaStore::L(Arc::new(
+            LocalMetaService::new("MetaStore-new-local-testing")
+                .await
+                .unwrap(),
+        ))
+    }
+
     pub fn arc(self) -> Arc<Self> {
         Arc::new(self)
     }
@@ -70,23 +80,23 @@ impl MetaStore {
     }
 
     pub async fn get_local_addr(&self) -> std::result::Result<Option<String>, MetaError> {
-        match self {
-            MetaStore::L(_) => Ok(None),
-            MetaStore::R(grpc_client) => {
-                let client_info = grpc_client.get_client_info().await?;
-                Ok(Some(client_info.client_addr))
-            }
-        }
+        let client = match self {
+            MetaStore::L(l) => l.deref().deref(),
+            MetaStore::R(grpc_client) => grpc_client,
+        };
+
+        let client_info = client.get_client_info().await?;
+        Ok(Some(client_info.client_addr))
     }
 
     pub async fn watch(&self, request: WatchRequest) -> Result<WatchStream, MetaError> {
-        match self {
-            MetaStore::L(_) => unreachable!(),
-            MetaStore::R(grpc_client) => {
-                let streaming = grpc_client.request(request).await?;
-                Ok(Box::pin(WatchResponseStream::create(streaming)))
-            }
-        }
+        let client = match self {
+            MetaStore::L(l) => l.deref(),
+            MetaStore::R(grpc_client) => grpc_client,
+        };
+
+        let streaming = client.request(request).await?;
+        Ok(Box::pin(WatchResponseStream::create(streaming)))
     }
 
     pub async fn new_acquired(
@@ -96,34 +106,12 @@ impl MetaStore {
         id: impl ToString,
         lease: Duration,
     ) -> Result<Permit, AcquireError> {
-        match self {
-            MetaStore::L(v) => {
-                let mut local_lock_map = v.locks.lock().await;
+        let client = match self {
+            MetaStore::L(l) => l.deref(),
+            MetaStore::R(grpc_client) => grpc_client,
+        };
 
-                let acquire_res = match local_lock_map.entry(prefix.to_string()) {
-                    Entry::Occupied(v) => v.get().clone(),
-                    Entry::Vacant(v) => v
-                        .insert(Arc::new(TokioSemaphore::new(capacity as usize)))
-                        .clone(),
-                };
-
-                match acquire_res.acquire_owned().await {
-                    Ok(guard) => Ok(Permit {
-                        stat: SharedAcquirerStat::new(),
-                        fu: Box::pin(async move {
-                            let _guard = guard;
-                            Ok(())
-                        }),
-                    }),
-                    Err(_e) => Err(AcquireError::ConnectionClosed(ConnectionClosed::new_str(
-                        "",
-                    ))),
-                }
-            }
-            MetaStore::R(grpc_client) => {
-                Semaphore::new_acquired(grpc_client.clone(), prefix, capacity, id, lease).await
-            }
-        }
+        Semaphore::new_acquired(client.clone(), prefix, capacity, id, lease).await
     }
 
     pub async fn new_acquired_by_time(
@@ -133,35 +121,12 @@ impl MetaStore {
         id: impl ToString,
         lease: Duration,
     ) -> Result<Permit, AcquireError> {
-        match self {
-            MetaStore::L(v) => {
-                let mut local_lock_map = v.locks.lock().await;
+        let client = match self {
+            MetaStore::L(l) => l.deref(),
+            MetaStore::R(grpc_client) => grpc_client,
+        };
 
-                let acquire_res = match local_lock_map.entry(prefix.to_string()) {
-                    Entry::Occupied(v) => v.get().clone(),
-                    Entry::Vacant(v) => v
-                        .insert(Arc::new(TokioSemaphore::new(capacity as usize)))
-                        .clone(),
-                };
-
-                match acquire_res.acquire_owned().await {
-                    Ok(guard) => Ok(Permit {
-                        stat: SharedAcquirerStat::new(),
-                        fu: Box::pin(async move {
-                            let _guard = guard;
-                            Ok(())
-                        }),
-                    }),
-                    Err(_e) => Err(AcquireError::ConnectionClosed(ConnectionClosed::new_str(
-                        "",
-                    ))),
-                }
-            }
-            MetaStore::R(grpc_client) => {
-                Semaphore::new_acquired_by_time(grpc_client.clone(), prefix, capacity, id, lease)
-                    .await
-            }
-        }
+        Semaphore::new_acquired_by_time(client.clone(), prefix, capacity, id, lease).await
     }
 }
 
@@ -211,8 +176,11 @@ impl MetaStoreProvider {
             );
 
             // NOTE: This can only be used for test: data will be removed when program quit.
-            let meta_store = MemMeta::default();
-            Ok(MetaStore::L(Arc::new(meta_store)))
+            Ok(MetaStore::L(Arc::new(
+                LocalMetaService::new("MetaStoreProvider-created")
+                    .await
+                    .unwrap(),
+            )))
         } else {
             info!(conf :? =(&self.rpc_conf); "use remote meta");
             let client = MetaGrpcClient::try_new(&self.rpc_conf)?;

--- a/src/meta/store/src/local.rs
+++ b/src/meta/store/src/local.rs
@@ -1,0 +1,267 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::fs;
+use std::net::TcpListener;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+
+use databend_common_base::base::GlobalSequence;
+use databend_common_base::base::Stoppable;
+use databend_common_meta_client::errors::CreationError;
+use databend_common_meta_client::ClientHandle;
+use databend_common_meta_client::MetaGrpcClient;
+use databend_common_meta_types::protobuf::raft_service_client::RaftServiceClient;
+use databend_meta::api::GrpcServer;
+use databend_meta::configs;
+use databend_meta::message::ForwardRequest;
+use databend_meta::message::ForwardRequestBody;
+use databend_meta::meta_service::MetaNode;
+use log::info;
+use log::warn;
+use tokio::time::sleep;
+
+/// A container for a locally started meta service, mainly for testing purpose.
+///
+/// The service will be shutdown if this struct is dropped.
+/// It deref to `ClientHandle` thus it can be used as a client.
+pub struct LocalMetaService {
+    _temp_dir: tempfile::TempDir,
+
+    /// For debugging
+    name: String,
+
+    pub config: configs::Config,
+
+    pub grpc_server: Option<Box<GrpcServer>>,
+
+    client: Arc<ClientHandle>,
+}
+
+impl fmt::Display for LocalMetaService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LocalMetaService({}: raft={} grpc={})",
+            self.name, self.config.raft_config.raft_api_port, self.config.grpc_api_address
+        )
+    }
+}
+
+/// The [LocalMetaService] implements the [Deref] trait, so it can be used as a [ClientHandle].
+impl Deref for LocalMetaService {
+    type Target = Arc<ClientHandle>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+impl Drop for LocalMetaService {
+    fn drop(&mut self) {
+        Self::rm_raft_dir(
+            &self.config,
+            format_args!("Drop LocalMetaService: {}", self),
+        );
+    }
+}
+
+impl LocalMetaService {
+    /// Create a new Config for test, with unique port assigned
+    ///
+    /// It brings up a meta-service process with the port number based on the base_port.
+    /// If it is None, 19_000 is used.
+    pub async fn new(name: impl fmt::Display) -> anyhow::Result<LocalMetaService> {
+        let name = name.to_string();
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let raft_port = next_port();
+
+        let mut config = configs::Config::default();
+
+        // On mac File::sync_all() takes 10 ms ~ 30 ms, 500 ms at worst, which very likely to fail a test.
+        if cfg!(target_os = "macos") {
+            warn!("Disabled fsync for meta service. fsync on mac is quite slow");
+            config.raft_config.no_sync = true;
+        }
+
+        config.raft_config.id = 0;
+
+        config.raft_config.config_id = raft_port.to_string();
+
+        // Use a unique dir for each instance.
+        config.raft_config.raft_dir = format!(
+            "{}/{}-{}/raft_dir",
+            temp_dir.path().display(),
+            name,
+            raft_port
+        );
+
+        // By default, create a meta node instead of open an existent one.
+        config.raft_config.single = true;
+
+        config.raft_config.raft_api_port = raft_port;
+        config.raft_config.raft_listen_host = "127.0.0.1".to_string();
+        config.raft_config.raft_advertise_host = "localhost".to_string();
+
+        let host = "127.0.0.1";
+
+        {
+            let grpc_port = next_port();
+            config.grpc_api_address = format!("{}:{}", host, grpc_port);
+            config.grpc_api_advertise_host = Some(host.to_string());
+        }
+
+        {
+            let http_port = next_port();
+            config.admin_api_address = format!("{}:{}", host, http_port);
+        }
+
+        info!("new LocalMetaService({}) with config: {:?}", name, config);
+
+        // Clean up the raft dir if it exists.
+        Self::rm_raft_dir(&config, "new LocalMetaService");
+
+        // Bring up the services
+        let meta_node = MetaNode::start(&config).await?;
+        let mut grpc_server = GrpcServer::create(config.clone(), meta_node);
+        grpc_server.start().await?;
+
+        let client = Self::grpc_client(&config).await?;
+
+        let local = LocalMetaService {
+            _temp_dir: temp_dir,
+            name,
+            config,
+            grpc_server: Some(Box::new(grpc_server)),
+            client,
+        };
+
+        Ok(local)
+    }
+
+    pub fn rm_raft_dir(config: &configs::Config, msg: impl fmt::Display + Copy) {
+        let raft_dir = &config.raft_config.raft_dir;
+
+        info!("{}: about to remove raft_dir: {:?}", msg, raft_dir);
+
+        let res = fs::remove_dir_all(raft_dir);
+        if let Err(e) = res {
+            warn!("{}: can not remove raft_dir {:?}, {:?}", msg, raft_dir, e);
+        } else {
+            info!("{}: OK removed raft_dir {:?}", msg, raft_dir)
+        }
+    }
+
+    async fn grpc_client(config: &configs::Config) -> Result<Arc<ClientHandle>, CreationError> {
+        let addr = config.grpc_api_address.clone();
+
+        let client = MetaGrpcClient::try_create(
+            vec![addr],
+            "root",
+            "xxx",
+            None,
+            Some(Duration::from_secs(10)),
+            None,
+        )?;
+
+        Ok(client)
+    }
+
+    pub async fn raft_client(
+        &self,
+    ) -> anyhow::Result<RaftServiceClient<tonic::transport::Channel>> {
+        let addr = self.config.raft_config.raft_api_addr().await?;
+
+        let mut last_error = None;
+
+        for _ in 0..6 {
+            let client = RaftServiceClient::connect(format!("http://{}", addr)).await;
+            match client {
+                Ok(x) => return Ok(x),
+                Err(err) => {
+                    warn!("can not yet connect to {}, {}, sleep a while", addr, err);
+                    last_error = Some(err);
+                    sleep(Duration::from_millis(50)).await;
+                }
+            }
+        }
+
+        Err(last_error.unwrap().into())
+    }
+
+    pub async fn assert_raft_server_connection(&self) -> anyhow::Result<()> {
+        let mut client = self.raft_client().await?;
+
+        let req = ForwardRequest {
+            forward_to_leader: 0,
+            body: ForwardRequestBody::Ping,
+        };
+
+        client.forward(req).await?;
+        Ok(())
+    }
+}
+
+fn next_port() -> u16 {
+    let base = get_machine_unique_base_port();
+
+    base + (GlobalSequence::next() as u16)
+}
+
+fn get_machine_unique_base_port() -> u16 {
+    static mut BASE: u16 = 19_000;
+    static BASE_ONCE: std::sync::Once = std::sync::Once::new();
+    unsafe {
+        BASE_ONCE.call_once(|| {
+            let (port, listener) = try_bind();
+            Box::leak(Box::new(listener));
+            BASE = port;
+        });
+        BASE
+    }
+}
+
+/// Occupy a port
+fn try_bind() -> (u16, TcpListener) {
+    let mut port = 19_000u16;
+
+    while port < 30_000 {
+        let address = format!("127.0.0.1:{port}");
+        let res = TcpListener::bind(&address);
+        match res {
+            Ok(listener) => {
+                info!("bind to {address} OK");
+                return (port, listener);
+            }
+            Err(e) => {
+                port += 500;
+                info!("bind to {address} failed: {e}; try next port: {}", port);
+            }
+        }
+    }
+
+    unreachable!("can not find available port")
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_local_meta_service() -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/src/meta/store/tests/it/kv_api.rs
+++ b/src/meta/store/tests/it/kv_api.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_store::LocalMetaService;
+
+#[derive(Clone)]
+struct MetaNodeUnitTestBuilder {}
+
+#[async_trait]
+impl kvapi::ApiBuilder<LocalMetaService> for MetaNodeUnitTestBuilder {
+    async fn build(&self) -> LocalMetaService {
+        LocalMetaService::new("UT-Meta").await.unwrap()
+    }
+
+    async fn build_cluster(&self) -> Vec<LocalMetaService> {
+        todo!()
+    }
+}
+
+/// It just tests the basic kv api to ensure the internal meta client handle works.
+#[tokio::test]
+async fn test_meta_node_kv_api() -> anyhow::Result<()> {
+    let builder = MetaNodeUnitTestBuilder {};
+
+    kvapi::TestSuite {}.test_single_node(&builder).await
+}

--- a/src/meta/store/tests/it/main.rs
+++ b/src/meta/store/tests/it/main.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod kv_api;

--- a/src/query/management/tests/it/warehouse.rs
+++ b/src/query/management/tests/it/warehouse.rs
@@ -23,8 +23,8 @@ use databend_common_base::runtime::Runtime;
 use databend_common_base::runtime::TrySpawn;
 use databend_common_exception::Result;
 use databend_common_management::*;
-use databend_common_meta_embedded::MemMeta;
 use databend_common_meta_kvapi::kvapi::KVApi;
+use databend_common_meta_store::LocalMetaService;
 use databend_common_meta_store::MetaStore;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
@@ -1561,7 +1561,9 @@ async fn nodes(lift: Duration, size: usize) -> Result<(MetaStore, WarehouseMgr, 
 }
 
 async fn new_cluster_api(lift: Duration) -> Result<(MetaStore, WarehouseMgr)> {
-    let test_api = MetaStore::L(Arc::new(MemMeta::default()));
+    let test_api = MetaStore::L(Arc::new(
+        LocalMetaService::new("management-test").await.unwrap(),
+    ));
     let cluster_manager = WarehouseMgr::create(test_api.clone(), "test-tenant-id", lift)?;
     Ok((test_api, cluster_manager))
 }

--- a/src/query/management/tests/it/workload.rs
+++ b/src/query/management/tests/it/workload.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use databend_common_base::base::tokio;
@@ -23,17 +22,16 @@ use databend_common_management::QuotaValue;
 use databend_common_management::WorkloadApi;
 use databend_common_management::WorkloadGroup;
 use databend_common_management::WorkloadMgr;
-use databend_common_meta_embedded::MemMeta;
 use databend_common_meta_store::MetaStore;
 
-fn create_workload_mgr() -> WorkloadMgr {
-    let test_api = MetaStore::L(Arc::new(MemMeta::default()));
+async fn create_workload_mgr() -> WorkloadMgr {
+    let test_api = MetaStore::new_local_testing().await;
     WorkloadMgr::create(test_api.clone(), "test-tenant-id").unwrap()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_workload_group() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
     let mut quotas = HashMap::new();
     quotas.insert(
         "cpu".to_string(),
@@ -77,7 +75,7 @@ async fn test_create_workload_group() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_workload_group() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
     let mut quotas = HashMap::new();
     quotas.insert(
         "cpu".to_string(),
@@ -110,7 +108,7 @@ async fn test_get_workload_group() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_drop_workload_group() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
     let group = WorkloadGroup {
         id: "".to_string(),
         name: "test_group".to_string(),
@@ -132,7 +130,7 @@ async fn test_drop_workload_group() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_rename_workload_group() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
     let group = WorkloadGroup {
         id: "".to_string(),
         name: "old_name".to_string(),
@@ -175,7 +173,7 @@ async fn test_rename_workload_group() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_alter_quotas() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
     let group = WorkloadGroup {
         id: "".to_string(),
         name: "test_group".to_string(),
@@ -223,7 +221,7 @@ async fn test_alter_quotas() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_all_workload_groups() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
 
     // Create multiple groups
     let group1 = WorkloadGroup {
@@ -250,7 +248,7 @@ async fn test_get_all_workload_groups() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_invalid_workload_group() -> Result<()> {
-    let mgr = create_workload_mgr();
+    let mgr = create_workload_mgr().await;
 
     // Test empty name
     let group = WorkloadGroup {

--- a/src/query/service/src/sessions/queue_mgr.rs
+++ b/src/query/service/src/sessions/queue_mgr.rs
@@ -260,6 +260,7 @@ impl<Data: QueueData> QueueManager<Data> {
     }
 }
 
+#[derive(Debug)]
 pub enum AcquireQueueGuard {
     Global(Option<Permit>),
     Local(Option<OwnedSemaphorePermit>),

--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -136,7 +136,7 @@ async fn test_serial_acquire() -> Result<()> {
                     // Time based semaphore is sensitive to time accuracy.
                     // Lower timestamp semaphore being inserted after higher timestamp semaphore results in both acquired.
                     // Thus, we have to make the gap between timestamp large enough.
-                    tokio::time::sleep(Duration::from_millis(300 * index as u64)).await;
+                    tokio::time::sleep(Duration::from_millis(500 * index as u64)).await;
 
                     let _guard = queue
                         .acquire(TestData {
@@ -144,7 +144,8 @@ async fn test_serial_acquire() -> Result<()> {
                             acquire_id: format!("TestData{}", index),
                         })
                         .await?;
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+
+                    tokio::time::sleep(Duration::from_millis(1_000)).await;
                     Result::<()>::Ok(())
                 })
             })
@@ -154,7 +155,14 @@ async fn test_serial_acquire() -> Result<()> {
             let _ = join_handle.await;
         }
 
-        assert!(instant.elapsed() >= Duration::from_secs(test_count as u64));
+        let elapsed = instant.elapsed();
+        let expected = Duration::from_secs(test_count as u64);
+        assert!(
+            elapsed >= expected,
+            "expect: elapsed: {:?} >= {:?}, ",
+            elapsed,
+            expected,
+        );
         assert_eq!(queue.length(), 0);
     }
     Ok(())
@@ -233,7 +241,7 @@ async fn test_list_acquire() -> Result<()> {
                     // Time based semaphore is sensitive to time accuracy.
                     // Lower timestamp semaphore being inserted after higher timestamp semaphore results in both acquired.
                     // Thus, we have to make the gap between timestamp large enough.
-                    tokio::time::sleep(Duration::from_millis(300 * index as u64)).await;
+                    tokio::time::sleep(Duration::from_millis(800 * index as u64)).await;
 
                     let _guard = queue
                         .acquire(TestData {
@@ -242,13 +250,13 @@ async fn test_list_acquire() -> Result<()> {
                         })
                         .await?;
 
-                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    tokio::time::sleep(Duration::from_secs(15)).await;
                     Result::<()>::Ok(())
                 })
             })
         }
 
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
         assert_eq!(queue.length(), test_count - 1);
     }
 

--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -132,6 +132,12 @@ async fn test_serial_acquire() -> Result<()> {
                 let barrier = barrier.clone();
                 databend_common_base::runtime::spawn(async move {
                     barrier.wait().await;
+
+                    // Time based semaphore is sensitive to time accuracy.
+                    // Lower timestamp semaphore being inserted after higher timestamp semaphore results in both acquired.
+                    // Thus, we have to make the gap between timestamp large enough.
+                    tokio::time::sleep(Duration::from_millis(300 * index as u64)).await;
+
                     let _guard = queue
                         .acquire(TestData {
                             lock_id: String::from("test_serial_acquire"),
@@ -223,6 +229,12 @@ async fn test_list_acquire() -> Result<()> {
                 let barrier = barrier.clone();
                 databend_common_base::runtime::spawn(async move {
                     barrier.wait().await;
+
+                    // Time based semaphore is sensitive to time accuracy.
+                    // Lower timestamp semaphore being inserted after higher timestamp semaphore results in both acquired.
+                    // Thus, we have to make the gap between timestamp large enough.
+                    tokio::time::sleep(Duration::from_millis(300 * index as u64)).await;
+
                     let _guard = queue
                         .acquire(TestData {
                             lock_id: String::from("test_list_acquire"),


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: start a meta-service as local meta for testing

- Replaced the in-memory meta-store with a meta-service running in a
  temporary directory for testing purposes.

- The in-memory meta-store was limited in functionality and did not
  provide a complete feature set.

- The new approach ensures full functionality during testing by
  simulating a real meta-service.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17821)
<!-- Reviewable:end -->
