### PR TITLE
chore: add a setting to disable runtime filter

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -417,6 +417,13 @@ impl DefaultSettings {
                 }),
                 ("enable_bloom_runtime_filter", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
+                    desc: "Enables bloom runtime filter optimization for JOIN.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
+                ("enable_runtime_filter", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
                     desc: "Enables runtime filter optimization for JOIN.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -422,7 +422,7 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
-                ("enable_runtime_filter", DefaultSettingValue {
+                ("enable_join_runtime_filter", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Enables runtime filter optimization for JOIN.",
                     mode: SettingMode::Both,

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -357,8 +357,8 @@ impl Settings {
         Ok(self.try_get_u64("enable_bloom_runtime_filter")? != 0)
     }
 
-    pub fn get_enable_runtime_filter(&self) -> Result<bool> {
-        Ok(self.try_get_u64("enable_runtime_filter")? != 0)
+    pub fn get_enable_join_runtime_filter(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_join_runtime_filter")? != 0)
     }
 
     pub fn get_prefer_broadcast_join(&self) -> Result<bool> {

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -357,6 +357,10 @@ impl Settings {
         Ok(self.try_get_u64("enable_bloom_runtime_filter")? != 0)
     }
 
+    pub fn get_enable_runtime_filter(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_runtime_filter")? != 0)
+    }
+
     pub fn get_prefer_broadcast_join(&self) -> Result<bool> {
         Ok(self.try_get_u64("prefer_broadcast_join")? != 0)
     }

--- a/src/query/sql/src/executor/physical_plans/physical_join_filter.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_join_filter.rs
@@ -145,6 +145,11 @@ impl JoinRuntimeFilter {
         build_keys: &[RemoteExpr],
         probe_keys: Vec<Option<(RemoteExpr<String>, usize, usize)>>,
     ) -> Result<PhysicalRuntimeFilters> {
+        // Early return if runtime filter is disabled in settings
+        if !ctx.get_settings().get_enable_runtime_filter()? {
+            return Ok(Default::default());
+        }
+
         // Early return if runtime filters are not supported for this join type
         if !Self::supported_join_type_for_runtime_filter(&join.join_type) {
             return Ok(Default::default());

--- a/src/query/sql/src/executor/physical_plans/physical_join_filter.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_join_filter.rs
@@ -146,7 +146,7 @@ impl JoinRuntimeFilter {
         probe_keys: Vec<Option<(RemoteExpr<String>, usize, usize)>>,
     ) -> Result<PhysicalRuntimeFilters> {
         // Early return if runtime filter is disabled in settings
-        if !ctx.get_settings().get_enable_runtime_filter()? {
+        if !ctx.get_settings().get_enable_join_runtime_filter()? {
             return Ok(Default::default());
         }
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -85,7 +85,7 @@ HashJoin
     └── estimated rows: 100.00
 
 statement ok
-set enable_runtime_filter=0
+set enable_join_runtime_filter=0
 
 query T
 explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a
@@ -140,7 +140,7 @@ HashJoin
     └── estimated rows: 100.00
 
 statement ok
-set enable_runtime_filter=1
+set enable_join_runtime_filter=1
 
 query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -139,6 +139,9 @@ HashJoin
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 100.00
 
+statement ok
+set enable_runtime_filter=1
+
 query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -84,6 +84,61 @@ HashJoin
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
 
+statement ok
+set enable_runtime_filter=0
+
+query T
+explain select * from t, t1, t2 where t.a = t1.a and t1.a = t2.a
+----
+HashJoin
+├── output columns: [t2.a (#2), t1.a (#1), t.a (#0)]
+├── join type: INNER
+├── build keys: [t.a (#0)]
+├── probe keys: [t2.a (#2)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+├── estimated rows: 1.00
+├── HashJoin(Build)
+│   ├── output columns: [t1.a (#1), t.a (#0)]
+│   ├── join type: INNER
+│   ├── build keys: [t.a (#0)]
+│   ├── probe keys: [t1.a (#1)]
+│   ├── keys is null equal: [false]
+│   ├── filters: []
+│   ├── build join filters:
+│   ├── estimated rows: 1.00
+│   ├── TableScan(Build)
+│   │   ├── table: default.join_reorder.t
+│   │   ├── output columns: [a (#0)]
+│   │   ├── read rows: 1
+│   │   ├── read size: < 1 KiB
+│   │   ├── partitions total: 1
+│   │   ├── partitions scanned: 1
+│   │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│   │   ├── push downs: [filters: [], limit: NONE]
+│   │   └── estimated rows: 1.00
+│   └── TableScan(Probe)
+│       ├── table: default.join_reorder.t1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 10
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 1
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│       ├── push downs: [filters: [], limit: NONE]
+│       └── estimated rows: 10.00
+└── TableScan(Probe)
+    ├── table: default.join_reorder.t2
+    ├── output columns: [a (#2)]
+    ├── read rows: 100
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 100.00
+
 query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

A new setting `enable_runtime_filter` has been added in this PR and is set to 1 by default. The runtime filter can be disabled by executing:
```SQL
SET enable_runtime_filter = 0;
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17869)
<!-- Reviewable:end -->
