### PR TITLE
fix: update failed with Unable to get field named...

### DIFF
--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0049_issue_18073.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0049_issue_18073.test
@@ -1,0 +1,27 @@
+statement ok
+CREATE OR REPLACE TABLE students (
+    code VARCHAR, 
+    score INT 
+);
+
+statement ok
+CREATE OR REPLACE TABLE pairs (
+    student1 VARCHAR,  
+    student2 VARCHAR,  
+    score1 INT,        
+    score2 INT         
+);
+
+statement ok
+UPDATE pairs AS p 
+SET p.score1 = data.s1, p.score2 = data.s2 
+FROM (
+    SELECT 
+        split_part(a.code, '_', 2) AS c1, a.score AS s1,
+        split_part(b.code, '_', 2) AS c2, b.score AS s2
+    FROM pairs AS p 
+    JOIN students AS a, students AS b 
+    WHERE split_part(a.code, '_', 2) = p.student1 
+        AND split_part(b.code, '_', 2) = p.student2
+) data  
+WHERE p.student1 = data.c1 AND p.student2 = data.c2;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
`MutationExpressionBindResult.target_table_index` is obtained through the name of the target table:
https://github.com/databendlabs/databend/blob/618f5d101b8c835107293995ae3b4470f3067f52/src/query/sql/src/planner/metadata/metadata.rs#L106-L126

In the erroneous UPDATE statement, the subquery contains a table with the same name as the target table, which resulted in obtaining an incorrect `target_table_index`,  leading to subsequent execution errors.

#18073

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18078)
<!-- Reviewable:end -->
