### PR TITLE
refactor: move transaction commit relevant code to interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,8 +4138,6 @@ dependencies = [
  "databend-common-version",
  "databend-enterprise-data-mask-feature",
  "databend-storages-common-cache",
- "databend-storages-common-io",
- "databend-storages-common-session",
  "databend-storages-common-table-meta",
  "databend_educe",
  "derive-visitor",

--- a/src/query/service/src/interpreters/interpreter.rs
+++ b/src/query/service/src/interpreters/interpreter.rs
@@ -56,6 +56,7 @@ use super::hook::vacuum_hook::hook_disk_temp_dir;
 use super::hook::vacuum_hook::hook_vacuum_temp_files;
 use super::InterpreterMetrics;
 use super::InterpreterQueryLog;
+use crate::interpreters::interpreter_txn_commit::execute_commit_statement;
 use crate::pipelines::executor::ExecutorSettings;
 use crate::pipelines::executor::PipelineCompleteExecutor;
 use crate::pipelines::executor::PipelinePullingExecutor;
@@ -240,6 +241,22 @@ pub async fn interpreter_plan_sql(
     result
 }
 
+async fn auto_commit_if_not_allowed_in_transaction(
+    ctx: Arc<QueryContext>,
+    stmt: &Statement,
+) -> Result<()> {
+    if !stmt.allowed_in_multi_statement() {
+        execute_commit_statement(ctx.clone()).await?;
+    }
+    if !stmt.is_transaction_command() && ctx.txn_mgr().lock().is_fail() {
+        let err = ErrorCode::CurrentTransactionIsAborted(
+            "Current transaction is aborted, commands ignored until end of transaction block",
+        );
+        return Err(err);
+    }
+    Ok(())
+}
+
 async fn plan_sql(
     ctx: Arc<QueryContext>,
     sql: &str,
@@ -254,6 +271,7 @@ async fn plan_sql(
 
     // Parse the SQL query, get extract additional information.
     let extras = planner.parse_sql(sql)?;
+    auto_commit_if_not_allowed_in_transaction(ctx.clone(), &extras.statement).await?;
     if !acquire_queue {
         // If queue guard is not required, plan the statement directly.
         let plan = planner.plan_stmt(&extras.statement).await?;

--- a/src/query/service/src/interpreters/interpreter_txn_commit.rs
+++ b/src/query/service/src/interpreters/interpreter_txn_commit.rs
@@ -13,13 +13,24 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_sql::execute_commit_statement;
+use databend_common_meta_app::principal::StageInfo;
+use databend_common_metrics::storage::metrics_inc_copy_purge_files_cost_milliseconds;
+use databend_common_metrics::storage::metrics_inc_copy_purge_files_counter;
+use databend_common_storage::init_stage_operator;
+use databend_common_storages_fuse::TableContext;
+use databend_storages_common_io::Files;
+use databend_storages_common_session::TxnManagerRef;
+use log::error;
+use log::info;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
+
 pub struct CommitInterpreter {
     ctx: Arc<QueryContext>,
 }
@@ -48,5 +59,109 @@ impl Interpreter for CommitInterpreter {
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         execute_commit_statement(self.ctx.clone()).await?;
         Ok(PipelineBuildResult::create())
+    }
+}
+
+struct ClearTxnManagerGuard(TxnManagerRef);
+
+impl Drop for ClearTxnManagerGuard {
+    fn drop(&mut self) {
+        self.0.lock().clear();
+    }
+}
+
+pub async fn execute_commit_statement(ctx: Arc<dyn TableContext>) -> Result<()> {
+    // After commit statement, current session should be in auto commit mode, no matter update meta success or not.
+    // Use this guard to clear txn manager before return.
+    let _guard = ClearTxnManagerGuard(ctx.txn_mgr().clone());
+    let is_active = ctx.txn_mgr().lock().is_active();
+    if is_active {
+        let catalog = ctx.get_default_catalog()?;
+
+        let req = ctx.txn_mgr().lock().req();
+
+        let update_summary = {
+            let table_descriptions = req
+                .update_table_metas
+                .iter()
+                .map(|(req, _)| (req.table_id, req.seq, req.new_table_meta.engine.clone()))
+                .collect::<Vec<_>>();
+            let stream_descriptions = req
+                .update_stream_metas
+                .iter()
+                .map(|s| (s.stream_id, s.seq, "stream"))
+                .collect::<Vec<_>>();
+            (table_descriptions, stream_descriptions)
+        };
+
+        let mismatched_tids = {
+            ctx.txn_mgr().lock().set_auto_commit();
+            let ret = catalog.retryable_update_multi_table_meta(req).await;
+            if let Err(ref e) = ret {
+                // other errors may occur, especially the version mismatch of streams,
+                // let's log it here for the convenience of diagnostics
+                error!(
+                    "Non-recoverable fault occurred during table metadata update: {}",
+                    e
+                );
+            }
+            ret?
+        };
+
+        match &mismatched_tids {
+            Ok(_) => {
+                info!(
+                    "Transaction committed successfully, updated targets: {:?}",
+                    update_summary
+                );
+            }
+            Err(e) => {
+                let err_msg = format!(
+                    "Due to concurrent transactions, explicit transaction commit failed. Conflicting table IDs: {:?}",
+                    e.iter().map(|(tid, _, _)| tid).collect::<Vec<_>>()
+                );
+                info!(
+                    "Transaction commit failed due to concurrent modifications. Conflicting table IDs: {:?}",
+                    e
+                );
+                return Err(ErrorCode::TableVersionMismatched(format!("{}", err_msg)));
+            }
+        }
+        let need_purge_files = ctx.txn_mgr().lock().need_purge_files();
+        for (stage_info, files) in need_purge_files {
+            try_purge_files(ctx.clone(), &stage_info, &files).await;
+        }
+    }
+    Ok(())
+}
+
+#[async_backtrace::framed]
+async fn try_purge_files(ctx: Arc<dyn TableContext>, stage_info: &StageInfo, files: &[String]) {
+    let start = Instant::now();
+    let op = init_stage_operator(stage_info);
+
+    match op {
+        Ok(op) => {
+            let file_op = Files::create(ctx, op);
+            if let Err(e) = file_op.remove_file_in_batch(files).await {
+                error!("Failed to delete files: {:?}, error: {}", files, e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to initialize stage operator, error: {}", e);
+        }
+    }
+
+    let elapsed = start.elapsed();
+    info!(
+        "[SQL-BINDER] Purged {} files, operation took {:?}",
+        files.len(),
+        elapsed
+    );
+
+    // Perf.
+    {
+        metrics_inc_copy_purge_files_counter(files.len() as u32);
+        metrics_inc_copy_purge_files_cost_milliseconds(elapsed.as_millis() as u32);
     }
 }

--- a/src/query/service/src/interpreters/interpreter_txn_commit.rs
+++ b/src/query/service/src/interpreters/interpreter_txn_commit.rs
@@ -153,11 +153,7 @@ async fn try_purge_files(ctx: Arc<dyn TableContext>, stage_info: &StageInfo, fil
     }
 
     let elapsed = start.elapsed();
-    info!(
-        "Purged {} files, operation took {:?}",
-        files.len(),
-        elapsed
-    );
+    info!("Purged {} files, operation took {:?}", files.len(), elapsed);
 
     // Perf.
     {

--- a/src/query/service/src/interpreters/interpreter_txn_commit.rs
+++ b/src/query/service/src/interpreters/interpreter_txn_commit.rs
@@ -154,7 +154,7 @@ async fn try_purge_files(ctx: Arc<dyn TableContext>, stage_info: &StageInfo, fil
 
     let elapsed = start.elapsed();
     info!(
-        "[SQL-BINDER] Purged {} files, operation took {:?}",
+        "Purged {} files, operation took {:?}",
         files.len(),
         elapsed
     );

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -34,8 +34,6 @@ databend-common-users = { workspace = true }
 databend-common-version = { workspace = true }
 databend-enterprise-data-mask-feature = { workspace = true }
 databend-storages-common-cache = { workspace = true }
-databend-storages-common-io = { workspace = true }
-databend-storages-common-session = { workspace = true }
 databend-storages-common-table-meta = { workspace = true }
 
 ahash = { workspace = true, features = ["no-rng"] }

--- a/src/query/sql/src/planner/binder/mod.rs
+++ b/src/query/sql/src/planner/binder/mod.rs
@@ -65,7 +65,6 @@ pub use bind_mutation::MutationStrategy;
 pub use bind_mutation::MutationType;
 pub use bind_query::bind_values;
 pub use bind_table_reference::parse_result_scan_args;
-pub use binder::execute_commit_statement;
 pub use binder::Binder;
 pub use builders::*;
 pub use column_binding::ColumnBinding;

--- a/src/query/sql/src/planner/mod.rs
+++ b/src/query/sql/src/planner/mod.rs
@@ -26,7 +26,6 @@ pub mod optimizer;
 mod planner_cache;
 pub mod plans;
 
-pub use binder::execute_commit_statement;
 pub use binder::parse_result_scan_args;
 pub use binder::BindContext;
 pub use binder::Binder;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Code for multi-statement transaction commits was located in the `databend-common-sql` crate, which made it difficult to reference fuse-related crates. So move transaction commit relevant code to interpreter

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  tests/sqllogictests/suites/ee/06_ee_stream/06_0007_stream_ddl_txn.test should cover

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17976)
<!-- Reviewable:end -->
