### PR TITLE
feat(optimizer): part support decorrelating correlated subqueries in join conditions

### DIFF
--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -206,11 +206,11 @@ pub struct Join {
 impl Default for Join {
     fn default() -> Self {
         Self {
-            equi_conditions: Default::default(),
-            non_equi_conditions: Default::default(),
+            equi_conditions: Vec::new(),
+            non_equi_conditions: Vec::new(),
             join_type: JoinType::Cross,
-            marker_index: Default::default(),
-            from_correlated_subquery: Default::default(),
+            marker_index: None,
+            from_correlated_subquery: false,
             need_hold_hash_table: false,
             is_lateral: false,
             single_to_inner: None,
@@ -480,6 +480,16 @@ impl Join {
         self.build_side_cache_info = None;
 
         Ok(())
+    }
+
+    pub fn has_subquery(&self) -> bool {
+        self.equi_conditions
+            .iter()
+            .any(|condition| condition.left.has_subquery() || condition.right.has_subquery())
+            || self
+                .non_equi_conditions
+                .iter()
+                .any(|expr| expr.has_subquery())
     }
 }
 

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -173,14 +173,7 @@ impl RelOperator {
             | RelOperator::RecursiveCteScan(_)
             | RelOperator::Mutation(_)
             | RelOperator::CompactBlock(_) => false,
-            RelOperator::Join(op) => {
-                op.equi_conditions.iter().any(|condition| {
-                    condition.left.has_subquery() || condition.right.has_subquery()
-                }) || op
-                    .non_equi_conditions
-                    .iter()
-                    .any(|expr| expr.has_subquery())
-            }
+            RelOperator::Join(op) => op.has_subquery(),
             RelOperator::EvalScalar(op) => op.items.iter().any(|expr| expr.scalar.has_subquery()),
             RelOperator::Filter(op) => op.predicates.iter().any(|expr| expr.has_subquery()),
             RelOperator::Aggregate(op) => {

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -1136,4 +1136,78 @@ where t.total_m = any (
 1 30
 
 statement ok
+create or replace table t1 as
+select * from (values 
+    (5, 7), 
+    (8, 6), 
+    (9, 9), 
+    (10, 1),
+    (11, 2)
+) t(a, b);
+
+statement ok
+create or replace table t2 as
+select * from (values 
+    (5, 1), 
+    (9, 2), 
+    (8, 3)
+) t(a, b);
+
+statement ok
+create or replace table t3 as
+select * from (values 
+    (5, 1), 
+    (8, 3)
+) t(a, b);
+
+query IIII
+select * from t1 full join t2 on t1.a = ( select a from t3 where b = t2.b ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+9 9 NULL NULL
+10 1 NULL NULL
+11 2 NULL NULL
+NULL NULL 9 2
+
+query IIII
+select * from t1 left join t2 on t1.a = ( select a from t3 where b = t2.b ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+9 9 NULL NULL
+10 1 NULL NULL
+11 2 NULL NULL
+
+query IIII
+select * from t1 right join t2 on t1.a = ( select a from t3 where b = t2.b ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+NULL NULL 9 2
+
+query IIII
+select * from t1 join t2 on t1.a = ( select a from t3 where b = t2.b ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+
+query IIII
+select * from t1 join t2 on t1.a - 1 = ( select a from t3 where b = t2.b ) + 1  order by t1.a;
+----
+10 1 8 3
+
+query IIII
+select * from t1 join t2 on ( select a from t3 where b = t2.b ) = ( select a from t3 where a = t1.a ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+
+query IIII
+select * from t1 join t2 on exists ( select a from t3 where a = t1.a and b = t2.b ) order by t1.a;
+----
+5 7 5 1
+8 6 8 3
+
+statement ok
 drop database d_subquery;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In the previous implementation, the subquery decorrelator did not handle correlated subqueries in join conditions.

In this PR:

* Support decorrelating correlated subqueries in `join.equi_conditions`. Example: `SELECT * FROM t1 JOIN t2 ON t1.a = (SELECT a FROM t3 WHERE b = t2.b)`
* Support decorrelating correlated subqueries in inner join `non_equi_conditions`. Example: `SELECT * FROM t1 JOIN t2 ON EXISTS (SELECT a FROM t3 WHERE a = t1.a AND b = t2.b)
`
* Do not support decorrelating correlated subqueries in `non_equi_conditions` for other join types

fixes: #17815

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17871)
<!-- Reviewable:end -->
