### PR TITLE
fix(query): add dynamic cast rules

### DIFF
--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -36,6 +36,7 @@ use crate::visit_expr;
 use crate::AutoCastRules;
 use crate::ColumnIndex;
 use crate::ConstantFolder;
+use crate::DynamicCastRules;
 use crate::ExprVisitor;
 use crate::FunctionContext;
 use crate::Scalar;
@@ -295,6 +296,7 @@ pub fn check_function<Index: ColumnIndex>(
     }
 
     let auto_cast_rules = fn_registry.get_auto_cast_rules(name);
+    let dynamic_cast_rules = fn_registry.get_dynamic_cast_rules(name);
 
     let mut fail_reasons = Vec::with_capacity(candidates.len());
     let mut checked_candidates = vec![];
@@ -304,7 +306,13 @@ pub fn check_function<Index: ColumnIndex>(
         .collect::<Vec<_>>();
     let need_sort = candidates.len() > 1 && args_not_const.iter().any(|contain| !*contain);
     for (seq, (id, func)) in candidates.iter().enumerate() {
-        match try_check_function(args, &func.signature, auto_cast_rules, fn_registry) {
+        match try_check_function(
+            args,
+            &func.signature,
+            auto_cast_rules,
+            &dynamic_cast_rules,
+            fn_registry,
+        ) {
             Ok((args, return_type, generics)) => {
                 let score = if need_sort {
                     args.iter()
@@ -455,12 +463,14 @@ pub fn try_check_function<Index: ColumnIndex>(
     args: &[Expr<Index>],
     sig: &FunctionSignature,
     auto_cast_rules: AutoCastRules,
+    dynamic_cast_rules: &DynamicCastRules,
     fn_registry: &FunctionRegistry,
 ) -> Result<(Vec<Expr<Index>>, DataType, Vec<DataType>)> {
     let subst = try_unify_signature(
         args.iter().map(Expr::data_type),
         sig.args_type.iter(),
         auto_cast_rules,
+        dynamic_cast_rules,
     )?;
 
     let checked_args = args
@@ -500,6 +510,7 @@ pub fn try_unify_signature(
     src_tys: impl IntoIterator<Item = &DataType> + ExactSizeIterator,
     dest_tys: impl IntoIterator<Item = &DataType> + ExactSizeIterator,
     auto_cast_rules: AutoCastRules,
+    dynamic_cast_rules: &DynamicCastRules,
 ) -> Result<Substitution> {
     if src_tys.len() != dest_tys.len() {
         return Err(ErrorCode::from_string_no_backtrace(format!(
@@ -512,7 +523,7 @@ pub fn try_unify_signature(
     let substs = src_tys
         .into_iter()
         .zip(dest_tys)
-        .map(|(src_ty, dest_ty)| unify(src_ty, dest_ty, auto_cast_rules))
+        .map(|(src_ty, dest_ty)| unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules))
         .collect::<Result<Vec<_>>>()?;
 
     Ok(substs
@@ -525,27 +536,34 @@ pub fn unify(
     src_ty: &DataType,
     dest_ty: &DataType,
     auto_cast_rules: AutoCastRules,
+    dynamic_cast_rules: &DynamicCastRules,
 ) -> Result<Substitution> {
     match (src_ty, dest_ty) {
         (ty, _) if ty.has_generic() => Err(ErrorCode::from_string_no_backtrace(
             "source type {src_ty} must not contain generic type".to_string(),
         )),
         (ty, DataType::Generic(idx)) => Ok(Substitution::equation(*idx, ty.clone())),
-        (src_ty, dest_ty) if can_auto_cast_to(src_ty, dest_ty, auto_cast_rules) => {
+        (src_ty, dest_ty)
+            if can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules) =>
+        {
             Ok(Substitution::empty())
         }
         (DataType::Null, DataType::Nullable(_)) => Ok(Substitution::empty()),
         (DataType::EmptyArray, DataType::Array(_)) => Ok(Substitution::empty()),
         (DataType::EmptyMap, DataType::Map(_)) => Ok(Substitution::empty()),
         (DataType::Nullable(src_ty), DataType::Nullable(dest_ty)) => {
-            unify(src_ty, dest_ty, auto_cast_rules)
+            unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
         }
-        (src_ty, DataType::Nullable(dest_ty)) => unify(src_ty, dest_ty, auto_cast_rules),
+        (src_ty, DataType::Nullable(dest_ty)) => {
+            unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
+        }
         (DataType::Array(src_ty), DataType::Array(dest_ty)) => {
-            unify(src_ty, dest_ty, auto_cast_rules)
+            unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
         }
         (DataType::Map(box src_ty), DataType::Map(box dest_ty)) => match (src_ty, dest_ty) {
-            (DataType::Tuple(_), DataType::Tuple(_)) => unify(src_ty, dest_ty, auto_cast_rules),
+            (DataType::Tuple(_), DataType::Tuple(_)) => {
+                unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
+            }
             (_, _) => unreachable!(),
         },
         (DataType::Tuple(src_tys), DataType::Tuple(dest_tys))
@@ -554,7 +572,9 @@ pub fn unify(
             let substs = src_tys
                 .iter()
                 .zip(dest_tys)
-                .map(|(src_ty, dest_ty)| unify(src_ty, dest_ty, auto_cast_rules))
+                .map(|(src_ty, dest_ty)| {
+                    unify(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
+                })
                 .collect::<Result<Vec<_>>>()?;
             let subst = substs
                 .into_iter()
@@ -601,13 +621,15 @@ pub fn can_auto_cast_to(
     src_ty: &DataType,
     dest_ty: &DataType,
     auto_cast_rules: AutoCastRules,
+    dynamic_cast_rules: &DynamicCastRules,
 ) -> bool {
     match (src_ty, dest_ty) {
         (src_ty, dest_ty) if src_ty == dest_ty => true,
         (src_ty, dest_ty)
-            if auto_cast_rules
-                .iter()
-                .any(|(src, dest)| src == src_ty && dest == dest_ty) =>
+            if dynamic_cast_rules.iter().any(|r| r(src_ty, dest_ty))
+                || auto_cast_rules
+                    .iter()
+                    .any(|(src, dest)| src == src_ty && dest == dest_ty) =>
         {
             true
         }
@@ -615,24 +637,25 @@ pub fn can_auto_cast_to(
         (DataType::EmptyArray, DataType::Array(_)) => true,
         (DataType::EmptyMap, DataType::Map(_)) => true,
         (DataType::Nullable(src_ty), DataType::Nullable(dest_ty)) => {
-            can_auto_cast_to(src_ty, dest_ty, auto_cast_rules)
+            can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
         }
-        (src_ty, DataType::Nullable(dest_ty)) => can_auto_cast_to(src_ty, dest_ty, auto_cast_rules),
+        (src_ty, DataType::Nullable(dest_ty)) => {
+            can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
+        }
         (DataType::Array(src_ty), DataType::Array(dest_ty)) => {
-            can_auto_cast_to(src_ty, dest_ty, auto_cast_rules)
+            can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
         }
         (DataType::Map(box src_ty), DataType::Map(box dest_ty)) => match (src_ty, dest_ty) {
             (DataType::Tuple(_), DataType::Tuple(_)) => {
-                can_auto_cast_to(src_ty, dest_ty, auto_cast_rules)
+                can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
             }
             (_, _) => unreachable!(),
         },
         (DataType::Tuple(src_tys), DataType::Tuple(dest_tys)) => {
             src_tys.len() == dest_tys.len()
-                && src_tys
-                    .iter()
-                    .zip(dest_tys)
-                    .all(|(src_ty, dest_ty)| can_auto_cast_to(src_ty, dest_ty, auto_cast_rules))
+                && src_tys.iter().zip(dest_tys).all(|(src_ty, dest_ty)| {
+                    can_auto_cast_to(src_ty, dest_ty, auto_cast_rules, dynamic_cast_rules)
+                })
         }
         (DataType::String, DataType::Decimal(_)) => true,
         (DataType::Decimal(x), DataType::Decimal(y)) => {
@@ -656,9 +679,14 @@ pub fn common_super_type(
     ty2: DataType,
     auto_cast_rules: AutoCastRules,
 ) -> Option<DataType> {
+    let dynamic_cast_rules = &vec![];
     match (ty1, ty2) {
-        (ty1, ty2) if can_auto_cast_to(&ty1, &ty2, auto_cast_rules) => Some(ty2),
-        (ty1, ty2) if can_auto_cast_to(&ty2, &ty1, auto_cast_rules) => Some(ty1),
+        (ty1, ty2) if can_auto_cast_to(&ty1, &ty2, auto_cast_rules, dynamic_cast_rules) => {
+            Some(ty2)
+        }
+        (ty1, ty2) if can_auto_cast_to(&ty2, &ty1, auto_cast_rules, dynamic_cast_rules) => {
+            Some(ty1)
+        }
         (DataType::Null, ty @ DataType::Nullable(_))
         | (ty @ DataType::Nullable(_), DataType::Null) => Some(ty),
         (DataType::Null, ty) | (ty, DataType::Null) => Some(DataType::Nullable(Box::new(ty))),

--- a/src/query/functions/src/scalars/mod.rs
+++ b/src/query/functions/src/scalars/mod.rs
@@ -52,6 +52,7 @@ use databend_functions_scalar_numeric_basic_arithmetic::register_numeric_basic_a
 pub use hash::CityHasher64;
 pub use hash::DFHash;
 pub use string::ALL_STRING_FUNC_NAMES;
+pub use string::PURE_STRING_FUNC_NAMES;
 
 pub fn register(registry: &mut FunctionRegistry) {
     variant::register(registry);

--- a/src/query/functions/src/scalars/string.rs
+++ b/src/query/functions/src/scalars/string.rs
@@ -79,6 +79,9 @@ pub const ALL_STRING_FUNC_NAMES: &[&str] = &[
     "regexp_substr",
 ];
 
+/// Functions that works with all strings, allow other types to be casted to string.
+pub const PURE_STRING_FUNC_NAMES: &[&str] = &["concat", "concat_ws"];
+
 pub fn register(registry: &mut FunctionRegistry) {
     registry.register_aliases("to_string", &["to_varchar", "to_text"]);
     registry.register_aliases("upper", &["ucase"]);

--- a/src/query/functions/tests/it/scalars/string.rs
+++ b/src/query/functions/tests/it/scalars/string.rs
@@ -427,6 +427,17 @@ fn test_concat(file: &mut impl Write) {
         "a",
         BooleanType::from_data(vec![false; 3]),
     )]);
+
+    let size = DecimalSize::new(10, 0).unwrap();
+    run_ast(file, "concat_ws(NULL, a, 2)", &[(
+        "a",
+        Decimal128Type::from_data_with_size([0, 1, 2], Some(size)),
+    )]);
+
+    run_ast(file, "concat(4, a, 2)", &[(
+        "a",
+        Decimal128Type::from_data_with_size([0, 1, 2], Some(size)),
+    )]);
 }
 
 fn test_bin(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions/tests/it/scalars/testdata/string.txt
@@ -2039,16 +2039,59 @@ evaluation (internal):
 +--------+----------------------------------------------------------------------------------+
 
 
-error: 
-  --> SQL:1:1
-  |
-1 | concat_ws('', a, 2)
-  | ^^^^^^^^^^^^^^^^^^^ no function matches signature `concat_ws(String, Boolean, UInt8)`, you might need to add explicit type casts.
+ast            : concat_ws('', a, 2)
+raw expr       : concat_ws('', a::Boolean, 2)
+checked expr   : concat_ws<String, String, String>("", CAST<Boolean>(a AS String), CAST<UInt8>(2_u8 AS String))
+optimized expr : "false2"
+evaluation:
++--------+---------+-----------------------+
+|        | a       | Output                |
++--------+---------+-----------------------+
+| Type   | Boolean | String                |
+| Domain | {FALSE} | {"false2"..="false2"} |
+| Row 0  | false   | 'false2'              |
+| Row 1  | false   | 'false2'              |
+| Row 2  | false   | 'false2'              |
++--------+---------+-----------------------+
+evaluation (internal):
++--------+--------------------------------------+
+| Column | Data                                 |
++--------+--------------------------------------+
+| a      | Boolean([0b_____000])                |
+| Output | StringColumn[false2, false2, false2] |
++--------+--------------------------------------+
 
-candidate functions:
-  concat_ws(String, String, String) :: String                      : unable to unify `Boolean` with `String`
-  concat_ws(String NULL, String NULL, String NULL) :: String NULL  : unable to unify `Boolean` with `String`
 
+ast            : concat_ws(NULL, a, 2)
+raw expr       : concat_ws(NULL, a::Decimal(10, 0), 2)
+checked expr   : concat_ws<String NULL, String NULL, String NULL>(CAST<NULL>(NULL AS String NULL), CAST<Decimal(10, 0)>(a AS String NULL), CAST<UInt8>(2_u8 AS String NULL))
+optimized expr : concat_ws<String NULL, String NULL, String NULL>(NULL, CAST<Decimal(10, 0)>(a AS String NULL), "2")
+output type    : String NULL
+output domain  : {""..} ∪ {NULL}
+output         : NULL
+
+
+ast            : concat(4, a, 2)
+raw expr       : concat(4, a::Decimal(10, 0), 2)
+checked expr   : concat<String, String, String>(CAST<UInt8>(4_u8 AS String), CAST<Decimal(10, 0)>(a AS String), CAST<UInt8>(2_u8 AS String))
+optimized expr : concat<String, String, String>("4", CAST<Decimal(10, 0)>(a AS String), "2")
+evaluation:
++--------+----------------+---------+
+|        | a              | Output  |
++--------+----------------+---------+
+| Type   | Decimal(10, 0) | String  |
+| Domain | {0..=2}        | {"4"..} |
+| Row 0  | 0              | '402'   |
+| Row 1  | 1              | '412'   |
+| Row 2  | 2              | '422'   |
++--------+----------------+---------+
+evaluation (internal):
++--------+-----------------------------+
+| Column | Data                        |
++--------+-----------------------------+
+| a      | Decimal128([0, 1, 2])       |
+| Output | StringColumn[402, 412, 422] |
++--------+-----------------------------+
 
 
 ast            : bin(a)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): add dynamic cast rules

 
Dynamic Cast Rules Implementation
This PR introduces dynamic cast rules to Databend's type system, enhancing the flexibility of type casting operations. Here's a summary of the changes:


Now `concat`, `concat_ws` will try to auto-cast other types into string type.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18103)
<!-- Reviewable:end -->
