### PR TITLE
chore(query): refactoring ValueType, introducing ColumnBuilderMut

### DIFF
--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -209,29 +209,24 @@ impl ValueVisitor for FilterVisitor<'_> {
         data_type: &DataType,
     ) -> Result<()> {
         let c = T::upcast_column_with_type(column.clone(), data_type);
-        let builder = ColumnBuilder::with_capacity(&c.data_type(), c.len());
-        let mut builder = T::try_downcast_owned_builder(builder).unwrap();
+        let mut builder = ColumnBuilder::with_capacity(&c.data_type(), c.len());
+        let mut inner_builder = T::downcast_builder(&mut builder);
         match self.strategy {
             IterationStrategy::IndexIterator => {
                 let iter = TrueIdxIter::new(self.original_rows, Some(self.filter));
                 iter.for_each(|index| {
-                    T::push_item(&mut builder, unsafe {
-                        T::index_column_unchecked(&column, index)
-                    })
+                    inner_builder.push_item(unsafe { T::index_column_unchecked(&column, index) });
                 });
             }
             _ => {
                 let iter = SlicesIterator::new(self.filter);
                 iter.for_each(|(start, len)| {
-                    T::append_column(&mut builder, &T::slice_column(&column, start..start + len))
+                    inner_builder.append_column(&T::slice_column(&column, start..start + len));
                 });
             }
         }
-
-        self.result = Some(Value::Column(T::upcast_column_with_type(
-            T::build_column(builder),
-            data_type,
-        )));
+        drop(inner_builder);
+        self.result = Some(Value::Column(builder.build()));
         Ok(())
     }
 

--- a/src/query/expression/src/lib.rs
+++ b/src/query/expression/src/lib.rs
@@ -42,6 +42,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(debug_closure_helpers)]
 #![feature(never_type)]
+#![feature(slice_as_array)]
 
 #[allow(dead_code)]
 mod block;

--- a/src/query/expression/src/types/any.rs
+++ b/src/query/expression/src/types/any.rs
@@ -17,6 +17,7 @@ use std::ops::Range;
 
 use crate::property::Domain;
 use crate::types::AccessType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::ValueType;
 use crate::values::Column;
@@ -92,6 +93,7 @@ impl AccessType for AnyType {
 
 impl ValueType for AnyType {
     type ColumnBuilder = ColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, _: &DataType) -> Scalar {
         scalar
@@ -106,12 +108,8 @@ impl ValueType for AnyType {
         col
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        Some(builder)
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        Some(builder)
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.into()
     }
 
     fn try_upcast_column_builder(
@@ -129,19 +127,27 @@ impl ValueType for AnyType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.push(item);
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
         builder.push_repeat(&item, n);
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.push_default();
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other: &Self::Column) {
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
         builder.append_column(other);
     }
 

--- a/src/query/expression/src/types/boolean.rs
+++ b/src/query/expression/src/types/boolean.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::fmt::Debug;
 use std::ops::Range;
 
 pub use databend_common_column::bitmap::*;
@@ -20,6 +21,7 @@ pub use databend_common_column::bitmap::*;
 use super::AccessType;
 use crate::property::Domain;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::GenericMap;
 use crate::types::ReturnType;
@@ -127,6 +129,7 @@ impl AccessType for BooleanType {
 
 impl ValueType for BooleanType {
     type ColumnBuilder = MutableBitmap;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, data_type: &DataType) -> Scalar {
         debug_assert!(data_type.is_boolean());
@@ -143,18 +146,8 @@ impl ValueType for BooleanType {
         Column::Boolean(col)
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Boolean(builder) => Some(builder),
-            _ => None,
-        }
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Boolean(builder) => Some(builder),
-            _ => None,
-        }
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.as_boolean_mut().unwrap().into()
     }
 
     fn try_upcast_column_builder(
@@ -173,11 +166,19 @@ impl ValueType for BooleanType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.push(item);
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
         if n == 1 {
             builder.push(item)
         } else {
@@ -185,12 +186,12 @@ impl ValueType for BooleanType {
         }
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.push(false);
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, bitmap: &Self::Column) {
-        builder.extend_from_bitmap(bitmap)
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
+        builder.extend_from_bitmap(other);
     }
 
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column {

--- a/src/query/expression/src/types/generic.rs
+++ b/src/query/expression/src/types/generic.rs
@@ -19,6 +19,7 @@ use super::ReturnType;
 use crate::property::Domain;
 use crate::types::AccessType;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::GenericMap;
 use crate::types::ValueType;
@@ -95,6 +96,7 @@ impl<const INDEX: usize> AccessType for GenericType<INDEX> {
 
 impl<const INDEX: usize> ValueType for GenericType<INDEX> {
     type ColumnBuilder = ColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, _: &DataType) -> Scalar {
         scalar
@@ -108,12 +110,8 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
         col
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        Some(builder)
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        Some(builder)
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.into()
     }
 
     fn try_upcast_column_builder(
@@ -131,19 +129,27 @@ impl<const INDEX: usize> ValueType for GenericType<INDEX> {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.push(item);
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
         builder.push_repeat(&item, n)
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.push_default();
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other: &Self::Column) {
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
         builder.append_column(other);
     }
 

--- a/src/query/expression/src/types/geography.rs
+++ b/src/query/expression/src/types/geography.rs
@@ -35,6 +35,7 @@ use crate::property::Domain;
 use crate::types::binary::BinaryColumn;
 use crate::types::binary::BinaryColumnBuilder;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::GenericMap;
 use crate::types::ReturnType;
@@ -178,6 +179,7 @@ impl AccessType for GeographyType {
 
 impl ValueType for GeographyType {
     type ColumnBuilder = BinaryColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, data_type: &DataType) -> Scalar {
         debug_assert!(data_type.is_geography());
@@ -194,18 +196,8 @@ impl ValueType for GeographyType {
         Column::Geography(col)
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Geography(builder) => Some(builder),
-            _ => None,
-        }
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Geography(builder) => Some(builder),
-            _ => None,
-        }
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.as_geography_mut().unwrap().into()
     }
 
     fn try_upcast_column_builder(
@@ -224,21 +216,32 @@ impl ValueType for GeographyType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.put_slice(item.0);
         builder.commit_row()
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
-        builder.push_repeat(item.0, n)
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
+        for _ in 0..n {
+            builder.put_slice(item.0);
+            builder.commit_row();
+        }
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
-        builder.commit_row()
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
+        builder.commit_row();
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other: &Self::Column) {
-        builder.append_column(&other.0)
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
+        builder.append_column(&other.0);
     }
 
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column {

--- a/src/query/expression/src/types/geometry.rs
+++ b/src/query/expression/src/types/geometry.rs
@@ -26,12 +26,13 @@ use super::AccessType;
 use super::ReturnType;
 use crate::property::Domain;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::GenericMap;
+use crate::types::Scalar;
+use crate::types::ScalarRef;
 use crate::types::ValueType;
 use crate::values::Column;
-use crate::values::Scalar;
-use crate::values::ScalarRef;
 use crate::ColumnBuilder;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -105,6 +106,7 @@ impl AccessType for GeometryType {
 
 impl ValueType for GeometryType {
     type ColumnBuilder = BinaryColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, data_type: &DataType) -> Scalar {
         debug_assert!(data_type.is_geometry());
@@ -121,18 +123,8 @@ impl ValueType for GeometryType {
         Column::Geometry(col)
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Geometry(builder) => Some(builder),
-            _ => None,
-        }
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Geometry(builder) => Some(builder),
-            _ => None,
-        }
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.as_geometry_mut().unwrap().into()
     }
 
     fn try_upcast_column_builder(
@@ -151,21 +143,32 @@ impl ValueType for GeometryType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.put_slice(item);
         builder.commit_row();
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
-        builder.push_repeat(item, n)
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
+        for _ in 0..n {
+            builder.put_slice(item);
+            builder.commit_row();
+        }
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.commit_row();
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other_builder: &Self::Column) {
-        builder.append_column(other_builder)
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
+        builder.append_column(other);
     }
 
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column {

--- a/src/query/expression/src/types/string.rs
+++ b/src/query/expression/src/types/string.rs
@@ -24,13 +24,14 @@ use super::AccessType;
 use crate::property::Domain;
 use crate::types::binary::BinaryColumn;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
+use crate::types::ColumnBuilder;
 use crate::types::DataType;
 use crate::types::GenericMap;
 use crate::types::ReturnType;
 use crate::types::ValueType;
 use crate::values::Column;
 use crate::values::Scalar;
-use crate::ColumnBuilder;
 use crate::ScalarRef;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,6 +131,7 @@ impl AccessType for StringType {
 
 impl ValueType for StringType {
     type ColumnBuilder = StringColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, data_type: &DataType) -> Scalar {
         debug_assert!(data_type.is_string());
@@ -146,18 +148,8 @@ impl ValueType for StringType {
         Column::String(col)
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::String(builder) => Some(builder),
-            _ => None,
-        }
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::String(builder) => Some(builder),
-            _ => None,
-        }
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.as_string_mut().unwrap().into()
     }
 
     fn try_upcast_column_builder(
@@ -176,20 +168,28 @@ impl ValueType for StringType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.put_and_commit(item);
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
         builder.push_repeat(item, n);
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.put_and_commit("");
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other_builder: &Self::Column) {
-        builder.append_column(other_builder)
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
+        builder.append_column(other);
     }
 
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column {

--- a/src/query/expression/src/types/variant.rs
+++ b/src/query/expression/src/types/variant.rs
@@ -35,6 +35,7 @@ use crate::property::Domain;
 use crate::types::map::KvPair;
 use crate::types::AnyType;
 use crate::types::ArgType;
+use crate::types::BuilderMut;
 use crate::types::DataType;
 use crate::types::DecimalScalar;
 use crate::types::GenericMap;
@@ -124,6 +125,7 @@ impl AccessType for VariantType {
 
 impl ValueType for VariantType {
     type ColumnBuilder = BinaryColumnBuilder;
+    type ColumnBuilderMut<'a> = BuilderMut<'a, Self>;
 
     fn upcast_scalar_with_type(scalar: Self::Scalar, data_type: &DataType) -> Scalar {
         debug_assert!(data_type.is_variant());
@@ -140,18 +142,8 @@ impl ValueType for VariantType {
         Column::Variant(col)
     }
 
-    fn try_downcast_builder(builder: &mut ColumnBuilder) -> Option<&mut Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Variant(builder) => Some(builder),
-            _ => None,
-        }
-    }
-
-    fn try_downcast_owned_builder(builder: ColumnBuilder) -> Option<Self::ColumnBuilder> {
-        match builder {
-            ColumnBuilder::Variant(builder) => Some(builder),
-            _ => None,
-        }
+    fn downcast_builder(builder: &mut ColumnBuilder) -> Self::ColumnBuilderMut<'_> {
+        builder.as_variant_mut().unwrap().into()
     }
 
     fn try_upcast_column_builder(
@@ -170,21 +162,29 @@ impl ValueType for VariantType {
         builder.len()
     }
 
-    fn push_item(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>) {
+    fn builder_len_mut(builder: &Self::ColumnBuilderMut<'_>) -> usize {
+        builder.len()
+    }
+
+    fn push_item_mut(builder: &mut Self::ColumnBuilderMut<'_>, item: Self::ScalarRef<'_>) {
         builder.put_slice(item);
         builder.commit_row();
     }
 
-    fn push_item_repeat(builder: &mut Self::ColumnBuilder, item: Self::ScalarRef<'_>, n: usize) {
+    fn push_item_repeat_mut(
+        builder: &mut Self::ColumnBuilderMut<'_>,
+        item: Self::ScalarRef<'_>,
+        n: usize,
+    ) {
         builder.push_repeat(item, n);
     }
 
-    fn push_default(builder: &mut Self::ColumnBuilder) {
+    fn push_default_mut(builder: &mut Self::ColumnBuilderMut<'_>) {
         builder.commit_row();
     }
 
-    fn append_column(builder: &mut Self::ColumnBuilder, other_builder: &Self::Column) {
-        builder.append_column(other_builder)
+    fn append_column_mut(builder: &mut Self::ColumnBuilderMut<'_>, other: &Self::Column) {
+        builder.append_column(other);
     }
 
     fn build_column(builder: Self::ColumnBuilder) -> Self::Column {

--- a/src/query/expression/src/values.rs
+++ b/src/query/expression/src/values.rs
@@ -2659,14 +2659,22 @@ impl ColumnBuilder {
                 Date => DateType,
                 Timestamp => TimestampType,
                 Interval => IntervalType,
+                Boolean => BooleanType,
+                Binary => BinaryType,
+                String => StringType,
+                Bitmap => BitmapType,
+                Variant => VariantType,
+                Geometry => GeometryType,
+                Geography => GeographyType,
             ],
             match self {
                 ColumnBuilder::T(b) => {
-                    Self::type_build::<T>(b, &T::data_type())
+                    T::upcast_column_with_type(T::build_column(b), &T::data_type())
                 }
                 ColumnBuilder::Null { len } => Column::Null { len },
                 ColumnBuilder::EmptyArray { len } => Column::EmptyArray { len },
                 ColumnBuilder::EmptyMap { len } => Column::EmptyMap { len },
+
                 ColumnBuilder::Number(builder) => Column::Number(builder.build()),
                 ColumnBuilder::Decimal(builder) => Column::Decimal(builder.build()),
                 ColumnBuilder::Array(builder) => Column::Array(Box::new(builder.build())),
@@ -2676,21 +2684,9 @@ impl ColumnBuilder {
                     assert!(fields.iter().map(|field| field.len()).all_equal());
                     Column::Tuple(fields.into_iter().map(|field| field.build()).collect())
                 }
-
-                ColumnBuilder::Boolean(b) => Column::Boolean(BooleanType::build_column(b)),
-                ColumnBuilder::Binary(b) => Column::Binary(BinaryType::build_column(b)),
-                ColumnBuilder::String(b) => Column::String(StringType::build_column(b)),
-                ColumnBuilder::Bitmap(b) => Column::Bitmap(BitmapType::build_column(b)),
-                ColumnBuilder::Variant(b) => Column::Variant(VariantType::build_column(b)),
-                ColumnBuilder::Geometry(b) => Column::Geometry(GeometryType::build_column(b)),
-                ColumnBuilder::Geography(b) => Column::Geography(GeographyType::build_column(b)),
                 ColumnBuilder::Vector(b) => Column::Vector(b.build()),
             }
         }
-    }
-
-    fn type_build<T: ValueType>(builder: T::ColumnBuilder, data_type: &DataType) -> Column {
-        T::upcast_column_with_type(T::build_column(builder), data_type)
     }
 
     pub fn build_scalar(self) -> Scalar {

--- a/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
+++ b/src/query/functions/src/aggregates/aggregate_approx_count_distinct.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_expression::types::AnyType;
+use databend_common_expression::types::BuilderMut;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::DateType;
 use databend_common_expression::types::NumberDataType;
@@ -63,7 +64,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<u64>,
+        mut builder: BuilderMut<'_, UInt64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         builder.push(self.count() as u64);

--- a/src/query/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/src/query/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -178,19 +178,12 @@ where
     fn merge_result(&self, builder: &mut ColumnBuilder) -> Result<()> {
         match &self.data {
             Some((_, arg)) => {
-                if let Some(inner) = A::try_downcast_builder(builder) {
-                    A::push_item(inner, A::to_scalar_ref(arg));
-                } else {
-                    let data_type = builder.data_type();
-                    builder.push(A::upcast_scalar_with_type(arg.clone(), &data_type).as_ref());
-                }
+                let mut inner = A::downcast_builder(builder);
+                inner.push_item(A::to_scalar_ref(arg));
             }
             None => {
-                if let Some(inner) = A::try_downcast_builder(builder) {
-                    A::push_default(inner);
-                } else {
-                    builder.push_default();
-                }
+                let mut inner = A::downcast_builder(builder);
+                inner.push_default();
             }
         }
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_avg.rs
+++ b/src/query/functions/src/aggregates/aggregate_avg.rs
@@ -89,7 +89,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<F64>,
+        mut builder: BuilderMut<'_, Float64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let value = self.value.as_() / (self.count as f64);
@@ -173,7 +173,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut T::ColumnBuilder,
+        mut builder: T::ColumnBuilderMut<'_>,
         function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         // # Safety
@@ -190,7 +190,7 @@ where
             .and_then(|v| v.checked_div(T::Scalar::from_i128(self.count)))
         {
             Some(value) => {
-                T::push_item(builder, T::to_scalar_ref(&value));
+                builder.push_item(T::to_scalar_ref(&value));
                 Ok(())
             }
             None => Err(ErrorCode::Overflow(format!(

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -100,7 +100,7 @@ struct BitmapRawResult;
 
 impl BitmapAggResult for BitmapCountResult {
     fn merge_result(place: AggrState, builder: &mut ColumnBuilder) -> Result<()> {
-        let builder = UInt64Type::try_downcast_builder(builder).unwrap();
+        let mut builder = UInt64Type::downcast_builder(builder);
         let state = place.get::<BitmapAggState>();
         builder.push(state.rb.as_ref().map(|rb| rb.len()).unwrap_or(0));
         Ok(())
@@ -113,7 +113,7 @@ impl BitmapAggResult for BitmapCountResult {
 
 impl BitmapAggResult for BitmapRawResult {
     fn merge_result(place: AggrState, builder: &mut ColumnBuilder) -> Result<()> {
-        let builder = BitmapType::try_downcast_builder(builder).unwrap();
+        let mut builder = BitmapType::downcast_builder(builder);
         let state = place.get::<BitmapAggState>();
         if let Some(rb) = state.rb.as_ref() {
             rb.serialize_into(&mut builder.data)?;

--- a/src/query/functions/src/aggregates/aggregate_covariance.rs
+++ b/src/query/functions/src/aggregates/aggregate_covariance.rs
@@ -255,7 +255,7 @@ where
     #[allow(unused_mut)]
     fn merge_result(&self, place: AggrState, builder: &mut ColumnBuilder) -> Result<()> {
         let state = place.get::<AggregateCovarianceState>();
-        let builder = NumberType::<F64>::try_downcast_builder(builder).unwrap();
+        let mut builder = NumberType::<F64>::downcast_builder(builder);
         builder.push(R::apply(state).into());
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_histogram.rs
+++ b/src/query/functions/src/aggregates/aggregate_histogram.rs
@@ -31,7 +31,6 @@ use databend_common_expression::AggregateFunctionRef;
 use databend_common_expression::Scalar;
 use serde::Deserialize;
 use serde::Serialize;
-use string::StringColumnBuilder;
 
 use super::FunctionData;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionDescription;
@@ -107,7 +106,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut StringColumnBuilder,
+        mut builder: BuilderMut<'_, StringType>,
         function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let histogram_data = unsafe {

--- a/src/query/functions/src/aggregates/aggregate_kurtosis.rs
+++ b/src/query/functions/src/aggregates/aggregate_kurtosis.rs
@@ -72,7 +72,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<F64>,
+        mut builder: BuilderMut<'_, Float64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if self.n <= 3 {

--- a/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
+++ b/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
@@ -150,9 +150,9 @@ impl AggregateFunction for MarkovTarin {
         else {
             unreachable!()
         };
-        let hash_builder = UInt32Type::try_downcast_builder(hash_builder).unwrap();
-        let total_builder = UInt32Type::try_downcast_builder(total_builder).unwrap();
-        let end_builder = UInt32Type::try_downcast_builder(end_builder).unwrap();
+        let mut hash_builder = UInt32Type::downcast_builder(hash_builder);
+        let mut total_builder = UInt32Type::downcast_builder(total_builder);
+        let mut end_builder = UInt32Type::downcast_builder(end_builder);
 
         let ArrayColumnBuilder::<AnyType> {
             builder: ColumnBuilder::Tuple(kv),
@@ -164,8 +164,8 @@ impl AggregateFunction for MarkovTarin {
         let [keys, values] = &mut kv[..] else {
             unreachable!()
         };
-        let keys = UInt32Type::try_downcast_builder(keys).unwrap();
-        let values = UInt32Type::try_downcast_builder(values).unwrap();
+        let mut keys = UInt32Type::downcast_builder(keys);
+        let mut values = UInt32Type::downcast_builder(values);
 
         for (hash, histogram) in model.table.iter() {
             hash_builder.push(*hash);

--- a/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
+++ b/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
@@ -24,9 +24,7 @@ use databend_common_base::obfuscator::CodePoint;
 use databend_common_base::obfuscator::NGramHash;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::array::ArrayColumnBuilder;
 use databend_common_expression::types::AccessType;
-use databend_common_expression::types::AnyType;
 use databend_common_expression::types::ArgType;
 use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::DataType;
@@ -145,37 +143,23 @@ impl AggregateFunction for MarkovTarin {
         let ColumnBuilder::Tuple(builders) = &mut array_builder.builder else {
             unreachable!()
         };
-        let [hash_builder, total_builder, end_builder, ColumnBuilder::Map(box bucket_builder)] =
-            &mut builders[..]
-        else {
+        let [hash_builder, total_builder, end_builder, bucket_builder] = &mut builders[..] else {
             unreachable!()
         };
         let mut hash_builder = UInt32Type::downcast_builder(hash_builder);
         let mut total_builder = UInt32Type::downcast_builder(total_builder);
         let mut end_builder = UInt32Type::downcast_builder(end_builder);
-
-        let ArrayColumnBuilder::<AnyType> {
-            builder: ColumnBuilder::Tuple(kv),
-            offsets: bucket_offsets,
-        } = bucket_builder
-        else {
-            unreachable!()
-        };
-        let [keys, values] = &mut kv[..] else {
-            unreachable!()
-        };
-        let mut keys = UInt32Type::downcast_builder(keys);
-        let mut values = UInt32Type::downcast_builder(values);
+        let mut bucket_builder =
+            MapType::<UInt32Type, UInt32Type>::downcast_builder(bucket_builder);
 
         for (hash, histogram) in model.table.iter() {
             hash_builder.push(*hash);
             total_builder.push(histogram.total.unwrap());
             end_builder.push(histogram.count_end);
             for (c, w) in histogram.buckets.iter() {
-                keys.push(*c);
-                values.push(*w);
+                bucket_builder.put_item((*c, *w));
             }
-            bucket_offsets.push(keys.len() as u64);
+            bucket_builder.commit_row();
         }
         array_builder.commit_row();
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_min_max_any.rs
+++ b/src/query/functions/src/aggregates/aggregate_min_max_any.rs
@@ -136,13 +136,13 @@ where C: ChangeIf<StringType> + Default
 
     fn merge_result(
         &mut self,
-        builder: &mut <StringType as ValueType>::ColumnBuilder,
+        mut builder: BuilderMut<'_, StringType>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if let Some(v) = &self.value {
-            StringType::push_item(builder, v.as_str());
+            builder.push_item(v.as_str());
         } else {
-            StringType::push_default(builder);
+            builder.push_default();
         }
         Ok(())
     }
@@ -244,13 +244,13 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut T::ColumnBuilder,
+        mut builder: T::ColumnBuilderMut<'_>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if let Some(v) = &self.value {
-            T::push_item(builder, T::to_scalar_ref(v));
+            builder.push_item(T::to_scalar_ref(v));
         } else {
-            T::push_default(builder);
+            builder.push_default();
         }
 
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_min_max_any_decimal.rs
+++ b/src/query/functions/src/aggregates/aggregate_min_max_any_decimal.rs
@@ -126,14 +126,14 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut T::ColumnBuilder,
+        mut builder: T::ColumnBuilderMut<'_>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if let Some(v) = self.value {
             let v = T::Scalar::from_u64_array(v);
-            T::push_item(builder, T::to_scalar_ref(&v));
+            builder.push_item(T::to_scalar_ref(&v));
         } else {
-            T::push_default(builder);
+            builder.push_default();
         }
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_mode.rs
+++ b/src/query/functions/src/aggregates/aggregate_mode.rs
@@ -90,18 +90,18 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut T::ColumnBuilder,
+        mut builder: T::ColumnBuilderMut<'_>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if self.frequency_map.is_empty() {
-            T::push_default(builder);
+            builder.push_default();
         } else {
             let (key, _) = self
                 .frequency_map
                 .iter()
                 .max_by_key(|&(_, value)| value)
                 .unwrap();
-            T::push_item(builder, T::to_scalar_ref(key));
+            builder.push_item(T::to_scalar_ref(key));
         }
 
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_disc.rs
@@ -18,7 +18,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::array::ArrayColumnBuilder;
+use databend_common_expression::types::array::ArrayColumnBuilderMut;
 use databend_common_expression::types::*;
 use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::Scalar;
@@ -78,7 +78,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut ArrayColumnBuilder<T>,
+        mut builder: ArrayColumnBuilderMut<'_, T>,
         function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let value_len = self.value.len();
@@ -134,7 +134,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut T::ColumnBuilder,
+        mut builder: T::ColumnBuilderMut<'_>,
         function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let value_len = self.value.len();
@@ -147,11 +147,11 @@ where
 
         let idx = ((value_len - 1) as f64 * quantile_disc_data.levels[0]).floor() as usize;
         if idx >= value_len {
-            T::push_default(builder);
+            builder.push_default();
         } else {
             self.value.as_mut_slice().select_nth_unstable(idx);
             let value = self.value.get(idx).unwrap();
-            T::push_item(builder, T::to_scalar_ref(value));
+            builder.push_item(T::to_scalar_ref(value));
         }
 
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
@@ -125,7 +125,7 @@ impl QuantileTDigestState {
             });
             builder.commit_row();
         } else {
-            let builder = NumberType::<F64>::try_downcast_builder(builder).unwrap();
+            let mut builder = NumberType::<F64>::downcast_builder(builder);
             let q = self.quantile(levels[0]);
             builder.push(q.into());
         }

--- a/src/query/functions/src/aggregates/aggregate_range_bound.rs
+++ b/src/query/functions/src/aggregates/aggregate_range_bound.rs
@@ -20,7 +20,7 @@ use borsh::BorshSerialize;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::compare_columns;
-use databend_common_expression::types::array::ArrayColumnBuilder;
+use databend_common_expression::types::array::ArrayColumnBuilderMut;
 use databend_common_expression::types::i256;
 use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::*;
@@ -179,7 +179,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut ArrayColumnBuilder<T>,
+        mut builder: ArrayColumnBuilderMut<'_, T>,
         function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let range_bound_data = unsafe {

--- a/src/query/functions/src/aggregates/aggregate_scalar_state.rs
+++ b/src/query/functions/src/aggregates/aggregate_scalar_state.rs
@@ -19,6 +19,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use databend_common_exception::Result;
 use databend_common_expression::types::Bitmap;
+use databend_common_expression::types::BuilderExt;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::ValueType;
 use databend_common_expression::ColumnBuilder;
@@ -230,17 +231,11 @@ where
     }
 
     fn merge_result(&mut self, builder: &mut ColumnBuilder) -> Result<()> {
+        let mut inner = T::downcast_builder(builder);
         if let Some(v) = &self.value {
-            if let Some(inner) = T::try_downcast_builder(builder) {
-                T::push_item(inner, T::to_scalar_ref(v));
-            } else {
-                let data_type = builder.data_type();
-                builder.push(T::upcast_scalar_with_type(v.clone(), &data_type).as_ref());
-            }
-        } else if let Some(inner) = T::try_downcast_builder(builder) {
-            T::push_default(inner);
+            inner.push_item(T::to_scalar_ref(v));
         } else {
-            builder.push_default();
+            inner.push_default();
         }
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_skewness.rs
+++ b/src/query/functions/src/aggregates/aggregate_skewness.rs
@@ -17,6 +17,7 @@ use borsh::BorshSerialize;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::number::*;
+use databend_common_expression::types::BuilderMut;
 use databend_common_expression::types::*;
 use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::AggregateFunctionRef;
@@ -69,7 +70,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<F64>,
+        mut builder: BuilderMut<'_, Float64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         if self.n <= 2 {

--- a/src/query/functions/src/aggregates/aggregate_stddev.rs
+++ b/src/query/functions/src/aggregates/aggregate_stddev.rs
@@ -22,7 +22,7 @@ use databend_common_exception::Result;
 use databend_common_expression::types::decimal::Decimal;
 use databend_common_expression::types::decimal::Decimal128Type;
 use databend_common_expression::types::decimal::Decimal256Type;
-use databend_common_expression::types::nullable::NullableColumnBuilder;
+use databend_common_expression::types::nullable::NullableColumnBuilderMut;
 use databend_common_expression::types::number::Number;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Float64Type;
@@ -96,7 +96,7 @@ impl<const TYPE: u8> StddevState<TYPE> {
 
     fn state_merge_result(
         &mut self,
-        builder: &mut NullableColumnBuilder<Float64Type>,
+        mut builder: NullableColumnBuilderMut<'_, Float64Type>,
     ) -> Result<()> {
         // For single-record inputs, VAR_SAMP and STDDEV_SAMP should return NULL
         if self.count <= 1 && (TYPE == VAR_SAMP || TYPE == STD_SAMP) {
@@ -141,7 +141,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut NullableColumnBuilder<Float64Type>,
+        builder: NullableColumnBuilderMut<'_, Float64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         self.state.state_merge_result(builder)
@@ -190,7 +190,7 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut NullableColumnBuilder<Float64Type>,
+        builder: NullableColumnBuilderMut<'_, Float64Type>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         self.state.state_merge_result(builder)

--- a/src/query/functions/src/aggregates/aggregate_string_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_string_agg.rs
@@ -172,7 +172,7 @@ impl AggregateFunction for AggregateStringAggFunction {
 
     fn merge_result(&self, place: AggrState, builder: &mut ColumnBuilder) -> Result<()> {
         let state = place.get::<StringAggState>();
-        let builder = StringType::try_downcast_builder(builder).unwrap();
+        let mut builder = StringType::downcast_builder(builder);
         if !state.values.is_empty() {
             let len = state.values.len() - self.delimiter.len();
             builder.put_and_commit(&state.values[..len]);

--- a/src/query/functions/src/aggregates/aggregate_sum.rs
+++ b/src/query/functions/src/aggregates/aggregate_sum.rs
@@ -22,6 +22,7 @@ use databend_common_expression::types::decimal::*;
 use databend_common_expression::types::number::*;
 use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::Buffer;
+use databend_common_expression::types::BuilderMut;
 use databend_common_expression::types::*;
 use databend_common_expression::utils::arithmetics_type::ResultTypeOfUnary;
 use databend_common_expression::with_number_mapped_type;
@@ -156,10 +157,10 @@ where
 
     fn merge_result(
         &mut self,
-        builder: &mut N::ColumnBuilder,
+        mut builder: N::ColumnBuilderMut<'_>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
-        N::push_item(builder, N::to_scalar_ref(&self.value));
+        builder.push_item(N::to_scalar_ref(&self.value));
         Ok(())
     }
 }
@@ -251,7 +252,7 @@ where T: Decimal<U64Array: BorshSerialize + BorshDeserialize> + std::ops::AddAss
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<T>,
+        mut builder: BuilderMut<'_, DecimalType<T>>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
         let v = T::from_u64_array(self.value);
@@ -309,10 +310,10 @@ impl UnaryState<IntervalType, IntervalType> for IntervalSumState {
 
     fn merge_result(
         &mut self,
-        builder: &mut Vec<months_days_micros>,
+        mut builder: BuilderMut<'_, IntervalType>,
         _function_data: Option<&dyn FunctionData>,
     ) -> Result<()> {
-        IntervalType::push_item(builder, IntervalType::to_scalar_ref(&self.value));
+        builder.push_item(IntervalType::to_scalar_ref(&self.value));
         Ok(())
     }
 }

--- a/src/query/functions/src/aggregates/aggregate_window_funnel.rs
+++ b/src/query/functions/src/aggregates/aggregate_window_funnel.rs
@@ -298,9 +298,8 @@ where
         Ok(())
     }
 
-    #[allow(unused_mut)]
     fn merge_result(&self, place: AggrState, builder: &mut ColumnBuilder) -> Result<()> {
-        let builder = UInt8Type::try_downcast_builder(builder).unwrap();
+        let mut builder = UInt8Type::downcast_builder(builder);
         let result = self.get_event_level(place);
         builder.push(result);
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Resolved a design flaw in the original `ValueType::try_downcast_builder`. So the unsafe `take_mut` in aggregate_unary.rs has been removed.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18102)
<!-- Reviewable:end -->
