### PR TITLE
fix(query): reuse the left's column binding in union as possible

### DIFF
--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -457,8 +457,17 @@ impl Binder {
                     left_col.index,
                     Some(ScalarExpr::CastExpr(left_coercion_expr)),
                 ));
+
+                let column_binding = self.create_derived_column_binding(
+                    left_col.column_name.clone(),
+                    coercion_types[idx].clone(),
+                    None,
+                );
+                new_bind_context.add_column_binding(column_binding);
             } else {
                 left_outputs.push((left_col.index, None));
+                // reuse the left column binding
+                new_bind_context.add_column_binding(left_col.clone());
             }
 
             if *right_col.data_type != coercion_types[idx] {
@@ -481,13 +490,6 @@ impl Binder {
             } else {
                 right_outputs.push((right_col.index, None));
             }
-
-            let column_binding = self.create_derived_column_binding(
-                left_col.column_name.clone(),
-                coercion_types[idx].clone(),
-                None,
-            );
-            new_bind_context.add_column_binding(column_binding);
         }
 
         Ok((new_bind_context, left_outputs, right_outputs))

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
@@ -74,6 +74,7 @@ impl Rule for RuleEliminateUnion {
         let union: UnionAll = s_expr.plan().clone().try_into()?;
 
         // Need to check that union's output indexes are the same as left child's output indexes
+        // currently this is always !false now, so the following codes are not necessary
         if !union
             .left_outputs
             .iter()

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
@@ -72,6 +72,16 @@ impl Rule for RuleEliminateUnion {
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let union: UnionAll = s_expr.plan().clone().try_into()?;
+
+        // Need to check that union's output indexes are the same as left child's output indexes
+        if !union
+            .left_outputs
+            .iter()
+            .all(|(idx, _)| union.output_indexes.contains(idx))
+        {
+            return Ok(());
+        }
+
         let left_child = s_expr.child(0)?;
         let right_child = s_expr.child(1)?;
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -269,7 +269,11 @@ settings (ddl_column_type_nullable=0) create table t2 as select number as b from
 query T
 explain select * from t1 where t1.a < 0 union all select a from t2 join t1 on t1.a = t2.b where a <0;
 ----
-EmptyResultScan
+UnionAll
+├── output columns: [a (#3)]
+├── estimated rows: 0.00
+├── EmptyResultScan
+└── EmptyResultScan
 
 
 query T
@@ -295,21 +299,29 @@ UnionAll
 query T
 explain select * from t1 union all select * from t2 where t2.b < 0;
 ----
-TableScan
-├── table: default.default.t1
-├── output columns: []
-├── read rows: 10000
-├── read size: 0
-├── partitions total: 1
-├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-├── push downs: [filters: [], limit: NONE]
-└── estimated rows: 10000.00
+UnionAll
+├── output columns: [a (#2)]
+├── estimated rows: 10000.00
+├── TableScan
+│   ├── table: default.default.t1
+│   ├── output columns: [a (#0)]
+│   ├── read rows: 10000
+│   ├── read size: 10.59 KiB
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 10000.00
+└── EmptyResultScan
 
 query T
 explain select * from t1 where t1.a < 0 union all select * from t2 where t2.b < 0;
 ----
-EmptyResultScan
+UnionAll
+├── output columns: [a (#2)]
+├── estimated rows: 0.00
+├── EmptyResultScan
+└── EmptyResultScan
 
 statement ok
 drop table t1;

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -345,8 +345,20 @@ SELECT COUNT(1), 'numbers(10)' FROM numbers(10)
 statement ok
 unset max_set_operator_count;
 
+statement ok
+select sum(number) as number, number* 3 as t   from numbers(100) group by t union all select  number, number* 3 as t from numbers(1000) where number < 0 ignore_result;
+----
+
+statement ok
+select t, sum(number) as number from (select sum(number) as number, number* 3 as t   from numbers(100) group by t union all select  number, number* 3 as t from numbers(1000) where number < 0) group by t ignore_result;
+----
+
 query I
-select * from numbers(100) union all select * from numbers(100) ignore_result;
+select  number::int32 from numbers(100) union all select number::int from numbers(100) where number < 0 ignore_result;
+----
+
+query I
+select  number::int32 from numbers(100) union all select number::int from numbers(100) where number > 0 ignore_result;
 ----
 
 statement ok

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -345,11 +345,11 @@ SELECT COUNT(1), 'numbers(10)' FROM numbers(10)
 statement ok
 unset max_set_operator_count;
 
-statement ok
+query I
 select sum(number) as number, number* 3 as t   from numbers(100) group by t union all select  number, number* 3 as t from numbers(1000) where number < 0 ignore_result;
 ----
 
-statement ok
+query I
 select t, sum(number) as number from (select sum(number) as number, number* 3 as t   from numbers(100) group by t union all select  number, number* 3 as t from numbers(1000) where number < 0) group by t ignore_result;
 ----
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix Union Column Binding and Union Elimination Rule
 
This PR addresses two issues in the SQL query planner related to UNION operations:

Column Binding Fix in UNION Operations:
1. Moves column binding logic for the left side of a UNION operation to happen immediately after processing each column
Ensures left column bindings are correctly reused when no type coercion is needed
2. Prevents potential issues with column binding references in complex UNION queries
3. Union Elimination Rule Enhancement:
Adds a safety check in the RuleEliminateUnion to verify that union's output indexes match the left child's output indexes
Prevents incorrect query plan transformations when the output indexes don't align

Improves query stability for certain UNION ALL patterns

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18053)
<!-- Reviewable:end -->
