### PR TITLE
feat(query): Support `fuse_virtual_column` function to show virtual column size

### DIFF
--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -30,6 +30,7 @@ use databend_common_storages_fuse::table_functions::FuseTimeTravelSizeFunc;
 use databend_common_storages_fuse::table_functions::FuseVacuumDropAggregatingIndex;
 use databend_common_storages_fuse::table_functions::FuseVacuumDropInvertedIndex;
 use databend_common_storages_fuse::table_functions::FuseVacuumTemporaryTable;
+use databend_common_storages_fuse::table_functions::FuseVirtualColumnFunc;
 use databend_common_storages_fuse::table_functions::SetCacheCapacity;
 use databend_common_storages_fuse::table_functions::TableFunctionTemplate;
 use databend_common_storages_iceberg::IcebergInspectTable;
@@ -188,6 +189,14 @@ impl TableFunctionFactory {
             (
                 next_id(),
                 Arc::new(TableFunctionTemplate::<FuseColumnFunc>::create),
+            ),
+        );
+
+        creators.insert(
+            "fuse_virtual_column".to_string(),
+            (
+                next_id(),
+                Arc::new(TableFunctionTemplate::<FuseVirtualColumnFunc>::create),
             ),
         );
 

--- a/src/query/storages/common/table_meta/src/meta/column_oriented_segment/block_meta.rs
+++ b/src/query/storages/common/table_meta/src/meta/column_oriented_segment/block_meta.rs
@@ -21,12 +21,15 @@ use super::ColumnOrientedSegment;
 use crate::meta::BlockMeta;
 use crate::meta::ColumnMeta;
 use crate::meta::ColumnMetaV0;
+use crate::meta::VirtualBlockMeta;
+
 pub trait AbstractBlockMeta: Send + Sync + 'static + Sized {
     fn block_size(&self) -> u64;
     fn file_size(&self) -> u64;
     fn row_count(&self) -> u64;
     fn location_path(&self) -> String;
     fn col_metas(&self, col_ids: &HashSet<ColumnId>) -> HashMap<ColumnId, ColumnMeta>;
+    fn virtual_block_meta(&self) -> Option<VirtualBlockMeta>;
 }
 
 impl AbstractBlockMeta for BlockMeta {
@@ -53,6 +56,10 @@ impl AbstractBlockMeta for BlockMeta {
 
     fn location_path(&self) -> String {
         self.location.0.to_string()
+    }
+
+    fn virtual_block_meta(&self) -> Option<VirtualBlockMeta> {
+        self.virtual_block_meta.clone()
     }
 }
 
@@ -97,6 +104,11 @@ impl AbstractBlockMeta for ColumnOrientedBlockMeta {
             .index(self.row_number)
             .unwrap()
             .to_string()
+    }
+
+    fn virtual_block_meta(&self) -> Option<VirtualBlockMeta> {
+        // TODO
+        None
     }
 }
 

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -222,12 +222,14 @@ impl BlockBuilder {
                 .as_ref()
                 .map(|v| v.size)
                 .unwrap_or_default(),
+            ngram_filter_index_size: bloom_index_state
+                .as_ref()
+                .map(|v| v.ngram_size)
+                .unwrap_or_default(),
             compression: self.write_settings.table_compression.into(),
             inverted_index_size,
             virtual_block_meta: None,
             create_on: Some(Utc::now()),
-            // TODO(kould): ngram index
-            ngram_filter_index_size: None,
         };
 
         let serialized = BlockSerialization {

--- a/src/query/storages/fuse/src/table_functions/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_block.rs
@@ -65,6 +65,14 @@ impl TableMetaFunc for FuseBlock {
                 "inverted_index_size",
                 TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::UInt64))),
             ),
+            TableField::new(
+                "ngram_index_size",
+                TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::UInt64))),
+            ),
+            TableField::new(
+                "virtual_column_size",
+                TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::UInt64))),
+            ),
         ])
     }
 
@@ -86,6 +94,8 @@ impl TableMetaFunc for FuseBlock {
         let mut bloom_filter_location = vec![];
         let mut bloom_filter_size = Vec::with_capacity(len);
         let mut inverted_index_size = Vec::with_capacity(len);
+        let mut ngram_index_size = Vec::with_capacity(len);
+        let mut virtual_column_size = Vec::with_capacity(len);
 
         let segments_io = SegmentsIO::create(ctx.clone(), tbl.operator.clone(), tbl.schema());
 
@@ -113,6 +123,13 @@ impl TableMetaFunc for FuseBlock {
                     );
                     bloom_filter_size.push(block.bloom_filter_index_size);
                     inverted_index_size.push(block.inverted_index_size);
+                    ngram_index_size.push(block.ngram_filter_index_size);
+                    virtual_column_size.push(
+                        block
+                            .virtual_block_meta
+                            .as_ref()
+                            .map(|m| m.virtual_column_size),
+                    );
 
                     row_num += 1;
                     if row_num >= limit {
@@ -156,6 +173,14 @@ impl TableMetaFunc for FuseBlock {
                 BlockEntry::new(
                     DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
                     Value::Column(UInt64Type::from_opt_data(inverted_index_size)),
+                ),
+                BlockEntry::new(
+                    DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
+                    Value::Column(UInt64Type::from_opt_data(ngram_index_size)),
+                ),
+                BlockEntry::new(
+                    DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
+                    Value::Column(UInt64Type::from_opt_data(virtual_column_size)),
                 ),
             ],
             row_num,

--- a/src/query/storages/fuse/src/table_functions/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segment.rs
@@ -57,6 +57,11 @@ impl TableMetaFunc for FuseSegment {
                 "bytes_compressed",
                 TableDataType::Number(NumberDataType::UInt64),
             ),
+            TableField::new("index_size", TableDataType::Number(NumberDataType::UInt64)),
+            TableField::new(
+                "virtual_block_count",
+                TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::UInt64))),
+            ),
         ])
     }
 
@@ -75,6 +80,8 @@ impl TableMetaFunc for FuseSegment {
         let mut row_count: Vec<u64> = Vec::with_capacity(len);
         let mut compressed: Vec<u64> = Vec::with_capacity(len);
         let mut uncompressed: Vec<u64> = Vec::with_capacity(len);
+        let mut index_size: Vec<u64> = Vec::with_capacity(len);
+        let mut virtual_block_count: Vec<Option<u64>> = Vec::with_capacity(len);
         let mut file_location: Vec<String> = Vec::with_capacity(len);
 
         let segments_io = SegmentsIO::create(ctx.clone(), tbl.operator.clone(), tbl.schema());
@@ -95,6 +102,8 @@ impl TableMetaFunc for FuseSegment {
                 row_count.push(segment.summary.row_count);
                 compressed.push(segment.summary.compressed_byte_size);
                 uncompressed.push(segment.summary.uncompressed_byte_size);
+                index_size.push(segment.summary.index_size);
+                virtual_block_count.push(segment.summary.virtual_block_count);
                 file_location.push(segment_locations[idx].0.clone());
 
                 row_num += 1;
@@ -116,6 +125,8 @@ impl TableMetaFunc for FuseSegment {
             UInt64Type::from_data(row_count),
             UInt64Type::from_data(uncompressed),
             UInt64Type::from_data(compressed),
+            UInt64Type::from_data(index_size),
+            UInt64Type::from_opt_data(virtual_block_count),
         ]))
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_virtual_column.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_virtual_column.rs
@@ -1,0 +1,219 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use databend_common_catalog::table::Table;
+use databend_common_exception::Result;
+use databend_common_expression::types::string::StringColumnBuilder;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::UInt32Type;
+use databend_common_expression::types::UInt64Type;
+use databend_common_expression::BlockEntry;
+use databend_common_expression::Column;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
+use databend_common_expression::TableSchemaRefExt;
+use databend_common_expression::Value;
+use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractBlockMeta;
+use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractSegment;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+
+use crate::io::read::ColumnOrientedSegmentReader;
+use crate::io::read::RowOrientedSegmentReader;
+use crate::io::read::SegmentReader;
+use crate::io::SegmentsIO;
+use crate::sessions::TableContext;
+use crate::table_functions::function_template::TableMetaFunc;
+use crate::table_functions::TableMetaFuncTemplate;
+use crate::FuseTable;
+
+pub struct FuseVirtualColumn;
+pub type FuseVirtualColumnFunc = TableMetaFuncTemplate<FuseVirtualColumn>;
+
+#[async_trait::async_trait]
+impl TableMetaFunc for FuseVirtualColumn {
+    fn schema() -> Arc<TableSchema> {
+        TableSchemaRefExt::create(vec![
+            TableField::new("snapshot_id", TableDataType::String),
+            TableField::new("timestamp", TableDataType::Timestamp),
+            TableField::new("virtual_block_location", TableDataType::String),
+            TableField::new(
+                "virtual_block_size",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new("row_count", TableDataType::Number(NumberDataType::UInt64)),
+            TableField::new("column_name", TableDataType::String),
+            TableField::new("column_type", TableDataType::String),
+            TableField::new("column_id", TableDataType::Number(NumberDataType::UInt32)),
+            TableField::new(
+                "block_offset",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new(
+                "bytes_compressed",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+        ])
+    }
+
+    async fn apply(
+        ctx: &Arc<dyn TableContext>,
+        tbl: &FuseTable,
+        snapshot: Arc<TableSnapshot>,
+        limit: Option<usize>,
+    ) -> Result<DataBlock> {
+        match tbl.is_column_oriented() {
+            true => {
+                Self::apply_generic::<ColumnOrientedSegmentReader>(ctx, tbl, snapshot, limit).await
+            }
+            false => {
+                Self::apply_generic::<RowOrientedSegmentReader>(ctx, tbl, snapshot, limit).await
+            }
+        }
+    }
+}
+
+impl FuseVirtualColumn {
+    async fn apply_generic<R: SegmentReader>(
+        ctx: &Arc<dyn TableContext>,
+        tbl: &FuseTable,
+        snapshot: Arc<TableSnapshot>,
+        limit: Option<usize>,
+    ) -> Result<DataBlock> {
+        let Some(virtual_schema) = tbl.table_info.meta.virtual_schema.clone() else {
+            return Ok(DataBlock::empty_with_schema(Arc::new(
+                FuseVirtualColumn::schema().into(),
+            )));
+        };
+
+        let limit = limit.unwrap_or(usize::MAX);
+        let len = std::cmp::min(snapshot.summary.block_count as usize, limit);
+
+        let snapshot_id = snapshot.snapshot_id.simple().to_string();
+        let timestamp = snapshot.timestamp.unwrap_or_default().timestamp_micros();
+        let mut virtual_block_location = StringColumnBuilder::with_capacity(len);
+        let mut virtual_block_size = vec![];
+        let mut row_count = vec![];
+
+        let mut column_name = StringColumnBuilder::with_capacity(len);
+        let mut column_type = StringColumnBuilder::with_capacity(len);
+        let mut column_id = vec![];
+        let mut block_offset = vec![];
+        let mut bytes_compressed = vec![];
+
+        let segments_io = SegmentsIO::create(ctx.clone(), tbl.operator.clone(), tbl.schema());
+
+        let mut row_num = 0;
+        let chunk_size =
+            std::cmp::min(ctx.get_settings().get_max_threads()? as usize * 4, len).max(1);
+
+        let schema = tbl.schema();
+        let projection = HashSet::new();
+        'FOR: for chunk in snapshot.segments.chunks(chunk_size) {
+            let segments = segments_io
+                .generic_read_compact_segments::<R>(chunk, true, &projection)
+                .await?;
+            for segment in segments {
+                let segment = segment?;
+                for block in segment.block_metas()? {
+                    let Some(block_meta) = block.virtual_block_meta() else {
+                        continue;
+                    };
+                    let mut column_metas: Vec<_> =
+                        block_meta.virtual_column_metas.into_iter().collect();
+                    column_metas.sort_by_key(|(id, _)| *id);
+                    let location = block_meta.virtual_location.0;
+
+                    for (id, column_meta) in column_metas.iter() {
+                        if let Some(f) = virtual_schema.fields.iter().find(|f| f.column_id == *id) {
+                            let Ok(source_field) = schema.field_of_column_id(f.source_column_id)
+                            else {
+                                continue;
+                            };
+
+                            virtual_block_location.put_and_commit(location.clone());
+                            virtual_block_size.push(block_meta.virtual_column_size);
+                            row_count.push(column_meta.num_values);
+
+                            let name = format!("{}{}", source_field.name, f.name);
+                            column_name.put_and_commit(&name);
+                            column_type.put_and_commit(column_meta.data_type().to_string());
+                            column_id.push(*id);
+
+                            let (offset, length) = column_meta.offset_length();
+                            block_offset.push(offset);
+                            bytes_compressed.push(length);
+
+                            row_num += 1;
+
+                            if row_num >= limit {
+                                break 'FOR;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(DataBlock::new(
+            vec![
+                BlockEntry::new(DataType::String, Value::Scalar(Scalar::String(snapshot_id))),
+                BlockEntry::new(
+                    DataType::Timestamp,
+                    Value::Scalar(Scalar::Timestamp(timestamp)),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Column(Column::String(virtual_block_location.build())),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::UInt64),
+                    Value::Column(UInt64Type::from_data(virtual_block_size)),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::UInt64),
+                    Value::Column(UInt64Type::from_data(row_count)),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Column(Column::String(column_name.build())),
+                ),
+                BlockEntry::new(
+                    DataType::String,
+                    Value::Column(Column::String(column_type.build())),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::UInt32),
+                    Value::Column(UInt32Type::from_data(column_id)),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::UInt64),
+                    Value::Column(UInt64Type::from_data(block_offset)),
+                ),
+                BlockEntry::new(
+                    DataType::Number(NumberDataType::UInt64),
+                    Value::Column(UInt64Type::from_data(bytes_compressed)),
+                ),
+            ],
+            row_num,
+        ))
+    }
+}

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -27,6 +27,7 @@ mod fuse_time_travel_size;
 mod fuse_vacuum_drop_aggregating_index;
 mod fuse_vacuum_drop_inverted_index;
 mod fuse_vacuum_temporary_table;
+mod fuse_virtual_column;
 mod set_cache_capacity;
 
 pub use clustering_information::ClusteringInformationFunc;
@@ -49,4 +50,5 @@ pub use fuse_time_travel_size::FuseTimeTravelSizeFunc;
 pub use fuse_vacuum_drop_aggregating_index::FuseVacuumDropAggregatingIndex;
 pub use fuse_vacuum_drop_inverted_index::FuseVacuumDropInvertedIndex;
 pub use fuse_vacuum_temporary_table::FuseVacuumTemporaryTable;
+pub use fuse_virtual_column::FuseVirtualColumnFunc;
 pub use set_cache_capacity::SetCacheCapacity;

--- a/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
@@ -21,6 +21,7 @@ fuse_vacuum2
 fuse_vacuum_drop_aggregating_index
 fuse_vacuum_drop_inverted_index
 fuse_vacuum_temporary_table
+fuse_virtual_column
 
 query T
 SHOW TABLE_FUNCTIONS LIKE 'fuse%' LIMIT 1

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
@@ -134,6 +134,23 @@ test_virtual_column t2 val 3000000000 ['a'] UInt64
 test_virtual_column t2 val 3000000001 ['b'] UInt64
 test_virtual_column t2 val 3000000002 ['c'] String
 
+query II
+select row_count, virtual_column_size from fuse_block('test_virtual_column', 't2')
+----
+3 806
+
+query IITTIII
+select virtual_block_size, row_count, column_name, column_type, column_id, block_offset, bytes_compressed from fuse_virtual_column('test_virtual_column', 't2')
+----
+806 3 val['a'] UInt64 NULL 3000000000 4 48
+806 3 val['b'] UInt64 NULL 3000000001 52 48
+806 3 val['c'] String NULL 3000000002 100 48
+
+query IIIIII
+select block_count, row_count, bytes_uncompressed, bytes_compressed, index_size, virtual_block_count from fuse_segment('test_virtual_column', 't2')
+----
+1 3 134 694 1235 1
+
 statement ok
 insert into t2 values(4, '{"a":44,"b":4,"c":"value"}'), (5, '{"a":55,"b":5,"c":"bend"}'), (6, '6')
 

--- a/tests/sqllogictests/suites/ee/08_ee_ngram_index/08_0000_ngram_index_base.test
+++ b/tests/sqllogictests/suites/ee/08_ee_ngram_index/08_0000_ngram_index_base.test
@@ -13,16 +13,28 @@
 ## limitations under the License.
 
 statement ok
-drop database if exists test_index
+drop database if exists test_gram_index
 
 statement ok
-create database test_index
+create database test_gram_index
 
 statement ok
-use test_index
+use test_gram_index
 
 statement ok
 CREATE TABLE t1 (id int, content string, NGRAM INDEX idx1 (content) gram_size = 5)
+
+statement ok
+INSERT INTO t1 VALUES
+(1, 'The quick brown fox jumps over the lazy dog'),
+(2, 'A picture is worth a thousand words'),
+(3, 'The early bird catches the worm'),
+(4, 'Actions speak louder than words');
+
+query III
+select row_count, bloom_filter_size, ngram_index_size from fuse_block('test_gram_index', 't1')
+----
+4 1049458 1048617
 
 statement ok
 CREATE TABLE t2 (id int, content string)
@@ -68,4 +80,5 @@ statement ok
 use default
 
 statement ok
-drop database test_index
+drop database test_gram_index
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces new function `fuse_virtual_column`, and add some fields to `fuse_block` and `fuse_segment` functions in Databend,
These additions are primarily intended for debugging and troubleshooting purposes related to virtual column and other indexes.

**Key Changes:**

1.  **New Function: `fuse_virtual_column`:**
    *   Introduces a new function, `fuse_virtual_column`, which exposes detailed information about virtual columns stored in the block metadata.
    *   This function provides insights into key attributes such as:
        *   `virtual_block_location`: The location of virtual column data.
        *   `virtual_block_size`: The size of virtual column data.
        *   `row_count`: The number of rows in the virtual column.
        *   `column_name`: The name of the virtual column.
        *   `column_type`: The data type of the virtual column.
        *   `column_id`: The column id of the virtual column.
        *   `block_offset`: The offset of the virtual column in the data file.
        *   `bytes_compressed`: The compressed length of the virtual column in the data file.
    *   This function is useful for understanding the structure and content of virtual columns at the block level.

2.  **Enhancement: `fuse_block` Function:**
    *   Adds two new fields to the `fuse_block` function output:
        *   `ngram_index_size`: The size of the N-gram index associated with the block.
        *   `virtual_column_size`: The total size of the virtual columns within the block.
    *   **Important Note:** The `bloom_index_size` already includes the `ngram_index_size`, as N-gram indexes are stored as part of Bloom index.

3.  **Enhancement: `fuse_segment` Function:**
    *   Adds two new fields to the `fuse_segment` function output:
        *   `index_size`: The total size of all indexes within the segment(include bloom index, ngram index, inverted index and virtual column).
        *   `virtual_block_count`: The number of blocks in the segment that contain virtual columns.


part of: #17083

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
