### PR TITLE
refactor: improve the schema mismatch error message

### DIFF
--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -441,7 +441,7 @@ impl DataBlock {
                         .map(|f| f.name().to_string())
                         .collect();
                     ErrorCode::BadArguments(format!(
-                        "Unable to get field named \"{}\". Valid fields: {:?}",
+                        "Column \"{}\" does not exist. Available columns are: {:?}",
                         dest_field.name(),
                         valid_fields
                     ))

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -366,7 +366,7 @@ impl DataSchema {
         }
         let valid_fields: Vec<String> = self.fields.iter().map(|f| f.name().clone()).collect();
         Err(ErrorCode::BadArguments(format!(
-            "Unable to get field named \"{}\". Valid fields: {:?}",
+            "Column \"{}\" does not exist. Available columns are: {:?}",
             name, valid_fields
         )))
     }
@@ -752,7 +752,7 @@ impl TableSchema {
         let valid_fields: Vec<String> = self.fields.iter().map(|f| f.name.clone()).collect();
 
         Err(ErrorCode::BadArguments(format!(
-            "Unable to get field named \"{}\". Valid fields: {:?}",
+            "Column \"{}\" does not exist. Available columns are: {:?}",
             name, valid_fields
         )))
     }

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -67,9 +67,9 @@ impl InsertInterpreter {
         // validate schema
         if select_schema.fields().len() != output_schema.fields().len() {
             return Err(ErrorCode::BadArguments(format!(
-                "Fields in select statement is not equal with expected, select fields: {}, insert fields: {}",
-                select_schema.fields().len(),
+                "Column count mismatch in INSERT: you specified {} columns but provided {} values. Please ensure these numbers match.",
                 output_schema.fields().len(),
+                select_schema.fields().len(),
             )));
         }
 

--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -492,7 +492,11 @@ impl Binder {
             };
             if clause.insert_operation.values.len() != source_schema.num_fields() {
                 return Err(ErrorCode::SemanticError(
-                    "insert columns and values are not matched".to_string(),
+                    format!(
+                        "Column count mismatch in INSERT: you specified {} columns but provided {} values. Please ensure these numbers match.",
+                        source_schema.num_fields(),
+                        clause.insert_operation.values.len()
+                    ),
                 ));
             }
             for (idx, expr) in clause.insert_operation.values.iter().enumerate() {

--- a/tests/sqllogictests/suites/base/03_common/03_0014_insert_into_select.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0014_insert_into_select.test
@@ -16,10 +16,10 @@ CREATE TABLE IF NOT EXISTS t2(a String, b String, c String, d String, e String, 
 statement ok
 CREATE TABLE IF NOT EXISTS t3(a String, b String, c String, d String) Engine = Fuse
 
-statement error (?s)1006.* Fields in select statement is not equal with expected, select fields: 4, insert fields: 5
+statement error (?s)1006.*Column count mismatch in INSERT.*you specified 5 columns but provided 4 values.*
 INSERT INTO t1 (a,b,c,d,e) select * from t3
 
-statement error (?s)1006.* Fields in select statement is not equal with expected, select fields: 3, insert fields: 5
+statement error (?s)1006.*Column count mismatch in INSERT.*you specified 5 columns but provided 3 values.*
 INSERT INTO t1 (a,b,c,d,e) select a,b,c from t3
 
 statement ok

--- a/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
@@ -141,6 +141,34 @@ CREATE TABLE IF NOT EXISTS db2.t2(a UInt32 null) Engine = Fuse
 statement ok
 INSERT INTO db2.t2 VALUES(1)
 
+# Test cases for error messages
+
+# Create test tables
+statement ok
+CREATE TABLE error_test_table (id INT, name VARCHAR, age INT) Engine = Fuse;
+
+# Test case 1: Column count mismatch in VALUES - too few values
+statement error (?s).*Column count mismatch in INSERT: you specified 3 columns but provided 2 values.*
+INSERT INTO error_test_table (id, name, age) VALUES (1, 'John');
+
+# Test case 2: Column count mismatch in VALUES - too many values
+statement error (?s).*Column count mismatch in INSERT: you specified 2 columns but provided 3 values.*
+INSERT INTO error_test_table (id, name) VALUES (1, 'John', 25);
+
+# Test case 3: Non-existent column in INSERT
+statement error (?s).*Column "salary" does not exist.*
+INSERT INTO error_test_table (id, name, salary) VALUES (1, 'John', 50000);
+
+# Test case 4: Column count mismatch in SELECT-based INSERT
+statement ok
+CREATE TABLE source_table (id INT, name VARCHAR) Engine = Fuse;
+
+statement ok
+INSERT INTO source_table VALUES (1, 'John');
+
+statement error (?s).*Column count mismatch in INSERT: you specified 3 columns but provided 2 values.*
+INSERT INTO error_test_table SELECT * FROM source_table;
+
 statement ok
 DROP DATABASE if exists db2
 

--- a/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
@@ -143,16 +143,22 @@ INSERT INTO db2.t2 VALUES(1)
 
 # Test cases for error messages
 
-# Create test tables
+# Create database and test tables
+statement ok
+CREATE DATABASE IF NOT EXISTS db1;
+
+statement ok
+USE db1;
+
 statement ok
 CREATE TABLE error_test_table (id INT, name VARCHAR, age INT) Engine = Fuse;
 
 # Test case 1: Column count mismatch in VALUES - too few values
-statement error (?s).*Column count mismatch in INSERT: you specified 3 columns but provided 2 values.*
+statement error (?s).*Column count mismatch in INSERT into table 'error_test_table': you specified 3 columns but provided 2 values.*
 INSERT INTO error_test_table (id, name, age) VALUES (1, 'John');
 
 # Test case 2: Column count mismatch in VALUES - too many values
-statement error (?s).*Column count mismatch in INSERT: you specified 2 columns but provided 3 values.*
+statement error (?s).*Column count mismatch in INSERT into table 'error_test_table': you specified 2 columns but provided 3 values.*
 INSERT INTO error_test_table (id, name) VALUES (1, 'John', 25);
 
 # Test case 3: Non-existent column in INSERT
@@ -166,7 +172,7 @@ CREATE TABLE source_table (id INT, name VARCHAR) Engine = Fuse;
 statement ok
 INSERT INTO source_table VALUES (1, 'John');
 
-statement error (?s).*Column count mismatch in INSERT: you specified 3 columns but provided 2 values.*
+statement error (?s).*Column count mismatch in INSERT into table 'error_test_table': you specified 3 columns but provided 2 values.*
 INSERT INTO error_test_table SELECT * FROM source_table;
 
 statement ok

--- a/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.result
+++ b/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.result
@@ -5,5 +5,5 @@ Error: APIError: QueryFailed: [1301]table option extrenal_location is invalid fo
 Error: APIError: QueryFailed: [1301]table option abc is invalid for alter table statement
 Error: APIError: QueryFailed: [1301]invalid block_per_segment option, can't be over 1000
 Error: APIError: QueryFailed: [1301]can't change storage_format for alter table statement
-Error: APIError: QueryFailed: [1006]Unable to get field named "b". Valid fields: ["a"]
+Error: APIError: QueryFailed: [1006]Column "b" does not exist. Available columns are: ["a"]
 Error: APIError: QueryFailed: [1301]Unsupported data type 'Decimal(4, 2)' for bloom index

--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
@@ -32,7 +32,7 @@ expects one row, 2 columns
 delete not allowed
 Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.
 update not allowed
-Error: APIError: QueryFailed: [1006]Unable to get field named "a". Valid fields: ["number", "c2"]
+Error: APIError: QueryFailed: [1006]Column "a" does not exist. Available columns are: ["number", "c2"]
 truncate not allowed
 Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.
 alter table column not allowed


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- Updated error messages for missing columns and column count mismatches in INSERT statements to be clearer and more user-friendly.
- Changed messages from "Unable to get field named..." to `Column "<name>" does not exist. Available columns are: [...]`.
- Improved INSERT mismatch message to: `Column count mismatch in INSERT: you specified X columns but provided Y values. Please ensure these numbers match.`

Only error messages and related tests changed; no business logic modified.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18117)
<!-- Reviewable:end -->
