### PR TITLE
feat(meta-service): add initialization complete flag for watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16202,8 +16202,8 @@ dependencies = [
 
 [[package]]
 name = "watcher"
-version = "0.2.0"
-source = "git+https://github.com/databendlabs/watcher?tag=v0.2.0#7bff8b42604a95ddda90fe42f329f1b72a526f06"
+version = "0.4.0"
+source = "git+https://github.com/databendlabs/watcher?tag=v0.4.0#a550d7cb0ac809cf719d55b4c4984aafb78f88e8"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,7 +524,7 @@ url = "2.5.4"
 uuid = { version = "1.10.0", features = ["std", "serde", "v4", "v7"] }
 volo-thrift = "0.10"
 walkdir = "2.3.2"
-watcher = { version = "0.2.0" }
+watcher = { version = "0.4.0" }
 wiremock = "0.6"
 wkt = "0.11.1"
 xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }
@@ -648,5 +648,5 @@ sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafus
 tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370" }
 tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370", package = "tantivy-common" }
 tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "0e300e9" }
-watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.2.0" }
+watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.4.0" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }

--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -79,26 +79,21 @@ The following is an illustration of the latest query-meta compatibility:
 `[, a.b.c)` denotes the range of versions from previous version(on the left column)(inclusive)
 upto `a.b.c` (exclusive).
 
-TODO: xx is the version in which semaphore is added. update it when merged.
 
-| `Meta\Query`       | 1.1.34) | [, 1.2.287) | [, 1.2.361) | [, xx) | [, +∞)           |
-|:-------------------|:--------|:------------|:------------|:-------|:-----------------|
-| [0.8.30, 0.8.35)   |         | ❌           | ❌           | ❌      | ❌                |
-| [0.8.35, 0.9.23)   |         | ❌           | ❌           | ❌      | ❌                |
-| [0.9.23, 0.9.42)   |         | ❌           | ❌           | ❌      | ❌                |
-| [0.9.42, 1.1.32)   |         | ❌           | ❌           | ❌      | ❌                |
-| [1.1.32, 1.2.63)   |         | ✅           | ❌           | ❌      | ❌                |
-| [1.2.63, 1.2.226)  |         | ✅           | ❌           | ❌      | ❌                |
-| [1.2.226, 1.2.258) |         | ✅           | ✅           | ❌      | ❌                |
-| [1.2.258, 1.2.663) |         | ✅           | ✅           | ✅      | ✅(no semaphore)  |
-| [1.2.663, 1.2.677) |         | ❌           | ✅           | ✅      | ✅(no semaphore)  |
-| [1.2.677, +∞)      |         | ❌           | ✅           | ✅      | ✅                |
+| `Meta\Query`       | 1.2.287) | [, 1.2.361) | [, 1.2.715) | [, 1.2.726)      | [, +∞) |
+|:-------------------|:---------|:------------|:------------|:-----------------|:-------|
+| [1.2.63, 1.2.226)  |          | ❌           | ❌            | ❌                | ❌      |
+| [1.2.226, 1.2.258) |          | ✅           | ❌            | ❌                | ❌      |
+| [1.2.258, 1.2.663) |          | ✅           | ✅            | ✅(no semaphore)  | ❌      |
+| [1.2.663, 1.2.677) |          | ✅           | ✅            | ✅(no semaphore)  | ❌      |
+| [1.2.677, +∞)      |          | ✅           | ✅            | ✅                | ✅      |
 
 History versions that are not included in the above chart:
 
 - Query `[0.7.59, 0.8.80)` is compatible with Meta `[0.8.30, 0.9.23)`.
 - Query `[0.8.80, 0.9.41)` is compatible with Meta `[0.8.35, 0.9.42)`.
 - Query `[0.9.41, 1.1.34)` is compatible with Meta `[0.8.35, 1.2.663)`.
+- Query `[1.1.34, 1.2.287)` is compatible with Meta `[1.1.32, 1.2.63)`.
 
 
 ## Compatibility between databend-meta

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -134,8 +134,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 ///   👥 client: semaphore(watch) requires `WatchRequest::initial_flush`(`1,2.677`),
 ///   other RPC does not require `1.2.677`, requires only `1.2.259`.
 ///
-/// - 2025-04-15: since TODO: add version when merged.
+/// - 2025-04-15: since 1.2.726
 ///   👥 client: requires `1,2.677`.
+///
+/// - 2025-05-08: since TODO: add version when merged.
+///   🖥 server: add `WatchResponse::is_initialization`,
 ///
 ///
 /// Server feature set:

--- a/src/meta/semaphore/src/meta_event_subscriber/processor.rs
+++ b/src/meta/semaphore/src/meta_event_subscriber/processor.rs
@@ -225,7 +225,7 @@ mod tests {
         let prev = PermitEntry::new("a", 1);
         let current = PermitEntry::new("b", 2);
 
-        let watch_response = WatchResponse::new3(
+        let watch_response = WatchResponse::new_change_event(
             sem_key.format_key(),
             Some(SeqV::new(1, prev.encode_to_vec()?)),
             Some(SeqV::new(2, current.encode_to_vec()?)),

--- a/src/meta/service/src/meta_service/watcher.rs
+++ b/src/meta/service/src/meta_service/watcher.rs
@@ -28,7 +28,9 @@ use tonic::Status;
 use watcher::dispatch::Command;
 use watcher::dispatch::DispatcherHandle as GenericDispatcherHandle;
 use watcher::type_config::KVChange;
+use watcher::type_config::KeyOf;
 use watcher::type_config::TypeConfig;
+use watcher::type_config::ValueOf;
 
 use crate::metrics::server_metrics;
 
@@ -42,8 +44,12 @@ impl TypeConfig for WatchTypes {
     type Response = WatchResponse;
     type Error = Status;
 
-    fn new_response(change: KVChange<Self>) -> Self::Response {
-        WatchResponse::new3(change.0, change.1, change.2)
+    fn new_initialize_response(key: KeyOf<Self>, value: ValueOf<Self>) -> Self::Response {
+        WatchResponse::new_initialization_event(key, value)
+    }
+
+    fn new_change_response(change: KVChange<Self>) -> Self::Response {
+        WatchResponse::new_change_event(change.0, change.1, change.2)
     }
 
     fn data_error(error: Error) -> Self::Error {

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -100,7 +100,24 @@ message Event {
   optional SeqV prev = 3;
 }
 
-message WatchResponse {Event event = 1;}
+// Response in a watch stream from server to the client.
+message WatchResponse {
+  // The event containing key-value change information or a value emitted during initial-flush.
+  // This includes the key, current value (if any), and previous value (if any).
+  Event event = 1;
+
+  // Indicates whether this event is part of the initialization.
+  // 
+  // When true:
+  // - The event represents an existing key-value record at the time the watch was established
+  // - These events are sent when initial_flush=true was specified in WatchRequest
+  // 
+  // When false:
+  // - The event represents a real-time change that occurred after the watch was established
+  // - A special event with no key-value data may be sent to indicate the completion
+  //   of the initial flush phase
+  bool is_initialization = 2;
+}
 
 // messages for txn
 message TxnCondition {

--- a/src/meta/types/src/proto_display/watch_display.rs
+++ b/src/meta/types/src/proto_display/watch_display.rs
@@ -34,7 +34,12 @@ impl fmt::Display for Event {
 
 impl fmt::Display for WatchResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.event.display())
+        let typ = if self.is_initialization {
+            "INIT"
+        } else {
+            "CHANGE"
+        };
+        write!(f, "{typ}:{}", self.event.display())
     }
 }
 
@@ -79,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_watch_response_display() {
-        let watch_response = WatchResponse {
+        let mut watch_response = WatchResponse {
             event: Some(Event {
                 key: "test_key".to_string(),
                 prev: Some(SeqV {
@@ -95,11 +100,24 @@ mod tests {
                     meta: None,
                 }),
             }),
+            is_initialization: false,
         };
-        assert_eq!(watch_response.to_string(), "(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+        assert_eq!(watch_response.to_string(), "CHANGE:(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
 
-        let watch_response = WatchResponse { event: None };
-        assert_eq!(watch_response.to_string(), "None");
+        watch_response.is_initialization = true;
+        assert_eq!(watch_response.to_string(), "INIT:(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+
+        let watch_response = WatchResponse {
+            event: None,
+            is_initialization: true,
+        };
+        assert_eq!(watch_response.to_string(), "INIT:None");
+
+        let watch_response = WatchResponse {
+            event: None,
+            is_initialization: false,
+        };
+        assert_eq!(watch_response.to_string(), "CHANGE:None");
     }
 
     #[test]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add initialization complete flag for watch

When a watch requires initialization flush, the server now sends a flag
message indicating when the initialization phase is completed.

With this flag, the `cache` module can determine whether data has been
fully initialized and is ready to serve, improving reliability of the
caching system.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17900)
<!-- Reviewable:end -->
