### PR TITLE
feat(meta-client): add `watch_with_initialization()` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,6 @@ dependencies = [
  "databend-common-meta-semaphore",
  "databend-common-meta-types",
  "databend-meta",
- "futures",
  "log",
  "tempfile",
  "tokio",

--- a/src/meta/app/src/data_id.rs
+++ b/src/meta/app/src/data_id.rs
@@ -31,6 +31,7 @@ use crate::tenant_key::resource::TenantResource;
 /// e.g. TableId, DatabaseId as a value.
 ///
 /// `DataId<R>` can be dereferenced to `u64`.
+/// `DataId<R>` will take place of `Id<T>` in future.
 ///
 /// When an id is used as a key in a key-value store,
 /// it is serialized in another way to keep order.

--- a/src/meta/client/src/client_handle.rs
+++ b/src/meta/client/src/client_handle.rs
@@ -29,6 +29,8 @@ use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
 use databend_common_meta_types::protobuf::StreamItem;
+use databend_common_meta_types::protobuf::WatchRequest;
+use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::ConnectionError;
 use databend_common_meta_types::MetaClientError;
 use databend_common_meta_types::MetaError;
@@ -45,6 +47,7 @@ use crate::grpc_metrics;
 use crate::message;
 use crate::message::Response;
 use crate::ClientWorkerRequest;
+use crate::InitFlag;
 use crate::RequestFor;
 use crate::Streamed;
 
@@ -102,6 +105,22 @@ impl ClientHandle {
             .await?;
 
         Ok(strm)
+    }
+
+    /// Watch without requiring the initialization support
+    pub async fn watch(
+        &self,
+        watch: WatchRequest,
+    ) -> Result<tonic::codec::Streaming<WatchResponse>, MetaClientError> {
+        self.request(watch).await
+    }
+
+    /// Watch with requiring the initialization support
+    pub async fn watch_with_initialization(
+        &self,
+        watch: WatchRequest,
+    ) -> Result<tonic::codec::Streaming<WatchResponse>, MetaClientError> {
+        self.request((watch, InitFlag)).await
     }
 
     /// Send a request to the internal worker task, which will be running in another runtime.

--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -44,6 +44,7 @@ use crate::message::GetClusterStatus;
 use crate::message::GetEndpoints;
 use crate::message::MakeEstablishedClient;
 use crate::message::Streamed;
+use crate::InitFlag;
 
 /// Bind a request type to its corresponding response type.
 pub trait RequestFor: Clone + fmt::Debug {
@@ -182,6 +183,10 @@ impl RequestFor for UpsertKV {
 }
 
 impl RequestFor for WatchRequest {
+    type Reply = tonic::codec::Streaming<WatchResponse>;
+}
+
+impl RequestFor for (WatchRequest, InitFlag) {
     type Reply = tonic::codec::Streaming<WatchResponse>;
 }
 

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -39,6 +39,7 @@ pub use grpc_action::MetaGrpcReq;
 pub use grpc_action::RequestFor;
 pub use grpc_client::MetaGrpcClient;
 pub use message::ClientWorkerRequest;
+pub use message::InitFlag;
 pub use message::Streamed;
 pub use required::FeatureSpec;
 pub use required::VersionTuple;

--- a/src/meta/client/src/required.rs
+++ b/src/meta/client/src/required.rs
@@ -34,6 +34,8 @@ pub mod features {
     pub const EXPORT_V1:           FeatureSpec = ("export_v1",           (1, 2, 315));
     pub const WATCH:               FeatureSpec = ("watch",               (1, 2, 259));
     pub const WATCH_INITIAL_FLUSH: FeatureSpec = ("watch/initial_flush", (1, 2, 677));
+    /// WatchResponse contains a flag to indicate whether the event is initialization event or change event.
+    pub const WATCH_INIT_FLAG:     FeatureSpec = ("watch/init_flag",     (1, 2, 736));
     pub const MEMBER_LIST:         FeatureSpec = ("member_list",         (1, 2, 259));
     pub const GET_CLUSTER_STATUS:  FeatureSpec = ("get_cluster_status",  (1, 2, 259));
     pub const GET_CLIENT_INFO:     FeatureSpec = ("get_client_info",     (1, 2, 259));
@@ -50,6 +52,7 @@ pub fn all() -> &'static [FeatureSpec] {
         features::EXPORT_V1,
         features::WATCH,
         features::WATCH_INITIAL_FLUSH,
+        features::WATCH_INIT_FLAG,
         features::MEMBER_LIST,
         features::GET_CLUSTER_STATUS,
         features::GET_CLIENT_INFO,
@@ -81,6 +84,8 @@ pub fn std() -> &'static [FeatureSpec] {
         // features::EXPORT_V1,
         features::WATCH,
         features::WATCH_INITIAL_FLUSH,
+        // MIN_METASRV_VER does not include this feature, thus it is optional
+        // features::WATCH_INIT_FLAG,
         features::MEMBER_LIST,
         features::GET_CLUSTER_STATUS,
         features::GET_CLIENT_INFO,
@@ -110,6 +115,7 @@ pub fn read_write_watch() -> &'static [FeatureSpec] {
         features::TRANSACTION,
         features::WATCH,
         features::WATCH_INITIAL_FLUSH,
+        features::WATCH_INIT_FLAG,
     ];
 
     REQUIRES

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -365,7 +365,7 @@ async fn test_watch_initialization_flush() -> anyhow::Result<()> {
             filter_type: FilterType::All.into(),
             initial_flush: true,
         };
-        client.request(watch).await?
+        client.watch_with_initialization(watch).await?
     };
 
     let cache = Arc::new(Mutex::new(BTreeMap::new()));

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -20,7 +20,6 @@ databend-common-meta-kvapi = { workspace = true }
 databend-common-meta-semaphore = { workspace = true }
 databend-common-meta-types = { workspace = true }
 databend-meta = { workspace = true }
-futures = { workspace = true }
 log = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -26,10 +26,8 @@ use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_semaphore::acquirer::Permit;
 use databend_common_meta_semaphore::errors::AcquireError;
 use databend_common_meta_semaphore::Semaphore;
-use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::MetaError;
-use futures::stream::TryStreamExt;
 pub use local::LocalMetaService;
 use log::info;
 use tokio_stream::Stream;
@@ -49,13 +47,15 @@ pub enum MetaStore {
     R(Arc<ClientHandle>),
 }
 
+/// Internally [`MetaStore`] contains a [`ClientHandle`] which is a client to either a local
+/// databend-meta service or a remote databend-meta service accessed via gRPC.
 impl Deref for MetaStore {
     type Target = Arc<ClientHandle>;
 
     fn deref(&self) -> &Self::Target {
         match self {
             MetaStore::L(l) => l.deref(),
-            MetaStore::R(r) => r,
+            MetaStore::R(grpc_client) => grpc_client,
         }
     }
 }
@@ -86,13 +86,6 @@ impl MetaStore {
     pub async fn get_local_addr(&self) -> Result<String, MetaError> {
         let client_info = self.get_client_info().await?;
         Ok(client_info.client_addr)
-    }
-
-    pub async fn watch(&self, request: WatchRequest) -> Result<WatchStream, MetaError> {
-        let client = self.deref();
-
-        let streaming = client.request(request).await?;
-        Ok(Box::pin(streaming.map_err(MetaError::from)))
     }
 
     pub async fn new_acquired(

--- a/src/meta/types/src/errors/meta_client_errors.rs
+++ b/src/meta/types/src/errors/meta_client_errors.rs
@@ -14,6 +14,7 @@
 
 use std::io;
 
+use databend_common_exception::ErrorCode;
 use tonic::Status;
 
 use crate::ConnectionError;
@@ -59,5 +60,11 @@ impl From<MetaClientError> for io::Error {
                 io::Error::new(io::ErrorKind::NotConnected, e.to_string())
             }
         }
+    }
+}
+
+impl From<MetaClientError> for ErrorCode {
+    fn from(e: MetaClientError) -> Self {
+        ErrorCode::MetaServiceError(e.to_string())
     }
 }

--- a/src/meta/types/src/errors/meta_errors.rs
+++ b/src/meta/types/src/errors/meta_errors.rs
@@ -23,6 +23,7 @@ use crate::InvalidArgument;
 use crate::InvalidReply;
 use crate::MetaAPIError;
 use crate::MetaClientError;
+use crate::MetaHandshakeError;
 use crate::MetaNetworkError;
 
 /// Top level error MetaNode would return.
@@ -84,6 +85,13 @@ impl From<errors::IncompleteStream> for MetaError {
     fn from(e: errors::IncompleteStream) -> Self {
         let net_err = MetaNetworkError::from(e);
         let client_err = MetaClientError::from(net_err);
+        Self::ClientError(client_err)
+    }
+}
+
+impl From<MetaHandshakeError> for MetaError {
+    fn from(e: MetaHandshakeError) -> Self {
+        let client_err = MetaClientError::from(e);
         Self::ClientError(client_err)
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-client): add `watch_with_initialization()` method

This method requires the databend-meta server to respond a
`is_initialization` flag in each watch response for the client to
distinguish between initialization events and key-value change events.
This feature is required by the cache mod.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17944)
<!-- Reviewable:end -->
