### PR TITLE
feat: new settings `data_retention_num_snapshots_to_keep`

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -193,6 +193,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=data_retention_time_in_days_max)),
                 }),
+                ("data_retention_num_snapshots_to_keep", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Specifies how many snapshots to retain during vacuum operations. Overrides 'data_retention_time_in_days'. If set to 0, this setting will be ignored.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=500)),
+                }),
                 ("max_spill_io_requests", DefaultSettingValue {
                     value: UserSettingValue::UInt64(default_max_spill_io_requests),
                     desc: "Sets the maximum number of concurrent spill I/O requests.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -234,6 +234,10 @@ impl Settings {
         self.try_get_u64("data_retention_time_in_days")
     }
 
+    pub fn get_data_retention_num_snapshots_to_keep(&self) -> Result<u64> {
+        self.try_get_u64("data_retention_num_snapshots_to_keep")
+    }
+
     pub fn get_max_storage_io_requests(&self) -> Result<u64> {
         self.try_get_u64("max_storage_io_requests")
     }

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0007_setting_num_snapshot_to_keep.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0007_setting_num_snapshot_to_keep.test
@@ -1,0 +1,73 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+create or replace database setting_num_snapshot_to_keep;
+
+statement ok
+use  setting_num_snapshot_to_keep;
+
+statement ok
+create or replace table t (c int) 'fs:///tmp/setting_num_snapshot_to_keep/';
+
+statement ok
+create or replace stage stage_av url = 'fs:///tmp/setting_num_snapshot_to_keep/';
+
+# Enable auto vacuum
+statement ok
+set enable_auto_vacuum = 1;
+
+# CASE1: Setting `data_retention_num_snapshots_to_keep` overrides 'data_retention_time_in_days'
+
+statement ok
+set data_retention_time_in_days = 2;
+
+statement ok
+set data_retention_num_snapshots_to_keep = 1;
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(2);
+
+onlyif mysql
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
+----
+1
+
+# CASE 2: Set  `data_retention_num_snapshots_to_keep` to 0 will make it effectless
+
+statement ok
+set data_retention_num_snapshots_to_keep = 0;
+
+statement ok
+insert into t values(1);
+
+statement ok
+insert into t values(2);
+
+onlyif mysql
+query I
+select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
+----
+3
+
+statement ok
+remove @stage_av;
+
+statement ok
+drop stage stage_av;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Adds new settings `data_retention_num_snapshots_to_keep`, which specifies how many snapshots to retain during vacuum operations.
- Overrides setting 'data_retention_time_in_days'
- If set to 0, this setting will be ignored


Docs of this new setting (and new table option of https://github.com/databendlabs/databend/pull/17884) will be updated in another PR.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17893)
<!-- Reviewable:end -->
