### PR TITLE
fix(query): change default format_null_as_str to false

### DIFF
--- a/src/common/io/src/format_settings.rs
+++ b/src/common/io/src/format_settings.rs
@@ -34,7 +34,7 @@ impl Default for FormatSettings {
             jiff_timezone: TimeZone::UTC,
             geometry_format: GeometryDataType::default(),
             enable_dst_hour_fix: false,
-            format_null_as_str: true,
+            format_null_as_str: false,
         }
     }
 }

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1116,7 +1116,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
                 ("format_null_as_str", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(1),
+                    value: UserSettingValue::UInt64(0),
                     desc: "Format NULL as str in query api response",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

We have already support json `null` in all drivers.
Changing this default to false, then we could correctly handle `Nullable(String)` with `'NULL'` in response.

- for: https://github.com/databendlabs/bendsql/issues/626

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18026)
<!-- Reviewable:end -->
