### PR TITLE
feat: adjust syntax of streaming load insert SQL.

### DIFF
--- a/src/query/ast/src/ast/statements/insert.rs
+++ b/src/query/ast/src/ast/statements/insert.rs
@@ -83,6 +83,7 @@ pub enum InsertSource {
         query: Box<Query>,
     },
     StreamingLoad {
+        stage_name: String,
         format_options: FileFormatOptions,
         on_error_mode: Option<String>,
     },
@@ -106,9 +107,11 @@ impl Display for InsertSource {
             InsertSource::RawValues { rest_str, .. } => write!(f, "VALUES {rest_str}"),
             InsertSource::Select { query } => write!(f, "{query}"),
             InsertSource::StreamingLoad {
+                stage_name,
                 format_options,
                 on_error_mode,
             } => {
+                write!(f, " from @{stage_name}")?;
                 write!(f, " FILE_FORMAT = ({})", format_options)?;
                 write!(
                     f,

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -3011,9 +3011,10 @@ pub fn insert_source(i: Input) -> IResult<InsertSource> {
 pub fn raw_insert_source(i: Input) -> IResult<InsertSource> {
     let streaming = map(
         rule! {
-           #file_format_clause ~ (ON_ERROR ~ ^"=" ~ ^#ident)?
+           FROM ~ #at_string ~ #file_format_clause ~ (ON_ERROR ~ ^"=" ~ ^#ident)?
         },
-        |(options, on_error_opt)| InsertSource::StreamingLoad {
+        |(_, stage_name, options, on_error_opt)| InsertSource::StreamingLoad {
+            stage_name,
             format_options: options,
             on_error_mode: on_error_opt.map(|v| v.2.to_string()),
         },

--- a/src/query/sql/src/planner/binder/ddl/stage.rs
+++ b/src/query/sql/src/planner/binder/ddl/stage.rs
@@ -63,6 +63,10 @@ impl Binder {
             None => {
                 if stage_name == "~" {
                     StageInfo::new_user_stage(&self.ctx.get_current_user()?.name)
+                } else if stage_name == "streaming_load" {
+                    return Err(ErrorCode::SemanticError(
+                        "`streaming_load` is a reserved stage name",
+                    ));
                 } else {
                     StageInfo::new_internal_stage(stage_name)
                 }

--- a/src/query/sql/src/planner/binder/insert.rs
+++ b/src/query/sql/src/planner/binder/insert.rs
@@ -157,9 +157,15 @@ impl Binder {
                 Ok(InsertInputSource::SelectPlan(Box::new(select_plan)))
             }
             InsertSource::StreamingLoad {
+                stage_name,
                 format_options,
                 on_error_mode,
             } => {
+                if stage_name != "streaming_load" {
+                    return Err(ErrorCode::SemanticError(
+                        "streaming load only support insert from `@streaming_load`",
+                    ));
+                }
                 let file_format_params = FileFormatParams::try_from_reader(
                     FileFormatOptionsReader::from_ast(&format_options),
                     false,

--- a/tests/suites/1_stateful/01_streaming_load/01_0001_streaming_load_ontime.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0001_streaming_load_ontime.sh
@@ -10,7 +10,7 @@ cat $TESTS_DATA_DIR/ddl/ontime.sql | sed 's/ontime/ontime_streaming_load/g' | $B
 
 function run() {
   echo "--$2"
-  curl -sS -H "x-databend-query-id:$2" -H "sql:insert into ontime_streaming_load file_format = ($1)" -F "upload=@/${TESTS_DATA_DIR}/$2" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
+  curl -sS -H "x-databend-query-id:$2" -H "sql:insert into ontime_streaming_load from @streaming_load file_format = ($1)" -F "upload=@/${TESTS_DATA_DIR}/$2" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
   echo
   echo "select count(1), avg(Year), sum(DayOfWeek)  from ontime_streaming_load;" | $BENDSQL_CLIENT_CONNECT
   echo "truncate table ontime_streaming_load" | $BENDSQL_CLIENT_CONNECT

--- a/tests/suites/1_stateful/01_streaming_load/01_0002_streaming_load_variant.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0002_streaming_load_variant.sh
@@ -10,7 +10,7 @@ cat ${TESTS_DATA_DIR}/ddl/variant_test.sql | $BENDSQL_CLIENT_CONNECT
 
 # run format path table
 function run() {
-  curl -sS -H "x-databend-query-id:$2" -H "sql:insert into $3 file_format = ($1)" -F "upload=@/${TESTS_DATA_DIR}/$2" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
+  curl -sS -H "x-databend-query-id:$2" -H "sql:insert into $3 from @streaming_load file_format = ($1)" -F "upload=@/${TESTS_DATA_DIR}/$2" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
   echo
 }
 

--- a/tests/suites/1_stateful/01_streaming_load/01_0003_streaming_load_dedup.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0003_streaming_load_dedup.sh
@@ -10,7 +10,7 @@ function run() {
 	echo ">>>> load $2 with format ($1), with label $3"
   curl -sS \
   -H "x-databend-query-id:$2" \
-  -H "sql:insert /*+ set_var(deduplicate_label='$3') */ into t1 file_format = ($1)" \
+  -H "sql:insert /*+ set_var(deduplicate_label='$3') */ into t1 from @streaming_load file_format = ($1)" \
   -F "upload=@/${TESTS_DATA_DIR}/$2" \
   -u root: -XPUT \
   "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"

--- a/tests/suites/1_stateful/01_streaming_load/01_0004_streaming_load_error.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0004_streaming_load_error.sh
@@ -10,7 +10,7 @@ function run() {
 	echo ">>>> load $2 with format ($1)"
   curl -sS \
   -H "x-databend-query-id:$2" \
-  -H "sql:insert into t1 file_format = ($1)" \
+  -H "sql:insert into t1 from @streaming_load file_format = ($1)" \
   -F "upload=@/${TESTS_DATA_DIR}/$2" \
   -u root: -XPUT \
   "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load" | jq .error.code

--- a/tests/suites/1_stateful/01_streaming_load/01_0005_streaming_load_compact.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0005_streaming_load_compact.sh
@@ -14,7 +14,7 @@ stmt "drop table if exists t1 all"
 stmt "CREATE TABLE t1 ( c0 string );"
 
 curl -sS \
--H "sql:insert /*+ set_var(input_read_buffer_size=100)  */into t1 file_format = (type = CSV)" \
+-H "sql:insert /*+ set_var(input_read_buffer_size=100)  */into t1 from @streaming_load file_format = (type = CSV)" \
 -H "X-databend-query-id: test" \
 -F "upload=@${DATA}" \
 -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
@@ -14,7 +14,7 @@ function run() {
   echo "--$2"
   stmt "copy into @streaming_load_parquet/$1.parquet from (select $2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;"
   echo ">>>> streaming load: $1.parquet $4 $5:"
-  curl -sS -H "x-databend-query-id:load-$1" -H "sql:insert into streaming_load_parquet($3) file_format = (type='parquet', missing_field_as=$4, null_if=($5))" -F "upload=@$DATA/$1.parquet" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
+  curl -sS -H "x-databend-query-id:load-$1" -H "sql:insert into streaming_load_parquet($3) from @streaming_load file_format = (type='parquet', missing_field_as=$4, null_if=($5))" -F "upload=@$DATA/$1.parquet" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
   echo
   echo "<<<<"
   query "select * from streaming_load_parquet;"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

new syntax `insert into <table> from @streaming_load file_format=(...)`
note since original insert do not support `from clause`,   `from clause` is only used for streaming load.
forbid user to create stage named `streaming_load`

- fixes: https://github.com/databendlabs/databend/issues/18036


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18062)
<!-- Reviewable:end -->
