### PR TITLE
fix: overflow error in get_partition_id()

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
@@ -215,7 +215,7 @@ impl HashJoinSpiller {
         } else {
             let mut hashes = self.get_hashes(data_block, join_type)?;
             for hash in hashes.iter_mut() {
-                *hash = Self::get_partition_id(*hash as usize, partition_bits) as u64;
+                *hash = Self::get_partition_id(*hash, partition_bits as u64);
             }
             let partition_blocks = DataBlock::scatter(data_block, &hashes, 1 << partition_bits)?;
             Ok(partition_blocks)
@@ -223,8 +223,8 @@ impl HashJoinSpiller {
     }
 
     #[inline(always)]
-    fn get_partition_id(hash: usize, bits: usize) -> usize {
-        (hash >> (32 - bits)) & ((1 << bits) - 1)
+    fn get_partition_id(hash: u64, bits: u64) -> u64 {
+        (hash >> (64 - bits)) & ((1 << bits) - 1)
     }
 
     // Get all hashes for build input data.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The value of `join_spilling_partition_bits` can be set from 0 to 64. The operation `hash >> (32 - bits)` may overflow, leading to a panic in debug mode and undefined behavior in release mode.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17906)
<!-- Reviewable:end -->
