### PR TITLE
feat: streaming load support values with placeholder.

### DIFF
--- a/src/query/service/src/servers/http/v1/streaming_load.rs
+++ b/src/query/service/src/servers/http/v1/streaming_load.rs
@@ -114,7 +114,7 @@ pub async fn streaming_load_handler(
 }
 
 #[async_backtrace::framed]
-pub async fn streaming_load_handler_inner(
+async fn streaming_load_handler_inner(
     http_context: &HttpQueryContext,
     req: &Request,
     multipart: Multipart,
@@ -165,18 +165,15 @@ pub async fn streaming_load_handler_inner(
     match &mut plan {
         Plan::Insert(insert) => {
             match &mut insert.source {
-                InsertInputSource::StreamingLoad {
-                    file_format: format,
-                    receiver,
-                    ..
-                } => {
-                    if !format.support_streaming_load() {
-                        return Err(poem::Error::from_string( format!( "[HTTP-STREAMING-LOAD] Unsupported file format: {}", format.get_type() ), StatusCode::BAD_REQUEST));
+                InsertInputSource::StreamingLoad(streaming_load)
+                 => {
+                    if !streaming_load.file_format.support_streaming_load() {
+                        return Err(poem::Error::from_string( format!( "[HTTP-STREAMING-LOAD] Unsupported file format: {}", streaming_load.file_format.get_type() ), StatusCode::BAD_REQUEST));
                     }
                     let (tx, rx) = tokio::sync::mpsc::channel(1);
-                    *receiver.lock() = Some(rx);
+                    *streaming_load.receiver.lock() = Some(rx);
 
-                    let format = format.clone();
+                    let format = streaming_load.file_format.clone();
                     let handler = query_context.spawn(execute_query(http_context.clone(), query_context.clone(), plan, mem_stat));
                     read_multi_part(multipart, &format, tx, input_read_buffer_size).await?;
 

--- a/src/query/sql/src/planner/binder/replace.rs
+++ b/src/query/sql/src/planner/binder/replace.rs
@@ -121,7 +121,7 @@ impl Binder {
                                 catalog_name.clone(),
                                 database_name.clone(),
                                 table_name.clone(),
-                                Arc::new(schema.clone().into()),
+                                schema.clone(),
                                 &values_str,
                                 CopyIntoTableMode::Replace,
                             )

--- a/src/query/sql/src/planner/plans/copy_into_table.rs
+++ b/src/query/sql/src/planner/plans/copy_into_table.rs
@@ -123,11 +123,13 @@ pub struct CopyIntoTablePlan {
     pub table_name: String,
     pub from_attachment: bool,
 
+    // given SQL: ... into table (c1, c2, c3, c4) values (1, ?, 'a', ?)
+    // required_values_schema = (c1, c2, c3, c4)
+    // required_source_schema = (c2, c4)
+    // values_consts = [1, 'a']
     pub required_values_schema: DataSchemaRef,
-    // ... into table(<columns>) ..  -> <columns>
     pub values_consts: Vec<Scalar>,
-    // (1, ?, 'a', ?) -> (1, 'a')
-    pub required_source_schema: DataSchemaRef, // (1, ?, 'a', ?) -> (?, ?)
+    pub required_source_schema: DataSchemaRef,
 
     pub write_mode: CopyIntoTableMode,
     pub validation_mode: ValidationMode,

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
@@ -4,6 +4,7 @@
 >>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3, '1' as c2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
 q1.parquet	624	1
 >>>> streaming load: q1.parquet error :
++ curl -sS -H x-databend-query-id:load-q1 -H 'sql:insert into streaming_load_parquet(c2,c3) values file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q1.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-q1","stats":{"rows":1,"bytes":25}}
 <<<<
 >>>> select * from streaming_load_parquet;
@@ -11,39 +12,43 @@ ok	1	2021-01-01
 <<<<
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3
->>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q1.parquet	426	1
->>>> streaming load: q1.parquet error :
-{"error":{"code":400,"message":"[HTTP-STREAMING-LOAD] Query execution failed: file q1.parquet missing column `c2`"}}
+>>>> copy into @streaming_load_parquet/q2.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+q2.parquet	426	1
+>>>> streaming load: q2.parquet error :
++ curl -sS -H x-databend-query-id:load-q2 -H 'sql:insert into streaming_load_parquet(c2,c3) values file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q2.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"error":{"code":400,"message":"[HTTP-STREAMING-LOAD] Query execution failed: file q2.parquet missing column `c2`"}}
 <<<<
 >>>> select * from streaming_load_parquet;
 <<<<
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3
->>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q1.parquet	426	1
->>>> streaming load: q1.parquet field_default :
-{"id":"load-q1","stats":{"rows":1,"bytes":21}}
+>>>> copy into @streaming_load_parquet/q3.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+q3.parquet	426	1
+>>>> streaming load: q3.parquet field_default :
++ curl -sS -H x-databend-query-id:load-q3 -H 'sql:insert into streaming_load_parquet(c2,c3) values file_format = (type='\''parquet'\'', missing_field_as=field_default, null_if=())' -F upload=@/tmp/streaming_load_parquet/q3.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-q3","stats":{"rows":1,"bytes":21}}
 <<<<
 >>>> select * from streaming_load_parquet;
 ok	NULL	2021-01-01
 <<<<
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3, 'my_null' as c1
->>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q1.parquet	643	1
->>>> streaming load: q1.parquet error :
-{"id":"load-q1","stats":{"rows":1,"bytes":26}}
+>>>> copy into @streaming_load_parquet/q4.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+q4.parquet	643	1
+>>>> streaming load: q4.parquet error :
++ curl -sS -H x-databend-query-id:load-q4 -H 'sql:insert into streaming_load_parquet(c1,c3) values file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q4.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-q4","stats":{"rows":1,"bytes":26}}
 <<<<
 >>>> select * from streaming_load_parquet;
 my_null	NULL	2021-01-01
 <<<<
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3, 'my_null' as c1
->>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q1.parquet	643	1
->>>> streaming load: q1.parquet error 'my_null':
-{"id":"load-q1","stats":{"rows":1,"bytes":7}}
+>>>> copy into @streaming_load_parquet/q5.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+q5.parquet	643	1
+>>>> streaming load: q5.parquet error 'my_null':
++ curl -sS -H x-databend-query-id:load-q5 -H 'sql:insert into streaming_load_parquet(c1,c3) values file_format = (type='\''parquet'\'', missing_field_as=error, null_if=('\''my_null'\''))' -F upload=@/tmp/streaming_load_parquet/q5.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-q5","stats":{"rows":1,"bytes":7}}
 <<<<
 >>>> select * from streaming_load_parquet;
 NULL	NULL	2021-01-01

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
@@ -14,7 +14,7 @@ function run() {
   echo "--$2"
   stmt "copy into @streaming_load_parquet/$1.parquet from (select $2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;"
   echo ">>>> streaming load: $1.parquet $4 $5:"
-  curl -sS -H "x-databend-query-id:load-$1" -H "sql:insert into streaming_load_parquet($3) values file_format = (type='parquet', missing_field_as=$4, null_if=($5))" -F "upload=@$DATA/$1.parquet" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load"
+  (set -x; curl -sS -H "x-databend-query-id:load-$1" -H "sql:insert into streaming_load_parquet($3) values file_format = (type='parquet', missing_field_as=$4, null_if=($5))" -F "upload=@$DATA/$1.parquet" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load")
   echo
   echo "<<<<"
   query "select * from streaming_load_parquet;"
@@ -22,9 +22,9 @@ function run() {
 }
 
 run "q1" "'2021-01-01' as c3, '1' as c2"  "c2,c3" "error" ""
-run "q1" "'2021-01-01' as c3"  "c2,c3" "error" ""
-run "q1" "'2021-01-01' as c3"  "c2,c3" "field_default" ""
-run "q1" "'2021-01-01' as c3, 'my_null' as c1"  "c1,c3" "error" ""
-run "q1" "'2021-01-01' as c3, 'my_null' as c1"  "c1,c3" "error" "'my_null'"
+run "q2" "'2021-01-01' as c3"  "c2,c3" "error" ""
+run "q3" "'2021-01-01' as c3"  "c2,c3" "field_default" ""
+run "q4" "'2021-01-01' as c3, 'my_null' as c1"  "c1,c3" "error" ""
+run "q5" "'2021-01-01' as c3, 'my_null' as c1"  "c1,c3" "error" "'my_null'"
 
 stmt "drop table if exists streaming_load_parquet"

--- a/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.result
+++ b/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.result
@@ -1,0 +1,43 @@
+>>>> create or replace stage streaming_load_07 url='fs:///tmp/streaming_load_07/';
+>>>> CREATE or replace TABLE streaming_load_07 (c1 string default 'ok', c2 int, c3 string, c4 date);
+--csv
+>>>> copy into @streaming_load_07/data.csv from (select '2020-01-02' as c4, 110 as c2) file_format=(type='csv')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+data.csv	17	1
++ curl -sS -H x-databend-query-id:load-csv -H 'sql:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) file_format = (type=csv)' -F upload=@/tmp/streaming_load_07/data.csv -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-csv","stats":{"rows":1,"bytes":39}}
+<<<<
+>>>> select * from streaming_load_07;
+ok	110	a	2020-01-02
+<<<<
+>>>> truncate table streaming_load_07
+--tsv
+>>>> copy into @streaming_load_07/data.tsv from (select '2020-01-02' as c4, 110 as c2) file_format=(type='tsv')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+data.tsv	15	1
++ curl -sS -H x-databend-query-id:load-tsv -H 'sql:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) file_format = (type=tsv)' -F upload=@/tmp/streaming_load_07/data.tsv -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-tsv","stats":{"rows":1,"bytes":39}}
+<<<<
+>>>> select * from streaming_load_07;
+ok	110	a	2020-01-02
+<<<<
+>>>> truncate table streaming_load_07
+--ndjson
+>>>> copy into @streaming_load_07/data.ndjson from (select '2020-01-02' as c4, 110 as c2) file_format=(type='ndjson')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+data.ndjson	29	1
++ curl -sS -H x-databend-query-id:load-ndjson -H 'sql:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) file_format = (type=ndjson)' -F upload=@/tmp/streaming_load_07/data.ndjson -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-ndjson","stats":{"rows":1,"bytes":39}}
+<<<<
+>>>> select * from streaming_load_07;
+ok	110	a	2020-01-02
+<<<<
+>>>> truncate table streaming_load_07
+--parquet
+>>>> copy into @streaming_load_07/data.parquet from (select '2020-01-02' as c4, 110 as c2) file_format=(type='parquet')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
+data.parquet	665	1
++ curl -sS -H x-databend-query-id:load-parquet -H 'sql:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) file_format = (type=parquet)' -F upload=@/tmp/streaming_load_07/data.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
+{"id":"load-parquet","stats":{"rows":1,"bytes":39}}
+<<<<
+>>>> select * from streaming_load_07;
+ok	110	a	2020-01-02
+<<<<
+>>>> truncate table streaming_load_07
+>>>> drop table if exists streaming_load_07

--- a/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+
+DATA="/tmp/streaming_load_07"
+rm -rf $DATA
+mkdir $DATA
+stmt "create or replace stage streaming_load_07 url='fs://$DATA/';"
+stmt "CREATE or replace TABLE streaming_load_07 (c1 string default 'ok', c2 int, c3 string, c4 date);"
+
+function run() {
+  echo "--$1"
+  stmt "copy into @streaming_load_07/data.$1 from (select '2020-01-02' as c4, 110 as c2) file_format=(type='$1')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;"
+  (set -x; curl -sS -H "x-databend-query-id:load-$1" -H "sql:insert into streaming_load_07(c3, c4, c2) values ('a', ?, ?) file_format = (type=$1)" -F "upload=@$DATA/data.$1" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load")
+  echo
+  echo "<<<<"
+  query "select * from streaming_load_07;"
+  stmt "truncate table streaming_load_07"
+}
+
+run "csv"
+run "tsv"
+run "ndjson"
+run "parquet"
+
+stmt "drop table if exists streaming_load_07"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

## motivation:

`insert with stage` already support this,   streaming load  need to support it too, in order to serve as an alternative of `insert with stage`


## example:

```
create table user (id string default uuid(), name string, age int, load_date date)

curl  -H "sql:insert into user(name, age,  load_date) values (?, ?, '2025-01-02') upload=@/tmp/name_age.csv "-u root: -XPUT http://localhost:8000/v1/streaming_load
```


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18129)
<!-- Reviewable:end -->
