### PR TITLE
fix: Fix duplicate metrics on different roots

### DIFF
--- a/src/common/storage/src/metrics_layer.rs
+++ b/src/common/storage/src/metrics_layer.rs
@@ -235,8 +235,31 @@ impl observe::MetricsIntercept for MetricsRecorder {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// observe::MetricLabels contains root but we don't want it.
+#[derive(Clone, Debug)]
 struct OperationLabels(observe::MetricLabels);
+
+impl PartialEq for OperationLabels {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.scheme == other.0.scheme
+            && self.0.namespace == other.0.namespace
+            && self.0.operation == other.0.operation
+            && self.0.error == other.0.error
+            && self.0.status_code == other.0.status_code
+    }
+}
+
+impl Eq for OperationLabels {}
+
+impl std::hash::Hash for OperationLabels {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.scheme.hash(state);
+        self.0.namespace.hash(state);
+        self.0.operation.hash(state);
+        self.0.error.hash(state);
+        self.0.status_code.hash(state);
+    }
+}
 
 impl EncodeLabelSet for OperationLabels {
     fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), fmt::Error> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Use the same operator over different roots can result in duplicate metrics. This PR get this fixed.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18014)
<!-- Reviewable:end -->
