### PR TITLE
refactor(metactl-import): when importing, also write the data version

### DIFF
--- a/src/meta/raft-store/src/ondisk/mod.rs
+++ b/src/meta/raft-store/src/ondisk/mod.rs
@@ -121,7 +121,7 @@ impl OnDisk {
         Ok(OnDisk::new(header, config))
     }
 
-    fn new(header: Header, config: &RaftConfig) -> Self {
+    pub fn new(header: Header, config: &RaftConfig) -> Self {
         let min_compatible = DATA_VERSION.min_compatible_data_version();
 
         if header.version < min_compatible {
@@ -358,7 +358,7 @@ impl OnDisk {
         Ok(())
     }
 
-    fn write_header(&self, header: &Header) -> Result<(), MetaStorageError> {
+    pub fn write_header(&self, header: &Header) -> Result<(), MetaStorageError> {
         Self::write_header_to_fs(&self.config, header)?;
         Ok(())
     }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(metactl-import): when importing, also write the data version

Before this commit, when importing, the data version (such as `V004`)
is not written to disk, and the data version is assumed to be the
oldest compatible version, and the on-disk data then will be upgraded to the
latest version. For example, when `databend-metactl` imports `V004`
data, the data on disk is left as `V002`, and then the data is upgraded
from `V002` to `V003` and finally to `V004`.

This is an unnecessary burden, and the upgrading process invokes the legacy
`sled-db` based storage, which leads to problems on NFS (`device busy`
error when deleting sled from disk after closing it).

This commit refines this behavior by directly writing the data
version such as `V004` to disk after importing. Thus there won't be an
unnecessary burden of upgrading the data, and it gets rid of the
necessity to access sled DB, which is a workaround for running on NFS.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues