### PR TITLE
refactor(meta-client): remove usage of obsolete `prev_value`

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -139,8 +139,12 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-04-15: since 1.2.726
 ///   👥 client: requires `1,2.677`.
 ///
-/// - 2025-05-08: since TODO: add version when merged.
+/// - 2025-05-08: since 1.2.736
 ///   🖥 server: add `WatchResponse::is_initialization`,
+///
+/// - 2025-06-09: since: TODO: add version when merged.
+///   👥 client: requires `>=1,2.677`: do not use TxnPutRequest.prev_value and TxnDeleteRequest.prev_value;
+///
 ///
 ///
 /// Server feature set:

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -745,7 +745,6 @@ impl kvapi::TestSuite {
                 TxnOp {
                     request: Some(txn_op::Request::Delete(TxnDeleteRequest {
                         key: txn_key1.clone(),
-                        prev_value: true,
                         match_seq: None,
                     })),
                 },

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -223,7 +223,6 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
         let pr = TxnPutRequest {
             key: p.key,
             value,
-            prev_value: p.prev_value,
             expire_at: p.expire_at,
             ttl_ms: p.ttl_ms,
         };

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -45,7 +45,10 @@ message TxnPutRequest {
 
   // Whether or not to return the prev value
   // Not used anymore
-  bool prev_value = 3;
+  // Since 1.2.304, 2024-01-17, the server always returns prev value,
+  // and client does not need to specify this field.
+  // bool prev_value = 3;
+  reserved 3;
 
   // Absolute expire time
   optional uint64 expire_at = 4;
@@ -68,7 +71,10 @@ message TxnDeleteRequest {
 
   // if or not return the prev value
   // Not used anymore
-  bool prev_value = 2;
+  // Since 1.2.304, 2024-01-17, the server always returns prev value,
+  // and client does not need to specify this field.
+  // bool prev_value = 2;
+  reserved 2;
 
   // Delete only if the `seq` matches the specified value.
   // Such a condition skips changed record and does not result in a transaction failure.
@@ -124,7 +130,7 @@ message TxnDeleteResponse {
 }
 
 // Delete by prefix request and response
-message TxnDeleteByPrefixRequest { string prefix = 1; }
+message TxnDeleteByPrefixRequest {string prefix = 1;}
 
 message TxnDeleteByPrefixResponse {
   string prefix = 1;

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -260,7 +260,6 @@ impl pb::TxnOp {
             request: Some(pb::txn_op::Request::Put(pb::TxnPutRequest {
                 key: key.to_string(),
                 value,
-                prev_value: true,
                 expire_at: None,
                 ttl_ms: None,
             })),
@@ -275,7 +274,6 @@ impl pb::TxnOp {
             request: Some(pb::txn_op::Request::Put(pb::TxnPutRequest {
                 key: key.to_string(),
                 value,
-                prev_value: true,
                 expire_at: None,
                 ttl_ms: ttl.map(|d| d.as_millis() as u64),
             })),
@@ -299,7 +297,6 @@ impl pb::TxnOp {
         pb::TxnOp {
             request: Some(pb::txn_op::Request::Delete(pb::TxnDeleteRequest {
                 key: key.to_string(),
-                prev_value: true,
                 match_seq: seq,
             })),
         }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-client): remove usage of obsolete `prev_value`

`TxnPutRequest.prev_value` and `TxnDeleteRequest.prev_value` inform the
server to respond with the value before the put or delete request.

Since 1.2.304, the meta-server always responds with the prev-value and
these two fields are never used.

The lease supported meta-server version is now 1.2.677, therefore we can
completely remove these two fields from the protocol.

This change is non-breaking.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18110)
<!-- Reviewable:end -->
