### PR TITLE
chore(meta-test): fix inaccurate expire time in test

### DIFF
--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -523,8 +523,12 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
         for i in 0..(32 + 1) {
             let k = format!("w_auto_gc_{}", i);
             let want = del_event(&k, 1 + i, &k, Some(KvMeta::new_expire(now_sec + 1)));
+            let want2 = del_event(&k, 1 + i, &k, Some(KvMeta::new_expire(now_sec + 2)));
             let msg = client_stream.message().await?.unwrap();
-            assert_eq!(Some(want), msg.event);
+            assert!(Some(want.clone()) == msg.event || Some(want2.clone()) == msg.event,
+                    "expect {:?} equals {:?} or {:?}; the expire time is not accurate, so we need to check both",
+                msg.event, want, want2
+            );
         }
 
         // Check event generated when applying the txn


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore(meta-test): fix inaccurate expire time in test

The actual expire time is calculated by adding the current timestamp and
a duration. When the test runs on a heavily load CI nodes, the actual
expire time may be inaccurate due to timing variations. In this commit,
we add some tolerance to the expire time comparison.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18025)
<!-- Reviewable:end -->
