### PR TITLE
fix(query): use local time for query log

### DIFF
--- a/src/query/storages/system/src/query_log_table.rs
+++ b/src/query/storages/system/src/query_log_table.rs
@@ -71,7 +71,7 @@ fn date_str<S>(dt: &i32, s: S) -> std::result::Result<S::Ok, S::Error>
 where S: Serializer {
     let t = DateTime::from_timestamp(i64::from(*dt) * 24 * 3600, 0)
         .unwrap()
-        .naive_utc();
+        .with_timezone(&chrono::Local);
     s.serialize_str(t.format("%Y-%m-%d").to_string().as_str())
 }
 
@@ -80,11 +80,10 @@ where S: Serializer {
     let t = DateTime::from_timestamp(
         dt / 1_000_000,
         TryFrom::try_from((dt % 1_000_000) * 1000).unwrap_or(0),
-        // u32::try_from((dt % 1_000_000) * 1000).unwrap_or(0),
     )
     .unwrap()
-    .naive_utc();
-    s.serialize_str(t.format("%Y-%m-%d %H:%M:%S%.6f").to_string().as_str())
+    .with_timezone(&chrono::Local);
+    s.serialize_str(t.to_rfc3339().to_string().as_str())
 }
 
 #[derive(Clone, Serialize)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Format query_start_time and query_end_time to local time RFC3339 with timezone.
- ref: https://github.com/databendlabs/databend/issues/17859

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17963)
<!-- Reviewable:end -->
