### PR TITLE
fix(cloudcontrol): increase max_decoding_message_size for task client

### DIFF
--- a/src/common/cloud_control/src/notification_client.rs
+++ b/src/common/cloud_control/src/notification_client.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use tonic::transport::Channel;
 use tonic::Request;
 
@@ -35,11 +33,14 @@ pub struct NotificationClient {
 
 impl NotificationClient {
     // TODO: add auth interceptor
-    pub async fn new(
-        channel: Channel,
-    ) -> databend_common_exception::Result<Arc<NotificationClient>> {
+    pub async fn new(channel: Channel) -> databend_common_exception::Result<NotificationClient> {
         let client = NotificationServiceClient::new(channel);
-        Ok(Arc::new(NotificationClient { client }))
+        Ok(NotificationClient { client })
+    }
+
+    pub fn with_max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.client = self.client.max_decoding_message_size(limit);
+        self
     }
 
     // TODO: richer error handling on Task Error

--- a/src/common/cloud_control/src/task_client.rs
+++ b/src/common/cloud_control/src/task_client.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_exception::Result;
 use tonic::transport::Channel;
 use tonic::Request;
@@ -43,9 +41,14 @@ pub struct TaskClient {
 
 impl TaskClient {
     // TODO: add auth interceptor
-    pub async fn new(channel: Channel) -> Result<Arc<TaskClient>> {
+    pub async fn new(channel: Channel) -> Result<TaskClient> {
         let task_client = TaskServiceClient::new(channel);
-        Ok(Arc::new(TaskClient { task_client }))
+        Ok(TaskClient { task_client })
+    }
+
+    pub fn with_max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.task_client = self.task_client.max_decoding_message_size(limit);
+        self
     }
 
     // TODO: richer error handling on Task Error


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Increase max_decoding_message_size from default 4MiB to 16GiB.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17966)
<!-- Reviewable:end -->
