### PR TITLE
fix: flaky test `test_release_cache_memory`

### DIFF
--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -938,6 +938,21 @@ mod tests {
             ColumnData::from_bytes(Bytes::new()),
         );
 
+        {
+            // Make sure at least the first key is written to disk cache
+
+            column_data_cache.insert(
+                "extra_key".to_string(),
+                ColumnData::from_bytes(Bytes::new()),
+            );
+
+            let disk_cache = column_data_cache.on_disk_cache().unwrap();
+            // Since the on-disk cache is populated asynchronously, we need to
+            // wait until the populate-queue is empty. At that time, at least
+            // the first key `test_key` should be written into the on-disk cache.
+            disk_cache.till_no_pending_items_in_queue();
+        }
+
         // 4. Populate block meta cache
         let block_meta_cache = cache_manager.get_block_meta_cache().unwrap();
         block_meta_cache.insert("not matter".to_string(), BlockMeta {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Make sure test data has been written disk key:

            The on-disk cache is populated asynchronously, we need to
            wait until the populate-queue is empty. At that time, at least
            the first cache item  should be written into the on-disk cache.



- fixes: #17998

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18000)
<!-- Reviewable:end -->
