### PR TITLE
feat: Iceberg Table supports equality delete of merge on read when reading

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -154,7 +154,7 @@ pub enum FunctionEval {
     },
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FunctionContext {
     pub tz: TimeZone,
     pub now: Zoned,

--- a/src/query/storages/parquet/src/copy_into_table/reader.rs
+++ b/src/query/storages/parquet/src/copy_into_table/reader.rs
@@ -54,7 +54,7 @@ impl RowGroupReaderForCopy {
             InMemoryRowGroup::new(&part.location, op.clone(), &part.meta, None, *read_settings);
         let mut _sorter = None;
         self.row_group_reader_builder
-            .fetch_and_build(row_group, None, &mut _sorter, None, batch_size)
+            .fetch_and_build(row_group, None, &mut _sorter, None, batch_size, None)
             .await
     }
 

--- a/src/query/storages/parquet/src/lib.rs
+++ b/src/query/storages/parquet/src/lib.rs
@@ -44,6 +44,8 @@ mod meta;
 mod schema;
 
 pub use copy_into_table::ParquetTableForCopy;
+pub use parquet_part::DeleteTask;
+pub use parquet_part::DeleteType;
 pub use parquet_part::ParquetFilePart;
 pub use parquet_part::ParquetPart;
 pub use parquet_reader::InmMemoryFile;

--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -27,6 +27,20 @@ use databend_common_exception::Result;
 
 use crate::partition::ParquetRowGroupPart;
 
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum DeleteType {
+    Position,
+    Equality,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct DeleteTask {
+    pub path: String,
+    pub ty: DeleteType,
+    /// equality ids for equality deletes (empty for positional deletes)
+    pub equality_ids: Vec<i32>,
+}
+
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug, Clone)]
 pub enum ParquetPart {
     File(ParquetFilePart),
@@ -34,7 +48,7 @@ pub enum ParquetPart {
     RowGroup(ParquetRowGroupPart),
     FileWithDeletes {
         inner: ParquetFilePart,
-        deletes: Vec<String>,
+        deletes: Vec<DeleteTask>,
     },
 }
 
@@ -114,7 +128,7 @@ impl PartInfo for ParquetPart {
                 let mut paths = Vec::with_capacity(deletes.len() + 1);
                 paths.push(&inner.file);
                 for delete in deletes {
-                    paths.push(delete);
+                    paths.push(&delete.path);
                 }
                 paths
             }

--- a/src/query/storages/parquet/src/parquet_reader/predicate.rs
+++ b/src/query/storages/parquet/src/parquet_reader/predicate.rs
@@ -39,6 +39,7 @@ use super::utils::transform_record_batch;
 use super::utils::FieldPaths;
 use crate::parquet_reader::utils::compute_output_field_paths;
 
+#[derive(Debug)]
 pub struct ParquetPredicate {
     func_ctx: FunctionContext,
 
@@ -66,15 +67,30 @@ impl ParquetPredicate {
         &self.field_paths
     }
 
-    pub fn evaluate_block(&self, block: &DataBlock) -> Result<Bitmap> {
+    pub fn evaluate_block(&self, block: &DataBlock) -> Result<Option<Bitmap>> {
         let evaluator = Evaluator::new(block, &self.func_ctx, &BUILTIN_FUNCTIONS);
-        let res = evaluator
-            .run(&self.filter)?
-            .convert_to_full_column(&DataType::Boolean, block.num_rows())
-            .as_boolean()
-            .cloned()
-            .unwrap();
-        Ok(res)
+        let bitmap =
+            if self.filter.data_type().is_nullable() {
+                evaluator
+                    .run(&self.filter)?
+                    .convert_to_full_column(
+                        &DataType::Nullable(Box::new(DataType::Boolean)),
+                        block.num_rows(),
+                    )
+                    .as_nullable()
+                    .map(|column| {
+                        Bitmap::from_iter(column.iter().map(|value| {
+                            value.and_then(|s| s.as_boolean().cloned()).unwrap_or(true)
+                        }))
+                    })
+            } else {
+                evaluator
+                    .run(&self.filter)?
+                    .convert_to_full_column(&DataType::Boolean, block.num_rows())
+                    .as_boolean()
+                    .cloned()
+            };
+        Ok(bitmap)
     }
 
     pub fn evaluate(
@@ -92,7 +108,7 @@ impl ParquetPredicate {
             block
         };
         let res = self.evaluate_block(&block)?;
-        Ok(bitmap_to_boolean_array(res))
+        Ok(bitmap_to_boolean_array(res.unwrap()))
     }
 
     pub fn schema(&self) -> &TableSchema {

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/no_prefetch.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/no_prefetch.rs
@@ -28,7 +28,10 @@ use parquet::schema::types::SchemaDescriptor;
 use super::policy::ReadPolicy;
 use super::policy::ReadPolicyBuilder;
 use super::policy::ReadPolicyImpl;
+use crate::parquet_reader::predicate::ParquetPredicate;
+use crate::parquet_reader::read_policy::utils::read_all;
 use crate::parquet_reader::row_group::InMemoryRowGroup;
+use crate::parquet_reader::utils::bitmap_to_boolean_array;
 use crate::parquet_reader::utils::transform_record_batch;
 use crate::parquet_reader::utils::FieldPaths;
 use crate::transformer::RecordBatchTransformer;
@@ -45,11 +48,48 @@ impl ReadPolicyBuilder for NoPretchPolicyBuilder {
     async fn fetch_and_build(
         &self,
         mut row_group: InMemoryRowGroup<'_>,
-        row_selection: Option<RowSelection>,
+        mut row_selection: Option<RowSelection>,
         _sorter: &mut Option<TopKSorter>,
         transformer: Option<RecordBatchTransformer>,
         batch_size: usize,
+        filter: Option<Arc<ParquetPredicate>>,
     ) -> Result<Option<ReadPolicyImpl>> {
+        if let Some(predicate) = filter {
+            row_group
+                .fetch(predicate.projection(), row_selection.as_ref())
+                .await?;
+
+            let num_rows = row_selection
+                .as_ref()
+                .map(|x| x.row_count())
+                .unwrap_or(row_group.row_count());
+
+            let block = read_all(
+                &DataSchema::from(predicate.schema()),
+                &row_group,
+                predicate.field_levels(),
+                row_selection.clone(),
+                predicate.field_paths(),
+                num_rows,
+            )?;
+            if let Some(filter) = predicate.evaluate_block(&block)? {
+                if filter.null_count() == num_rows {
+                    // All rows in current row group are filtered out.
+                    return Ok(None);
+                }
+                let filter = bitmap_to_boolean_array(filter);
+                let sel = RowSelection::from_filters(&[filter]);
+                match row_selection.as_mut() {
+                    Some(selection) => {
+                        *selection = selection.and_then(&sel);
+                    }
+                    None => {
+                        row_selection = Some(sel);
+                    }
+                }
+            }
+        }
+
         row_group.fetch(&self.projection, None).await?;
         let reader = ParquetRecordBatchReader::try_new_with_row_groups(
             &self.field_levels,

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/policy.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/policy.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::TopKSorter;
 use parquet::arrow::arrow_reader::RowSelection;
 
+use crate::parquet_reader::predicate::ParquetPredicate;
 use crate::parquet_reader::row_group::InMemoryRowGroup;
 use crate::transformer::RecordBatchTransformer;
 
@@ -66,6 +69,7 @@ pub trait ReadPolicyBuilder: Send + Sync {
         _sorter: &mut Option<TopKSorter>,
         _transformer: Option<RecordBatchTransformer>,
         _batch_size: usize,
+        _filter: Option<Arc<ParquetPredicate>>,
     ) -> Result<Option<ReadPolicyImpl>> {
         unreachable!()
     }

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
@@ -206,7 +206,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
                 self.predicate.field_paths(),
                 num_rows,
             )?;
-            let filter = self.predicate.evaluate_block(&block)?.unwrap();
+            let filter = self.predicate.evaluate_block(&block)?;
             if filter.null_count() == num_rows {
                 // All rows in current row group are filtered out.
                 return Ok(None);

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
@@ -161,6 +161,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
         sorter: &mut Option<TopKSorter>,
         transformer: Option<RecordBatchTransformer>,
         batch_size: usize,
+        _filter: Option<Arc<ParquetPredicate>>,
     ) -> Result<Option<ReadPolicyImpl>> {
         let mut num_rows = selection
             .as_ref()
@@ -205,7 +206,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
                 self.predicate.field_paths(),
                 num_rows,
             )?;
-            let filter = self.predicate.evaluate_block(&block)?;
+            let filter = self.predicate.evaluate_block(&block)?.unwrap();
             if filter.null_count() == num_rows {
                 // All rows in current row group are filtered out.
                 return Ok(None);

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/topk_only.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/topk_only.rs
@@ -35,6 +35,7 @@ use super::policy::ReadPolicyBuilder;
 use super::policy::ReadPolicyImpl;
 use super::utils::evaluate_topk;
 use super::utils::read_all;
+use crate::parquet_reader::predicate::ParquetPredicate;
 use crate::parquet_reader::row_group::InMemoryRowGroup;
 use crate::parquet_reader::topk::BuiltTopK;
 use crate::parquet_reader::topk::ParquetTopK;
@@ -136,6 +137,7 @@ impl ReadPolicyBuilder for TopkOnlyPolicyBuilder {
         sorter: &mut Option<TopKSorter>,
         transformer: Option<RecordBatchTransformer>,
         batch_size: usize,
+        _filter: Option<Arc<ParquetPredicate>>,
     ) -> Result<Option<ReadPolicyImpl>> {
         debug_assert!(sorter.is_some());
         let sorter = sorter.as_mut().unwrap();

--- a/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
@@ -318,9 +318,12 @@ impl<'a> ParquetReaderBuilder<'a> {
             op_registry: self.op_registry.clone(),
             batch_size,
             schema_desc: self.schema_desc.clone(),
+            arrow_schema: self.arrow_schema.clone(),
             policy_builders,
             default_policy,
             transformer,
+            table_schema: self.table_schema.clone(),
+            partition_columns: self.partition_columns.clone(),
         })
     }
 

--- a/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
@@ -410,9 +410,6 @@ impl RowGroupReader {
                     });
                     let eq_expr = Self::build_eq_expr(data_type.clone(), column_expr, scalar_expr);
                     let not_expr = Self::build_not_expr(eq_expr);
-                    // TIPS: 合并所需的column
-                    // 其它的policy忽略filter
-                    // position delete多一点测试
                     combined_predicate = Self::build_and_expr(combined_predicate, not_expr);
                 }
             }

--- a/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
@@ -15,35 +15,59 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use arrow_array::ArrayRef;
+use arrow_schema::FieldRef;
+use databend_common_catalog::plan::PrewhereInfo;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::ColumnRef;
+use databend_common_expression::Constant;
+use databend_common_expression::Expr;
+use databend_common_expression::FieldIndex;
+use databend_common_expression::FunctionCall;
+use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
+use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TopKSorter;
+use databend_common_expression::Value;
+use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_metrics::storage::metrics_inc_omit_filter_rowgroups;
 use databend_common_metrics::storage::metrics_inc_omit_filter_rows;
 use databend_common_storage::OperatorRegistry;
 use futures::future::try_join_all;
+use futures::StreamExt;
 use opendal::Operator;
+use opendal::Reader;
+use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::metadata::RowGroupMetaData;
 use parquet::format::PageLocation;
 use parquet::schema::types::SchemaDescPtr;
 
+use crate::parquet_part::DeleteTask;
 use crate::parquet_reader::policy::PolicyBuilders;
 use crate::parquet_reader::policy::PolicyType;
 use crate::parquet_reader::policy::ReadPolicyImpl;
 use crate::parquet_reader::policy::POLICY_PREDICATE_ONLY;
+use crate::parquet_reader::predicate::build_predicate;
+use crate::parquet_reader::predicate::ParquetPredicate;
 use crate::parquet_reader::row_group::InMemoryRowGroup;
 use crate::partition::ParquetRowGroupPart;
 use crate::read_settings::ReadSettings;
 use crate::transformer::RecordBatchTransformer;
+use crate::DeleteType;
+use crate::ParquetFileReader;
 use crate::ParquetReaderBuilder;
 use crate::ParquetSourceType;
 
@@ -77,6 +101,20 @@ static DELETES_FILE_PUSHDOWN_INFO: LazyLock<PushDownInfo> = LazyLock::new(|| Pus
     sample: None,
 });
 
+enum DeleteResult {
+    Positions(Vec<i64>),
+    Equality {
+        predicate: Expr<String>,
+        related_columns: Vec<FieldIndex>,
+    },
+}
+
+#[derive(Debug)]
+pub struct DeleteFilter {
+    row_selection: RowSelection,
+    predicate: Arc<ParquetPredicate>,
+}
+
 /// The reader to read a row group.
 pub struct RowGroupReader {
     pub(super) ctx: Arc<dyn TableContext>,
@@ -85,7 +123,10 @@ pub struct RowGroupReader {
     pub(super) default_policy: PolicyType,
     pub(super) policy_builders: PolicyBuilders,
 
+    pub(super) table_schema: TableSchemaRef,
     pub(super) schema_desc: SchemaDescPtr,
+    pub(super) arrow_schema: Option<arrow_schema::Schema>,
+    pub(super) partition_columns: Vec<String>,
     pub(super) transformer: Option<RecordBatchTransformer>,
     // Options
     pub(super) batch_size: usize,
@@ -107,8 +148,8 @@ impl RowGroupReader {
         read_settings: &ReadSettings,
         part: &ParquetRowGroupPart,
         topk_sorter: &mut Option<TopKSorter>,
-        delete_info: Option<(&ParquetMetaData, &[String])>,
-        delete_selection: &mut Option<RowSelection>,
+        delete_info: Option<(&ParquetMetaData, &[DeleteTask])>,
+        delete_filter: &mut Option<DeleteFilter>,
     ) -> Result<Option<ReadPolicyImpl>> {
         if let Some((sorter, min_max)) = topk_sorter.as_ref().zip(part.sort_min_max.as_ref()) {
             if sorter.never_match(min_max) {
@@ -128,46 +169,78 @@ impl RowGroupReader {
             page_locations.as_deref(),
             *read_settings,
         );
-        if let (Some((parquet_meta, delete_files)), true) =
-            (delete_info, delete_selection.is_none())
-        {
+        if let (Some((parquet_meta, delete_files)), true) = (delete_info, delete_filter.is_none()) {
             let futures = delete_files.iter().map(|delete| async {
-                let (op, path) = self.op_registry.get_operator_path(delete)?;
-                let meta = op.stat(path).await?;
-                let info = &DELETES_FILE_PUSHDOWN_INFO;
-
-                let mut builder = ParquetReaderBuilder::create(
-                    self.ctx.clone(),
-                    Arc::new(op),
-                    DELETES_FILE_TABLE_SCHEMA.clone(),
-                    DELETES_FILE_SCHEMA.clone(),
-                )?
-                .with_push_downs(Some(info));
-                let reader = builder.build_full_reader(ParquetSourceType::Iceberg, false)?;
-                let mut stream = reader
-                    .prepare_data_stream(path, meta.content_length(), None)
-                    .await?;
-                let mut positional_deletes = Vec::new();
-
-                while let Some(block) = reader.read_block_from_stream(&mut stream).await? {
-                    let num_rows = block.num_rows();
-                    let column = block.columns()[0].to_column(num_rows);
-                    let column = column.as_number().unwrap().as_int64().unwrap();
-
-                    positional_deletes.extend_from_slice(column.as_slice())
+                let (op, path) = self.op_registry.get_operator_path(&delete.path)?;
+                match delete.ty {
+                    DeleteType::Position => {
+                        let positional_deletes =
+                            Self::load_position_deletes(self.ctx.clone(), op, path).await?;
+                        Result::Ok(DeleteResult::Positions(positional_deletes))
+                    }
+                    DeleteType::Equality => {
+                        let (predicate, related_columns) = Self::load_equality_deletes(
+                            &self.ctx,
+                            &self.table_schema,
+                            &delete.equality_ids,
+                            op,
+                            path,
+                        )
+                        .await?;
+                        Result::Ok(DeleteResult::Equality {
+                            predicate,
+                            related_columns,
+                        })
+                    }
                 }
-
-                Result::Ok(positional_deletes)
             });
-            let positional_deletes = try_join_all(futures)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
-            *delete_selection = Some(Self::build_deletes_row_selection(
-                parquet_meta.row_groups(),
-                positional_deletes,
-            )?);
+
+            let mut positional_deletes = Vec::new();
+            let mut equality_expr = Expr::Constant(Constant {
+                span: None,
+                scalar: Scalar::Boolean(true),
+                data_type: DataType::Nullable(Box::new(DataType::Boolean)),
+            });
+
+            let mut prewhere_columns = Vec::new();
+            for result in try_join_all(futures).await? {
+                match result {
+                    DeleteResult::Positions(positions) => {
+                        positional_deletes.extend_from_slice(&positions);
+                    }
+                    DeleteResult::Equality {
+                        predicate,
+                        related_columns,
+                    } => {
+                        equality_expr = Self::build_and_expr(equality_expr, predicate);
+                        prewhere_columns.extend_from_slice(&related_columns);
+                    }
+                }
+            }
+            prewhere_columns.sort();
+            positional_deletes.sort();
+
+            let prewhere_info = PrewhereInfo {
+                output_columns: Projection::Columns(prewhere_columns.clone()),
+                prewhere_columns: Projection::Columns(prewhere_columns),
+                remain_columns: Projection::Columns(vec![]),
+                filter: equality_expr.as_remote_expr(),
+                virtual_column_ids: None,
+            };
+            let row_selection =
+                Self::build_deletes_row_selection(parquet_meta.row_groups(), positional_deletes)?;
+            let (predicate, _) = build_predicate(
+                self.ctx.get_function_context()?,
+                &prewhere_info,
+                &self.table_schema,
+                &self.schema_desc,
+                &self.partition_columns,
+                self.arrow_schema.as_ref(),
+            )?;
+            *delete_filter = Some(DeleteFilter {
+                row_selection,
+                predicate,
+            });
         }
         let mut part_selection = part
             .selectors
@@ -190,9 +263,11 @@ impl RowGroupReader {
             part_selection,
             // The Pos in DeleteFile is global in Parquet.
             // Therefore, it is necessary to split it in units of RowGroup.
-            delete_selection
-                .as_mut()
-                .map(|selection| selection.split_off(part.meta.num_rows() as usize)),
+            delete_filter.as_mut().map(|selection| {
+                selection
+                    .row_selection
+                    .split_off(part.meta.num_rows() as usize)
+            }),
         ) {
             (Some(result_selection), Some(delete_selection)) => {
                 Some(result_selection.intersection(&delete_selection))
@@ -200,6 +275,9 @@ impl RowGroupReader {
             (Some(selection), None) | (None, Some(selection)) => Some(selection),
             (None, None) => None,
         };
+        let filter = delete_filter
+            .as_ref()
+            .map(|filter| filter.predicate.clone());
 
         let builder = &self.policy_builders[policy as usize];
         builder
@@ -209,8 +287,199 @@ impl RowGroupReader {
                 topk_sorter,
                 self.transformer.clone(),
                 self.batch_size,
+                filter,
             )
             .await
+    }
+
+    async fn load_position_deletes(
+        ctx: Arc<dyn TableContext>,
+        op: Operator,
+        path: &str,
+    ) -> Result<Vec<i64>> {
+        let meta = op.stat(path).await?;
+        let info = &DELETES_FILE_PUSHDOWN_INFO;
+
+        let mut builder = ParquetReaderBuilder::create(
+            ctx,
+            Arc::new(op),
+            DELETES_FILE_TABLE_SCHEMA.clone(),
+            DELETES_FILE_SCHEMA.clone(),
+        )?
+        .with_push_downs(Some(info));
+        let reader = builder.build_full_reader(ParquetSourceType::Iceberg, false)?;
+        let mut stream = reader
+            .prepare_data_stream(path, meta.content_length(), None)
+            .await?;
+        let mut positional_deletes = Vec::new();
+
+        while let Some(block) = reader.read_block_from_stream(&mut stream).await? {
+            let num_rows = block.num_rows();
+            let column = block.columns()[0].to_column(num_rows);
+            let column = column.as_number().unwrap().as_int64().unwrap();
+
+            positional_deletes.extend_from_slice(column.as_slice())
+        }
+        Ok(positional_deletes)
+    }
+
+    async fn load_equality_deletes(
+        ctx: &Arc<dyn TableContext>,
+        table_schema: &TableSchema,
+        equality_ids: &[i32],
+        op: Operator,
+        path: &str,
+    ) -> Result<(Expr<String>, Vec<FieldIndex>)> {
+        let batch_size = ctx.get_settings().get_parquet_max_block_size()? as usize;
+        let meta = op.stat(path).await?;
+        let reader: Reader = op.reader(path).await?;
+        let reader = ParquetFileReader::new(reader, meta.content_length());
+        let mut stream =
+            ParquetRecordBatchStreamBuilder::new_with_options(reader, ArrowReaderOptions::new())
+                .await?
+                .with_batch_size(batch_size)
+                .build()?;
+
+        let mut combined_predicate = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Boolean(true),
+            data_type: DataType::Nullable(Box::new(DataType::Boolean)),
+        });
+        let fn_field_id = |field: &FieldRef| {
+            field
+                .metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .and_then(|value| value.parse::<i32>().ok())
+        };
+
+        let mut related_columns = Vec::new();
+        while let Some(record_batch) = stream.next().await {
+            let record_batch = record_batch?;
+
+            if record_batch.num_columns() == 0 {
+                return Ok((
+                    Expr::Constant(Constant {
+                        span: None,
+                        scalar: Scalar::Boolean(true),
+                        data_type: DataType::Nullable(Box::new(DataType::Boolean)),
+                    }),
+                    Vec::new(),
+                ));
+            }
+
+            let fields_with_columns = record_batch
+                .schema_ref()
+                .fields()
+                .iter()
+                .zip(record_batch.columns().iter())
+                .filter(|(field, _)| {
+                    fn_field_id(field).map(|field_id| equality_ids.contains(&field_id))
+                        == Some(true)
+                })
+                .collect::<Vec<_>>();
+
+            for (field, array) in fields_with_columns.iter() {
+                let table_field = TableField::try_from(field.as_ref())?;
+                let (field_index, _) = table_schema
+                    .column_with_name(table_field.name())
+                    .ok_or_else(|| {
+                        ErrorCode::UnknownColumn(format!(
+                            "Unknown column name: {}",
+                            table_field.name()
+                        ))
+                    })?;
+                related_columns.push(field_index);
+
+                let data_type = DataType::from(table_field.data_type());
+                let column = Value::from_arrow_rs(ArrayRef::clone(array), &data_type)?;
+
+                for i in 0..column.len() {
+                    let Some(scala) = column.index(i) else { break };
+                    let column_name = table_field.name().to_string();
+                    let column_expr = Expr::ColumnRef(ColumnRef {
+                        span: None,
+                        id: column_name.clone(),
+                        data_type: data_type.clone(),
+                        display_name: column_name,
+                    });
+                    let scalar_ty = scala.infer_data_type();
+                    let scalar_expr = Expr::Constant(Constant {
+                        span: None,
+                        scalar: scala.to_owned(),
+                        data_type: scalar_ty.clone(),
+                    });
+                    let eq_expr = Self::build_eq_expr(data_type.clone(), column_expr, scalar_expr);
+                    let not_expr = Self::build_not_expr(eq_expr);
+                    // TIPS: 合并所需的column
+                    // 其它的policy忽略filter
+                    // position delete多一点测试
+                    combined_predicate = Self::build_and_expr(combined_predicate, not_expr);
+                }
+            }
+        }
+
+        Ok((combined_predicate, related_columns))
+    }
+
+    fn build_and_expr(expr_0: Expr<String>, expr_1: Expr<String>) -> Expr<String> {
+        let and_generics = vec![
+            DataType::Nullable(Box::new(DataType::Boolean)),
+            DataType::Nullable(Box::new(DataType::Boolean)),
+        ];
+        let and_args = vec![expr_0.clone(), expr_1];
+        let (function_id, function) = BUILTIN_FUNCTIONS
+            .search_candidates("and", &[], and_args.as_slice())
+            .into_iter()
+            .find(|(_, function)| function.signature.args_type == and_generics)
+            .unwrap();
+        Expr::FunctionCall(FunctionCall {
+            span: None,
+            id: Box::new(function_id),
+            function,
+            generics: and_generics,
+            args: and_args,
+            return_type: DataType::Nullable(Box::new(DataType::Boolean)),
+        })
+    }
+
+    fn build_not_expr(eq_expr: Expr<String>) -> Expr<String> {
+        let not_generics = vec![DataType::Nullable(Box::new(DataType::Boolean))];
+        let not_args = vec![eq_expr];
+        let (function_id, function) = BUILTIN_FUNCTIONS
+            .search_candidates("not", &[], not_args.as_slice())
+            .into_iter()
+            .find(|(_, function)| function.signature.args_type == not_generics)
+            .unwrap();
+        Expr::FunctionCall(FunctionCall {
+            span: None,
+            id: Box::new(function_id),
+            function,
+            generics: not_generics,
+            args: not_args,
+            return_type: DataType::Nullable(Box::new(DataType::Boolean)),
+        })
+    }
+
+    fn build_eq_expr(
+        data_type: DataType,
+        column_expr: Expr<String>,
+        scalar_expr: Expr<String>,
+    ) -> Expr<String> {
+        let eq_args = vec![column_expr, scalar_expr];
+        let eq_generics = vec![data_type.clone(), data_type];
+        let (function_id, function) = BUILTIN_FUNCTIONS
+            .search_candidates("eq", &[], eq_args.as_slice())
+            .into_iter()
+            .find(|(_, function)| function.signature.args_type == eq_generics)
+            .unwrap();
+        Expr::FunctionCall(FunctionCall {
+            span: None,
+            id: Box::new(function_id),
+            function,
+            generics: eq_generics,
+            args: eq_args,
+            return_type: DataType::Nullable(Box::new(DataType::Boolean)),
+        })
     }
 
     fn build_deletes_row_selection(

--- a/tests/sqllogictests/scripts/docker-compose-iceberg-tpch.yml
+++ b/tests/sqllogictests/scripts/docker-compose-iceberg-tpch.yml
@@ -63,3 +63,13 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c " until (/usr/bin/mc config host add minio http://127.0.0.1:9000 admin password) do echo '...waiting...' && sleep 1; done; /usr/bin/mc rm -r --force minio/iceberg-tpch; /usr/bin/mc mb minio/iceberg-tpch; /usr/bin/mc policy set public minio/iceberg-tpch; tail -f /dev/null "
+
+  iceberg-driver:
+    depends_on:
+      - mc
+    environment:
+      - AWS_REGION=us-east-1
+    build:
+      context: ./iceberg-driver
+      dockerfile: Dockerfile
+    network_mode: "host"

--- a/tests/sqllogictests/scripts/iceberg-driver/.gitignore
+++ b/tests/sqllogictests/scripts/iceberg-driver/.gitignore
@@ -1,0 +1,39 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+data/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/tests/sqllogictests/scripts/iceberg-driver/Dockerfile
+++ b/tests/sqllogictests/scripts/iceberg-driver/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.9.5-eclipse-temurin-11 AS builder
+
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests && ls -lh target
+
+FROM eclipse-temurin:11-jdk-alpine
+
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+CMD ["java", "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED", "-jar", "app.jar"]

--- a/tests/sqllogictests/scripts/iceberg-driver/README.md
+++ b/tests/sqllogictests/scripts/iceberg-driver/README.md
@@ -1,0 +1,6 @@
+# Iceberg Driver
+
+Use some high-level APIs directly in Iceberg Java to generate data
+
+For: 
+- Equality Delete

--- a/tests/sqllogictests/scripts/iceberg-driver/pom.xml
+++ b/tests/sqllogictests/scripts/iceberg-driver/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>iceberg-equality-delete</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <scala.binary.version>2.13</scala.binary.version>
+        <spark.binary.version>3.3</spark.binary.version>
+
+        <spark.version>3.3.2</spark.version>
+
+        <hadoop.version>3.3.0</hadoop.version>
+
+        <iceberg.veriosn>1.5.1</iceberg.veriosn>
+
+        <jackson.version>2.13.4.2</jackson.version>
+        <aws.sdk.version>2.20.80</aws.sdk.version>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-aws-bundle</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-spark-runtime-${spark.binary.version}_${scala.binary.version}</artifactId>
+            <version>${iceberg.veriosn}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-spark-extensions-${spark.binary.version}_${scala.binary.version}</artifactId>
+            <version>${iceberg.veriosn}</version>
+        </dependency>
+
+        <!-- spark -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.13</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.example.Driver</mainClass>
+                        </manifest>
+                    </archive>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/sqllogictests/scripts/iceberg-driver/src/main/java/org/example/Driver.java
+++ b/tests/sqllogictests/scripts/iceberg-driver/src/main/java/org/example/Driver.java
@@ -1,0 +1,146 @@
+package org.example;
+
+import org.apache.iceberg.*;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class DeleteRecord {
+    Schema schema;
+    Record record;
+    String fieldName;
+
+    public DeleteRecord(Schema schema, Record record, String fieldName) {
+        this.schema = schema;
+        this.record = record;
+        this.fieldName = fieldName;
+    }
+
+    int fieldId() {
+        return this.schema.findField(this.fieldName).fieldId();
+    }
+}
+
+public class Driver {
+
+    public static void main(String[] args) throws SQLException, NoSuchTableException, IOException {
+        SparkSession spark = SparkSession.builder()
+                .appName("CSV to Iceberg REST Catalog").master("local[*]")
+                // Iceberg REST Catalog
+                .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
+                .config("spark.sql.catalog.iceberg.type", "rest")
+                .config("spark.sql.catalog.iceberg.uri", "http://127.0.0.1:8181")
+                .config("spark.sql.catalog.iceberg.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
+                .config("spark.sql.catalog.iceberg.warehouse", "s3://iceberg-tpch/")
+                .config("spark.sql.catalog.iceberg.s3.access-key-id", "admin")
+                .config("spark.sql.catalog.iceberg.s3.secret-access-key", "password")
+                .config("spark.sql.catalog.iceberg.s3.path-style-access", "true")
+                .config("spark.sql.catalog.iceberg.s3.endpoint", "http://127.0.0.1:9000")
+                .config("spark.sql.catalog.iceberg.client.region", "us-east-1")
+                .config("spark.jars.packages",
+                        "org.apache.iceberg:iceberg-aws-bundle:1.6.1,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1")
+
+                .getOrCreate();
+
+        spark.sql("CREATE OR REPLACE TABLE iceberg.test.test_equality_merge_on_read_deletes (\n" +
+                "    dt     date,\n" +
+                "    number integer,\n" +
+                "    letter string\n" +
+                ")\n" +
+                "USING iceberg\n" +
+                "TBLPROPERTIES (\n" +
+                "    'write.delete.mode'='merge-on-read',\n" +
+                "    'write.update.mode'='merge-on-read',\n" +
+                "    'write.merge.mode'='merge-on-read',\n" +
+                "    'format-version'='2'\n" +
+                ");");
+        spark.sql("INSERT INTO iceberg.test.test_equality_merge_on_read_deletes\n" +
+                "VALUES\n" +
+                "    (CAST('2023-03-01' AS date), 1, 'a'),\n" +
+                "    (CAST('2023-03-02' AS date), 2, 'b'),\n" +
+                "    (CAST('2023-03-03' AS date), 3, 'c'),\n" +
+                "    (CAST('2023-03-04' AS date), 4, 'd'),\n" +
+                "    (CAST('2023-03-05' AS date), 5, 'e'),\n" +
+                "    (CAST('2023-03-06' AS date), 6, 'f'),\n" +
+                "    (CAST('2023-03-07' AS date), 7, 'g'),\n" +
+                "    (CAST('2023-03-08' AS date), 8, 'h'),\n" +
+                "    (CAST('2023-03-09' AS date), 9, 'i'),\n" +
+                "    (CAST('2023-03-10' AS date), 10, 'j'),\n" +
+                "    (CAST('2023-03-11' AS date), 11, 'k'),\n" +
+                "    (CAST('2023-03-12' AS date), 12, 'l');");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CatalogProperties.URI, "http://127.0.0.1:8181");
+        properties.put(CatalogProperties.WAREHOUSE_LOCATION, "s3://iceberg-tpch/");
+        properties.put("io-impl", "org.apache.iceberg.aws.s3.S3FileIO");
+        properties.put("s3.access-key-id", "admin");
+        properties.put("s3.secret-access-key", "password");
+        properties.put("s3.endpoint", "http://127.0.0.1:9000");
+        properties.put("s3.path-style-access", "true");
+        properties.put("s3.region", "us-east-1");
+
+        RESTCatalog restCatalog = new RESTCatalog();
+        restCatalog.initialize("rest", properties);
+
+        TableIdentifier tableId = TableIdentifier.of("test", "test_equality_merge_on_read_deletes");
+        Table table = restCatalog.loadTable(tableId);
+        System.out.println("Loaded table: " + table.name());
+
+        RowDelta rowDelta = table.newRowDelta();
+        PartitionSpec spec = table.spec();
+
+        List<DeleteRecord> deleteRecords = new ArrayList<>();
+
+        Schema number = table.schema().select("number");
+        Record deleteRecord0 = GenericRecord.create(number);
+        deleteRecord0.setField("number", 3);
+        deleteRecords.add(new DeleteRecord(number, deleteRecord0, "number"));
+
+        Schema letter = table.schema().select("letter");
+        Record deleteRecord1 = GenericRecord.create(letter);
+        deleteRecord1.setField("letter", "k");
+        deleteRecords.add(new DeleteRecord(letter, deleteRecord1, "letter"));
+
+        for (int i = 0; i < deleteRecords.size(); i++) {
+            String deleteFilePath = "s3://iceberg-tpch/test/test_equality_merge_on_read_deletes/data/equality-delete-file-" + i + ".parquet";
+            OutputFile outputFile = table.io().newOutputFile(deleteFilePath);
+
+            FileAppender<Record> appender = Parquet.write(outputFile)
+                    .schema(deleteRecords.get(i).schema)
+                    .createWriterFunc(GenericParquetWriter::buildWriter)
+                    .build();
+
+            appender.add(deleteRecords.get(i).record);
+            appender.close();
+
+            PartitionData partitionData = new PartitionData(table.spec().partitionType());
+
+            DeleteFile deleteFile = FileMetadata.deleteFileBuilder(spec)
+                    .ofEqualityDeletes(deleteRecords.get(i).fieldId())
+                    .withFormat(FileFormat.PARQUET)
+                    .withPath(deleteFilePath)
+                    .withPartition(partitionData)
+                    .withFileSizeInBytes(appender.length())
+                    .withMetrics(appender.metrics())
+                    .withSplitOffsets(appender.splitOffsets())
+                    .withSortOrder(table.sortOrder())
+                    .build();
+
+            rowDelta.addDeletes(deleteFile);
+        }
+        rowDelta.commit();
+    }
+}

--- a/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
@@ -97,4 +97,8 @@ spark.sql(
     f"DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number > 9"
 )
 
+spark.sql(
+    f"DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number = 3"
+)
+
 spark.stop()

--- a/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
@@ -57,48 +57,4 @@ spark.sql(
     f"""INSERT INTO iceberg.test.t1_orc VALUES (0, 0, 'a'), (1, 1, 'b'), (2, 2, 'c'), (3, 3, 'd'), (4, null, null);"""
 )
 
-spark.sql(
-    f"""
-CREATE OR REPLACE TABLE iceberg.test.test_positional_merge_on_read_deletes (
-    dt     date,
-    number integer,
-    letter string
-)
-USING iceberg
-TBLPROPERTIES (
-    'write.delete.mode'='merge-on-read',
-    'write.update.mode'='merge-on-read',
-    'write.merge.mode'='merge-on-read',
-    'format-version'='2'
-);
-"""
-)
-
-spark.sql(
-    f"""
-INSERT INTO iceberg.test.test_positional_merge_on_read_deletes
-VALUES
-    (CAST('2023-03-01' AS date), 1, 'a'),
-    (CAST('2023-03-02' AS date), 2, 'b'),
-    (CAST('2023-03-03' AS date), 3, 'c'),
-    (CAST('2023-03-04' AS date), 4, 'd'),
-    (CAST('2023-03-05' AS date), 5, 'e'),
-    (CAST('2023-03-06' AS date), 6, 'f'),
-    (CAST('2023-03-07' AS date), 7, 'g'),
-    (CAST('2023-03-08' AS date), 8, 'h'),
-    (CAST('2023-03-09' AS date), 9, 'i'),
-    (CAST('2023-03-10' AS date), 10, 'j'),
-    (CAST('2023-03-11' AS date), 11, 'k'),
-    (CAST('2023-03-12' AS date), 12, 'l');
-"""
-)
-
-spark.sql(
-    f"DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number > 9"
-)
-
-spark.sql(
-    f"DELETE FROM iceberg.test.test_positional_merge_on_read_deletes WHERE number = 3"
-)
-
 spark.stop()

--- a/tests/sqllogictests/suites/tpch_iceberg/base.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/base.test
@@ -59,7 +59,6 @@ select * from test_positional_merge_on_read_deletes;
 ----
 2023-03-01 1 a
 2023-03-02 2 b
-2023-03-03 3 c
 2023-03-04 4 d
 2023-03-05 5 e
 2023-03-06 6 f

--- a/tests/sqllogictests/suites/tpch_iceberg/base.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/base.test
@@ -54,45 +54,30 @@ select c1, c3 from t1_orc;
 3 d
 4 NULL
 
+# test_merge_on_read_deletes: DELETE FROM test_merge_on_read_deletes WHERE letter = 'k' OR number = 3 OR (number > 4 AND number < 7)
 query TTI rowsort
-select * from test_positional_merge_on_read_deletes;
+select * from test_merge_on_read_deletes;
 ----
 2023-03-01 1 a
 2023-03-02 2 b
 2023-03-04 4 d
-2023-03-05 5 e
-2023-03-06 6 f
-2023-03-07 7 g
-2023-03-08 8 h
-2023-03-09 9 i
-
-# test_equality_merge_on_read_deletes: DELETE FROM test_equality_merge_on_read_deletes WHERE letter = 'k' AND number = 3
-query TTI rowsort
-select * from test_equality_merge_on_read_deletes;
-----
-2023-03-01 1 a
-2023-03-02 2 b
-2023-03-04 4 d
-2023-03-05 5 e
-2023-03-06 6 f
 2023-03-07 7 g
 2023-03-08 8 h
 2023-03-09 9 i
 2023-03-10 10 j
 2023-03-12 12 l
+2023-03-30 6 z
 
 # test projection
 query T rowsort
-select dt from test_equality_merge_on_read_deletes;
+select dt from test_merge_on_read_deletes;
 ----
 2023-03-01
 2023-03-02
 2023-03-04
-2023-03-05
-2023-03-06
 2023-03-07
 2023-03-08
 2023-03-09
 2023-03-10
 2023-03-12
-
+2023-03-30

--- a/tests/sqllogictests/suites/tpch_iceberg/base.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/base.test
@@ -55,6 +55,7 @@ select c1, c3 from t1_orc;
 4 NULL
 
 # test_merge_on_read_deletes: DELETE FROM test_merge_on_read_deletes WHERE letter = 'k' OR number = 3 OR (number > 4 AND number < 7)
+# Tips: `2023-03-30 6 z` is new row
 query TTI rowsort
 select * from test_merge_on_read_deletes;
 ----

--- a/tests/sqllogictests/suites/tpch_iceberg/base.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/base.test
@@ -65,3 +65,34 @@ select * from test_positional_merge_on_read_deletes;
 2023-03-07 7 g
 2023-03-08 8 h
 2023-03-09 9 i
+
+# test_equality_merge_on_read_deletes: DELETE FROM test_equality_merge_on_read_deletes WHERE letter = 'k' AND number = 3
+query TTI rowsort
+select * from test_equality_merge_on_read_deletes;
+----
+2023-03-01 1 a
+2023-03-02 2 b
+2023-03-04 4 d
+2023-03-05 5 e
+2023-03-06 6 f
+2023-03-07 7 g
+2023-03-08 8 h
+2023-03-09 9 i
+2023-03-10 10 j
+2023-03-12 12 l
+
+# test projection
+query T rowsort
+select dt from test_equality_merge_on_read_deletes;
+----
+2023-03-01
+2023-03-02
+2023-03-04
+2023-03-05
+2023-03-06
+2023-03-07
+2023-03-08
+2023-03-09
+2023-03-10
+2023-03-12
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
When reading IcebergTable, the deleted data is filtered out by the File component predicate of Equality Delete.

Equality Delete File Format:
![image](https://github.com/user-attachments/assets/57d33d39-50ca-499f-9f01-02cbef9e92c9)
![image](https://github.com/user-attachments/assets/fd251f26-5801-4ce0-8af7-e096c7f364e6)
The corresponding Field contains constants with the same value, which are deleted.

Tips: 
Equality Delete is currently only supported in Iceberg Java, so the Iceberg Driver is introduced
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test 

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18015)
<!-- Reviewable:end -->
