### PR TITLE
fix(storage): disable_credential_loader not been updated while role_arn set

### DIFF
--- a/src/meta/app/src/storage/storage_params.rs
+++ b/src/meta/app/src/storage/storage_params.rs
@@ -204,6 +204,11 @@ impl StorageParams {
                 s1.external_id = s2.external_id;
                 s1.master_key = s2.master_key;
                 s1.network_config = s2.network_config;
+                s1.disable_credential_loader = s2.disable_credential_loader;
+                // Remove disable_credential_loader is role_arn has been set.
+                if !s1.role_arn.is_empty() {
+                    s1.disable_credential_loader = false;
+                }
                 Ok(Self::S3(s1))
             }
             (s1, s2) => Err(ErrorCode::StorageOther(format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

We have a runtime check for `disable_credential_loader`, but its value is stored in metasrv and won't be updated when `role_arn` changes.

Before:

- changing role_arn doesn't work for existing external table.

After:

- changing role_arn works for existing external table.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18115)
<!-- Reviewable:end -->
