### PR TITLE
refactor(meta): sleep a second before removing dir when cleaning up sled during upgrade

### DIFF
--- a/src/meta/raft-store/src/ondisk/upgrade_to_v004.rs
+++ b/src/meta/raft-store/src/ondisk/upgrade_to_v004.rs
@@ -229,6 +229,11 @@ impl OnDisk {
 
         drop_sled_db();
 
+        // Sleep a while to make sure the sled db is dropped and released in the underlying file system.
+        // There is an issue without sleep:
+        // Error: std::io::error::Error: std::io::error::Error: Device or resource busy (os error 16); when:(remove dir /var/lib/databend/raft/heap; when remove V003 raft-log store based on sled: '/var/lib/databend/raft')
+        tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
+
         //</_databend/meta_1/
         // ▸ df_meta/
         // ▸ heap/


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): sleep a second before removing dir when cleaning up sled during upgrade

NFS may hold the resource for longer thus there might be an error such
as:

```
Error: std::io::error::Error: std::io::error::Error: Device or resource busy (os error 16);
    when:(remove dir /var/lib/databend/raft/heap;
    when remove V003 raft-log store based on sled: '/var/lib/databend/raft')
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18018)
<!-- Reviewable:end -->
