### PR TITLE
chore(optimizer): enhance the optimizer trace

### DIFF
--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -48,7 +48,7 @@ impl Config {
             },
             stderr: StderrConfig {
                 on: true,
-                level: "INFO".to_string(),
+                level: "WARN".to_string(),
                 format: "text".to_string(),
             },
             ..Default::default()

--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -48,7 +48,7 @@ impl Config {
             },
             stderr: StderrConfig {
                 on: true,
-                level: "WARN".to_string(),
+                level: "INFO".to_string(),
                 format: "text".to_string(),
             },
             ..Default::default()

--- a/src/query/sql/src/planner/optimizer/optimizer_api.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer_api.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use databend_common_exception::Result;
 
 use crate::optimizer::ir::Memo;
 use crate::optimizer::ir::SExpr;
+use crate::optimizer::pipeline::OptimizerTraceCollector;
 
 /// Trait defining the interface for query optimizers.
 #[async_trait::async_trait]
@@ -30,5 +33,11 @@ pub trait Optimizer: Send + Sync {
     /// Default implementation returns None for optimizers that don't use a memo.
     fn memo(&self) -> Option<&Memo> {
         None
+    }
+
+    /// Set the trace collector for this optimizer.
+    /// Default implementation does nothing.
+    fn set_trace_collector(&mut self, _collector: Arc<OptimizerTraceCollector>) {
+        // Default implementation does nothing
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizer_context.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer_context.rs
@@ -154,18 +154,20 @@ impl OptimizerContext {
         let settings = self.get_table_ctx().get_settings();
         match settings.get_optimizer_skip_list() {
             Ok(skip_list) if !skip_list.is_empty() => {
-                let skip_items: Vec<&str> = skip_list.split(',').map(str::trim).collect();
+                let name_lower = name.to_lowercase();
+                let is_disabled = skip_list
+                    .split(',')
+                    .map(str::trim)
+                    .any(|item| item.to_lowercase() == name_lower);
 
-                if skip_items.contains(&name) {
+                if is_disabled {
                     log::warn!(
                         "Skipping optimizer component: {} (found in optimizer_skip_list: {})",
                         name,
                         skip_list
                     );
-                    true
-                } else {
-                    false
                 }
+                is_disabled
             }
             _ => false,
         }

--- a/src/query/sql/src/planner/optimizer/optimizer_context.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer_context.rs
@@ -148,4 +148,26 @@ impl OptimizerContext {
     pub fn get_enable_trace(self: &Arc<Self>) -> bool {
         *self.enable_trace.read()
     }
+
+    /// Check if an optimizer or rule is disabled based on optimizer_skip_list setting
+    pub fn is_optimizer_disabled(self: &Arc<Self>, name: &str) -> bool {
+        let settings = self.get_table_ctx().get_settings();
+        match settings.get_optimizer_skip_list() {
+            Ok(skip_list) if !skip_list.is_empty() => {
+                let skip_items: Vec<&str> = skip_list.split(',').map(str::trim).collect();
+
+                if skip_items.contains(&name) {
+                    log::warn!(
+                        "Skipping optimizer component: {} (found in optimizer_skip_list: {})",
+                        name,
+                        skip_list
+                    );
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
@@ -67,6 +67,13 @@ impl RecursiveRuleOptimizer {
         let mut s_expr = s_expr.clone();
         for rule_id in rules {
             let rule = RuleFactory::create_rule(*rule_id, self.ctx.clone())?;
+
+            // Check if this rule should be skipped based on optimizer_skip_list
+            let rule_name = rule.name();
+            if self.ctx.is_optimizer_disabled(&rule_name) {
+                continue;
+            }
+
             let mut state = TransformResult::new();
             if rule
                 .matchers()

--- a/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
@@ -110,8 +110,8 @@ impl RecursiveRuleOptimizer {
                     let result = &state.results()[0];
 
                     // Only trace if collector exists and tracing is enabled
-                    if let Some(collector) = &self.trace_collector {
-                        if self.ctx.get_enable_trace() {
+                    if self.ctx.get_enable_trace() {
+                        if let Some(collector) = &self.trace_collector {
                             let metadata_ref = self.ctx.get_metadata();
                             let metadata = &metadata_ref.read();
 

--- a/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/recursive/recursive.rs
@@ -94,33 +94,37 @@ impl RecursiveRuleOptimizer {
             {
                 s_expr.set_applied_rule(&rule.id());
 
-                // Record the expression before rule application and start time
+                // Save the expression before rule application
                 let before_expr = s_expr.clone();
+
+                // Measure execution time
                 let start_time = Instant::now();
 
                 // Apply the rule
                 rule.apply(&s_expr, &mut state)?;
 
-                // Calculate execution time
+                // Calculate duration
                 let duration = start_time.elapsed();
 
                 if !state.results().is_empty() {
                     let result = &state.results()[0];
 
-                    // If tracing is enabled, record the rule application
+                    // Only trace if collector exists and tracing is enabled
                     if let Some(collector) = &self.trace_collector {
-                        let metadata_ref = self.ctx.get_metadata();
-                        let metadata = &metadata_ref.read();
+                        if self.ctx.get_enable_trace() {
+                            let metadata_ref = self.ctx.get_metadata();
+                            let metadata = &metadata_ref.read();
 
-                        // Record detailed information about the rule application
-                        collector.trace_rule(
-                            rule_name,
-                            self.name(),
-                            duration,
-                            &before_expr,
-                            result,
-                            metadata,
-                        )?;
+                            // Record detailed information about the rule application
+                            collector.trace_rule(
+                                rule_name,
+                                self.name(),
+                                duration,
+                                &before_expr,
+                                result,
+                                metadata,
+                            )?;
+                        }
                     }
 
                     // Recursively optimize the result

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
@@ -66,6 +66,10 @@ pub type RulePtr = Box<dyn Rule>;
 pub trait Rule {
     fn id(&self) -> RuleID;
 
+    fn name(&self) -> String {
+        self.id().to_string()
+    }
+
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()>;
 
     fn matchers(&self) -> &[Matcher];

--- a/src/query/sql/src/planner/optimizer/pipeline/mod.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/mod.rs
@@ -19,3 +19,4 @@ mod trace;
 
 pub use pipeline::OptimizerPipeline;
 pub use trace::OptimizerTrace;
+pub use trace::OptimizerTraceCollector;

--- a/src/query/sql/src/planner/optimizer/pipeline/pipeline.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/pipeline.rs
@@ -69,13 +69,6 @@ impl OptimizerPipeline {
             return self;
         }
 
-        // Get trace collector
-        let trace_collector = self.get_trace_collector();
-
-        // Call set_trace_collector method
-        let mut optimizer = optimizer;
-        optimizer.set_trace_collector(trace_collector);
-
         self.optimizers.push(Box::new(optimizer));
         self
     }
@@ -113,8 +106,14 @@ impl OptimizerPipeline {
         // Then apply all optimizers in sequence
         let mut current_expr = self.s_expr.clone();
         let total_optimizers = self.optimizers.len();
+        let trace_collector = self.get_trace_collector();
 
         for (idx, optimizer) in self.optimizers.iter_mut().enumerate() {
+            // Set trace collector
+            if self.opt_ctx.get_enable_trace() {
+                optimizer.set_trace_collector(trace_collector.clone());
+            }
+
             // Save the expression before optimization
             let before_expr = current_expr.clone();
 

--- a/src/query/sql/src/planner/optimizer/pipeline/pipeline.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/pipeline.rs
@@ -37,7 +37,7 @@ pub struct OptimizerPipeline {
     memo: Option<Memo>,
 
     /// The trace collector for generating reports
-    trace_collector: OptimizerTraceCollector,
+    trace_collector: Arc<OptimizerTraceCollector>,
 
     s_expr: SExpr,
 }
@@ -49,7 +49,7 @@ impl OptimizerPipeline {
             opt_ctx,
             optimizers: Vec::new(),
             memo: None,
-            trace_collector: OptimizerTraceCollector::new(),
+            trace_collector: Arc::new(OptimizerTraceCollector::new()),
             s_expr,
         };
 
@@ -69,6 +69,13 @@ impl OptimizerPipeline {
         if self.opt_ctx.is_optimizer_disabled(&optimizer_name) {
             return self;
         }
+
+        // Get trace collector
+        let trace_collector = self.get_trace_collector();
+
+        // Call set_trace_collector method
+        let mut optimizer = optimizer;
+        optimizer.set_trace_collector(trace_collector);
 
         self.optimizers.push(Box::new(optimizer));
         self
@@ -158,5 +165,10 @@ impl OptimizerPipeline {
                 Memo::create()
             }
         }
+    }
+
+    /// Get the trace collector
+    pub fn get_trace_collector(&self) -> Arc<OptimizerTraceCollector> {
+        self.trace_collector.clone()
     }
 }

--- a/src/query/sql/src/planner/optimizer/pipeline/trace/mod.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/trace/mod.rs
@@ -16,6 +16,5 @@ mod expr_diff;
 #[allow(clippy::module_inception)]
 mod trace;
 
-pub use trace::OptimizerExecution;
 pub use trace::OptimizerTrace;
 pub use trace::OptimizerTraceCollector;

--- a/src/query/sql/src/planner/optimizer/pipeline/trace/trace.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/trace/trace.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use databend_common_exception::Result;
@@ -22,192 +22,112 @@ use parking_lot::Mutex;
 use crate::optimizer::ir::SExpr;
 use crate::Metadata;
 
+/// Represents a trace entry for a rule execution
+#[derive(Clone)]
+pub struct RuleTrace {
+    /// The name of the rule
+    pub name: String,
+    /// The execution time of the rule
+    pub time: Duration,
+    /// Whether the rule had an effect (changed the expression)
+    pub had_effect: bool,
+    /// The diff between before and after expressions
+    pub diff: String,
+}
+
+impl RuleTrace {
+    /// Create a new rule trace
+    pub fn new(name: String, time: Duration, had_effect: bool, diff: String) -> Self {
+        Self {
+            name,
+            time,
+            had_effect,
+            diff,
+        }
+    }
+}
+
 /// Represents a trace entry for an optimizer execution
 #[derive(Clone)]
 pub struct OptimizerTrace {
     /// The name of the optimizer
-    pub optimizer_name: String,
+    pub name: String,
     /// The index of the optimizer in the pipeline
-    pub optimizer_index: usize,
+    pub index: usize,
     /// The total number of optimizers in the pipeline
-    pub total_optimizers: usize,
+    pub total: usize,
     /// The execution time of the optimizer
-    pub execution_time: Duration,
+    pub time: Duration,
     /// Whether the optimizer had an effect (changed the expression)
     pub had_effect: bool,
+    /// The diff between before and after expressions
+    pub diff: String,
 }
 
 impl OptimizerTrace {
     /// Create a new optimizer trace
     pub fn new(
-        optimizer_name: String,
-        optimizer_index: usize,
-        total_optimizers: usize,
-        execution_time: Duration,
+        name: String,
+        index: usize,
+        total: usize,
+        time: Duration,
         had_effect: bool,
+        diff: String,
     ) -> Self {
         Self {
-            optimizer_name,
-            optimizer_index,
-            total_optimizers,
-            execution_time,
-            had_effect,
-        }
-    }
-
-    /// Log the trace entry with expression diff
-    pub fn log(&self, before_expr: &SExpr, after_expr: &SExpr, metadata: &Metadata) -> Result<()> {
-        let mut output = String::new();
-
-        // Add header with effect information
-        let effect_status = if self.had_effect {
-            "Applied"
-        } else {
-            "No Effect"
-        };
-
-        output.push_str(&format!(
-            "================ {} Optimizer [{}/{}]: {} (execution time: {:.2?}) ================\n",
-            effect_status,
-            self.optimizer_index,
-            self.total_optimizers,
-            self.optimizer_name,
-            self.execution_time
-        ));
-
-        // Only generate and show diff if there was an effect
-        if self.had_effect {
-            let diff = before_expr.diff(after_expr, metadata)?;
-            output.push_str(&format!("{}\n", diff));
-        }
-
-        info!("{}", output);
-
-        Ok(())
-    }
-}
-
-/// Represents the execution of a rule
-#[derive(Clone)]
-pub struct RuleExecution {
-    /// The name of the rule
-    pub name: String,
-    /// The execution time of the rule
-    pub time: Duration,
-    /// The optimizer this rule belongs to
-    pub optimizer_name: String,
-    /// Whether the rule had an effect (changed the expression)
-    pub had_effect: bool,
-}
-
-impl RuleExecution {
-    /// Create a new rule execution record
-    pub fn new(name: String, optimizer_name: String, time: Duration, had_effect: bool) -> Self {
-        Self {
             name,
-            optimizer_name,
+            index,
+            total,
             time,
             had_effect,
+            diff,
         }
     }
-
-    /// Log the rule execution with expression diff
-    pub fn log(&self, before_expr: &SExpr, after_expr: &SExpr, metadata: &Metadata) -> Result<()> {
-        let mut output = String::new();
-
-        // Add header with effect information
-        let effect_status = if self.had_effect {
-            "Applied"
-        } else {
-            "No Effect"
-        };
-
-        output.push_str(&format!(
-            "================ {} Rule: {} (in optimizer: {}) (execution time: {:.2?}) ================\n",
-            effect_status,
-            self.name,
-            self.optimizer_name,
-            self.time
-        ));
-
-        // Only generate and show diff if there was an effect
-        if self.had_effect {
-            let diff = before_expr.diff(after_expr, metadata)?;
-            output.push_str(&format!("{}", diff));
-        }
-
-        info!("{}", output);
-
-        Ok(())
-    }
-}
-
-/// Contains information about an optimizer execution
-pub struct OptimizerExecution<'a> {
-    /// Name of the optimizer
-    pub name: String,
-    /// Index of the optimizer in the pipeline
-    pub index: usize,
-    /// Total number of optimizers in the pipeline
-    pub total: usize,
-    /// Execution time
-    pub time: Duration,
-    /// Expression before optimization
-    pub before: &'a SExpr,
-    /// Expression after optimization
-    pub after: &'a SExpr,
 }
 
 /// Represents a trace collector for optimizer and rule executions
 pub struct OptimizerTraceCollector {
-    /// The collection of optimizer traces
-    traces: Mutex<Vec<OptimizerTrace>>,
-    /// The collection of rule executions, organized by optimizer
-    rule_executions: Mutex<HashMap<String, Vec<RuleExecution>>>,
+    /// The collection of optimizer traces, ordered by index
+    optimizers: Mutex<BTreeMap<usize, OptimizerTrace>>,
+    /// The collection of rule traces, organized by optimizer name
+    rules: Mutex<BTreeMap<String, Vec<RuleTrace>>>,
 }
 
 impl OptimizerTraceCollector {
     /// Create a new trace collector
     pub fn new() -> Self {
         Self {
-            traces: Mutex::new(Vec::new()),
-            rule_executions: Mutex::new(HashMap::new()),
+            optimizers: Mutex::new(BTreeMap::new()),
+            rules: Mutex::new(BTreeMap::new()),
         }
     }
 
-    /// Set whether tracing is enabled (this is now a no-op as tracing is controlled externally)
-    pub fn set_enable_trace(&self, _enable: bool) {
-        // No-op - tracing is now controlled externally
-    }
-
-    /// Create a trace, add it to the collection, and log it
+    /// Create a trace, add it to the collection
     pub fn trace_optimizer(
         &self,
-        execution: OptimizerExecution,
+        name: String,
+        index: usize,
+        total: usize,
+        time: Duration,
+        before: &SExpr,
+        after: &SExpr,
         metadata: &Metadata,
     ) -> Result<()> {
-        // More robust check for expression changes
-        let diff = execution.before.diff(execution.after, metadata)?;
+        // Check for expression changes
+        let diff = before.diff(after, metadata)?;
         let had_effect = !diff.is_empty() && diff != "No differences found.";
 
-        let trace = OptimizerTrace::new(
-            execution.name,
-            execution.index,
-            execution.total,
-            execution.time,
-            had_effect,
-        );
+        // Create optimizer trace
+        let trace = OptimizerTrace::new(name.clone(), index, total, time, had_effect, diff);
 
-        // Add to collection
-        self.traces.lock().push(trace.clone());
-
-        // Log the trace
-        trace.log(execution.before, execution.after, metadata)?;
+        // Store optimizer trace
+        let mut optimizers = self.optimizers.lock();
+        optimizers.insert(index, trace);
 
         Ok(())
     }
 
-    /// Create a trace for a rule, add it to the collection, and log it
+    /// Create a trace for a rule, add it to the collection
     pub fn trace_rule(
         &self,
         rule_name: String,
@@ -217,216 +137,256 @@ impl OptimizerTraceCollector {
         after: &SExpr,
         metadata: &Metadata,
     ) -> Result<()> {
-        // Check if the rule had an effect on the expression
+        // Check if the rule had an effect
         let diff = before.diff(after, metadata)?;
         let had_effect = !diff.is_empty() && diff != "No differences found.";
 
-        // Create a rule execution record
-        let execution = RuleExecution::new(rule_name, optimizer_name.clone(), time, had_effect);
+        // Create the rule trace
+        let rule_trace = RuleTrace::new(rule_name, time, had_effect, diff);
 
-        // Log the trace
-        execution.log(before, after, metadata)?;
+        // IMPORTANT: Always acquire locks in the same order as log_report to prevent deadlocks
+        // First acquire optimizers lock
+        if had_effect {
+            let mut optimizers = self.optimizers.lock();
+            for optimizer in optimizers.values_mut() {
+                if optimizer.name == optimizer_name {
+                    optimizer.had_effect = true;
+                    break;
+                }
+            }
+        }
 
-        // Add the rule execution to the corresponding optimizer's collection
-        self.rule_executions
-            .lock()
-            .entry(optimizer_name)
-            .or_default()
-            .push(execution);
+        // Then acquire rules lock
+        let mut rules = self.rules.lock();
+        rules.entry(optimizer_name).or_default().push(rule_trace);
 
         Ok(())
     }
 
-    /// Generate and log the report
+    /// Generate and log the optimizer trace report
     pub fn log_report(&self) {
+        // Get copies of the data
+        let optimizers = self.optimizers.lock().clone();
+        let rules = self.rules.lock().clone();
+
+        // Check if there's any data to report
+        if optimizers.is_empty() && rules.is_empty() {
+            info!("No optimizers or rules were applied. Enable tracing with 'SET enable_optimizer_trace = 1;'");
+            return;
+        }
+
+        // First, generate and log the summary report
+        self.log_summary_report(&optimizers, &rules);
+
+        // Then, generate and log detailed reports for each optimizer
+        for optimizer in optimizers.values() {
+            self.log_optimizer_detail_report(optimizer, rules.get(&optimizer.name));
+        }
+    }
+
+    /// Generate and log the summary report
+    fn log_summary_report(
+        &self,
+        optimizers: &BTreeMap<usize, OptimizerTrace>,
+        rules: &BTreeMap<String, Vec<RuleTrace>>,
+    ) {
         let mut report = String::new();
-        report.push_str("================ Optimizer Trace Report ================\n");
+        report.push_str("================ Optimizer Execution Summary ================\n\n");
 
-        // Log optimizer traces
-        let traces = self.traces.lock();
-        if !traces.is_empty() {
-            report.push_str("--- Optimizers ---\n");
-            for trace in &*traces {
-                let effect_status = if trace.had_effect {
-                    "Applied"
-                } else {
-                    "No Effect"
-                };
-                report.push_str(&format!(
-                    "{} Optimizer [{}/{}]: {} (execution time: {:.2?})\n",
-                    effect_status,
-                    trace.optimizer_index,
-                    trace.total_optimizers,
-                    trace.optimizer_name,
-                    trace.execution_time
-                ));
-            }
-        }
+        // Calculate statistics
+        let total_optimizers = optimizers.len();
+        let applied_optimizers = optimizers.values().filter(|t| t.had_effect).count();
+        let total_optimizer_time: Duration = optimizers.values().map(|t| t.time).sum();
 
-        // Log rule traces
-        let rule_executions = self.rule_executions.lock();
-        if !rule_executions.is_empty() {
-            report.push_str("\n--- Rules by Optimizer ---\n");
-
-            // Output each optimizer and its rules
-            for (optimizer_name, rules) in &*rule_executions {
-                report.push_str(&format!("Optimizer: {}\n", optimizer_name));
-
-                // Count the number of effective rules for this optimizer
-                let applied_rules = rules.iter().filter(|r| r.had_effect).count();
-
-                // Calculate the total execution time of all rules for this optimizer
-                let total_time: Duration = rules.iter().map(|r| r.time).sum();
-
-                // Output each rule's execution status
-                for rule in rules {
-                    let effect_status = if rule.had_effect {
-                        "Applied"
-                    } else {
-                        "No Effect"
-                    };
-                    report.push_str(&format!(
-                        "  {} Rule: {} (execution time: {:.2?})\n",
-                        effect_status, rule.name, rule.time
-                    ));
-                }
-
-                // Output a summary of rule executions for this optimizer
-                report.push_str(&format!(
-                    "  Summary: {}/{} rules had effect (total execution time: {:.2?})\n\n",
-                    applied_rules,
-                    rules.len(),
-                    total_time
-                ));
-            }
-        }
-
-        // Output overall summary
-        let traces = self.traces.lock();
-        let rule_executions = self.rule_executions.lock();
-
-        let total_optimizers = traces.len();
-        let applied_optimizers = traces.iter().filter(|t| t.had_effect).count();
-        let total_optimizer_time: Duration = traces.iter().map(|t| t.execution_time).sum();
-
-        let total_rules: usize = rule_executions.values().map(|rules| rules.len()).sum();
-        let applied_rules: usize = rule_executions
+        let total_rules: usize = rules.values().map(|rules| rules.len()).sum();
+        let applied_rules: usize = rules
             .values()
             .flat_map(|rules| rules.iter())
             .filter(|r| r.had_effect)
             .count();
-        let total_rule_time: Duration = rule_executions
+        let total_rule_time: Duration = rules
             .values()
             .flat_map(|rules| rules.iter())
             .map(|r| r.time)
             .sum();
 
-        report.push_str(&format!(
-                "\nSummary:\n  Optimizers: {}/{} had effect (total time: {:.2?})\n  Rules: {}/{} had effect (total time: {:.2?})\n",
-                applied_optimizers, total_optimizers, total_optimizer_time,
-                applied_rules, total_rules, total_rule_time
-            ));
-
-        info!("{}", report);
-    }
-
-    /// Generate a summary report of applied optimizers and rules
-    pub fn generate_report(&self) -> String {
-        if self.traces.lock().is_empty() && self.rule_executions.lock().is_empty() {
-            return "No optimizers or rules were applied.\nEnable tracing with 'SET enable_optimizer_trace = 1;'".to_string();
-        }
-
-        let mut report = String::new();
-        report.push_str("================ Optimizer Execution Summary ================\n\n");
-
-        // Report optimizers that had an effect
+        // Report applied optimizers
         report.push_str("Applied Optimizers:\n");
         let mut has_applied = false;
-        let traces = self.traces.lock();
 
-        for trace in &*traces {
-            if trace.had_effect {
+        for optimizer in optimizers.values() {
+            if optimizer.had_effect {
                 has_applied = true;
+
+                // Output optimizer information
                 report.push_str(&format!(
                     "  - [{}] {} (execution time: {:.2?})\n",
-                    trace.optimizer_index, trace.optimizer_name, trace.execution_time
+                    optimizer.index, optimizer.name, optimizer.time
                 ));
+
+                // Find rules for this optimizer
+                if let Some(optimizer_rules) = rules.get(&optimizer.name) {
+                    // Process rules
+                    let applied_rules: Vec<_> =
+                        optimizer_rules.iter().filter(|r| r.had_effect).collect();
+                    let non_applied_rules: Vec<_> =
+                        optimizer_rules.iter().filter(|r| !r.had_effect).collect();
+
+                    if !applied_rules.is_empty() {
+                        report.push_str("    ├── Applied Rules:\n");
+                        for (i, rule) in applied_rules.iter().enumerate() {
+                            let is_last =
+                                i == applied_rules.len() - 1 && non_applied_rules.is_empty();
+                            let prefix = if is_last {
+                                "    │   └── "
+                            } else {
+                                "    │   ├── "
+                            };
+                            report.push_str(&format!(
+                                "{prefix}[{}.{}] {} (execution time: {:.2?})\n",
+                                optimizer.index,
+                                i + 1,
+                                rule.name,
+                                rule.time
+                            ));
+                        }
+                    }
+
+                    if !non_applied_rules.is_empty() {
+                        report.push_str("    └── Non-Applied Rules:\n");
+                        for (i, rule) in non_applied_rules.iter().enumerate() {
+                            let is_last = i == non_applied_rules.len() - 1;
+                            let prefix = if is_last {
+                                "        └── "
+                            } else {
+                                "        ├── "
+                            };
+                            report.push_str(&format!(
+                                "{prefix}[{}.{}] {} (execution time: {:.2?})\n",
+                                optimizer.index,
+                                applied_rules.len() + i + 1,
+                                rule.name,
+                                rule.time
+                            ));
+                        }
+                    }
+                }
             }
         }
 
+        // If no optimizers had an effect
         if !has_applied {
             report.push_str("  None\n");
         }
 
-        // Report optimizers that had no effect
+        // Report non-applied optimizers
         report.push_str("\nNon-Applied Optimizers:\n");
         let mut has_non_applied = false;
-        let traces = self.traces.lock();
 
-        for trace in &*traces {
-            if !trace.had_effect {
+        for optimizer in optimizers.values() {
+            if !optimizer.had_effect {
                 has_non_applied = true;
+
+                // Output optimizer information
                 report.push_str(&format!(
                     "  - [{}] {} (execution time: {:.2?})\n",
-                    trace.optimizer_index, trace.optimizer_name, trace.execution_time
+                    optimizer.index, optimizer.name, optimizer.time
                 ));
-            }
-        }
 
-        if !has_non_applied {
-            report.push_str("  None\n");
-        }
+                // Find rules for this optimizer
+                if let Some(optimizer_rules) = rules.get(&optimizer.name) {
+                    // Process non-applied rules
+                    let non_applied_rules: Vec<_> =
+                        optimizer_rules.iter().filter(|r| !r.had_effect).collect();
 
-        // Report rules that had an effect
-        report.push_str("\nApplied Rules by Optimizer:\n");
-        let mut has_applied_rules = false;
-        let rule_executions = self.rule_executions.lock();
-
-        for (optimizer_name, rules) in &*rule_executions {
-            let applied_rules: Vec<_> = rules.iter().filter(|r| r.had_effect).collect();
-            if !applied_rules.is_empty() {
-                has_applied_rules = true;
-                report.push_str(&format!("  Optimizer: {}\n", optimizer_name));
-                for rule in applied_rules {
-                    report.push_str(&format!(
-                        "    - {} (execution time: {:.2?})\n",
-                        rule.name, rule.time
-                    ));
+                    if !non_applied_rules.is_empty() {
+                        report.push_str("    └── Non-Applied Rules:\n");
+                        for (i, rule) in non_applied_rules.iter().enumerate() {
+                            let is_last = i == non_applied_rules.len() - 1;
+                            let prefix = if is_last {
+                                "        └── "
+                            } else {
+                                "        ├── "
+                            };
+                            report.push_str(&format!(
+                                "{prefix}[{}.{}] {} (execution time: {:.2?})\n",
+                                optimizer.index,
+                                i + 1,
+                                rule.name,
+                                rule.time
+                            ));
+                        }
+                    }
                 }
             }
         }
 
-        if !has_applied_rules {
+        // If all optimizers had an effect
+        if !has_non_applied {
             report.push_str("  None\n");
         }
 
-        // Total statistics
-        let traces = self.traces.lock();
-        let rule_executions = self.rule_executions.lock();
-
-        let total_optimizers = traces.len();
-        let applied_optimizers = traces.iter().filter(|t| t.had_effect).count();
-        let total_optimizer_time: Duration = traces.iter().map(|t| t.execution_time).sum();
-
-        let total_rules: usize = rule_executions.values().map(|rules| rules.len()).sum();
-        let applied_rules: usize = rule_executions
-            .values()
-            .flat_map(|rules| rules.iter())
-            .filter(|r| r.had_effect)
-            .count();
-        let total_rule_time: Duration = rule_executions
-            .values()
-            .flat_map(|rules| rules.iter())
-            .map(|r| r.time)
-            .sum();
-
+        // Output summary
         report.push_str(&format!(
-            "\nSummary:\n  Optimizers: {}/{} had effect (total time: {:.2?})\n  Rules: {}/{} had effect (total time: {:.2?})\n",
-            applied_optimizers, total_optimizers, total_optimizer_time,
-            applied_rules, total_rules, total_rule_time
+            "\nSummary: {}/{} optimizers had effect (total execution time: {:.2?})\n",
+            applied_optimizers, total_optimizers, total_optimizer_time
         ));
 
-        report
+        if total_rules > 0 {
+            report.push_str(&format!(
+                "Rules: {}/{} rules had effect (total execution time: {:.2?})\n",
+                applied_rules, total_rules, total_rule_time
+            ));
+        }
+
+        info!("{}", report);
+    }
+
+    /// Generate and log detailed report for a specific optimizer
+    fn log_optimizer_detail_report(
+        &self,
+        optimizer: &OptimizerTrace,
+        optimizer_rules: Option<&Vec<RuleTrace>>,
+    ) {
+        let effect_status = if optimizer.had_effect {
+            "Applied"
+        } else {
+            "No Effect"
+        };
+
+        // Build the complete report in a single string
+        let mut report = format!(
+            "================ {} Optimizer [{}/{}]: {} (execution time: {:.2?}) ================\n",
+            effect_status, optimizer.index, optimizer.total, optimizer.name, optimizer.time
+        );
+
+        // Add optimizer diff if it had an effect
+        if optimizer.had_effect {
+            report.push_str(&optimizer.diff);
+            report.push('\n');
+        }
+
+        // Add rule details if available
+        if let Some(rules) = optimizer_rules {
+            for (i, rule) in rules.iter().enumerate() {
+                if rule.had_effect {
+                    report.push_str(&format!(
+                        "---- Rule [{}.{}]: {} (execution time: {:.2?}) ----\n",
+                        optimizer.index,
+                        i + 1,
+                        rule.name,
+                        rule.time
+                    ));
+
+                    // Add rule diff
+                    report.push_str(&rule.diff);
+                    report.push('\n');
+                }
+            }
+        }
+
+        // Log the entire report in a single call
+        info!("{}", report);
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/pipeline/trace/trace.rs
+++ b/src/query/sql/src/planner/optimizer/pipeline/trace/trace.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use databend_common_exception::Result;
 use log::info;
+use parking_lot::Mutex;
 
 use crate::optimizer::ir::SExpr;
 use crate::Metadata;
@@ -85,6 +87,61 @@ impl OptimizerTrace {
     }
 }
 
+/// Represents the execution of a rule
+#[derive(Clone)]
+pub struct RuleExecution {
+    /// The name of the rule
+    pub name: String,
+    /// The execution time of the rule
+    pub time: Duration,
+    /// The optimizer this rule belongs to
+    pub optimizer_name: String,
+    /// Whether the rule had an effect (changed the expression)
+    pub had_effect: bool,
+}
+
+impl RuleExecution {
+    /// Create a new rule execution record
+    pub fn new(name: String, optimizer_name: String, time: Duration, had_effect: bool) -> Self {
+        Self {
+            name,
+            optimizer_name,
+            time,
+            had_effect,
+        }
+    }
+
+    /// Log the rule execution with expression diff
+    pub fn log(&self, before_expr: &SExpr, after_expr: &SExpr, metadata: &Metadata) -> Result<()> {
+        let mut output = String::new();
+
+        // Add header with effect information
+        let effect_status = if self.had_effect {
+            "Applied"
+        } else {
+            "No Effect"
+        };
+
+        output.push_str(&format!(
+            "================ {} Rule: {} (in optimizer: {}) (execution time: {:.2?}) ================\n",
+            effect_status,
+            self.name,
+            self.optimizer_name,
+            self.time
+        ));
+
+        // Only generate and show diff if there was an effect
+        if self.had_effect {
+            let diff = before_expr.diff(after_expr, metadata)?;
+            output.push_str(&format!("{}", diff));
+        }
+
+        info!("{}", output);
+
+        Ok(())
+    }
+}
+
 /// Contains information about an optimizer execution
 pub struct OptimizerExecution<'a> {
     /// Name of the optimizer
@@ -101,36 +158,38 @@ pub struct OptimizerExecution<'a> {
     pub after: &'a SExpr,
 }
 
-/// Collects and manages optimizer traces for generating reports
-#[derive(Default)]
+/// Represents a trace collector for optimizer and rule executions
 pub struct OptimizerTraceCollector {
-    /// Collected traces from optimizer executions
-    traces: Vec<OptimizerTrace>,
-    /// Whether tracing is enabled
-    enable_trace: bool,
+    /// Whether to enable trace collection
+    enable_trace: Mutex<bool>,
+    /// The collection of optimizer traces
+    traces: Mutex<Vec<OptimizerTrace>>,
+    /// The collection of rule executions, organized by optimizer
+    rule_executions: Mutex<HashMap<String, Vec<RuleExecution>>>,
 }
 
 impl OptimizerTraceCollector {
-    /// Create a new optimizer trace collector
+    /// Create a new trace collector
     pub fn new() -> Self {
         Self {
-            traces: Vec::new(),
-            enable_trace: false,
+            enable_trace: Mutex::new(false),
+            traces: Mutex::new(Vec::new()),
+            rule_executions: Mutex::new(HashMap::new()),
         }
     }
 
     /// Set whether tracing is enabled
-    pub fn set_enable_trace(&mut self, enable: bool) {
-        self.enable_trace = enable;
+    pub fn set_enable_trace(&self, enable: bool) {
+        *self.enable_trace.lock() = enable;
     }
 
     /// Create a trace, add it to the collection, and log it
     pub fn trace_optimizer(
-        &mut self,
+        &self,
         execution: OptimizerExecution,
         metadata: &Metadata,
     ) -> Result<()> {
-        if !self.enable_trace {
+        if !*self.enable_trace.lock() {
             return Ok(());
         }
 
@@ -147,7 +206,7 @@ impl OptimizerTraceCollector {
         );
 
         // Add to collection
-        self.traces.push(trace.clone());
+        self.traces.lock().push(trace.clone());
 
         // Log the trace
         trace.log(execution.before, execution.after, metadata)?;
@@ -155,17 +214,139 @@ impl OptimizerTraceCollector {
         Ok(())
     }
 
+    /// Create a trace for a rule, add it to the collection, and log it
+    pub fn trace_rule(
+        &self,
+        rule_name: String,
+        optimizer_name: String,
+        time: Duration,
+        before: &SExpr,
+        after: &SExpr,
+        metadata: &Metadata,
+    ) -> Result<()> {
+        if !*self.enable_trace.lock() {
+            return Ok(());
+        }
+
+        // Check if the rule had an effect on the expression
+        let diff = before.diff(after, metadata)?;
+        let had_effect = !diff.is_empty() && diff != "No differences found.";
+
+        // Create a rule execution record
+        let execution = RuleExecution::new(rule_name, optimizer_name.clone(), time, had_effect);
+
+        // Log the trace
+        execution.log(before, after, metadata)?;
+
+        // Add the rule execution to the corresponding optimizer's collection
+        self.rule_executions
+            .lock()
+            .entry(optimizer_name)
+            .or_default()
+            .push(execution);
+
+        Ok(())
+    }
+
     /// Generate and log the report
     pub fn log_report(&self) {
-        if self.enable_trace && !self.traces.is_empty() {
-            info!("{}", self.generate_report());
+        if *self.enable_trace.lock() {
+            let mut report = String::new();
+            report.push_str("================ Optimizer Trace Report ================\n");
+
+            // Log optimizer traces
+            let traces = self.traces.lock();
+            if !traces.is_empty() {
+                report.push_str("--- Optimizers ---\n");
+                for trace in &*traces {
+                    let effect_status = if trace.had_effect {
+                        "Applied"
+                    } else {
+                        "No Effect"
+                    };
+                    report.push_str(&format!(
+                        "{} Optimizer [{}/{}]: {} (execution time: {:.2?})\n",
+                        effect_status,
+                        trace.optimizer_index,
+                        trace.total_optimizers,
+                        trace.optimizer_name,
+                        trace.execution_time
+                    ));
+                }
+            }
+
+            // Log rule traces
+            let rule_executions = self.rule_executions.lock();
+            if !rule_executions.is_empty() {
+                report.push_str("\n--- Rules by Optimizer ---\n");
+
+                // Output each optimizer and its rules
+                for (optimizer_name, rules) in &*rule_executions {
+                    report.push_str(&format!("Optimizer: {}\n", optimizer_name));
+
+                    // Count the number of effective rules for this optimizer
+                    let applied_rules = rules.iter().filter(|r| r.had_effect).count();
+
+                    // Calculate the total execution time of all rules for this optimizer
+                    let total_time: Duration = rules.iter().map(|r| r.time).sum();
+
+                    // Output each rule's execution status
+                    for rule in rules {
+                        let effect_status = if rule.had_effect {
+                            "Applied"
+                        } else {
+                            "No Effect"
+                        };
+                        report.push_str(&format!(
+                            "  {} Rule: {} (execution time: {:.2?})\n",
+                            effect_status, rule.name, rule.time
+                        ));
+                    }
+
+                    // Output a summary of rule executions for this optimizer
+                    report.push_str(&format!(
+                        "  Summary: {}/{} rules had effect (total execution time: {:.2?})\n\n",
+                        applied_rules,
+                        rules.len(),
+                        total_time
+                    ));
+                }
+            }
+
+            // Output overall summary
+            let traces = self.traces.lock();
+            let rule_executions = self.rule_executions.lock();
+
+            let total_optimizers = traces.len();
+            let applied_optimizers = traces.iter().filter(|t| t.had_effect).count();
+            let total_optimizer_time: Duration = traces.iter().map(|t| t.execution_time).sum();
+
+            let total_rules: usize = rule_executions.values().map(|rules| rules.len()).sum();
+            let applied_rules: usize = rule_executions
+                .values()
+                .flat_map(|rules| rules.iter())
+                .filter(|r| r.had_effect)
+                .count();
+            let total_rule_time: Duration = rule_executions
+                .values()
+                .flat_map(|rules| rules.iter())
+                .map(|r| r.time)
+                .sum();
+
+            report.push_str(&format!(
+                "\nSummary:\n  Optimizers: {}/{} had effect (total time: {:.2?})\n  Rules: {}/{} had effect (total time: {:.2?})\n",
+                applied_optimizers, total_optimizers, total_optimizer_time,
+                applied_rules, total_rules, total_rule_time
+            ));
+
+            info!("{}", report);
         }
     }
 
-    /// Generate a summary report of applied optimizers
+    /// Generate a summary report of applied optimizers and rules
     pub fn generate_report(&self) -> String {
-        if self.traces.is_empty() {
-            return "No optimizers were applied.".to_string();
+        if self.traces.lock().is_empty() && self.rule_executions.lock().is_empty() {
+            return "No optimizers or rules were applied.".to_string();
         }
 
         let mut report = String::new();
@@ -174,8 +355,9 @@ impl OptimizerTraceCollector {
         // Report optimizers that had an effect
         report.push_str("Applied Optimizers:\n");
         let mut has_applied = false;
+        let traces = self.traces.lock();
 
-        for trace in &self.traces {
+        for trace in &*traces {
             if trace.had_effect {
                 has_applied = true;
                 report.push_str(&format!(
@@ -192,8 +374,9 @@ impl OptimizerTraceCollector {
         // Report optimizers that had no effect
         report.push_str("\nNon-Applied Optimizers:\n");
         let mut has_non_applied = false;
+        let traces = self.traces.lock();
 
-        for trace in &self.traces {
+        for trace in &*traces {
             if !trace.had_effect {
                 has_non_applied = true;
                 report.push_str(&format!(
@@ -207,16 +390,61 @@ impl OptimizerTraceCollector {
             report.push_str("  None\n");
         }
 
+        // Report rules that had an effect
+        report.push_str("\nApplied Rules by Optimizer:\n");
+        let mut has_applied_rules = false;
+        let rule_executions = self.rule_executions.lock();
+
+        for (optimizer_name, rules) in &*rule_executions {
+            let applied_rules: Vec<_> = rules.iter().filter(|r| r.had_effect).collect();
+            if !applied_rules.is_empty() {
+                has_applied_rules = true;
+                report.push_str(&format!("  Optimizer: {}\n", optimizer_name));
+                for rule in applied_rules {
+                    report.push_str(&format!(
+                        "    - {} (execution time: {:.2?})\n",
+                        rule.name, rule.time
+                    ));
+                }
+            }
+        }
+
+        if !has_applied_rules {
+            report.push_str("  None\n");
+        }
+
         // Total statistics
-        let total_optimizers = self.traces.len();
-        let applied_optimizers = self.traces.iter().filter(|t| t.had_effect).count();
-        let total_time: Duration = self.traces.iter().map(|t| t.execution_time).sum();
+        let traces = self.traces.lock();
+        let rule_executions = self.rule_executions.lock();
+
+        let total_optimizers = traces.len();
+        let applied_optimizers = traces.iter().filter(|t| t.had_effect).count();
+        let total_optimizer_time: Duration = traces.iter().map(|t| t.execution_time).sum();
+
+        let total_rules: usize = rule_executions.values().map(|rules| rules.len()).sum();
+        let applied_rules: usize = rule_executions
+            .values()
+            .flat_map(|rules| rules.iter())
+            .filter(|r| r.had_effect)
+            .count();
+        let total_rule_time: Duration = rule_executions
+            .values()
+            .flat_map(|rules| rules.iter())
+            .map(|r| r.time)
+            .sum();
 
         report.push_str(&format!(
-            "\nSummary: {}/{} optimizers had effect (total execution time: {:.2?})\n",
-            applied_optimizers, total_optimizers, total_time
+            "\nSummary:\n  Optimizers: {}/{} had effect (total time: {:.2?})\n  Rules: {}/{} had effect (total time: {:.2?})\n",
+            applied_optimizers, total_optimizers, total_optimizer_time,
+            applied_rules, total_rules, total_rule_time
         ));
 
         report
+    }
+}
+
+impl Default for OptimizerTraceCollector {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- `SET optimizer_skip_list = 'CascadesOptimizer,PushDownFilterJoin,EliminateFilter'`, the optimizer will not apply CascadesOptimizer, PushDownFilterJoin& EliminateFilter Rules.
- Enhance the optimizer trace log: `set enable_optimizer_trace=1`

<details>
<summary>Optimizer Trace Example</summary>

```
 ========== OPTIMIZERS SUMMARY TRACE ==========

[✓] 0: SubqueryDecorrelatorOptimizer (259.42µs)

[✗] 1: RuleStatsAggregateOptimizer (39.58µs)

[✗] 2: CollectStatisticsOptimizer (1.02ms)

[✗] 3: RuleNormalizeAggregateOptimizer (45.67µs)

[✓] 4: PullUpFilterOptimizer (346.29µs)

[✓] 5: RecursiveRuleOptimizer[EliminateSort,EliminateUnion,...(28)] (423.78ms)
  └── Rules: 7/30 Applied (23%)
    Rules Summary:
      [✗] 5.0: EliminateSort (481.35µs)
      [✗] 5.1: EliminateUnion (141.21µs)
      [✓] 5.2: MergeEvalScalar (293.75µs)
      [✗] 5.3: FilterNulls (184.34µs)
      [✗] 5.4: EliminateFilter (490.12µs)
      [✗] 5.5: MergeFilter (136.78µs)
      [✗] 5.6: NormalizeScalarFilter (194.70µs)
      [✗] 5.7: PushDownFilterUnion (132.50µs)
      [✓] 5.8: PushDownFilterAggregate (145.24µs)
      [✗] 5.9: PushDownFilterWindow (129.67µs)
      [✗] 5.10: PushDownFilterWindowTopN (130.38µs)
      [✗] 5.11: PushDownFilterSort (132.79µs)
      [✓] 5.12: PushDownFilterEvalScalar (1.09ms)
      [✓] 5.13: PushDownFilterJoin (2.82ms)
      [✗] 5.14: PushDownFilterProjectSet (123.59µs)
      [✗] 5.15: PushDownLimit (120.34µs)
      [✗] 5.16: PushDownLimitUnion (121.17µs)
      [✗] 5.17: PushDownSortEvalScalar (128.17µs)
      [✗] 5.18: PushDownLimitEvalScalar (122.92µs)
      [✓] 5.19: PushDownLimitSort (123.58µs)
      [✗] 5.20: PushDownLimitWindow (120.45µs)
      [✗] 5.21: RulePushDownRankLimitAggregate (145.17µs)
      [✗] 5.22: PushDownLimitOuterJoin (117.37µs)
      [✗] 5.23: PushDownLimitScan (116.42µs)
      [✗] 5.24: SemiToInnerJoin (171.17µs)
      [✗] 5.25: FoldCountAggregate (229.93µs)
      [✗] 5.26: TryApplyAggIndex (267.66µs)
      [✓] 5.27: PushDownFilterScan (202.92µs)
      [✓] 5.28: PushDownPrewhere (352.96µs)
      [✗] 5.29: PushDownSortScan (129.63µs)
    Total Applied Rules: 7/30 (23%)
    Total Non-Applied Rules: 23/30 (77%)

[✓] 6: RecursiveRuleOptimizer[SplitAggregate] (4.21ms)
  └── Rules: 1/1 Applied (100%)
    Rules Summary:
      [✓] 6.0: SplitAggregate (74.66µs)
    Total Applied Rules: 1/1 (100%)
    Total Non-Applied Rules: 0/1 (0%)

[✓] 7: DPhpyOptimizer (2.47ms)

[✗] 8: SingleToInnerOptimizer (17.96µs)

[✓] 9: DeduplicateJoinConditionOptimizer (55.92µs)

[✗] 10: RecursiveRuleOptimizer[CommuteJoin] (2.64ms)
  └── Rules: 0/1 Applied (0%)
    Rules Summary:
      [✗] 10.0: CommuteJoin (153.62µs)
    Total Applied Rules: 0/1 (0%)
    Total Non-Applied Rules: 1/1 (100%)

[✗] 11: CascadesOptimizer (2.04ms)

[✓] 12: RecursiveRuleOptimizer[EliminateEvalScalar] (4.11ms)
  └── Rules: 1/1 Applied (100%)
    Rules Summary:
      [✓] 12.0: EliminateEvalScalar (817.13µs)
    Total Applied Rules: 1/1 (100%)
    Total Non-Applied Rules: 0/1 (0%)


2025-05-30T18:05:24.331867+08:00  INFO databend_common_sql::planner::optimizer::pipeline::trace::trace: trace.rs:321 [✓] 0: SubqueryDecorrelatorOptimizer (259.42µs)

  Changes:
     Limit
     ├── limit: [100]
     ├── offset: [0]
     └── Sort
         ├── sort keys: [default.customer.c_customer_id (#79) ASC NULLS LAST]
         ├── limit: [NONE]
         └── EvalScalar
             ├── scalars: [customer.c_customer_id (#79) AS (#79)]
             └── Filter
    -            ├── filters: [gt(ctr1.ctr_total_return (#48), SUBQUERY), eq(store.s_store_sk (#49), ctr1.ctr_store_sk (#7)), eq(store.s_state (#73), 'TN'), eq(ctr1.ctr_customer_sk (#3), customer.c_customer_sk (#78))]
    -            ├── subquerys
    -            │   └── Subquery (Scalar)
    -            │       ├── output_column: derived.sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147)
    -            │       └── EvalScalar
    -            │           ├── scalars: [multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
    -            │           └── Aggregate(Initial)
    -            │               ├── group items: []
    -            │               ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
    -            │               └── EvalScalar
    -            │                   ├── scalars: [ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144)]
    -            │                   └── Filter
    -            │                       ├── filters: [eq(ctr1.ctr_store_sk (#7), ctr2.ctr_store_sk (#103))]
    -            │                       └── EvalScalar
    -            │                           ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), Sum(sr_return_amt) (#144) AS (#144)]
    -            │                           └── Aggregate(Initial)
    -            │                               ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
    -            │                               ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
    -            │                               └── EvalScalar
    -            │                                   ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107)]
    -            │                                   └── Filter
    -            │                                       ├── filters: [eq(store_returns.sr_returned_date_sk (#96), date_dim.d_date_sk (#116)), eq(date_dim.d_year (#122), 2001)]
    -            │                                       └── Join(Cross)
    -            │                                           ├── build keys: []
    -            │                                           ├── probe keys: []
    -            │                                           ├── other filters: []
    -            │                                           ├── Scan
    -            │                                           │   ├── table: default.store_returns (#4)
    -            │                                           │   ├── filters: []
    -            │                                           │   ├── order by: []
    -            │                                           │   └── limit: NONE
    -            │                                           └── Scan
    -            │                                               ├── table: default.date_dim (#5)
    -            │                                               ├── filters: []
    -            │                                               ├── order by: []
    -            │                                               └── limit: NONE
    -            └── Join(Cross)
    -                ├── build keys: []
    -                ├── probe keys: []
    +            ├── filters: [gt(ctr1.ctr_total_return (#48), scalar_subquery_147 (#147)), eq(store.s_store_sk (#49), ctr1.ctr_store_sk (#7)), eq(store.s_state (#73), 'TN'), eq(ctr1.ctr_customer_sk (#3), customer.c_customer_sk (#78))]
    +            └── Join(Left)
    +                ├── build keys: [sr_store_sk (#103)]
    +                ├── probe keys: [sr_store_sk (#7)]
                     ├── other filters: []
                     ├── Join(Cross)
                     │   ├── build keys: []
                     │   ├── probe keys: []
                     │   ├── other filters: []
    -                │   ├── EvalScalar
    -                │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
    -                │   │   └── Aggregate(Initial)
    -                │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
    -                │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
    -                │   │       └── EvalScalar
    -                │   │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11)]
    -                │   │           └── Filter
    -                │   │               ├── filters: [eq(store_returns.sr_returned_date_sk (#0), date_dim.d_date_sk (#20)), eq(date_dim.d_year (#26), 2001)]
    -                │   │               └── Join(Cross)
    -                │   │                   ├── build keys: []
    -                │   │                   ├── probe keys: []
    -                │   │                   ├── other filters: []
    -                │   │                   ├── Scan
    -                │   │                   │   ├── table: default.store_returns (#0)
    -                │   │                   │   ├── filters: []
    -                │   │                   │   ├── order by: []
    -                │   │                   │   └── limit: NONE
    -                │   │                   └── Scan
    -                │   │                       ├── table: default.date_dim (#1)
    -                │   │                       ├── filters: []
    -                │   │                       ├── order by: []
    -                │   │                       └── limit: NONE
    +                │   ├── Join(Cross)
    +                │   │   ├── build keys: []
    +                │   │   ├── probe keys: []
    +                │   │   ├── other filters: []
    +                │   │   ├── EvalScalar
    +                │   │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
    +                │   │   │   └── Aggregate(Initial)
    +                │   │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
    +                │   │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
    +                │   │   │       └── EvalScalar
    +                │   │   │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11)]
    +                │   │   │           └── Filter
    +                │   │   │               ├── filters: [eq(store_returns.sr_returned_date_sk (#0), date_dim.d_date_sk (#20)), eq(date_dim.d_year (#26), 2001)]
    +                │   │   │               └── Join(Cross)
    +                │   │   │                   ├── build keys: []
    +                │   │   │                   ├── probe keys: []
    +                │   │   │                   ├── other filters: []
    +                │   │   │                   ├── Scan
    +                │   │   │                   │   ├── table: default.store_returns (#0)
    +                │   │   │                   │   ├── filters: []
    +                │   │   │                   │   ├── order by: []
    +                │   │   │                   │   └── limit: NONE
    +                │   │   │                   └── Scan
    +                │   │   │                       ├── table: default.date_dim (#1)
    +                │   │   │                       ├── filters: []
    +                │   │   │                       ├── order by: []
    +                │   │   │                       └── limit: NONE
    +                │   │   └── Scan
    +                │   │       ├── table: default.store (#2)
    +                │   │       ├── filters: []
    +                │   │       ├── order by: []
    +                │   │       └── limit: NONE
                     │   └── Scan
    -                │       ├── table: default.store (#2)
    +                │       ├── table: default.customer (#3)
                     │       ├── filters: []
                     │       ├── order by: []
                     │       └── limit: NONE
    -                └── Scan
    -                    ├── table: default.customer (#3)
    -                    ├── filters: []
    -                    ├── order by: []
    -                    └── limit: NONE
    +                └── EvalScalar
    +                    ├── scalars: [outer.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
    +                    └── Aggregate(Initial)
    +                        ├── group items: [outer.sr_store_sk (#103) AS (#103)]
    +                        ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
    +                        └── EvalScalar
    +                            ├── scalars: [outer.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144)]
    +                            └── Filter
    +                                ├── filters: [eq(sr_store_sk (#103), ctr2.ctr_store_sk (#103))]
    +                                └── EvalScalar
    +                                    ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), Sum(sr_return_amt) (#144) AS (#144)]
    +                                    └── Aggregate(Initial)
    +                                        ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
    +                                        ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
    +                                        └── EvalScalar
    +                                            ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107)]
    +                                            └── Filter
    +                                                ├── filters: [eq(store_returns.sr_returned_date_sk (#96), date_dim.d_date_sk (#116)), eq(date_dim.d_year (#122), 2001)]
    +                                                └── Join(Cross)
    +                                                    ├── build keys: []
    +                                                    ├── probe keys: []
    +                                                    ├── other filters: []
    +                                                    ├── Scan
    +                                                    │   ├── table: default.store_returns (#4)
    +                                                    │   ├── filters: []
    +                                                    │   ├── order by: []
    +                                                    │   └── limit: NONE
    +                                                    └── Scan
    +                                                        ├── table: default.date_dim (#5)
    +                                                        ├── filters: []
    +                                                        ├── order by: []
    +                                                        └── limit: NONE


2025-05-30T18:05:24.331880+08:00  INFO databend_common_sql::planner::optimizer::pipeline::trace::trace: trace.rs:321 [✗] 1: RuleStatsAggregateOptimizer (39.58µs)

... ...
 
2025-05-30T18:05:24.332173+08:00  INFO databend_common_sql::planner::optimizer::pipeline::trace::trace: trace.rs:321 [✓] 5: RecursiveRuleOptimizer[EliminateSort,EliminateUnion,...(28)] (423.78ms)

  Changes:
     Limit
     ├── limit: [100]
     ├── offset: [0]
     └── Sort
         ├── sort keys: [default.customer.c_customer_id (#79) ASC NULLS LAST]
    -    ├── limit: [NONE]
    -    └── Filter
    -        ├── filters: [eq(store.s_store_sk (#156), ctr1.ctr_store_sk (#157)), eq(ctr1.ctr_customer_sk (#159), customer.c_customer_sk (#160)), gt(ctr1.ctr_total_return (#154), scalar_subquery_147 (#155)), eq(store.s_state (#158), 'TN')]
    -        └── EvalScalar
    -            ├── scalars: [customer.c_customer_id (#79) AS (#79), ctr1.ctr_total_return (#48) AS (#154), scalar_subquery_147 (#147) AS (#155), store.s_store_sk (#49) AS (#156), ctr1.ctr_store_sk (#7) AS (#157), store.s_state (#73) AS (#158), ctr1.ctr_customer_sk (#3) AS (#159), customer.c_customer_sk (#78) AS (#160)]
    -            └── Join(Left)
    -                ├── build keys: [sr_store_sk (#103)]
    -                ├── probe keys: [sr_store_sk (#7)]
    -                ├── other filters: []
    -                ├── Join(Cross)
    -                │   ├── build keys: []
    -                │   ├── probe keys: []
    -                │   ├── other filters: []
    -                │   ├── Join(Cross)
    -                │   │   ├── build keys: []
    -                │   │   ├── probe keys: []
    -                │   │   ├── other filters: []
    -                │   │   ├── EvalScalar
    -                │   │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
    -                │   │   │   └── Aggregate(Initial)
    -                │   │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
    -                │   │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
    -                │   │   │       └── Filter
    -                │   │   │           ├── filters: [eq(date_dim.d_year (#150), 2001), eq(store_returns.sr_returned_date_sk (#148), date_dim.d_date_sk (#149))]
    -                │   │   │           └── EvalScalar
    -                │   │   │               ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
    -                │   │   │               └── Join(Cross)
    -                │   │   │                   ├── build keys: []
    -                │   │   │                   ├── probe keys: []
    -                │   │   │                   ├── other filters: []
    -                │   │   │                   ├── Scan
    -                │   │   │                   │   ├── table: default.store_returns (#0)
    -                │   │   │                   │   ├── filters: []
    -                │   │   │                   │   ├── order by: []
    -                │   │   │                   │   └── limit: NONE
    -                │   │   │                   └── Scan
    -                │   │   │                       ├── table: default.date_dim (#1)
    -                │   │   │                       ├── filters: []
    -                │   │   │                       ├── order by: []
    -                │   │   │                       └── limit: NONE
    -                │   │   └── Scan
    -                │   │       ├── table: default.store (#2)
    -                │   │       ├── filters: []
    -                │   │       ├── order by: []
    -                │   │       └── limit: NONE
    -                │   └── Scan
    -                │       ├── table: default.customer (#3)
    -                │       ├── filters: []
    -                │       ├── order by: []
    -                │       └── limit: NONE
    -                └── EvalScalar
    -                    ├── scalars: [outer.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
    -                    └── Aggregate(Initial)
    -                        ├── group items: [outer.sr_store_sk (#103) AS (#103)]
    -                        ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
    -                        └── Filter
    -                            ├── filters: [eq(sr_store_sk (#103), ctr2.ctr_store_sk (#103))]
    +    ├── limit: [100]
    +    └── EvalScalar
    +        ├── scalars: [customer.c_customer_id (#79) AS (#79), ctr1.ctr_total_return (#48) AS (#154), scalar_subquery_147 (#147) AS (#155), store.s_store_sk (#49) AS (#156), ctr1.ctr_store_sk (#7) AS (#157), store.s_state (#73) AS (#158), ctr1.ctr_customer_sk (#3) AS (#159), customer.c_customer_sk (#78) AS (#160)]
    +        └── Join(Inner)
    +            ├── build keys: [sr_store_sk (#103), sr_store_sk (#103)]
    +            ├── probe keys: [sr_store_sk (#7), store.s_store_sk (#49)]
    +            ├── other filters: [gt(ctr1.ctr_total_return (#48), scalar_subquery_147 (#147))]
    +            ├── Join(Inner)
    +            │   ├── build keys: [customer.c_customer_sk (#78)]
    +            │   ├── probe keys: [ctr1.ctr_customer_sk (#3)]
    +            │   ├── other filters: []
    +            │   ├── Join(Inner)
    +            │   │   ├── build keys: [store.s_store_sk (#49)]
    +            │   │   ├── probe keys: [sr_store_sk (#7)]
    +            │   │   ├── other filters: []
    +            │   │   ├── EvalScalar
    +            │   │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
    +            │   │   │   └── Aggregate(Initial)
    +            │   │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
    +            │   │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
    +            │   │   │       └── EvalScalar
    +            │   │   │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
    +            │   │   │           └── Join(Inner)
    +            │   │   │               ├── build keys: [date_dim.d_date_sk (#20)]
    +            │   │   │               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
    +            │   │   │               ├── other filters: []
    +            │   │   │               ├── Scan
    +            │   │   │               │   ├── table: default.store_returns (#0)
    +            │   │   │               │   ├── filters: []
    +            │   │   │               │   ├── order by: []
    +            │   │   │               │   └── limit: NONE
    +            │   │   │               └── Scan
    +            │   │   │                   ├── table: default.date_dim (#1)
    +            │   │   │                   ├── filters: [eq(date_dim.d_year (#26), 2001)]
    +            │   │   │                   ├── order by: []
    +            │   │   │                   └── limit: NONE
    +            │   │   └── Scan
    +            │   │       ├── table: default.store (#2)
    +            │   │       ├── filters: [eq(store.s_state (#73), 'TN')]
    +            │   │       ├── order by: []
    +            │   │       └── limit: NONE
    +            │   └── Scan
    +            │       ├── table: default.customer (#3)
    +            │       ├── filters: []
    +            │       ├── order by: []
    +            │       └── limit: NONE
    +            └── EvalScalar
    +                ├── scalars: [outer.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
    +                └── Aggregate(Initial)
    +                    ├── group items: [outer.sr_store_sk (#103) AS (#103)]
    +                    ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
    +                    └── EvalScalar
    +                        ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), outer.sr_store_sk (#103) AS (#103), store_returns.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144), Sum(sr_return_amt) (#144) AS (#144)]
    +                        └── Aggregate(Initial)
    +                            ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
    +                            ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
                                 └── EvalScalar
    -                                ├── scalars: [outer.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144)]
    -                                └── EvalScalar
    -                                    ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), Sum(sr_return_amt) (#144) AS (#144)]
    -                                    └── Aggregate(Initial)
    -                                        ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
    -                                        ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
    -                                        └── Filter
    -                                            ├── filters: [eq(date_dim.d_year (#153), 2001), eq(store_returns.sr_returned_date_sk (#151), date_dim.d_date_sk (#152))]
    -                                            └── EvalScalar
    -                                                ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
    -                                                └── Join(Cross)
    -                                                    ├── build keys: []
    -                                                    ├── probe keys: []
    -                                                    ├── other filters: []
    -                                                    ├── Scan
    -                                                    │   ├── table: default.store_returns (#4)
    -                                                    │   ├── filters: []
    -                                                    │   ├── order by: []
    -                                                    │   └── limit: NONE
    -                                                    └── Scan
    -                                                        ├── table: default.date_dim (#5)
    -                                                        ├── filters: []
    -                                                        ├── order by: []
    -                                                        └── limit: NONE
    +                                ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
    +                                └── Join(Inner)
    +                                    ├── build keys: [date_dim.d_date_sk (#116)]
    +                                    ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
    +                                    ├── other filters: []
    +                                    ├── Scan
    +                                    │   ├── table: default.store_returns (#4)
    +                                    │   ├── filters: []
    +                                    │   ├── order by: []
    +                                    │   └── limit: NONE
    +                                    └── Scan
    +                                        ├── table: default.date_dim (#5)
    +                                        ├── filters: [eq(date_dim.d_year (#122), 2001)]
    +                                        ├── order by: []
    +                                        └── limit: NONE

  RecursiveRuleOptimizer[EliminateSort,EliminateUnion,...(28)] Rules Summary:
    [✗] 5.0: EliminateSort (481.35µs)
    [✗] 5.1: EliminateUnion (141.21µs)
    [✓] 5.2: MergeEvalScalar (293.75µs)
    [✗] 5.3: FilterNulls (184.34µs)
    [✗] 5.4: EliminateFilter (490.12µs)
    [✗] 5.5: MergeFilter (136.78µs)
    [✗] 5.6: NormalizeScalarFilter (194.70µs)
    [✗] 5.7: PushDownFilterUnion (132.50µs)
    [✓] 5.8: PushDownFilterAggregate (145.24µs)
    [✗] 5.9: PushDownFilterWindow (129.67µs)
    [✗] 5.10: PushDownFilterWindowTopN (130.38µs)
    [✗] 5.11: PushDownFilterSort (132.79µs)
    [✓] 5.12: PushDownFilterEvalScalar (1.09ms)
    [✓] 5.13: PushDownFilterJoin (2.82ms)
    [✗] 5.14: PushDownFilterProjectSet (123.59µs)
    [✗] 5.15: PushDownLimit (120.34µs)
    [✗] 5.16: PushDownLimitUnion (121.17µs)
    [✗] 5.17: PushDownSortEvalScalar (128.17µs)
    [✗] 5.18: PushDownLimitEvalScalar (122.92µs)
    [✓] 5.19: PushDownLimitSort (123.58µs)
    [✗] 5.20: PushDownLimitWindow (120.45µs)
    [✗] 5.21: RulePushDownRankLimitAggregate (145.17µs)
    [✗] 5.22: PushDownLimitOuterJoin (117.37µs)
    [✗] 5.23: PushDownLimitScan (116.42µs)
    [✗] 5.24: SemiToInnerJoin (171.17µs)
    [✗] 5.25: FoldCountAggregate (229.93µs)
    [✗] 5.26: TryApplyAggIndex (267.66µs)
    [✓] 5.27: PushDownFilterScan (202.92µs)
    [✓] 5.28: PushDownPrewhere (352.96µs)
    [✗] 5.29: PushDownSortScan (129.63µs)

  Total Applied Rules: 7/30 (23%)
  Total Non-Applied Rules: 23/30 (77%)

  Applied Rules Details:
    [✓] 5.2: MergeEvalScalar (293.75µs)
      Changes:
         EvalScalar
        -├── scalars: [outer.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144)]
        -└── EvalScalar
        -    ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), Sum(sr_return_amt) (#144) AS (#144)]
        -    └── Aggregate(Initial)
        -        ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
        -        ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
        -        └── EvalScalar
        -            ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
        -            └── Join(Inner)
        -                ├── build keys: [date_dim.d_date_sk (#116)]
        -                ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
        -                ├── other filters: []
        -                ├── Scan
        -                │   ├── table: default.store_returns (#4)
        -                │   ├── filters: []
        -                │   ├── order by: []
        -                │   └── limit: NONE
        -                └── Scan
        -                    ├── table: default.date_dim (#5)
        -                    ├── filters: [eq(date_dim.d_year (#122), 2001)]
        -                    ├── order by: []
        -                    └── limit: NONE
        +├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), outer.sr_store_sk (#103) AS (#103), store_returns.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144), Sum(sr_return_amt) (#144) AS (#144)]
        +└── Aggregate(Initial)
        +    ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
        +    ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
        +    └── EvalScalar
        +        ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
        +        └── Join(Inner)
        +            ├── build keys: [date_dim.d_date_sk (#116)]
        +            ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
        +            ├── other filters: []
        +            ├── Scan
        +            │   ├── table: default.store_returns (#4)
        +            │   ├── filters: []
        +            │   ├── order by: []
        +            │   └── limit: NONE
        +            └── Scan
        +                ├── table: default.date_dim (#5)
        +                ├── filters: [eq(date_dim.d_year (#122), 2001)]
        +                ├── order by: []
        +                └── limit: NONE

    [✓] 5.8: PushDownFilterAggregate (145.24µs)
      Changes:
        -Filter
        -├── filters: [eq(outer.sr_store_sk (#103), outer.sr_store_sk (#103))]
        -└── Aggregate(Initial)
        -    ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
        -    ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
        +Aggregate(Initial)
        +├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
        +├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
        +└── Filter
        +    ├── filters: [eq(outer.sr_store_sk (#103), outer.sr_store_sk (#103))]
             └── EvalScalar
                 ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
                 └── Join(Inner)
                     ├── build keys: [date_dim.d_date_sk (#116)]
                     ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
                     ├── other filters: []
                     ├── Scan
                     │   ├── table: default.store_returns (#4)
                     │   ├── filters: []
                     │   ├── order by: []
                     │   └── limit: NONE
                     └── Scan
                         ├── table: default.date_dim (#5)
                         ├── filters: [eq(date_dim.d_year (#122), 2001)]
                         ├── order by: []
                         └── limit: NONE

    [✓] 5.12: PushDownFilterEvalScalar (1.09ms)
      Changes:
        -Filter
        -├── filters: [eq(store.s_store_sk (#156), ctr1.ctr_store_sk (#157)), eq(ctr1.ctr_customer_sk (#159), customer.c_customer_sk (#160)), gt(ctr1.ctr_total_return (#154), scalar_subquery_147 (#155)), eq(store.s_state (#158), 'TN')]
        -└── EvalScalar
        -    ├── scalars: [customer.c_customer_id (#79) AS (#79), ctr1.ctr_total_return (#48) AS (#154), scalar_subquery_147 (#147) AS (#155), store.s_store_sk (#49) AS (#156), ctr1.ctr_store_sk (#7) AS (#157), store.s_state (#73) AS (#158), ctr1.ctr_customer_sk (#3) AS (#159), customer.c_customer_sk (#78) AS (#160)]
        +EvalScalar
        +├── scalars: [customer.c_customer_id (#79) AS (#79), ctr1.ctr_total_return (#48) AS (#154), scalar_subquery_147 (#147) AS (#155), store.s_store_sk (#49) AS (#156), ctr1.ctr_store_sk (#7) AS (#157), store.s_state (#73) AS (#158), ctr1.ctr_customer_sk (#3) AS (#159), customer.c_customer_sk (#78) AS (#160)]
        +└── Filter
        +    ├── filters: [eq(store.s_store_sk (#49), ctr1.ctr_store_sk (#7)), eq(ctr1.ctr_customer_sk (#3), customer.c_customer_sk (#78)), gt(ctr1.ctr_total_return (#48), scalar_subquery_147 (#147)), eq(store.s_state (#73), 'TN')]
             └── Join(Left)
                 ├── build keys: [sr_store_sk (#103)]
                 ├── probe keys: [sr_store_sk (#7)]
                 ├── other filters: []
                 ├── Join(Cross)
                 │   ├── build keys: []
                 │   ├── probe keys: []
                 │   ├── other filters: []
                 │   ├── Join(Cross)
                 │   │   ├── build keys: []
                 │   │   ├── probe keys: []
                 │   │   ├── other filters: []
                 │   │   ├── EvalScalar
                 │   │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
                 │   │   │   └── Aggregate(Initial)
                 │   │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
                 │   │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
                 │   │   │       └── EvalScalar
                 │   │   │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
                 │   │   │           └── Join(Inner)
                 │   │   │               ├── build keys: [date_dim.d_date_sk (#20)]
                 │   │   │               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
                 │   │   │               ├── other filters: []
                 │   │   │               ├── Scan
                 │   │   │               │   ├── table: default.store_returns (#0)
                 │   │   │               │   ├── filters: []
                 │   │   │               │   ├── order by: []
                 │   │   │               │   └── limit: NONE
                 │   │   │               └── Scan
                 │   │   │                   ├── table: default.date_dim (#1)
                 │   │   │                   ├── filters: [eq(date_dim.d_year (#26), 2001)]
                 │   │   │                   ├── order by: []
                 │   │   │                   └── limit: NONE
                 │   │   └── Scan
                 │   │       ├── table: default.store (#2)
                 │   │       ├── filters: []
                 │   │       ├── order by: []
                 │   │       └── limit: NONE
                 │   └── Scan
                 │       ├── table: default.customer (#3)
                 │       ├── filters: []
                 │       ├── order by: []
                 │       └── limit: NONE
                 └── EvalScalar
                     ├── scalars: [outer.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
                     └── Aggregate(Initial)
                         ├── group items: [outer.sr_store_sk (#103) AS (#103)]
                         ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
                         └── EvalScalar
                             ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), outer.sr_store_sk (#103) AS (#103), store_returns.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144), Sum(sr_return_amt) (#144) AS (#144)]
                             └── Aggregate(Initial)
                                 ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
                                 ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
                                 └── EvalScalar
                                     ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
                                     └── Join(Inner)
                                         ├── build keys: [date_dim.d_date_sk (#116)]
                                         ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
                                         ├── other filters: []
                                         ├── Scan
                                         │   ├── table: default.store_returns (#4)
                                         │   ├── filters: []
                                         │   ├── order by: []
                                         │   └── limit: NONE
                                         └── Scan
                                             ├── table: default.date_dim (#5)
                                             ├── filters: [eq(date_dim.d_year (#122), 2001)]
                                             ├── order by: []
                                             └── limit: NONE

    [✓] 5.13: PushDownFilterJoin (2.82ms)
      Changes:
        -Filter
        -├── filters: [eq(sr_store_sk (#7), store.s_store_sk (#49)), eq(store.s_state (#73), 'TN')]
        -└── Join(Cross)
        -    ├── build keys: []
        -    ├── probe keys: []
        -    ├── other filters: []
        -    ├── EvalScalar
        -    │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
        -    │   └── Aggregate(Initial)
        -    │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
        -    │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
        -    │       └── EvalScalar
        -    │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
        -    │           └── Join(Inner)
        -    │               ├── build keys: [date_dim.d_date_sk (#20)]
        -    │               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
        -    │               ├── other filters: []
        -    │               ├── Scan
        -    │               │   ├── table: default.store_returns (#0)
        -    │               │   ├── filters: []
        -    │               │   ├── order by: []
        -    │               │   └── limit: NONE
        -    │               └── Scan
        -    │                   ├── table: default.date_dim (#1)
        -    │                   ├── filters: [eq(date_dim.d_year (#26), 2001)]
        -    │                   ├── order by: []
        -    │                   └── limit: NONE
        +Join(Inner)
        +├── build keys: [store.s_store_sk (#49)]
        +├── probe keys: [sr_store_sk (#7)]
        +├── other filters: []
        +├── EvalScalar
        +│   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
        +│   └── Aggregate(Initial)
        +│       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
        +│       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
        +│       └── EvalScalar
        +│           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
        +│           └── Join(Inner)
        +│               ├── build keys: [date_dim.d_date_sk (#20)]
        +│               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
        +│               ├── other filters: []
        +│               ├── Scan
        +│               │   ├── table: default.store_returns (#0)
        +│               │   ├── filters: []
        +│               │   ├── order by: []
        +│               │   └── limit: NONE
        +│               └── Scan
        +│                   ├── table: default.date_dim (#1)
        +│                   ├── filters: [eq(date_dim.d_year (#26), 2001)]
        +│                   ├── order by: []
        +│                   └── limit: NONE
        +└── Filter
        +    ├── filters: [eq(store.s_state (#73), 'TN')]
             └── Scan
                 ├── table: default.store (#2)
                 ├── filters: []
                 ├── order by: []
                 └── limit: NONE

    [✓] 5.19: PushDownLimitSort (123.58µs)
      Changes:
         Limit
         ├── limit: [100]
         ├── offset: [0]
         └── Sort
             ├── sort keys: [default.customer.c_customer_id (#79) ASC NULLS LAST]
        -    ├── limit: [NONE]
        +    ├── limit: [100]
             └── EvalScalar
                 ├── scalars: [customer.c_customer_id (#79) AS (#79), ctr1.ctr_total_return (#48) AS (#154), scalar_subquery_147 (#147) AS (#155), store.s_store_sk (#49) AS (#156), ctr1.ctr_store_sk (#7) AS (#157), store.s_state (#73) AS (#158), ctr1.ctr_customer_sk (#3) AS (#159), customer.c_customer_sk (#78) AS (#160)]
                 └── Join(Inner)
                     ├── build keys: [sr_store_sk (#103), sr_store_sk (#103)]
                     ├── probe keys: [sr_store_sk (#7), store.s_store_sk (#49)]
                     ├── other filters: [gt(ctr1.ctr_total_return (#48), scalar_subquery_147 (#147))]
                     ├── Join(Inner)
                     │   ├── build keys: [customer.c_customer_sk (#78)]
                     │   ├── probe keys: [ctr1.ctr_customer_sk (#3)]
                     │   ├── other filters: []
                     │   ├── Join(Inner)
                     │   │   ├── build keys: [store.s_store_sk (#49)]
                     │   │   ├── probe keys: [sr_store_sk (#7)]
                     │   │   ├── other filters: []
                     │   │   ├── EvalScalar
                     │   │   │   ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), Sum(sr_return_amt) (#48) AS (#48)]
                     │   │   │   └── Aggregate(Initial)
                     │   │   │       ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
                     │   │   │       ├── aggregate functions: [Sum(sr_return_amt) AS (#48)]
                     │   │   │       └── EvalScalar
                     │   │   │           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
                     │   │   │           └── Join(Inner)
                     │   │   │               ├── build keys: [date_dim.d_date_sk (#20)]
                     │   │   │               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
                     │   │   │               ├── other filters: []
                     │   │   │               ├── Scan
                     │   │   │               │   ├── table: default.store_returns (#0)
                     │   │   │               │   ├── filters: []
                     │   │   │               │   ├── order by: []
                     │   │   │               │   └── limit: NONE
                     │   │   │               └── Scan
                     │   │   │                   ├── table: default.date_dim (#1)
                     │   │   │                   ├── filters: [eq(date_dim.d_year (#26), 2001)]
                     │   │   │                   ├── order by: []
                     │   │   │                   └── limit: NONE
                     │   │   └── Scan
                     │   │       ├── table: default.store (#2)
                     │   │       ├── filters: [eq(store.s_state (#73), 'TN')]
                     │   │       ├── order by: []
                     │   │       └── limit: NONE
                     │   └── Scan
                     │       ├── table: default.customer (#3)
                     │       ├── filters: []
                     │       ├── order by: []
                     │       └── limit: NONE
                     └── EvalScalar
                         ├── scalars: [outer.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
                         └── Aggregate(Initial)
                             ├── group items: [outer.sr_store_sk (#103) AS (#103)]
                             ├── aggregate functions: [sum(ctr_total_return) AS (#145), count(ctr_total_return) AS (#146)]
                             └── EvalScalar
                                 ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), outer.sr_store_sk (#103) AS (#103), store_returns.sr_store_sk (#103) AS (#103), ctr2.ctr_total_return (#144) AS (#144), ctr2.ctr_total_return (#144) AS (#144), Sum(sr_return_amt) (#144) AS (#144)]
                                 └── Aggregate(Initial)
                                     ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
                                     ├── aggregate functions: [Sum(sr_return_amt) AS (#144)]
                                     └── EvalScalar
                                         ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
                                         └── Join(Inner)
                                             ├── build keys: [date_dim.d_date_sk (#116)]
                                             ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
                                             ├── other filters: []
                                             ├── Scan
                                             │   ├── table: default.store_returns (#4)
                                             │   ├── filters: []
                                             │   ├── order by: []
                                             │   └── limit: NONE
                                             └── Scan
                                                 ├── table: default.date_dim (#5)
                                                 ├── filters: [eq(date_dim.d_year (#122), 2001)]
                                                 ├── order by: []
                                                 └── limit: NONE

    [✓] 5.27: PushDownFilterScan (202.92µs)
      Changes:
         Filter
         ├── filters: [eq(store.s_state (#73), 'TN')]
         └── Scan
             ├── table: default.store (#2)
        -    ├── filters: []
        +    ├── filters: [eq(store.s_state (#73), 'TN')]
             ├── order by: []
             └── limit: NONE

    [✓] 5.28: PushDownPrewhere (352.96µs)
      Changes:
        -Filter
        +Scan
        +├── table: default.store (#2)
         ├── filters: [eq(store.s_state (#73), 'TN')]
        -└── Scan
        -    ├── table: default.store (#2)
        -    ├── filters: [eq(store.s_state (#73), 'TN')]
        -    ├── order by: []
        -    └── limit: NONE
        +├── order by: []
        +└── limit: NONE
```

</details>

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - For debug

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18032)
<!-- Reviewable:end -->
