### PR TITLE
feat: support like any

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -37,7 +37,6 @@ use crate::optimizer::optimizers::operator::SubqueryDecorrelatorOptimizer;
 use crate::optimizer::optimizers::operator::UnnestResult;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
-use crate::plans::ComparisonOp;
 use crate::plans::ConstantExpr;
 use crate::plans::Filter;
 use crate::plans::FunctionCall;
@@ -47,6 +46,7 @@ use crate::plans::JoinType;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
 use crate::plans::ScalarExpr;
+use crate::plans::SubqueryComparisonOp;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
 use crate::ColumnSet;
@@ -671,7 +671,10 @@ impl SubqueryDecorrelatorOptimizer {
             if let RelOperator::ProjectSet(project_set) = project_set_expr.plan() {
                 if project_set.srfs.len() != 1
                     || project_set.srfs[0].index != srf_column_index
-                    || subquery.compare_op != Some(ComparisonOp::Equal)
+                    || !matches!(
+                        subquery.compare_op,
+                        Some(SubqueryComparisonOp::Equal) | Some(SubqueryComparisonOp::Like)
+                    )
                     || subquery.typ != SubqueryType::Any
                 {
                     return Ok(None);

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -35,7 +35,6 @@ use crate::plans::Aggregate;
 use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
-use crate::plans::ComparisonOp;
 use crate::plans::ConstantExpr;
 use crate::plans::EvalScalar;
 use crate::plans::Filter;
@@ -48,6 +47,7 @@ use crate::plans::RelOperator;
 use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
 use crate::plans::Sort;
+use crate::plans::SubqueryComparisonOp;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
 use crate::plans::UDAFCall;
@@ -774,15 +774,17 @@ impl SubqueryDecorrelatorOptimizer {
 
 pub fn check_child_expr_in_subquery(
     child_expr: &ScalarExpr,
-    op: &ComparisonOp,
+    op: &SubqueryComparisonOp,
 ) -> Result<(ScalarExpr, bool)> {
     match child_expr {
-        ScalarExpr::BoundColumnRef(_) => Ok((child_expr.clone(), op != &ComparisonOp::Equal)),
+        ScalarExpr::BoundColumnRef(_) => {
+            Ok((child_expr.clone(), op != &SubqueryComparisonOp::Equal))
+        }
         ScalarExpr::FunctionCall(func) => {
             for arg in &func.arguments {
                 let _ = check_child_expr_in_subquery(arg, op)?;
             }
-            Ok((child_expr.clone(), op != &ComparisonOp::Equal))
+            Ok((child_expr.clone(), op != &SubqueryComparisonOp::Equal))
         }
         ScalarExpr::ConstantExpr(_) => Ok((child_expr.clone(), true)),
         ScalarExpr::CastExpr(cast) => {

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -743,6 +743,55 @@ impl<'a> TryFrom<&'a BinaryOperator> for ComparisonOp {
     }
 }
 
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum SubqueryComparisonOp {
+    Equal,
+    NotEqual,
+    // Greater ">"
+    GT,
+    // Less "<"
+    LT,
+    // Greater or equal ">="
+    GTE,
+    // Less or equal "<="
+    LTE,
+    // Like operator for pattern matching
+    Like,
+}
+
+impl SubqueryComparisonOp {
+    pub fn to_func_name(&self) -> &'static str {
+        match &self {
+            SubqueryComparisonOp::Equal => "eq",
+            SubqueryComparisonOp::NotEqual => "noteq",
+            SubqueryComparisonOp::GT => "gt",
+            SubqueryComparisonOp::LT => "lt",
+            SubqueryComparisonOp::GTE => "gte",
+            SubqueryComparisonOp::LTE => "lte",
+            SubqueryComparisonOp::Like => "like",
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a BinaryOperator> for SubqueryComparisonOp {
+    type Error = ErrorCode;
+
+    fn try_from(op: &'a BinaryOperator) -> Result<Self> {
+        match op {
+            BinaryOperator::Gt => Ok(Self::GT),
+            BinaryOperator::Lt => Ok(Self::LT),
+            BinaryOperator::Gte => Ok(Self::GTE),
+            BinaryOperator::Lte => Ok(Self::LTE),
+            BinaryOperator::Eq => Ok(Self::Equal),
+            BinaryOperator::NotEq => Ok(Self::NotEqual),
+            BinaryOperator::Like => Ok(Self::Like),
+            _ => Err(ErrorCode::SemanticError(format!(
+                "Unsupported subquery comparison operator {op}"
+            ))),
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct AggregateFunctionScalarSortDesc {
     pub expr: ScalarExpr,
@@ -902,7 +951,7 @@ pub struct SubqueryExpr {
     // The expr that is used to compare the result of the subquery (IN/ANY/ALL), such as `t1.a in (select t2.a from t2)`, t1.a is `child_expr`.
     pub child_expr: Option<Box<ScalarExpr>>,
     // Comparison operator for Any/All, such as t1.a = Any (...), `compare_op` is `=`.
-    pub compare_op: Option<ComparisonOp>,
+    pub compare_op: Option<SubqueryComparisonOp>,
     // Output column of Any/All and scalar subqueries.
     pub output_column: ColumnBinding,
     pub projection_index: Option<IndexType>,

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -141,7 +141,6 @@ use crate::plans::AsyncFunctionArgument;
 use crate::plans::AsyncFunctionCall;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
-use crate::plans::ComparisonOp;
 use crate::plans::ConstantExpr;
 use crate::plans::DictGetFunctionArgument;
 use crate::plans::DictionarySource;
@@ -154,6 +153,7 @@ use crate::plans::RedisSource;
 use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
 use crate::plans::SqlSource;
+use crate::plans::SubqueryComparisonOp;
 use crate::plans::SubqueryExpr;
 use crate::plans::SubqueryType;
 use crate::plans::UDAFCall;
@@ -529,7 +529,7 @@ impl<'a> TypeChecker<'a> {
                 {
                     match subquery_modifier {
                         SubqueryModifier::Any | SubqueryModifier::Some => {
-                            let comparison_op = ComparisonOp::try_from(op)?;
+                            let comparison_op = SubqueryComparisonOp::try_from(op)?;
                             self.resolve_subquery(
                                 SubqueryType::Any,
                                 subquery,
@@ -1006,7 +1006,7 @@ impl<'a> TypeChecker<'a> {
                     SubqueryType::Any,
                     subquery,
                     Some(*expr.clone()),
-                    Some(ComparisonOp::Equal),
+                    Some(SubqueryComparisonOp::Equal),
                 )?
             }
 
@@ -3369,7 +3369,7 @@ impl<'a> TypeChecker<'a> {
         typ: SubqueryType,
         subquery: &Query,
         child_expr: Option<Expr>,
-        compare_op: Option<ComparisonOp>,
+        compare_op: Option<SubqueryComparisonOp>,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
         let mut binder = Binder::new(
             self.ctx.clone(),
@@ -5262,7 +5262,7 @@ impl<'a> TypeChecker<'a> {
             span: None,
             subquery: Box::new(distinct_const_scan),
             child_expr: child_scalar,
-            compare_op: Some(ComparisonOp::Equal),
+            compare_op: Some(SubqueryComparisonOp::Equal),
             output_column: ctx.columns[0].clone(),
             projection_index: None,
             data_type: Box::new(data_type),

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -746,3 +746,57 @@ EmptyResultScan
 
 statement ok
 drop table if exists t;
+
+statement ok
+create table t (i string);
+
+statement ok
+insert into t values('database'), ('databend');
+
+query T
+explain select * from t where i like any (select 'data%');
+----
+Filter
+├── output columns: [t.i (#0)]
+├── filters: [is_true(like(t.i (#0), 'data%'))]
+├── estimated rows: 0.40
+└── TableScan
+    ├── table: default.default.t
+    ├── output columns: [i (#0)]
+    ├── read rows: 2
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like(t.i (#0), 'data%'))], limit: NONE]
+    └── estimated rows: 2.00
+
+query T
+explain select * from t where i like any (SELECT c1 FROM (VALUES ('data')) words(c1));
+----
+HashJoin
+├── output columns: [t.i (#0)]
+├── join type: LEFT SEMI
+├── build keys: []
+├── probe keys: []
+├── keys is null equal: []
+├── filters: [like(t.i (#0), CAST(subquery_1 (#1) AS String NULL))]
+├── build join filters:
+├── estimated rows: 2.00
+├── ConstantTableScan(Build)
+│   ├── output columns: [c1 (#1)]
+│   └── column 0: ['data']
+└── TableScan(Probe)
+    ├── table: default.default.t
+    ├── output columns: [i (#0)]
+    ├── read rows: 2
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 2.00
+
+statement ok
+drop table if exists t;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```shell
select * from t1 where c1 like any (select '%llo%');

select
  *
from
  t1
where
  c1 like any (
    select
      '%llo%'
  )

╭──────────────────╮
│        c1        │
│ Nullable(String) │
├──────────────────┤
│ hello            │
╰──────────────────╯
1 row read in 0.070 sec. Processed 1 row, 18 B (14.29 rows/s, 257 B/s)

```

- fixes: [#[Link the issue here]](https://github.com/databendlabs/databend/issues/18091)

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
