### PR TITLE
feat(query): Interval kin support iw and hh24

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -866,6 +866,7 @@ pub enum IntervalKind {
     Second,
     Doy,
     Week,
+    ISOWeek,
     Dow,
     Epoch,
     MicroSecond,
@@ -891,6 +892,7 @@ impl Display for IntervalKind {
             IntervalKind::YearWeek => "YEARWEEK",
             IntervalKind::Millennium => "MILLENNIUM",
             IntervalKind::Week => "WEEK",
+            IntervalKind::ISOWeek => "ISOWEEK",
             IntervalKind::Epoch => "EPOCH",
             IntervalKind::MicroSecond => "MICROSECOND",
         })

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -1812,6 +1812,7 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
     let doy = value(IntervalKind::Doy, rule! { DOY });
     let dow = value(IntervalKind::Dow, rule! { DOW });
     let isodow = value(IntervalKind::ISODow, rule! { ISODOW });
+    let isoweek = value(IntervalKind::ISOWeek, rule! { ISOWEEK });
     let week = value(IntervalKind::Week, rule! { WEEK });
     let epoch = value(IntervalKind::Epoch, rule! { EPOCH });
     let microsecond = value(IntervalKind::MicroSecond, rule! { MICROSECOND });
@@ -1871,6 +1872,7 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
         rule! { #literal_string_eq_ignore_case("HOUR")
             | #literal_string_eq_ignore_case("H")
             | #literal_string_eq_ignore_case("HH")
+            | #literal_string_eq_ignore_case("HH24")
             | #literal_string_eq_ignore_case("HR")
             | #literal_string_eq_ignore_case("HOURS")
             | #literal_string_eq_ignore_case("HRS")
@@ -1937,6 +1939,11 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
         },
     );
 
+    let isoweek_str = value(
+        IntervalKind::ISOWeek,
+        rule! { #literal_string_eq_ignore_case("IW") },
+    );
+
     let epoch_str = value(
         IntervalKind::Epoch,
         rule! { #literal_string_eq_ignore_case("EPOCH")
@@ -1983,6 +1990,7 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
             | #epoch
             | #microsecond
             | #isodow
+            | #isoweek
             | #millennium
             | #yearweek
         ),
@@ -2001,6 +2009,7 @@ pub fn interval_kind(i: Input) -> IResult<IntervalKind> {
             | #epoch_str
             | #microsecond_str
             | #isodow_str
+            | #isoweek_str
             | #yearweek_str
             | #millennium_str
         ),

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -763,6 +763,8 @@ pub enum TokenKind {
     IS,
     #[token("ISODOW", ignore(ascii_case))]
     ISODOW,
+    #[token("ISOWEEK", ignore(ascii_case))]
+    ISOWEEK,
     #[token("ISOYEAR", ignore(ascii_case))]
     ISOYEAR,
     #[token("JOIN", ignore(ascii_case))]

--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -2324,6 +2324,7 @@ fn register_rounder_functions(registry: &mut FunctionRegistry) {
     );
 
     // date | timestamp -> date
+    registry.register_aliases("to_monday", &["to_start_of_iso_week"]);
     rounder_functions_helper::<ToLastMonday>(registry, "to_monday");
     rounder_functions_helper::<ToLastSunday>(registry, "to_start_of_week");
     rounder_functions_helper::<ToStartOfMonth>(registry, "to_start_of_month");

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -75,6 +75,7 @@ substring_utf8 -> substr
 subtract -> minus
 to_char -> to_string
 to_datetime -> to_timestamp
+to_start_of_iso_week -> to_monday
 to_text -> to_string
 to_varchar -> to_string
 trunc -> truncate

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3194,6 +3194,10 @@ impl<'a> TypeChecker<'a> {
             ASTIntervalKind::Millennium => {
                 self.resolve_function(span, "millennium", vec![], &[arg])
             }
+            ASTIntervalKind::ISOWeek => Err(ErrorCode::SemanticError(
+                "Not support interval type ISOWeek".to_string(),
+            )
+            .set_span(span)),
         }
     }
 
@@ -3278,6 +3282,13 @@ impl<'a> TypeChecker<'a> {
                         span: None,
                         value: Literal::UInt64(week_start as u64)
                     }],
+                )
+            }
+            ASTIntervalKind::ISOWeek => {
+                self.resolve_function(
+                    span,
+                    "to_start_of_iso_week", vec![],
+                    &[date],
                 )
             }
             ASTIntervalKind::Day => {

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -292,6 +292,32 @@ select trunc('2025-02-05 00:01:00', week);
 ----
 2025-02-03
 
+
+query T
+SELECT TRUNC('2025-06-11'::Date, 'IW');
+----
+2025-06-09
+
+query T
+SELECT TRUNC('2025-06-09'::Date, 'IW');
+----
+2025-06-09
+
+query T
+SELECT TRUNC('2023-12-31'::Date, 'IW');
+----
+2023-12-25
+
+query T
+SELECT TRUNC('2024-01-01'::Date, 'IW');
+----
+2024-01-01
+
+query T
+select TRUNC('2025-06-09 10:11:12'::Datetime, 'HH24');
+----
+2025-06-09 10:00:00.000000
+
 query FF
 SELECT
     MONTHS_BETWEEN('2019-03-15'::DATE,


### PR DESCRIPTION



I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`iw` is ISOWeek.
`hh24` is hour.


In main will return parse err:

```sql
SELECT TRUNC(DATE '2024-01-01', 'IW');

select TRUNC('2025-06-09 10:11:12'::Datetime, 'HH24');

```

In pr:

```sql
query T
SELECT TRUNC('2024-01-01'::Date, 'IW');
----
2024-01-01

query T
select TRUNC('2025-06-09 10:11:12'::Datetime, 'HH24');
----
2025-06-09 10:00:00.000000

```

- fixes: https://github.com/databendlabs/databend/issues/18106
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18114)
<!-- Reviewable:end -->
