### PR TITLE
chore(query): remove `upcast_gat` method

### DIFF
--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -367,13 +367,10 @@ pub trait ValueType: Debug + Clone + PartialEq + Sized + 'static {
     type ColumnIterator<'a>: Iterator<Item = Self::ScalarRef<'a>> + TrustedLen;
     type ColumnBuilder: Debug + Clone;
 
-    /// Upcast GAT type's lifetime.
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short>;
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar;
     fn to_scalar_ref(scalar: &Self::Scalar) -> Self::ScalarRef<'_>;
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>>;
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>>;
     fn try_downcast_column(col: &Column) -> Option<Self::Column>;
     fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain>;
 

--- a/src/query/expression/src/types/any.rs
+++ b/src/query/expression/src/types/any.rs
@@ -35,11 +35,6 @@ impl ValueType for AnyType {
     type ColumnIterator<'a> = ColumnIterator<'a>;
     type ColumnBuilder = ColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_owned()
     }
@@ -48,7 +43,7 @@ impl ValueType for AnyType {
         scalar.as_ref()
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         Some(scalar.clone())
     }
 

--- a/src/query/expression/src/types/array.rs
+++ b/src/query/expression/src/types/array.rs
@@ -44,11 +44,6 @@ impl<T: ValueType> ValueType for ArrayType<T> {
     type ColumnIterator<'a> = ArrayIterator<'a, T>;
     type ColumnBuilder = ArrayColumnBuilder<T>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: T::Column) -> T::Column {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/binary.rs
+++ b/src/query/expression/src/types/binary.rs
@@ -41,11 +41,6 @@ impl ValueType for BinaryType {
     type ColumnIterator<'a> = BinaryColumnIter<'a>;
     type ColumnBuilder = BinaryColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: &'long [u8]) -> &'short [u8] {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_vec()
     }
@@ -54,7 +49,7 @@ impl ValueType for BinaryType {
         scalar
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_binary().cloned()
     }
 

--- a/src/query/expression/src/types/bitmap.rs
+++ b/src/query/expression/src/types/bitmap.rs
@@ -40,11 +40,6 @@ impl ValueType for BitmapType {
     type ColumnIterator<'a> = BinaryColumnIter<'a>;
     type ColumnBuilder = BinaryColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_vec()
     }
@@ -53,7 +48,7 @@ impl ValueType for BitmapType {
         scalar
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_bitmap().cloned()
     }
 

--- a/src/query/expression/src/types/boolean.rs
+++ b/src/query/expression/src/types/boolean.rs
@@ -40,11 +40,6 @@ impl ValueType for BooleanType {
     type ColumnIterator<'a> = databend_common_column::bitmap::utils::BitmapIter<'a>;
     type ColumnBuilder = MutableBitmap;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: bool) -> bool {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/date.rs
+++ b/src/query/expression/src/types/date.rs
@@ -70,11 +70,6 @@ impl ValueType for DateType {
     type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, i32>>;
     type ColumnBuilder = Vec<i32>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: i32) -> i32 {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -64,10 +64,6 @@ impl<Num: Decimal> ValueType for DecimalType<Num> {
     type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, Num>>;
     type ColumnBuilder = Vec<Num>;
 
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/empty_array.rs
+++ b/src/query/expression/src/types/empty_array.rs
@@ -37,9 +37,6 @@ impl ValueType for EmptyArrayType {
     type ColumnIterator<'a> = std::iter::RepeatN<()>;
     type ColumnBuilder = usize;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(_: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {}
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/empty_map.rs
+++ b/src/query/expression/src/types/empty_map.rs
@@ -37,9 +37,6 @@ impl ValueType for EmptyMapType {
     type ColumnIterator<'a> = std::iter::RepeatN<()>;
     type ColumnBuilder = usize;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(_: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {}
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/generic.rs
+++ b/src/query/expression/src/types/generic.rs
@@ -38,11 +38,6 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
     type ColumnIterator<'a> = ColumnIterator<'a>;
     type ColumnBuilder = ColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_owned()
     }
@@ -51,7 +46,7 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
         scalar.as_ref()
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         Some(scalar.clone())
     }
 

--- a/src/query/expression/src/types/geography.rs
+++ b/src/query/expression/src/types/geography.rs
@@ -117,11 +117,6 @@ impl ValueType for GeographyType {
     type ColumnIterator<'a> = GeographyIterator<'a>;
     type ColumnBuilder = BinaryColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: GeographyRef<'long>) -> GeographyRef<'short> {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_owned()
     }
@@ -130,7 +125,7 @@ impl ValueType for GeographyType {
         scalar.as_ref()
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_geography().cloned()
     }
 

--- a/src/query/expression/src/types/geometry.rs
+++ b/src/query/expression/src/types/geometry.rs
@@ -44,11 +44,6 @@ impl ValueType for GeometryType {
     type ColumnIterator<'a> = BinaryColumnIter<'a>;
     type ColumnBuilder = BinaryColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: &'long [u8]) -> &'short [u8] {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_vec()
     }
@@ -57,7 +52,7 @@ impl ValueType for GeometryType {
         scalar
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_geometry().cloned()
     }
 

--- a/src/query/expression/src/types/interval.rs
+++ b/src/query/expression/src/types/interval.rs
@@ -44,11 +44,6 @@ impl ValueType for IntervalType {
     type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, months_days_micros>>;
     type ColumnBuilder = Vec<months_days_micros>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: months_days_micros) -> months_days_micros {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/map.rs
+++ b/src/query/expression/src/types/map.rs
@@ -41,11 +41,6 @@ impl<K: ValueType, V: ValueType> ValueType for KvPair<K, V> {
     type ColumnIterator<'a> = KvIterator<'a, K, V>;
     type ColumnBuilder = KvColumnBuilder<K, V>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        (K::upcast_gat(long.0), V::upcast_gat(long.1))
-    }
-
     fn to_owned_scalar((k, v): Self::ScalarRef<'_>) -> Self::Scalar {
         (K::to_owned_scalar(k), V::to_owned_scalar(v))
     }
@@ -54,7 +49,7 @@ impl<K: ValueType, V: ValueType> ValueType for KvPair<K, V> {
         (K::to_scalar_ref(k), V::to_scalar_ref(v))
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         match scalar {
             ScalarRef::Tuple(fields) if fields.len() == 2 => Some((
                 K::try_downcast_scalar(&fields[0])?,
@@ -337,11 +332,6 @@ impl<K: ValueType, V: ValueType> ValueType for MapType<K, V> {
     type Domain = Option<(K::Domain, V::Domain)>;
     type ColumnIterator<'a> = <MapInternal<K, V> as ValueType>::ColumnIterator<'a>;
     type ColumnBuilder = <MapInternal<K, V> as ValueType>::ColumnBuilder;
-
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {
-        <MapInternal<K, V> as ValueType>::upcast_gat(long)
-    }
 
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         <MapInternal<K, V> as ValueType>::to_owned_scalar(scalar)

--- a/src/query/expression/src/types/null.rs
+++ b/src/query/expression/src/types/null.rs
@@ -38,9 +38,6 @@ impl ValueType for NullType {
     type ColumnIterator<'a> = std::iter::RepeatN<()>;
     type ColumnBuilder = usize;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(_: Self::ScalarRef<'long>) -> Self::ScalarRef<'short> {}
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -45,13 +45,6 @@ impl<T: ValueType> ValueType for NullableType<T> {
     type ColumnIterator<'a> = NullableIterator<'a, T>;
     type ColumnBuilder = NullableColumnBuilder<T>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(
-        long: Option<T::ScalarRef<'long>>,
-    ) -> Option<T::ScalarRef<'short>> {
-        long.map(|long| T::upcast_gat(long))
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.map(T::to_owned_scalar)
     }
@@ -60,7 +53,7 @@ impl<T: ValueType> ValueType for NullableType<T> {
         scalar.as_ref().map(T::to_scalar_ref)
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         match scalar {
             ScalarRef::Null => Some(None),
             scalar => Some(Some(T::try_downcast_scalar(scalar)?)),

--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -109,11 +109,6 @@ impl<Num: Number> ValueType for NumberType<Num> {
     type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, Num>>;
     type ColumnBuilder = Vec<Num>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: Num) -> Num {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -43,11 +43,6 @@ impl ValueType for StringType {
     type ColumnIterator<'a> = StringIterator<'a>;
     type ColumnBuilder = StringColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: &'long str) -> &'short str {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_string()
     }
@@ -56,7 +51,7 @@ impl ValueType for StringType {
         scalar
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_string().cloned()
     }
 

--- a/src/query/expression/src/types/timestamp.rs
+++ b/src/query/expression/src/types/timestamp.rs
@@ -75,11 +75,6 @@ impl ValueType for TimestampType {
     type ColumnIterator<'a> = std::iter::Cloned<std::slice::Iter<'a, i64>>;
     type ColumnBuilder = Vec<i64>;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: i64) -> i64 {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar
     }

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -58,11 +58,6 @@ impl ValueType for VariantType {
     type ColumnIterator<'a> = BinaryColumnIter<'a>;
     type ColumnBuilder = BinaryColumnBuilder;
 
-    #[inline]
-    fn upcast_gat<'short, 'long: 'short>(long: &'long [u8]) -> &'short [u8] {
-        long
-    }
-
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
         scalar.to_vec()
     }
@@ -71,7 +66,7 @@ impl ValueType for VariantType {
         scalar
     }
 
-    fn try_downcast_scalar<'a>(scalar: &'a ScalarRef) -> Option<Self::ScalarRef<'a>> {
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
         scalar.as_variant().cloned()
     }
 

--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -657,7 +657,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                         array_column
                             .iter()
                             .zip(T::iter_column(&col))
-                            .map(|(array, c)| T::iter_column(&array).contains(&T::upcast_gat(c))),
+                            .map(|(array, c)| {
+                                T::iter_column(&array).any(|v| T::equal(v, c.clone()))
+                            }),
                         &[],
                     ),
                 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Removed the upcast_gat method from various ValueType implementations to simplify the trait.
* Updated the try_downcast_scalar method signature.
* Adjusted related methods in TopKSorter to align with the changes in ValueType trait.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17836)
<!-- Reviewable:end -->
