### PR TITLE
refactor: Optimize PostgreSQL to strftime Format

### DIFF
--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -50,7 +50,6 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 recursive = { workspace = true }
-regex = { workspace = true }
 roaring = { workspace = true, features = ["serde"] }
 rust_decimal = { workspace = true }
 rustls = { workspace = true }

--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -195,7 +195,7 @@ impl Default for FunctionContext {
             enable_strict_datetime_parser: true,
             random_function_seed: false,
             week_start: 0,
-            date_format_style: "mysql".to_string(),
+            date_format_style: "oracle".to_string(),
         }
     }
 }

--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -355,10 +355,10 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
                 if format.is_empty() {
                     output.push_null();
                 } else {
-                    let format = if ctx.func_ctx.date_format_style == *"mysql" {
-                        format.to_string()
-                    } else {
+                    let format = if ctx.func_ctx.date_format_style == *"oracle" {
                         pg_format_to_strftime(format)
+                    } else {
+                        format.to_string()
                     };
                     match NaiveDate::parse_from_str(date_string, &format) {
                         Ok(res) => {
@@ -381,10 +381,10 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
                 if format.is_empty() {
                     output.push_null();
                 } else {
-                    let format = if ctx.func_ctx.date_format_style == *"mysql" {
-                        format.to_string()
-                    } else {
+                    let format = if ctx.func_ctx.date_format_style == *"oracle" {
                         pg_format_to_strftime(format)
+                    } else {
+                        format.to_string()
                     };
                     match NaiveDate::parse_from_str(date, &format) {
                         Ok(res) => {
@@ -410,10 +410,10 @@ fn string_to_format_datetime(
         return Ok((0, true));
     }
 
-    let format = if ctx.func_ctx.date_format_style == *"mysql" {
-        format.to_string()
-    } else {
+    let format = if ctx.func_ctx.date_format_style == *"oracle" {
         pg_format_to_strftime(format)
+    } else {
+        format.to_string()
     };
 
     let (mut tm, offset) = BrokenDownTime::parse_prefix(&format, timestamp)
@@ -721,10 +721,10 @@ fn register_to_string(registry: &mut FunctionRegistry) {
         vectorize_with_builder_2_arg::<TimestampType, StringType, NullableType<StringType>>(
             |micros, format, output, ctx| {
                 let ts = micros.to_timestamp(ctx.func_ctx.tz.clone());
-                let format = if ctx.func_ctx.date_format_style == *"mysql" {
-                    format.to_string()
-                } else {
+                let format = if ctx.func_ctx.date_format_style == *"oracle" {
                     pg_format_to_strftime(format)
+                } else {
+                    format.to_string()
                 };
                 let format = replace_time_format(&format);
                 let mut buf = String::new();

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -332,7 +332,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::String(vec!["PostgreSQL".into(), "MySQL".into(), "Experimental".into(), "Hive".into(), "Prql".into()])),
                 }),
                 ("date_format_style", DefaultSettingValue {
-                    value: UserSettingValue::String("MySQL".to_owned()),
+                    value: UserSettingValue::String("Oracle".to_owned()),
                     desc: "Sets the date format style(Used by datetime functions). Available values include \"MySQL\",  \"Oracle\".",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -1426,27 +1426,27 @@ statement ok
 drop table t
 
 query T
-settings (date_format_style='Oracle') select to_string('2022-02-02', '精彩的YYYY年，美丽的MMmonth,激动のDDd');
+select to_string('2022-02-02', '精彩的YYYY年，美丽的MMmonth,激动のDDd');
 ----
 精彩的2022年，美丽的02month,激动の02d
 
 query T
-settings (date_format_style='Oracle') select to_string('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
+select to_string('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
 ----
 Apr 05 12AM:00:00, 24
 
 query T
-settings (date_format_style='Oracle') select str_to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的YYYY年，美丽的MM month,激动のDDd');
+select str_to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的YYYY年，美丽的MM month,激动のDDd');
 ----
 2022-02-02
 
 query T
-settings (date_format_style='Oracle') select to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的YYYY年，美丽的MM month,激动のDDd');
+select to_date('精彩的2022年，美丽的02month,激动の02d', '精彩的YYYY年，美丽的MM month,激动のDDd');
 ----
 2022-02-02
 
 query T
-settings (date_format_style='Oracle') select str_to_timestamp('2022年02月04日，03时58分59秒', 'YYYY年MM月DD日，HH24时MI分SS秒');
+select str_to_timestamp('2022年02月04日，03时58分59秒', 'YYYY年MM月DD日，HH24时MI分SS秒');
 ----
 2022-02-04 03:58:59.000000
 
@@ -1471,17 +1471,17 @@ select date_format('2022-02-04T03:58:59', '%x'), strftime('2022-02-04T03:58:59',
 2022-02-04 03:58:59 2022-02-04 03:58:59
 
 query TTT
-settings (date_format_style='Oracle') select to_char('2024-04-05'::DATE, 'mon dd, yyyy');
+select to_char('2024-04-05'::DATE, 'mon dd, yyyy');
 ----
 Apr 05, 2024
 
 query TTT
-settings (timezone = 'Asia/Shanghai', date_format_style='Oracle') select to_char('2024-04-05'::DATE, 'mon dd, yyyy TZH');
+settings (timezone = 'Asia/Shanghai') select to_char('2024-04-05'::DATE, 'mon dd, yyyy TZH');
 ----
 Apr 05, 2024 +08
 
 query TTT
-settings (date_format_style='Oracle') select to_char('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
+select to_char('2024-04-05T00:00:00'::TIMESTAMP, 'mon dd HH12AM:MI:SS, yy');
 ----
 Apr 05 12AM:00:00, 24
 


### PR DESCRIPTION
date_format_style default value modify to Oracle

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

refactor date_format_style default value MySQL -> Oracle

#### **Pattern Matching Optimization**  
- Implemented "longest match first" strategy by descending pattern length sort  
- Added word boundary checks for `MON` to prevent false matches (e.g., distinguish "MON" from "MONTH")  

#### **Case Sensitivity Handling**  
- Case-insensitive matching for PostgreSQL formats (e.g., `YYYY`/`HH12`)  
- Strict case preservation for strftime literals (e.g., `%Y`/`%B`)  

#### **Memory Efficiency**  
- Pre-allocated output buffer (capacity = input length + safety margin)  
- Byte-indexed operations to minimize UTF-8 decoding overhead  

#### **Edge Case Handling**  
- Automatic escaping of `%` symbols in input (e.g., `%%Y` → `%%Y`)  
- Unmatched content preserved verbatim for lossless conversion  

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18042)
<!-- Reviewable:end -->
