### PR TITLE
feat(query): Support `as_decimal` function for variant type

### DIFF
--- a/src/common/io/src/interval.rs
+++ b/src/common/io/src/interval.rs
@@ -136,6 +136,14 @@ impl IntervalToStringCast {
 }
 
 impl Interval {
+    pub fn new(months: i32, days: i32, micros: i64) -> Self {
+        Self {
+            months,
+            days,
+            micros,
+        }
+    }
+
     pub fn from_string(str: &str) -> Result<Self> {
         Self::from_cstring(str.as_bytes())
     }

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -381,13 +381,20 @@ impl<'a> Evaluator<'a> {
                 DataType::Nullable(box DataType::Variant) | DataType::Variant,
                 DataType::Nullable(box DataType::Boolean)
                 | DataType::Nullable(box DataType::Number(_))
+                | DataType::Nullable(box DataType::Decimal(_))
                 | DataType::Nullable(box DataType::String)
+                | DataType::Nullable(box DataType::Binary)
                 | DataType::Nullable(box DataType::Date)
-                | DataType::Nullable(box DataType::Timestamp),
+                | DataType::Nullable(box DataType::Timestamp)
+                | DataType::Nullable(box DataType::Interval),
             ) => {
                 // allow cast variant to nullable types.
                 let inner_dest_ty = dest_type.remove_nullable();
-                let cast_fn = format!("to_{}", inner_dest_ty.to_string().to_lowercase());
+                let cast_fn = if inner_dest_ty.is_decimal() {
+                    "to_decimal".to_owned()
+                } else {
+                    format!("to_{}", inner_dest_ty.to_string().to_lowercase())
+                };
                 if let Some(new_value) = self.run_simple_cast(
                     span,
                     src_type,
@@ -410,12 +417,19 @@ impl<'a> Evaluator<'a> {
                 DataType::Nullable(box DataType::Variant) | DataType::Variant,
                 DataType::Boolean
                 | DataType::Number(_)
+                | DataType::Decimal(_)
                 | DataType::String
+                | DataType::Binary
                 | DataType::Date
-                | DataType::Timestamp,
+                | DataType::Timestamp
+                | DataType::Interval,
             ) => {
                 // allow cast variant to not null types.
-                let cast_fn = format!("to_{}", dest_type.to_string().to_lowercase());
+                let cast_fn = if dest_type.is_decimal() {
+                    "to_decimal".to_owned()
+                } else {
+                    format!("to_{}", dest_type.to_string().to_lowercase())
+                };
                 if let Some(new_value) = self.run_simple_cast(
                     span,
                     src_type,

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -319,6 +319,20 @@ impl<T: Decimal> Value<DecimalType<T>> {
     }
 }
 
+impl<T: Decimal> Value<NullableType<DecimalType<T>>> {
+    pub fn upcast_decimal(self, size: DecimalSize) -> Value<AnyType> {
+        match self {
+            Value::Scalar(Some(scalar)) => Value::Scalar(T::upcast_scalar(scalar, size)),
+            Value::Scalar(None) => Value::Scalar(Scalar::Null),
+            Value::Column(col) => {
+                let nullable_column =
+                    NullableColumn::new(T::upcast_column(col.column, size), col.validity);
+                Value::Column(Column::Nullable(Box::new(nullable_column)))
+            }
+        }
+    }
+}
+
 impl Value<AnyType> {
     pub fn convert_to_full_column(&self, ty: &DataType, num_rows: usize) -> Column {
         match self {

--- a/src/query/functions/src/scalars/decimal/src/cast.rs
+++ b/src/query/functions/src/scalars/decimal/src/cast.rs
@@ -68,25 +68,25 @@ pub fn register_to_decimal(registry: &mut FunctionRegistry) {
 
         let decimal_size =
             DecimalSize::new_unchecked(params[0].get_i64()? as _, params[1].get_i64()? as _);
-
         let decimal_type = DecimalDataType::from_size(decimal_size).ok()?;
 
+        let return_type = if from_type == DataType::Variant {
+            DataType::Nullable(Box::new(DataType::Decimal(decimal_type.size())))
+        } else {
+            DataType::Decimal(decimal_type.size())
+        };
         Some(Function {
             signature: FunctionSignature {
                 name: "to_decimal".to_string(),
                 args_type: vec![from_type.clone()],
-                return_type: DataType::Decimal(decimal_type.size()),
+                return_type,
             },
             eval: FunctionEval::Scalar {
-                calc_domain: if matches!(from_type, DataType::Variant) {
-                    Box::new(|_, _| FunctionDomain::MayThrow)
-                } else {
-                    Box::new(move |ctx, d| {
-                        convert_to_decimal_domain(ctx, d[0].clone(), decimal_type)
-                            .map(|d| FunctionDomain::Domain(Domain::Decimal(d)))
-                            .unwrap_or(FunctionDomain::MayThrow)
-                    })
-                },
+                calc_domain: Box::new(move |ctx, d| {
+                    convert_to_decimal_domain(ctx, d[0].clone(), decimal_type)
+                        .map(|d| FunctionDomain::Domain(Domain::Decimal(d)))
+                        .unwrap_or(FunctionDomain::MayThrow)
+                }),
                 eval: Box::new(move |args, ctx| {
                     convert_to_decimal(&args[0], ctx, &from_type, decimal_type)
                 }),
@@ -123,6 +123,40 @@ pub fn register_to_decimal(registry: &mut FunctionRegistry) {
             Some(Arc::new(f.error_to_null().passthrough_nullable()))
         })),
     );
+
+    let as_decimal = FunctionFactory::Closure(Box::new(|params, args_type: &[DataType]| {
+        if args_type.len() != 1 {
+            return None;
+        }
+        if args_type[0].remove_nullable() != DataType::Variant {
+            return None;
+        }
+        let precision = if !params.is_empty() {
+            params[0].get_i64()? as u8
+        } else {
+            MAX_DECIMAL128_PRECISION
+        };
+        let scale = if params.len() > 1 {
+            params[1].get_i64()? as u8
+        } else {
+            0
+        };
+        let decimal_size = DecimalSize::new(precision, scale).ok()?;
+        let decimal_type = DecimalDataType::from_size(decimal_size).ok()?;
+
+        Some(Arc::new(Function {
+            signature: FunctionSignature {
+                name: "as_decimal".to_string(),
+                args_type: args_type.to_vec(),
+                return_type: DataType::Nullable(Box::new(DataType::Decimal(decimal_size))),
+            },
+            eval: FunctionEval::Scalar {
+                calc_domain: Box::new(|_, _| FunctionDomain::Full),
+                eval: Box::new(move |args, ctx| convert_as_decimal(&args[0], ctx, decimal_type)),
+            },
+        }))
+    }));
+    registry.register_function_factory("as_decimal", as_decimal);
 }
 
 pub fn register_decimal_to_float<T: Number>(registry: &mut FunctionRegistry) {
@@ -428,11 +462,27 @@ where
         }
         DataType::Variant => {
             let arg = arg.try_downcast().unwrap();
-            variant_to_decimal::<T>(arg, ctx, dest_type)
+            let result = variant_to_decimal::<T>(arg, ctx, dest_type, false);
+            return result.upcast_decimal(size);
         }
         _ => unreachable!("to_decimal not support this DataType"),
     };
     result.upcast_decimal(size)
+}
+
+fn convert_as_decimal(
+    arg: &Value<AnyType>,
+    ctx: &mut EvalContext,
+    dest_type: DecimalDataType,
+) -> Value<AnyType> {
+    let size = dest_type.size();
+    with_decimal_mapped_type!(|DECIMAL_TYPE| match dest_type {
+        DecimalDataType::DECIMAL_TYPE(_) => {
+            let arg = arg.try_downcast().unwrap();
+            let result = variant_to_decimal::<DECIMAL_TYPE>(arg, ctx, dest_type, true);
+            result.upcast_decimal(size)
+        }
+    })
 }
 
 pub fn convert_to_decimal_domain(
@@ -627,9 +677,9 @@ where
 }
 
 #[inline]
-pub(super) fn get_round_val<T: Decimal>(x: T, scale: u32, ctx: &mut EvalContext) -> Option<T> {
+pub(super) fn get_round_val<T: Decimal>(x: T, scale: u32, rounding_mode: bool) -> Option<T> {
     let mut round_val = None;
-    if ctx.func_ctx.rounding_mode && scale > 0 {
+    if rounding_mode && scale > 0 {
         // Checking whether numbers need to be added or subtracted to calculate rounding
         if let Some(r) = x.checked_rem(T::e(scale)) {
             if let Some(m) = r.checked_div(T::e(scale - 1)) {
@@ -675,7 +725,7 @@ fn decimal_256_to_128(
 
         vectorize_with_builder_1_arg::<DecimalType<i256>, DecimalType<i128>>(
             |x: i256, builder: &mut Vec<i128>, ctx: &mut EvalContext| {
-                let round_val = get_round_val::<i256>(x, scale_diff, ctx);
+                let round_val = get_round_val::<i256>(x, scale_diff, ctx.func_ctx.rounding_mode);
                 let y = match (x.checked_div(factor), round_val) {
                     (Some(x), Some(round_val)) => x.checked_add(round_val),
                     (Some(x), None) => Some(x),
@@ -734,7 +784,7 @@ where
         vectorize_with_builder_1_arg::<DecimalType<F>, DecimalType<T>>(
             |x: F, builder: &mut Vec<T>, ctx: &mut EvalContext| {
                 let x = T::from(x);
-                let round_val = get_round_val::<T>(x, scale_diff, ctx);
+                let round_val = get_round_val::<T>(x, scale_diff, ctx.func_ctx.rounding_mode);
                 let y = match (x.checked_div(factor), round_val) {
                     (Some(x), Some(round_val)) => x.checked_add(round_val),
                     (Some(x), None) => Some(x),

--- a/src/query/functions/src/scalars/decimal/src/cast_from_jsonb.rs
+++ b/src/query/functions/src/scalars/decimal/src/cast_from_jsonb.rs
@@ -17,82 +17,30 @@ use std::ops::Mul;
 
 use databend_common_expression::serialize::read_decimal_with_size;
 use databend_common_expression::types::i256;
-use databend_common_expression::types::ArgType;
+use databend_common_expression::types::nullable::NullableColumnBuilder;
 use databend_common_expression::types::Decimal;
 use databend_common_expression::types::DecimalDataType;
 use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::DecimalType;
+use databend_common_expression::types::MutableBitmap;
+use databend_common_expression::types::NullableType;
 use databend_common_expression::types::Number;
-use databend_common_expression::types::NumberType;
 use databend_common_expression::types::VariantType;
-use databend_common_expression::vectorize_with_builder_1_arg;
+use databend_common_expression::types::F64;
 use databend_common_expression::EvalContext;
 use databend_common_expression::Value;
-use jsonb::RawJsonb;
+use jsonb::Number as JsonbNumber;
+use jsonb::Value as JsonbValue;
 use num_traits::AsPrimitive;
 
 use crate::cast::get_round_val;
-
-fn json_number_to_decimal<T>(
-    value: jsonb::Number,
-    dest_type: DecimalDataType,
-    max: T,
-    min: T,
-    multiplier: T,
-    multiplier_f64: f64,
-    ctx: &mut EvalContext,
-) -> Result<T, u32>
-where
-    T: Decimal + Mul<Output = T> + Div<Output = T>,
-{
-    let dest_size = dest_type.size();
-    match value {
-        jsonb::Number::Int64(v) => {
-            integer_to_decimal_scalar::<T, NumberType<i64>>(v, dest_size, multiplier)
-        }
-        jsonb::Number::UInt64(v) => {
-            integer_to_decimal_scalar::<T, NumberType<u64>>(v, dest_size, multiplier)
-        }
-        jsonb::Number::Float64(v) => {
-            let mut x = v * multiplier_f64;
-            if ctx.func_ctx.rounding_mode {
-                x = x.round();
-            }
-            let x = T::from_float(x);
-            if x > max || x < min {
-                Err(line!())
-            } else {
-                Ok(x)
-            }
-        }
-        jsonb::Number::Decimal128(d) => {
-            let from_size = DecimalSize::new_unchecked(d.precision, d.scale);
-            let x = T::from_i128(d.value);
-            decimal_resize::<T>(ctx, x, from_size, dest_size, min, max)
-        }
-        jsonb::Number::Decimal256(d) => {
-            let from_size = DecimalSize::new_unchecked(d.precision, d.scale);
-            match dest_type {
-                DecimalDataType::Decimal128(_) => {
-                    let x = i256(d.value);
-                    let min = i256::min_for_precision(dest_size.precision());
-                    let max = i256::max_for_precision(dest_size.precision());
-                    decimal_resize(ctx, x, from_size, dest_size, min, max).map(T::from_i256)
-                }
-                DecimalDataType::Decimal256(_) => {
-                    let x = T::from_i256(i256(d.value));
-                    decimal_resize::<T>(ctx, x, from_size, dest_size, min, max)
-                }
-            }
-        }
-    }
-}
 
 pub(super) fn variant_to_decimal<T>(
     from: Value<VariantType>,
     ctx: &mut EvalContext,
     dest_type: DecimalDataType,
-) -> Value<DecimalType<T>>
+    only_cast_number: bool,
+) -> Value<NullableType<DecimalType<T>>>
 where
     T: Decimal + Mul<Output = T> + Div<Output = T>,
 {
@@ -101,95 +49,176 @@ where
     let multiplier_f64: f64 = (10_f64).powi(size.scale() as i32).as_();
     let min = T::min_for_precision(size.precision());
     let max = T::max_for_precision(size.precision());
-    let f = |val: &[u8], builder: &mut Vec<T>, ctx: &mut EvalContext| {
-        let raw_jsonb = RawJsonb::new(val);
-        if let Ok(Some(b)) = raw_jsonb.as_bool() {
-            let value = if b {
-                T::e(size.scale() as u32)
-            } else {
-                T::zero()
-            };
-            builder.push(value);
-            return;
-        }
-        if let Ok(Some(x)) = raw_jsonb.as_str() {
-            let value = match read_decimal_with_size::<T>(
-                x.as_bytes(),
-                size,
-                true,
-                ctx.func_ctx.rounding_mode,
-            ) {
-                Ok((d, _)) => d,
-                Err(e) => {
-                    ctx.set_error(builder.len(), e);
-                    T::zero()
-                }
-            };
-            builder.push(value);
-            return;
-        }
-        let value = match raw_jsonb
-            .as_number()
-            .map_err(|e| format!("{e}"))
-            .and_then(|r| r.ok_or("invalid json type".to_string()))
-            .and_then(|v| {
-                json_number_to_decimal(v, dest_type, max, min, multiplier, multiplier_f64, ctx)
-                    .map_err(|line| format!("decimal overflow at line: {line})"))
-            }) {
-            Ok(v) => v,
-            Err(e) => {
-                ctx.set_error(builder.len(), e);
-                T::one()
-            }
-        };
-        builder.push(value);
+
+    let is_scalar = from.as_scalar().is_some();
+    let len = if is_scalar { 1 } else { ctx.num_rows };
+    let mut builder = NullableColumnBuilder {
+        builder: Vec::with_capacity(len),
+        validity: MutableBitmap::with_capacity(len),
     };
 
-    vectorize_with_builder_1_arg::<VariantType, DecimalType<T>>(f)(from, ctx)
-}
-
-fn integer_to_decimal_scalar<T, S>(
-    x: S::ScalarRef<'_>,
-    size: DecimalSize,
-    multiplier: T,
-) -> Result<T, u32>
-where
-    T: Decimal + Mul<Output = T>,
-    S: ArgType,
-    for<'a> S::ScalarRef<'a>: Number + AsPrimitive<i128>,
-{
-    let min_for_precision = T::min_for_precision(size.precision());
-    let max_for_precision = T::max_for_precision(size.precision());
-    if let Some(x) = T::from_i128(x.as_()).checked_mul(multiplier) {
-        if x > max_for_precision || x < min_for_precision {
-            Err(line!())
-        } else {
-            Ok(x)
+    for index in 0..len {
+        if let Some(validity) = &ctx.validity {
+            if !validity.get_bit(index) {
+                builder.push_null();
+                continue;
+            }
         }
+        let val = unsafe { from.index_unchecked(index) };
+        match cast_to_decimal(
+            val,
+            min,
+            max,
+            multiplier,
+            multiplier_f64,
+            size,
+            dest_type,
+            ctx.func_ctx.rounding_mode,
+            only_cast_number,
+        ) {
+            Ok(Some(val)) => builder.push(val),
+            Ok(None) => builder.push_null(),
+            Err(err) => {
+                ctx.set_error(builder.len(), err);
+                builder.push_null();
+            }
+        }
+    }
+    if is_scalar {
+        Value::Scalar(builder.build_scalar())
     } else {
-        Err(line!())
+        Value::Column(builder.build())
     }
 }
 
-fn decimal_resize<D>(
-    ctx: &mut EvalContext,
-    x: D,
+fn cast_to_decimal<T>(
+    val: &[u8],
+    min: T,
+    max: T,
+    multiplier: T,
+    multiplier_f64: f64,
+    dest_size: DecimalSize,
+    dest_type: DecimalDataType,
+    rounding_mode: bool,
+    only_cast_number: bool,
+) -> Result<Option<T>, String>
+where
+    T: Decimal + Mul<Output = T> + Div<Output = T>,
+{
+    let value = jsonb::from_slice(val).map_err(|e| format!("Invalid jsonb value, {e}"))?;
+    match value {
+        JsonbValue::Number(num) => match num {
+            JsonbNumber::Int64(v) => integer_to_decimal(v, min, max, multiplier).map(|v| Some(v)),
+            JsonbNumber::UInt64(v) => integer_to_decimal(v, min, max, multiplier).map(|v| Some(v)),
+            JsonbNumber::Float64(v) => {
+                float_to_decimal(F64::from(v), min, max, multiplier_f64, rounding_mode)
+                    .map(|v| Some(v))
+            }
+            JsonbNumber::Decimal128(d) => {
+                let from_size = DecimalSize::new_unchecked(d.precision, d.scale);
+                let x = T::from_i128(d.value);
+                decimal_to_decimal::<T>(x, min, max, from_size, dest_size, rounding_mode)
+                    .map(|v| Some(v))
+            }
+            JsonbNumber::Decimal256(d) => {
+                let from_size = DecimalSize::new_unchecked(d.precision, d.scale);
+                match dest_type {
+                    DecimalDataType::Decimal128(_) => {
+                        let x = i256(d.value);
+                        let min = i256::min_for_precision(dest_size.precision());
+                        let max = i256::max_for_precision(dest_size.precision());
+                        decimal_to_decimal::<i256>(x, min, max, from_size, dest_size, rounding_mode)
+                            .map(|v| Some(T::from_i256(v)))
+                    }
+                    DecimalDataType::Decimal256(_) => {
+                        let x = T::from_i256(i256(d.value));
+                        decimal_to_decimal::<T>(x, min, max, from_size, dest_size, rounding_mode)
+                            .map(|v| Some(v))
+                    }
+                }
+            }
+        },
+        _ => {
+            if only_cast_number {
+                return Ok(None);
+            }
+            match value {
+                JsonbValue::Null => Ok(None),
+                JsonbValue::Bool(b) => {
+                    let v = if b {
+                        T::e(dest_size.scale() as u32)
+                    } else {
+                        T::zero()
+                    };
+                    Ok(Some(v))
+                }
+                JsonbValue::String(s) => {
+                    read_decimal_with_size::<T>(s.as_bytes(), dest_size, true, rounding_mode)
+                        .map_err(|e| {
+                            format!("Falied to cast to variant value `{s}` to decimal, {e}")
+                        })
+                        .map(|(v, _)| Some(v))
+                }
+                _ => Err("Unsupported json type".to_string()),
+            }
+        }
+    }
+}
+
+fn integer_to_decimal<T, N>(x: N, min: T, max: T, multiplier: T) -> Result<T, String>
+where
+    T: Decimal + Mul<Output = T>,
+    N: Number + AsPrimitive<i128> + std::fmt::Display,
+{
+    if let Some(y) = T::from_i128(x.as_()).checked_mul(multiplier) {
+        if y <= max && y >= min {
+            return Ok(y);
+        }
+    }
+    Err(format!("Decimal overflow, value `{x}`"))
+}
+
+fn float_to_decimal<T, N>(
+    x: N,
+    min: T,
+    max: T,
+    multiplier: f64,
+    rounding_mode: bool,
+) -> Result<T, String>
+where
+    T: Decimal,
+    N: Number + AsPrimitive<f64> + std::fmt::Display,
+{
+    let mut value = x.as_() * multiplier;
+    if rounding_mode {
+        value = value.round();
+    }
+    let y = T::from_float(value);
+    if y <= max && y >= min {
+        return Ok(y);
+    }
+    Err(format!("Decimal overflow, value `{x}`"))
+}
+
+fn decimal_to_decimal<T>(
+    x: T,
+    min: T,
+    max: T,
     from_size: DecimalSize,
     dest_size: DecimalSize,
-    min: D,
-    max: D,
-) -> Result<D, u32>
+    rounding_mode: bool,
+) -> Result<T, String>
 where
-    D: Decimal + Div<Output = D>,
+    T: Decimal + Div<Output = T>,
 {
     if from_size.scale() == dest_size.scale() && from_size.precision() <= dest_size.precision() {
         Ok(x)
     } else if from_size.scale() > dest_size.scale() {
         let scale_diff = (from_size.scale() - dest_size.scale()) as u32;
-        let factor = D::e(scale_diff);
-        let source_factor = D::e(from_size.scale() as u32);
+        let factor = T::e(scale_diff);
+        let source_factor = T::e(from_size.scale() as u32);
 
-        let round_val = get_round_val::<D>(x, scale_diff, ctx);
+        let round_val = get_round_val::<T>(x, scale_diff, rounding_mode);
         let y = match (x.checked_div(factor), round_val) {
             (Some(x), Some(round_val)) => x.checked_add(round_val),
             (Some(x), None) => Some(x),
@@ -198,17 +227,17 @@ where
 
         match y {
             Some(y)
-                if y <= max && y >= min && (y != D::zero() || x / source_factor == D::zero()) =>
+                if y <= max && y >= min && (y != T::zero() || x / source_factor == T::zero()) =>
             {
                 Ok(y)
             }
-            _ => Err(line!()),
+            _ => Err("Decimal overflow".to_string()),
         }
     } else {
-        let factor = D::e((dest_size.scale() - from_size.scale()) as u32);
+        let factor = T::e((dest_size.scale() - from_size.scale()) as u32);
         match x.checked_mul(factor) {
             Some(y) if y <= max && y >= min => Ok(y),
-            _ => Err(line!()),
+            _ => Err("Decimal overflow".to_string()),
         }
     }
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -209,6 +209,7 @@ Functions overloads:
 1 as_boolean(Variant NULL) :: Boolean NULL
 0 as_date(Variant) :: Date NULL
 1 as_date(Variant NULL) :: Date NULL
+0 as_decimal FACTORY
 0 as_float(Variant) :: Float64 NULL
 1 as_float(Variant NULL) :: Float64 NULL
 0 as_integer(Variant) :: Int64 NULL

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -1010,6 +1010,24 @@ output domain  : {12.34..=12.34}
 output         : 12.34
 
 
+ast            : as_decimal(parse_json('12.34'))
+raw expr       : as_decimal(parse_json('12.34'))
+checked expr   : as_decimal<Variant>(CAST<String>("12.34" AS Variant))
+optimized expr : 12_d128(38,0)
+output type    : Decimal(38, 0) NULL
+output domain  : {12..=12}
+output         : 12
+
+
+ast            : as_decimal(10, 2)(parse_json('12.34'))
+raw expr       : as_decimal(10, 2)(parse_json('12.34'))
+checked expr   : as_decimal<Variant>(10, 2)(CAST<String>("12.34" AS Variant))
+optimized expr : 12.34_d128(10,2)
+output type    : Decimal(10, 2) NULL
+output domain  : {12.34..=12.34}
+output         : 12.34
+
+
 ast            : as_string(parse_json('"ab"'))
 raw expr       : as_string(parse_json('"ab"'))
 checked expr   : as_string<Variant>(CAST<String>("\"ab\"" AS Variant))
@@ -1794,7 +1812,7 @@ ast            : to_decimal(3, 2)(to_variant(1.23))
 raw expr       : to_decimal(3, 2)(to_variant(1.23))
 checked expr   : to_decimal<Variant>(3, 2)(to_variant<T0=Decimal(3, 2)><T0>(1.23_d128(3,2)))
 optimized expr : 1.23_d128(3,2)
-output type    : Decimal(3, 2)
+output type    : Decimal(3, 2) NULL
 output domain  : {1.23..=1.23}
 output         : 1.23
 
@@ -1803,7 +1821,7 @@ ast            : to_decimal(2, 1)(to_variant(1.23))
 raw expr       : to_decimal(2, 1)(to_variant(1.23))
 checked expr   : to_decimal<Variant>(2, 1)(to_variant<T0=Decimal(3, 2)><T0>(1.23_d128(3,2)))
 optimized expr : 1.2_d128(2,1)
-output type    : Decimal(2, 1)
+output type    : Decimal(2, 1) NULL
 output domain  : {1.2..=1.2}
 output         : 1.2
 
@@ -1812,7 +1830,7 @@ error:
   --> SQL:1:1
   |
 1 | to_decimal(1, 1)(to_variant(1.23))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ decimal overflow at line: 205) while evaluating function `to_decimal(1, 1)('1.23')` in expr `to_decimal(1, 1)(to_variant(1.23))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow while evaluating function `to_decimal(1, 1)('1.23')` in expr `to_decimal(1, 1)(to_variant(1.23))`
 
 
 
@@ -1820,7 +1838,7 @@ ast            : to_decimal(76, 1)(to_variant(1.23))
 raw expr       : to_decimal(76, 1)(to_variant(1.23))
 checked expr   : to_decimal<Variant>(76, 1)(to_variant<T0=Decimal(3, 2)><T0>(1.23_d128(3,2)))
 optimized expr : 1.2_d256(76,1)
-output type    : Decimal(76, 1)
+output type    : Decimal(76, 1) NULL
 output domain  : {1.2..=1.2}
 output         : 1.2
 
@@ -1829,7 +1847,7 @@ ast            : to_decimal(4, 3)(to_variant(1.23))
 raw expr       : to_decimal(4, 3)(to_variant(1.23))
 checked expr   : to_decimal<Variant>(4, 3)(to_variant<T0=Decimal(3, 2)><T0>(1.23_d128(3,2)))
 optimized expr : 1.230_d128(4,3)
-output type    : Decimal(4, 3)
+output type    : Decimal(4, 3) NULL
 output domain  : {1.230..=1.230}
 output         : 1.230
 
@@ -1838,7 +1856,7 @@ error:
   --> SQL:1:1
   |
 1 | to_decimal(3, 3)(to_variant(1.23))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ decimal overflow at line: 211) while evaluating function `to_decimal(3, 3)('1.23')` in expr `to_decimal(3, 3)(to_variant(1.23))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow while evaluating function `to_decimal(3, 3)('1.23')` in expr `to_decimal(3, 3)(to_variant(1.23))`
 
 
 
@@ -1846,7 +1864,7 @@ ast            : to_decimal(38, 2)(to_variant(1000000000000000000000000000000000
 raw expr       : to_decimal(38, 2)(to_variant(100000000000000000000000000000000000.01))
 checked expr   : to_decimal<Variant>(38, 2)(to_variant<T0=Decimal(38, 2)><T0>(100000000000000000000000000000000000.01_d128(38,2)))
 optimized expr : 100000000000000000000000000000000000.01_d128(38,2)
-output type    : Decimal(38, 2)
+output type    : Decimal(38, 2) NULL
 output domain  : {100000000000000000000000000000000000.01..=100000000000000000000000000000000000.01}
 output         : 100000000000000000000000000000000000.01
 
@@ -1855,7 +1873,7 @@ ast            : to_decimal(39, 2)(to_variant(1000000000000000000000000000000000
 raw expr       : to_decimal(39, 2)(to_variant(1000000000000000000000000000000000000.01))
 checked expr   : to_decimal<Variant>(39, 2)(to_variant<T0=Decimal(39, 2)><T0>(1000000000000000000000000000000000000.01_d256(39,2)))
 optimized expr : 1000000000000000000000000000000000000.01_d256(39,2)
-output type    : Decimal(39, 2)
+output type    : Decimal(39, 2) NULL
 output domain  : {1000000000000000000000000000000000000.01..=1000000000000000000000000000000000000.01}
 output         : 1000000000000000000000000000000000000.01
 
@@ -1864,7 +1882,7 @@ ast            : to_decimal(38, 1)(to_variant(1000000000000000000000000000000000
 raw expr       : to_decimal(38, 1)(to_variant(1000000000000000000000000000000000000.01))
 checked expr   : to_decimal<Variant>(38, 1)(to_variant<T0=Decimal(39, 2)><T0>(1000000000000000000000000000000000000.01_d256(39,2)))
 optimized expr : 1000000000000000000000000000000000000.0_d128(38,1)
-output type    : Decimal(38, 1)
+output type    : Decimal(38, 1) NULL
 output domain  : {1000000000000000000000000000000000000.0..=1000000000000000000000000000000000000.0}
 output         : 1000000000000000000000000000000000000.0
 
@@ -1873,7 +1891,7 @@ error:
   --> SQL:1:1
   |
 1 | to_decimal(38, 3)(to_variant(1000000000000000000000000000000000000.01))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ decimal overflow at line: 211) while evaluating function `to_decimal(38, 3)('1e36')` in expr `to_decimal(38, 3)(to_variant(1000000000000000000000000000000000000.01))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow while evaluating function `to_decimal(38, 3)('1e36')` in expr `to_decimal(38, 3)(to_variant(1000000000000000000000000000000000000.01))`
 
 
 
@@ -1881,7 +1899,7 @@ ast            : to_decimal(39, 1)(to_variant(1000000000000000000000000000000000
 raw expr       : to_decimal(39, 1)(to_variant(1000000000000000000000000000000000000.01))
 checked expr   : to_decimal<Variant>(39, 1)(to_variant<T0=Decimal(39, 2)><T0>(1000000000000000000000000000000000000.01_d256(39,2)))
 optimized expr : 1000000000000000000000000000000000000.0_d256(39,1)
-output type    : Decimal(39, 1)
+output type    : Decimal(39, 1) NULL
 output domain  : {1000000000000000000000000000000000000.0..=1000000000000000000000000000000000000.0}
 output         : 1000000000000000000000000000000000000.0
 
@@ -1890,15 +1908,24 @@ error:
   --> SQL:1:1
   |
 1 | to_decimal(39, 3)(to_variant(1000000000000000000000000000000000000.01))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ decimal overflow at line: 211) while evaluating function `to_decimal(39, 3)('1e36')` in expr `to_decimal(39, 3)(to_variant(1000000000000000000000000000000000000.01))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow while evaluating function `to_decimal(39, 3)('1e36')` in expr `to_decimal(39, 3)(to_variant(1000000000000000000000000000000000000.01))`
 
+
+
+ast            : to_decimal(3, 2)(parse_json('null'))
+raw expr       : to_decimal(3, 2)(parse_json('null'))
+checked expr   : to_decimal<Variant>(3, 2)(CAST<String>("null" AS Variant))
+optimized expr : NULL
+output type    : Decimal(3, 2) NULL
+output domain  : {NULL}
+output         : NULL
 
 
 ast            : to_decimal(3, 2)(parse_json('"3.14"'))
 raw expr       : to_decimal(3, 2)(parse_json('"3.14"'))
 checked expr   : to_decimal<Variant>(3, 2)(CAST<String>("\"3.14\"" AS Variant))
 optimized expr : 3.14_d128(3,2)
-output type    : Decimal(3, 2)
+output type    : Decimal(3, 2) NULL
 output domain  : {3.14..=3.14}
 output         : 3.14
 
@@ -1907,7 +1934,7 @@ ast            : to_decimal(2, 1)(parse_json('true'))
 raw expr       : to_decimal(2, 1)(parse_json('true'))
 checked expr   : to_decimal<Variant>(2, 1)(CAST<String>("true" AS Variant))
 optimized expr : 1.0_d128(2,1)
-output type    : Decimal(2, 1)
+output type    : Decimal(2, 1) NULL
 output domain  : {1.0..=1.0}
 output         : 1.0
 

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -504,6 +504,8 @@ fn test_as_type(file: &mut impl Write) {
     run_ast(file, "as_integer(parse_json('123'))", &[]);
     run_ast(file, "as_float(parse_json('\"ab\"'))", &[]);
     run_ast(file, "as_float(parse_json('12.34'))", &[]);
+    run_ast(file, "as_decimal(parse_json('12.34'))", &[]);
+    run_ast(file, "as_decimal(10, 2)(parse_json('12.34'))", &[]);
     run_ast(file, "as_string(parse_json('\"ab\"'))", &[]);
     run_ast(file, "as_string(parse_json('12.34'))", &[]);
     run_ast(file, "as_array(parse_json('[1,2,3]'))", &[]);
@@ -660,8 +662,8 @@ fn test_to_type(file: &mut impl Write) {
         &[],
     );
 
+    run_ast(file, "to_decimal(3, 2)(parse_json('null'))", &[]);
     run_ast(file, "to_decimal(3, 2)(parse_json('\"3.14\"'))", &[]);
-
     run_ast(file, "to_decimal(2, 1)(parse_json('true'))", &[]);
 
     run_ast(file, "to_boolean(parse_json(s))", &[(

--- a/tests/sqllogictests/suites/query/functions/02_0056_function_semi_structureds_as.test
+++ b/tests/sqllogictests/suites/query/functions/02_0056_function_semi_structureds_as.test
@@ -58,25 +58,30 @@ select as_object(parse_json('{"k": 123}'))
 ----
 {"k":123}
 
-query TT
-select to_binary('abc')::variant, as_binary(to_binary('abc')::variant)
+query TTTT
+select to_binary('abc')::variant, to_binary(to_binary('abc')::variant), to_binary(parse_json('"abc"')), as_binary(to_binary('abc')::variant)
 ----
-"616263" 616263
+"616263" 616263 616263 616263
 
-query TT
-select to_date('2025-01-01')::variant, as_date(to_date('2025-01-01')::variant)
+query TTTT
+select to_date('2025-01-01')::variant, to_date(to_date('2025-01-01')::variant), to_date(parse_json('"2025-01-01"')), as_date(to_date('2025-01-01')::variant)
 ----
-"2025-01-01" 2025-01-01
+"2025-01-01" 2025-01-01 2025-01-01 2025-01-01
 
-query TT
-select to_timestamp('2025-01-01 10:00:00')::variant, as_timestamp(to_timestamp('2025-01-01 10:00:00')::variant)
+query TTTT
+select to_timestamp('2025-01-01 10:00:00')::variant, to_timestamp(to_timestamp('2025-01-01 10:00:00')::variant), to_timestamp(parse_json('"2025-01-01 10:00:00"')), as_timestamp(to_timestamp('2025-01-01 10:00:00')::variant)
 ----
-"2025-01-01 10:00:00.000000" 2025-01-01 10:00:00.000000
+"2025-01-01 10:00:00.000000" 2025-01-01 10:00:00.000000 2025-01-01 10:00:00.000000 2025-01-01 10:00:00.000000
 
-query TT
-select to_interval('10 months 2 days')::variant, as_interval(to_interval('10 months 2 days')::variant)
+query TTTT
+select to_interval('10 months 2 days')::variant, to_interval(to_interval('10 months 2 days')::variant), to_interval(parse_json('"10 months 2 days"')), as_interval(to_interval('10 months 2 days')::variant)
 ----
-"10 months 2 days" 10 months 2 days
+"10 months 2 days" 10 months 2 days 10 months 2 days 10 months 2 days
+
+query TTTT
+select to_decimal(10, 2)(parse_json('3.14')), as_decimal(parse_json('3.14')), as_decimal(10, 2)(parse_json('3.14')), as_decimal(parse_json('3.14'), 10, 2)
+----
+3.14 3 3.14 3.14
 
 query B
 select is_null_value(parse_json('null'))
@@ -226,5 +231,4 @@ select id, v, is_null_value(v), is_boolean(v), is_integer(v), is_float(v), is_st
 
 statement ok
 DROP DATABASE db1
-
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces the following improvements:

- Adds `as_decimal` function to convert Variant-type numbers to DECIMAL
- Optimizes `to_decimal` to properly handle Variant-type NULL values (converting to SQL NULL)
- Improves parsing of Variant strings in following cast functions: `to_date`, `to_timestamp`, `to_interval`, `to_binary`.

for example
```sql
root@0.0.0.0:48000/default/default> select as_decimal(parse_json('10.23'), 5, 2);

select
  as_decimal(parse_json('10.23'), 5, 2)

╭───────────────────────────────────────╮
│ as_decimal(parse_json('10.23'), 5, 2) │
│             Decimal(4, 2)             │
├───────────────────────────────────────┤
│                                 10.23 │
╰───────────────────────────────────────╯
1 row read in 0.015 sec. Processed 1 row, 1 B (66.67 rows/s, 66 B/s)

root@0.0.0.0:48000/default/default> select to_date(parse_json('"2025-01-01"'));

select
  to_date(parse_json('"2025-01-01"'))

╭─────────────────────────────────────╮
│ to_date(parse_json('"2025-01-01"')) │
│                 Date                │
├─────────────────────────────────────┤
│ 2025-01-01                          │
╰─────────────────────────────────────╯
1 row read in 0.012 sec. Processed 1 row, 1 B (83.33 rows/s, 83 B/s)
```

- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
