### PR TITLE
fix(meta-semaphore): deadlock between meta-service semaphores

### DIFF
--- a/src/meta/semaphore/src/queue/semaphore_queue.rs
+++ b/src/meta/semaphore/src/queue/semaphore_queue.rs
@@ -71,7 +71,8 @@ impl SemaphoreQueue {
     /// In order not to starve any acquire requests(such as, smaller `value` should not starve one with large `value`)
     /// new entry enters acquired queue if:
     /// - there is enough capacity;
-    /// - `waiting` queue is empty.
+    /// - or the first `waiting` has smaller seq than the last in the `acquired`,
+    ///   this ensure no permit waits each other when a smaller seq entry is received after a larger seq entry.
     ///
     /// Otherwise, it will be added to the waiting queue.
     pub fn insert(&mut self, sem_seq: PermitSeq, entry: PermitEntry) -> Vec<PermitEvent> {
@@ -123,18 +124,44 @@ impl SemaphoreQueue {
         true
     }
 
-    /// Move the waiting semaphores to acquired if there is enough capacity
+    /// Move the waiting semaphores to acquired.
+    ///
+    /// Move one entry if:
+    /// - there is enough capacity,
+    /// - or the first `waiting` has smaller seq than the last in the `acquired`.
+    ///
+    /// The second scenario happens when a smaller seq entry is received after a larger seq entry.
+    /// In this case, the smaller seq entry must be inserted too, even it exceeds the capacity.
+    ///
+    /// Otherwise, two semaphore entries would BLOCK EACH OTHER.
+    ///
+    /// For example, `A` has seq 1, `B` has seq 2. the capacity is 1.
+    /// - Process `A` received sem `B` first, then sem `A`;
+    /// - Process `B` received sem `A` first, then sem `B`.
+    ///
+    /// ```text
+    /// |             acquired    waiting
+    /// | Process A:  [ B ]       [ A ]
+    /// | Process B:  [ A ]       [ B ]
+    /// ```
+    ///
+    /// And then two processes blocks each other:
+    /// - Process `A` await sem `B` to be removed from `acquired` queue, which await Process `B` to remove sem `B`.
+    /// - Process `B` await sem `A` to be removed from `acquired` queue, which await Process `A` to remove sem `A`.
     fn move_waiting_to_acquired(&mut self) -> Vec<(PermitSeq, PermitEntry)> {
         let mut moved = vec![];
 
         loop {
             let first = self.waiting.first_key_value();
 
-            let Some((_seq, entry)) = first else {
+            let Some((seq, entry)) = first else {
                 break;
             };
 
-            if !self.is_capacity_enough(entry) {
+            // Consistency guarantee: see the method doc
+            if self.is_capacity_enough(entry) || Some(*seq) < self.last_acquired_seq() {
+                // go on moving waiting to acquired.
+            } else {
                 break;
             }
 
@@ -143,6 +170,11 @@ impl SemaphoreQueue {
             self.try_acquire(seq, entry);
         }
         moved
+    }
+
+    fn last_acquired_seq(&self) -> Option<PermitSeq> {
+        let last_acquired = self.acquired.last_key_value();
+        last_acquired.map(|(seq, _)| *seq)
     }
 
     fn is_acquired(&self, sem_seq: &PermitSeq) -> bool {
@@ -287,6 +319,44 @@ mod tests {
                 BTreeMap::from([(3, ent("t3", 4)), (4, ent("t4", 1))])
             );
         }
+    }
+
+    /// When a smaller seq permit is inserted, it should be acquired immediately.
+    ///
+    /// See [`SemaphoreQueue::move_waiting_to_acquired`] for more details.
+    #[test]
+    fn test_insert_smaller_seq() {
+        let mut queue = SemaphoreQueue {
+            size: 0,
+            capacity: 1,
+            acquired: BTreeMap::new(),
+            waiting: BTreeMap::new(),
+        };
+
+        let entry1 = || ent("t1", 1);
+        let entry2 = || ent("t2", 1);
+        let entry3 = || ent("t3", 1);
+
+        // 2 is acquired, 3 is waiting.
+
+        let events = queue.insert(2, entry2());
+        assert_eq!(events, vec![acquired(2, entry2())]);
+        let events = queue.insert(3, entry3());
+        assert_eq!(events, vec![]);
+
+        assert!(queue.is_acquired(&2));
+        assert!(!queue.is_acquired(&3));
+        assert_eq!(queue.waiting, BTreeMap::from([(3, ent("t3", 1))]));
+
+        // 1 is acquired because it smaller than 2.
+
+        let events = queue.insert(1, entry1());
+
+        assert_eq!(events, vec![acquired(1, entry1())]);
+        assert_eq!(queue.size, 2);
+        assert!(queue.is_acquired(&1));
+        assert!(queue.is_acquired(&2));
+        assert_eq!(queue.waiting, BTreeMap::from([(3, ent("t3", 1))]));
     }
 
     #[test]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix(meta-semaphore): deadlock between meta-service semaphores

### Problem

Before this commit, when a smaller seq semaphore is inserted after a
larger seq one, the smaller one may not be acquired because the capacity
is exhausted. This might lead to a deadlock:

For example, `A` has seq 1, `B` has seq 2. the capacity is 1.
- Process `A` received sem `B` first, then sem `A`;
- Process `B` received sem `A` first, then sem `B`.

```text
|             acquired    waiting
| Process A:  [ B ]       [ A ]
| Process B:  [ A ]       [ B ]
```

And then two processes blocks each other:
- Process `A` await sem `B` to be removed from `acquired` queue, which await Process `B` to remove sem `B`.
- Process `B` await sem `A` to be removed from `acquired` queue, which await Process `A` to remove sem `A`.

### Solution

In this commit, a semaphore permit is always acquired even when the
capacity is full, if it's seq is smaller than the last one in the
`acquired` queue, which means this smaller seq is inserted out of order.

Therefore a smaller seq semaphore can always be acquired on each
databend-query node. There won't be a deadlock.

Tons of thanks to @dqhl76 for addressing this issue!

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17986)
<!-- Reviewable:end -->
