### PR TITLE
feat(query): support result_scan and last_query_id in http handler

### DIFF
--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -53,9 +53,6 @@ use crate::sessions::TableContext;
 
 pub struct ExecutionError;
 
-const MIN_QUERY_ID_HISTORY: i32 = -64;
-const MAX_QUERY_ID_HISTORY: i32 = -1;
-
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ExecuteStateKind {
     Starting,
@@ -162,23 +159,22 @@ pub struct ExecutorSessionState {
     pub temp_tbl_mgr: TempTblMgrRef,
     pub variables: HashMap<String, Scalar>,
     pub last_query_ids: Vec<String>,
-    pub last_query_result_cache_keys: Vec<String>,
+    pub last_query_result_cache_key: String,
 }
 
 impl ExecutorSessionState {
     pub fn new(session: Arc<Session>) -> Self {
         let mut last_query_ids = Vec::with_capacity(64);
-        let mut last_query_result_cache_keys = Vec::with_capacity(64);
+        let mut last_query_result_cache_key = String::new();
 
-        for i in MIN_QUERY_ID_HISTORY..=MAX_QUERY_ID_HISTORY {
-            let last_query_id = session.get_last_query_id(i);
-            if !last_query_id.is_empty() {
-                if let Some(meta_key) = session.get_query_result_cache_key(&last_query_id) {
-                    last_query_ids.push(last_query_id);
-                    last_query_result_cache_keys.push(meta_key);
-                }
+        let last_query_id = session.get_last_query_id(-1);
+        if !last_query_id.is_empty() {
+            if let Some(meta_key) = session.get_query_result_cache_key(&last_query_id) {
+                last_query_ids.push(last_query_id);
+                last_query_result_cache_key = meta_key;
             }
         }
+
         Self {
             current_catalog: session.get_current_catalog(),
             current_database: session.get_current_database(),
@@ -189,7 +185,7 @@ impl ExecutorSessionState {
             temp_tbl_mgr: session.temp_tbl_mgr(),
             variables: session.get_all_variables(),
             last_query_ids,
-            last_query_result_cache_keys,
+            last_query_result_cache_key,
         }
     }
 }

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -53,6 +53,9 @@ use crate::sessions::TableContext;
 
 pub struct ExecutionError;
 
+const MIN_QUERY_ID_HISTORY: i32 = -64;
+const MAX_QUERY_ID_HISTORY: i32 = -1;
+
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ExecuteStateKind {
     Starting,
@@ -158,10 +161,24 @@ pub struct ExecutorSessionState {
     pub txn_manager: TxnManagerRef,
     pub temp_tbl_mgr: TempTblMgrRef,
     pub variables: HashMap<String, Scalar>,
+    pub last_query_ids: Vec<String>,
+    pub last_query_result_cache_keys: Vec<String>,
 }
 
 impl ExecutorSessionState {
     pub fn new(session: Arc<Session>) -> Self {
+        let mut last_query_ids = Vec::with_capacity(64);
+        let mut last_query_result_cache_keys = Vec::with_capacity(64);
+
+        for i in MIN_QUERY_ID_HISTORY..=MAX_QUERY_ID_HISTORY {
+            let last_query_id = session.get_last_query_id(i);
+            if !last_query_id.is_empty() {
+                if let Some(meta_key) = session.get_query_result_cache_key(&last_query_id) {
+                    last_query_ids.push(last_query_id);
+                    last_query_result_cache_keys.push(meta_key);
+                }
+            }
+        }
         Self {
             current_catalog: session.get_current_catalog(),
             current_database: session.get_current_database(),
@@ -171,6 +188,8 @@ impl ExecutorSessionState {
             txn_manager: session.txn_mgr(),
             temp_tbl_mgr: session.temp_tbl_mgr(),
             variables: session.get_all_variables(),
+            last_query_ids,
+            last_query_result_cache_keys,
         }
     }
 }

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -482,13 +482,13 @@ impl HttpQuery {
                 if !state.variables.is_empty() {
                     session.set_all_variables(state.get_variables()?)
                 }
-                if !session_conf.last_query_ids[0].is_empty()
-                    && !state.last_query_result_cache_key.is_empty()
-                {
-                    session.update_query_ids_results(
-                        session_conf.last_query_ids[0].to_string(),
-                        state.last_query_result_cache_key.to_string(),
-                    )
+                if let Some(id) = session_conf.last_query_ids.first() {
+                    if !id.is_empty() && !state.last_query_result_cache_key.is_empty() {
+                        session.update_query_ids_results(
+                            id.to_owned(),
+                            state.last_query_result_cache_key.to_owned(),
+                        );
+                    }
                 }
             }
 

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -375,6 +375,10 @@ impl Session {
             .update_query_ids_results(query_id, Some(result_cache_key))
     }
 
+    pub fn get_last_query_id(&self, index: i32) -> String {
+        self.session_ctx.get_last_query_id(index)
+    }
+
     pub fn txn_mgr(&self) -> TxnManagerRef {
         self.session_ctx.txn_mgr()
     }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1548,7 +1548,6 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
-                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1575,7 +1574,6 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
-                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1597,7 +1595,6 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
-                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1621,7 +1618,6 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
-                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1647,7 +1643,6 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
-                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1665,7 +1660,6 @@ async fn test_affect() -> Result<()> {
         let session = result.1.session.map(|s| HttpSessionConf {
             last_server_info: None,
             last_query_ids: vec![],
-            last_query_result_cache_keys: vec![],
             ..s
         });
 

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1548,6 +1548,7 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
+                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1574,6 +1575,7 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
+                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1595,6 +1597,7 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
+                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1618,6 +1621,7 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
+                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1643,6 +1647,7 @@ async fn test_affect() -> Result<()> {
                 need_keep_alive: false,
                 last_server_info: None,
                 last_query_ids: vec![],
+                last_query_result_cache_keys: vec![],
                 internal: None,
             }),
         ),
@@ -1660,6 +1665,7 @@ async fn test_affect() -> Result<()> {
         let session = result.1.session.map(|s| HttpSessionConf {
             last_server_info: None,
             last_query_ids: vec![],
+            last_query_result_cache_keys: vec![],
             ..s
         });
 

--- a/src/tests/sqlsmith/src/http_client.rs
+++ b/src/tests/sqlsmith/src/http_client.rs
@@ -87,6 +87,8 @@ pub(crate) struct HttpSessionConf {
     pub(crate) last_server_info: Option<ServerInfo>,
     #[serde(default)]
     pub(crate) last_query_ids: Vec<String>,
+    #[serde(default)]
+    pub(crate) last_query_result_cache_keys: Vec<String>,
     pub(crate) internal: Option<String>,
 }
 

--- a/src/tests/sqlsmith/src/http_client.rs
+++ b/src/tests/sqlsmith/src/http_client.rs
@@ -27,7 +27,9 @@ use reqwest::header::HeaderValue;
 use reqwest::Client;
 use reqwest::ClientBuilder;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use serde::Serializer;
 use url::Url;
 
 struct GlobalCookieStore {
@@ -87,9 +89,54 @@ pub(crate) struct HttpSessionConf {
     pub(crate) last_server_info: Option<ServerInfo>,
     #[serde(default)]
     pub(crate) last_query_ids: Vec<String>,
+    /// hide state not useful to clients
+    /// so client only need to know there is a String field `internal`,
+    /// which need to carry with session/conn
     #[serde(default)]
-    pub(crate) last_query_result_cache_keys: Vec<String>,
-    pub(crate) internal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "serialize_as_json_string",
+        deserialize_with = "deserialize_from_json_string"
+    )]
+    pub(crate) internal: Option<HttpSessionStateInternal>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Eq, PartialEq)]
+pub struct HttpSessionStateInternal {
+    /// value is JSON of Scalar
+    variables: Vec<(String, String)>,
+    pub last_query_result_cache_key: String,
+}
+
+fn serialize_as_json_string<S>(
+    value: &Option<HttpSessionStateInternal>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(complex_value) => {
+            let json_string =
+                serde_json::to_string(complex_value).map_err(serde::ser::Error::custom)?;
+            serializer.serialize_some(&json_string)
+        }
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_from_json_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<HttpSessionStateInternal>, D::Error>
+where D: Deserializer<'de> {
+    let json_string: Option<String> = Option::deserialize(deserializer)?;
+    match json_string {
+        Some(s) => {
+            let complex_value = serde_json::from_str(&s).map_err(serde::de::Error::custom)?;
+            Ok(Some(complex_value))
+        }
+        None => Ok(None),
+    }
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/tests/sqllogictests/src/util.rs
+++ b/tests/sqllogictests/src/util.rs
@@ -67,6 +67,8 @@ pub struct HttpSessionConf {
     pub last_server_info: Option<ServerInfo>,
     #[serde(default)]
     pub last_query_ids: Vec<String>,
+    #[serde(default)]
+    pub last_query_result_cache_keys: Vec<String>,
     pub internal: Option<String>,
 }
 

--- a/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0014_result_scan.test
@@ -1,26 +1,23 @@
 # The HTTP interface does not support session state function (last_query_id).
 
-onlyif mysql
 statement ok
 DROP DATABASE IF EXISTS db20_14;
 
-onlyif mysql
 statement ok
 CREATE DATABASE db20_14;
 
-onlyif mysql
 statement ok
 USE db20_14;
 
-onlyif mysql
+
 statement ok
 CREATE TABLE IF NOT EXISTS t1 (a INT);
 
-onlyif mysql
+
 statement ok
 INSERT INTO t1 VALUES (1), (2), (3);
 
-onlyif mysql
+
 query I
 SELECT * FROM t1 ORDER BY a;
 ----
@@ -28,19 +25,23 @@ SELECT * FROM t1 ORDER BY a;
 2
 3
 
-onlyif mysql
+
 statement ok
 SET enable_query_result_cache = 1;
 
-onlyif mysql
+
 statement ok
 SET query_result_cache_min_execute_secs = 0;
+
 
 onlyif mysql
 statement error `RESULT_SCAN` failed: No cache key found in current session for query ID '.*'\.
 SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 
-onlyif mysql
+onlyif http
+statement error The `RESULT_SCAN` function requires a 'query_id' parameter. Please specify a valid query ID
+SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
+
 query I
 SELECT * FROM t1 ORDER BY a;
 ----
@@ -48,7 +49,7 @@ SELECT * FROM t1 ORDER BY a;
 2
 3
 
-onlyif mysql
+
 query I
 SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 ----
@@ -57,7 +58,7 @@ SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 3
 
 # multiple executions should return the same result
-onlyif mysql
+
 query I
 SELECT * FROM RESULT_SCAN(last_query_id());
 ----
@@ -65,11 +66,11 @@ SELECT * FROM RESULT_SCAN(last_query_id());
 2
 3
 
-onlyif mysql
+
 statement ok
 INSERT INTO t1 VALUES (4);
 
-onlyif mysql
+
 query I
 SELECT * FROM t1 ORDER BY a;
 ----
@@ -78,7 +79,7 @@ SELECT * FROM t1 ORDER BY a;
 3
 4
 
-onlyif mysql
+
 query I
 SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 ----
@@ -87,7 +88,7 @@ SELECT * FROM RESULT_SCAN(last_query_id()) ORDER BY a;
 3
 4
 
-onlyif mysql
+
 query I
 SELECT * FROM RESULT_SCAN(last_query_id(-1)) ORDER BY a;
 ----
@@ -96,14 +97,14 @@ SELECT * FROM RESULT_SCAN(last_query_id(-1)) ORDER BY a;
 3
 4
 
-onlyif mysql
+
 statement ok
 SET enable_query_result_cache = 0;
 
-onlyif mysql
+
 statement ok
 DROP TABLE t1;
 
-onlyif mysql
+
 statement ok
 DROP DATABASE db20_14;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

**Problem**:
HTTP sessions in Databend are ephemeral - they terminate after each query completes. This prevents HTTP clients from using `RESULT_SCAN` and `last_query_id()` functions, which rely on session-stored query history. These features currently only work with persistent MySQL protocol connections.

**Solution**:
This PR enables HTTP clients to maintain query history by storing `last_query_id` and result cache metadata in the HTTP configuration, allowing state transfer between requests.

**Changes**:
1. **Session State Enhancement**:
   - Added `last_query_ids` and `last_query_result_cache_keys` arrays to `ExecutorSessionState` (stores last 64 queries)
   - Enabled query history persistence for HTTP sessions

2. **HTTP Handler Updates**:
   - Extended `HttpSessionConf` to include `last_query_result_cache_keys`
   - Added validation for matching array lengths between query IDs and cache keys
   - HTTP clients can now pass query history back to subsequent requests

3. **Bug Fix**:
   - Fixed `RESULT_SCAN` functionality in HTTP mode (was MySQL-only)
   - Updated logic tests to verify HTTP handler behavior

**Impact**:
HTTP clients can now use `RESULT_SCAN` and `last_query_id()` functions, achieving feature parity with MySQL protocol.  


<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18043)
<!-- Reviewable:end -->
