### PR TITLE
chore(query): last_day support default interval type

### DIFF
--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1216,9 +1216,18 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
 
     let last_day = map(
         rule! {
-            LAST_DAY ~ "(" ~ #subexpr(0) ~ "," ~ #interval_kind ~ ")"
+            LAST_DAY ~ "(" ~ #subexpr(0) ~ ("," ~ #interval_kind)? ~ ")"
         },
-        |(_, _, date, _, unit, _)| ExprElement::LastDay { unit, date },
+        |(_, _, date, opt_unit, _)| {
+            if let Some((_, unit)) = opt_unit {
+                ExprElement::LastDay { unit, date }
+            } else {
+                ExprElement::LastDay {
+                    unit: IntervalKind::Month,
+                    date,
+                }
+            }
+        },
     );
 
     let previous_day = map(

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1265,6 +1265,8 @@ fn test_expr() {
         r#"date_part(year, d)"#,
         r#"datepart(year, d)"#,
         r#"DATEDIFF(SECOND, to_timestamp('2024-01-01 21:01:35.423179'), to_timestamp('2023-12-31 09:38:18.165575'))"#,
+        r#"last_day(to_date('2024-10-22'), week)"#,
+        r#"last_day(to_date('2024-10-22'))"#,
         r#"date_sub(QUARTER, 1, to_date('2018-01-02'))"#,
         r#"datebetween(QUARTER, to_date('2018-01-02'), to_date('2018-04-02'))"#,
         r#"position('a' in str)"#,

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -1916,6 +1916,92 @@ DateDiff {
 
 
 ---------- Input ----------
+last_day(to_date('2024-10-22'), week)
+---------- Output ---------
+LAST_DAY(to_date('2024-10-22'), WEEK)
+---------- AST ------------
+LastDay {
+    span: Some(
+        0..37,
+    ),
+    unit: Week,
+    date: FunctionCall {
+        span: Some(
+            9..30,
+        ),
+        func: FunctionCall {
+            distinct: false,
+            name: Identifier {
+                span: Some(
+                    9..16,
+                ),
+                name: "to_date",
+                quote: None,
+                ident_type: None,
+            },
+            args: [
+                Literal {
+                    span: Some(
+                        17..29,
+                    ),
+                    value: String(
+                        "2024-10-22",
+                    ),
+                },
+            ],
+            params: [],
+            order_by: [],
+            window: None,
+            lambda: None,
+        },
+    },
+}
+
+
+---------- Input ----------
+last_day(to_date('2024-10-22'))
+---------- Output ---------
+LAST_DAY(to_date('2024-10-22'), MONTH)
+---------- AST ------------
+LastDay {
+    span: Some(
+        0..31,
+    ),
+    unit: Month,
+    date: FunctionCall {
+        span: Some(
+            9..30,
+        ),
+        func: FunctionCall {
+            distinct: false,
+            name: Identifier {
+                span: Some(
+                    9..16,
+                ),
+                name: "to_date",
+                quote: None,
+                ident_type: None,
+            },
+            args: [
+                Literal {
+                    span: Some(
+                        17..29,
+                    ),
+                    value: String(
+                        "2024-10-22",
+                    ),
+                },
+            ],
+            params: [],
+            order_by: [],
+            window: None,
+            lambda: None,
+        },
+    },
+}
+
+
+---------- Input ----------
 date_sub(QUARTER, 1, to_date('2018-01-02'))
 ---------- Output ---------
 DATE_SUB(QUARTER, 1, to_date('2018-01-02'))

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -36,6 +36,11 @@ select last_day(to_date('2024-02-01'), month);
 ----
 2024-02-29
 
+query B
+select last_day(to_date('2024-02-01'), month)=last_day(to_date('2024-02-01'));
+----
+1
+
 query T
 select last_day(to_date('2024-02-01'), quarter);
 ----


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Syntax
```sql
LAST_DAY( <date_or_timetamp_expr> [ , <date_part> ] )
```
The interval type for which to find the last day. Accepted values are week, month, quarter, and year.

default with: month

- fixes: #18021
- 
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18022)
<!-- Reviewable:end -->
