### PR TITLE
feat(meta-client-semaphore): generate semaphore sequence using timestamps to reduce conflicts

### DIFF
--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -272,7 +272,7 @@ impl MetaGrpcClient {
         loop {
             let recv_res = req_rx.recv().await;
             let Some(mut worker_request) = recv_res else {
-                warn!("{} handle closed. worker quit", self);
+                info!("{} handle closed. worker quit", self);
                 return;
             };
 

--- a/src/meta/semaphore/src/acquirer/mod.rs
+++ b/src/meta/semaphore/src/acquirer/mod.rs
@@ -18,5 +18,6 @@ mod permit;
 mod stat;
 
 pub(crate) use acquirer::Acquirer;
+pub(crate) use acquirer::SeqPolicy;
 pub use permit::Permit;
 pub use stat::SharedAcquirerStat;

--- a/src/meta/semaphore/src/acquirer/stat.rs
+++ b/src/meta/semaphore/src/acquirer/stat.rs
@@ -160,12 +160,14 @@ impl fmt::Display for SharedAcquirerStat {
         }
 
         if let Some(end) = window_end {
-            write!(
-                f,
-                ")=({:.1?}-{:.1?})",
-                window_start.unwrap().duration_since(base),
-                end.duration_since(base)
-            )?;
+            if let Some(start) = window_start {
+                write!(
+                    f,
+                    ")=({:.1?}-{:.1?})",
+                    start.duration_since(base),
+                    end.duration_since(base)
+                )?;
+            }
         }
 
         write!(f, "], ")?;

--- a/src/meta/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
+++ b/src/meta/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
@@ -115,3 +115,53 @@ async fn test_semaphore_guard_future() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_semaphore_time_based() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let a0 = || addresses[0].clone();
+    let a1 = || addresses[1].clone();
+    let a2 = || addresses[2].clone();
+
+    let cli = make_grpc_client(vec![a1(), a2(), a0()])?;
+
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Two semaphores in this test.
+    let s1 = "s1";
+    let s2 = "s2";
+
+    // Two semaphore in s1 can be acquired
+    let _s1g1 = Semaphore::new_acquired_by_time(client(), s1, 2, "id11", secs(3)).await?;
+    let s1g2 = Semaphore::new_acquired_by_time(client(), s1, 2, "id12", secs(3)).await?;
+
+    // Two semaphore in s2 can be acquired
+    let _s2g1 = Semaphore::new_acquired_by_time(client(), s2, 2, "id21", secs(3)).await?;
+    let _s2g2 = Semaphore::new_acquired_by_time(client(), s2, 2, "id22", secs(3)).await?;
+
+    // Another semaphore in s1 can not be acquired
+
+    let fu = Semaphore::new_acquired_by_time(client(), s1, 2, "id13", secs(3));
+    let s1g3 = timeout(Duration::from_secs(1), fu).await;
+
+    assert!(
+        s1g3.is_err(),
+        "s1g3 can not acquire because run out of capacity"
+    );
+
+    // Release s1g2, then s1g4 can be acquired
+
+    drop(s1g2);
+
+    let _s1g4 = Semaphore::new_acquired_by_time(client(), s1, 2, "id14", secs(3)).await?;
+
+    Ok(())
+}


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-client-semaphore): generate semaphore sequence using timestamps to reduce conflicts

### Context:

Previously, the semaphore sequence (`seq`) generation relied on a
generator key in the meta-service. This approach required a
compare-and-swap (CAS) loop, where:
1. A `seq` was generated from the generator key.
2. The semaphore permit key (derived from the `seq`) was inserted into
   the meta-service, before the generator key is updated again by other
   processes.

Under high concurrency, this method caused frequent conflicts during the
CAS loop, leading to repeated retries and increased latency.

### Changes:

- Replaced the existing sequence generation logic with a timestamp-based
  policy.
- The new approach directly uses the current timestamp as the `seq`
  value and attempts to insert it into the meta-service.
- If a duplicate key conflict occurs (e.g., due to concurrent requests),
  the process retries. However, the conflict rate is significantly
  reduced, as timestamp values are less likely to collide.

### Benefits:

- Drastically reduces the conflict rate during semaphore sequence
  generation, especially under high-concurrency scenarios.
- Most requests now require only a single RPC to insert the permit,
  minimizing latency.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17878)
<!-- Reviewable:end -->
