### PR TITLE
feat: Iceberg Table supports delete positions of merge on read when reading

### DIFF
--- a/.github/actions/test_sqllogic_iceberg_tpch/action.yml
+++ b/.github/actions/test_sqllogic_iceberg_tpch/action.yml
@@ -29,7 +29,7 @@ runs:
         fi
         tar -zxf ${data_dir}/tpch.tar.gz -C $data_dir
 
-        pip install pyspark
+        pip install pyspark==3.5.0
         python3 tests/sqllogictests/scripts/prepare_iceberg_tpch_data.py
         python3 tests/sqllogictests/scripts/prepare_iceberg_test_data.py
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=274b0d5fa#274b0d5fa2835e704a9be6903f41be467b9e24ab"
+source = "git+https://github.com/databendlabs/iceberg-rust?rev=d5cca1c15f240f3cb04e57569bce648933b1c79b#d5cca1c15f240f3cb04e57569bce648933b1c79b"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.4.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=274b0d5fa#274b0d5fa2835e704a9be6903f41be467b9e24ab"
+source = "git+https://github.com/databendlabs/iceberg-rust?rev=d5cca1c15f240f3cb04e57569bce648933b1c79b#d5cca1c15f240f3cb04e57569bce648933b1c79b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8693,7 +8693,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-hms"
 version = "0.4.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=274b0d5fa#274b0d5fa2835e704a9be6903f41be467b9e24ab"
+source = "git+https://github.com/databendlabs/iceberg-rust?rev=d5cca1c15f240f3cb04e57569bce648933b1c79b#d5cca1c15f240f3cb04e57569bce648933b1c79b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8717,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=274b0d5fa#274b0d5fa2835e704a9be6903f41be467b9e24ab"
+source = "git+https://github.com/databendlabs/iceberg-rust?rev=d5cca1c15f240f3cb04e57569bce648933b1c79b#d5cca1c15f240f3cb04e57569bce648933b1c79b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8737,7 +8737,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.4.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=274b0d5fa#274b0d5fa2835e704a9be6903f41be467b9e24ab"
+source = "git+https://github.com/databendlabs/iceberg-rust?rev=d5cca1c15f240f3cb04e57569bce648933b1c79b#d5cca1c15f240f3cb04e57569bce648933b1c79b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,13 +338,13 @@ hyper = "1"
 hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio", "service"] }
 
 ## in branch dev
-iceberg = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "274b0d5fa", features = [
+iceberg = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b", features = [
     "storage-all",
 ] }
-iceberg-catalog-glue = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "274b0d5fa" }
-iceberg-catalog-hms = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "274b0d5fa" }
-iceberg-catalog-rest = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "274b0d5fa" }
-iceberg-catalog-s3tables = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "274b0d5fa" }
+iceberg-catalog-glue = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b" }
+iceberg-catalog-hms = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b" }
+iceberg-catalog-rest = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b" }
+iceberg-catalog-s3tables = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b" }
 
 # Explicitly specify compatible AWS SDK versions
 aws-config = "1.5.18"

--- a/src/query/storages/iceberg/src/partition.rs
+++ b/src/query/storages/iceberg/src/partition.rs
@@ -28,13 +28,25 @@ pub(crate) fn convert_file_scan_task(task: iceberg::scan::FileScanTask) -> Box<d
             Box::new(part)
         }
         DataFileFormat::Parquet => {
-            let file = ParquetFilePart {
+            let fn_part = || ParquetFilePart {
                 file: task.data_file_path.clone(),
                 compressed_size: task.length,
                 estimated_uncompressed_size: task.length * 5,
                 dedup_key: format!("{}_{}", task.data_file_path, task.length),
             };
-            Box::new(ParquetPart::File(file))
+
+            if !task.deletes.is_empty() {
+                Box::new(ParquetPart::FileWithDeletes {
+                    inner: fn_part(),
+                    deletes: task
+                        .deletes
+                        .iter()
+                        .map(|file| file.file_path.clone())
+                        .collect(),
+                })
+            } else {
+                Box::new(ParquetPart::File(fn_part()))
+            }
         }
         _ => unimplemented!(),
     }

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -418,6 +418,7 @@ impl IcebergTable {
         }
 
         let tasks: Vec<_> = scan
+            .with_delete_file_processing_enabled(true)
             .build()
             .map_err(|err| ErrorCode::Internal(format!("iceberg table scan build: {err:?}")))?
             .plan_files()

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/no_prefetch.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/no_prefetch.rs
@@ -45,7 +45,7 @@ impl ReadPolicyBuilder for NoPretchPolicyBuilder {
     async fn build(
         &self,
         mut row_group: InMemoryRowGroup<'_>,
-        _row_selection: Option<RowSelection>,
+        row_selection: Option<RowSelection>,
         _sorter: &mut Option<TopKSorter>,
         transformer: Option<RecordBatchTransformer>,
         batch_size: usize,
@@ -55,7 +55,7 @@ impl ReadPolicyBuilder for NoPretchPolicyBuilder {
             &self.field_levels,
             &row_group,
             batch_size,
-            None,
+            row_selection,
         )?;
         Ok(Some(Box::new(NoPrefetchPolicy {
             field_paths: self.field_paths.clone(),

--- a/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
@@ -57,6 +57,7 @@ pub struct ParquetReaderBuilder<'a> {
     arrow_schema: Option<arrow_schema::Schema>,
 
     push_downs: Option<&'a PushDownInfo>,
+    delete_files: Option<Vec<String>>,
     options: ParquetReadOptions,
     // only for full file reader
     pruner: Option<ParquetPruner>,
@@ -111,6 +112,7 @@ impl<'a> ParquetReaderBuilder<'a> {
             arrow_schema,
             schema_desc_from,
             push_downs: None,
+            delete_files: None,
             options: Default::default(),
             pruner: None,
             topk: None,
@@ -123,6 +125,11 @@ impl<'a> ParquetReaderBuilder<'a> {
 
     pub fn with_push_downs(mut self, push_downs: Option<&'a PushDownInfo>) -> Self {
         self.push_downs = push_downs;
+        self
+    }
+
+    pub fn with_delete_files(mut self, delete_files: Option<Vec<String>>) -> Self {
+        self.delete_files = delete_files;
         self
     }
 
@@ -305,6 +312,7 @@ impl<'a> ParquetReaderBuilder<'a> {
         };
 
         Ok(RowGroupReader {
+            ctx: self.ctx.clone(),
             op_registry: self.op_registry.clone(),
             batch_size,
             schema_desc: self.schema_desc.clone(),

--- a/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
@@ -13,15 +13,26 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::LazyLock;
 
+use databend_common_catalog::plan::Projection;
+use databend_common_catalog::plan::PushDownInfo;
+use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
 use databend_common_expression::TopKSorter;
 use databend_common_metrics::storage::metrics_inc_omit_filter_rowgroups;
 use databend_common_metrics::storage::metrics_inc_omit_filter_rows;
 use databend_common_storage::OperatorRegistry;
+use futures::future::try_join_all;
 use opendal::Operator;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::metadata::RowGroupMetaData;
 use parquet::format::PageLocation;
 use parquet::schema::types::SchemaDescPtr;
 
@@ -33,9 +44,42 @@ use crate::parquet_reader::row_group::InMemoryRowGroup;
 use crate::partition::ParquetRowGroupPart;
 use crate::read_settings::ReadSettings;
 use crate::transformer::RecordBatchTransformer;
+use crate::ParquetReaderBuilder;
+use crate::ParquetSourceType;
+
+static DELETES_FILE_SCHEMA: LazyLock<arrow_schema::Schema> = LazyLock::new(|| {
+    arrow_schema::Schema::new(vec![
+        arrow_schema::Field::new("file_path", arrow_schema::DataType::Utf8, false),
+        arrow_schema::Field::new("pos", arrow_schema::DataType::Int64, false),
+    ])
+});
+
+static DELETES_FILE_TABLE_SCHEMA: LazyLock<Arc<TableSchema>> = LazyLock::new(|| {
+    Arc::new(TableSchema::new(vec![
+        TableField::new("file_path", TableDataType::String),
+        TableField::new("pos", TableDataType::Number(NumberDataType::Int64)),
+    ]))
+});
+
+static DELETES_FILE_PUSHDOWN_INFO: LazyLock<PushDownInfo> = LazyLock::new(|| PushDownInfo {
+    projection: Some(Projection::Columns(vec![1])),
+    output_columns: None,
+    filters: None,
+    is_deterministic: false,
+    prewhere: None,
+    limit: None,
+    order_by: vec![],
+    virtual_column: None,
+    lazy_materialization: false,
+    agg_index: None,
+    change_type: None,
+    inverted_index: None,
+    sample: None,
+});
 
 /// The reader to read a row group.
 pub struct RowGroupReader {
+    pub(super) ctx: Arc<dyn TableContext>,
     pub(super) op_registry: Arc<dyn OperatorRegistry>,
 
     pub(super) default_policy: PolicyType,
@@ -63,6 +107,8 @@ impl RowGroupReader {
         read_settings: &ReadSettings,
         part: &ParquetRowGroupPart,
         topk_sorter: &mut Option<TopKSorter>,
+        delete_info: Option<(&ParquetMetaData, &[String])>,
+        delete_selection: &mut Option<RowSelection>,
     ) -> Result<Option<ReadPolicyImpl>> {
         if let Some((sorter, min_max)) = topk_sorter.as_ref().zip(part.sort_min_max.as_ref()) {
             if sorter.never_match(min_max) {
@@ -82,7 +128,48 @@ impl RowGroupReader {
             page_locations.as_deref(),
             *read_settings,
         );
-        let mut selection = part
+        if let (Some((parquet_meta, delete_files)), true) =
+            (delete_info, delete_selection.is_none())
+        {
+            let futures = delete_files.iter().map(|delete| async {
+                let (op, path) = self.op_registry.get_operator_path(delete)?;
+                let meta = op.stat(path).await?;
+                let info = &DELETES_FILE_PUSHDOWN_INFO;
+
+                let mut builder = ParquetReaderBuilder::create(
+                    self.ctx.clone(),
+                    Arc::new(op),
+                    DELETES_FILE_TABLE_SCHEMA.clone(),
+                    DELETES_FILE_SCHEMA.clone(),
+                )?
+                .with_push_downs(Some(info));
+                let reader = builder.build_full_reader(ParquetSourceType::Iceberg, false)?;
+                let mut stream = reader
+                    .prepare_data_stream(path, meta.content_length(), None)
+                    .await?;
+                let mut positional_deletes = Vec::new();
+
+                while let Some(block) = reader.read_block_from_stream(&mut stream).await? {
+                    let num_rows = block.num_rows();
+                    let column = block.columns()[0].to_column(num_rows);
+                    let column = column.as_number().unwrap().as_int64().unwrap();
+
+                    positional_deletes.extend_from_slice(column.as_slice())
+                }
+
+                Result::Ok(positional_deletes)
+            });
+            let positional_deletes = try_join_all(futures)
+                .await?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            *delete_selection = Some(Self::build_deletes_row_selection(
+                parquet_meta.row_groups(),
+                positional_deletes,
+            )?);
+        }
+        let mut part_selection = part
             .selectors
             .as_ref()
             .map(|x| x.iter().map(RowSelector::from).collect::<Vec<_>>())
@@ -94,20 +181,114 @@ impl RowGroupReader {
             // PRED_ONLY (0b01) -> NO_PREFETCH (0b00)
             // PRED_AND_TOPK (0b11) -> TOPK_ONLY (0b10)
             policy &= !POLICY_PREDICATE_ONLY;
-            selection = None;
+            part_selection = None;
             metrics_inc_omit_filter_rowgroups(1);
             metrics_inc_omit_filter_rows(row_group.row_count() as u64);
         }
+
+        let selections = match (
+            part_selection,
+            // The Pos in DeleteFile is global in Parquet.
+            // Therefore, it is necessary to split it in units of RowGroup.
+            delete_selection
+                .as_mut()
+                .map(|selection| selection.split_off(part.meta.num_rows() as usize)),
+        ) {
+            (Some(result_selection), Some(delete_selection)) => {
+                Some(result_selection.intersection(&delete_selection))
+            }
+            (Some(selection), None) | (None, Some(selection)) => Some(selection),
+            (None, None) => None,
+        };
 
         let builder = &self.policy_builders[policy as usize];
         builder
             .build(
                 row_group,
-                selection,
+                selections,
                 topk_sorter,
                 self.transformer.clone(),
                 self.batch_size,
             )
             .await
+    }
+
+    fn build_deletes_row_selection(
+        row_group_metadata_list: &[RowGroupMetaData],
+        positional_deletes: Vec<i64>,
+    ) -> Result<RowSelection> {
+        debug_assert!(positional_deletes.is_sorted());
+        let mut results: Vec<RowSelector> = Vec::new();
+        let mut current_row_group_base_idx: u64 = 0;
+        let mut delete_vector_iter = positional_deletes.into_iter().map(|i| i as u64);
+        let mut next_deleted_row_idx_opt = delete_vector_iter.next();
+
+        for row_group_metadata in row_group_metadata_list.iter() {
+            let row_group_num_rows = row_group_metadata.num_rows() as u64;
+            let next_row_group_base_idx = current_row_group_base_idx + row_group_num_rows;
+
+            let mut next_deleted_row_idx = match next_deleted_row_idx_opt {
+                Some(next_deleted_row_idx) => {
+                    // if the index of the next deleted row is beyond this row group, add a selection for
+                    // the remainder of this row group and skip to the next row group
+                    if next_deleted_row_idx >= next_row_group_base_idx {
+                        results.push(RowSelector::select(row_group_num_rows as usize));
+                        continue;
+                    }
+
+                    next_deleted_row_idx
+                }
+
+                // If there are no more pos deletes, add a selector for the entirety of this row group.
+                _ => {
+                    results.push(RowSelector::select(row_group_num_rows as usize));
+                    continue;
+                }
+            };
+
+            let mut current_idx = current_row_group_base_idx;
+            'chunks: while next_deleted_row_idx < next_row_group_base_idx {
+                // `select` all rows that precede the next delete index
+                if current_idx < next_deleted_row_idx {
+                    let run_length = next_deleted_row_idx - current_idx;
+                    results.push(RowSelector::select(run_length as usize));
+                    current_idx += run_length;
+                }
+
+                // `skip` all consecutive deleted rows in the current row group
+                let mut run_length = 0;
+                while next_deleted_row_idx == current_idx
+                    && next_deleted_row_idx < next_row_group_base_idx
+                {
+                    run_length += 1;
+                    current_idx += 1;
+
+                    next_deleted_row_idx_opt = delete_vector_iter.next();
+                    next_deleted_row_idx = match next_deleted_row_idx_opt {
+                        Some(next_deleted_row_idx) => next_deleted_row_idx,
+                        _ => {
+                            // We've processed the final positional delete.
+                            // Conclude the skip and then break so that we select the remaining
+                            // rows in the row group and move on to the next row group
+                            results.push(RowSelector::skip(run_length));
+                            break 'chunks;
+                        }
+                    };
+                }
+                if run_length > 0 {
+                    results.push(RowSelector::skip(run_length));
+                }
+            }
+
+            if current_idx < next_row_group_base_idx {
+                results.push(RowSelector::select(
+                    (next_row_group_base_idx - current_idx) as usize,
+                ));
+            }
+
+            current_row_group_base_idx += row_group_num_rows;
+        }
+
+        Ok(RowSelection::from(results))
     }
 }

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::sync::LazyLock;
 
 use bytes::Bytes;
 use databend_common_base::base::Progress;
@@ -25,7 +24,6 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::plan::InternalColumnType;
 use databend_common_catalog::plan::ParquetReadOptions;
-use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::TopK;
 use databend_common_catalog::query_kind::QueryKind;
@@ -39,9 +37,6 @@ use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::TableDataType;
-use databend_common_expression::TableField;
-use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TopKSorter;
 use databend_common_expression::Value;
@@ -52,9 +47,7 @@ use databend_common_pipeline_core::processors::ProcessorPtr;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::FileStatus;
 use databend_common_storage::OperatorRegistry;
-use futures::future::try_join_all;
 use parquet::arrow::parquet_to_arrow_schema;
-use parquet::file::metadata::RowGroupMetaData;
 
 use crate::meta::check_parquet_schema;
 use crate::meta::read_metadata_async_cached;
@@ -63,41 +56,10 @@ use crate::parquet_reader::policy::ReadPolicyImpl;
 use crate::parquet_reader::ParquetWholeFileReader;
 use crate::parquet_reader::RowGroupReader;
 use crate::partition::ParquetRowGroupPart;
-use crate::partition::SerdeRowSelector;
 use crate::read_settings::ReadSettings;
 use crate::ParquetFilePart;
 use crate::ParquetPart;
 use crate::ParquetReaderBuilder;
-
-static DELETES_FILE_SCHEMA: LazyLock<arrow_schema::Schema> = LazyLock::new(|| {
-    arrow_schema::Schema::new(vec![
-        arrow_schema::Field::new("file_path", arrow_schema::DataType::Utf8, false),
-        arrow_schema::Field::new("pos", arrow_schema::DataType::Int64, false),
-    ])
-});
-
-static DELETES_FILE_TABLE_SCHEMA: LazyLock<Arc<TableSchema>> = LazyLock::new(|| {
-    Arc::new(TableSchema::new(vec![
-        TableField::new("file_path", TableDataType::String),
-        TableField::new("pos", TableDataType::Number(NumberDataType::Int64)),
-    ]))
-});
-
-static DELETES_FILE_PUSHDOWN_INFO: LazyLock<PushDownInfo> = LazyLock::new(|| PushDownInfo {
-    projection: Some(Projection::Columns(vec![1])),
-    output_columns: None,
-    filters: None,
-    is_deterministic: false,
-    prewhere: None,
-    limit: None,
-    order_by: vec![],
-    virtual_column: None,
-    lazy_materialization: false,
-    agg_index: None,
-    change_type: None,
-    inverted_index: None,
-    sample: None,
-});
 
 enum State {
     Init,
@@ -327,6 +289,8 @@ impl Processor for ParquetSource {
                                     ),
                                     part,
                                     &mut self.topk_sorter,
+                                    None,
+                                    &mut None,
                                 )
                                 .await?
                             {
@@ -368,45 +332,8 @@ impl Processor for ParquetSource {
                             }
                         }
                         ParquetPart::FileWithDeletes { inner, deletes } => {
-                            let futures = deletes.iter().map(|delete| async {
-                                let (op, path) = self.op_registry.get_operator_path(delete)?;
-                                let meta = op.stat(path).await?;
-                                let info = &DELETES_FILE_PUSHDOWN_INFO;
-
-                                let mut builder = ParquetReaderBuilder::create(
-                                    self.ctx.clone(),
-                                    Arc::new(op),
-                                    DELETES_FILE_TABLE_SCHEMA.clone(),
-                                    DELETES_FILE_SCHEMA.clone(),
-                                )?
-                                .with_push_downs(Some(info));
-                                let reader =
-                                    builder.build_full_reader(ParquetSourceType::Iceberg, false)?;
-                                let mut stream = reader
-                                    .prepare_data_stream(path, meta.content_length(), None)
-                                    .await?;
-                                let mut positional_deletes = Vec::new();
-
-                                while let Some(block) =
-                                    reader.read_block_from_stream(&mut stream).await?
-                                {
-                                    let num_rows = block.num_rows();
-                                    let column = block.columns()[0].to_column(num_rows);
-                                    let column = column.as_number().unwrap().as_int64().unwrap();
-
-                                    positional_deletes.extend_from_slice(column.as_slice())
-                                }
-
-                                Result::Ok(positional_deletes)
-                            });
-                            let positional_deletes = try_join_all(futures)
-                                .await?
-                                .into_iter()
-                                .flatten()
-                                .collect::<Vec<_>>();
-                            let readers = self
-                                .get_rows_readers(inner, Some(positional_deletes))
-                                .await?;
+                            let readers =
+                                self.get_rows_readers(inner, Some(deletes.clone())).await?;
                             if !readers.is_empty() {
                                 self.state = State::ReadRowGroup {
                                     readers,
@@ -430,7 +357,7 @@ impl ParquetSource {
     async fn get_rows_readers(
         &mut self,
         part: &ParquetFilePart,
-        positional_deletes: Option<Vec<i64>>,
+        delete_files: Option<Vec<String>>,
     ) -> Result<VecDeque<(ReadPolicyImpl, u64)>> {
         // Let's read the small file directly
         let (op, path) = self.row_group_reader.operator(part.file.as_str())?;
@@ -438,9 +365,6 @@ impl ParquetSource {
         let meta =
             read_metadata_async_cached(path, &op, Some(part.compressed_size), &part.dedup_key)
                 .await?;
-        let selectors = positional_deletes
-            .map(|deletes| Self::build_deletes_row_selection(meta.row_groups(), deletes))
-            .transpose()?;
 
         let from_stage_table = matches!(self.source_type, ParquetSourceType::StageTable);
         if from_stage_table {
@@ -485,6 +409,12 @@ impl ParquetSource {
 
         let mut start_row = 0;
         let mut readers = VecDeque::with_capacity(meta.num_row_groups());
+        // Deleted files only belong to the same Parquet, so they only need to be loaded once
+        let mut buf_delete_selection = None;
+        let delete_info = delete_files
+            .as_ref()
+            .map(|files| (meta.as_ref(), files.as_slice()));
+
         for rg in meta.row_groups() {
             let part = ParquetRowGroupPart {
                 location: part.file.clone(),
@@ -496,7 +426,7 @@ impl ParquetSource {
                 sort_min_max: None,
                 omit_filter: false,
                 page_locations: None,
-                selectors: selectors.clone(),
+                selectors: None,
             };
             start_row += rg.num_rows() as u64;
 
@@ -505,6 +435,8 @@ impl ParquetSource {
                     &ReadSettings::from_ctx(&self.ctx)?.with_enable_cache(!from_stage_table),
                     &part,
                     &mut self.topk_sorter,
+                    delete_info,
+                    &mut buf_delete_selection,
                 )
                 .await?;
 
@@ -513,101 +445,6 @@ impl ParquetSource {
             }
         }
         Ok(readers)
-    }
-
-    fn build_deletes_row_selection(
-        row_group_metadata_list: &[RowGroupMetaData],
-        positional_deletes: Vec<i64>,
-    ) -> Result<Vec<SerdeRowSelector>> {
-        debug_assert!(positional_deletes.is_sorted());
-        let mut results: Vec<SerdeRowSelector> = Vec::new();
-        let mut current_row_group_base_idx: u64 = 0;
-        let mut delete_vector_iter = positional_deletes.into_iter().map(|i| i as u64);
-        let mut next_deleted_row_idx_opt = delete_vector_iter.next();
-
-        for row_group_metadata in row_group_metadata_list.iter() {
-            let row_group_num_rows = row_group_metadata.num_rows() as u64;
-            let next_row_group_base_idx = current_row_group_base_idx + row_group_num_rows;
-
-            let mut next_deleted_row_idx = match next_deleted_row_idx_opt {
-                Some(next_deleted_row_idx) => {
-                    // if the index of the next deleted row is beyond this row group, add a selection for
-                    // the remainder of this row group and skip to the next row group
-                    if next_deleted_row_idx >= next_row_group_base_idx {
-                        results.push(SerdeRowSelector {
-                            row_count: row_group_num_rows as usize,
-                            skip: false,
-                        });
-                        continue;
-                    }
-
-                    next_deleted_row_idx
-                }
-
-                // If there are no more pos deletes, add a selector for the entirety of this row group.
-                _ => {
-                    results.push(SerdeRowSelector {
-                        row_count: row_group_num_rows as usize,
-                        skip: false,
-                    });
-                    continue;
-                }
-            };
-
-            let mut current_idx = current_row_group_base_idx;
-            'chunks: while next_deleted_row_idx < next_row_group_base_idx {
-                // `select` all rows that precede the next delete index
-                if current_idx < next_deleted_row_idx {
-                    let run_length = next_deleted_row_idx - current_idx;
-                    results.push(SerdeRowSelector {
-                        row_count: run_length as usize,
-                        skip: false,
-                    });
-                    current_idx += run_length;
-                }
-
-                // `skip` all consecutive deleted rows in the current row group
-                let mut run_length = 0;
-                while next_deleted_row_idx == current_idx
-                    && next_deleted_row_idx < next_row_group_base_idx
-                {
-                    run_length += 1;
-                    current_idx += 1;
-
-                    next_deleted_row_idx_opt = delete_vector_iter.next();
-                    next_deleted_row_idx = match next_deleted_row_idx_opt {
-                        Some(next_deleted_row_idx) => next_deleted_row_idx,
-                        _ => {
-                            // We've processed the final positional delete.
-                            // Conclude the skip and then break so that we select the remaining
-                            // rows in the row group and move on to the next row group
-                            results.push(SerdeRowSelector {
-                                row_count: run_length,
-                                skip: true,
-                            });
-                            break 'chunks;
-                        }
-                    };
-                }
-                if run_length > 0 {
-                    results.push(SerdeRowSelector {
-                        row_count: run_length,
-                        skip: true,
-                    });
-                }
-            }
-
-            if current_idx < next_row_group_base_idx {
-                results.push(SerdeRowSelector {
-                    row_count: (next_row_group_base_idx - current_idx) as usize,
-                    skip: false,
-                });
-            }
-
-            current_row_group_base_idx += row_group_num_rows;
-        }
-
-        Ok(results)
     }
 }
 

--- a/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
@@ -16,6 +16,10 @@ spark = (
         "spark.jars.packages",
         "org.apache.iceberg:iceberg-aws-bundle:1.6.1,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1",
     )
+    # for delete file
+    .config("spark.sql.shuffle.partitions", "1")
+    # for delete file
+    .config("spark.default.parallelism", "1")
     .getOrCreate()
 )
 
@@ -52,5 +56,43 @@ TBLPROPERTIES (
 spark.sql(
     f"""INSERT INTO iceberg.test.t1_orc VALUES (0, 0, 'a'), (1, 1, 'b'), (2, 2, 'c'), (3, 3, 'd'), (4, null, null);"""
 )
+
+spark.sql(
+    f"""
+CREATE OR REPLACE TABLE iceberg.test.test_positional_merge_on_read_deletes (
+    dt     date,
+    number integer,
+    letter string
+)
+USING iceberg
+TBLPROPERTIES (
+    'write.delete.mode'='merge-on-read',
+    'write.update.mode'='merge-on-read',
+    'write.merge.mode'='merge-on-read',
+    'format-version'='2'
+);
+"""
+)
+
+spark.sql(
+    f"""
+INSERT INTO iceberg.test.test_positional_merge_on_read_deletes
+VALUES
+    (CAST('2023-03-01' AS date), 1, 'a'),
+    (CAST('2023-03-02' AS date), 2, 'b'),
+    (CAST('2023-03-03' AS date), 3, 'c'),
+    (CAST('2023-03-04' AS date), 4, 'd'),
+    (CAST('2023-03-05' AS date), 5, 'e'),
+    (CAST('2023-03-06' AS date), 6, 'f'),
+    (CAST('2023-03-07' AS date), 7, 'g'),
+    (CAST('2023-03-08' AS date), 8, 'h'),
+    (CAST('2023-03-09' AS date), 9, 'i'),
+    (CAST('2023-03-10' AS date), 10, 'j'),
+    (CAST('2023-03-11' AS date), 11, 'k'),
+    (CAST('2023-03-12' AS date), 12, 'l');
+"""
+)
+
+spark.sql(f"DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number > 9")
 
 spark.stop()

--- a/tests/sqllogictests/suites/tpch_iceberg/base.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/base.test
@@ -53,3 +53,16 @@ select c1, c3 from t1_orc;
 2 c
 3 d
 4 NULL
+
+query TTI rowsort
+select * from test_positional_merge_on_read_deletes;
+----
+2023-03-01 1 a
+2023-03-02 2 b
+2023-03-03 3 c
+2023-03-04 4 d
+2023-03-05 5 e
+2023-03-06 6 f
+2023-03-07 7 g
+2023-03-08 8 h
+2023-03-09 9 i


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When reading the Iceberg Table, identify Position Deletes and skip the deleted data.

After the Iceberg table is set to merge on read, deleting data will generate multiple delete files. 
For example:
`DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number > 9` This sql will generate the delete file: 00000-2-09da4c32-2cd8-4d90-b4e2-2ed02928a009-00001-deletes.parquet, used to indicate the data that needs to be marked as deleted in the related data files.
![image](https://github.com/user-attachments/assets/05a989cf-7bb6-4a8a-8c17-cd8cb661ddc4)

This PR will generate corresponding `RowSelection` in the Iceberg Table's `plan_files` for the corresponding delete files in the data file to skip the data on `ParquetSource`.

dep: https://github.com/databendlabs/iceberg-rust/pull/2

Tips: The Pos in DeleteFile is global in Parquet. Please pay attention to whether the Selection during RowGroup reading will affect it.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17982)
<!-- Reviewable:end -->
