### PR TITLE
feat: impl `Escape <escape>` for `LIKE/NOT LIKE/LIKE ANY`

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -85,12 +85,28 @@ pub enum Expr {
         subquery: Box<Query>,
         not: bool,
     },
-    /// `LIKE (SELECT ...)`
+    /// `LIKE (SELECT ...) [ESCAPE '<escape>']`
     LikeSubquery {
         span: Span,
         expr: Box<Expr>,
         subquery: Box<Query>,
         modifier: SubqueryModifier,
+        escape: Option<String>,
+    },
+    /// `<right> LIKE ANY <right> ESCAPE '<escape>'`
+    LikeAnyWithEscape {
+        span: Span,
+        left: Box<Expr>,
+        right: Box<Expr>,
+        escape: String,
+    },
+    /// `<right> [NOT] LIKE <right> ESCAPE '<escape>'`
+    LikeWithEscape {
+        span: Span,
+        left: Box<Expr>,
+        right: Box<Expr>,
+        is_not: bool,
+        escape: String,
     },
     /// `BETWEEN ... AND ...`
     Between {
@@ -292,6 +308,8 @@ impl Expr {
             | Expr::InList { span, .. }
             | Expr::InSubquery { span, .. }
             | Expr::LikeSubquery { span, .. }
+            | Expr::LikeAnyWithEscape { span, .. }
+            | Expr::LikeWithEscape { span, .. }
             | Expr::Between { span, .. }
             | Expr::BinaryOp { span, .. }
             | Expr::JsonOp { span, .. }
@@ -366,6 +384,12 @@ impl Expr {
                 merge_span(low.whole_span(), high.whole_span()),
             ),
             Expr::BinaryOp {
+                span, left, right, ..
+            }
+            | Expr::LikeWithEscape {
+                span, left, right, ..
+            }
+            | Expr::LikeAnyWithEscape {
                 span, left, right, ..
             } => merge_span(merge_span(*span, left.whole_span()), right.whole_span()),
             Expr::JsonOp {
@@ -609,10 +633,36 @@ impl Display for Expr {
                     expr,
                     subquery,
                     modifier,
+                    escape,
                     ..
                 } => {
                     write_expr(expr, Some(affix), true, f)?;
                     write!(f, " LIKE {modifier} ({subquery})")?;
+                    if let Some(escape) = escape {
+                        write!(f, " ESCAPE '{escape}'")?;
+                    }
+                }
+                Expr::LikeAnyWithEscape {
+                    left,
+                    right,
+                    escape,
+                    ..
+                } => {
+                    write_expr(left, Some(affix), true, f)?;
+                    write!(f, " LIKE ANY {right} ESCAPE '{escape}'")?;
+                }
+                Expr::LikeWithEscape {
+                    left,
+                    right,
+                    is_not,
+                    escape,
+                    ..
+                } => {
+                    write_expr(left, Some(affix), true, f)?;
+                    if *is_not {
+                        write!(f, " NOT")?;
+                    }
+                    write!(f, " LIKE {right} ESCAPE '{escape}'")?;
                 }
                 Expr::Between {
                     expr,
@@ -1469,9 +1519,9 @@ pub enum BinaryOperator {
     And,
     Or,
     Xor,
-    Like,
-    LikeAny,
-    NotLike,
+    Like(Option<String>),
+    NotLike(Option<String>),
+    LikeAny(Option<String>),
     Regexp,
     RLike,
     NotRegexp,
@@ -1511,7 +1561,8 @@ impl BinaryOperator {
             BinaryOperator::BitwiseShiftRight => "bit_shift_right".to_string(),
             BinaryOperator::Caret => "pow".to_string(),
             BinaryOperator::L2Distance => "l2_distance".to_string(),
-            BinaryOperator::LikeAny => "like_any".to_string(),
+            BinaryOperator::LikeAny(_) => "like_any".to_string(),
+            BinaryOperator::Like(_) => "like".to_string(),
             _ => {
                 let name = format!("{:?}", self);
                 name.to_lowercase()
@@ -1577,13 +1628,13 @@ impl Display for BinaryOperator {
             BinaryOperator::Xor => {
                 write!(f, "XOR")
             }
-            BinaryOperator::Like => {
+            BinaryOperator::Like(_) => {
                 write!(f, "LIKE")
             }
-            BinaryOperator::LikeAny => {
+            BinaryOperator::LikeAny(_) => {
                 write!(f, "LIKE ANY")
             }
-            BinaryOperator::NotLike => {
+            BinaryOperator::NotLike(_) => {
                 write!(f, "NOT LIKE")
             }
             BinaryOperator::Regexp => {
@@ -2075,7 +2126,9 @@ impl ExprReplacer {
             Expr::UnaryOp { expr, .. } => {
                 self.replace_expr(expr);
             }
-            Expr::BinaryOp { left, right, .. } => {
+            Expr::BinaryOp { left, right, .. }
+            | Expr::LikeWithEscape { left, right, .. }
+            | Expr::LikeAnyWithEscape { left, right, .. } => {
                 self.replace_expr(left);
                 self.replace_expr(right);
             }

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -168,10 +168,15 @@ pub enum ExprElement {
         subquery: Box<Query>,
         not: bool,
     },
-    /// `LIKE (SELECT ...)`
+    /// `LIKE (SELECT ...) [ESCAPE '<escape>']`
     LikeSubquery {
         modifier: SubqueryModifier,
         subquery: Box<Query>,
+        escape: Option<String>,
+    },
+    /// `ESCAPE '<escape>'`
+    Escape {
+        escape: String,
     },
     /// `BETWEEN ... AND ...`
     Between {
@@ -352,6 +357,9 @@ const IS_DISTINCT_FROM_AFFIX: Affix = Affix::Infix(Precedence(BETWEEN_PREC), Ass
 const IN_LIST_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
 const IN_SUBQUERY_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
 const LIKE_SUBQUERY_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
+const LIKE_ANY_WITH_ESCAPE_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
+const LIKE_WITH_ESCAPE_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
+const ESCAPE_AFFIX: Affix = Affix::Postfix(Precedence(BETWEEN_PREC));
 const JSON_OP_AFFIX: Affix = Affix::Infix(Precedence(40), Associativity::Left);
 const PG_CAST_AFFIX: Affix = Affix::Postfix(Precedence(60));
 
@@ -378,9 +386,9 @@ const fn binary_affix(op: &BinaryOperator) -> Affix {
         BinaryOperator::Lt => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::Gte => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::Lte => Affix::Infix(Precedence(20), Associativity::Left),
-        BinaryOperator::Like => Affix::Infix(Precedence(20), Associativity::Left),
-        BinaryOperator::LikeAny => Affix::Infix(Precedence(20), Associativity::Left),
-        BinaryOperator::NotLike => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::Like(_) => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::LikeAny(_) => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::NotLike(_) => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::Regexp => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::NotRegexp => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::RLike => Affix::Infix(Precedence(20), Associativity::Left),
@@ -417,6 +425,7 @@ impl ExprElement {
             ExprElement::InList { .. } => IN_LIST_AFFIX,
             ExprElement::InSubquery { .. } => IN_SUBQUERY_AFFIX,
             ExprElement::LikeSubquery { .. } => LIKE_SUBQUERY_AFFIX,
+            ExprElement::Escape { .. } => ESCAPE_AFFIX,
             ExprElement::UnaryOp { op } => unary_affix(op),
             ExprElement::BinaryOp { op } => binary_affix(op),
             ExprElement::JsonOp { .. } => JSON_OP_AFFIX,
@@ -466,6 +475,8 @@ impl Expr {
             Expr::InList { .. } => IN_LIST_AFFIX,
             Expr::InSubquery { .. } => IN_SUBQUERY_AFFIX,
             Expr::LikeSubquery { .. } => LIKE_SUBQUERY_AFFIX,
+            Expr::LikeAnyWithEscape { .. } => LIKE_ANY_WITH_ESCAPE_AFFIX,
+            Expr::LikeWithEscape { .. } => LIKE_WITH_ESCAPE_AFFIX,
             Expr::UnaryOp { op, .. } => unary_affix(op),
             Expr::BinaryOp { op, .. } => binary_affix(op),
             Expr::JsonOp { .. } => JSON_OP_AFFIX,
@@ -845,11 +856,54 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                 subquery,
                 not,
             },
-            ExprElement::LikeSubquery { subquery, modifier } => Expr::LikeSubquery {
+            ExprElement::LikeSubquery {
+                subquery,
+                modifier,
+                escape,
+            } => Expr::LikeSubquery {
                 span: transform_span(elem.span.tokens),
                 expr: Box::new(lhs),
                 subquery,
                 modifier,
+                escape,
+            },
+            ExprElement::Escape { escape } => match lhs {
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::Like(_),
+                    left,
+                    right,
+                } => Expr::LikeWithEscape {
+                    span,
+                    left,
+                    right,
+                    is_not: false,
+                    escape,
+                },
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::NotLike(_),
+                    left,
+                    right,
+                } => Expr::LikeWithEscape {
+                    span,
+                    left,
+                    right,
+                    is_not: true,
+                    escape,
+                },
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::LikeAny(_),
+                    left,
+                    right,
+                } => Expr::LikeAnyWithEscape {
+                    span,
+                    left,
+                    right,
+                    escape,
+                },
+                _ => return Err("escape clause must be after LIKE/NOT LIKE/LIKE ANY binary expr"),
             },
             ExprElement::Between { low, high, not } => Expr::Between {
                 span: transform_span(elem.span.tokens),
@@ -911,9 +965,9 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
     );
     let like_subquery = map(
         rule! {
-            LIKE ~ ( ANY | SOME | ALL ) ~ "(" ~ #query ~ ^")"
+            LIKE ~ ( ANY | SOME | ALL ) ~ "(" ~ #query ~ ^")" ~ (ESCAPE ~  ^#literal_string)?
         },
-        |(_, m, _, subquery, _)| {
+        |(_, m, _, subquery, _, option_escape)| {
             let modifier = match m.kind {
                 TokenKind::ALL => SubqueryModifier::All,
                 TokenKind::ANY => SubqueryModifier::Any,
@@ -923,8 +977,15 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
             ExprElement::LikeSubquery {
                 modifier,
                 subquery: Box::new(subquery),
+                escape: option_escape.map(|(_, escape)| escape),
             }
         },
+    );
+    let escape = map(
+        rule! {
+            ESCAPE ~  ^#literal_string
+        },
+        |(_, escape)| ExprElement::Escape { escape },
     );
     let between = map(
         rule! {
@@ -1386,6 +1447,7 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
                 | #list_comprehensions: "[expr for x in ... [if ...]]"
                 | #count_all_with_window : "`COUNT(*) OVER ...`"
                 | #function_call
+                | #escape: "`ESCAPE '<escape>'`"
             ),
             rule!(
                 #case : "`CASE ... END`"
@@ -1440,9 +1502,9 @@ pub fn binary_op(i: Input) -> IResult<BinaryOperator> {
             value(BinaryOperator::And, rule! { AND }),
             value(BinaryOperator::Or, rule! { OR }),
             value(BinaryOperator::Xor, rule! { XOR }),
-            value(BinaryOperator::LikeAny, rule! { LIKE ~ ANY }),
-            value(BinaryOperator::Like, rule! { LIKE }),
-            value(BinaryOperator::NotLike, rule! { NOT ~ LIKE }),
+            value(BinaryOperator::LikeAny(None), rule! { LIKE ~ ANY }),
+            value(BinaryOperator::Like(None), rule! { LIKE }),
+            value(BinaryOperator::NotLike(None), rule! { NOT ~ LIKE }),
             value(BinaryOperator::Regexp, rule! { REGEXP }),
             value(BinaryOperator::NotRegexp, rule! { NOT ~ REGEXP }),
             value(BinaryOperator::RLike, rule! { RLIKE }),

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1282,6 +1282,8 @@ fn test_expr() {
         r#"(arr[0]:a).b"#,
         r#"arr[4]["k"]"#,
         r#"a rlike '^11'"#,
+        r#"a like '%1$%1%' escape '$'"#,
+        r#"a not like '%1$%1%' escape '$'"#,
         r#"'中文'::text not in ('a', 'b')"#,
         r#"G.E.B IS NOT NULL AND col1 not between col2 and (1 + col3) DIV sum(col4)"#,
         r#"sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END"#,
@@ -1293,9 +1295,11 @@ fn test_expr() {
             AND l_shipmode IN ('AIR', 'AIR REG')
             AND l_shipinstruct = 'DELIVER IN PERSON'"#,
         r#"'中文'::text LIKE ANY ('a', 'b')"#,
+        r#"'中文'::text LIKE ANY ('a', 'b') ESCAPE '$'"#,
         r#"'中文'::text LIKE ANY (SELECT 'a', 'b')"#,
         r#"'中文'::text LIKE ALL (SELECT 'a', 'b')"#,
         r#"'中文'::text LIKE SOME (SELECT 'a', 'b')"#,
+        r#"'中文'::text LIKE ANY (SELECT 'a', 'b') ESCAPE '$'"#,
         r#"nullif(1, 1)"#,
         r#"nullif(a, b)"#,
         r#"coalesce(1, 2, 3)"#,
@@ -1354,6 +1358,8 @@ fn test_expr_error() {
             AND col1 NOT BETWEEN col2 AND
             AND 1 + col3 DIV sum(col4)
         "#,
+        r#"CAST(1 AS STRING) ESCAPE '$'"#,
+        r#"1 + 1 ESCAPE '$'"#,
     ];
 
     for case in cases {

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -52,7 +52,7 @@ error:
   --> SQL:1:10
   |
 1 | CAST(col1)
-  | ----     ^ unexpected `)`, expecting `AS`, `,`, `(`, `IS`, `NOT`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, or 42 more ...
+  | ----     ^ unexpected `)`, expecting `AS`, `,`, `(`, `IS`, `NOT`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, or 43 more ...
   | |         
   | while parsing `CAST(... AS ...)`
   | while parsing expression
@@ -81,7 +81,7 @@ error:
 1 | $ abc + 3
   | ^
   | |
-  | unexpected `$`, expecting `IS`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, `DATE_DIFF`, `DATEDIFF`, `DATESUB`, or 40 more ...
+  | unexpected `$`, expecting `IS`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, `DATE_DIFF`, `DATEDIFF`, `DATESUB`, or 41 more ...
   | while parsing expression
 
 
@@ -113,5 +113,29 @@ error:
   |          --- while parsing `[NOT] BETWEEN ... AND ...`
 3 | AND 1 + col3 DIV sum(col4)
   | ^^^ expected more tokens for expression
+
+
+---------- Input ----------
+CAST(1 AS STRING) ESCAPE '$'
+---------- Output ---------
+error:
+  --> SQL:1:19
+  |
+1 | CAST(1 AS STRING) ESCAPE '$'
+  | ----              ^^^^^^ escape clause must be after LIKE/NOT LIKE/LIKE ANY binary expr
+  | |
+  | while parsing expression
+
+
+---------- Input ----------
+1 + 1 ESCAPE '$'
+---------- Output ---------
+error:
+  --> SQL:1:7
+  |
+1 | 1 + 1 ESCAPE '$'
+  | -     ^^^^^^ escape clause must be after LIKE/NOT LIKE/LIKE ANY binary expr
+  | |
+  | while parsing expression
 
 

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -2735,6 +2735,88 @@ BinaryOp {
 
 
 ---------- Input ----------
+a like '%1$%1%' escape '$'
+---------- Output ---------
+a LIKE '%1$%1%' ESCAPE '$'
+---------- AST ------------
+LikeWithEscape {
+    span: Some(
+        2..6,
+    ),
+    left: ColumnRef {
+        span: Some(
+            0..1,
+        ),
+        column: ColumnRef {
+            database: None,
+            table: None,
+            column: Name(
+                Identifier {
+                    span: Some(
+                        0..1,
+                    ),
+                    name: "a",
+                    quote: None,
+                    ident_type: None,
+                },
+            ),
+        },
+    },
+    right: Literal {
+        span: Some(
+            7..15,
+        ),
+        value: String(
+            "%1$%1%",
+        ),
+    },
+    is_not: false,
+    escape: "$",
+}
+
+
+---------- Input ----------
+a not like '%1$%1%' escape '$'
+---------- Output ---------
+a NOT LIKE '%1$%1%' ESCAPE '$'
+---------- AST ------------
+LikeWithEscape {
+    span: Some(
+        2..10,
+    ),
+    left: ColumnRef {
+        span: Some(
+            0..1,
+        ),
+        column: ColumnRef {
+            database: None,
+            table: None,
+            column: Name(
+                Identifier {
+                    span: Some(
+                        0..1,
+                    ),
+                    name: "a",
+                    quote: None,
+                    ident_type: None,
+                },
+            ),
+        },
+    },
+    right: Literal {
+        span: Some(
+            11..19,
+        ),
+        value: String(
+            "%1$%1%",
+        ),
+    },
+    is_not: true,
+    escape: "$",
+}
+
+
+---------- Input ----------
 '中文'::text not in ('a', 'b')
 ---------- Output ---------
 '中文'::STRING NOT IN('a', 'b')
@@ -3617,7 +3699,9 @@ BinaryOp {
     span: Some(
         15..23,
     ),
-    op: LikeAny,
+    op: LikeAny(
+        None,
+    ),
     left: Cast {
         span: Some(
             8..14,
@@ -3656,6 +3740,57 @@ BinaryOp {
             },
         ],
     },
+}
+
+
+---------- Input ----------
+'中文'::text LIKE ANY ('a', 'b') ESCAPE '$'
+---------- Output ---------
+'中文'::STRING LIKE ANY ('a', 'b') ESCAPE '$'
+---------- AST ------------
+LikeAnyWithEscape {
+    span: Some(
+        15..23,
+    ),
+    left: Cast {
+        span: Some(
+            8..14,
+        ),
+        expr: Literal {
+            span: Some(
+                0..8,
+            ),
+            value: String(
+                "中文",
+            ),
+        },
+        target_type: String,
+        pg_style: true,
+    },
+    right: Tuple {
+        span: Some(
+            24..34,
+        ),
+        exprs: [
+            Literal {
+                span: Some(
+                    25..28,
+                ),
+                value: String(
+                    "a",
+                ),
+            },
+            Literal {
+                span: Some(
+                    30..33,
+                ),
+                value: String(
+                    "b",
+                ),
+            },
+        ],
+    },
+    escape: "$",
 }
 
 
@@ -3734,6 +3869,7 @@ LikeSubquery {
         ignore_result: false,
     },
     modifier: Any,
+    escape: None,
 }
 
 
@@ -3812,6 +3948,7 @@ LikeSubquery {
         ignore_result: false,
     },
     modifier: All,
+    escape: None,
 }
 
 
@@ -3890,6 +4027,88 @@ LikeSubquery {
         ignore_result: false,
     },
     modifier: Some,
+    escape: None,
+}
+
+
+---------- Input ----------
+'中文'::text LIKE ANY (SELECT 'a', 'b') ESCAPE '$'
+---------- Output ---------
+'中文'::STRING LIKE ANY (SELECT 'a', 'b') ESCAPE '$'
+---------- AST ------------
+LikeSubquery {
+    span: Some(
+        15..52,
+    ),
+    expr: Cast {
+        span: Some(
+            8..14,
+        ),
+        expr: Literal {
+            span: Some(
+                0..8,
+            ),
+            value: String(
+                "中文",
+            ),
+        },
+        target_type: String,
+        pg_style: true,
+    },
+    subquery: Query {
+        span: Some(
+            25..40,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    25..40,
+                ),
+                hints: None,
+                distinct: false,
+                top_n: None,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                32..35,
+                            ),
+                            value: String(
+                                "a",
+                            ),
+                        },
+                        alias: None,
+                    },
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                37..40,
+                            ),
+                            value: String(
+                                "b",
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: None,
+                having: None,
+                window_list: None,
+                qualify: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+    modifier: Any,
+    escape: Some(
+        "$",
+    ),
 }
 
 

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -3948,7 +3948,9 @@ Query {
                                                         span: Some(
                                                             299..307,
                                                         ),
-                                                        op: NotLike,
+                                                        op: NotLike(
+                                                            None,
+                                                        ),
                                                         left: ColumnRef {
                                                             span: Some(
                                                                 289..298,

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -546,7 +546,7 @@ error:
   --> SQL:1:41
   |
 1 | SELECT * FROM t GROUP BY GROUPING SETS ()
-  | ------                                  ^ unexpected `)`, expecting `(`, `IS`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, `DATE_DIFF`, `DATEDIFF`, or 40 more ...
+  | ------                                  ^ unexpected `)`, expecting `(`, `IS`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `NOT`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, `POSITION`, `IdentVariable`, `DATE_ADD`, `DATE_DIFF`, `DATEDIFF`, or 41 more ...
   | |                                        
   | while parsing `SELECT ...`
 
@@ -968,7 +968,7 @@ error:
   --> SQL:1:65
   |
 1 | CREATE FUNCTION IF NOT EXISTS isnotempty AS(p) -> not(is_null(p)
-  | ------                                   --       ----          ^ unexpected end of input, expecting `)`, `(`, `WITHIN`, `IGNORE`, `RESPECT`, `OVER`, `IS`, `NOT`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, or 46 more ...
+  | ------                                   --       ----          ^ unexpected end of input, expecting `)`, `(`, `WITHIN`, `IGNORE`, `RESPECT`, `OVER`, `IS`, `NOT`, `IN`, `LIKE`, `EXISTS`, `BETWEEN`, `+`, `-`, `*`, `/`, `//`, `DIV`, `%`, `||`, `<->`, `>`, `<`, `>=`, `<=`, `=`, `<>`, `!=`, `^`, `AND`, `OR`, `XOR`, `REGEXP`, `RLIKE`, `SOUNDS`, <BitWiseOr>, <BitWiseAnd>, <BitWiseXor>, <ShiftLeft>, <ShiftRight>, `->`, `->>`, `#>`, `#>>`, `?`, `?|`, `?&`, `@>`, `<@`, `@?`, `@@`, `#-`, <Factorial>, <SquareRoot>, <BitWiseNot>, <CubeRoot>, <Abs>, `CAST`, `TRY_CAST`, `::`, or 47 more ...
   | |                                        |        |  |          
   | |                                        |        |  while parsing `(<expr> [, ...])`
   | |                                        |        while parsing expression

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -868,3 +868,23 @@ impl<Index: ColumnIndex> ExprVisitor<Index> for RewriteCast {
         }
     }
 }
+
+pub fn convert_escape_pattern(pattern: &str, escape_char: char) -> String {
+    let mut result = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == escape_char {
+            if let Some(next_char) = chars.next() {
+                result.push('\\');
+                result.push(next_char);
+            } else {
+                result.push(escape_char);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}

--- a/src/query/expression/tests/it/like_pattern_escape.rs
+++ b/src/query/expression/tests/it/like_pattern_escape.rs
@@ -1,0 +1,28 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_expression::type_check::convert_escape_pattern;
+
+#[test]
+fn test_convert_escape_pattern() {
+    assert_eq!(convert_escape_pattern("%$%%", '$'), "%\\%%");
+
+    assert_eq!(convert_escape_pattern("_$_%", '$'), "_\\_%");
+
+    assert_eq!(convert_escape_pattern("100$%", '$'), "100\\%");
+
+    assert_eq!(convert_escape_pattern("\\\\_%", '\\'), "\\\\\\_%");
+
+    assert_eq!(convert_escape_pattern("hello", '$'), "hello");
+}

--- a/src/query/expression/tests/it/main.rs
+++ b/src/query/expression/tests/it/main.rs
@@ -41,6 +41,8 @@ mod serde;
 mod sort;
 mod types;
 
+mod like_pattern_escape;
+
 fn rand_block_for_all_types(num_rows: usize) -> DataBlock {
     let types = get_all_test_data_types();
     let mut columns = Vec::with_capacity(types.len());

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use databend_common_expression::generate_like_pattern;
+use databend_common_expression::type_check;
 use databend_common_expression::types::boolean::BooleanDomain;
 use databend_common_expression::types::string::StringDomain;
 use databend_common_expression::types::AccessType;
@@ -855,11 +856,20 @@ fn register_like(registry: &mut FunctionRegistry) {
     registry.register_passthrough_nullable_2_arg::<VariantType, StringType, BooleanType, _, _>(
         "like",
         |_, _, _| FunctionDomain::Full,
-        variant_vectorize_like_jsonb(),
+        |arg1, arg2, ctx| {
+            variant_vectorize_like_jsonb()(arg1, arg2, Value::Scalar("".to_string()), ctx)
+        },
+    );
+    registry.register_passthrough_nullable_3_arg::<VariantType, StringType, StringType, BooleanType, _, _>(
+        "like",
+        |_, _, _, _| FunctionDomain::Full,
+       |arg1, arg2, arg3, ctx| {
+           variant_vectorize_like_jsonb()(arg1, arg2, arg3, ctx)
+       },
     );
 
     registry.register_function_factory("like_any", FunctionFactory::Closure(Box::new(|_, args_type: &[DataType]| {
-        if args_type.len() != 2 {
+        if args_type.len() < 2 || args_type.len() > 3 {
             return None;
         }
         let is_nullable = args_type[0].is_nullable();
@@ -867,17 +877,25 @@ fn register_like(registry: &mut FunctionRegistry) {
         if !arg_type.is_string() && !arg_type.is_variant() {
             return None;
         }
-        let DataType::Tuple(patterns_ty) = &args_type[1] else {
-            return None;
+        let mut new_args_type =  match &args_type[1] {
+            DataType::Tuple(patterns_ty) => {
+                if patterns_ty.iter().any(|ty| !ty.is_string() && !ty.is_variant()) {
+                    return None;
+                }
+                vec![arg_type, DataType::Tuple(vec![DataType::String; patterns_ty.len()])]
+            }
+            DataType::String =>
+                vec![arg_type, DataType::String],
+            _ => return None,
         };
-        if patterns_ty.iter().any(|ty| !ty.is_string() && !ty.is_variant()) {
-            return None;
+        if args_type.len() > 2 {
+            new_args_type.push(DataType::String);
         }
 
         let function = Function {
             signature: FunctionSignature {
                 name: "like_any".to_string(),
-                args_type: vec![arg_type, DataType::Tuple(vec![DataType::String; patterns_ty.len()])],
+                args_type: new_args_type,
                 return_type: DataType::Boolean,
             },
             eval: FunctionEval::Scalar {
@@ -887,18 +905,23 @@ fn register_like(registry: &mut FunctionRegistry) {
                     let input_all_scalars = arg.as_scalar().is_some();
                     let process_rows = if input_all_scalars { 1 } else { ctx.num_rows };
 
-                    let Some(Scalar::Tuple(patterns)) = &args[1].as_scalar() else {
-                        ctx.set_error(1, "The second parameter of `like_any` must be of Tuple type");
-                        return Value::Scalar(Scalar::Boolean(Default::default()));
+                    let patterns = match args[1].as_scalar() {
+                        Some(Scalar::Tuple(patterns)) => patterns.clone(),
+                        Some(Scalar::String(pattern)) => vec![Scalar::String(pattern.clone())],
+                        _ => {
+                            ctx.set_error(1, "The second parameter of `like_any` must be of Tuple or String type");
+                            return Value::Scalar(Scalar::Boolean(Default::default()));
+                        }
                     };
+                    let escape: Value<StringType> = args.get(2).cloned().and_then(|value| value.try_downcast()).unwrap_or(Value::Scalar("".to_string()));
 
                     let result = if let Some(value) = arg.try_downcast::<StringType>() {
                         let like = vectorize_like(|str, pattern_type| pattern_type.compare(str));
-                        patterns.iter().map(|pattern| like(value.clone(), Value::<StringType>::Scalar(pattern.as_string().unwrap().clone()), ctx))
+                        patterns.iter().map(|pattern| like(value.clone(), Value::<StringType>::Scalar(pattern.as_string().unwrap().clone()), escape.clone(), ctx))
                             .collect::<Vec<_>>()
                     } else if let Some(value) = arg.try_downcast::<VariantType>() {
                         let like = variant_vectorize_like_jsonb();
-                        patterns.iter().map(|pattern| like(value.clone(), Value::<StringType>::Scalar(pattern.as_string().unwrap().clone()), ctx))
+                        patterns.iter().map(|pattern| like(value.clone(), Value::<StringType>::Scalar(pattern.as_string().unwrap().clone()), escape.clone(), ctx))
                             .collect::<Vec<_>>()
                     } else {
                         ctx.set_error(1, "The first parameter of 'like_any' can only be of type String or Variant");
@@ -908,8 +931,8 @@ fn register_like(registry: &mut FunctionRegistry) {
                     let mut builder = BooleanType::create_builder(process_rows, ctx.generics);
 
                     let patterns_len = patterns.len();
-                    for like_result in result {
-                        builder.push((0..patterns_len).any(|i| like_result.index(i).unwrap()));
+                    for row in 0..process_rows {
+                        builder.push((0..patterns_len).any(|i| result[i].index(row).unwrap()));
                     }
                     if input_all_scalars {
                         Value::<BooleanType>::Scalar(BooleanType::build_scalar(builder))
@@ -931,34 +954,46 @@ fn register_like(registry: &mut FunctionRegistry) {
         "like",
         |_, lhs, rhs| {
             if rhs.max.as_ref() == Some(&rhs.min) {
-                let pattern_type = generate_like_pattern(rhs.min.as_bytes(), 1);
-
-                if matches!(pattern_type, LikePattern::OrdinalStr(_)) {
-                    return lhs.domain_eq(rhs);
-                }
-
-                if matches!(pattern_type, LikePattern::EndOfPercent(_)) {
-                    let mut pat_str = rhs.min.clone();
-                    // remove the last char '%'
-                    pat_str.pop();
-                    let pat_len = pat_str.chars().count();
-                    let other = StringDomain {
-                        min: pat_str.clone(),
-                        max: Some(pat_str),
-                    };
-                    let lhs = StringDomain {
-                        min: lhs.min.chars().take(pat_len).collect(),
-                        max: lhs
-                            .max
-                            .as_ref()
-                            .map(|max| max.chars().take(pat_len).collect()),
-                    };
-                    return lhs.domain_eq(&other);
+                if let Some(value) = calc_like_domain(lhs, rhs.min.to_string()) {
+                    return value;
                 }
             }
             FunctionDomain::Full
         },
-        vectorize_like(|str, pattern_type| pattern_type.compare(str)),
+        |arg1, arg2, ctx| {
+            vectorize_like(|str, pattern_type| pattern_type.compare(str))(
+                arg1,
+                arg2,
+                Value::Scalar("".to_string()),
+                ctx,
+            )
+        },
+    );
+
+    registry.register_passthrough_nullable_3_arg::<StringType, StringType, StringType, BooleanType, _, _>(
+        "like",
+        |_, lhs, rhs, escape| {
+            if rhs.max.as_ref() == Some(&rhs.min) && escape.max.as_ref() == Some(&escape.min) {
+                let pattern = escape
+                    .min
+                    .chars()
+                    .next()
+                    .map(|escape| type_check::convert_escape_pattern(&rhs.min, escape))
+                    .unwrap_or(rhs.min.to_string());
+                if let Some(value) = calc_like_domain(lhs, pattern) {
+                    return value;
+                }
+            }
+            FunctionDomain::Full
+        },
+        |arg1, arg2, arg3, ctx| {
+            vectorize_like(|str, pattern_type| pattern_type.compare(str))(
+                arg1,
+                arg2,
+                arg3,
+                ctx,
+            )
+        },
     );
 
     registry.register_passthrough_nullable_2_arg::<StringType, StringType, BooleanType, _, _>(
@@ -1002,9 +1037,45 @@ fn register_like(registry: &mut FunctionRegistry) {
     );
 }
 
-fn variant_vectorize_like_jsonb(
-) -> impl Fn(Value<VariantType>, Value<StringType>, &mut EvalContext) -> Value<BooleanType> + Copy + Sized
-{
+fn calc_like_domain(lhs: &StringDomain, pattern: String) -> Option<FunctionDomain<BooleanType>> {
+    let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+
+    if matches!(pattern_type, LikePattern::OrdinalStr(_)) {
+        return Some(lhs.domain_eq(&StringDomain {
+            min: pattern.clone(),
+            max: Some(pattern),
+        }));
+    }
+
+    if matches!(pattern_type, LikePattern::EndOfPercent(_)) {
+        let mut pat_str = pattern;
+        // remove the last char '%'
+        pat_str.pop();
+        let pat_len = pat_str.chars().count();
+        let other = StringDomain {
+            min: pat_str.clone(),
+            max: Some(pat_str),
+        };
+        let lhs = StringDomain {
+            min: lhs.min.chars().take(pat_len).collect(),
+            max: lhs
+                .max
+                .as_ref()
+                .map(|max| max.chars().take(pat_len).collect()),
+        };
+        return Some(lhs.domain_eq(&other));
+    }
+    None
+}
+
+fn variant_vectorize_like_jsonb() -> impl Fn(
+    Value<VariantType>,
+    Value<StringType>,
+    Value<StringType>,
+    &mut EvalContext,
+) -> Value<BooleanType>
+       + Copy
+       + Sized {
     variant_vectorize_like(|val, pattern_type| match pattern_type {
         LikePattern::OrdinalStr(_)
         | LikePattern::StartOfPercent(_)
@@ -1035,88 +1106,128 @@ fn variant_vectorize_like_jsonb(
 
 fn vectorize_like(
     func: impl Fn(&[u8], &LikePattern) -> bool + Copy,
-) -> impl Fn(Value<StringType>, Value<StringType>, &mut EvalContext) -> Value<BooleanType> + Copy {
-    move |arg1, arg2, _ctx| match (arg1, arg2) {
-        (Value::Scalar(arg1), Value::Scalar(arg2)) => {
-            let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-            Value::Scalar(func(arg1.as_bytes(), &pattern_type))
-        }
-        (Value::Column(arg1), Value::Scalar(arg2)) => {
-            let arg1_iter = StringType::iter_column(&arg1);
-            let mut builder = MutableBitmap::with_capacity(arg1.len());
-            let pattern_type = generate_like_pattern(arg2.as_bytes(), arg1.total_bytes_len());
-            if let LikePattern::SurroundByPercent(searcher) = pattern_type {
-                for arg1 in arg1_iter {
-                    builder.push(searcher.search(arg1.as_bytes()).is_some());
+) -> impl Fn(
+    Value<StringType>,
+    Value<StringType>,
+    Value<StringType>,
+    &mut EvalContext,
+) -> Value<BooleanType>
+       + Copy {
+    move |arg1, arg2, arg3, _ctx| {
+        let Value::Scalar(escape) = arg3 else {
+            unreachable!()
+        };
+        match (arg1, arg2) {
+            (Value::Scalar(arg1), Value::Scalar(arg2)) => {
+                let pattern = convert_escape_pattern(&escape, arg2);
+                let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+                Value::Scalar(func(arg1.as_bytes(), &pattern_type))
+            }
+            (Value::Column(arg1), Value::Scalar(arg2)) => {
+                let arg1_iter = StringType::iter_column(&arg1);
+                let mut builder = MutableBitmap::with_capacity(arg1.len());
+                let pattern = convert_escape_pattern(&escape, arg2);
+                let pattern_type =
+                    generate_like_pattern(pattern.as_bytes(), arg1.total_bytes_len());
+                if let LikePattern::SurroundByPercent(searcher) = pattern_type {
+                    for arg1 in arg1_iter {
+                        builder.push(searcher.search(arg1.as_bytes()).is_some());
+                    }
+                } else {
+                    for arg1 in arg1_iter {
+                        builder.push(func(arg1.as_bytes(), &pattern_type));
+                    }
                 }
-            } else {
-                for arg1 in arg1_iter {
+
+                Value::Column(builder.into())
+            }
+            (Value::Scalar(arg1), Value::Column(arg2)) => {
+                let arg2_iter = StringType::iter_column(&arg2);
+                let mut builder = MutableBitmap::with_capacity(arg2.len());
+                for arg2 in arg2_iter {
+                    let pattern = convert_escape_pattern(&escape, arg2.to_string());
+                    let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
                     builder.push(func(arg1.as_bytes(), &pattern_type));
                 }
+                Value::Column(builder.into())
             }
-
-            Value::Column(builder.into())
-        }
-        (Value::Scalar(arg1), Value::Column(arg2)) => {
-            let arg2_iter = StringType::iter_column(&arg2);
-            let mut builder = MutableBitmap::with_capacity(arg2.len());
-            for arg2 in arg2_iter {
-                let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-                builder.push(func(arg1.as_bytes(), &pattern_type));
+            (Value::Column(arg1), Value::Column(arg2)) => {
+                let arg1_iter = StringType::iter_column(&arg1);
+                let arg2_iter = StringType::iter_column(&arg2);
+                let mut builder = MutableBitmap::with_capacity(arg2.len());
+                for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
+                    let pattern = convert_escape_pattern(&escape, arg2.to_string());
+                    let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+                    builder.push(func(arg1.as_bytes(), &pattern_type));
+                }
+                Value::Column(builder.into())
             }
-            Value::Column(builder.into())
-        }
-        (Value::Column(arg1), Value::Column(arg2)) => {
-            let arg1_iter = StringType::iter_column(&arg1);
-            let arg2_iter = StringType::iter_column(&arg2);
-            let mut builder = MutableBitmap::with_capacity(arg2.len());
-            for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
-                let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-                builder.push(func(arg1.as_bytes(), &pattern_type));
-            }
-            Value::Column(builder.into())
         }
     }
 }
 
 fn variant_vectorize_like(
     func: impl Fn(&[u8], &LikePattern) -> bool + Copy,
-) -> impl Fn(Value<VariantType>, Value<StringType>, &mut EvalContext) -> Value<BooleanType> + Copy {
-    move |arg1, arg2, _ctx| match (arg1, arg2) {
-        (Value::Scalar(arg1), Value::Scalar(arg2)) => {
-            let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-            Value::Scalar(func(&arg1, &pattern_type))
-        }
-        (Value::Column(arg1), Value::Scalar(arg2)) => {
-            let arg1_iter = VariantType::iter_column(&arg1);
+) -> impl Fn(
+    Value<VariantType>,
+    Value<StringType>,
+    Value<StringType>,
+    &mut EvalContext,
+) -> Value<BooleanType>
+       + Copy {
+    move |arg1, arg2, arg3, _ctx| {
+        let Value::Scalar(escape) = arg3 else {
+            unreachable!()
+        };
+        match (arg1, arg2) {
+            (Value::Scalar(arg1), Value::Scalar(arg2)) => {
+                let pattern = convert_escape_pattern(&escape, arg2);
+                let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+                Value::Scalar(func(&arg1, &pattern_type))
+            }
+            (Value::Column(arg1), Value::Scalar(arg2)) => {
+                let arg1_iter = VariantType::iter_column(&arg1);
 
-            let pattern_type = generate_like_pattern(arg2.as_bytes(), arg1.total_bytes_len());
-            let mut builder = MutableBitmap::with_capacity(arg1.len());
-            for arg1 in arg1_iter {
-                builder.push(func(arg1, &pattern_type));
+                let pattern = convert_escape_pattern(&escape, arg2);
+                let pattern_type =
+                    generate_like_pattern(pattern.as_bytes(), arg1.total_bytes_len());
+                let mut builder = MutableBitmap::with_capacity(arg1.len());
+                for arg1 in arg1_iter {
+                    builder.push(func(arg1, &pattern_type));
+                }
+                Value::Column(builder.into())
             }
-            Value::Column(builder.into())
-        }
-        (Value::Scalar(arg1), Value::Column(arg2)) => {
-            let arg2_iter = StringType::iter_column(&arg2);
-            let mut builder = MutableBitmap::with_capacity(arg2.len());
-            for arg2 in arg2_iter {
-                let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-                builder.push(func(&arg1, &pattern_type));
+            (Value::Scalar(arg1), Value::Column(arg2)) => {
+                let arg2_iter = StringType::iter_column(&arg2);
+                let mut builder = MutableBitmap::with_capacity(arg2.len());
+                for arg2 in arg2_iter {
+                    let pattern = convert_escape_pattern(&escape, arg2.to_string());
+                    let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+                    builder.push(func(&arg1, &pattern_type));
+                }
+                Value::Column(builder.into())
             }
-            Value::Column(builder.into())
-        }
-        (Value::Column(arg1), Value::Column(arg2)) => {
-            let arg1_iter = VariantType::iter_column(&arg1);
-            let arg2_iter = StringType::iter_column(&arg2);
-            let mut builder = MutableBitmap::with_capacity(arg2.len());
-            for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
-                let pattern_type = generate_like_pattern(arg2.as_bytes(), 1);
-                builder.push(func(arg1, &pattern_type));
+            (Value::Column(arg1), Value::Column(arg2)) => {
+                let arg1_iter = VariantType::iter_column(&arg1);
+                let arg2_iter = StringType::iter_column(&arg2);
+                let mut builder = MutableBitmap::with_capacity(arg2.len());
+                for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
+                    let pattern = convert_escape_pattern(&escape, arg2.to_string());
+                    let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
+                    builder.push(func(arg1, &pattern_type));
+                }
+                Value::Column(builder.into())
             }
-            Value::Column(builder.into())
         }
     }
+}
+
+fn convert_escape_pattern(escape: &str, arg2: String) -> String {
+    escape
+        .chars()
+        .next()
+        .map(|escape| type_check::convert_escape_pattern(&arg2, escape))
+        .unwrap_or(arg2)
 }
 
 fn vectorize_regexp(

--- a/src/query/functions/src/test_utils.rs
+++ b/src/query/functions/src/test_utils.rs
@@ -197,7 +197,7 @@ fn transform_expr(ast: AExpr, columns: &[(&str, DataType)]) -> RawExpr {
             left,
             right,
         } => match op {
-            BinaryOperator::NotLike => {
+            BinaryOperator::NotLike(_) => {
                 unimplemented!("please use `not (a like b)` instead")
             }
             BinaryOperator::NotRLike | BinaryOperator::NotRegexp => {

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -2239,8 +2239,12 @@ Functions overloads:
 8 length(Binary NULL) :: UInt64 NULL
 0 like(Variant, String) :: Boolean
 1 like(Variant NULL, String NULL) :: Boolean NULL
-2 like(String, String) :: Boolean
-3 like(String NULL, String NULL) :: Boolean NULL
+2 like(Variant, String, String) :: Boolean
+3 like(Variant NULL, String NULL, String NULL) :: Boolean NULL
+4 like(String, String) :: Boolean
+5 like(String NULL, String NULL) :: Boolean NULL
+6 like(String, String, String) :: Boolean
+7 like(String NULL, String NULL, String NULL) :: Boolean NULL
 0 like_any FACTORY
 0 ln(UInt8) :: Float64
 1 ln(UInt8 NULL) :: Float64 NULL

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -705,19 +705,18 @@ impl SubqueryDecorrelatorOptimizer {
                     &subquery.data_type,
                 );
                 let child_expr = *subquery.child_expr.as_ref().unwrap().clone();
-                let op = *subquery.compare_op.as_ref().unwrap();
+                let op = subquery.compare_op.as_ref().unwrap().clone();
                 let (right_condition, is_non_equi_condition) =
                     check_child_expr_in_subquery(&child_expr, &op)?;
                 let (left_conditions, right_conditions, non_equi_conditions) =
                     if !is_non_equi_condition {
                         (vec![left_condition], vec![right_condition], vec![])
                     } else {
-                        let other_condition = ScalarExpr::FunctionCall(FunctionCall {
-                            span: subquery.span,
-                            func_name: op.to_func_name().to_string(),
-                            params: vec![],
-                            arguments: vec![right_condition, left_condition],
-                        });
+                        let other_condition = ScalarExpr::FunctionCall(op.to_func_call(
+                            subquery.span,
+                            right_condition,
+                            left_condition,
+                        ));
                         (vec![], vec![], vec![other_condition])
                     };
                 // Add a marker column to save comparison result.

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -66,6 +67,7 @@ use databend_common_expression::infer_schema_type;
 use databend_common_expression::shrink_scalar;
 use databend_common_expression::type_check;
 use databend_common_expression::type_check::check_number;
+use databend_common_expression::type_check::convert_escape_pattern;
 use databend_common_expression::types::decimal::DecimalScalar;
 use databend_common_expression::types::decimal::DecimalSize;
 use databend_common_expression::types::decimal::MAX_DECIMAL128_PRECISION;
@@ -521,25 +523,7 @@ impl<'a> TypeChecker<'a> {
                 left,
                 right,
                 ..
-            } => {
-                if let Expr::Subquery {
-                    subquery,
-                    modifier: Some(subquery_modifier),
-                    ..
-                } = &**right
-                {
-                    self.resolve_scalar_subquery(
-                        subquery,
-                        left,
-                        span,
-                        &right.span(),
-                        subquery_modifier,
-                        op,
-                    )?
-                } else {
-                    self.resolve_binary_op(*span, op, left.as_ref(), right.as_ref())?
-                }
-            }
+            } => self.resolve_binary_op_or_subquery(span, op, left, right)?,
 
             Expr::JsonOp {
                 span,
@@ -993,19 +977,49 @@ impl<'a> TypeChecker<'a> {
                     Some(SubqueryComparisonOp::Equal),
                 )?
             }
+
             Expr::LikeSubquery {
                 subquery,
                 expr,
                 span,
                 modifier,
+                escape,
             } => self.resolve_scalar_subquery(
                 subquery,
                 expr,
                 span,
                 span,
                 modifier,
-                &BinaryOperator::Like,
+                &BinaryOperator::Like(escape.clone()),
             )?,
+
+            Expr::LikeAnyWithEscape {
+                span,
+                left,
+                right,
+                escape,
+            } => self.resolve_binary_op_or_subquery(
+                span,
+                &BinaryOperator::LikeAny(Some(escape.clone())),
+                left,
+                right,
+            )?,
+
+            Expr::LikeWithEscape {
+                span,
+                left,
+                right,
+                is_not,
+                escape,
+            } => {
+                let like_op = if *is_not {
+                    BinaryOperator::NotLike(Some(escape.clone()))
+                } else {
+                    BinaryOperator::Like(Some(escape.clone()))
+                };
+
+                self.resolve_binary_op_or_subquery(span, &like_op, left, right)?
+            }
 
             expr @ Expr::MapAccess { span, .. } => {
                 let mut expr = expr;
@@ -1170,6 +1184,25 @@ impl<'a> TypeChecker<'a> {
             }
         };
         Ok(Box::new((scalar, data_type)))
+    }
+
+    fn resolve_binary_op_or_subquery(
+        &mut self,
+        span: &Span,
+        op: &BinaryOperator,
+        left: &Expr,
+        right: &Expr,
+    ) -> Result<Box<(ScalarExpr, DataType)>> {
+        if let Expr::Subquery {
+            subquery,
+            modifier: Some(subquery_modifier),
+            ..
+        } = right
+        {
+            self.resolve_scalar_subquery(subquery, left, span, &right.span(), subquery_modifier, op)
+        } else {
+            self.resolve_binary_op(*span, op, left, right)
+        }
     }
 
     fn resolve_scalar_subquery(
@@ -3077,9 +3110,9 @@ impl<'a> TypeChecker<'a> {
         right: &Expr,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
         match op {
-            BinaryOperator::NotLike | BinaryOperator::NotRegexp | BinaryOperator::NotRLike => {
+            BinaryOperator::NotLike(_) | BinaryOperator::NotRegexp | BinaryOperator::NotRLike => {
                 let positive_op = match op {
-                    BinaryOperator::NotLike => BinaryOperator::Like,
+                    BinaryOperator::NotLike(escape) => BinaryOperator::Like(escape.clone()),
                     BinaryOperator::NotRegexp => BinaryOperator::Regexp,
                     BinaryOperator::NotRLike => BinaryOperator::RLike,
                     _ => unreachable!(),
@@ -3104,17 +3137,19 @@ impl<'a> TypeChecker<'a> {
                     vec![left, right],
                 )
             }
-            BinaryOperator::Like => {
+            BinaryOperator::Like(escape) => {
                 // Convert `Like` to compare function , such as `p_type like PROMO%` will be converted to `p_type >= PROMO and p_type < PROMP`
                 if let Expr::Literal {
                     value: Literal::String(str),
                     ..
                 } = right
                 {
-                    return self.resolve_like(op, span, left, right, str);
+                    return self.resolve_like(op, span, left, right, str, escape);
                 }
-                let name = op.to_func_name();
-                self.resolve_function(span, name.as_str(), vec![], &[left, right])
+                self.resolve_like_escape(op, span, left, right, escape)
+            }
+            BinaryOperator::LikeAny(escape) => {
+                self.resolve_like_escape(op, span, left, right, escape)
             }
             BinaryOperator::Eq | BinaryOperator::NotEq => {
                 let name = op.to_func_name();
@@ -4343,13 +4378,22 @@ impl<'a> TypeChecker<'a> {
         left: &Expr,
         right: &Expr,
         like_str: &str,
+        escape: &Option<String>,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
-        if check_const(like_str) {
+        let new_like_str = if let Some(escape) = escape {
+            Cow::Owned(convert_escape_pattern(
+                like_str,
+                escape.chars().next().unwrap(),
+            ))
+        } else {
+            Cow::Borrowed(like_str)
+        };
+        if check_const(&new_like_str) {
             // Convert to equal comparison
             self.resolve_binary_op(span, &BinaryOperator::Eq, left, right)
-        } else if check_prefix(like_str) {
+        } else if check_prefix(&new_like_str) {
             // Convert to `a >= like_str and a < like_str + 1`
-            let mut char_vec: Vec<char> = like_str[0..like_str.len() - 1].chars().collect();
+            let mut char_vec: Vec<char> = new_like_str[0..new_like_str.len() - 1].chars().collect();
             let len = char_vec.len();
             let ascii_val = *char_vec.last().unwrap() as u8 + 1;
             char_vec[len - 1] = ascii_val as char;
@@ -4357,7 +4401,7 @@ impl<'a> TypeChecker<'a> {
             let (new_left, _) =
                 *self.resolve_binary_op(span, &BinaryOperator::Gte, left, &Expr::Literal {
                     span: None,
-                    value: Literal::String(like_str[..like_str.len() - 1].to_owned()),
+                    value: Literal::String(new_like_str[..new_like_str.len() - 1].to_owned()),
                 })?;
             let (new_right, _) =
                 *self.resolve_binary_op(span, &BinaryOperator::Lt, left, &Expr::Literal {
@@ -4366,9 +4410,28 @@ impl<'a> TypeChecker<'a> {
                 })?;
             self.resolve_scalar_function_call(span, "and", vec![], vec![new_left, new_right])
         } else {
-            let name = op.to_func_name();
-            self.resolve_function(span, name.as_str(), vec![], &[left, right])
+            self.resolve_like_escape(op, span, left, right, escape)
         }
+    }
+
+    fn resolve_like_escape(
+        &mut self,
+        op: &BinaryOperator,
+        span: Span,
+        left: &Expr,
+        right: &Expr,
+        escape: &Option<String>,
+    ) -> Result<Box<(ScalarExpr, DataType)>> {
+        let name = op.to_func_name();
+        let escape_expr = escape.as_ref().map(|escape| Expr::Literal {
+            span,
+            value: Literal::String(escape.clone()),
+        });
+        let mut arguments = vec![left, right];
+        if let Some(expr) = &escape_expr {
+            arguments.push(expr)
+        }
+        self.resolve_function(span, name.as_str(), vec![], &arguments)
     }
 
     fn resolve_udf(

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
@@ -5,7 +5,7 @@ statement ok
 create table t1 (s varchar);
 
 statement ok
-insert into t1 values('abcde'), ('abce'), ('abcd['), ('abcd');
+insert into t1 values('abcde'), ('abce'), ('abcd['), ('abcd'), ('ab%cd');
 
 query T
 select * from t1 where s like 'abcd%' order by s;
@@ -20,21 +20,21 @@ explain select * from t1 where s like 'abcd%' order by s;
 Sort
 ├── output columns: [t1.s (#0)]
 ├── sort keys: [s ASC NULLS LAST]
-├── estimated rows: 0.80
+├── estimated rows: 1.00
 └── Filter
     ├── output columns: [t1.s (#0)]
     ├── filters: [is_true(t1.s (#0) >= 'abcd'), is_true(t1.s (#0) < 'abce')]
-    ├── estimated rows: 0.80
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.default.t1
         ├── output columns: [s (#0)]
-        ├── read rows: 4
+        ├── read rows: 5
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
         ├── push downs: [filters: [and_filters(t1.s (#0) >= 'abcd', t1.s (#0) < 'abce')], limit: NONE]
-        └── estimated rows: 4.00
+        └── estimated rows: 5.00
 
 query T
 select * from t1 where s like 'abcd' order by s;
@@ -47,18 +47,117 @@ explain select * from t1 where s like 'abcd' order by s;
 Sort
 ├── output columns: [t1.s (#0)]
 ├── sort keys: [s ASC NULLS LAST]
-├── estimated rows: 2.00
+├── estimated rows: 1.00
 └── Filter
     ├── output columns: [t1.s (#0)]
     ├── filters: [is_true(t1.s (#0) = 'abcd')]
-    ├── estimated rows: 2.00
+    ├── estimated rows: 1.00
     └── TableScan
         ├── table: default.default.t1
         ├── output columns: [s (#0)]
-        ├── read rows: 4
+        ├── read rows: 5
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
         ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
         ├── push downs: [filters: [is_true(t1.s (#0) = 'abcd')], limit: NONE]
-        └── estimated rows: 4.00
+        └── estimated rows: 5.00
+
+query T
+select * from t1 where s like any ('abc%');
+----
+abcde
+abce
+abcd[
+abcd
+
+
+query T
+explain select * from t1 where s like any ('abc%');
+----
+Filter
+├── output columns: [t1.s (#0)]
+├── filters: [is_true(like_any(t1.s (#0), 'abc%'))]
+├── estimated rows: 1.00
+└── TableScan
+    ├── table: default.default.t1
+    ├── output columns: [s (#0)]
+    ├── read rows: 5
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like_any(t1.s (#0), 'abc%'))], limit: NONE]
+    └── estimated rows: 5.00
+
+query T
+select * from t1 where s like any ('abc%', '%bcd');
+----
+abcde
+abce
+abcd[
+abcd
+
+query T
+explain select * from t1 where s like any ('abc%', '%bcd');
+----
+Filter
+├── output columns: [t1.s (#0)]
+├── filters: [is_true(like_any(t1.s (#0), ('abc%', '%bcd')))]
+├── estimated rows: 1.00
+└── TableScan
+    ├── table: default.default.t1
+    ├── output columns: [s (#0)]
+    ├── read rows: 5
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like_any(t1.s (#0), ('abc%', '%bcd')))], limit: NONE]
+    └── estimated rows: 5.00
+
+query T
+select * from t1 where s like '%b$%c%' escape '$';
+----
+ab%cd
+
+query T
+explain select * from t1 where s like '%b$%c%' escape '$';
+----
+Filter
+├── output columns: [t1.s (#0)]
+├── filters: [is_true(like(t1.s (#0), '%b$%c%', '$'))]
+├── estimated rows: 2.50
+└── TableScan
+    ├── table: default.default.t1
+    ├── output columns: [s (#0)]
+    ├── read rows: 5
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like(t1.s (#0), '%b$%c%', '$'))], limit: NONE]
+    └── estimated rows: 5.00
+
+query T
+select * from t1 where s like any ('%b$%c%') escape '$';
+----
+ab%cd
+
+query T
+explain select * from t1 where s like any ('%b$%c%') escape '$';
+----
+Filter
+├── output columns: [t1.s (#0)]
+├── filters: [is_true(like_any(t1.s (#0), '%b$%c%', '$'))]
+├── estimated rows: 1.00
+└── TableScan
+    ├── table: default.default.t1
+    ├── output columns: [s (#0)]
+    ├── read rows: 5
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like_any(t1.s (#0), '%b$%c%', '$'))], limit: NONE]
+    └── estimated rows: 5.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -751,25 +751,14 @@ statement ok
 create table t (i string);
 
 statement ok
-insert into t values('database'), ('databend');
+insert into t values('database'), ('databend'), ('data%base');
 
 query T
-explain select * from t where i like any ('data%', '%bend');
+select * from t where i like any (select 'data%');
 ----
-Filter
-├── output columns: [t.i (#0)]
-├── filters: [is_true(like_any(t.i (#0), ('data%', '%bend')))]
-├── estimated rows: 0.40
-└── TableScan
-    ├── table: default.default.t
-    ├── output columns: [i (#0)]
-    ├── read rows: 2
-    ├── read size: < 1 KiB
-    ├── partitions total: 1
-    ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    ├── push downs: [filters: [is_true(like_any(t.i (#0), ('data%', '%bend')))], limit: NONE]
-    └── estimated rows: 2.00
+database
+databend
+data%base
 
 query T
 explain select * from t where i like any (select 'data%');
@@ -777,20 +766,27 @@ explain select * from t where i like any (select 'data%');
 Filter
 ├── output columns: [t.i (#0)]
 ├── filters: [is_true(like(t.i (#0), 'data%'))]
-├── estimated rows: 0.40
+├── estimated rows: 0.60
 └── TableScan
     ├── table: default.default.t
     ├── output columns: [i (#0)]
-    ├── read rows: 2
+    ├── read rows: 3
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     ├── push downs: [filters: [is_true(like(t.i (#0), 'data%'))], limit: NONE]
-    └── estimated rows: 2.00
+    └── estimated rows: 3.00
 
 query T
-explain select * from t where i like any (SELECT c1 FROM (VALUES ('data')) words(c1));
+select * from t where i like any (SELECT c1 FROM (VALUES ('data%')) words(c1));
+----
+database
+databend
+data%base
+
+query T
+explain select * from t where i like any (SELECT c1 FROM (VALUES ('data%')) words(c1));
 ----
 HashJoin
 ├── output columns: [t.i (#0)]
@@ -800,20 +796,74 @@ HashJoin
 ├── keys is null equal: []
 ├── filters: [like(t.i (#0), CAST(subquery_1 (#1) AS String NULL))]
 ├── build join filters:
-├── estimated rows: 2.00
+├── estimated rows: 3.00
 ├── ConstantTableScan(Build)
 │   ├── output columns: [c1 (#1)]
-│   └── column 0: ['data']
+│   └── column 0: ['data%']
 └── TableScan(Probe)
     ├── table: default.default.t
     ├── output columns: [i (#0)]
-    ├── read rows: 2
+    ├── read rows: 3
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
     ├── push downs: [filters: [], limit: NONE]
-    └── estimated rows: 2.00
+    └── estimated rows: 3.00
+
+query T
+select * from t where i like any (select 'data$%%') escape '$';
+----
+data%base
+
+query T
+explain select * from t where i like any (select 'data$%%') escape '$';
+----
+Filter
+├── output columns: [t.i (#0)]
+├── filters: [is_true(like(t.i (#0), 'data$%%', '$'))]
+├── estimated rows: 0.60
+└── TableScan
+    ├── table: default.default.t
+    ├── output columns: [i (#0)]
+    ├── read rows: 3
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [is_true(like(t.i (#0), 'data$%%', '$'))], limit: NONE]
+    └── estimated rows: 3.00
+
+query T
+select * from t where i like any (SELECT c1 FROM (VALUES ('data$%%')) words(c1)) escape '$';
+----
+data%base
+
+query T
+explain select * from t where i like any (SELECT c1 FROM (VALUES ('data$%%')) words(c1)) escape '$';
+----
+HashJoin
+├── output columns: [t.i (#0)]
+├── join type: LEFT SEMI
+├── build keys: []
+├── probe keys: []
+├── keys is null equal: []
+├── filters: [like(t.i (#0), CAST(subquery_1 (#1) AS String NULL), '$')]
+├── build join filters:
+├── estimated rows: 3.00
+├── ConstantTableScan(Build)
+│   ├── output columns: [c1 (#1)]
+│   └── column 0: ['data$%%']
+└── TableScan(Probe)
+    ├── table: default.default.t
+    ├── output columns: [i (#0)]
+    ├── read rows: 3
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 3.00
 
 statement ok
 drop table if exists t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- `[NOT] LIKE <expr> ESCAPE ‘<escape>’`
- `LIKE ANY (<pattern1>, [<pattern2>, ...]) ESCAPE ‘<escape>’`
- `LIKE ANY (SELECT ...) ESCAPE ‘<escape>’`

fixes: https://github.com/databendlabs/databend/issues/18096

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
