### PR TITLE
fix(bind): parent `BindContext` missing when binding union

### DIFF
--- a/src/query/sql/src/planner/dataframe.rs
+++ b/src/query/sql/src/planner/dataframe.rs
@@ -499,8 +499,9 @@ impl Dataframe {
         let (s_expr, bind_context) = self.binder.bind_union(
             None,
             None,
-            self.bind_context,
-            dataframe.bind_context,
+            None,
+            &self.bind_context,
+            &dataframe.bind_context,
             self.s_expr,
             dataframe.s_expr,
             false,
@@ -515,8 +516,9 @@ impl Dataframe {
         let (s_expr, bind_context) = self.binder.bind_union(
             None,
             None,
-            self.bind_context,
-            dataframe.bind_context,
+            None,
+            &self.bind_context,
+            &dataframe.bind_context,
             self.s_expr,
             dataframe.s_expr,
             true,

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -2,28 +2,16 @@ statement ok
 use default
 
 statement ok
-DROP TABLE IF EXISTS data2013
+CREATE OR REPLACE TABLE data2013 (name String, value UInt32)
 
 statement ok
-DROP TABLE IF EXISTS data2014
+CREATE OR REPLACE TABLE data2014 (name String, value UInt32)
 
 statement ok
-DROP TABLE IF EXISTS data2015
+CREATE OR REPLACE TABLE data2015 (data_name String, data_value UInt32)
 
 statement ok
-DROP TABLE IF EXISTS data2016
-
-statement ok
-CREATE TABLE data2013 (name String, value UInt32)
-
-statement ok
-CREATE TABLE data2014 (name String, value UInt32)
-
-statement ok
-CREATE TABLE data2015 (data_name String, data_value UInt32)
-
-statement ok
-CREATE TABLE data2016 (name String, value UInt32)
+CREATE OR REPLACE TABLE data2016 (name String, value UInt32)
 
 statement ok
 INSERT INTO data2013(name,value) VALUES('Alice', 1000), ('Bob', 2000), ('Carol', 5000)
@@ -395,6 +383,14 @@ query I
 WITH cte1 AS ( SELECT t1.test FROM t1 WHERE t1.test = 0 ) ,cte2 AS ( SELECT cte1.test FROM cte1 WHERE cte1.test = 1  UNION ALL  SELECT cte1.test FROM cte1 WHERE cte1.test = 0 ) SELECT * FROM cte2;
 ----
 0
+
+query I
+select * from (select 1 n) t2
+where exists (
+select 1 from (select * from numbers(5) union select * from numbers(5)) t where t.number = t2.n
+);
+----
+1
 
 statement ok
 drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```sql
select * from (select 1 n) t2
where exists (
select 1 from (select * from numbers(5) union select * from numbers(5)) t where t.number = t2.n
);

```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18097)
<!-- Reviewable:end -->
