### PR TITLE
fix: flay test `03_0004_auto_vacuum.test`

### DIFF
--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0004_auto_vacuum.test
@@ -30,6 +30,12 @@ set enable_auto_vacuum = 1;
 statement ok
 create or replace table t (c int) 'fs:///tmp/auto_vacuum/';
 
+statement ok
+create or replace stage stage_av url = 'fs:///tmp/auto_vacuum/';
+
+statement ok
+remove @stage_av/ pattern = '.*';
+
 # prepare data
 statement ok
 insert into t values(1);
@@ -40,8 +46,6 @@ insert into t values(2);
 statement ok
 insert into t values(3);
 
-statement ok
-create or replace stage stage_av url = 'fs:///tmp/auto_vacuum/';
 
 # expect there are 3 segments/blocks/snapshots
 onlyif http
@@ -113,10 +117,14 @@ statement ok
 create or replace table t (c int) 'fs:///tmp/auto_vacuum_case2/';
 
 statement ok
-alter table t set options(data_retention_period_in_hours = 0);
+create or replace stage stage_av url = 'fs:///tmp/auto_vacuum_case2/';
 
 statement ok
-create or replace stage stage_av url = 'fs:///tmp/auto_vacuum_case2/';
+remove @stage_av/ pattern = '.*';
+
+statement ok
+alter table t set options(data_retention_period_in_hours = 0);
+
 
 statement ok
 insert into t values(1);
@@ -150,12 +158,22 @@ select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 # Test autovacuum policy `ByNumSnapshotsToKeep` #
 #################################################
 
+# Setting retention period to zero enables aggressive but safe vacuuming:
+# All historical data not referenced by the latest snapshot will be removed.
+# Note: With zero retention, concurrent transaction conflicts cannot be resolved.
+# Only the first committed transaction succeeds; all others will be aborted.
+statement ok
+set data_retention_time_in_days = 0;
+
 # CASE 1: Create table with data_retention_num_snapshots_to_keep table option
 statement ok
 create or replace table t (c int) 'fs:///tmp/auto_vacuum_case3/' data_retention_num_snapshots_to_keep = 3;
 
 statement ok
 create or replace stage stage_av url = 'fs:///tmp/auto_vacuum_case3/';
+
+statement ok
+remove @stage_av/ pattern = '.*';
 
 statement ok
 set enable_auto_vacuum = 1;
@@ -174,7 +192,7 @@ insert into t values(4);
 
 
 # Insert 4 time, but only 3 snapshots will be kept
-onlyif mysql
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 ----
@@ -190,19 +208,19 @@ insert into t values(5);
 statement ok
 optimize table t compact;
 
-onlyif mysql
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_sg%';
 ----
 1
 
-onlyif mysql
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%\/_b\/%';
 ----
 1
 
-onlyif mysql
+onlyif http
 query I
 select count() from list_stage(location=> '@stage_av') where name like '%_ss%';
 ----
@@ -229,4 +247,3 @@ remove @stage_av;
 
 statement ok
 drop stage stage_av;
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Tweak test case settings Since vacuum2 is active by default now, in the test case that expects all historical data that no longer referenced by the lasted snapshot to be vacuumed, data_retention_time_in_days should be set to zero.
- Change handler constraint from 'mysql' to 'http' By now, CI only guarantees that all EE suites could be tested using http handler, the 'mysql' handler may only be applied to some of the EE tests.

- Cleanup test stage before each test case to ensure clean state


- fixes: #18037

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18038)
<!-- Reviewable:end -->
