### PR TITLE
chore(query): add string view dict/freq/onevalue encoding for native format

### DIFF
--- a/src/common/column/src/binview/builder.rs
+++ b/src/common/column/src/binview/builder.rs
@@ -132,7 +132,6 @@ impl<T: ViewType + ?Sized> BinaryViewColumnBuilder<T> {
         let len = v.length;
         if len <= 12 {
             self.total_bytes_len += len as usize;
-            debug_assert!(self.views.capacity() > self.views.len());
             self.views.push(v)
         } else {
             let data = buffers.get_unchecked(v.buffer_idx as usize);
@@ -141,6 +140,15 @@ impl<T: ViewType + ?Sized> BinaryViewColumnBuilder<T> {
             let t = T::from_bytes_unchecked(bytes);
             self.push_value(t)
         }
+    }
+
+    /// # Safety
+    /// - caller ensure that view is duplicated
+    #[inline]
+    pub(crate) unsafe fn push_duplicated_view_unchecked(&mut self, v: View) {
+        let len = v.length;
+        self.total_bytes_len += len as usize;
+        self.views.push(v);
     }
 
     pub fn push_value<V: AsRef<T>>(&mut self, value: V) {

--- a/src/common/column/src/binview/view.rs
+++ b/src/common/column/src/binview/view.rs
@@ -49,6 +49,11 @@ impl View {
         unsafe { std::mem::transmute(self) }
     }
 
+    #[inline(always)]
+    pub fn as_i128(self) -> i128 {
+        unsafe { std::mem::transmute(self) }
+    }
+
     /// Create a new inline view without verifying the length
     ///
     /// # Safety

--- a/src/common/native/src/compression/mod.rs
+++ b/src/common/native/src/compression/mod.rs
@@ -18,6 +18,7 @@ pub mod binary;
 pub mod boolean;
 pub mod double;
 pub mod integer;
+pub mod view;
 
 pub use basic::CommonCompression;
 use databend_common_expression::types::Bitmap;

--- a/src/common/native/src/compression/view/mod.rs
+++ b/src/common/native/src/compression/view/mod.rs
@@ -1,0 +1,55 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_column::binview::BinaryViewColumn;
+use databend_common_column::bitmap::Bitmap;
+use databend_common_expression::types::Buffer;
+
+use super::basic::CommonCompression;
+use crate::compression::integer::compress_integer;
+use crate::error::Result;
+use crate::write::WriteOptions;
+
+pub fn compress_view(
+    col: &BinaryViewColumn,
+    validity: Option<Bitmap>,
+    buf: &mut Vec<u8>,
+    write_options: WriteOptions,
+) -> Result<()> {
+    // choose compressor
+    let col = col.gc_with_dict(validity.clone());
+    let view_array: Buffer<i128> = col.views().iter().map(|x| x.as_i128()).collect();
+    compress_integer(&view_array, validity, write_options.clone(), buf)?;
+    compress_buffers(&col, buf, write_options.default_compression)
+}
+
+fn compress_buffers(
+    array: &BinaryViewColumn,
+    buf: &mut Vec<u8>,
+    c: CommonCompression,
+) -> Result<()> {
+    let codec = c.to_compression() as u8;
+    buf.extend_from_slice(&(array.data_buffers().len() as u32).to_le_bytes());
+    // let's encode the buffers
+    for buffer in array.data_buffers().iter() {
+        buf.extend_from_slice(&[codec as u8]);
+        let pos = buf.len();
+        buf.extend_from_slice(&[0u8; 8]);
+
+        let compressed_size = c.compress(buffer.as_slice(), buf)?;
+        buf[pos..pos + 4].copy_from_slice(&(compressed_size as u32).to_le_bytes());
+        buf[pos + 4..pos + 8].copy_from_slice(&(buffer.len() as u32).to_le_bytes());
+    }
+    Ok(())
+}

--- a/src/common/native/src/read/array/view.rs
+++ b/src/common/native/src/read/array/view.rs
@@ -23,6 +23,7 @@ use databend_common_expression::types::Buffer;
 use databend_common_expression::Column;
 use databend_common_expression::TableDataType;
 
+use crate::compression::integer::decompress_integer;
 use crate::error::Result;
 use crate::nested::InitNested;
 use crate::nested::NestedState;
@@ -112,22 +113,21 @@ fn read_view_col<R: NativeReadBuf>(
     data_type: TableDataType,
     validity: Option<Bitmap>,
 ) -> Result<Column> {
-    let mut scratch = vec![0; 9];
-    let (_c, _compressed_size, _uncompressed_size) = read_compress_header(reader, &mut scratch)?;
+    let mut scratch = Vec::new();
+    let mut views: Vec<i128> = Vec::with_capacity(length);
+    decompress_integer(reader, length, &mut views, &mut scratch)?;
 
-    let mut buffer = vec![View::default(); length];
-    let temp_data =
-        unsafe { std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u8, length * 16) };
-    reader.read_exact(temp_data)?;
-    let views = Buffer::from(buffer);
+    let views: Buffer<i128> = views.into();
+    let views = unsafe { std::mem::transmute::<Buffer<i128>, Buffer<View>>(views) };
 
     let buffer_len = reader.read_u32::<LittleEndian>()?;
-    let mut buffers = Vec::with_capacity(buffer_len as _);
+    let mut buffers = Vec::with_capacity(buffer_len as usize);
 
     for _ in 0..buffer_len {
         scratch.clear();
         let (compression, compressed_size, uncompressed_size) =
             read_compress_header(reader, &mut scratch)?;
+
         let c = CommonCompression::try_from(&compression)?;
         let mut buffer = vec![];
         c.decompress_common_binary(
@@ -137,12 +137,13 @@ fn read_view_col<R: NativeReadBuf>(
             &mut buffer,
             &mut scratch,
         )?;
+
         buffers.push(Buffer::from(buffer));
     }
 
     let col = unsafe {
         Column::String(Utf8ViewColumn::new_unchecked_unknown_md(
-            views,
+            views.into(),
             buffers.into(),
             None,
         ))

--- a/src/common/native/src/write/serialize.rs
+++ b/src/common/native/src/write/serialize.rs
@@ -60,7 +60,9 @@ pub fn write<W: Write>(
             }
         }),
         Column::Boolean(column) => write_bitmap(w, &column, validity, write_options, scratch),
-        Column::String(column) => write_view::<W>(w, &column.to_binview(), write_options, scratch),
+        Column::String(column) => {
+            write_view::<W>(w, &column.to_binview(), validity, write_options, scratch)
+        }
         Column::Timestamp(column) => {
             write_primitive::<i64, W>(w, &column, validity, write_options, scratch)
         }

--- a/src/common/native/src/write/view.rs
+++ b/src/common/native/src/write/view.rs
@@ -15,43 +15,21 @@
 use std::io::Write;
 
 use databend_common_column::binview::BinaryViewColumn;
-use databend_common_column::binview::View;
+use databend_common_column::bitmap::Bitmap;
 
 use super::WriteOptions;
+use crate::compression::view::compress_view;
 use crate::error::Result;
 
 pub(crate) fn write_view<W: Write>(
     w: &mut W,
     array: &BinaryViewColumn,
+    validity: Option<Bitmap>,
     write_options: WriteOptions,
-    buf: &mut Vec<u8>,
+    scratch: &mut Vec<u8>,
 ) -> Result<()> {
-    // TODO: adaptive gc and dict by stats
-    let array = array.clone().gc();
-    let c = write_options.default_compression;
-    let codec = c.to_compression();
-
-    let total_size = array.len() * std::mem::size_of::<View>()
-        + array.data_buffers().iter().map(|x| x.len()).sum::<usize>();
-    w.write_all(&[codec as u8])?;
-    w.write_all(&(total_size as u32).to_le_bytes())?;
-    w.write_all(&(total_size as u32).to_le_bytes())?;
-
-    let input_buf: &[u8] = bytemuck::cast_slice(array.views().as_slice());
-    w.write_all(input_buf)?;
-    w.write_all(&(array.data_buffers().len() as u32).to_le_bytes())?;
-
-    for buffer in array.data_buffers().iter() {
-        buf.clear();
-        let pos = buf.len();
-        w.write_all(&[codec as u8])?;
-        buf.extend_from_slice(&[0u8; 8]);
-
-        let compressed_size = c.compress(buffer.as_slice(), buf)?;
-        buf[pos..pos + 4].copy_from_slice(&(compressed_size as u32).to_le_bytes());
-        buf[pos + 4..pos + 8].copy_from_slice(&(buffer.len() as u32).to_le_bytes());
-        w.write_all(buf.as_slice())?;
-        buf.clear();
-    }
+    scratch.clear();
+    compress_view(array, validity, scratch, write_options)?;
+    w.write_all(scratch.as_slice())?;
     Ok(())
 }

--- a/src/common/native/tests/it/native/io.rs
+++ b/src/common/native/tests/it/native/io.rs
@@ -110,6 +110,25 @@ fn test_freq() {
 }
 
 #[test]
+fn test_dict_string() {
+    let size = WRITE_PAGE * 5;
+
+    let values = vec![
+        (0..size)
+            .map(|s| format!("stringxxxxxxxx{}", s % 4))
+            .collect::<Vec<_>>(),
+        // (0..size)
+        //     .map(|s| format!("abc{}", s % 4))
+        //     .collect::<Vec<_>>(),
+    ];
+    for v in values {
+        let col = StringColumn::from_iter(v.iter());
+        let chunk = vec![Column::String(col)];
+        test_write_read(chunk);
+    }
+}
+
+#[test]
 fn test_bitpacking() {
     let size = WRITE_PAGE * 5;
     let chunk = vec![

--- a/src/query/storages/fuse/benches/bench.rs
+++ b/src/query/storages/fuse/benches/bench.rs
@@ -19,7 +19,7 @@ fn main() {
 // Timer precision: 10 ns
 // bench                fastest       │ slowest       │ median        │ mean          │ samples │ iters
 // ╰─ dummy                           │               │               │               │         │
-//    ├─ arrow_ipc_desc                 │               │               │               │         │
+//    ├─ native_deser                 │               │               │               │         │
 //    │  ├─ LZ4         588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 1       │ 1
 //    │  │              3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │         │
 //    │  ╰─ Zstd        832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 1       │ 1
@@ -98,7 +98,7 @@ mod dummy {
     }
 
     #[divan::bench(args = [TableCompression::LZ4, TableCompression::Zstd])]
-    fn arrow_ipc_desc(bencher: divan::Bencher, compression: TableCompression) {
+    fn native_deser(bencher: divan::Bencher, compression: TableCompression) {
         // write the block into temp memory buffers
         // prepare the metas
         // use deserialize_chunk to read back into block

--- a/src/query/storages/fuse/benches/bench.rs
+++ b/src/query/storages/fuse/benches/bench.rs
@@ -16,7 +16,20 @@ fn main() {
     divan::main()
 }
 
-#[divan::bench_group(max_time = 1)]
+// Timer precision: 10 ns
+// bench                fastest       │ slowest       │ median        │ mean          │ samples │ iters
+// ╰─ dummy                           │               │               │               │         │
+//    ├─ arrow_ipc_desc                 │               │               │               │         │
+//    │  ├─ LZ4         588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 1       │ 1
+//    │  │              3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │         │
+//    │  ╰─ Zstd        832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 1       │ 1
+//    │                 1.942 GB/s    │ 1.942 GB/s    │ 1.942 GB/s    │ 1.942 GB/s    │         │
+//    ╰─ parquet_deser                │               │               │               │         │
+//       ├─ LZ4         807.5 ms      │ 807.5 ms      │ 807.5 ms      │ 807.5 ms      │ 1       │ 1
+//       │              3.176 GB/s    │ 3.176 GB/s    │ 3.176 GB/s    │ 3.176 GB/s    │         │
+//       ╰─ Zstd        1.009 s       │ 1.009 s       │ 1.009 s       │ 1.009 s       │ 1       │ 1
+//                      1.425 GB/s    │ 1.425 GB/s    │ 1.425 GB/s    │ 1.425 GB/s    │         │
+#[divan::bench_group(max_time = 3)]
 mod dummy {
     use std::sync::Arc;
 
@@ -85,7 +98,7 @@ mod dummy {
     }
 
     #[divan::bench(args = [TableCompression::LZ4, TableCompression::Zstd])]
-    fn native_deser(bencher: divan::Bencher, compression: TableCompression) {
+    fn arrow_ipc_desc(bencher: divan::Bencher, compression: TableCompression) {
         // write the block into temp memory buffers
         // prepare the metas
         // use deserialize_chunk to read back into block

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -35,8 +35,7 @@ pub const FUSE_TBL_VIRTUAL_BLOCK_PREFIX: &str = "_vb";
 pub const FUSE_TBL_AGG_INDEX_PREFIX: &str = "_i_a";
 pub const FUSE_TBL_INVERTED_INDEX_PREFIX: &str = "_i_i";
 
-pub const DEFAULT_ROW_PER_PAGE: usize = 131072;
-pub const DEFAULT_ROW_PER_PAGE_FOR_BLOCKING: usize = 2048;
+pub const DEFAULT_ROW_PER_PAGE: usize = 8192;
 pub const DEFAULT_ROW_PER_INDEX: usize = 100000;
 
 pub const DEFAULT_AVG_DEPTH_THRESHOLD: f64 = 0.001;

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -121,7 +121,6 @@ use crate::NavigationPoint;
 use crate::Table;
 use crate::TableStatistics;
 use crate::DEFAULT_ROW_PER_PAGE;
-use crate::DEFAULT_ROW_PER_PAGE_FOR_BLOCKING;
 use crate::FUSE_OPT_KEY_ATTACH_COLUMN_IDS;
 use crate::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
@@ -273,12 +272,7 @@ impl FuseTable {
     }
 
     pub fn get_write_settings(&self) -> WriteSettings {
-        let default_rows_per_page = if self.operator.info().native_capability().blocking {
-            DEFAULT_ROW_PER_PAGE_FOR_BLOCKING
-        } else {
-            DEFAULT_ROW_PER_PAGE
-        };
-        let max_page_size = self.get_option(FUSE_OPT_KEY_ROW_PER_PAGE, default_rows_per_page);
+        let max_page_size = self.get_option(FUSE_OPT_KEY_ROW_PER_PAGE, DEFAULT_ROW_PER_PAGE);
         let block_per_seg =
             self.get_option(FUSE_OPT_KEY_BLOCK_PER_SEGMENT, DEFAULT_BLOCK_PER_SEGMENT);
 

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -230,7 +230,7 @@ impl BlockReader {
                 ));
                 match nums_rows {
                     Some(rows) => {
-                        debug_assert_eq!(rows, column.len(), "Column  lengths are not equal")
+                        debug_assert_eq!(rows, column.len(), "Column lengths are not equal")
                     }
                     None => nums_rows = Some(column.len()),
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): add string view dict/freq/onevalue encoding for native format

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

We measure the performance of deserialization for different formats in `fuse/bench.rs`
```
 Timer precision: 10 ns
 bench                fastest       │ slowest       │ median        │ mean          │ samples │ iters
 ╰─ dummy                           │               │               │               │         │
    ├─ native_deser                 │               │               │               │         │
    │  ├─ LZ4         588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 588.9 ms      │ 1       │ 1
    │  │              3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │ 3.873 GB/s    │         │
    │  ╰─ Zstd        832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 832.1 ms      │ 1       │ 1
    │                 1.942 GB/s    │ 1.942 GB/s    │ 1.942 GB/s    │ 1.942 GB/s    │         │
    ╰─ parquet_deser                │               │               │               │         │
       ├─ LZ4         807.5 ms      │ 807.5 ms      │ 807.5 ms      │ 807.5 ms      │ 1       │ 1
       │              3.176 GB/s    │ 3.176 GB/s    │ 3.176 GB/s    │ 3.176 GB/s    │         │
       ╰─ Zstd        1.009 s       │ 1.009 s       │ 1.009 s       │ 1.009 s       │ 1       │ 1
                      1.425 GB/s    │ 1.425 GB/s    │ 1.425 GB/s    │ 1.425 GB/s    │         │

```

And in tpch10
 lineitem  cached in hybrid cache (disk & memory)
 remote storage is minio
 lz4 compression by default

```
Test Tpch Q1 without filter

lineitem native:  
cold run:   0.974sec   hot run: 0.625 secs
lineitem parquet:
cold run:   1.840sec  hot run: 1.245 sec

```


## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
