### PR TITLE
fix(query): sort will still be OOM even if spill is enabled

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
@@ -199,6 +199,10 @@ where
         let unit_size = self.memory_settings.spill_unit_size;
         let num_merge = bytes.div_ceil(unit_size).max(2);
         let batch_rows = rows.div_ceil(num_merge);
+
+        /// The memory will be doubled during merging.
+        const MERGE_RATIO: usize = 2;
+        let num_merge = num_merge.div_ceil(MERGE_RATIO).max(2);
         log::info!("determine sort spill params, buffer_bytes: {bytes}, buffer_rows: {rows}, spill_unit_size: {unit_size}, batch_rows: {batch_rows}, batch_num_merge {num_merge}");
         SortSpillParams {
             batch_rows,
@@ -459,7 +463,9 @@ where
                         .await?;
                 }
                 if input > max || finished && input > 0 {
-                    spill_sort.sort_input_data(std::mem::take(input_data), &self.aborting)?;
+                    spill_sort
+                        .sort_input_data(std::mem::take(input_data), &self.aborting)
+                        .await?;
                 }
                 if finished {
                     self.state = State::Sort;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -605,6 +605,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=100)),
                 }),
+                ("sort_spilling_to_disk_bytes_limit", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Sets the maximum amount of local disk in bytes that sorter can use before spilling data to storage during one query execution.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
                 ("sort_spilling_batch_bytes", DefaultSettingValue {
                     value: UserSettingValue::UInt64(8 * 1024 * 1024),
                     desc: "Sets the uncompressed size that merge sorter will spill to storage",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -490,6 +490,10 @@ impl Settings {
         Ok(self.try_get_u64("sort_spilling_memory_ratio")? as usize)
     }
 
+    pub fn get_sort_spilling_to_disk_bytes_limit(&self) -> Result<usize> {
+        Ok(self.try_get_u64("sort_spilling_to_disk_bytes_limit")? as usize)
+    }
+
     pub fn get_group_by_shuffle_mode(&self) -> Result<String> {
         self.try_get_string("group_by_shuffle_mode")
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. Reduce num_merge .
2. The `sort_input_data` will spill blocks earlier. 
3. Add configuration `sort_spilling_to_disk_bytes_limit` to allow sort spill to local .

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17883)
<!-- Reviewable:end -->
