### PR TITLE
chore: improve error messages for non-existent columns in mutation operations

### DIFF
--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -187,9 +187,11 @@ impl Binder {
             files: stmt.files.clone(),
             pattern,
         };
+
+        let dest_entity_name = format!("{database_name}.{table_name}");
         let stage_schema = match &stmt.dst_columns {
-            Some(cols) => self.schema_project(&table.schema(), cols)?,
-            None => self.schema_project(&table.schema(), &[])?,
+            Some(cols) => self.schema_project(&table.schema(), cols, &dest_entity_name)?,
+            None => self.schema_project(&table.schema(), &[], &dest_entity_name)?,
         };
 
         let required_values_schema: DataSchemaRef = Arc::new(stage_schema.clone().into());

--- a/src/query/sql/src/planner/binder/insert_multi_table.rs
+++ b/src/query/sql/src/planner/binder/insert_multi_table.rs
@@ -203,7 +203,12 @@ impl Binder {
             let mut casted_schema = if target_columns.is_empty() {
                 target_table.schema()
             } else {
-                self.schema_project(&target_table.schema(), target_columns.as_ref())?
+                let dest_entity_name = format!("{database_name}.{table_name}");
+                self.schema_project(
+                    &target_table.schema(),
+                    target_columns.as_ref(),
+                    &dest_entity_name,
+                )?
             };
 
             let default_indices = source_columns

--- a/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
@@ -141,6 +141,10 @@ CREATE TABLE IF NOT EXISTS db2.t2(a UInt32 null) Engine = Fuse
 statement ok
 INSERT INTO db2.t2 VALUES(1)
 
+# Test cases for column not exist error
+statement error (?s)1006(.*)Table "db2.t2" does not have a column with name "c_no_exist"
+insert into db2.t2(a, c_no_exist) values(1, 2);
+
 statement ok
 DROP DATABASE if exists db2
 

--- a/tests/sqllogictests/suites/base/03_common/03_0035_update.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0035_update.test
@@ -56,6 +56,10 @@ select count(*) = 2 from t1 WHERE a = 3
 statement error 1006
 UPDATE t1 SET a = 3, a = 4 WHERE b > '2022-12-31'
 
+# Test cases for column not exist error
+statement error (?s)1006(.*)Table "db1.t1" does not have a column with name "c_not_exist"
+UPDATE t1 SET a = 3, c_not_exist = 4 WHERE b > '2022-12-31'
+
 statement ok
 CREATE TABLE IF NOT EXISTS t2(a Int, b Date)
 

--- a/tests/sqllogictests/suites/base/03_common/03_0046_copy_into_from_stage.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0046_copy_into_from_stage.test
@@ -19,6 +19,10 @@ copy into @stage_t4 from (SELECT to_string(number) as str from numbers(10));
 statement ok
 COPY INTO t4 from @stage_t4 pattern='.*' FILE_FORMAT = (TYPE = 'parquet') PURGE=true FORCE=true max_files=10000;
 
+# Test cases for column not exist error
+statement error (?s)1006(.*)Table "default.t4" does not have a column with name "c_not_exist"
+COPY INTO t4(str, c_not_exist) from @stage_t4 pattern='.*' FILE_FORMAT = (TYPE = 'parquet') PURGE=true FORCE=true max_files=10000;
+
 statement ok
 DROP STAGE IF EXISTS stage_t4;
 

--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.result
@@ -32,7 +32,9 @@ expects one row, 2 columns
 delete not allowed
 Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.
 update not allowed
-Error: APIError: QueryFailed: [1006]Unable to get field named "a". Valid fields: ["number", "c2"]
+Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.
+column not exists
+Error: APIError: QueryFailed: [1006]Table "default.attach_read_only" does not have a column with name "a"
 truncate not allowed
 Error: APIError: QueryFailed: [3905]Modification not permitted: Table 'attach_read_only' is READ ONLY, preventing any changes or updates.
 alter table column not allowed

--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
@@ -65,6 +65,9 @@ echo "delete not allowed"
 echo "DELETE from attach_read_only" | $BENDSQL_CLIENT_CONNECT
 
 echo "update not allowed"
+echo "UPDATE attach_read_only set number = 1" | $BENDSQL_CLIENT_CONNECT
+
+echo "column not exists"
 echo "UPDATE attach_read_only set a = 1" | $BENDSQL_CLIENT_CONNECT
 
 echo "truncate not allowed"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add `try_resolve_field_in_schema` function to provide better error messages when columns don't exist
- Include database and table name in error messages (e.g., Table "db.tbl" does not have a column with name "column")
- Update mutation operations (UPDATE, INSERT, COPY INTO) to use the new error handling
- Add test cases for column not exist error scenarios in:
  - UPDATE statement
  - INSERT statement
  - COPY INTO statement
  

Without this PR:

~~~
mysql> insert into test(id, c_not_exist) values(1,2);
ERROR 1105 (HY000): BadArguments. Code: 1006, Text = Unable to get field named "c_not_exist". Valid fields: ["id", "payload", "file_name", "create_date", "processed_date", "retry_count", "load_id", "record_id", "source_record_id"].
~~~  
  
With this PR:

~~~
mysql> insert into test(id, c_not_exist) values(1,2);
ERROR 1105 (HY000): BadArguments. Code: 1006, Text = Table "default.test" does not have a column with name "c_not_exist".
~~~  

  

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):  improve error messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18119)
<!-- Reviewable:end -->
