### PR TITLE
chore: Bump opendal to 0.53.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10800,9 +10800,9 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.53.1"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f407ca2797ca6c010720aa3cedfa0187430e4f70b729c75c33142d44021f59"
+checksum = "11ff9e9656d1cb3c58582ea18e6d9e71076a7ab2614207821d1242d7da2daed5"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,7 +394,7 @@ object = "0.36.5"
 object_store_opendal = { version = "0.51.0" }
 once_cell = "1.15.0"
 openai_api_rust = "0.1"
-opendal = { version = "0.53.1", features = [
+opendal = { version = "0.53.2", features = [
     "layers-fastrace",
     "layers-prometheus-client",
     "layers-async-backtrace",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Bump OpenDAL 0.53.2 to get the following PR in:

- https://github.com/apache/opendal/pull/6154

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17930)
<!-- Reviewable:end -->
