### PR TITLE
chore: add `release_cache_memory` to CacheManager

### DIFF
--- a/src/query/storages/common/cache/src/cache.rs
+++ b/src/query/storages/common/cache/src/cache.rs
@@ -50,4 +50,6 @@ pub trait CacheAccessor {
     }
 
     fn name(&self) -> &str;
+
+    fn clear(&self);
 }

--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -351,8 +351,8 @@ impl CacheManager {
     ///
     /// # Parameters
     /// * `clearance_level` - Determines how aggressively to clear caches:
-    ///   * `CacheClearanceLevel::Basic`: Clears caches that may consume significant memory
-    ///   * `CacheClearanceLevel::Deep`: Clears both basic caches and extra caches to release more memory
+    ///   * `CacheClearanceLevel::Basic`: Clears basic caches that may consume significant memory
+    ///   * `CacheClearanceLevel::Deep`: Performs a more aggressive clearing, including both basic caches and extra caches
     pub fn release_cache_memory(&self, clearance_level: CacheClearanceLevel) {
         /// Clears basic caches that may consume a significant amount of memory
         fn clear_basic_caches(me: &CacheManager) {
@@ -464,8 +464,9 @@ impl CacheManager {
         if let Some(cache) = cache_slot.get() {
             let name = cache.name();
             info!(
-                "reset cache {}: dropping {} bytes, ",
+                "clearing cache {}: dropping {} items, size {}",
                 name,
+                cache.len(),
                 cache.bytes_size()
             );
             cache.clear();

--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -44,6 +44,7 @@ use crate::caches::TableSnapshotCache;
 use crate::caches::TableSnapshotStatisticCache;
 use crate::providers::HybridCache;
 use crate::providers::HybridCacheExt;
+use crate::CacheAccessor;
 use crate::DiskCacheAccessor;
 use crate::DiskCacheBuilder;
 use crate::InMemoryLruCache;
@@ -73,6 +74,14 @@ impl<T: Clone> CacheSlot<T> {
     fn get(&self) -> Option<T> {
         self.cache.read().clone()
     }
+}
+
+/// Specifies the level of aggression when clearing memory caches.
+pub enum CacheClearanceLevel {
+    /// Clears only basic caches that may consume significant memory
+    Basic,
+    /// Performs a more aggressive clearing, including both basic caches and extra caches
+    Deep,
 }
 
 /// Where all the caches reside
@@ -335,6 +344,43 @@ impl CacheManager {
         self.table_snapshot_cache.get()
     }
 
+    /// Releases memory occupied by caches
+    ///
+    /// This method is used to free up memory resources by clearing various caches
+    /// in the system. The extent of cache clearing depends on the specified clearance level.
+    ///
+    /// # Parameters
+    /// * `clearance_level` - Determines how aggressively to clear caches:
+    ///   * `CacheClearanceLevel::Basic`: Clears caches that may consume significant memory
+    ///   * `CacheClearanceLevel::Deep`: Clears both basic caches and extra caches to release more memory
+    pub fn release_cache_memory(&self, clearance_level: CacheClearanceLevel) {
+        /// Clears basic caches that may consume a significant amount of memory
+        fn clear_basic_caches(me: &CacheManager) {
+            CacheManager::clear_cache(&me.in_memory_table_data_cache);
+            CacheManager::clear_cache(&me.segment_block_metas_cache);
+            // Only the in-memory part of column_data_cache will be cleared
+            CacheManager::clear_cache(&me.column_data_cache);
+            CacheManager::clear_cache(&me.block_meta_cache);
+        }
+
+        fn clear_extra_caches(me: &CacheManager) {
+            // These caches are typically not memory usage heavy, and have more significant impact
+            // for the query performance, consider clearing them when the memory pressure is
+            // high.
+            CacheManager::clear_cache(&me.compact_segment_info_cache);
+            CacheManager::clear_cache(&me.bloom_index_filter_cache);
+            CacheManager::clear_cache(&me.bloom_index_meta_cache);
+        }
+
+        match clearance_level {
+            CacheClearanceLevel::Basic => clear_basic_caches(self),
+            CacheClearanceLevel::Deep => {
+                clear_basic_caches(self);
+                clear_extra_caches(self)
+            }
+        }
+    }
+
     pub fn set_cache_capacity(&self, name: &str, new_capacity: u64) -> Result<()> {
         match name {
             MEMORY_CACHE_TABLE_DATA => {
@@ -412,6 +458,17 @@ impl CacheManager {
         } else {
             let new_cache = Self::new_bytes_cache(name, new_capacity as usize);
             cache.set(new_cache)
+        }
+    }
+    fn clear_cache<C: CacheAccessor + Clone>(cache_slot: &CacheSlot<C>) {
+        if let Some(cache) = cache_slot.get() {
+            let name = cache.name();
+            info!(
+                "reset cache {}: dropping {} bytes, ",
+                name,
+                cache.bytes_size()
+            );
+            cache.clear();
         }
     }
 
@@ -680,11 +737,26 @@ const MEMORY_CACHE_BLOCK_META: &str = "memory_cache_block_meta";
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::ArrayRef;
+    use arrow::array::Int32Array;
+    use bytes::Bytes;
     use databend_common_config::CacheConfig;
     use databend_common_config::DiskCacheInnerConfig;
+    use databend_storages_common_index::filters::FilterBuilder;
+    use databend_storages_common_index::filters::FilterImpl;
+    use databend_storages_common_index::filters::Xor8Builder;
+    use databend_storages_common_index::BloomIndexMeta;
+    use databend_storages_common_table_meta::meta::BlockMeta;
+    use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+    use databend_storages_common_table_meta::meta::Compression;
+    use databend_storages_common_table_meta::meta::MetaEncoding;
+    use databend_storages_common_table_meta::meta::RawBlockMeta;
     use tempfile::TempDir;
 
     use super::*;
+    use crate::ColumnData;
     fn config_with_disk_cache_enabled(cache_path: &str) -> CacheConfig {
         CacheConfig {
             data_cache_storage: CacheStorageTypeInnerConfig::Disk,
@@ -822,6 +894,160 @@ mod tests {
         // All disk caches should be disabled, even if disk caches are toggled on
         cache_manager.set_allows_disk_cache(true);
         assert!(all_disk_cache_disabled(&cache_manager));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_release_cache_memory() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().to_string_lossy().clone();
+        let max_server_memory_usage = 1024 * 1024;
+
+        let mut cache_config = config_with_disk_cache_enabled(&cache_path);
+
+        // Configure cache with sufficient capacity for testing
+        cache_config.table_data_deserialized_data_bytes = 1024 * 1024;
+        cache_config.block_meta_count = 10;
+        cache_config.data_cache_in_memory_bytes = 1024 * 1024;
+
+        let ee_mode = true;
+        let cache_manager = CacheManager::try_new(
+            &cache_config,
+            &max_server_memory_usage,
+            "test_tenant_id",
+            ee_mode,
+        )?;
+
+        // ----- POPULATE BASIC CACHES -----
+
+        // 1. Populate in-memory table data cache
+        let in_memory_table_data_cache = cache_manager.get_table_data_array_cache().unwrap();
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        in_memory_table_data_cache.insert("not matter".to_string(), (array, 1));
+
+        // 2. Populate segment block metas cache
+        let segment_block_metas_cache = cache_manager.get_segment_block_metas_cache().unwrap();
+        segment_block_metas_cache.insert("not matter".to_string(), vec![]);
+
+        // 3. Populate column data cache
+        let column_data_cache = cache_manager.get_column_data_cache().unwrap();
+        column_data_cache.insert(
+            "not matter".to_string(),
+            ColumnData::from_bytes(Bytes::new()),
+        );
+
+        // 4. Populate block meta cache
+        let block_meta_cache = cache_manager.get_block_meta_cache().unwrap();
+        block_meta_cache.insert("not matter".to_string(), BlockMeta {
+            row_count: 0,
+            block_size: 0,
+            file_size: 0,
+            col_stats: Default::default(),
+            col_metas: Default::default(),
+            cluster_stats: None,
+            location: ("".to_string(), 0),
+            bloom_filter_index_location: None,
+            bloom_filter_index_size: 0,
+            inverted_index_size: None,
+            ngram_filter_index_size: None,
+            virtual_block_meta: None,
+            compression: Compression::Lz4,
+            create_on: None,
+        });
+
+        // ----- POPULATE EXTRA CACHES -----
+
+        // 1. Populate compact segment info cache
+        let compact_segment_info_cache = cache_manager.get_table_segment_cache().unwrap();
+        compact_segment_info_cache.insert("not matter".to_string(), CompactSegmentInfo {
+            format_version: 0,
+            summary: Default::default(),
+            raw_block_metas: RawBlockMeta {
+                bytes: vec![],
+                encoding: MetaEncoding::Bincode,
+                compression: Default::default(),
+            },
+        });
+
+        // 2. Populate bloom index filter cache
+        let bloom_index_filter_cache = cache_manager.get_bloom_index_filter_cache().unwrap();
+        let mut builder = Xor8Builder::create();
+        builder.add_key(&"what ever".to_string());
+        let xor8_filter = builder.build()?;
+        bloom_index_filter_cache.insert("not matter".to_string(), FilterImpl::Xor(xor8_filter));
+
+        // 3. Populate bloom index meta cache
+        let bloom_index_meta_cache = cache_manager.get_bloom_index_meta_cache().unwrap();
+        bloom_index_meta_cache.insert("not matter".to_string(), BloomIndexMeta { columns: vec![] });
+
+        // ----- VERIFY INITIAL CACHE STATE -----
+        // Verify all caches are correctly populated
+        assert!(!cache_manager.get_table_data_array_cache().is_empty());
+        assert!(!cache_manager
+            .get_segment_block_metas_cache()
+            .unwrap()
+            .is_empty());
+        assert!(!cache_manager.get_column_data_cache().is_empty());
+        assert!(!cache_manager.get_block_meta_cache().is_empty());
+        assert!(!cache_manager.get_table_segment_cache().is_empty());
+        assert!(!cache_manager.get_bloom_index_filter_cache().is_empty());
+        assert!(!cache_manager.get_bloom_index_meta_cache().is_empty());
+
+        // 4.
+        // ----- TEST BASIC CLEARANCE LEVEL -----
+
+        // Clear caches with Basic clearance level
+        cache_manager.release_cache_memory(CacheClearanceLevel::Basic);
+
+        // Verify basic caches are cleared
+        assert!(in_memory_table_data_cache.is_empty());
+        assert!(cache_manager
+            .get_segment_block_metas_cache()
+            .unwrap()
+            .is_empty());
+        assert!(cache_manager.get_block_meta_cache().is_empty());
+
+        // Verify hybrid column data cache behavior:
+        // - On-disk cache of table data should remain populated
+        assert!(!cache_manager.get_column_data_cache().is_empty());
+        // - In-memory cache of table data should be cleared
+        assert!(cache_manager
+            .get_column_data_cache()
+            .unwrap()
+            .in_memory_cache()
+            .unwrap()
+            .is_empty());
+
+        // Verify extra caches remain intact after Basic clearance
+        assert!(!cache_manager.get_table_segment_cache().is_empty());
+        assert!(!cache_manager.get_bloom_index_filter_cache().is_empty());
+        assert!(!cache_manager.get_bloom_index_meta_cache().is_empty());
+
+        // 5.
+        // ----- TEST DEEP CLEARANCE LEVEL -----
+
+        // Clear caches with Deep clearance level
+        cache_manager.release_cache_memory(CacheClearanceLevel::Deep);
+
+        // Verify extra caches are now cleared
+        assert!(cache_manager.get_table_segment_cache().is_empty());
+
+        // Verify in-memory part of hybrid bloom index meta caches are cleared
+        assert!(cache_manager
+            .get_bloom_index_meta_cache()
+            .unwrap()
+            .in_memory_cache()
+            .unwrap()
+            .is_empty());
+
+        // Verify in-memory part of hybrid bloom index filter caches are cleared
+        assert!(cache_manager
+            .get_bloom_index_filter_cache()
+            .unwrap()
+            .in_memory_cache()
+            .unwrap()
+            .is_empty());
 
         Ok(())
     }

--- a/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache/disk_cache_lru.rs
@@ -130,6 +130,10 @@ impl CacheAccessor for LruDiskCacheHolder {
         let cache = self.read();
         cache.len()
     }
+
+    fn clear(&self) {
+        // Does nothing for disk cache
+    }
 }
 
 /// The crc32 checksum is stored at the end of `bytes` and encoded as le u32.

--- a/src/query/storages/common/cache/src/providers/disk_cache_builder.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache_builder.rs
@@ -183,6 +183,10 @@ impl CacheAccessor for DiskCacheAccessor {
     fn len(&self) -> usize {
         self.lru_disk_cache.len()
     }
+
+    fn clear(&self) {
+        // For disk cache, clear nothing
+    }
 }
 
 struct CachePopulationWorker<T> {

--- a/src/query/storages/common/cache/src/providers/hybrid_cache.rs
+++ b/src/query/storages/common/cache/src/providers/hybrid_cache.rs
@@ -219,6 +219,11 @@ where
     fn name(&self) -> &str {
         self.name.as_str()
     }
+
+    fn clear(&self) {
+        // Only clear the in-memory cache
+        self.memory_cache.clear()
+    }
 }
 
 #[cfg(test)]

--- a/src/query/storages/common/cache/src/providers/memory_cache.rs
+++ b/src/query/storages/common/cache/src/providers/memory_cache.rs
@@ -158,6 +158,11 @@ mod impls {
         fn name(&self) -> &str {
             &self.name
         }
+
+        fn clear(&self) {
+            let mut guard = self.inner.write();
+            guard.clear()
+        }
     }
 
     // Wrap an Option<CacheAccessor>, and impl CacheAccessor for it
@@ -242,6 +247,13 @@ mod impls {
             match self.as_ref() {
                 None => 0,
                 Some(cache) => cache.bytes_capacity(),
+            }
+        }
+
+        fn clear(&self) {
+            match self.as_ref() {
+                None => (),
+                Some(cache) => cache.clear(),
             }
         }
     }

--- a/src/query/storages/common/table_meta/src/meta/current/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/current/mod.rs
@@ -26,6 +26,7 @@ pub use v2::VirtualBlockMeta;
 pub use v2::VirtualColumnMeta;
 pub use v3::TableSnapshotStatistics;
 pub use v4::CompactSegmentInfo;
+pub use v4::RawBlockMeta;
 pub use v4::SegmentInfo;
 pub use v4::TableSnapshot;
 pub use v4::TableSnapshotLite;

--- a/src/query/storages/common/table_meta/src/meta/v4/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/mod.rs
@@ -16,6 +16,7 @@ mod segment;
 mod snapshot;
 
 pub use segment::CompactSegmentInfo;
+pub use segment::RawBlockMeta;
 pub use segment::SegmentInfo;
 pub use snapshot::TableSnapshot;
 pub use snapshot::TableSnapshotLite;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Preparing for the related part of `memory_gc_handle`

https://github.com/databendlabs/databend/blob/7fd47b98354ec729ad37c03c863e86ebcf1f64b7/src/query/service/src/global_services.rs#L204-L213

Add new method ` pub fn CacheManager::release_cache_memory(&self, clearance_level: CacheClearanceLevel) -> ()`
~~~
    /// Releases memory occupied by caches
    ///
    /// This method is used to free up memory resources by clearing various caches
    /// in the system. The extent of cache clearing depends on the specified clearance level.
    ///
    /// # Parameters
    /// * `clearance_level` - Determines how aggressively to clear caches:
    ///   * `CacheClearanceLevel::Basic`: Clears caches that may consume significant memory
    ///   * `CacheClearanceLevel::Deep`: Clears both basic caches and extra caches to release more memory
~~~

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17946)
<!-- Reviewable:end -->
