### PR TITLE
chore(query): auto cast int to string for concat functions

### DIFF
--- a/src/query/functions/src/cast_rules.rs
+++ b/src/query/functions/src/cast_rules.rs
@@ -378,6 +378,6 @@ pub const CAST_INT_TO_UINT64: AutoCastRules = &[
 pub fn get_cast_int_to_string_rules() -> Vec<(DataType, DataType)> {
     ALL_NUMERICS_TYPES
         .iter()
-        .map(|ty| (DataType::Number(ty.clone()), DataType::String))
+        .map(|ty| (DataType::Number(*ty), DataType::String))
         .collect()
 }

--- a/src/query/functions/src/cast_rules.rs
+++ b/src/query/functions/src/cast_rules.rs
@@ -49,7 +49,15 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     for func_name in ALL_STRING_FUNC_NAMES {
         registry.register_additional_cast_rules(func_name, GENERAL_CAST_RULES.iter().cloned());
-        registry.register_additional_cast_rules(func_name, CAST_FROM_STRING_RULES.iter().cloned());
+        if ["concat", "concat_ws"].contains(func_name) {
+            registry.register_additional_cast_rules(
+                func_name,
+                get_cast_int_to_string_rules().into_iter(),
+            )
+        } else {
+            registry
+                .register_additional_cast_rules(func_name, CAST_FROM_STRING_RULES.iter().cloned());
+        }
         registry.register_additional_cast_rules(func_name, CAST_FROM_VARIANT_RULES());
         registry.register_additional_cast_rules(func_name, CAST_INT_TO_UINT64.iter().cloned());
     }
@@ -366,3 +374,10 @@ pub const CAST_INT_TO_UINT64: AutoCastRules = &[
         DataType::Number(NumberDataType::UInt64),
     ),
 ];
+
+pub fn get_cast_int_to_string_rules() -> Vec<(DataType, DataType)> {
+    ALL_NUMERICS_TYPES
+        .iter()
+        .map(|ty| (DataType::Number(ty.clone()), DataType::String))
+        .collect()
+}

--- a/src/query/functions/tests/it/scalars/array.rs
+++ b/src/query/functions/tests/it/scalars/array.rs
@@ -38,7 +38,7 @@ fn test_array() {
     test_array_append(file);
     test_array_indexof(file);
     test_array_unique(file);
-    test_array_distinct(file);
+    test_array_distinct_intersection(file);
     test_array_sum(file);
     test_array_avg(file);
     test_array_count(file);
@@ -316,7 +316,7 @@ fn test_array_unique(file: &mut impl Write) {
     ]);
 }
 
-fn test_array_distinct(file: &mut impl Write) {
+fn test_array_distinct_intersection(file: &mut impl Write) {
     run_ast(file, "array_distinct([])", &[]);
     run_ast(file, "array_distinct([1, 1, 2, 2, 3, NULL])", &[]);
     run_ast(
@@ -331,6 +331,12 @@ fn test_array_distinct(file: &mut impl Write) {
         ("c", Int16Type::from_data(vec![3i16, 1, 3, 4])),
         ("d", Int16Type::from_data(vec![4i16, 2, 3, 4])),
     ]);
+
+    run_ast(
+        file,
+        "array_intersection(['a', NULL, 'a', 'b', NULL, 'c', 'd'], ['a', 'd'])",
+        &[],
+    );
 }
 
 fn test_array_sum(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/string.rs
+++ b/src/query/functions/tests/it/scalars/string.rs
@@ -373,6 +373,7 @@ fn test_trim(file: &mut impl Write) {
 }
 
 fn test_concat(file: &mut impl Write) {
+    run_ast(file, "concat('5', 3, 4)", &[]);
     run_ast(file, "concat('5', '3', '4')", &[]);
     run_ast(file, "concat(NULL, '3', '4')", &[]);
     run_ast(

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -1206,6 +1206,15 @@ evaluation (internal):
 +--------+--------------------------------------------------------------------------------------+
 
 
+ast            : array_intersection(['a', NULL, 'a', 'b', NULL, 'c', 'd'], ['a', 'd'])
+raw expr       : array_intersection(array('a', NULL, 'a', 'b', NULL, 'c', 'd'), array('a', 'd'))
+checked expr   : array_intersection<T0=String NULL><Array(T0), Array(T0)>(array<T0=String NULL><T0, T0, T0, T0, T0, T0, T0>(CAST<String>("a" AS String NULL), CAST<NULL>(NULL AS String NULL), CAST<String>("a" AS String NULL), CAST<String>("b" AS String NULL), CAST<NULL>(NULL AS String NULL), CAST<String>("c" AS String NULL), CAST<String>("d" AS String NULL)), CAST<Array(String)>(array<T0=String><T0, T0>("a", "d") AS Array(String NULL)))
+optimized expr : ['a', 'd']
+output type    : Array(String NULL)
+output domain  : [{"a"..="d"}]
+output         : ['a', 'd']
+
+
 ast            : array_sum([])
 raw expr       : array_sum(array())
 checked expr   : array_sum<Array(Nothing)>(array<>())

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -155,6 +155,8 @@ Functions overloads:
 0 array_indexof(NULL, NULL) :: NULL
 1 array_indexof(Array(T0), T0) :: UInt64
 2 array_indexof(Array(T0) NULL, T0 NULL) :: UInt64 NULL
+0 array_intersection(Array(T0), Array(T0)) :: Array(T0)
+1 array_intersection(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
 0 array_kurtosis FACTORY
 0 array_max FACTORY
 0 array_median FACTORY

--- a/src/query/functions/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions/tests/it/scalars/testdata/string.txt
@@ -1858,6 +1858,15 @@ evaluation (internal):
 +--------+----------------------------+
 
 
+ast            : concat('5', 3, 4)
+raw expr       : concat('5', 3, 4)
+checked expr   : concat<String, String, String>("5", CAST<UInt8>(3_u8 AS String), CAST<UInt8>(4_u8 AS String))
+optimized expr : "534"
+output type    : String
+output domain  : {"534"..="534"}
+output         : '534'
+
+
 ast            : concat('5', '3', '4')
 raw expr       : concat('5', '3', '4')
 checked expr   : concat<String, String, String>("5", "3", "4")

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0003_ddl_create_add_computed_column.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0003_ddl_create_add_computed_column.test
@@ -87,7 +87,7 @@ alter table t2 modify column b drop stored
 statement ok
 create table t3(a string, b string as (concat(a, '-')) stored)
 
-statement error 1117
+statement ok
 alter table t3 modify column a float
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


1. auto cast int to string for concat functions
2. add `array_intersection` function which outputs array with element both in arg0 and arg1.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17891)
<!-- Reviewable:end -->
