### PR TITLE
refactor(query): Optimize `FLATTEN` function with filter condition

### DIFF
--- a/src/query/functions/src/srfs/variant.rs
+++ b/src/query/functions/src/srfs/variant.rs
@@ -768,7 +768,11 @@ impl FlattenGenerator {
     ) {
         if let Ok(Some(vals)) = input.array_values() {
             for (i, val) in vals.into_iter().enumerate() {
-                let inner_path = format!("{}[{}]", path, i);
+                let inner_path = if path_builder.is_some() {
+                    format!("{}[{}]", path, i)
+                } else {
+                    "".to_string()
+                };
 
                 if let Some(key_builder) = key_builder {
                     key_builder.push_null();
@@ -822,10 +826,14 @@ impl FlattenGenerator {
                 if let Some(key_builder) = key_builder {
                     key_builder.push(key.as_ref());
                 }
-                let inner_path = if !path.is_empty() {
-                    format!("{}.{}", path, key)
+                let inner_path = if path_builder.is_some() {
+                    if !path.is_empty() {
+                        format!("{}.{}", path, key)
+                    } else {
+                        key
+                    }
                 } else {
-                    key
+                    "".to_string()
                 };
                 if let Some(path_builder) = path_builder {
                     path_builder.put_and_commit(&inner_path);

--- a/src/query/sql/src/executor/physical_plans/physical_eval_scalar.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_eval_scalar.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -21,16 +22,22 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::RemoteExpr;
+use databend_common_expression::Scalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
 use crate::executor::explain::PlanStatsInfo;
 use crate::executor::physical_plan::PhysicalPlan;
 use crate::executor::physical_plan_builder::PhysicalPlanBuilder;
+use crate::optimizer::ir::Matcher;
 use crate::optimizer::ir::SExpr;
+use crate::plans::Filter;
 use crate::plans::FunctionCall;
 use crate::plans::ProjectSet;
+use crate::plans::RelOp;
 use crate::plans::RelOperator;
 use crate::plans::ScalarExpr;
+use crate::plans::ScalarItem;
+use crate::plans::Visitor;
 use crate::ColumnSet;
 use crate::IndexType;
 use crate::TypeCheck;
@@ -99,15 +106,12 @@ impl PhysicalPlanBuilder {
             self.build(s_expr.child(0)?, required).await
         } else {
             let child = s_expr.child(0)?;
-            let input = if let RelOperator::ProjectSet(project_set) = child.plan() {
-                let new_project_set =
-                    self.prune_flatten_columns(eval_scalar, project_set, &required);
-                let mut new_child = child.clone();
-                new_child.plan = Arc::new(new_project_set.into());
-                self.build(&new_child, required).await?
-            } else {
-                self.build(child, required).await?
-            };
+            let input =
+                if let Some(new_child) = self.try_eliminate_flatten_columns(&used, child)? {
+                    self.build(&new_child, required).await?
+                } else {
+                    self.build(child, required).await?
+                };
 
             let column_projections: HashSet<usize> = column_projections
                 .union(self.metadata.read().get_retained_column())
@@ -171,45 +175,136 @@ impl PhysicalPlanBuilder {
         }))
     }
 
-    // The flatten function returns a tuple, which contains 6 columns.
-    // Only keep columns required by parent plan, other columns can be pruned
-    // to reduce the memory usage.
-    fn prune_flatten_columns(
+    fn try_eliminate_flatten_columns(
         &mut self,
-        eval_scalar: &crate::plans::EvalScalar,
+        scalar_items: &Vec<ScalarItem>,
+        s_expr: &SExpr,
+    ) -> Result<Option<SExpr>> {
+        // (1) ProjectSet
+        //      \
+        //       *
+        //
+        // (2) Filter
+        //      \
+        //       ProjectSet
+        //        \
+        //         *
+        let matchers = vec![
+            Matcher::MatchOp {
+                op_type: RelOp::ProjectSet,
+                children: vec![Matcher::Leaf],
+            },
+            Matcher::MatchOp {
+                op_type: RelOp::Filter,
+                children: vec![Matcher::MatchOp {
+                    op_type: RelOp::ProjectSet,
+                    children: vec![Matcher::Leaf],
+                }],
+            },
+        ];
+
+        let mut matched = false;
+        for matcher in matchers {
+            if matcher.matches(s_expr) {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            return Ok(None);
+        }
+
+        if let RelOperator::Filter(filter) = s_expr.plan() {
+            let child = s_expr.child(0)?;
+            let project_set: ProjectSet = child.plan().clone().try_into()?;
+            let Some(new_project_set) =
+                self.eliminate_flatten_columns(scalar_items, Some(filter), &project_set)
+            else {
+                return Ok(None);
+            };
+            let mut new_child = child.clone();
+            new_child.plan = Arc::new(new_project_set.into());
+            let new_filter =
+                SExpr::create_unary(Arc::new(s_expr.plan().clone()), Arc::new(new_child));
+            Ok(Some(new_filter))
+        } else {
+            let project_set: ProjectSet = s_expr.plan().clone().try_into()?;
+            let Some(new_project_set) =
+                self.eliminate_flatten_columns(scalar_items, None, &project_set)
+            else {
+                return Ok(None);
+            };
+            let mut new_expr = s_expr.clone();
+            new_expr.plan = Arc::new(new_project_set.into());
+            Ok(Some(new_expr))
+        }
+    }
+
+    // The flatten function returns a tuple, which contains 6 columns.
+    // Only keep columns required by parent plan, other columns can be eliminated
+    // to reduce the memory usage.
+    fn eliminate_flatten_columns(
+        &mut self,
+        scalar_items: &Vec<ScalarItem>,
+        filter: Option<&Filter>,
         project_set: &ProjectSet,
-        required: &ColumnSet,
-    ) -> ProjectSet {
+    ) -> Option<ProjectSet> {
+        let mut has_flatten = false;
         let mut project_set = project_set.clone();
         for srf_item in &mut project_set.srfs {
             if let ScalarExpr::FunctionCall(srf_func) = &srf_item.scalar {
                 if srf_func.func_name == "flatten" {
-                    // Store the columns required by the parent plan in params.
-                    let mut params = Vec::new();
-                    for item in &eval_scalar.items {
-                        if !required.contains(&item.index) {
-                            continue;
-                        }
-                        if let ScalarExpr::FunctionCall(func) = &item.scalar {
-                            if func.func_name == "get" && !func.arguments.is_empty() {
-                                if let ScalarExpr::BoundColumnRef(column_ref) = &func.arguments[0] {
-                                    if column_ref.column.index == srf_item.index {
-                                        params.push(func.params[0].clone());
-                                    }
-                                }
-                            }
+                    has_flatten = true;
+                    let mut visitor = FlattenColumnsVisitor {
+                        params: BTreeSet::new(),
+                        column_index: srf_item.index,
+                    };
+                    // Collect columns required by the parent plan in params.
+                    for item in scalar_items {
+                        visitor.visit(&item.scalar).unwrap();
+                    }
+                    if let Some(filter) = filter {
+                        for pred in &filter.predicates {
+                            visitor.visit(pred).unwrap();
                         }
                     }
 
                     srf_item.scalar = ScalarExpr::FunctionCall(FunctionCall {
                         span: srf_func.span,
                         func_name: srf_func.func_name.clone(),
-                        params,
+                        params: visitor.params.into_iter().collect::<Vec<_>>(),
                         arguments: srf_func.arguments.clone(),
                     });
                 }
             }
         }
-        project_set
+        if has_flatten {
+            Some(project_set)
+        } else {
+            None
+        }
+    }
+}
+
+struct FlattenColumnsVisitor {
+    params: BTreeSet<Scalar>,
+    column_index: IndexType,
+}
+
+impl<'a> Visitor<'a> for FlattenColumnsVisitor {
+    // Collect the params in get function which is used to extract the inner column of flatten function.
+    fn visit_function_call(&mut self, func: &'a FunctionCall) -> Result<()> {
+        if func.func_name == "get" && !func.arguments.is_empty() {
+            if let ScalarExpr::BoundColumnRef(column_ref) = &func.arguments[0] {
+                if column_ref.column.index == self.column_index {
+                    self.params.insert(func.params[0].clone());
+                    return Ok(());
+                }
+            }
+        }
+        for expr in &func.arguments {
+            self.visit(expr)?;
+        }
+        Ok(())
     }
 }

--- a/src/query/sql/src/executor/physical_plans/physical_eval_scalar.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_eval_scalar.rs
@@ -106,12 +106,11 @@ impl PhysicalPlanBuilder {
             self.build(s_expr.child(0)?, required).await
         } else {
             let child = s_expr.child(0)?;
-            let input =
-                if let Some(new_child) = self.try_eliminate_flatten_columns(&used, child)? {
-                    self.build(&new_child, required).await?
-                } else {
-                    self.build(child, required).await?
-                };
+            let input = if let Some(new_child) = self.try_eliminate_flatten_columns(&used, child)? {
+                self.build(&new_child, required).await?
+            } else {
+                self.build(child, required).await?
+            };
 
             let column_projections: HashSet<usize> = column_projections
                 .union(self.metadata.read().get_retained_column())

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -111,6 +111,31 @@ EvalScalar
         └── estimated rows: 0.00
 
 query T
+EXPLAIN SELECT t.a, f.seq, f.value FROM t, LATERAL FLATTEN(input => t.b) f where f.key = 'k'
+----
+EvalScalar
+├── output columns: [t.a (#0), seq (#3), value (#7)]
+├── expressions: [get(1)(flatten(t.b (#1)) (#2)), get(5)(flatten(t.b (#1)) (#2))]
+├── estimated rows: 0.00
+└── Filter
+    ├── output columns: [t.a (#0), flatten(t.b (#1)) (#2)]
+    ├── filters: [is_true(get(2)(flatten(t.b (#1)) (#2)) = 'k')]
+    ├── estimated rows: 0.00
+    └── ProjectSet
+        ├── output columns: [t.a (#0), flatten(t.b (#1)) (#2)]
+        ├── estimated rows: 0.00
+        ├── set returning functions: flatten(1, 2, 5)(t.b (#1))
+        └── TableScan
+            ├── table: default.project_set.t
+            ├── output columns: [a (#0), b (#1)]
+            ├── read rows: 0
+            ├── read size: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
+
+query T
 EXPLAIN SELECT json_each(t.b), unnest(t.b) FROM t
 ----
 EvalScalar

--- a/tests/sqllogictests/suites/query/lateral.test
+++ b/tests/sqllogictests/suites/query/lateral.test
@@ -127,6 +127,13 @@ running 1
 swimming 1
 writing 1
 
+query ITT
+SELECT u.user_id, f.value::STRING, f.path AS activity FROM
+    user_activities u,
+    LATERAL FLATTEN(input => u.activities) f WHERE f.value = 'reading'
+----
+1 reading [0]
+
 statement ok
 CREATE TABLE persons(id int, c variant)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR enhances the performance of the `FLATTEN` function in Databend, specifically addressing the issue of potential Out-of-Memory (OOM) errors caused by data replication.

**Background:**

The `FLATTEN` function is a set-returning function that transforms nested JSON data into a tabular format. It generates six new columns: `seq`, `key`, `path`, `index`, `value`, and `this`. The `this` column contains the original JSON data. Due to the nature of set-returning functions, the number of rows can significantly increase, leading to substantial data duplication in the `this` column and potential OOM issues.

PR #13935 introduced column pruning for `FLATTEN`, which avoids generating data for columns not explicitly selected by the user. However, this optimization was bypassed when the SQL query included filter conditions.

**This PR's Contribution:**

This PR introduces filter condition matching to the `FLATTEN` function. Now, even when the SQL query contains filter statements, the column pruning optimization will still be applied. This means that the `this` column (and other unneeded columns) will not be populated with redundant data, even when filters are present, significantly reducing memory usage and improving query performance.

**Benefits:**

*   **Reduced Memory Consumption:** By applying column pruning even with filters, this PR minimizes data replication and reduces the risk of OOM errors.
*   **Improved Query Performance:** Less data to process translates to faster query execution times.

**Verification:**

We can verify the effectiveness of this optimization by using the `EXPLAIN` command. The output of `flatten` function have params to identify the columns that generated data. Params and columns have the following mapping relation.

| param | column |
| ----- | ------ |
| 1     | seq    |
| 2     | key    |
| 3     | path   |
| 4     | index  |
| 5     | value  |
| 6     | this   |


**Example:**
```sql
CREATE TABLE persons(id int, c variant);

INSERT INTO persons (id, c) VALUES
    (12712555, '{"name":{"first":"John","last":"Smith"},"contact":[{"business":[{"type":"phone","content":"555-1234"},{"type":"email","content":"j.smith@company.com"}]}]}'),
    (98127771, '{"name":{"first":"Jane","last":"Doe"},"contact":[{"business":[{"type":"phone","content":"555-1236"},{"type":"email","content":"j.doe@company.com"}]}]}');

SELECT p.id, f.key, f.path, f.value FROM persons p, LATERAL FLATTEN(input => p.c) f WHERE key = 'name';
╭─────────────────────────────────────────────────────────────────────────────────────────╮
│        id       │        key       │       path       │              value              │
│ Nullable(Int32) │ Nullable(String) │ Nullable(String) │        Nullable(Variant)        │
├─────────────────┼──────────────────┼──────────────────┼─────────────────────────────────┤
│        12712555 │ name             │ name             │ {"first":"John","last":"Smith"} │
│        98127771 │ name             │ name             │ {"first":"Jane","last":"Doe"}   │
╰─────────────────────────────────────────────────────────────────────────────────────────╯

EXPLAIN SELECT p.id, f.key, f.path, f.value FROM persons p, LATERAL FLATTEN(input => p.c) f WHERE key = 'name';
-[ EXPLAIN ]-----------------------------------
EvalScalar
├── output columns: [p.id (#0), key (#10), path (#11), value (#13)]
├── expressions: [get(2)(flatten(p.c (#1)) (#8)), get(3)(flatten(p.c (#1)) (#8)), get(5)(flatten(p.c (#1)) (#8))]
├── estimated rows: 1.20
└── Filter
    ├── output columns: [p.id (#0), flatten(p.c (#1)) (#8)]
    ├── filters: [is_true(get(2)(flatten(p.c (#1)) (#8)) = 'name')]
    ├── estimated rows: 1.20
    └── ProjectSet
        ├── output columns: [p.id (#0), flatten(p.c (#1)) (#8)]
        ├── estimated rows: 6.00
        ├── set returning functions: flatten(2, 3, 5)(p.c (#1))
        └── TableScan
            ├── table: default.default.persons
            ├── output columns: [id (#0), c (#1)]
            ├── read rows: 2
            ├── read size: < 1 KiB
            ├── partitions total: 1
            ├── partitions scanned: 1
            ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
            ├── push downs: [filters: [], limit: NONE]
            └── estimated rows: 2.00
```


- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17892)
<!-- Reviewable:end -->
