### PR TITLE
fix(storage): Move timeout layer before to ensure cancel safety

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -116,18 +116,8 @@ pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
 /// Please balance the performance and compile time.
 pub fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
     let ob = Operator::new(builder)?
-        // NOTE
-        //
-        // Magic happens here. We will add a layer upon original
-        // storage operator so that all underlying storage operations
-        // will send to storage runtime.
-        .layer(RuntimeLayer::new(GlobalIORuntime::instance()))
-        .finish();
-
-    // Make sure the http client has been updated.
-    ob.update_http_client(|_| HttpClient::with(StorageHttpClient::default()));
-
-    let mut op = ob
+        // Timeout layer is required to be the first layer so that internal
+        // futures can be cancelled safely when the timeout is reached.
         .layer({
             let retry_timeout = env::var("_DATABEND_INTERNAL_RETRY_TIMEOUT")
                 .ok()
@@ -153,6 +143,18 @@ pub fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
 
             timeout_layer
         })
+        // NOTE
+        //
+        // Magic happens here. We will add a layer upon original
+        // storage operator so that all underlying storage operations
+        // will send to storage runtime.
+        .layer(RuntimeLayer::new(GlobalIORuntime::instance()))
+        .finish();
+
+    // Make sure the http client has been updated.
+    ob.update_http_client(|_| HttpClient::with(StorageHttpClient::default()));
+
+    let mut op = ob
         // Add retry
         .layer(
             RetryLayer::new()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

**Move Timeout Layer Attachment to Ensure Cancel Safety and Reentrancy**

This PR adjusts the timing of when the timeout layer is added in the `build_operator` function (`src/common/storage/src/operator.rs`). The timeout layer is now attached earlier in the operator construction process.

**Key Points:**
- **Moved the timeout layer attachment:** The timeout layer is now added as the very first layer, before other layers are applied.
- **Reason:** The timeout layer requires its internal state to be cancel safe. By attaching it first, we ensure that all subsequent operations are protected, and that the operator remains reentrant after a timeout occurs.
- **Effect:** This change guarantees that when a timeout is triggered, the internal state can be safely cancelled and retried, improving the robustness and correctness of storage operations.

**Motivation:**  
Timeout layers must be cancel safe to support reentrancy after timeouts. Attaching the timeout layer first ensures this property is upheld, preventing potential issues with state consistency and retry logic.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17902)
<!-- Reviewable:end -->
