### PR TITLE
fix(query): system.columns will return empty result when `where database in (y,x)`

### DIFF
--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -48,7 +48,7 @@ use log::warn;
 use crate::generate_catalog_meta;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
-use crate::util::find_eq_filter;
+use crate::util::find_eq_or_filter;
 
 pub struct ColumnsTable {
     table_info: TableInfo,
@@ -269,6 +269,7 @@ pub(crate) async fn dump_tables(
 
     let mut filtered_db_names: Option<Vec<String>> = None;
     let mut filtered_table_names: Option<Vec<String>> = None;
+    let mut invalid_optimize = false;
 
     if let Some(push_downs) = push_downs {
         if let Some(filter) = push_downs.filters.as_ref().map(|f| &f.filter) {
@@ -276,22 +277,26 @@ pub(crate) async fn dump_tables(
             let mut databases: Vec<String> = Vec::new();
             let mut tables: Vec<String> = Vec::new();
 
-            find_eq_filter(&expr, &mut |col_name, scalar| {
-                if col_name == "database" {
-                    if let Scalar::String(database) = scalar {
-                        if !databases.contains(database) {
-                            databases.push(database.clone());
+            invalid_optimize = find_eq_or_filter(
+                &expr,
+                &mut |col_name, scalar| {
+                    if col_name == "database" {
+                        if let Scalar::String(database) = scalar {
+                            if !databases.contains(database) {
+                                databases.push(database.clone());
+                            }
+                        }
+                    } else if col_name == "table" {
+                        if let Scalar::String(table) = scalar {
+                            if !tables.contains(table) {
+                                tables.push(table.clone());
+                            }
                         }
                     }
-                } else if col_name == "table" {
-                    if let Scalar::String(table) = scalar {
-                        if !tables.contains(table) {
-                            tables.push(table.clone());
-                        }
-                    }
-                }
-                Ok(())
-            });
+                    Ok(())
+                },
+                invalid_optimize,
+            );
             if !databases.is_empty() {
                 filtered_db_names = Some(databases);
             }
@@ -308,6 +313,11 @@ pub(crate) async fn dump_tables(
     };
 
     let mut final_dbs: Vec<Arc<dyn Database>> = Vec::new();
+
+    if invalid_optimize {
+        filtered_db_names = None;
+        filtered_table_names = None;
+    }
 
     match (filtered_db_names, &visibility_checker) {
         (Some(db_names), Some(checker)) => {

--- a/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.result
+++ b/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.result
@@ -28,3 +28,6 @@ Error: APIError: QueryFailed: [1063]Permission denied: User 'a'@'%' does not hav
 0
 1
 0
+=== FIX ISSUE 18056 ===
+db1	t	id1
+======

--- a/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
@@ -50,3 +50,16 @@ echo "drop database nogrant" | $BENDSQL_CLIENT_CONNECT
 echo "drop database grant_db" | $BENDSQL_CLIENT_CONNECT
 echo "drop table default.test_t" | $BENDSQL_CLIENT_CONNECT
 echo "drop user a" | $BENDSQL_CLIENT_CONNECT
+
+echo "=== FIX ISSUE 18056 ==="
+echo "create or replace database db1;" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table db1.t(id1 int);" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace database db2;" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table db2.t(id2 int);" | $BENDSQL_CLIENT_CONNECT
+echo "drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
+echo "create user a identified by 'password';" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on db1.t to a;" | $BENDSQL_CLIENT_CONNECT
+
+echo "select database, table, name from system.columns where database in ('db1', 'db2') and table='t';" | $USER_A_CONNECT
+echo "drop database if exists db1; drop database if exists db2; drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
+echo "======"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Problem
This PR fixes system.columns returning incomplete results when users have partial grants and queries include multi-database conditions like WHERE database IN (...). 

The root cause was the old filtering mechanism, find_eq_filter, failing to correctly process such complex filters. 

### Solution
By replacing it with find_eq_or_filter, the system now accurately identifies and displays all accessible metadata, significantly improving system.columns reliability for users with granular access rights.




<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->
- fixes: #18056

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18063)
<!-- Reviewable:end -->
