### PR TITLE
fix: when the WithIn Function arguments all are not `Nullable`, `OrderBy` fails

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_function_factory.rs
+++ b/src/query/functions/src/aggregates/aggregate_function_factory.rs
@@ -240,11 +240,11 @@ impl AggregateFunctionFactory {
         if arguments.iter().all(|f| !f.is_nullable_or_null()) {
             let mut agg =
                 self.get_impl(name, params, arguments, sort_descs.clone(), &mut features)?;
-            if or_null {
-                agg = AggregateFunctionOrNullAdaptor::create(agg, features)?
-            }
             if !sort_descs.is_empty() {
                 agg = AggregateFunctionSortAdaptor::create(agg, sort_descs)?
+            }
+            if or_null {
+                agg = AggregateFunctionOrNullAdaptor::create(agg, features)?
             }
             return Ok(agg);
         }
@@ -276,11 +276,11 @@ impl AggregateFunctionFactory {
             nested,
             features.clone(),
         )?;
-        if or_null {
-            agg = AggregateFunctionOrNullAdaptor::create(agg, features)?
-        }
         if !sort_descs.is_empty() {
             agg = AggregateFunctionSortAdaptor::create(agg, sort_descs)?
+        }
+        if or_null {
+            agg = AggregateFunctionOrNullAdaptor::create(agg, features)?
         }
         Ok(agg)
     }

--- a/src/query/functions/src/aggregates/aggregate_function_factory.rs
+++ b/src/query/functions/src/aggregates/aggregate_function_factory.rs
@@ -238,12 +238,15 @@ impl AggregateFunctionFactory {
         }
 
         if arguments.iter().all(|f| !f.is_nullable_or_null()) {
-            let agg = self.get_impl(name, params, arguments, sort_descs.clone(), &mut features)?;
-            return if or_null {
-                AggregateFunctionOrNullAdaptor::create(agg, features)
-            } else {
-                Ok(agg)
-            };
+            let mut agg =
+                self.get_impl(name, params, arguments, sort_descs.clone(), &mut features)?;
+            if or_null {
+                agg = AggregateFunctionOrNullAdaptor::create(agg, features)?
+            }
+            if !sort_descs.is_empty() {
+                agg = AggregateFunctionSortAdaptor::create(agg, sort_descs)?
+            }
+            return Ok(agg);
         }
 
         let nested = if name.to_lowercase().strip_suffix(STATE_SUFFIX).is_some() {

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -1,4 +1,4 @@
-query I
+    query I
 SELECT sum(number) from numbers_mt(10000)
 ----
 49995000
@@ -555,3 +555,27 @@ DROP TABLE aggr
 
 statement ok
 DROP DATABASE db1
+
+query TT rowsort
+select city,string_agg(var,'|') within group(order by var) as t
+from (
+    select 'a' as city,'123' as var
+    union all
+    select 'a' as city,'456' as var
+    union all
+    select 'b' as city,'aaa' as var
+    union all
+    select 'b' as city,'bbb' as var
+) t
+group by city;
+----
+a 123|456
+b aaa|bbb
+
+query TT rowsort
+select city, string_agg(var, '|') within group(order by var )
+from (values ('a', '123'), ('a', '456'), ('b', 'aaa'), ('b', 'bbb')) t(city, var)
+group by city;
+----
+a 123|456
+b aaa|bbb

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -1,4 +1,4 @@
-    query I
+query I
 SELECT sum(number) from numbers_mt(10000)
 ----
 49995000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

These two cases do not execute OrderBy because they return early and do not use `AggregateFunctionSortAdaptor`
```
select city, string_agg(var, '|') within group(order by var )
from (values ('a', '123'), ('a', '456'), ('b', 'aaa'), ('b', 'bbb')) t(city, var)
group by city;

select city,string_agg(var,'|') within group(order by var) as t
from (
    select 'a' as city,'123' as var
    union all
    select 'a' as city,'456' as var
    union all
    select 'b' as city,'aaa' as var
    union all
    select 'b' as city,'bbb' as var
) t
group by city;
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18041)
<!-- Reviewable:end -->
