### PR TITLE
chore: enable Lz4Raw for parquet reading compatibility

### DIFF
--- a/src/query/storages/common/table_meta/src/table/table_compression.rs
+++ b/src/query/storages/common/table_meta/src/table/table_compression.rs
@@ -92,7 +92,7 @@ impl From<meta::Compression> for ParquetCompression {
             meta::Compression::Snappy => ParquetCompression::SNAPPY,
             meta::Compression::Zstd => ParquetCompression::ZSTD(ZstdLevel::default()),
             meta::Compression::None => ParquetCompression::UNCOMPRESSED,
-            meta::Compression::Lz4 => panic!("deprecated lz4"),
+            meta::Compression::Lz4 => ParquetCompression::LZ4_RAW,
             meta::Compression::Gzip => ParquetCompression::GZIP(GzipLevel::default()),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

    chore: enable Lz4Raw for parquet reading compatibility
    
    Re-enable Lz4Raw compression support in the reading path to maintain
    compatibility with existing objects that were compacted with parquet Lz4Raw.
    
    Note: The writing path remains unchanged - no new Lz4Raw compressed data
    will be generated.



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Test manually 

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
