### PR TITLE
feat(query): add decode and to_char(timestamp, format) function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,6 +3355,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "recursive",
+ "regex",
  "roaring",
  "rust_decimal",
  "rustls 0.23.27",

--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -998,6 +998,20 @@ pub struct FunctionCall {
     pub lambda: Option<Lambda>,
 }
 
+impl Default for FunctionCall {
+    fn default() -> Self {
+        Self {
+            distinct: false,
+            name: Identifier::from_name(None, ""),
+            args: vec![],
+            params: vec![],
+            order_by: vec![],
+            window: None,
+            lambda: None,
+        }
+    }
+}
+
 impl Display for FunctionCall {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let FunctionCall {

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -50,6 +50,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 recursive = { workspace = true }
+regex = { workspace = true }
 roaring = { workspace = true, features = ["serde"] }
 rust_decimal = { workspace = true }
 rustls = { workspace = true }

--- a/src/query/functions/src/scalars/other.rs
+++ b/src/query/functions/src/scalars/other.rs
@@ -21,6 +21,8 @@ use databend_common_base::base::convert_byte_size;
 use databend_common_base::base::convert_number_size;
 use databend_common_base::base::uuid::Uuid;
 use databend_common_base::base::OrderedFloat;
+use databend_common_expression::date_helper::DateConverter;
+use databend_common_expression::date_helper::PGDateTimeFormatter;
 use databend_common_expression::error_to_null;
 use databend_common_expression::types::boolean::BooleanDomain;
 use databend_common_expression::types::nullable::NullableColumn;
@@ -480,6 +482,19 @@ fn register_num_to_char(registry: &mut FunctionRegistry) {
                         builder.commit_row()
                     }
                 }
+            },
+        ),
+    );
+
+    registry.register_passthrough_nullable_2_arg::<TimestampType, StringType, StringType, _, _>(
+        "to_char",
+        |_, _, _| FunctionDomain::Full,
+        vectorize_with_builder_2_arg::<TimestampType, StringType, StringType>(
+            |micros, format, output, ctx| {
+                let ts = micros.to_timestamp(ctx.func_ctx.tz.clone());
+                let res = PGDateTimeFormatter::format(ts, format.as_ref());
+                output.put_str(&res);
+                output.commit_row();
             },
         ),
     );

--- a/tests/sqllogictests/suites/query/functions/02_0010_function_if.test
+++ b/tests/sqllogictests/suites/query/functions/02_0010_function_if.test
@@ -22,7 +22,7 @@ select [{}] from numbers(3)
 [{}]
 [{}]
 
-query B
+query ?
 select if(number>1, true, false) from numbers(3) order by number
 ----
 0
@@ -51,21 +51,21 @@ zero
 Z+
 Z+
 
-query B
+query ?
 select if(number<1, true, null) from numbers(3) order by number
 ----
 1
 NULL
 NULL
 
-query F
+query ?
 select if(number<4, number, number / 0) from numbers(3) order by number
 ----
 0.0
 1.0
 2.0
 
-query F
+query ?
 select if(number>4, number / 0, number) from numbers(3) order by number
 ----
 0.0
@@ -75,7 +75,7 @@ select if(number>4, number / 0, number) from numbers(3) order by number
 statement error 1006
 select if(number<4, number / 0, number) from numbers(3) order by number
 
-query F
+query ?
 select if (number > 0, 1 / number, null) from numbers(2);
 ----
 NULL
@@ -111,12 +111,12 @@ multi-if
 statement error 1065
 select if(number = 4, 3) from numbers(1)
 
-query F
+query ?
 select if(number = 1, number, number = 0, number, number / 0) from numbers(1)
 ----
 0.0
 
-query F
+query ?
 select if (number > 0, 1 / number, null) from numbers(2);
 ----
 NULL
@@ -160,18 +160,34 @@ select if(true, number, null), if(false, number, null) from numbers(1)
 0 NULL
 
 statement ok
-drop table if exists t
+CREATE or replace TABLE t (a int);
 
 statement ok
-create table t(a int null, b int)
-
-statement ok
-insert into t values(null, 1)
+INSERT INTO t (a) VALUES
+    (1),
+    (2),
+    (NULL),
+    (4);
 
 query II
-select a, b, a*2, if(b=1, a*2, b) from t
+select a, a*2, if(a=1, a*2, a*3) from t
 ----
-NULL 1 NULL NULL
+1 2 2
+2 4 6
+NULL NULL NULL
+4 8 12
+
+query II
+select a, decode(a, 1, 'one',
+	2, 'two',
+	NULL, '-NULL-',
+	'other'
+) AS decode_result from t
+----
+1 one
+2 two
+NULL -NULL-
+4 other
 
 statement ok
 drop table t

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1440,6 +1440,17 @@ select date_format('2022-02-04T03:58:59', '%x'), strftime('2022-02-04T03:58:59',
 ----
 2022-02-04 03:58:59 2022-02-04 03:58:59
 
+query TTT
+select to_char('2024-04-05'::DATE, 'mon dd, yyyy');
+----
+Apr 05, 2024
+
+query TTT
+select to_char('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
+----
+Apr 05 12AM:00:00, 24
+
+
 statement error (?s)1006.*%i
 select date_format('2022-2-04T03:58:59', '%i');
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

feat(query): add decode and to_char(timestamp, format) function

- New Features:

1. Added to_char function for PostgreSQL-style date/time formatting
Implemented DECODE function similar to Oracle's CASE statement
Added case-insensitive date/time format specifiers

```
 DECODE( <expr> , <search1> , <result1> [ , <search2> , <result2> ... ] [ , <default> ] )
```

Note that `null = null` equals `true` for the search result.

example:
```
statement ok
CREATE or replace TABLE t (a int);

statement ok
INSERT INTO t (a) VALUES
    (1),
    (2),
    (NULL),
    (4);

query II
select a, a*2, if(a=1, a*2, a*3) from t
----
1 2 2
2 4 6
NULL NULL NULL
4 8 12

query II
select a, decode(a, 1, 'one',
	2, 'two',
	NULL, '-NULL-',
	'other'
) AS decode_result from t
----
1 one
2 two
NULL -NULL-
4 other
```

2. Added regex dependency for case-insensitive pattern matching
Implemented PGDateTimeFormatter with support for:

```
Year formats (YYYY, YY)
Month formats (MM, MON, MMMM)
Day formats (DD, DY)
Time formats (HH24, HH12, AM/PM)
Minutes (MI), Seconds (SS)
Fractional seconds (FF)
Timezone (TZH, TZM)
ISO year (UUUU)
```
Example:
```
query TTT
select to_char('2024-04-05'::DATE, 'mon dd, yyyy');
----
Apr 05, 2024

query TTT
select to_char('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
----
Apr 05 12AM:00:00, 24


```
 

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
