### PR TITLE
fix(query): fix replace into partial parse insert source

### DIFF
--- a/src/query/ast/src/ast/statements/replace.rs
+++ b/src/query/ast/src/ast/statements/replace.rs
@@ -31,6 +31,7 @@ pub struct ReplaceStmt {
     pub catalog: Option<Identifier>,
     pub database: Option<Identifier>,
     pub table: Identifier,
+    pub is_conflict: bool,
     pub on_conflict_columns: Vec<Identifier>,
     pub columns: Vec<Identifier>,
     pub source: InsertSource,
@@ -59,7 +60,10 @@ impl Display for ReplaceStmt {
         }
 
         // on_conflict_columns must be non-empty
-        write!(f, " ON CONFLICT")?;
+        write!(f, " ON")?;
+        if self.is_conflict {
+            write!(f, " CONFLICT")?;
+        }
         write!(f, " (")?;
         write_comma_separated_list(f, &self.on_conflict_columns)?;
         write!(f, ")")?;

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -2955,7 +2955,7 @@ pub fn replace_stmt(allow_raw: bool) -> impl FnMut(Input) -> IResult<Statement> 
                 (catalog, database, table),
                 opt_columns,
                 _,
-                _,
+                opt_conflict,
                 _,
                 on_conflict_columns,
                 _,
@@ -2967,6 +2967,7 @@ pub fn replace_stmt(allow_raw: bool) -> impl FnMut(Input) -> IResult<Statement> 
                     catalog,
                     database,
                     table,
+                    is_conflict: opt_conflict.is_some(),
                     on_conflict_columns,
                     columns: opt_columns
                         .map(|(_, columns, _)| columns)

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -777,7 +777,7 @@ Some(
 ---------- Input ----------
 replace into test on(c) select sum(c) as c from source group by v;
 ---------- Output ---------
-REPLACE INTO test ON CONFLICT (c) SELECT sum(c) AS c FROM source GROUP BY v
+REPLACE INTO test ON (c) SELECT sum(c) AS c FROM source GROUP BY v
 ---------- AST ------------
 Replace(
     ReplaceStmt {
@@ -792,6 +792,7 @@ Replace(
             quote: None,
             ident_type: None,
         },
+        is_conflict: false,
         on_conflict_columns: [
             Identifier {
                 span: Some(
@@ -1028,7 +1029,7 @@ Explain {
 ---------- Input ----------
 explain replace into test on(c) select sum(c) as c from source group by v;
 ---------- Output ---------
-EXPLAIN REPLACE INTO test ON CONFLICT (c) SELECT sum(c) AS c FROM source GROUP BY v
+EXPLAIN REPLACE INTO test ON (c) SELECT sum(c) AS c FROM source GROUP BY v
 ---------- AST ------------
 Explain {
     kind: Plan,
@@ -1049,6 +1050,7 @@ Explain {
                 quote: None,
                 ident_type: None,
             },
+            is_conflict: false,
             on_conflict_columns: [
                 Identifier {
                     span: Some(

--- a/src/query/sql/src/planner/binder/replace.rs
+++ b/src/query/sql/src/planner/binder/replace.rs
@@ -40,6 +40,7 @@ impl Binder {
             catalog,
             database,
             table,
+            is_conflict: _,
             on_conflict_columns,
             columns,
             source,

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -19,6 +19,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::InsertSource;
 use databend_common_ast::ast::InsertStmt;
 use databend_common_ast::ast::Literal;
+use databend_common_ast::ast::ReplaceStmt;
 use databend_common_ast::ast::Statement;
 use databend_common_ast::parser::parse_raw_insert_stmt;
 use databend_common_ast::parser::parse_raw_replace_stmt;
@@ -50,7 +51,6 @@ use crate::NameResolutionContext;
 use crate::VariableNormalizer;
 
 const PROBE_INSERT_INITIAL_TOKENS: usize = 128;
-const PROBE_INSERT_MAX_TOKENS: usize = 128 * 8;
 
 pub struct Planner {
     pub(crate) ctx: Arc<dyn TableContext>,
@@ -188,7 +188,8 @@ impl Planner {
                                 ..
                             }),
                         ..
-                    }) | Ok(PlanExtras {
+                    })
+                    | Ok(PlanExtras {
                         statement:
                             Statement::Replace(ReplaceStmt {
                                 source: InsertSource::Select { .. },
@@ -198,6 +199,7 @@ impl Planner {
                     }) => {
                         maybe_partial_insert = true;
                     }
+                    _ => {}
                 }
             }
 

--- a/src/tests/sqlsmith/src/sql_gen/dml.rs
+++ b/src/tests/sqlsmith/src/sql_gen/dml.rs
@@ -195,6 +195,7 @@ impl<'a, R: Rng + 'a> SqlGenerator<'a, R> {
             catalog: None,
             database: table.db_name.clone(),
             table: table.name.clone(),
+            is_conflict: true,
             on_conflict_columns,
             columns,
             source,

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -514,7 +514,7 @@ select * from t order by c;
 3
 
 statement ok
-create or replace table test (c int);
+create or replace table test (c int64);
 
 statement ok
 create or replace table source (c int, v string);

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -536,5 +536,9 @@ select sum(c) from test;
 statement ok
 explain replace into test on(c) select sum(c) as c from source group by v;
 
+# partial parse insert source
+statement ok
+replace into test (c) on conflict (c) select sum(c) as c from source where c >= 0 and c >= 1 and c >= 2 and c >= 3 and c >= 4 and c >= 5 and c >= 6 and c >= 7 and c >= 8 and c >= 9 and c >= 10 and c >= 11 and c >= 12 and c >= 13 and c >= 14 and c >= 15 and c >= 16 and c >= 17 and c >= 18 and c >= 19 and c >= 20 and c >= 21 and c >=22 and c >= 23 and c >= 24 and true and true and now() >= '2025-01-01' and date(now()) < date(add_hours(now(),24));
+
 statement ok
 DROP DATABASE db_09_0023


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR addresses a bug in the parsing of `REPLACE INTO` statements, specifically when they contain long `WHERE` clauses.

**Problem:**

To prevent excessively long SQL queries from slowing down the parser, the `REPLACE INTO` parser initially attempts to parse only the first 128 tokens. If this initial parse fails, the parser then attempts to parse the complete SQL statement. However, in certain scenarios, the truncated SQL (the first 128 tokens) could be parsed *successfully* without errors, but with a different semantic meaning than the original, complete SQL statement. This leads to incorrect results.

**Example:**

The following SQL statement demonstrates the issue:

```sql
replace into test (c) on conflict (c) select sum(c) as c from source 
where c >= 0 and c >= 1 and c >= 2 and c >= 3 and c >= 4 and c >= 5 and c >= 6 
and c >= 7 and c >= 8 and c >= 9 and c >= 10 and c >= 11 and c >= 12 and c >= 13 
and c >= 14 and c >= 15 and c >= 16 and c >= 17 and c >= 18 and c >= 19 and c >= 20 
and c >= 21 and c >=22 and c >= 23 and c >= 24 and true and true 
and now() >= '2025-01-01' and date(now()) < date(add_hours(now(),24));
```

The initial 128-token parse would truncate the query to:

```sql
replace into test (c) on conflict (c) select sum(c) as c from source 
where c >= 0 and c >= 1 and c >= 2 and c >= 3 and c >= 4 and c >= 5 and c >= 6 
and c >= 7 and c >= 8 and c >= 9 and c >= 10 and c >= 11 and c >= 12 and c >= 13 
and c >= 14 and c >= 15 and c >= 16 and c >= 17 and c >= 18 and c >= 19 and c >= 20 
and c >= 21 and c >=22 and c >= 23 and c >= 24 and true and true 
and now();
```

This truncated query is syntactically valid but has a significantly different WHERE clause, and report the following error. In some case, it may don't report an error but success insert or update incorrect data.

```
  |                                                                                                                                                                                                                                                                                                                                                                                           ^^^ no function matches signature `and(Boolean NULL, Timestamp)`, you might need to add explicit type casts.

candidate functions:
  and(Boolean, Boolean) :: Boolean                 : unable to unify `Boolean NULL` with `Boolean`
  and(Boolean NULL, Boolean NULL) :: Boolean NULL  : unable to unify `Timestamp` with `Boolean`
```

**Fix:**

This PR modifies the `REPLACE INTO` parser and always parse the complete SQL statement if the initial SQL has a select insert source. This ensures that the full semantic meaning of the query is captured, regardless of the length of the WHERE clause.

- fixes: #[Link the issue here]


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18085)
<!-- Reviewable:end -->
