### PR TITLE
chore(query): generate cte tmp tbl should in current_catalog

### DIFF
--- a/src/query/sql/src/planner/binder/bind_query/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind.rs
@@ -216,9 +216,10 @@ impl Binder {
         };
         expr_replacer.replace_query(&mut as_query);
 
+        let catalog = self.ctx.get_current_catalog();
         let create_table_stmt = CreateTableStmt {
             create_option: CreateOption::Create,
-            catalog: Some(Identifier::from_name(Span::None, CATALOG_DEFAULT)),
+            catalog: Some(Identifier::from_name(Span::None, catalog.clone())),
             database: Some(Identifier::from_name(Span::None, database.clone())),
             table: table_identifier,
             source: None,
@@ -246,6 +247,6 @@ impl Binder {
         self.ctx.add_m_cte_temp_table(&database, &table_name);
 
         self.ctx
-            .evict_table_from_cache(CATALOG_DEFAULT, &database, &table_name)
+            .evict_table_from_cache(&catalog, &database, &table_name)
     }
 }

--- a/tests/sqllogictests/suites/tpch_iceberg/queries.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/queries.test
@@ -12,6 +12,9 @@ CONNECTION=(
     "s3.endpoint"='http://127.0.0.1:9000'
 );
 
+statement ok
+use catalog default;
+
 # Q1
 query I
 select


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The introduction of Iceberg catalog support in Databend means that internally-generated CTEs can no longer be directly created under the DEFAULT catalog.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/17989)
<!-- Reviewable:end -->
