### PR TITLE
chore: remove useless logic test on `explain_ngram_index.test`

### DIFF
--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_ngram_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_ngram_index.test
@@ -104,24 +104,6 @@ Filter
     └── estimated rows: 16.00
 
 query T
-EXPLAIN SELECT id, content FROM t1 WHERE content LIKE 'A picture%'
-----
-Filter
-├── output columns: [t1.id (#0), t1.content (#1)]
-├── filters: [is_true(t1.content (#1) >= 'A picture'), is_true(t1.content (#1) < 'A picturf')]
-├── estimated rows: 3.20
-└── TableScan
-    ├── table: default.test_ngram_index_db.t1
-    ├── output columns: [id (#0), content (#1)]
-    ├── read rows: 2
-    ├── read size: < 1 KiB
-    ├── partitions total: 8
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 8 to 1>]
-    ├── push downs: [filters: [and_filters(t1.content (#1) >= 'A picture', t1.content (#1) < 'A picturf')], limit: NONE]
-    └── estimated rows: 16.00
-
-query T
 EXPLAIN SELECT id, content FROM t1 WHERE content LIKE '%风来%'
 ----
 Filter
@@ -217,21 +199,6 @@ TableScan
 ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 8 to 8, bloom pruning: 8 to 1>]
 ├── push downs: [filters: [is_true(like(t2.content (#1), '%your eggs'))], limit: NONE]
 └── estimated rows: 0.03
-
-query T
-EXPLAIN SELECT id, content FROM t2 WHERE content LIKE 'A picture%'
-----
-TableScan
-├── table: default.test_ngram_index_db.t2
-├── output columns: [id (#0), content (#1)]
-├── read rows: 2
-├── read size: < 1 KiB
-├── partitions total: 8
-├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 8 to 1>]
-├── push downs: [filters: [and_filters(t2.content (#1) >= 'A picture', t2.content (#1) < 'A picturf')], limit: NONE]
-└── estimated rows: 3.20
-
 
 query T
 SELECT id, content FROM t1 WHERE content LIKE '%your eggs%'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix the issue that ci fails after merging https://github.com/databendlabs/databend/pull/17852

The error is caused by the row number estimation problem of the SQL statement `EXPLAIN SELECT id, content FROM t1 WHERE content LIKE 'A picture%'`, which is affected by https://github.com/databendlabs/databend/pull/17873 (Affects the results of `SelectivityEstimator::compute_binary_comparison_selectivity`)
This SQL statement will be rewritten as `EXPLAIN SELECT id, content FROM t1 WHERE content content >= 'A picture' and content < 'A picturf'`this test has nothing to do with ngram index.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17887)
<!-- Reviewable:end -->
