### PR TITLE
fix(cache): fix improper config usage in cache manager

### DIFF
--- a/src/query/storages/common/cache/src/manager.rs
+++ b/src/query/storages/common/cache/src/manager.rs
@@ -299,12 +299,11 @@ impl CacheManager {
 
             let segment_block_metas_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_SEGMENT_BLOCK_METAS,
-                config.block_meta_count as usize,
+                config.segment_block_metas_count as usize,
             );
 
             let block_meta_cache = Self::new_items_cache_slot(
                 MEMORY_CACHE_BLOCK_META,
-                // TODO replace this config
                 config.block_meta_count as usize,
             );
 
@@ -910,6 +909,7 @@ mod tests {
         // Configure cache with sufficient capacity for testing
         cache_config.table_data_deserialized_data_bytes = 1024 * 1024;
         cache_config.block_meta_count = 10;
+        cache_config.segment_block_metas_count = 20;
         cache_config.data_cache_in_memory_bytes = 1024 * 1024;
 
         let ee_mode = true;
@@ -1064,6 +1064,43 @@ mod tests {
             .in_memory_cache()
             .unwrap()
             .is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cache_manager_block_meta_config() -> Result<()> {
+        let max_server_memory_usage = 1024 * 1024;
+
+        let cache_config = CacheConfig {
+            enable_table_meta_cache: true,
+            segment_block_metas_count: 10,
+            block_meta_count: 20,
+            ..Default::default()
+        };
+
+        let ee_mode = false;
+        let cache_manager = CacheManager::try_new(
+            &cache_config,
+            &max_server_memory_usage,
+            "test_tenant_id",
+            ee_mode,
+        )?;
+
+        assert_eq!(
+            cache_manager
+                .get_segment_block_metas_cache()
+                .unwrap()
+                .items_capacity(),
+            10
+        );
+        assert_eq!(
+            cache_manager
+                .get_block_meta_cache()
+                .unwrap()
+                .items_capacity(),
+            20
+        );
 
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Correct the implementation to properly respect configuration parameters for block metadata caching. 


Previously, the configuration values for `segment_block_metas_count` and `block_meta_count` were not being correctly applied. 

Added test case to verify proper configuration handling.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18002)
<!-- Reviewable:end -->
