### PR TITLE
refactor: bendsave should be able to output its built version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,6 +2973,7 @@ dependencies = [
  "databend-common-meta-types",
  "databend-common-storage",
  "databend-common-users",
+ "databend-common-version",
  "databend-enterprise-query",
  "databend-meta",
  "databend-query",

--- a/src/bendsave/Cargo.toml
+++ b/src/bendsave/Cargo.toml
@@ -15,6 +15,7 @@ databend-common-meta-control = { workspace = true }
 databend-common-meta-types = { workspace = true }
 databend-common-storage = { workspace = true }
 databend-common-users = { workspace = true }
+databend-common-version = { workspace = true }
 databend-enterprise-query = { workspace = true }
 databend-meta = { workspace = true }
 databend-query = { workspace = true }

--- a/src/bendsave/src/main.rs
+++ b/src/bendsave/src/main.rs
@@ -17,6 +17,7 @@ use clap::Parser;
 use clap::Subcommand;
 use databend_bendsave::backup;
 use databend_bendsave::restore;
+use databend_common_version::DATABEND_COMMIT_VERSION;
 use logforth::append;
 use logforth::filter::EnvFilter;
 use logforth::Dispatch;
@@ -25,6 +26,7 @@ use logforth::Logger;
 #[derive(Parser)]
 #[command(name = "bendsave")]
 #[command(about = "Databend backup and restore tool", long_about = None)]
+#[command(version = & ** DATABEND_COMMIT_VERSION)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: bendsave should be able to output its built version

In this commit, add `--version` / `-V` to `bendsave` to output its built
version:

```text
./target/debug/databend-bendsave --version
bendsave v1.2.743-nightly-59f0b3f41f(rust-1.88.0-nightly-2025-05-28T02:46:42.024829000Z)
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18020)
<!-- Reviewable:end -->
