### PR TITLE
feat: Add new settings to choose use gloabl runtime for segements read 

### DIFF
--- a/src/common/base/src/runtime/mod.rs
+++ b/src/common/base/src/runtime/mod.rs
@@ -51,6 +51,7 @@ pub use runtime::try_spawn_blocking;
 pub use runtime::Dropper;
 pub use runtime::JoinHandle;
 pub use runtime::Runtime;
+pub use runtime::Semaphore;
 pub use runtime::TrySpawn;
 pub use runtime::GLOBAL_TASK;
 pub use runtime_tracker::LimitMemGuard;

--- a/src/common/base/src/runtime/runtime.rs
+++ b/src/common/base/src/runtime/runtime.rs
@@ -33,7 +33,7 @@ use tokio::runtime::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::sync::OwnedSemaphorePermit;
-use tokio::sync::Semaphore;
+pub use tokio::sync::Semaphore;
 
 use crate::runtime::catch_unwind::CatchUnwindFuture;
 use crate::runtime::drop_guard;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1263,6 +1263,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("fuse_segment_read_use_global_runtime", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Use global runtime for fuse segment read (0: independent runtime, 1: global runtime)",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("enable_optimizer_trace", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Enables optimizer trace.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -948,4 +948,8 @@ impl Settings {
     pub fn get_trace_sample_rate(&self) -> Result<u64> {
         self.try_get_u64("trace_sample_rate")
     }
+
+    pub fn get_fuse_segment_read_use_global_runtime(&self) -> Result<bool> {
+        Ok(self.try_get_u64("fuse_segment_read_use_global_runtime")? != 0)
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Feature: Configurable Runtime for Fuse Segment Read

This PR introduces a new setting to control whether fuse segment reads use the global runtime or an independent runtime, providing more flexibility and potential performance tuning for segment reading operations.

#### Key Changes

1. **New Setting Added**
    - **`fuse_segment_read_use_global_runtime`**:  
      - Type: `UInt64` (0 or 1, default 0)
      - Description: "Use global runtime for fuse segment read (0: independent runtime, 1: global runtime)"
      - Scope: Both user and system
      - Added to `DefaultSettings` and getter method in `Settings`.

2. **Fuse Segment Read Logic Updated**
    - In `SegmentsIO::read_segments`, the code now checks the new setting:
        - If enabled (`1`), segment read tasks are executed using the global IO runtime and a semaphore for concurrency control.
        - If disabled (`0`, default), the existing `execute_futures_in_parallel` logic is used.
    - This allows dynamic switching between runtime strategies without code changes.

3. **Re-exports and Imports**
    - Re-exported `Semaphore` from `tokio::sync` via `databend_common_base::runtime`.
    - Updated imports in relevant modules to support the new logic.

#### Motivation

- **Performance Tuning**: Some workloads may benefit from using the global IO runtime for segment reads, while others may prefer isolated runtimes.
- **Configurability**: Allows users and administrators to toggle this behavior at runtime via settings.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17903)
<!-- Reviewable:end -->
