### PR TITLE
feat: support select from AVRO files.

### DIFF
--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -1671,7 +1671,7 @@ impl TableContext for QueryContext {
                 };
                 OrcTable::try_create(info).await
             }
-            FileFormatParams::NdJson(..) => {
+            FileFormatParams::NdJson(..) | FileFormatParams::Avro(..) => {
                 let schema = Arc::new(TableSchema::new(vec![TableField::new(
                     "_$1", // TODO: this name should be in visible
                     TableDataType::Variant,
@@ -1731,7 +1731,7 @@ impl TableContext for QueryContext {
             }
             _ => {
                 return Err(ErrorCode::Unimplemented(format!(
-                    "The file format in the query stage is not supported. Currently supported formats are: Parquet, NDJson, CSV, and TSV. Provided format: '{}'.",
+                    "The file format in the query stage is not supported. Currently supported formats are: Parquet, NDJson, AVRO, CSV, and TSV. Provided format: '{}'.",
                     stage_info.file_format_params
                 )));
             }

--- a/src/query/storages/stage/src/read/avro/avro_to_jsonb.rs
+++ b/src/query/storages/stage/src/read/avro/avro_to_jsonb.rs
@@ -15,54 +15,126 @@
 use std::collections::BTreeMap;
 
 use apache_avro::types::Value;
+use apache_avro::Schema;
+use databend_common_expression::types::i256;
+use databend_common_expression::types::Decimal;
+use databend_common_expression::types::MAX_DECIMAL128_PRECISION;
+use databend_common_expression::types::MAX_DECIMAL256_PRECISION;
+use num_bigint::BigInt;
 
-pub(super) fn to_jsonb(value: &Value) -> Result<jsonb::Value, String> {
-    let jvalue = match value {
-        Value::Null => jsonb::Value::Null,
-        Value::Boolean(v) => jsonb::Value::Bool(*v),
-        Value::Int(v) => jsonb::Value::from(*v),
-        Value::Long(v) => jsonb::Value::from(*v),
-        Value::Float(v) => jsonb::Value::from(*v),
-        Value::Double(v) => jsonb::Value::from(*v),
-        Value::String(v) => jsonb::Value::from(v.as_str()),
-        Value::Enum(_, v) => jsonb::Value::from(v.as_str()),
-        Value::Uuid(v) => jsonb::Value::from(v.to_string()),
-        Value::Union(_, v) => to_jsonb(v)?,
-        Value::Array(v) => {
+pub(super) fn to_jsonb<'a>(value: &'a Value, schema: &Schema) -> Result<jsonb::Value<'a>, String> {
+    let jvalue = match (value, schema) {
+        // primaries
+        (Value::Null, Schema::Null) => jsonb::Value::Null,
+        (Value::Boolean(v), Schema::Boolean) => jsonb::Value::Bool(*v),
+        (Value::Int(v), Schema::Int) => jsonb::Value::from(*v),
+        (Value::Long(v), Schema::Long) => jsonb::Value::from(*v),
+        (Value::Float(v), Schema::Float) => jsonb::Value::from(*v),
+        (Value::Double(v), Schema::Double) => jsonb::Value::from(*v),
+        (Value::String(v), Schema::String) => jsonb::Value::from(v.as_str()),
+        (Value::Enum(_, v), Schema::Enum(_)) => jsonb::Value::from(v.as_str()),
+        (Value::Uuid(v), Schema::Uuid) => jsonb::Value::from(v.to_string()),
+        (Value::Bytes(v), Schema::Bytes) | (Value::Fixed(_, v), Schema::Fixed(_)) => {
+            jsonb::Value::Binary(v)
+        }
+        (Value::Decimal(d), Schema::Decimal(schema)) => {
+            let big_int = <BigInt>::from(d.to_owned());
+            jsonb::Value::Number(convert_decimal(schema.precision, schema.scale, big_int)?)
+        }
+        (Value::BigDecimal(d), Schema::BigDecimal) => {
+            let precision = d.digits() as usize;
+            let (big_int, scale) = d.clone().into_bigint_and_exponent();
+            jsonb::Value::Number(convert_decimal(precision, scale as usize, big_int)?)
+        }
+        (Value::Date(d), Schema::Date) => jsonb::Value::Date(jsonb::Date { value: *d }),
+        (Value::TimeMillis(t), Schema::TimeMillis) => {
+            jsonb::Value::Number(jsonb::Number::Int64(*t as i64))
+        }
+        (Value::TimeMicros(t), Schema::TimeMicros) => {
+            jsonb::Value::Number(jsonb::Number::Int64(*t))
+        }
+        (Value::TimestampMillis(v), Schema::TimestampMillis)
+        | (Value::LocalTimestampMillis(v), Schema::LocalTimestampMillis) => {
+            jsonb::Value::Timestamp(jsonb::Timestamp {
+                value: (*v) * 1_000_000,
+            })
+        }
+        (Value::LocalTimestampMicros(v), Schema::LocalTimestampMicros) => {
+            jsonb::Value::Timestamp(jsonb::Timestamp {
+                value: (*v) * 1_000,
+            })
+        }
+        (Value::LocalTimestampNanos(v), Schema::LocalTimestampNanos) => {
+            jsonb::Value::Timestamp(jsonb::Timestamp { value: (*v) })
+        }
+        (Value::Duration(d), Schema::Duration) => {
+            let months: u32 = d.months().into();
+            let days: u32 = d.days().into();
+            let millis: u32 = d.millis().into();
+            jsonb::Value::Interval(jsonb::Interval {
+                months: months as i32,
+                days: days as i32,
+                micros: (millis * 1000) as i64,
+            })
+        }
+
+        // container
+        (Value::Union(i, v), Schema::Union(union_schema)) => {
+            to_jsonb(v, &union_schema.variants()[(*i) as usize])?
+        }
+        (Value::Array(v), Schema::Array(array_schema)) => {
             let mut array = Vec::with_capacity(v.len());
             for v in v {
-                array.push(to_jsonb(v)?)
+                array.push(to_jsonb(v, &array_schema.items)?)
             }
             jsonb::Value::Array(array)
         }
-        Value::Map(v) => {
+        (Value::Map(v), Schema::Map(map_schema)) => {
             let mut array = Vec::with_capacity(v.len());
             for (k, v) in v {
-                array.push((k.clone(), to_jsonb(v)?));
+                array.push((k.clone(), to_jsonb(v, &map_schema.types)?));
             }
             jsonb::Value::Object(BTreeMap::from_iter(array))
         }
-        Value::Record(v) => {
+        (Value::Record(v), Schema::Record(record_schema)) => {
             let mut array = Vec::with_capacity(v.len());
-            for (k, v) in v {
-                array.push((k.clone(), to_jsonb(v)?));
+            for (i, (k, v)) in v.iter().enumerate() {
+                array.push((k.clone(), to_jsonb(v, &record_schema.fields[i].schema)?));
             }
             jsonb::Value::Object(BTreeMap::from_iter(array))
         }
-        _ => return Err(format!("Cannot convert {:?} to JSONB", value)),
-        // Value::Bytes(_v) | Value::Fixed(_, _v) => {}
-        // Value::Date(_) => {}
-        // Value::Decimal(_) => {}
-        // Value::BigDecimal(_) => {}
-        // Value::TimeMillis(_) => {}
-        // Value::TimeMicros(_) => {}
-        // Value::TimestampMillis(_) => {}
-        // Value::TimestampMicros(_) => {}
-        // Value::TimestampNanos(_) => {}
-        // Value::LocalTimestampMillis(_) => {}
-        // Value::LocalTimestampMicros(_) => {}
-        // Value::LocalTimestampNanos(_) => {}
-        // Value::Duration(_) => {}
+        _ => {
+            return Err(format!(
+                "bug: avro schema and value not match: schema = {:?}, value = {:?}",
+                schema, value
+            ))
+        }
     };
     Ok(jvalue)
+}
+
+fn convert_decimal(
+    precision: usize,
+    scale: usize,
+    big_int: BigInt,
+) -> Result<jsonb::Number, String> {
+    let max_128 = MAX_DECIMAL128_PRECISION as usize;
+    let max_256 = MAX_DECIMAL256_PRECISION as usize;
+    if precision <= max_128 {
+        Ok(jsonb::Number::Decimal128(jsonb::Decimal128 {
+            precision: precision as u8,
+            scale: scale as u8,
+            value: i128::from_bigint(big_int).ok_or("too many bits for i128".to_string())?,
+        }))
+    } else if precision <= max_256 {
+        Ok(jsonb::Number::Decimal256(jsonb::Decimal256 {
+            precision: precision as u8,
+            scale: scale as u8,
+            value: i256::from_bigint(big_int)
+                .ok_or("too many bits for i256".to_string())?
+                .0,
+        }))
+    } else {
+        return Err(format!("Decimal precision too large: {}", precision));
+    }
 }

--- a/tests/sqllogictests/suites/stage/formats/avro/avro_query.test
+++ b/tests/sqllogictests/suites/stage/formats/avro/avro_query.test
@@ -1,0 +1,23 @@
+query 
+SELECT metadata$filename, metadata$file_row_number, $1 FROM '@data_s3/avro/' ( FILES => ('map.avro', 'number.avro', 'array.avro', 'nested_record.avro'), FILE_FORMAT => 'avro') order by metadata$filename, metadata$file_row_number
+----
+testbucket/data/avro/array.avro 0 {"tags":["tall","rich","handsome"]}
+testbucket/data/avro/array.avro 1 {"tags":[]}
+testbucket/data/avro/map.avro 0 {"scores":{"math":100}}
+testbucket/data/avro/map.avro 1 {"scores":{}}
+testbucket/data/avro/nested_record.avro 0 {"id":0,"info":{"contact":{"email":"yang@m","phone":"911"},"name":"yang"}}
+testbucket/data/avro/nested_record.avro 1 {"id":1,"info":{"contact":{"email":"wang@m","phone":null},"name":"wang"}}
+testbucket/data/avro/number.avro 0 {"c_double":1.7976931348623157e308,"c_float":3.4028234663852886e38,"c_int":2147483647,"c_long":9223372036854775807}
+testbucket/data/avro/number.avro 1 {"c_double":-1.7976931348623157e308,"c_float":-3.4028234663852886e38,"c_int":-2147483648,"c_long":-9223372036854775808}
+
+statement ok
+create or replace table t(scores variant, filename string, file_row_number int)
+
+statement ok
+copy into t from (SELECT $1, metadata$filename, metadata$file_row_number FROM '@data_s3/avro/map.avro') file_format=(type=avro)
+
+query
+select * from t order by filename,file_row_number
+----
+{"scores":{"math":100}} testbucket/data/avro/map.avro 0
+{"scores":{}} testbucket/data/avro/map.avro 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

# Complete Avro File Loading Support

In https://github.com/databendlabs/databend/pull/17548 we introduced the `COPY INTO <table>` feature for Avro files. This PR completes the Avro loading functionality by adding support for:

1. Direct querying of Avro files
2. COPY with transformation
3. Accessing metadata columns `metadata$filename` and `metadata$file_row_number`

## Summary of Avro Loading Features

After these changes, Avro files behave very similarly to NDJSON files when reading:

1. **COPY without transformation**:
   - Assumes top-level schema is a record and matches fields by name
   - More efficient for bulk loading
   - Doesn't require all files to have identical schema:
     - Field order doesn't matter
     - Supports file format option `missing_field_as = ERROR | FIELD_DEFAULT` (including nested records)
     - Supports loading different Avro types into one Databend field via auto-casting

2. **Query and COPY with transformation**:
   - Treats each row as a variant referenced by `$1`
   - Each Avro type is mapped to a variant type
   - More flexible and stable as type mappings are less likely to change

## Examples

Given an Avro file with schema `user` and table `user(id int, name string)`:

```json
{
  "type": "record",
  "name": "user",
  "fields": [
    {
      "name": "id",
      "type": "long"
    },
    {
      "name": "name",
      "type": "string"
    }
  ]
}
```
SQL exmaples:

```
-- Basic COPY
COPY INTO user FROM @stage file_format=(type=avro);

-- Query with metadata
SELECT 
    metadata$filename as file,
    metadata$file_row_number as row, 
    cast($1:id as int) as id, 
    $1:name as name
FROM @stage(file_format=>'avro');

-- COPY with transformation
COPY INTO user FROM (
    SELECT 
        $1:id::int as id,
        $1:name as name
    FROM @stage(file_format=>'avro')
) file_format=(type=avro);
```

## Type Mapping to Variant

Variants are stored as JSONB in Databend. While most mappings are straightforward, some special cases to note:

- Time Types:
   - JSONB doesn't have a Time type, so TimeMillis and TimeMicros are mapped to int64
   - Users should keep the original type in mind when working with these values
- Decimal Types:
   - Decimals will be loaded as either decimal128 or decimal256
   - May report an error if the precision is too large
- Enum Types:
   - Mapped to string values

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17953)
<!-- Reviewable:end -->
