### PR TITLE
feat(parse): Simplify the matching pattern when parse function, avoid exponential backtracking

### DIFF
--- a/src/query/ast/benches/bench.rs
+++ b/src/query/ast/benches/bench.rs
@@ -16,12 +16,14 @@ fn main() {
     divan::main()
 }
 
-// bench                  fastest       │ slowest       │ median        │ mean          │ samples │ iters
-// ╰─ dummy                             │               │               │               │         │
-//    ├─ deep_query       122 µs        │ 324.3 µs      │ 127.2 µs      │ 130.1 µs      │ 100     │ 100
-//    ├─ large_query      1.366 ms      │ 1.686 ms      │ 1.409 ms      │ 1.417 ms      │ 100     │ 100
-//    ├─ large_statement  1.336 ms      │ 1.441 ms      │ 1.391 ms      │ 1.39 ms       │ 100     │ 100
-//    ╰─ wide_expr        556 µs        │ 697.2 µs      │ 578.3 µs      │ 580.5 µs      │ 100     │ 100
+// bench                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
+// ╰─ dummy                                │               │               │               │         │
+//    ├─ deep_function_call  732.9 ms      │ 732.9 ms      │ 732.9 ms      │ 732.9 ms      │ 1       │ 1
+//    ├─ deep_query          319.4 µs      │ 515.6 µs      │ 333.4 µs      │ 335.3 µs      │ 100     │ 100
+//    ├─ large_query         1.998 ms      │ 2.177 ms      │ 2.032 ms      │ 2.038 ms      │ 100     │ 100
+//    ├─ large_statement     1.952 ms      │ 2.079 ms      │ 2.016 ms      │ 2.011 ms      │ 100     │ 100
+//    ╰─ wide_expr           620.4 µs      │ 783.7 µs      │ 646 µs        │ 646.4 µs      │ 100     │ 100
+
 #[divan::bench_group(max_time = 0.5)]
 mod dummy {
     use databend_common_ast::parser::parse_expr;
@@ -56,6 +58,14 @@ mod dummy {
     #[divan::bench]
     fn wide_expr() {
         let case = r#"a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a AND a"#;
+        let tokens = tokenize_sql(case).unwrap();
+        let expr = parse_expr(&tokens, Dialect::PostgreSQL).unwrap();
+        divan::black_box(expr);
+    }
+
+    #[divan::bench]
+    fn deep_function_call() {
+        let case = r#"ROUND(6378.138 * 2 * ASIN(SQRT(POW(SIN(RADIANS(CASE WHEN MOD(EXTRACT(SECOND FROM CURRENT_TIMESTAMP), 2) = 0 THEN 45.6789 ELSE 30.1234 END - IFNULL(NULLIF((SELECT 37.7749), 0), 15.4321))), 2) + POW(SIN(RADIANS((SELECT -122.4194) / 2)), 2) * COS(RADIANS(LEAST(60, GREATEST(20, (SELECT 25.5))))))) * (1000 + (RAND() * 500 - 250)), 2)"#;
         let tokens = tokenize_sql(case).unwrap();
         let expr = parse_expr(&tokens, Dialect::PostgreSQL).unwrap();
         divan::black_box(expr);

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -982,7 +982,7 @@ error:
   --> SQL:1:65
   |
 1 | CREATE FUNCTION IF NOT EXISTS isnotempty AS(p) -> not(is_null(p)
-  | ------                                   --       ----          ^ unexpected end of input, expecting `)`, `IGNORE`, `RESPECT`, `OVER`, `WITHIN`, `(`, `IS`, `NOT`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, or 45 more ...
+  | ------                                   --       ----          ^ unexpected end of input, expecting `)`, `(`, `WITHIN`, `IGNORE`, `RESPECT`, `OVER`, `IS`, `NOT`, `IN`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `LIKE`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, or 45 more ...
   | |                                        |        |  |          
   | |                                        |        |  while parsing `(<expr> [, ...])`
   | |                                        |        while parsing expression


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Databend may take a very long time to parse multiple layers of function calls
```sql
select ROUND(6378.138 * 2 * ASIN(SQRT(POW(SIN((IF(1 = 2, NULL, 10) * PI() / 180 - 40.051816 * PI() / 180) / 2), 2))) * 1000, 0) distance;

Before: 
1 row read in 25.504 sec. Processed 1 row, 1 B (0.04 row/s, 0 B/s)

After:
1 row read in 1.115 sec. Processed 1 row, 1 B (0.90 row/s, 0 B/s)

```
This is because there are many similar matching patterns when parsing function calls, and simple function calls need to fail to match complex expressions before entering. This will cause multiple nested simple function calls to fail to match correctly (the matching order is the last pattern).
![94b9082cd84cc97d4fde9e3fe2a24b9](https://github.com/user-attachments/assets/4839b4f4-1321-408f-9288-3a4c8bdcdfc2)

This PR simplifies the matching patterns in function calls as much as possible and rearranges the order to avoid this situation.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17942)
<!-- Reviewable:end -->
