### PR TITLE
fix: HTTP requests should only be logged the first time they occur

### DIFF
--- a/src/query/service/src/servers/http/middleware/session.rs
+++ b/src/query/service/src/servers/http/middleware/session.rs
@@ -400,6 +400,14 @@ impl<E> HTTPSessionEndpoint<E> {
             .await?;
         login_history.user_name = user_name.clone();
 
+        // If cookie_session_id is set, we disable writing to login_history.
+        // The cookie_session_id is initially issued by the server to the client upon the first successful login.
+        // For all subsequent requests, the client includes this session_id with each request.
+        // This indicates the user is already logged in, so we skip recording another login event.
+        if cookie_session_id.is_some() {
+            login_history.disable_write = true;
+        }
+
         let client_session_id = match (&authed_client_session_id, &cookie_session_id) {
             (Some(id1), Some(id2)) => {
                 if id1 != id2 {

--- a/src/query/service/src/servers/login_history.rs
+++ b/src/query/service/src/servers/login_history.rs
@@ -49,6 +49,9 @@ pub struct LoginHistory {
     pub session_id: String,
     pub node_id: String,
     pub error_message: String,
+
+    #[serde(skip)]
+    pub disable_write: bool,
 }
 
 impl LoginHistory {
@@ -57,6 +60,9 @@ impl LoginHistory {
     }
 
     pub fn write_to_log(&self) {
+        if self.disable_write {
+            return;
+        }
         let event_str = serde_json::to_string(&self).unwrap();
         info!(target: "databend::log::login", "{}", event_str);
     }
@@ -75,6 +81,7 @@ impl Default for LoginHistory {
             session_id: "".to_string(),
             node_id: "".to_string(),
             error_message: "".to_string(),
+            disable_write: false,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

If `cookie_session_id` is set, we disable writing to login_history.
- The `cookie_session_id` is initially issued by the server to the client upon the first successful login.
- For all subsequent requests, the client includes this session_id with each request. This indicates the user is already logged in, so we skip recording another login event.

After this PR:

**only the first HTTP request will be logged into `system_history.login_history`**

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - minor fix

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18074)
<!-- Reviewable:end -->
