### PR TITLE
refactor(meta-server): remove TxnReply::error

### DIFF
--- a/src/meta/api/src/reply.rs
+++ b/src/meta/api/src/reply.rs
@@ -33,18 +33,8 @@ where T: DeserializeOwned {
     }
 }
 
-/// Convert txn response to `success` and a series of `TxnOpResponse`.
-pub fn txn_reply_to_api_result(
-    txn_reply: TxnReply,
-) -> Result<(bool, Vec<TxnOpResponse>), MetaAPIError> {
-    if txn_reply.error.is_empty() {
-        Ok((txn_reply.success, txn_reply.responses))
-    } else {
-        let err: MetaAPIError = serde_json::from_str(&txn_reply.error)
-            .map_err(|e| InvalidReply::new("invalid TxnReply.error", &e))?;
-
-        Err(err)
-    }
+pub fn unpack_txn_reply(txn_reply: TxnReply) -> (bool, Vec<TxnOpResponse>) {
+    (txn_reply.success, txn_reply.responses)
 }
 
 #[cfg(test)]

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -44,7 +44,7 @@ use display_more::DisplaySliceExt;
 use log::debug;
 
 use crate::kv_app_error::KVAppError;
-use crate::reply::txn_reply_to_api_result;
+use crate::reply::unpack_txn_reply;
 
 pub const DEFAULT_MGET_SIZE: usize = 256;
 
@@ -247,7 +247,7 @@ pub async fn send_txn(
 ) -> Result<(bool, Vec<TxnOpResponse>), MetaError> {
     debug!("send txn: {}", txn_req);
     let tx_reply = kv_api.transaction(txn_req).await?;
-    let (succ, responses) = txn_reply_to_api_result(tx_reply)?;
+    let (succ, responses) = unpack_txn_reply(tx_reply);
     debug!("txn success: {}: {}", succ, responses.display_n::<20>());
     Ok((succ, responses))
 }

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -127,6 +127,8 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2024-12-20: since 1.2.676
 ///   🖥 server: add `TxnRequest::operations`,
 ///   to specify a complex bool expression and corresponding operations
+///   🖥 server: no longer use `TxnReply::error`
+///   👥 client: no longer use `TxnReply::error`
 ///
 /// - 2024-12-26: since 1.2.677
 ///   🖥 server: add `WatchRequest::initial_flush`,
@@ -139,9 +141,11 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-04-15: since 1.2.726
 ///   👥 client: requires `1,2.677`.
 ///
-/// - 2025-05-08: since TODO: add version when merged.
+/// - 2025-05-08: since 1.2.736
 ///   🖥 server: add `WatchResponse::is_initialization`,
 ///
+/// - 2025-06-09: since TODO: update when merged
+///   🖥 server: remove `TxnReply::error`
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -210,12 +210,13 @@ impl MetaServiceImpl {
                 (endpoint, txn_reply)
             }
             Err(err) => {
+                network_metrics::incr_request_result(false);
                 error!("txn request failed: {:?}", err);
                 return Err(Status::internal(err.to_string()));
             }
         };
 
-        network_metrics::incr_request_result(txn_reply.error.is_empty());
+        network_metrics::incr_request_result(true);
 
         Ok((endpoint, txn_reply))
     }

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -249,7 +249,8 @@ message TxnReply {
   repeated TxnOpResponse responses = 2;
 
   // Not used
-  string error = 3;
+  // string error = 3;
+  reserved 3;
 
   // Identifies which execution path was taken
   string execution_path = 4;

--- a/src/meta/types/src/proto_display/mod.rs
+++ b/src/meta/types/src/proto_display/mod.rs
@@ -224,10 +224,9 @@ impl Display for TxnReply {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "TxnReply{{ success: {}, responses: {}, error: {}}}",
+            "TxnReply{{ success: {}, responses: {}}}",
             self.success,
             VecDisplay::new_at_most(&self.responses, 5),
-            self.error
         )
     }
 }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -83,7 +83,6 @@ impl pb::TxnReply {
         Self {
             success: execution_path != "else",
             responses: vec![],
-            error: "".to_string(),
             execution_path,
         }
     }

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use databend_common_base::base::tokio::sync::Mutex;
 use databend_common_exception::ErrorCode;
-use databend_common_meta_api::reply::txn_reply_to_api_result;
+use databend_common_meta_api::reply::unpack_txn_reply;
 use databend_common_meta_api::txn_backoff::txn_backoff;
 use databend_common_meta_api::txn_cond_seq;
 use databend_common_meta_api::txn_op_del;
@@ -370,7 +370,7 @@ impl RoleApi for RoleMgr {
             if need_transfer {
                 let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
                 let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
-                let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+                let (succ, _) = unpack_txn_reply(tx_reply);
                 debug!(
                     succ = succ;
                     "transfer_ownership_to_admin"
@@ -434,7 +434,7 @@ impl RoleApi for RoleMgr {
             let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
 
             let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
-            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+            let (succ, _) = unpack_txn_reply(tx_reply);
 
             if succ {
                 return Ok(());
@@ -519,7 +519,7 @@ impl RoleApi for RoleMgr {
             let txn_req = TxnRequest::new(condition.clone(), if_then.clone());
 
             let tx_reply = self.kv_api.transaction(txn_req.clone()).await?;
-            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+            let (succ, _) = unpack_txn_reply(tx_reply);
 
             if succ {
                 return Ok(());

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -18,7 +18,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_api::kv_pb_api::KVPbApi;
 use databend_common_meta_api::kv_pb_api::UpsertPB;
-use databend_common_meta_api::reply::txn_reply_to_api_result;
+use databend_common_meta_api::reply::unpack_txn_reply;
 use databend_common_meta_api::txn_cond_eq_seq;
 use databend_common_meta_api::txn_cond_seq;
 use databend_common_meta_api::txn_op_del;
@@ -152,7 +152,7 @@ impl StageApi for StageMgr {
                 dels,
             );
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+            let (succ, _) = unpack_txn_reply(tx_reply);
 
             if succ {
                 return Ok(());
@@ -214,7 +214,7 @@ impl StageApi for StageMgr {
             );
 
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+            let (succ, _) = unpack_txn_reply(tx_reply);
 
             if succ {
                 return Ok(0);
@@ -275,7 +275,7 @@ impl StageApi for StageMgr {
                 if_then,
             );
             let tx_reply = self.kv_api.transaction(txn_req).await?;
-            let (succ, _) = txn_reply_to_api_result(tx_reply)?;
+            let (succ, _) = unpack_txn_reply(tx_reply);
 
             if succ {
                 return Ok(());


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-server): remove TxnReply::error

The `error` field is not used since 1.2.676; and is removed in this
commit.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18112)
<!-- Reviewable:end -->
