### PR TITLE
chore(query): refactoring `BlockEntry`

### DIFF
--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -227,14 +227,17 @@ impl InternalColumn {
 
                 UInt64Type::from_data(row_ids).into()
             }
-            InternalColumnType::BlockName => {
-                BlockEntry::from_arg_scalar::<StringType>(meta.block_location.clone())
-            }
-            InternalColumnType::SegmentName => {
-                BlockEntry::from_arg_scalar::<StringType>(meta.segment_location.clone())
-            }
-            InternalColumnType::SnapshotName => BlockEntry::from_arg_scalar::<StringType>(
+            InternalColumnType::BlockName => BlockEntry::new_const_column_arg::<StringType>(
+                meta.block_location.clone(),
+                num_rows,
+            ),
+            InternalColumnType::SegmentName => BlockEntry::new_const_column_arg::<StringType>(
+                meta.segment_location.clone(),
+                num_rows,
+            ),
+            InternalColumnType::SnapshotName => BlockEntry::new_const_column_arg::<StringType>(
                 meta.snapshot_location.clone().unwrap_or_default(),
+                num_rows,
             ),
             InternalColumnType::BaseRowId => {
                 let uuid =

--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -32,7 +32,6 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::FromData;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
-use databend_common_expression::Value;
 use databend_common_expression::BASE_BLOCK_IDS_COLUMN_ID;
 use databend_common_expression::BASE_ROW_ID_COLUMN_ID;
 use databend_common_expression::BLOCK_NAME_COLUMN_ID;
@@ -263,9 +262,10 @@ impl InternalColumn {
             }
             InternalColumnType::BaseBlockIds => {
                 assert!(meta.base_block_ids.is_some());
-                BlockEntry::new(
+                BlockEntry::new_const_column(
                     DataType::Array(Box::new(DataType::Decimal(DecimalSize::default_128()))),
-                    Value::Scalar(meta.base_block_ids.clone().unwrap()),
+                    meta.base_block_ids.clone().unwrap(),
+                    num_rows,
                 )
             }
             InternalColumnType::SearchMatched => {

--- a/src/query/catalog/src/plan/stream_column.rs
+++ b/src/query/catalog/src/plan/stream_column.rs
@@ -124,12 +124,7 @@ impl StreamColumnMeta {
 
 pub fn build_origin_block_row_num(num_rows: usize) -> BlockEntry {
     let row_ids = (0..num_rows as u64).collect();
-    let column = Value::Column(UInt64Type::from_data(row_ids));
-
-    BlockEntry::new(
-        DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
-        column.wrap_nullable(None),
-    )
+    UInt64Type::from_data(row_ids).wrap_nullable(None).into()
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/query/catalog/src/plan/stream_column.rs
+++ b/src/query/catalog/src/plan/stream_column.rs
@@ -194,7 +194,7 @@ impl StreamColumn {
         match &self.column_type {
             StreamColumnType::OriginVersion | StreamColumnType::RowVersion => unreachable!(),
             StreamColumnType::OriginBlockId => {
-                BlockEntry::from_value(meta.build_origin_block_id(), || {
+                BlockEntry::new(meta.build_origin_block_id(), || {
                     (
                         DataType::Nullable(Box::new(DataType::Decimal(DecimalSize::default_128()))),
                         num_rows,

--- a/src/query/catalog/src/plan/stream_column.rs
+++ b/src/query/catalog/src/plan/stream_column.rs
@@ -193,10 +193,14 @@ impl StreamColumn {
     pub fn generate_column_values(&self, meta: &StreamColumnMeta, num_rows: usize) -> BlockEntry {
         match &self.column_type {
             StreamColumnType::OriginVersion | StreamColumnType::RowVersion => unreachable!(),
-            StreamColumnType::OriginBlockId => BlockEntry::new(
-                DataType::Nullable(Box::new(DataType::Decimal(DecimalSize::default_128()))),
-                meta.build_origin_block_id(),
-            ),
+            StreamColumnType::OriginBlockId => {
+                BlockEntry::from_value(meta.build_origin_block_id(), || {
+                    (
+                        DataType::Nullable(Box::new(DataType::Decimal(DecimalSize::default_128()))),
+                        num_rows,
+                    )
+                })
+            }
             StreamColumnType::OriginRowNum => build_origin_block_row_num(num_rows),
         }
     }

--- a/src/query/ee/tests/it/storages/fuse/operations/virtual_columns_builder.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/virtual_columns_builder.rs
@@ -62,36 +62,27 @@ async fn test_virtual_column_builder() -> Result<()> {
 
     let block = DataBlock::new(
         vec![
-            BlockEntry::new(
-                DataType::Number(NumberDataType::Int32),
-                Value::Column(Int32Type::from_data(vec![1, 2, 3])),
-            ),
-            BlockEntry::new(
-                DataType::Nullable(Box::new(DataType::Variant)),
-                Value::Column(VariantType::from_opt_data(vec![
-                    Some(
-                        OwnedJsonb::from_str(
-                            r#"{"a": 1, "b": {"c": "x"}, "e": [{"f": 100}, 200]}"#,
-                        )
+            (Int32Type::from_data(vec![1, 2, 3])).into(),
+            (VariantType::from_opt_data(vec![
+                Some(
+                    OwnedJsonb::from_str(r#"{"a": 1, "b": {"c": "x"}, "e": [{"f": 100}, 200]}"#)
                         .unwrap()
                         .to_vec(),
-                    ),
-                    Some(
-                        OwnedJsonb::from_str(
-                            r#"{"a": 2, "b": {"c": "y", "d": true}, "e": [{"f": 300}, 400]}"#,
-                        )
+                ),
+                Some(
+                    OwnedJsonb::from_str(
+                        r#"{"a": 2, "b": {"c": "y", "d": true}, "e": [{"f": 300}, 400]}"#,
+                    )
+                    .unwrap()
+                    .to_vec(),
+                ),
+                Some(
+                    OwnedJsonb::from_str(r#"{"a": 3, "b": {"d": false}, "e": [{"f": 500}, 600]}"#)
                         .unwrap()
                         .to_vec(),
-                    ),
-                    Some(
-                        OwnedJsonb::from_str(
-                            r#"{"a": 3, "b": {"d": false}, "e": [{"f": 500}, 600]}"#,
-                        )
-                        .unwrap()
-                        .to_vec(),
-                    ), // 'c' is missing here
-                ])),
-            ),
+                ), // 'c' is missing here
+            ]))
+            .into(),
         ],
         3,
     );

--- a/src/query/expression/src/aggregate/group_hash.rs
+++ b/src/query/expression/src/aggregate/group_hash.rs
@@ -603,7 +603,7 @@ mod tests {
             let mut target = vec![0; data.num_rows()];
             for (i, entry) in data.columns().iter().enumerate() {
                 let indices = [0, 3, 8];
-                group_hash_value_spread(&indices, entry.value.to_owned(), i == 0, &mut target)?;
+                group_hash_value_spread(&indices, entry.value(), i == 0, &mut target)?;
             }
 
             assert_eq!(

--- a/src/query/expression/src/aggregate/group_hash.rs
+++ b/src/query/expression/src/aggregate/group_hash.rs
@@ -565,7 +565,6 @@ mod tests {
     use crate::BlockEntry;
     use crate::DataBlock;
     use crate::FromData;
-    use crate::Scalar;
     use crate::Value;
 
     fn merge_hash_slice(ls: &[u64]) -> u64 {
@@ -576,24 +575,10 @@ mod tests {
     fn test_value_spread() -> Result<()> {
         let data = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![3, 1, 2, 2, 4, 3, 7, 0, 3])),
-                ),
-                BlockEntry::new(
-                    StringType::data_type(),
-                    Value::Scalar(Scalar::String("a".to_string())),
-                ),
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![3, 1, 3, 2, 2, 3, 4, 3, 3])),
-                ),
-                BlockEntry::new(
-                    StringType::data_type(),
-                    Value::Column(StringType::from_data(vec![
-                        "a", "b", "c", "d", "e", "f", "g", "h", "i",
-                    ])),
-                ),
+                Int32Type::from_data(vec![3, 1, 2, 2, 4, 3, 7, 0, 3]).into(),
+                BlockEntry::new_const_column_arg::<StringType>("a".to_string(), 9),
+                Int32Type::from_data(vec![3, 1, 3, 2, 2, 3, 4, 3, 3]).into(),
+                StringType::from_data(vec!["a", "b", "c", "d", "e", "f", "g", "h", "i"]).into(),
             ],
             9,
         );

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -519,10 +519,18 @@ impl DataBlock {
     }
 
     #[inline]
-    pub fn add_column(&mut self, entry: BlockEntry) {
+    pub fn add_entry(&mut self, mut entry: BlockEntry) {
+        if let InnerEntry::Const(_, _, n) = &mut entry.0 {
+            *n = Some(self.num_rows)
+        }
         self.entries.push(entry);
         #[cfg(debug_assertions)]
         self.check_valid().unwrap();
+    }
+
+    #[inline]
+    pub fn add_column(&mut self, column: Column) {
+        self.add_entry(column.into());
     }
 
     #[inline]

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -91,16 +91,13 @@ impl BlockEntry {
         }
     }
 
-    pub fn to_column(&self, num_rows: usize) -> Column {
+    pub fn to_column(&self) -> Column {
         match self {
-            BlockEntry::Const(scalar, data_type, n) => {
-                debug_assert_eq!(num_rows, *n);
-                Value::<AnyType>::Scalar(scalar.clone()).convert_to_full_column(data_type, num_rows)
+            BlockEntry::Const(scalar, data_type, num_rows) => {
+                Value::<AnyType>::Scalar(scalar.clone())
+                    .convert_to_full_column(data_type, *num_rows)
             }
-            BlockEntry::Column(column) => {
-                debug_assert_eq!(num_rows, column.len());
-                column.clone()
-            }
+            BlockEntry::Column(column) => column.clone(),
         }
     }
 

--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -237,8 +237,8 @@ impl DataBlock {
         }
     }
 
-    fn check_columns_valid(columns: &[BlockEntry], num_rows: usize) -> Result<()> {
-        for entry in columns.iter() {
+    fn check_columns_valid(entries: &[BlockEntry], num_rows: usize) -> Result<()> {
+        for entry in entries.iter() {
             match entry {
                 BlockEntry::Const(_, _, n) => {
                     if *n != num_rows {
@@ -400,10 +400,10 @@ impl DataBlock {
 
     pub fn slice(&self, range: Range<usize>) -> Self {
         assert!(
-            range.end <= self.num_rows(),
+            range.end <= self.num_rows,
             "range {:?} out of len {}",
             range,
-            self.num_rows()
+            self.num_rows
         );
         let entries = self
             .entries

--- a/src/query/expression/src/converts/arrow/to.rs
+++ b/src/query/expression/src/converts/arrow/to.rs
@@ -249,7 +249,7 @@ impl DataBlock {
             .into_iter()
             .zip(arrow_schema.fields())
         {
-            let column = entry.value.into_column().unwrap();
+            let column = entry.into_column().unwrap();
             let column = column.maybe_gc();
             let array = column.into_arrow_rs();
 

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1186,7 +1186,7 @@ impl<'a> Evaluator<'a> {
                 Value::Column(col) => col.len(),
             });
 
-        let entry = BlockEntry::from_value(value, || (src_type.clone(), num_rows));
+        let entry = BlockEntry::new(value, || (src_type.clone(), num_rows));
         let block = DataBlock::new(vec![entry], num_rows);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
         let result = evaluator.eval_common_call(&call, validity, expr_display, options)?;

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1186,7 +1186,8 @@ impl<'a> Evaluator<'a> {
                 Value::Column(col) => col.len(),
             });
 
-        let block = DataBlock::new(vec![BlockEntry::new(src_type.clone(), value)], num_rows);
+        let entry = BlockEntry::from_value(value, || (src_type.clone(), num_rows));
+        let block = DataBlock::new(vec![entry], num_rows);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
         let result = evaluator.eval_common_call(&call, validity, expr_display, options)?;
         Ok(Some(result))
@@ -1441,7 +1442,7 @@ impl<'a> Evaluator<'a> {
                 for i in 0..lambda_idx {
                     let scalar = unsafe { args[i].index_unchecked(idx) };
                     let entry =
-                        BlockEntry::new(data_types[i].clone(), Value::Scalar(scalar.to_owned()));
+                        BlockEntry::new_const_column(data_types[i].clone(), scalar.to_owned(), 1);
                     entries.push(entry);
                 }
                 let scalar = unsafe { args[lambda_idx].index_unchecked(idx) };

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1395,11 +1395,10 @@ impl<'a> Evaluator<'a> {
         for i in 1..column.len() {
             let arg1 = unsafe { column.index_unchecked(i).to_owned() };
             let mut entries = col_entries.clone();
-            entries.push(BlockEntry::new(
-                col_type.clone(),
-                Value::Scalar(arg0.clone()),
-            ));
-            entries.push(BlockEntry::new(col_type.clone(), Value::Scalar(arg1)));
+            entries.extend_from_slice(&[
+                BlockEntry::new_const_column(col_type.clone(), arg0.clone(), 1),
+                BlockEntry::new_const_column(col_type.clone(), arg1, 1),
+            ]);
             let block = DataBlock::new(entries, 1);
             let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
             let result = evaluator.run(expr)?;

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1212,7 +1212,7 @@ impl<'a> Evaluator<'a> {
             .data_block
             .columns()
             .iter()
-            .find_map(|col| col.as_column().map(|col| col.len()));
+            .find_map(|col| col.as_column().map(Column::len));
 
         // Evaluate the condition first and then partially evaluate the result branches.
         let mut validity = validity.unwrap_or_else(|| Bitmap::new_constant(true, num_rows));

--- a/src/query/expression/src/filter/selector.rs
+++ b/src/query/expression/src/filter/selector.rs
@@ -424,7 +424,7 @@ impl<'a> Selector<'a> {
         buffers: SelectionBuffers,
         has_false: bool,
     ) -> Result<usize> {
-        let column = self.evaluator.data_block().get_by_offset(id).value.clone();
+        let column = self.evaluator.data_block().get_by_offset(id).value();
         self.select_value(column, data_type, buffers, has_false)
     }
 

--- a/src/query/expression/src/input_columns.rs
+++ b/src/query/expression/src/input_columns.rs
@@ -35,7 +35,7 @@ impl Index<usize> for InputColumns<'_> {
         match self {
             Self::Slice(slice) => slice.index(index),
             Self::Block(BlockProxy { args, data }) => {
-                data.get_by_offset(args[index]).value.as_column().unwrap()
+                data.get_by_offset(args[index]).as_column().unwrap()
             }
         }
     }
@@ -140,10 +140,8 @@ pub struct BlockProxy<'a> {
 }
 
 impl<'a> BlockProxy<'a> {
-    pub fn data_types(&self) -> Vec<&'a DataType> {
+    pub fn data_types(&self) -> Vec<DataType> {
         let Self { args, data } = self;
-        args.iter()
-            .map(|&i| &data.get_by_offset(i).data_type)
-            .collect::<Vec<_>>()
+        args.iter().map(|&i| data.data_type(i)).collect::<Vec<_>>()
     }
 }

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -69,7 +69,7 @@ impl DataBlock {
         let num_columns = blocks[0].num_columns();
         let mut concat_columns = Vec::with_capacity(num_columns);
         for i in 0..num_columns {
-            concat_columns.push(BlockEntry::from_value(
+            concat_columns.push(BlockEntry::new(
                 Self::concat_columns(&block_refs, i)?,
                 || (blocks[0].data_type(i), num_rows),
             ))

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -65,16 +65,15 @@ impl DataBlock {
             return Ok(blocks[0].clone());
         }
 
+        let num_rows = blocks.iter().map(|c| c.num_rows()).sum();
         let num_columns = blocks[0].num_columns();
         let mut concat_columns = Vec::with_capacity(num_columns);
         for i in 0..num_columns {
-            concat_columns.push(BlockEntry::new(
-                blocks[0].data_type(i),
+            concat_columns.push(BlockEntry::from_value(
                 Self::concat_columns(&block_refs, i)?,
+                || (blocks[0].data_type(i), num_rows),
             ))
         }
-
-        let num_rows = blocks.iter().map(|c| c.num_rows()).sum();
 
         Ok(DataBlock::new(concat_columns, num_rows))
     }

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -93,11 +93,9 @@ impl DataBlock {
             return Ok(entry0.value());
         }
 
-        let columns_iter = blocks.iter().map(|block| {
-            block
-                .get_by_offset(column_index)
-                .to_column(block.num_rows())
-        });
+        let columns_iter = blocks
+            .iter()
+            .map(|block| block.get_by_offset(column_index).to_column());
         Ok(Value::Column(Column::concat_columns(columns_iter)?))
     }
 }

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -51,12 +51,9 @@ impl DataBlock {
                     .columns()
                     .iter()
                     .map(|entry| {
-                        filter_visitor.visit_value(entry.value.clone())?;
+                        filter_visitor.visit_value(entry.value())?;
                         let result = filter_visitor.result.take().unwrap();
-                        Ok(BlockEntry {
-                            value: result,
-                            data_type: entry.data_type.clone(),
-                        })
+                        Ok(BlockEntry::new(entry.data_type(), result))
                     })
                     .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -53,7 +53,9 @@ impl DataBlock {
                     .map(|entry| {
                         filter_visitor.visit_value(entry.value())?;
                         let result = filter_visitor.result.take().unwrap();
-                        Ok(BlockEntry::new(entry.data_type(), result))
+                        Ok(BlockEntry::from_value(result, || {
+                            (entry.data_type(), filter_visitor.filter_rows)
+                        }))
                     })
                     .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/filter.rs
+++ b/src/query/expression/src/kernels/filter.rs
@@ -53,7 +53,7 @@ impl DataBlock {
                     .map(|entry| {
                         filter_visitor.visit_value(entry.value())?;
                         let result = filter_visitor.result.take().unwrap();
-                        Ok(BlockEntry::from_value(result, || {
+                        Ok(BlockEntry::new(result, || {
                             (entry.data_type(), filter_visitor.filter_rows)
                         }))
                     })

--- a/src/query/expression/src/kernels/group_by.rs
+++ b/src/query/expression/src/kernels/group_by.rs
@@ -27,13 +27,10 @@ use crate::HashMethodKeysU128;
 use crate::HashMethodKeysU256;
 
 impl DataBlock {
-    pub fn choose_hash_method(chunk: &DataBlock, indices: &[usize]) -> Result<HashMethodKind> {
+    pub fn choose_hash_method(block: &DataBlock, indices: &[usize]) -> Result<HashMethodKind> {
         let hash_key_types = indices
             .iter()
-            .map(|&offset| {
-                let col = chunk.get_by_offset(offset);
-                Ok(col.data_type.clone())
-            })
+            .map(|&offset| Ok(block.data_type(offset)))
             .collect::<Result<Vec<_>>>();
 
         let hash_key_types = hash_key_types?;

--- a/src/query/expression/src/kernels/sort.rs
+++ b/src/query/expression/src/kernels/sort.rs
@@ -100,7 +100,7 @@ impl DataBlock {
         let mut sort_compare = SortCompare::new(descriptions.to_owned(), num_rows, limit);
 
         for desc in descriptions.iter() {
-            let array = block.get_by_offset(desc.offset).value.clone();
+            let array = block.get_by_offset(desc.offset).value();
             sort_compare.visit_value(array)?;
             sort_compare.increment_column_index();
         }

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -65,12 +65,9 @@ impl DataBlock {
             .columns()
             .iter()
             .map(|entry| {
-                taker.visit_value(entry.value.clone())?;
+                taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry {
-                    value: result,
-                    data_type: entry.data_type.clone(),
-                })
+                Ok(BlockEntry::new(entry.data_type(), result))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -67,7 +67,7 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::from_value(result, || {
+                Ok(BlockEntry::new(result, || {
                     (entry.data_type(), taker.indices.len())
                 }))
             })

--- a/src/query/expression/src/kernels/take.rs
+++ b/src/query/expression/src/kernels/take.rs
@@ -67,7 +67,9 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::new(entry.data_type(), result))
+                Ok(BlockEntry::from_value(result, || {
+                    (entry.data_type(), taker.indices.len())
+                }))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_chunks.rs
+++ b/src/query/expression/src/kernels/take_chunks.rs
@@ -76,7 +76,7 @@ impl DataBlock {
 
                 let ty = columns[0].0.data_type();
                 if ty.is_null() {
-                    return BlockEntry::new(ty, Value::Scalar(Scalar::Null));
+                    return BlockEntry::new_const_column(ty, Scalar::Null, result_size);
                 }
 
                 // if they are all same scalars

--- a/src/query/expression/src/kernels/take_chunks.rs
+++ b/src/query/expression/src/kernels/take_chunks.rs
@@ -80,11 +80,15 @@ impl DataBlock {
                 }
 
                 // if they are all same scalars
-                if entries[0].is_const() {
+                if let Some((scalar, data_type, _)) = entries[0].as_const() {
                     let all_same_scalar =
                         entries.iter().copied().map(BlockEntry::value).all_equal();
                     if all_same_scalar {
-                        return entries[0].clone();
+                        return BlockEntry::new_const_column(
+                            data_type.clone(),
+                            scalar.clone(),
+                            result_size,
+                        );
                     }
                 }
 

--- a/src/query/expression/src/kernels/take_compact.rs
+++ b/src/query/expression/src/kernels/take_compact.rs
@@ -47,7 +47,9 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::new(entry.data_type(), result))
+                Ok(BlockEntry::from_value(result, || {
+                    (entry.data_type(), num_rows)
+                }))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_compact.rs
+++ b/src/query/expression/src/kernels/take_compact.rs
@@ -47,9 +47,7 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::from_value(result, || {
-                    (entry.data_type(), num_rows)
-                }))
+                Ok(BlockEntry::new(result, || (entry.data_type(), num_rows)))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_compact.rs
+++ b/src/query/expression/src/kernels/take_compact.rs
@@ -45,12 +45,9 @@ impl DataBlock {
             .columns()
             .iter()
             .map(|entry| {
-                taker.visit_value(entry.value.clone())?;
+                taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry {
-                    value: result,
-                    data_type: entry.data_type.clone(),
-                })
+                Ok(BlockEntry::new(entry.data_type(), result))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_ranges.rs
+++ b/src/query/expression/src/kernels/take_ranges.rs
@@ -50,7 +50,9 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::new(entry.data_type(), result))
+                Ok(BlockEntry::from_value(result, || {
+                    (entry.data_type(), num_rows)
+                }))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_ranges.rs
+++ b/src/query/expression/src/kernels/take_ranges.rs
@@ -48,12 +48,9 @@ impl DataBlock {
             .columns()
             .iter()
             .map(|entry| {
-                taker.visit_value(entry.value.clone())?;
+                taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry {
-                    value: result,
-                    data_type: entry.data_type.clone(),
-                })
+                Ok(BlockEntry::new(entry.data_type(), result))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/kernels/take_ranges.rs
+++ b/src/query/expression/src/kernels/take_ranges.rs
@@ -50,9 +50,7 @@ impl DataBlock {
             .map(|entry| {
                 taker.visit_value(entry.value())?;
                 let result = taker.result.take().unwrap();
-                Ok(BlockEntry::from_value(result, || {
-                    (entry.data_type(), num_rows)
-                }))
+                Ok(BlockEntry::new(result, || (entry.data_type(), num_rows)))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -295,11 +295,11 @@ impl<T: AccessType> NullableColumn<T> {
         self.validity.len()
     }
 
-    pub fn column_ref(&self) -> &T::Column {
+    pub fn column(&self) -> &T::Column {
         &self.column
     }
 
-    pub fn validity_ref(&self) -> &Bitmap {
+    pub fn validity(&self) -> &Bitmap {
         &self.validity
     }
 

--- a/src/query/expression/src/utils/block_debug.rs
+++ b/src/query/expression/src/utils/block_debug.rs
@@ -214,7 +214,7 @@ fn create_box_table(
 
             let mut v = vec![];
             for block_entry in block.columns() {
-                let value = block_entry.value.index(row).unwrap().to_string();
+                let value = block_entry.index(row).unwrap().to_string();
                 if replace_newline {
                     v.push(value.to_string().replace('\n', "\\n"));
                 } else {

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -93,8 +93,8 @@ impl Debug for DataBlock {
         for (i, entry) in self.columns().iter().enumerate() {
             table.add_row(vec![
                 i.to_string(),
-                entry.data_type.to_string(),
-                format!("{:?}", entry.value),
+                entry.data_type().to_string(),
+                format!("{:?}", entry.value()),
             ]);
         }
 
@@ -113,7 +113,7 @@ impl Display for DataBlock {
             let row: Vec<_> = self
                 .columns()
                 .iter()
-                .map(|entry| entry.value.index(index).unwrap().to_string())
+                .map(|entry| entry.index(index).unwrap().to_string())
                 .map(Cell::new)
                 .collect();
             table.add_row(row);

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -68,7 +68,7 @@ pub fn eval_function(
                     data_type: ty.clone(),
                     display_name: String::new(),
                 },
-                BlockEntry::from_value(val, || (ty, num_rows)),
+                BlockEntry::new(val, || (ty, num_rows)),
             )
         })
         .unzip();

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -68,7 +68,7 @@ pub fn eval_function(
                     data_type: ty.clone(),
                     display_name: String::new(),
                 },
-                BlockEntry::new(ty, val),
+                BlockEntry::from_value(val, || (ty, num_rows)),
             )
         })
         .unzip();

--- a/src/query/expression/src/utils/udf_client.rs
+++ b/src/query/expression/src/utils/udf_client.rs
@@ -207,7 +207,7 @@ impl UDFFlightClient {
             .collect::<Vec<_>>();
         let expect_return_type = output_fields
             .iter()
-            .map(|f| f.data_type().clone())
+            .map(|f| f.data_type())
             .collect::<Vec<_>>();
         if remote_arg_types != arg_types {
             return Err(ErrorCode::UDFSchemaMismatch(format!(
@@ -226,7 +226,7 @@ impl UDFFlightClient {
             )));
         }
 
-        if &expect_return_type[0] != return_type {
+        if expect_return_type[0] != return_type {
             return Err(ErrorCode::UDFSchemaMismatch(format!(
                 "UDF return type mismatch on UDF function {}, expected return type: {}, actual return type: {}",
                 func_name,

--- a/src/query/expression/tests/it/block.rs
+++ b/src/query/expression/tests/it/block.rs
@@ -17,7 +17,6 @@ use databend_common_expression::block_debug::box_render;
 use databend_common_expression::types::number::NumberScalar;
 use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_expression::types::AccessType;
-use databend_common_expression::types::AnyType;
 use databend_common_expression::types::ArrayColumn;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
@@ -30,7 +29,6 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::FromData;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 
 use crate::common::new_block;
 

--- a/src/query/expression/tests/it/block.rs
+++ b/src/query/expression/tests/it/block.rs
@@ -85,14 +85,11 @@ fn test_box_render_block() {
 fn test_block_entry_memory_size() {
     let scalar_u8 = Scalar::Number(NumberScalar::UInt8(1));
 
-    let entry = BlockEntry::new(
-        DataType::Number(NumberDataType::UInt8),
-        Value::<AnyType>::Scalar(scalar_u8),
-    );
+    let entry = BlockEntry::new_const_column(DataType::Number(NumberDataType::UInt8), scalar_u8, 1);
     assert_eq!(1, entry.memory_size());
 
     let scalar_str = Scalar::String("abc".to_string());
-    let entry = BlockEntry::new(DataType::String, Value::<AnyType>::Scalar(scalar_str));
+    let entry = BlockEntry::new_const_column(DataType::String, scalar_str, 1);
     assert_eq!(3, entry.memory_size());
 
     let col = StringType::from_data((0..10).map(|x| x.to_string()).collect::<Vec<_>>());

--- a/src/query/expression/tests/it/common.rs
+++ b/src/query/expression/tests/it/common.rs
@@ -14,20 +14,15 @@
 
 use std::io::Write;
 
-use databend_common_expression::BlockEntry;
 use databend_common_expression::BlockRowIndex;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
 
 type MergeSlice = (usize, usize, usize);
 
 pub fn new_block(columns: &[Column]) -> DataBlock {
     let len = columns.first().map_or(1, |c| c.len());
-    let columns = columns
-        .iter()
-        .map(|col| BlockEntry::new(col.data_type(), Value::Column(col.clone())))
-        .collect();
+    let columns = columns.iter().map(|col| col.clone().into()).collect();
 
     DataBlock::new(columns, len)
 }

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -121,16 +121,10 @@ pub fn test_pass() {
         ];
         for i in 0..3 {
             let mut columns = Vec::with_capacity(3);
-            columns.push(BlockEntry::new(
-                DataType::Number(NumberDataType::UInt8),
-                Value::Column(UInt8Type::from_data(vec![(i + 10) as u8; 4])),
-            ));
-            columns.push(BlockEntry::new(
-                DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt8))),
-                Value::Column(UInt8Type::from_data_with_validity(
-                    vec![(i + 10) as u8; 4],
-                    vec![true, true, false, false],
-                )),
+            columns.push(UInt8Type::from_data(vec![(i + 10) as u8; 4]).into());
+            columns.push(UInt8Type::from_data_with_validity(
+                vec![(i + 10) as u8; 4],
+                vec![true, true, false, false],
             ));
             blocks.push(DataBlock::new(columns, 4))
         }
@@ -152,17 +146,11 @@ pub fn test_pass() {
         ];
         for i in 0..3 {
             let columns = vec![
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt8),
-                    Value::Column(UInt8Type::from_data(vec![(i + 10) as u8; 4])),
-                ),
-                BlockEntry::new(
-                    DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt8))),
-                    Value::Column(UInt8Type::from_data_with_validity(
-                        vec![(i + 10) as u8; 4],
-                        vec![true, true, false, false],
-                    )),
-                ),
+                UInt8Type::from_data(vec![(i + 10) as u8; 4]).into(),
+                UInt8Type::from_data_with_validity(vec![(i + 10) as u8; 4], vec![
+                    true, true, false, false,
+                ])
+                .into(),
                 BlockEntry::new(
                     DataType::Array(Box::new(DataType::String)),
                     Value::Scalar(Scalar::Array(StringType::from_data(vec![

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -294,8 +294,8 @@ pub fn test_take_and_filter_and_concat() -> databend_common_exception::Result<()
                 FilterVisitor::new(&filter).with_strategy(IterationStrategy::IndexIterator);
 
             for col in random_block.columns() {
-                f1.visit_value(col.value.clone())?;
-                f2.visit_value(col.value.clone())?;
+                f1.visit_value(col.value())?;
+                f2.visit_value(col.value())?;
 
                 let l = f1.take_result();
                 let r = f2.take_result();
@@ -325,14 +325,7 @@ pub fn test_take_and_filter_and_concat() -> databend_common_exception::Result<()
         .map(|index| {
             let columns = blocks
                 .iter()
-                .map(|block| {
-                    block
-                        .get_by_offset(index)
-                        .value
-                        .clone()
-                        .into_column()
-                        .unwrap()
-                })
+                .map(|block| block.get_by_offset(index).value().into_column().unwrap())
                 .collect_vec();
             Column::take_downcast_column_vec(&columns)
         })
@@ -363,14 +356,14 @@ pub fn test_take_and_filter_and_concat() -> databend_common_exception::Result<()
     let columns_4 = block_4.columns();
     let columns_5 = block_5.columns();
     for idx in 0..columns_1.len() {
-        assert_eq!(columns_1[idx].data_type, columns_2[idx].data_type);
-        assert_eq!(columns_1[idx].value, columns_2[idx].value);
-        assert_eq!(columns_1[idx].data_type, columns_3[idx].data_type);
-        assert_eq!(columns_1[idx].value, columns_3[idx].value);
-        assert_eq!(columns_1[idx].data_type, columns_4[idx].data_type);
-        assert_eq!(columns_1[idx].value, columns_4[idx].value);
-        assert_eq!(columns_1[idx].data_type, columns_5[idx].data_type);
-        assert_eq!(columns_1[idx].value, columns_5[idx].value);
+        assert_eq!(columns_1[idx].data_type(), columns_2[idx].data_type());
+        assert_eq!(columns_1[idx].value(), columns_2[idx].value());
+        assert_eq!(columns_1[idx].data_type(), columns_3[idx].data_type());
+        assert_eq!(columns_1[idx].value(), columns_3[idx].value());
+        assert_eq!(columns_1[idx].data_type(), columns_4[idx].data_type());
+        assert_eq!(columns_1[idx].value(), columns_4[idx].value());
+        assert_eq!(columns_1[idx].data_type(), columns_5[idx].data_type());
+        assert_eq!(columns_1[idx].value(), columns_5[idx].value());
     }
 
     Ok(())
@@ -449,8 +442,8 @@ pub fn test_take_compact() -> databend_common_exception::Result<()> {
         let columns_1 = block_1.columns();
         let columns_2 = block_2.columns();
         for idx in 0..columns_1.len() {
-            assert_eq!(columns_1[idx].data_type, columns_2[idx].data_type);
-            assert_eq!(columns_1[idx].value, columns_2[idx].value);
+            assert_eq!(columns_1[idx].data_type(), columns_2[idx].data_type());
+            assert_eq!(columns_1[idx].value(), columns_2[idx].value());
         }
     }
 
@@ -606,8 +599,8 @@ pub fn test_scatter() -> databend_common_exception::Result<()> {
         let columns_1 = block_1.columns();
         let columns_2 = block_2.columns();
         for idx in 0..columns_1.len() {
-            assert_eq!(columns_1[idx].data_type, columns_2[idx].data_type);
-            assert_eq!(columns_1[idx].value, columns_2[idx].value);
+            assert_eq!(columns_1[idx].data_type(), columns_2[idx].data_type());
+            assert_eq!(columns_1[idx].value(), columns_2[idx].value());
         }
     }
 

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -122,10 +122,12 @@ pub fn test_pass() {
         for i in 0..3 {
             let mut columns = Vec::with_capacity(3);
             columns.push(UInt8Type::from_data(vec![(i + 10) as u8; 4]).into());
-            columns.push(UInt8Type::from_data_with_validity(
-                vec![(i + 10) as u8; 4],
-                vec![true, true, false, false],
-            ));
+            columns.push(
+                UInt8Type::from_data_with_validity(vec![(i + 10) as u8; 4], vec![
+                    true, true, false, false,
+                ])
+                .into(),
+            );
             blocks.push(DataBlock::new(columns, 4))
         }
 

--- a/src/query/expression/tests/it/kernel.rs
+++ b/src/query/expression/tests/it/kernel.rs
@@ -38,7 +38,6 @@ use databend_common_expression::FromData;
 use databend_common_expression::IterationStrategy;
 use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
-use databend_common_expression::Value;
 use goldenfile::Mint;
 
 use crate::common::*;
@@ -120,15 +119,15 @@ pub fn test_pass() {
             (0, 0, 3),
         ];
         for i in 0..3 {
-            let mut columns = Vec::with_capacity(3);
-            columns.push(UInt8Type::from_data(vec![(i + 10) as u8; 4]).into());
-            columns.push(
+            let mut entries = Vec::with_capacity(3);
+            entries.push(UInt8Type::from_data(vec![(i + 10) as u8; 4]).into());
+            entries.push(
                 UInt8Type::from_data_with_validity(vec![(i + 10) as u8; 4], vec![
                     true, true, false, false,
                 ])
                 .into(),
             );
-            blocks.push(DataBlock::new(columns, 4))
+            blocks.push(DataBlock::new(entries, 4))
         }
 
         run_take_block(&mut file, &indices, &blocks);
@@ -153,19 +152,18 @@ pub fn test_pass() {
                     true, true, false, false,
                 ])
                 .into(),
-                BlockEntry::new(
+                BlockEntry::new_const_column(
                     DataType::Array(Box::new(DataType::String)),
-                    Value::Scalar(Scalar::Array(StringType::from_data(vec![
+                    Scalar::Array(StringType::from_data(vec![
                         (20 + i).to_string(),
                         (30 + i).to_string(),
-                    ]))),
-                ),
-                BlockEntry::new(
-                    DataType::Tuple(vec![DataType::Boolean, DataType::Date]),
-                    Value::Scalar(Scalar::Tuple(vec![
-                        Scalar::Boolean(i % 2 == 0),
-                        Scalar::Date(9 + i),
                     ])),
+                    4,
+                ),
+                BlockEntry::new_const_column(
+                    DataType::Tuple(vec![DataType::Boolean, DataType::Date]),
+                    Scalar::Tuple(vec![Scalar::Boolean(i % 2 == 0), Scalar::Date(9 + i)]),
+                    4,
                 ),
             ];
             blocks.push(DataBlock::new(columns, 4))
@@ -364,24 +362,23 @@ pub fn test_concat_scalar() -> databend_common_exception::Result<()> {
     use databend_common_expression::types::DataType;
     use databend_common_expression::DataBlock;
     use databend_common_expression::Scalar;
-    use databend_common_expression::Value;
 
     let ty = DataType::Number(NumberDataType::UInt8);
-    let scalar = Value::Scalar(Scalar::Number(NumberScalar::UInt8(1)));
-    let column = Value::Column(UInt8Type::from_data(vec![2, 3]));
+    let scalar = Scalar::Number(NumberScalar::UInt8(1));
+    let column = UInt8Type::from_data(vec![2, 3]);
 
     let blocks = [
         DataBlock::new(
             vec![
-                BlockEntry::new(ty.clone(), scalar.clone()),
-                BlockEntry::new(ty.clone(), scalar.clone()),
+                BlockEntry::new_const_column(ty.clone(), scalar.clone(), 2),
+                BlockEntry::new_const_column(ty.clone(), scalar.clone(), 2),
             ],
             2,
         ),
         DataBlock::new(
             vec![
-                BlockEntry::new(ty.clone(), scalar.clone()),
-                BlockEntry::new(ty.clone(), column),
+                BlockEntry::new_const_column(ty.clone(), scalar.clone(), 2),
+                column.into(),
             ],
             2,
         ),
@@ -389,11 +386,8 @@ pub fn test_concat_scalar() -> databend_common_exception::Result<()> {
     let block = DataBlock::concat(&blocks)?;
     let expect = DataBlock::new(
         vec![
-            BlockEntry::new(ty.clone(), scalar.clone()),
-            BlockEntry::new(
-                ty.clone(),
-                Value::Column(UInt8Type::from_data(vec![1, 1, 2, 3])),
-            ),
+            BlockEntry::new_const_column(ty.clone(), scalar.clone(), 4),
+            UInt8Type::from_data(vec![1, 1, 2, 3]).into(),
         ],
         4,
     );

--- a/src/query/expression/tests/it/meta_scalar.rs
+++ b/src/query/expression/tests/it/meta_scalar.rs
@@ -36,9 +36,9 @@ pub fn test_legacy_converts() -> databend_common_exception::Result<()> {
         for entry in random_block
             .columns()
             .iter()
-            .filter(|c| !c.data_type.remove_nullable().is_binary())
+            .filter(|c| !c.data_type().remove_nullable().is_binary())
         {
-            let column = entry.value.as_column().unwrap().clone();
+            let column = entry.as_column().unwrap().clone();
 
             let legacy_column: LegacyColumn = column.clone().into();
             let convert_back_column: Column = legacy_column.into();
@@ -47,7 +47,7 @@ pub fn test_legacy_converts() -> databend_common_exception::Result<()> {
             let mut v3_scalars = vec![];
 
             for row in 0..rows {
-                let scalar = entry.value.index(row).unwrap().to_owned();
+                let scalar = entry.value().index(row).unwrap().to_owned();
                 let legacy_scalar: LegacyScalar = scalar.clone().into();
                 v3_scalars.push(legacy_scalar.clone());
 
@@ -83,13 +83,13 @@ pub fn test_simple_converts() -> databend_common_exception::Result<()> {
         for entry in random_block
             .columns()
             .iter()
-            .filter(|c| !c.data_type.remove_nullable().is_binary())
+            .filter(|c| !c.data_type().remove_nullable().is_binary())
         {
             let mut scalars = vec![];
             let mut simple_scalars = vec![];
 
             for row in 0..rows {
-                let scalar = entry.value.index(row).unwrap().to_owned();
+                let scalar = entry.value().index(row).unwrap().to_owned();
                 let simple_scalar: IndexScalar = scalar.clone().try_into().unwrap();
                 simple_scalars.push(simple_scalar.clone());
                 scalars.push(scalar.clone());

--- a/src/query/expression/tests/it/sort.rs
+++ b/src/query/expression/tests/it/sort.rs
@@ -100,11 +100,11 @@ fn test_block_sort() -> Result<()> {
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
             assert_eq!(
-                entry.value.as_column().unwrap(),
+                entry.as_column().unwrap(),
                 expect,
                 "the column after sort is wrong, expect: {:?}, got: {:?}",
                 expect,
-                entry.value
+                entry.value()
             );
         }
     }
@@ -181,11 +181,11 @@ fn test_block_sort() -> Result<()> {
 
         for (entry, expect) in res.columns().iter().zip(expected.iter()) {
             assert_eq!(
-                entry.value.as_column().unwrap(),
+                entry.as_column().unwrap(),
                 expect,
                 "the column after sort is wrong, expect: {:?}, got: {:?}",
                 expect,
-                entry.value
+                entry.value()
             );
         }
     }
@@ -235,8 +235,8 @@ fn sort_concat() {
         let columns_1 = block_1.columns();
         let columns_2 = block_2.columns();
         for idx in 0..columns_1.len() {
-            assert_eq!(columns_1[idx].data_type, columns_2[idx].data_type);
-            assert_eq!(columns_1[idx].value, columns_2[idx].value);
+            assert_eq!(columns_1[idx].data_type(), columns_2[idx].data_type());
+            assert_eq!(columns_1[idx].value(), columns_2[idx].value());
         }
     }
 }

--- a/src/query/expression/tests/it/types.rs
+++ b/src/query/expression/tests/it/types.rs
@@ -77,7 +77,7 @@ fn test_convert_types() {
 
     let random_block = rand_block_for_all_types(1024);
     for (idx, c) in random_block.columns().iter().enumerate() {
-        let c = c.value.as_column().unwrap().clone();
+        let c = c.as_column().unwrap().clone();
 
         let data = serialize_column(&c);
         let c2 = deserialize_column(&data).unwrap();

--- a/src/query/formats/src/output_format/csv.rs
+++ b/src/query/formats/src/output_format/csv.rs
@@ -81,7 +81,7 @@ impl<const WITH_NAMES: bool, const WITH_TYPES: bool> OutputFormat
             .convert_to_full()
             .columns()
             .iter()
-            .map(|val| val.value.clone().into_column().unwrap())
+            .map(|val| val.as_column().unwrap().clone())
             .collect();
 
         for row_index in 0..rows_size {

--- a/src/query/formats/src/output_format/json.rs
+++ b/src/query/formats/src/output_format/json.rs
@@ -201,7 +201,7 @@ impl OutputFormat for JSONOutputFormat {
             }
             res.push(b'{');
             for (c, value) in data_block.columns().iter().enumerate() {
-                let scalar = unsafe { value.value.index_unchecked(row) };
+                let scalar = unsafe { value.index_unchecked(row) };
                 let value = scalar_to_json(scalar, &self.format_settings);
 
                 res.push(b'\"');

--- a/src/query/formats/src/output_format/ndjson.rs
+++ b/src/query/formats/src/output_format/ndjson.rs
@@ -74,7 +74,7 @@ impl<const STRINGS: bool, const COMPACT: bool, const WITH_NAMES: bool, const WIT
             .convert_to_full()
             .columns()
             .iter()
-            .map(|column| column.value.clone().into_column().unwrap())
+            .map(|column| column.value().into_column().unwrap())
             .collect();
 
         for row_index in 0..rows_size {

--- a/src/query/formats/src/output_format/tsv.rs
+++ b/src/query/formats/src/output_format/tsv.rs
@@ -79,7 +79,7 @@ impl<const WITH_NAMES: bool, const WITH_TYPES: bool> OutputFormat
             .convert_to_full()
             .columns()
             .iter()
-            .map(|column| column.value.clone().into_column().unwrap())
+            .map(|column| column.value().into_column().unwrap())
             .collect();
 
         for row_index in 0..rows_size {

--- a/src/query/functions/src/aggregates/adaptors/aggregate_sort_adaptor.rs
+++ b/src/query/functions/src/aggregates/adaptors/aggregate_sort_adaptor.rs
@@ -28,13 +28,11 @@ use databend_common_expression::AggrStateRegistry;
 use databend_common_expression::AggrStateType;
 use databend_common_expression::AggregateFunction;
 use databend_common_expression::AggregateFunctionRef;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::InputColumns;
 use databend_common_expression::Scalar;
 use databend_common_expression::SortColumnDescription;
-use databend_common_expression::Value;
 use itertools::Itertools;
 
 use crate::aggregates::borsh_deserialize_state;
@@ -161,7 +159,7 @@ impl AggregateFunction for AggregateFunctionSortAdaptor {
                     for value in values {
                         builder.push(value.as_ref());
                     }
-                    BlockEntry::new(data_type.clone(), Value::Column(builder.build()))
+                    builder.build().into()
                 })
                 .collect_vec(),
             num_rows,
@@ -245,7 +243,7 @@ impl AggregateFunctionSortAdaptor {
             state.data_types = Vec::with_capacity(columns.len());
 
             for column in columns.iter() {
-                state.data_types.push(column.data_type().clone());
+                state.data_types.push(column.data_type());
                 state.columns.push(
                     num_rows
                         .map(|num| Vec::with_capacity(num))

--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -46,7 +46,6 @@ use databend_common_expression::vectorize_with_builder_1_arg;
 use databend_common_expression::vectorize_with_builder_2_arg;
 use databend_common_expression::vectorize_with_builder_3_arg;
 use databend_common_expression::with_number_mapped_type;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
@@ -1036,11 +1035,7 @@ fn register_array_aggr(registry: &mut FunctionRegistry) {
                     asc: sort_desc.0,
                     nulls_first: sort_desc.1,
                 }];
-                let columns = vec![BlockEntry::new(
-                    arr.data_type(),
-                    Value::Column(arr)
-                )];
-                match DataBlock::sort(&DataBlock::new(columns, len), &sort_desc, None) {
+                match DataBlock::sort(&DataBlock::new(vec![arr.into()], len), &sort_desc, None) {
                     Ok(block) => {
                         let sorted_arr = block.columns()[0].value().into_column().unwrap();
                         output.push(sorted_arr);

--- a/src/query/functions/src/scalars/array.rs
+++ b/src/query/functions/src/scalars/array.rs
@@ -1036,13 +1036,13 @@ fn register_array_aggr(registry: &mut FunctionRegistry) {
                     asc: sort_desc.0,
                     nulls_first: sort_desc.1,
                 }];
-                let columns = vec![BlockEntry{
-                    data_type: arr.data_type(),
-                    value: Value::Column(arr)
-                }];
+                let columns = vec![BlockEntry::new(
+                    arr.data_type(),
+                    Value::Column(arr)
+                )];
                 match DataBlock::sort(&DataBlock::new(columns, len), &sort_desc, None) {
                     Ok(block) => {
-                        let sorted_arr = block.columns()[0].value.clone().into_column().unwrap();
+                        let sorted_arr = block.columns()[0].value().into_column().unwrap();
                         output.push(sorted_arr);
                     }
                     Err(err) => {

--- a/src/query/functions/src/scalars/decimal/src/cast.rs
+++ b/src/query/functions/src/scalars/decimal/src/cast.rs
@@ -1109,9 +1109,7 @@ pub fn strict_decimal_data_type(data: DataBlock) -> Result<DataBlock, String> {
             if let Some((_, msg)) = ctx.errors.take() {
                 Err(msg)
             } else {
-                Ok(BlockEntry::from_value(value, || {
-                    (entry.data_type(), num_rows)
-                }))
+                Ok(BlockEntry::new(value, || (entry.data_type(), num_rows)))
             }
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/src/query/functions/tests/it/aggregates/mod.rs
+++ b/src/query/functions/tests/it/aggregates/mod.rs
@@ -25,7 +25,6 @@ use databend_common_expression::type_check;
 use databend_common_expression::types::AnyType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::AggrState;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
@@ -68,10 +67,7 @@ pub fn run_agg_ast(
 
     let num_rows = columns.iter().map(|col| col.1.len()).max().unwrap_or(0);
     let block = DataBlock::new(
-        columns
-            .iter()
-            .map(|(_, col)| BlockEntry::new(col.data_type(), Value::Column(col.clone())))
-            .collect::<Vec<_>>(),
+        columns.iter().map(|(_, col)| col.clone().into()).collect(),
         num_rows,
     );
 

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -367,14 +367,14 @@ fn test_if_function() -> Result<()> {
     let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
     let block = DataBlock::new(
         vec![
-            BlockEntry {
-                data_type: UInt8Type::data_type(),
-                value: Value::Column(UInt8Type::from_data(vec![2_u8, 1])),
-            },
-            BlockEntry {
-                data_type: Int32Type::data_type().wrap_nullable(),
-                value: Value::Scalar(Scalar::Number(NumberScalar::Int32(2400_i32))),
-            },
+            BlockEntry::new(
+                UInt8Type::data_type(),
+                Value::Column(UInt8Type::from_data(vec![2_u8, 1])),
+            ),
+            BlockEntry::new(
+                Int32Type::data_type().wrap_nullable(),
+                Value::Scalar(Scalar::Number(NumberScalar::Int32(2400_i32))),
+            ),
         ],
         2,
     );

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -367,13 +367,11 @@ fn test_if_function() -> Result<()> {
     let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
     let block = DataBlock::new(
         vec![
-            BlockEntry::new(
-                UInt8Type::data_type(),
-                Value::Column(UInt8Type::from_data(vec![2_u8, 1])),
-            ),
-            BlockEntry::new(
+            UInt8Type::from_data(vec![2_u8, 1]).into(),
+            BlockEntry::new_const_column(
                 Int32Type::data_type().wrap_nullable(),
-                Value::Scalar(Scalar::Number(NumberScalar::Int32(2400_i32))),
+                Scalar::Number(NumberScalar::Int32(2400)),
+                2,
             ),
         ],
         2,

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -140,8 +140,8 @@ pub fn run_ast_with_context(file: &mut impl Write, text: impl AsRef<str>, mut ct
         let block = DataBlock::new(
             ctx.columns
                 .iter()
-                .map(|(_, col)| BlockEntry::new(col.data_type(), Value::Column(col.clone())))
-                .collect::<Vec<_>>(),
+                .map(|(_, col)| col.clone().into())
+                .collect(),
             num_rows,
         );
 

--- a/src/query/functions/tests/it/scalars/testdata/decimal_to_decimal_cast.txt
+++ b/src/query/functions/tests/it/scalars/testdata/decimal_to_decimal_cast.txt
@@ -46,7 +46,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(123.45::DECIMAL(5,2) AS DECIMAL(5,4))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(5, 4)(123.45)` in expr `CAST(123.45 AS Decimal(5, 4))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(5, 4)(123.45)` in expr `CAST(123.45 AS Decimal(5, 4))`
 
 
 
@@ -54,7 +54,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(123::DECIMAL(3,0) AS DECIMAL(3,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(3, 2)(123)` in expr `CAST(CAST(123 AS Decimal(3, 0)) AS Decimal(3, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(3, 2)(123)` in expr `CAST(CAST(123 AS Decimal(3, 0)) AS Decimal(3, 2))`
 
 
 
@@ -428,7 +428,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(12345.67::DECIMAL(7,2) AS DECIMAL(5,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(5, 2)(12345.67)` in expr `CAST(12345.67 AS Decimal(5, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(5, 2)(12345.67)` in expr `CAST(12345.67 AS Decimal(5, 2))`
 
 
 
@@ -436,7 +436,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(999.99::DECIMAL(5,2) AS DECIMAL(4,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(4, 2)(999.99)` in expr `CAST(999.99 AS Decimal(4, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(4, 2)(999.99)` in expr `CAST(999.99 AS Decimal(4, 2))`
 
 
 
@@ -444,7 +444,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(99.9::DECIMAL(3,1) AS DECIMAL(2,1))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(2, 1)(99.9)` in expr `CAST(99.9 AS Decimal(2, 1))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(2, 1)(99.9)` in expr `CAST(99.9 AS Decimal(2, 1))`
 
 
 
@@ -461,7 +461,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(-123.45::DECIMAL(5,2) AS DECIMAL(4,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(4, 2)(-123.45)` in expr `CAST(- 123.45 AS Decimal(4, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(4, 2)(-123.45)` in expr `CAST(- 123.45 AS Decimal(4, 2))`
 
 
 
@@ -469,7 +469,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(99.99::DECIMAL(4,2) AS DECIMAL(3,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(3, 2)(99.99)` in expr `CAST(99.99 AS Decimal(3, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(3, 2)(99.99)` in expr `CAST(99.99 AS Decimal(3, 2))`
 
 
 
@@ -477,7 +477,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(9.99::DECIMAL(3,2) AS DECIMAL(2,2))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 884 while evaluating function `to_decimal(2, 2)(9.99)` in expr `CAST(9.99 AS Decimal(2, 2))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 885 while evaluating function `to_decimal(2, 2)(9.99)` in expr `CAST(9.99 AS Decimal(2, 2))`
 
 
 
@@ -503,7 +503,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(12345678901234567890.123456789::DECIMAL(38,9) AS DECIMAL(18,4))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 863 while evaluating function `to_decimal(18, 4)(12345678901234567890.123456789)` in expr `CAST(CAST(12345678901234567890.123456789 AS Decimal(38, 9)) AS Decimal(18, 4))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 864 while evaluating function `to_decimal(18, 4)(12345678901234567890.123456789)` in expr `CAST(CAST(12345678901234567890.123456789 AS Decimal(38, 9)) AS Decimal(18, 4))`
 
 
 
@@ -629,7 +629,7 @@ error:
   --> SQL:1:1
   |
 1 | CAST(a AS DECIMAL(5,1))
-  | ^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 863 while evaluating function `to_decimal(5, 1)(1234567.89)` in expr `CAST(a AS Decimal(5, 1))`
+  | ^^^^^^^^^^^^^^^^^^^^^^^ Decimal overflow at line : 864 while evaluating function `to_decimal(5, 1)(1234567.89)` in expr `CAST(a AS Decimal(5, 1))`
 
 
 

--- a/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
@@ -136,8 +136,8 @@ async fn test_duplicate_processor() -> Result<()> {
     let out1 = downstream_input1.pull_data().unwrap()?;
     let out2 = downstream_input2.pull_data().unwrap()?;
 
-    assert!(out1.columns()[0].value.as_column().unwrap().eq(&col));
-    assert!(out2.columns()[0].value.as_column().unwrap().eq(&col));
+    assert!(out1.columns()[0].as_column().unwrap().eq(&col));
+    assert!(out2.columns()[0].as_column().unwrap().eq(&col));
 
     Ok(())
 }

--- a/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
@@ -155,7 +155,7 @@ async fn test_shuffle_processor() -> Result<()> {
 
     let block = downstream_input1.pull_data().unwrap()?;
     downstream_input1.set_need_data();
-    assert!(block.columns()[0].value.as_column().unwrap().eq(&col1));
+    assert!(block.columns()[0].as_column().unwrap().eq(&col1));
     assert!(matches!(
         processor.event_with_cause(EventCause::Output(0))?,
         Event::NeedData
@@ -195,7 +195,7 @@ async fn test_shuffle_processor() -> Result<()> {
 
     let block = downstream_input2.pull_data().unwrap()?;
     downstream_input2.set_need_data();
-    assert!(block.columns()[0].value.as_column().unwrap().eq(&col3));
+    assert!(block.columns()[0].as_column().unwrap().eq(&col3));
     assert!(matches!(
         processor.event_with_cause(EventCause::Output(1))?,
         Event::NeedData
@@ -233,7 +233,7 @@ async fn test_shuffle_processor() -> Result<()> {
 
     let block = downstream_input3.pull_data().unwrap()?;
     downstream_input3.set_need_data();
-    assert!(block.columns()[0].value.as_column().unwrap().eq(&col2));
+    assert!(block.columns()[0].as_column().unwrap().eq(&col2));
     assert!(matches!(
         processor.event_with_cause(EventCause::Output(2))?,
         Event::NeedData
@@ -271,7 +271,7 @@ async fn test_shuffle_processor() -> Result<()> {
 
     let block = downstream_input4.pull_data().unwrap()?;
     downstream_input4.set_need_data();
-    assert!(block.columns()[0].value.as_column().unwrap().eq(&col4));
+    assert!(block.columns()[0].as_column().unwrap().eq(&col4));
     assert!(matches!(
         processor.event_with_cause(EventCause::Output(3))?,
         Event::NeedData

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
@@ -79,18 +79,15 @@ impl RowConverter<BinaryColumn> for CommonRowConverter {
         let columns = columns
             .iter()
             .map(|entry| match entry {
-                BlockEntry::Const(scalar, _, _) => {
-                    match scalar {
-                        Scalar::Variant(val) => {
-                            // convert variant value to comparable format.
-                            let raw_jsonb = RawJsonb::new(val);
-                            let buf = raw_jsonb.convert_to_comparable();
-                            let s = Scalar::Variant(buf);
-                            ColumnBuilder::repeat(&s.as_ref(), num_rows, &entry.data_type()).build()
-                        }
-                        _ => entry.to_column(num_rows),
-                    }
+                BlockEntry::Const(Scalar::Variant(val), _, _) => {
+                    // convert variant value to comparable format.
+                    let raw_jsonb = RawJsonb::new(val);
+                    let buf = raw_jsonb.convert_to_comparable();
+                    let s = Scalar::Variant(buf);
+                    ColumnBuilder::repeat(&s.as_ref(), num_rows, &entry.data_type()).build()
                 }
+                BlockEntry::Const(_, _, _) => entry.to_column(num_rows),
+
                 BlockEntry::Column(c) => {
                     let data_type = c.data_type();
                     if !data_type.remove_nullable().is_variant() {

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/common.rs
@@ -86,7 +86,7 @@ impl RowConverter<BinaryColumn> for CommonRowConverter {
                     let s = Scalar::Variant(buf);
                     ColumnBuilder::repeat(&s.as_ref(), num_rows, &entry.data_type()).build()
                 }
-                BlockEntry::Const(_, _, _) => entry.to_column(num_rows),
+                BlockEntry::Const(_, _, _) => entry.to_column(),
 
                 BlockEntry::Column(c) => {
                     let data_type = c.data_type();

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
@@ -178,7 +178,7 @@ impl<T: ArgType> SimpleRowConverter<T> {
 
         match entry {
             BlockEntry::Const(_, _, n) => {
-                let col = entry.to_column(n.unwrap());
+                let col = entry.to_column(*n);
                 R::from_column(&col)
             }
             BlockEntry::Column(c) => R::from_column(c),

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
@@ -177,8 +177,8 @@ impl<T: ArgType> SimpleRowConverter<T> {
         }
 
         match entry {
-            BlockEntry::Const(_, _, n) => {
-                let col = entry.to_column(*n);
+            BlockEntry::Const(_, _, _) => {
+                let col = entry.to_column();
                 R::from_column(&col)
             }
             BlockEntry::Column(c) => R::from_column(c),

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/rows/simple.rs
@@ -162,7 +162,7 @@ impl<T: ArgType> SimpleRowConverter<T> {
     fn convert_rows<R: Rows>(
         &self,
         columns: &[BlockEntry],
-        num_rows: usize,
+        _num_rows: usize,
         asc: bool,
     ) -> Result<R> {
         assert!(asc == R::IS_ASC_COLUMN);
@@ -176,11 +176,12 @@ impl<T: ArgType> SimpleRowConverter<T> {
             )));
         }
 
-        if let Some(c) = entry.as_column() {
-            return R::from_column(c);
+        match entry {
+            BlockEntry::Const(_, _, n) => {
+                let col = entry.to_column(n.unwrap());
+                R::from_column(&col)
+            }
+            BlockEntry::Column(c) => R::from_column(c),
         }
-
-        let col = entry.to_column(num_rows);
-        R::from_column(&col)
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
@@ -121,10 +121,10 @@ where
                 .convert(&order_by_cols, block.num_rows())?;
             if self.output_order_col {
                 let order_col = rows.to_column();
-                block.add_column(BlockEntry {
-                    data_type: order_col.data_type(),
-                    value: Value::Column(order_col),
-                });
+                block.add_column(BlockEntry::new(
+                    order_col.data_type(),
+                    Value::Column(order_col),
+                ));
             }
             rows
         };

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
@@ -16,11 +16,9 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
-use databend_common_expression::Value;
 
 use super::sort::RowConverter;
 use super::sort::Rows;
@@ -121,10 +119,7 @@ where
                 .convert(&order_by_cols, block.num_rows())?;
             if self.output_order_col {
                 let order_col = rows.to_column();
-                block.add_column(BlockEntry::new(
-                    order_col.data_type(),
-                    Value::Column(order_col),
-                ));
+                block.add_column(order_col);
             }
             rows
         };

--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -92,12 +92,9 @@ impl Interpreter for ShowCreateCatalogInterpreter {
 
         let block = DataBlock::new(
             vec![
-                BlockEntry::new(DataType::String, Value::Scalar(Scalar::String(name))),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(catalog_type)),
-                ),
-                BlockEntry::new(DataType::String, Value::Scalar(Scalar::String(option))),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(name), 1),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(catalog_type), 1),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(option), 1),
             ],
             1,
         );

--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -19,7 +19,6 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
 use databend_common_meta_app::storage::StorageParams;

--- a/src/query/service/src/interpreters/interpreter_database_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_show_create.rs
@@ -20,7 +20,6 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_sql::plans::ShowCreateDatabasePlan;
 
 use crate::interpreters::Interpreter;

--- a/src/query/service/src/interpreters/interpreter_database_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_show_create.rs
@@ -74,14 +74,8 @@ impl Interpreter for ShowCreateDatabaseInterpreter {
 
         PipelineBuildResult::from_blocks(vec![DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(name.to_string())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(info.clone())),
-                ),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(name.to_string()), 1),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(info.clone()), 1),
             ],
             1,
         )])

--- a/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
@@ -86,15 +86,12 @@ impl Interpreter for ShowCreateDictionaryInterpreter {
             quoted_ident_case_sensitive: settings.get_quoted_ident_case_sensitive()?,
         };
 
-        let create_query: String =
+        let create_query =
             Self::show_create_query(catalog.as_ref(), &dictionary, &dict_name, &settings).await?;
         let block = DataBlock::new(
             vec![
-                BlockEntry::new(DataType::String, Value::Scalar(Scalar::String(dict_name))),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(create_query)),
-                ),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(dict_name), 1),
+                BlockEntry::new_const_column(DataType::String, Scalar::String(create_query), 1),
             ],
             1,
         );

--- a/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_dictionary_show_create.rs
@@ -24,7 +24,6 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::DictionaryIdentity;
 use databend_common_meta_app::schema::DictionaryMeta;

--- a/src/query/service/src/interpreters/interpreter_presign.rs
+++ b/src/query/service/src/interpreters/interpreter_presign.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::VariantType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
@@ -103,18 +105,12 @@ impl Interpreter for PresignInterpreter {
 
         let block = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(presigned_req.method().as_str().to_string())),
+                BlockEntry::new_const_column_arg::<StringType>(
+                    presigned_req.method().as_str().to_string(),
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::Variant,
-                    Value::Scalar(Scalar::Variant(header.to_vec())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(presigned_req.uri().to_string())),
-                ),
+                BlockEntry::new_const_column_arg::<VariantType>(header.to_vec(), 1),
+                BlockEntry::new_const_column_arg::<StringType>(presigned_req.uri().to_string(), 1),
             ],
             1,
         );

--- a/src/query/service/src/interpreters/interpreter_presign.rs
+++ b/src/query/service/src/interpreters/interpreter_presign.rs
@@ -16,13 +16,10 @@ use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::VariantType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_storages_stage::StageTable;
 use jsonb::Value as JsonbValue;
 use log::debug;

--- a/src/query/service/src/interpreters/interpreter_set.rs
+++ b/src/query/service/src/interpreters/interpreter_set.rs
@@ -197,7 +197,7 @@ impl Interpreter for SetInterpreter {
                 datablock
                     .columns()
                     .iter()
-                    .map(|c| c.value.index(0).unwrap().to_owned())
+                    .map(|c| c.index(0).unwrap().to_owned())
                     .collect()
             }
         };

--- a/src/query/service/src/interpreters/interpreter_table_exists.rs
+++ b/src/query/service/src/interpreters/interpreter_table_exists.rs
@@ -21,7 +21,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_sql::plans::ExistsTablePlan;
 
 use crate::interpreters::Interpreter;
@@ -62,9 +61,10 @@ impl Interpreter for ExistsTableInterpreter {
         };
 
         PipelineBuildResult::from_blocks(vec![DataBlock::new(
-            vec![BlockEntry::new(
+            vec![BlockEntry::new_const_column(
                 DataType::Number(NumberDataType::UInt8),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt8(result))),
+                Scalar::Number(NumberScalar::UInt8(result)),
+                1,
             )],
             1,
         )])

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -375,7 +375,7 @@ impl ReclusterTableInterpreter {
 
         // Store each clustering key's bounds in the variables collection
         for entry in keys_bounds.columns().iter() {
-            let v = entry.value.index(0).unwrap().to_owned();
+            let v = entry.index(0).unwrap().to_owned();
             variables.push_back(v);
         }
 

--- a/src/query/service/src/interpreters/interpreter_table_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_show_create.rs
@@ -21,12 +21,10 @@ use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
+use databend_common_expression::types::StringType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::ComputedExpr;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_sql::plans::ShowCreateTablePlan;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ATTACH_COLUMN_IDS;
@@ -105,14 +103,8 @@ impl Interpreter for ShowCreateTableInterpreter {
 
         let block = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(table.name().to_string())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(create_query)),
-                ),
+                BlockEntry::new_const_column_arg::<StringType>(table.name().to_string(), 1),
+                BlockEntry::new_const_column_arg::<StringType>(create_query, 1),
             ],
             1,
         );

--- a/src/query/service/src/interpreters/util.rs
+++ b/src/query/service/src/interpreters/util.rs
@@ -159,7 +159,6 @@ impl Client for ScriptClient {
             ))
         })?;
         let cell = col
-            .value
             .index(row)
             .ok_or_else(|| {
                 ErrorCode::ScriptExecutionError(format!(

--- a/src/query/service/src/local/executor.rs
+++ b/src/query/service/src/local/executor.rs
@@ -24,7 +24,6 @@ use databend_common_catalog::session_type::SessionType;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::AccessType;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::SendableDataBlockStream;
 use databend_common_meta_app::principal::GrantObject;
@@ -108,9 +107,7 @@ impl SessionExecutor {
                 while let Some(row) = rows.next().await {
                     if let Ok(row) = row {
                         let num_rows = row.num_rows();
-                        let col = row.columns()[0]
-                            .value
-                            .convert_to_full_column(&DataType::String, num_rows);
+                        let col = row.get_by_offset(0).to_column(num_rows);
                         let value = StringType::try_downcast_column(&col).unwrap();
                         for r in value.iter() {
                             keywords.push(r.to_string());

--- a/src/query/service/src/local/executor.rs
+++ b/src/query/service/src/local/executor.rs
@@ -106,8 +106,7 @@ impl SessionExecutor {
             if let Ok((mut rows, _, _, _)) = rows {
                 while let Some(row) = rows.next().await {
                     if let Ok(row) = row {
-                        let num_rows = row.num_rows();
-                        let col = row.get_by_offset(0).to_column(num_rows);
+                        let col = row.get_by_offset(0).to_column();
                         let value = StringType::try_downcast_column(&col).unwrap();
                         for r in value.iter() {
                             keywords.push(r.to_string());

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_meta.rs
@@ -42,7 +42,7 @@ pub struct SerializedPayload {
 impl SerializedPayload {
     pub fn get_group_by_column(&self) -> &Column {
         let entry = self.data_block.columns().last().unwrap();
-        entry.value.as_column().unwrap()
+        entry.as_column().unwrap()
     }
 
     pub fn convert_to_aggregate_table(

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_spill_writer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_spill_writer.rs
@@ -198,16 +198,15 @@ pub fn agg_spilling_aggregate_payload(
             continue;
         }
 
-        let data_block = payload.aggregate_flush_all()?;
+        let data_block = payload.aggregate_flush_all()?.consume_convert_to_full();
         rows += data_block.num_rows();
 
         let begin = write_size;
-        let columns = data_block.columns().to_vec();
+        let columns = data_block.columns();
         let mut columns_data = Vec::with_capacity(columns.len());
         let mut columns_layout = Vec::with_capacity(columns.len());
-        for column in columns.into_iter() {
-            let column = column.into_column(data_block.num_rows());
-            let column_data = serialize_column(&column);
+        for entry in columns.iter() {
+            let column_data = serialize_column(entry.as_column().unwrap());
             write_size += column_data.len() as u64;
             columns_layout.push(column_data.len() as u64);
             columns_data.push(column_data);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
@@ -122,9 +122,8 @@ impl TransformDeserializer {
                             let columns = data_block
                                 .columns()
                                 .iter()
-                                .map(|c| c.value.clone().into_column())
-                                .try_collect::<Vec<_>>()
-                                .unwrap();
+                                .map(|c| c.as_column().unwrap().clone())
+                                .collect::<Vec<_>>();
 
                             let buckets =
                                 NumberType::<i64>::try_downcast_column(&columns[0]).unwrap();

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
@@ -210,7 +210,7 @@ fn exchange_agg_spilling_aggregate_payload(
         let mut columns_layout = Vec::with_capacity(columns.len());
 
         for entry in columns.into_iter() {
-            let column = entry.to_column(data_block.num_rows());
+            let column = entry.to_column();
             let column_data = serialize_column(&column);
             write_size += column_data.len() as u64;
             columns_layout.push(column_data.len() as u64);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
@@ -209,8 +209,8 @@ fn exchange_agg_spilling_aggregate_payload(
         let mut columns_data = Vec::with_capacity(columns.len());
         let mut columns_layout = Vec::with_capacity(columns.len());
 
-        for column in columns.into_iter() {
-            let column = column.into_column(data_block.num_rows());
+        for entry in columns.into_iter() {
+            let column = entry.to_column(data_block.num_rows());
             let column_data = serialize_column(&column);
             write_size += column_data.len() as u64;
             columns_layout.push(column_data.len() as u64);

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_expand.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_expand.rs
@@ -71,13 +71,13 @@ impl Transform for TransformExpandGroupingSets {
                 if bits & (1 << i) == 0 {
                     // This column should be set to NULLs.
                     *entry = BlockEntry::new(
-                        entry.data_type.wrap_nullable(),
+                        entry.data_type().wrap_nullable(),
                         Value::Scalar(Scalar::Null),
                     )
                 } else {
                     *entry = BlockEntry::new(
-                        entry.data_type.wrap_nullable(),
-                        entry.value.clone().wrap_nullable(None),
+                        entry.data_type().wrap_nullable(),
+                        entry.value().wrap_nullable(None),
                     )
                 }
             }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_expand.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_expand.rs
@@ -19,7 +19,6 @@ use databend_common_expression::types::NumberScalar;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_pipeline_transforms::processors::Transform;
 
 pub struct TransformExpandGroupingSets {
@@ -46,42 +45,46 @@ impl Transform for TransformExpandGroupingSets {
         let dup_group_by_cols = self
             .group_bys
             .iter()
-            .map(|i| data.columns()[*i].clone())
+            .map(|i| data.get_by_offset(*i).clone())
             .collect::<Vec<_>>();
 
         for &id in &self.grouping_ids {
             // Repeat data for each grouping set.
-            let grouping_id_column = BlockEntry::new(
+            let grouping_id_column = BlockEntry::new_const_column(
                 DataType::Number(NumberDataType::UInt32),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt32(id as u32))),
+                Scalar::Number(NumberScalar::UInt32(id as u32)),
+                num_rows,
             );
-            let mut columns = data
+            let mut entries = data
                 .columns()
                 .iter()
                 .cloned()
-                .chain(dup_group_by_cols.iter().cloned())
-                .chain(vec![grouping_id_column])
+                .chain(dup_group_by_cols.clone())
+                .chain(Some(grouping_id_column))
                 .collect::<Vec<_>>();
             let bits = !id;
             for i in 0..num_group_bys {
                 let entry = unsafe {
                     let offset = self.group_bys.get_unchecked(i);
-                    columns.get_unchecked_mut(*offset)
+                    entries.get_unchecked_mut(*offset)
                 };
                 if bits & (1 << i) == 0 {
                     // This column should be set to NULLs.
-                    *entry = BlockEntry::new(
+                    *entry = BlockEntry::new_const_column(
                         entry.data_type().wrap_nullable(),
-                        Value::Scalar(Scalar::Null),
+                        Scalar::Null,
+                        num_rows,
                     )
                 } else {
-                    *entry = BlockEntry::new(
-                        entry.data_type().wrap_nullable(),
-                        entry.value().wrap_nullable(None),
-                    )
+                    match entry {
+                        BlockEntry::Const(_, data_type, _) => {
+                            *data_type = data_type.wrap_nullable();
+                        }
+                        BlockEntry::Column(column) => *column = column.clone().wrap_nullable(None),
+                    };
                 }
             }
-            output_blocks.push(DataBlock::new(columns, num_rows));
+            output_blocks.push(DataBlock::new(entries, num_rows));
         }
 
         DataBlock::concat(&output_blocks)

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_single_key.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_single_key.rs
@@ -281,7 +281,7 @@ impl AccumulatingTransform for FinalSingleStateAggregator {
             .enumerate()
         {
             for block in self.to_merge_data.iter() {
-                let state = block.get_by_offset(idx).value.as_column().unwrap();
+                let state = block.get_by_offset(idx).as_column().unwrap();
                 func.batch_merge_single(place, state)?;
             }
             func.merge_result(place, builder)?;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -187,8 +187,8 @@ pub(crate) fn wrap_true_validity(
     num_rows: usize,
     true_validity: &Bitmap,
 ) -> BlockEntry {
-    let col = entry.to_column(num_rows);
-    if matches!(col, Column::Null { .. }) || col.as_nullable().is_some() {
+    let col = entry.to_column();
+    if col.is_null() || col.is_nullable() {
         entry.clone()
     } else {
         let mut validity = true_validity.clone();

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -188,13 +188,11 @@ pub(crate) fn wrap_true_validity(
     true_validity: &Bitmap,
 ) -> BlockEntry {
     let col = entry.to_column(num_rows);
-    let data_type = &entry.data_type();
     if matches!(col, Column::Null { .. }) || col.as_nullable().is_some() {
         entry.clone()
     } else {
         let mut validity = true_validity.clone();
         validity.slice(0, num_rows);
-        let col = NullableColumn::new_column(col, validity);
-        BlockEntry::new(data_type.wrap_nullable(), Value::Column(col))
+        NullableColumn::new_column(col, validity).into()
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/common.rs
@@ -183,14 +183,14 @@ impl HashJoinState {
 }
 
 pub(crate) fn wrap_true_validity(
-    column: &BlockEntry,
+    entry: &BlockEntry,
     num_rows: usize,
     true_validity: &Bitmap,
 ) -> BlockEntry {
-    let (value, data_type) = (&column.value, &column.data_type);
-    let col = value.convert_to_full_column(data_type, num_rows);
+    let col = entry.to_column(num_rows);
+    let data_type = &entry.data_type();
     if matches!(col, Column::Null { .. }) || col.as_nullable().is_some() {
-        column.clone()
+        entry.clone()
     } else {
         let mut validity = true_validity.clone();
         validity.slice(0, num_rows);

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -700,10 +700,7 @@ impl HashJoinBuildState {
                 .map(|index| {
                     let full_columns = data_blocks
                         .iter()
-                        .map(|block| {
-                            let rows = block.num_rows();
-                            block.get_by_offset(index).to_column(rows)
-                        })
+                        .map(|block| block.get_by_offset(index).to_column())
                         .collect::<Vec<_>>();
                     Column::take_downcast_column_vec(&full_columns)
                 })

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -30,7 +30,6 @@ use databend_common_exception::Result;
 use databend_common_expression::arrow::and_validities;
 use databend_common_expression::types::DataType;
 use databend_common_expression::Column;
-use databend_common_expression::ColumnBuilder;
 use databend_common_expression::ColumnVec;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
@@ -41,7 +40,6 @@ use databend_common_expression::HashMethodSerializer;
 use databend_common_expression::HashMethodSingleBinary;
 use databend_common_expression::KeysState;
 use databend_common_expression::RemoteExpr;
-use databend_common_expression::Value;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_hashtable::BinaryHashJoinHashMap;
 use databend_common_hashtable::HashJoinHashMap;
@@ -696,23 +694,15 @@ impl HashJoinBuildState {
         {
             let num_columns = data_blocks[0].num_columns();
             let columns_data_type: Vec<DataType> = (0..num_columns)
-                .map(|index| data_blocks[0].get_by_offset(index).data_type.clone())
+                .map(|index| data_blocks[0].data_type(index))
                 .collect();
             let columns: Vec<ColumnVec> = (0..num_columns)
                 .map(|index| {
                     let full_columns = data_blocks
                         .iter()
                         .map(|block| {
-                            let entry = block.get_by_offset(index);
                             let rows = block.num_rows();
-                            match &entry.value {
-                                Value::Scalar(s) => {
-                                    let builder =
-                                        ColumnBuilder::repeat(&s.as_ref(), rows, &entry.data_type);
-                                    builder.build()
-                                }
-                                Value::Column(c) => c.clone(),
-                            }
+                            block.get_by_offset(index).to_column(rows)
                         })
                         .collect::<Vec<_>>();
                     Column::take_downcast_column_vec(&full_columns)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -260,10 +260,11 @@ impl HashJoinProbeState {
         let probe_keys = (&keys_columns).into();
 
         let probe_has_null = if self.join_type() == JoinType::LeftMark {
-            match &input.get_by_offset(0).value {
-                Value::Scalar(Scalar::Null) => true,
-                Value::Column(Column::Nullable(c)) if c.validity.null_count() > 0 => true,
-                _ => false,
+            let entry = input.get_by_offset(0);
+            if let Some(Column::Nullable(c)) = entry.as_column() {
+                c.validity_ref().null_count() > 0
+            } else {
+                entry.as_scalar().unwrap().is_null()
             }
         } else {
             false

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -269,6 +269,8 @@ impl HashJoinProbeState {
             } else {
                 entry.as_scalar().unwrap().is_null()
             }
+        } else {
+            false
         };
         input = input.project(&self.probe_projections);
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -261,13 +261,14 @@ impl HashJoinProbeState {
 
         let probe_has_null = if self.join_type() == JoinType::LeftMark {
             let entry = input.get_by_offset(0);
-            if let Some(Column::Nullable(c)) = entry.as_column() {
-                c.validity_ref().null_count() > 0
+            if let Some(column) = entry.as_column() {
+                column
+                    .as_nullable()
+                    .map(|c| c.validity_ref().null_count() > 0)
+                    .unwrap_or(false)
             } else {
                 entry.as_scalar().unwrap().is_null()
             }
-        } else {
-            false
         };
         input = input.project(&self.probe_projections);
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
@@ -40,7 +40,7 @@ impl HashJoinProbeState {
         if build_num_rows == 1 {
             for col in build_block.columns() {
                 let scalar = unsafe { col.index_unchecked(0) };
-                probe_block.add_column(BlockEntry::new(
+                probe_block.add_entry(BlockEntry::new(
                     col.data_type(),
                     Value::Scalar(scalar.to_owned()),
                 ));
@@ -72,14 +72,12 @@ impl HashJoinProbeState {
 
         for col in probe_block.columns() {
             let scalar = unsafe { col.index_unchecked(take_index) };
-            replicated_probe_block.add_column(BlockEntry::new(
+            replicated_probe_block.add_entry(BlockEntry::new(
                 col.data_type(),
                 Value::Scalar(scalar.to_owned()),
             ));
         }
-        for col in build_block.columns() {
-            replicated_probe_block.add_column(col.clone());
-        }
+        replicated_probe_block.merge_block(build_block.clone());
         Ok(replicated_probe_block)
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
@@ -39,9 +39,9 @@ impl HashJoinProbeState {
         let build_block = DataBlock::concat(build_blocks)?;
         if build_num_rows == 1 {
             for col in build_block.columns() {
-                let scalar = unsafe { col.value.index_unchecked(0) };
+                let scalar = unsafe { col.index_unchecked(0) };
                 probe_block.add_column(BlockEntry::new(
-                    col.data_type.clone(),
+                    col.data_type(),
                     Value::Scalar(scalar.to_owned()),
                 ));
             }
@@ -71,9 +71,9 @@ impl HashJoinProbeState {
         let mut replicated_probe_block = DataBlock::new(columns, build_num_rows);
 
         for col in probe_block.columns() {
-            let scalar = unsafe { col.value.index_unchecked(take_index) };
+            let scalar = unsafe { col.index_unchecked(take_index) };
             replicated_probe_block.add_column(BlockEntry::new(
-                col.data_type.clone(),
+                col.data_type(),
                 Value::Scalar(scalar.to_owned()),
             ));
         }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -40,7 +38,7 @@ impl HashJoinProbeState {
         if build_num_rows == 1 {
             for col in build_block.columns() {
                 let scalar = unsafe { col.index_unchecked(0) };
-                probe_block.add_const_column(col.data_type(), scalar.to_owned());
+                probe_block.add_const_column(scalar.to_owned(), col.data_type());
             }
             return Ok(vec![probe_block]);
         }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/cross_join.rs
@@ -40,10 +40,7 @@ impl HashJoinProbeState {
         if build_num_rows == 1 {
             for col in build_block.columns() {
                 let scalar = unsafe { col.index_unchecked(0) };
-                probe_block.add_entry(BlockEntry::new(
-                    col.data_type(),
-                    Value::Scalar(scalar.to_owned()),
-                ));
+                probe_block.add_const_column(col.data_type(), scalar.to_owned());
             }
             return Ok(vec![probe_block]);
         }
@@ -72,10 +69,7 @@ impl HashJoinProbeState {
 
         for col in probe_block.columns() {
             let scalar = unsafe { col.index_unchecked(take_index) };
-            replicated_probe_block.add_entry(BlockEntry::new(
-                col.data_type(),
-                Value::Scalar(scalar.to_owned()),
-            ));
+            replicated_probe_block.add_const_column(scalar.to_owned(), col.data_type());
         }
         replicated_probe_block.merge_block(build_block.clone());
         Ok(replicated_probe_block)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
@@ -241,7 +241,7 @@ impl HashJoinProbeState {
                         &probe_state.true_validity,
                     ),
                 };
-                result_block.add_column(entry);
+                result_block.add_entry(entry);
             }
         }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
@@ -392,10 +392,7 @@ impl HashJoinProbeState {
                     .build_schema
                     .fields()
                     .iter()
-                    .map(|df| BlockEntry {
-                        data_type: df.data_type().clone(),
-                        value: Value::Scalar(Scalar::Null),
-                    })
+                    .map(|df| BlockEntry::new(df.data_type().clone(), Value::Scalar(Scalar::Null)))
                     .collect(),
                 unmatched_idx,
             );
@@ -456,9 +453,8 @@ impl HashJoinProbeState {
                 build_block
                     .columns()
                     .iter()
-                    .map(|c| BlockEntry {
-                        value: Value::Scalar(Scalar::Null),
-                        data_type: c.data_type.wrap_nullable(),
+                    .map(|c| {
+                        BlockEntry::new(c.data_type().wrap_nullable(), Value::Scalar(Scalar::Null))
                     })
                     .collect::<Vec<_>>()
             } else {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark_join.rs
@@ -19,6 +19,7 @@ use databend_common_exception::Result;
 use databend_common_expression::types::AccessType;
 use databend_common_expression::types::BooleanType;
 use databend_common_expression::types::NullableType;
+use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Expr;
 use databend_common_expression::KeyAccessor;
@@ -130,7 +131,7 @@ impl HashJoinProbeState {
             .input
             .columns()
             .iter()
-            .map(|c| c.to_column(input_num_rows))
+            .map(BlockEntry::to_column)
             .collect::<Vec<_>>();
         let markers = probe_state.markers.as_mut().unwrap();
         self.hash_join_state

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/result_blocks.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/result_blocks.rs
@@ -19,7 +19,6 @@ use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::KeyAccessor;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_hashtable::HashJoinHashtableLike;
 
 use super::ProbeState;
@@ -152,16 +151,10 @@ impl HashJoinProbeState {
             None
         };
         let build_block = if build_state.generation_state.is_build_projected {
-            let null_build_block = DataBlock::new(
-                self.hash_join_state
-                    .build_schema
-                    .fields()
-                    .iter()
-                    .map(|df| BlockEntry::new(df.data_type().clone(), Value::Scalar(Scalar::Null)))
-                    .collect(),
-                input_num_rows,
-            );
-            Some(null_build_block)
+            let entries = self.hash_join_state.build_schema.fields().iter().map(|df| {
+                BlockEntry::new_const_column(df.data_type().clone(), Scalar::Null, input_num_rows)
+            });
+            Some(DataBlock::from_iter(entries, input_num_rows))
         } else {
             None
         };

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/result_blocks.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/result_blocks.rs
@@ -157,10 +157,7 @@ impl HashJoinProbeState {
                     .build_schema
                     .fields()
                     .iter()
-                    .map(|df| BlockEntry {
-                        data_type: df.data_type().clone(),
-                        value: Value::Scalar(Scalar::Null),
-                    })
+                    .map(|df| BlockEntry::new(df.data_type().clone(), Value::Scalar(Scalar::Null)))
                     .collect(),
                 input_num_rows,
             );

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
@@ -128,8 +128,8 @@ impl IEJoinState {
             return false;
         }
 
-        let left_l1_column = left_block.get_by_offset(0).to_column(left_len);
-        let right_l1_column = right_block.get_by_offset(0).to_column(right_len);
+        let left_l1_column = left_block.get_by_offset(0).to_column();
+        let right_l1_column = right_block.get_by_offset(0).to_column();
         // If `left_l1_column` and `right_l1_column` have intersection && `left_l2_column` and `right_l2_column` have intersection, return true
         let (left_l1_min, left_l1_max, right_l1_min, right_l1_max) = match self.l1_order {
             true => {
@@ -216,9 +216,8 @@ impl RangeJoinState {
         // Merge `left_sorted_blocks` to one block
         let mut merged_blocks = DataBlock::concat(&left_sorted_blocks)?;
         // extract the second column
-        let num_rows = merged_blocks.num_rows();
-        let l1 = &merged_blocks.get_by_offset(0).to_column(num_rows);
-        let l1_index_column = merged_blocks.get_by_offset(2).to_column(num_rows);
+        let l1 = &merged_blocks.get_by_offset(0).to_column();
+        let l1_index_column = merged_blocks.get_by_offset(2).to_column();
 
         let mut l2_sorted_blocks = Vec::with_capacity(left_sorted_blocks.len());
         for block in left_sorted_blocks.iter() {

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
@@ -22,7 +22,6 @@ use databend_common_expression::types::NumberColumnBuilder;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::types::UInt64Type;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
@@ -211,10 +210,7 @@ impl RangeJoinState {
             for idx in count..(count + block.num_rows()) {
                 column_builder.push(NumberScalar::UInt64(idx as u64));
             }
-            block.add_column(BlockEntry::new(
-                DataType::Number(NumberDataType::UInt64),
-                Value::Column(Column::Number(column_builder.build())),
-            ));
+            block.add_column(Column::Number(column_builder.build()));
             count += block.num_rows();
         }
         // Merge `left_sorted_blocks` to one block
@@ -366,9 +362,7 @@ impl RangeJoinState {
             indices.len(),
         );
         // Merge left_result_block and right_result_block
-        for col in right_result_block.columns() {
-            left_result_block.add_column(col.clone());
-        }
+        left_result_block.merge_block(right_result_block);
         for filter in self.other_conditions.iter() {
             left_result_block = filter_block(left_result_block, filter)?;
         }

--- a/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
@@ -105,9 +105,7 @@ impl RangeJoinState {
                         indices.len(),
                     );
                     // Merge left_result_block and right_result_block
-                    for col in right_result_block.columns() {
-                        left_result_block.add_column(col.clone());
-                    }
+                    left_result_block.merge_block(right_result_block);
                     for filter in self.other_conditions.iter() {
                         left_result_block = filter_block(left_result_block, filter)?;
                     }

--- a/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
@@ -43,11 +43,11 @@ impl RangeJoinState {
         let left_len = left_sorted_block.num_rows();
         let right_len = right_sort_block.num_rows();
 
-        let left_idx_col = &left_sorted_block.get_by_offset(1).to_column(left_len);
-        let left_join_key_col = &left_sorted_block.get_by_offset(0).to_column(left_len);
+        let left_idx_col = &left_sorted_block.get_by_offset(1).to_column();
+        let left_join_key_col = &left_sorted_block.get_by_offset(0).to_column();
 
-        let right_idx_col = &right_sort_block.get_by_offset(1).to_column(right_len);
-        let right_join_key_col = &right_sort_block.get_by_offset(0).to_column(right_len);
+        let right_idx_col = &right_sort_block.get_by_offset(1).to_column();
+        let right_join_key_col = &right_sort_block.get_by_offset(0).to_column();
 
         let mut i = 0;
         let mut j = 0;

--- a/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
-use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::DataBlock;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::SortColumnDescription;
-use databend_common_functions::BUILTIN_FUNCTIONS;
 
 use crate::pipelines::processors::transforms::range_join::filter_block;
 use crate::pipelines::processors::transforms::range_join::RangeJoinState;
@@ -46,27 +43,11 @@ impl RangeJoinState {
         let left_len = left_sorted_block.num_rows();
         let right_len = right_sort_block.num_rows();
 
-        let left_idx_col = &left_sorted_block.columns()[1]
-            .value
-            .convert_to_full_column(&DataType::Number(NumberDataType::Int64), left_len);
-        let left_join_key_col = &left_sorted_block.columns()[0].value.convert_to_full_column(
-            self.conditions[0]
-                .left_expr
-                .as_expr(&BUILTIN_FUNCTIONS)
-                .data_type(),
-            left_sorted_block.num_rows(),
-        );
+        let left_idx_col = &left_sorted_block.get_by_offset(1).to_column(left_len);
+        let left_join_key_col = &left_sorted_block.get_by_offset(0).to_column(left_len);
 
-        let right_idx_col = &right_sort_block.columns()[1]
-            .value
-            .convert_to_full_column(&DataType::Number(NumberDataType::Int64), right_len);
-        let right_join_key_col = &right_sort_block.columns()[0].value.convert_to_full_column(
-            self.conditions[0]
-                .right_expr
-                .as_expr(&BUILTIN_FUNCTIONS)
-                .data_type(),
-            right_sort_block.num_rows(),
-        );
+        let right_idx_col = &right_sort_block.get_by_offset(1).to_column(right_len);
+        let right_join_key_col = &right_sort_block.get_by_offset(0).to_column(right_len);
 
         let mut i = 0;
         let mut j = 0;

--- a/src/query/service/src/pipelines/processors/transforms/transform_add_internal_columns.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_add_internal_columns.rs
@@ -44,9 +44,8 @@ impl Transform for TransformAddInternalColumns {
                 .ok_or_else(|| ErrorCode::Internal("It's a bug"))?;
             let num_rows = block.num_rows();
             for internal_column in self.internal_columns.values() {
-                let column =
-                    internal_column.generate_column_values(&internal_column_meta, num_rows);
-                block.add_column(column);
+                let entry = internal_column.generate_column_values(&internal_column_meta, num_rows);
+                block.add_entry(entry);
             }
             block = block.add_meta(internal_column_meta.inner)?;
         }

--- a/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
@@ -18,10 +18,8 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::UInt64Type;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::GetSequenceNextValueReq;
 use databend_common_meta_app::schema::SequenceIdent;
 use databend_common_pipeline_transforms::processors::AsyncTransform;
@@ -99,10 +97,10 @@ pub async fn transform_sequence(
     ctx: &Arc<QueryContext>,
     data_block: &mut DataBlock,
     sequence_name: &String,
-    data_type: &DataType,
+    _data_type: &DataType,
 ) -> Result<()> {
     let count = data_block.num_rows() as u64;
-    let value = if count == 0 {
+    let column = if count == 0 {
         UInt64Type::from_data(vec![])
     } else {
         let tenant = ctx.get_tenant();
@@ -115,8 +113,7 @@ pub async fn transform_sequence(
         let range = resp.start..resp.start + count;
         UInt64Type::from_data(range.collect::<Vec<u64>>())
     };
-    let entry = BlockEntry::new(data_type.clone(), Value::Column(value));
-    data_block.add_column(entry);
+    data_block.add_column(column);
 
     Ok(())
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
@@ -115,10 +115,7 @@ pub async fn transform_sequence(
         let range = resp.start..resp.start + count;
         UInt64Type::from_data(range.collect::<Vec<u64>>())
     };
-    let entry = BlockEntry {
-        data_type: data_type.clone(),
-        value: Value::Column(value),
-    };
+    let entry = BlockEntry::new(data_type.clone(), Value::Column(value));
     data_block.add_column(entry);
 
     Ok(())

--- a/src/query/service/src/pipelines/processors/transforms/transform_cast_schema.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_cast_schema.rs
@@ -110,7 +110,7 @@ pub fn cast_schema(
     exprs: &[Expr],
     func_ctx: &FunctionContext,
 ) -> Result<DataBlock> {
-    let mut columns = Vec::with_capacity(exprs.len());
+    let mut entries = Vec::with_capacity(exprs.len());
     let evaluator = Evaluator::new(&data_block, func_ctx, &BUILTIN_FUNCTIONS);
     for (i, (field, expr)) in to_schema.fields().iter().zip(exprs.iter()).enumerate() {
         let value = evaluator.run(expr).map_err(|err| {
@@ -123,8 +123,8 @@ pub fn cast_schema(
             );
             err.add_message(msg)
         })?;
-        let column = BlockEntry::new(field.data_type().clone(), value);
-        columns.push(column);
+        let entry = BlockEntry::new(value, || (field.data_type().clone(), data_block.num_rows()));
+        entries.push(entry);
     }
-    Ok(DataBlock::new(columns, data_block.num_rows()))
+    Ok(DataBlock::new(entries, data_block.num_rows()))
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
@@ -605,7 +605,7 @@ impl TransformAsyncFunction {
         let entry = data_block.get_by_offset(arg_index);
         let value = op.dict_get(&entry.value(), data_type, dict_arg).await?;
         let entry = BlockEntry::new(data_type.clone(), value);
-        data_block.add_column(entry);
+        data_block.add_entry(entry);
 
         Ok(())
     }

--- a/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
@@ -604,7 +604,7 @@ impl TransformAsyncFunction {
         let arg_index = arg_indices[0];
         let entry = data_block.get_by_offset(arg_index);
         let value = op.dict_get(&entry.value(), data_type, dict_arg).await?;
-        let entry = BlockEntry::new(data_type.clone(), value);
+        let entry = BlockEntry::new(value, || (data_type.clone(), data_block.num_rows()));
         data_block.add_entry(entry);
 
         Ok(())

--- a/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_dictionary.rs
@@ -603,11 +603,8 @@ impl TransformAsyncFunction {
         // only support one key field.
         let arg_index = arg_indices[0];
         let entry = data_block.get_by_offset(arg_index);
-        let value = op.dict_get(&entry.value, data_type, dict_arg).await?;
-        let entry = BlockEntry {
-            data_type: data_type.clone(),
-            value,
-        };
+        let value = op.dict_get(&entry.value(), data_type, dict_arg).await?;
+        let entry = BlockEntry::new(data_type.clone(), value);
         data_block.add_column(entry);
 
         Ok(())

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
@@ -26,7 +26,6 @@ use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Evaluator;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
-use databend_common_expression::Value;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
@@ -254,15 +253,13 @@ fn check_type(
     }
 
     if left_data_type.remove_nullable() == right_data_type.remove_nullable() {
-        let origin_column = block.get_by_offset(index).clone();
+        let origin = block.get_by_offset(index).clone();
         let mut builder = ColumnBuilder::with_capacity(left_data_type, block.num_rows());
-        let value = origin_column.value;
         for idx in 0..block.num_rows() {
-            let scalar = value.index(idx).unwrap();
+            let scalar = origin.index(idx).unwrap();
             builder.push(scalar);
         }
-        let col = builder.build();
-        Ok(BlockEntry::new(left_data_type.clone(), Value::Column(col)))
+        Ok(builder.build().into())
     } else {
         Err(ErrorCode::IllegalDataType(
             "The data type on both sides of the union does not match",

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_block.rs
@@ -205,16 +205,20 @@ pub fn project_block(
         .map(|(left, right)| {
             if is_left {
                 if let Some(expr) = &left.1 {
-                    let column = BlockEntry::new(expr.data_type().clone(), evaluator.run(expr)?);
-                    Ok(column)
+                    let entry = BlockEntry::new(evaluator.run(expr)?, || {
+                        (expr.data_type().clone(), num_rows)
+                    });
+                    Ok(entry)
                 } else {
                     Ok(block
                         .get_by_offset(left_schema.index_of(&left.0.to_string())?)
                         .clone())
                 }
             } else if let Some(expr) = &right.1 {
-                let column = BlockEntry::new(expr.data_type().clone(), evaluator.run(expr)?);
-                Ok(column)
+                let entry = BlockEntry::new(evaluator.run(expr)?, || {
+                    (expr.data_type().clone(), num_rows)
+                });
+                Ok(entry)
             } else if left.1.is_some() {
                 Ok(block
                     .get_by_offset(right_schema.index_of(&right.0.to_string())?)

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
@@ -20,11 +20,9 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -161,10 +159,7 @@ where
             .row_converter
             .convert(&order_by_cols, block.num_rows())?;
         let order_col = rows.to_column();
-        block.add_column(BlockEntry::new(
-            order_col.data_type(),
-            Value::Column(order_col),
-        ));
+        block.add_column(order_col);
         Ok((rows, block))
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_sort.rs
@@ -161,10 +161,10 @@ where
             .row_converter
             .convert(&order_by_cols, block.num_rows())?;
         let order_col = rows.to_column();
-        block.add_column(BlockEntry {
-            data_type: order_col.data_type(),
-            value: Value::Column(order_col),
-        });
+        block.add_column(BlockEntry::new(
+            order_col.data_type(),
+            Value::Column(order_col),
+        ));
         Ok((rows, block))
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_sort/sort_spill.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_sort/sort_spill.rs
@@ -615,10 +615,7 @@ impl Debug for SpillableBlock {
 }
 
 fn sort_column(data: &DataBlock, sort_row_offset: usize) -> &Column {
-    data.get_by_offset(sort_row_offset)
-        .value
-        .as_column()
-        .unwrap()
+    data.get_by_offset(sort_row_offset).as_column().unwrap()
 }
 
 /// BoundBlockStream is a stream of blocks that are cutoff less or equal than bound.

--- a/src/query/service/src/pipelines/processors/transforms/transform_merge_sort/sort_spill.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_merge_sort/sort_spill.rs
@@ -819,12 +819,10 @@ mod tests {
     use databend_common_expression::types::Int32Type;
     use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::StringType;
-    use databend_common_expression::BlockEntry;
     use databend_common_expression::Column;
     use databend_common_expression::DataField;
     use databend_common_expression::DataSchemaRefExt;
     use databend_common_expression::FromData;
-    use databend_common_expression::Value;
     use databend_common_pipeline_transforms::processors::sort::convert_rows;
     use databend_common_pipeline_transforms::processors::sort::SimpleRowsAsc;
     use databend_common_pipeline_transforms::sort::SimpleRowsDesc;
@@ -868,7 +866,7 @@ mod tests {
         .into_iter()
         .map(|mut data| {
             let col = convert_rows(schema.clone(), &sort_desc, data.clone()).unwrap();
-            data.add_column(BlockEntry::new(col.data_type(), Value::Column(col)));
+            data.add_column(col);
             SpillableBlock::new(data, sort_row_offset)
         })
         .collect::<VecDeque<_>>();

--- a/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
@@ -377,10 +377,9 @@ impl BlockingTransform for TransformSRF {
                     }
                     let data_block = DataBlock::concat(&result_data_blocks)?;
                     debug_assert!(data_block.num_rows() == result_size);
-                    let block_entry =
-                        BlockEntry::from_value(data_block.get_by_offset(0).value(), || {
-                            (data_block.data_type(0), result_size)
-                        });
+                    let block_entry = BlockEntry::new(data_block.get_by_offset(0).value(), || {
+                        (data_block.data_type(0), result_size)
+                    });
                     if block_is_empty {
                         result = DataBlock::new(vec![block_entry], result_size);
                         block_is_empty = false;

--- a/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
@@ -145,15 +145,14 @@ impl BlockingTransform for TransformSRF {
         let mut result = DataBlock::empty();
         let mut block_is_empty = true;
         for column in input.columns() {
-            let mut builder = ColumnBuilder::with_capacity(&column.data_type, result_size);
+            let mut builder = ColumnBuilder::with_capacity(&column.data_type(), result_size);
             for (i, max_nums) in self.num_rows.iter().take(used).enumerate() {
-                let scalar_ref = unsafe { column.value.index_unchecked(i) };
+                let scalar_ref = unsafe { column.index_unchecked(i) };
                 for _ in 0..*max_nums {
                     builder.push(scalar_ref.clone());
                 }
             }
-            let block_entry =
-                BlockEntry::new(column.data_type.clone(), Value::Column(builder.build()));
+            let block_entry = BlockEntry::new(column.data_type(), Value::Column(builder.build()));
             if block_is_empty {
                 result = DataBlock::new(vec![block_entry], result_size);
                 block_is_empty = false;
@@ -399,8 +398,8 @@ impl BlockingTransform for TransformSRF {
                     let data_block = DataBlock::concat(&result_data_blocks)?;
                     debug_assert!(data_block.num_rows() == result_size);
                     let block_entry = BlockEntry::new(
-                        data_block.get_by_offset(0).data_type.clone(),
-                        data_block.get_by_offset(0).value.clone(),
+                        data_block.data_type(0),
+                        data_block.get_by_offset(0).value(),
                     );
                     if block_is_empty {
                         result = DataBlock::new(vec![block_entry], result_size);

--- a/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_srf.rs
@@ -372,15 +372,15 @@ impl BlockingTransform for TransformSRF {
                             );
                         }
 
-                        let block_entry = BlockEntry::new(srf_expr.return_type.clone(), row_result);
+                        let block_entry = row_result.into_column().unwrap().into();
                         result_data_blocks.push(DataBlock::new(vec![block_entry], self.num_rows[i]))
                     }
                     let data_block = DataBlock::concat(&result_data_blocks)?;
                     debug_assert!(data_block.num_rows() == result_size);
-                    let block_entry = BlockEntry::new(
-                        data_block.data_type(0),
-                        data_block.get_by_offset(0).value(),
-                    );
+                    let block_entry =
+                        BlockEntry::from_value(data_block.get_by_offset(0).value(), || {
+                            (data_block.data_type(0), result_size)
+                        });
                     if block_is_empty {
                         result = DataBlock::new(vec![block_entry], result_size);
                         block_is_empty = false;

--- a/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
@@ -32,6 +32,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::Value;
 use databend_common_pipeline_transforms::processors::Transform;
 use databend_common_sql::executor::physical_plans::UdfFunctionDesc;
 use databend_common_sql::plans::UDFLanguage;
@@ -332,8 +333,20 @@ impl TransformUdfScript {
             .map(|i| {
                 let arg = data_block.get_by_offset(*i).clone();
                 if contains_variant(&arg.data_type()) {
-                    let new_arg =
-                        BlockEntry::new(arg.data_type(), transform_variant(&arg.value(), true)?);
+                    let new_arg = match arg {
+                        BlockEntry::Const(scalar, data_type, n) => {
+                            let scalar = transform_variant(&Value::Scalar(scalar), true)?
+                                .into_scalar()
+                                .unwrap();
+                            BlockEntry::new_const_column(data_type, scalar, n)
+                        }
+                        BlockEntry::Column(column) => {
+                            transform_variant(&Value::Column(column), true)?
+                                .into_column()
+                                .unwrap()
+                                .into()
+                        }
+                    };
                     Ok(new_arg)
                 } else {
                     Ok(arg)
@@ -399,7 +412,9 @@ impl TransformUdfScript {
                     ))
                 },
             )?;
-            BlockEntry::new(func.data_type.as_ref().clone(), value)
+            BlockEntry::new(value, || {
+                (*func.data_type.to_owned(), data_block.num_rows())
+            })
         } else {
             result_block.get_by_offset(0).clone()
         };

--- a/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf_script.rs
@@ -390,7 +390,7 @@ impl TransformUdfScript {
                 ))
             })?;
 
-        let col = if contains_variant(&func.data_type) {
+        let entry = if contains_variant(&func.data_type) {
             let value = transform_variant(&result_block.get_by_offset(0).value(), false).map_err(
                 |err| {
                     ErrorCode::UDFDataError(format!(
@@ -404,15 +404,15 @@ impl TransformUdfScript {
             result_block.get_by_offset(0).clone()
         };
 
-        if col.data_type() != func.data_type.as_ref().clone() {
+        if entry.data_type() != func.data_type.as_ref().clone() {
             return Err(ErrorCode::UDFDataError(format!(
                 "Function {:?} returned column with data type {:?} but expected {:?}",
                 func.name,
-                col.data_type(),
+                entry.data_type(),
                 func.data_type
             )));
         }
-        data_block.add_column(col);
+        data_block.add_entry(entry);
         Ok(())
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_udf_server.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf_server.rs
@@ -135,11 +135,9 @@ impl TransformUdfServer {
             .iter()
             .map(|i| {
                 let arg = data_block.get_by_offset(*i).clone();
-                if contains_variant(&arg.data_type) {
-                    let new_arg = BlockEntry::new(
-                        arg.data_type.clone(),
-                        transform_variant(&arg.value, true)?,
-                    );
+                if contains_variant(&arg.data_type()) {
+                    let new_arg =
+                        BlockEntry::new(arg.data_type(), transform_variant(&arg.value(), true)?);
                     Ok(new_arg)
                 } else {
                     Ok(arg)
@@ -150,7 +148,7 @@ impl TransformUdfServer {
         let fields = block_entries
             .iter()
             .enumerate()
-            .map(|(idx, arg)| DataField::new(&format!("arg{}", idx + 1), arg.data_type.clone()))
+            .map(|(idx, arg)| DataField::new(&format!("arg{}", idx + 1), arg.data_type()))
             .collect::<Vec<_>>();
         let data_schema = DataSchema::new(fields);
 
@@ -213,11 +211,8 @@ impl TransformUdfServer {
         }
 
         let col = if contains_variant(&func.data_type) {
-            let value = transform_variant(&result_block.get_by_offset(0).value, false)?;
-            BlockEntry {
-                data_type: result_fields[0].data_type().clone(),
-                value,
-            }
+            let value = transform_variant(&result_block.get_by_offset(0).value(), false)?;
+            BlockEntry::new(result_fields[0].data_type().clone(), value)
         } else {
             result_block.get_by_offset(0).clone()
         };

--- a/src/query/service/src/pipelines/processors/transforms/transform_udf_server.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_udf_server.rs
@@ -210,14 +210,14 @@ impl TransformUdfServer {
             )));
         }
 
-        let col = if contains_variant(&func.data_type) {
+        let entry = if contains_variant(&func.data_type) {
             let value = transform_variant(&result_block.get_by_offset(0).value(), false)?;
             BlockEntry::new(result_fields[0].data_type().clone(), value)
         } else {
             result_block.get_by_offset(0).clone()
         };
 
-        data_block.add_column(col);
+        data_block.add_entry(entry);
         drop(permit);
         Ok(data_block)
     }

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
@@ -93,7 +93,7 @@ impl WindowPartitionTopNExchange {
         let mut sort_compare = SortCompare::with_force_equality(self.sort_desc.to_vec(), rows);
 
         for &offset in &self.partition_indices {
-            let array = block.get_by_offset(offset).value.clone();
+            let array = block.get_by_offset(offset).value();
             sort_compare.visit_value(array).unwrap();
             sort_compare.increment_column_index();
         }
@@ -101,7 +101,7 @@ impl WindowPartitionTopNExchange {
         let partition_equality = sort_compare.equality_index().to_vec();
 
         for desc in self.sort_desc.iter().skip(self.partition_indices.len()) {
-            let array = block.get_by_offset(desc.offset).value.clone();
+            let array = block.get_by_offset(desc.offset).value();
             sort_compare.visit_value(array).unwrap();
             sort_compare.increment_column_index();
         }
@@ -121,8 +121,7 @@ impl WindowPartitionTopNExchange {
         let mut hashes = vec![0u64; rows];
         for (i, &offset) in self.partition_indices.iter().enumerate() {
             let entry = block.get_by_offset(offset);
-            group_hash_value_spread(&hash_indices, entry.value.to_owned(), i == 0, &mut hashes)
-                .unwrap();
+            group_hash_value_spread(&hash_indices, entry.value(), i == 0, &mut hashes).unwrap();
         }
 
         let mut partition_permutation = vec![Vec::new(); self.num_partitions as usize];

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
@@ -175,7 +175,6 @@ mod tests {
     use databend_common_expression::types::StringType;
     use databend_common_expression::BlockEntry;
     use databend_common_expression::FromData;
-    use databend_common_expression::Scalar;
     use databend_common_expression::Value;
 
     use super::*;
@@ -196,24 +195,10 @@ mod tests {
 
         let data = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![3, 1, 2, 2, 4, 3, 7, 0, 3])),
-                ),
-                BlockEntry::new(
-                    StringType::data_type(),
-                    Value::Scalar(Scalar::String("a".to_string())),
-                ),
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![3, 1, 3, 2, 2, 3, 4, 3, 3])),
-                ),
-                BlockEntry::new(
-                    StringType::data_type(),
-                    Value::Column(StringType::from_data(vec![
-                        "a", "b", "c", "d", "e", "f", "g", "h", "i",
-                    ])),
-                ),
+                Int32Type::from_data(vec![3, 1, 2, 2, 4, 3, 7, 0, 3]).into(),
+                BlockEntry::new_const_column_arg::<StringType>("a".to_string(), 9),
+                Int32Type::from_data(vec![3, 1, 3, 2, 2, 3, 4, 3, 3]).into(),
+                StringType::from_data(vec!["a", "b", "c", "d", "e", "f", "g", "h", "i"]).into(),
             ],
             9,
         );

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_partial_top_n_exchange.rs
@@ -170,12 +170,10 @@ impl WindowPartitionTopNExchange {
 
 #[cfg(test)]
 mod tests {
-    use databend_common_expression::types::ArgType;
     use databend_common_expression::types::Int32Type;
     use databend_common_expression::types::StringType;
     use databend_common_expression::BlockEntry;
     use databend_common_expression::FromData;
-    use databend_common_expression::Value;
 
     use super::*;
 
@@ -246,14 +244,8 @@ mod tests {
 
         let data = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![7, 7, 7, 6, 5, 5, 4, 1, 3, 1, 1])),
-                ),
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![7, 6, 5, 5, 5, 4, 3, 3, 2, 3, 3])),
-                ),
+                Int32Type::from_data(vec![7, 7, 7, 6, 5, 5, 4, 1, 3, 1, 1]).into(),
+                Int32Type::from_data(vec![7, 6, 5, 5, 5, 4, 3, 3, 2, 3, 3]).into(),
             ],
             11,
         );
@@ -291,14 +283,8 @@ mod tests {
 
         let data = DataBlock::new(
             vec![
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![5, 2, 3, 3, 2, 2, 1, 1, 1, 1, 1])),
-                ),
-                BlockEntry::new(
-                    Int32Type::data_type(),
-                    Value::Column(Int32Type::from_data(vec![2, 2, 4, 3, 2, 2, 5, 4, 3, 3, 3])),
-                ),
+                Int32Type::from_data(vec![5, 2, 3, 3, 2, 2, 1, 1, 1, 1, 1]).into(),
+                Int32Type::from_data(vec![2, 2, 4, 3, 2, 2, 5, 4, 3, 3, 3]).into(),
             ],
             11,
         );

--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -25,14 +25,12 @@ use databend_common_exception::Result;
 use databend_common_expression::arithmetics_type::ResultTypeOfUnary;
 use databend_common_expression::types::Number;
 use databend_common_expression::types::NumberScalar;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::SortColumnDescription;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -453,10 +451,7 @@ impl<T: Number> TransformWindow<T> {
                     ColumnBuilder::with_capacity(&data_type, 0),
                 );
                 let new_column = builder.build();
-                output.add_column(BlockEntry::new(
-                    new_column.data_type(),
-                    Value::Column(new_column),
-                ));
+                output.add_column(new_column);
                 self.outputs.push_back(output);
                 self.next_output_block += 1;
             } else {

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -196,11 +196,7 @@ impl PlanFragment {
                         let columns = block
                             .columns()
                             .iter()
-                            .map(|entry| {
-                                entry
-                                    .value
-                                    .convert_to_full_column(&entry.data_type, block.num_rows())
-                            })
+                            .map(|entry| entry.to_column(block.num_columns()))
                             .collect::<Vec<Column>>();
                         let source = DataSource::ConstTable(ConstTableColumn {
                             columns,

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -23,7 +23,6 @@ use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
 use databend_common_settings::ReplaceIntoShuffleStrategy;
 use databend_common_sql::executor::physical_plans::CompactSource;
 use databend_common_sql::executor::physical_plans::ConstantTableScan;
@@ -183,7 +182,7 @@ impl PlanFragment {
                     let entries = values
                         .columns
                         .iter()
-                        .map(|col| BlockEntry::new(col.data_type(), Value::Column(col.clone())))
+                        .map(|col| col.clone().into())
                         .collect::<Vec<BlockEntry>>();
                     let block = DataBlock::new(entries, values.num_rows);
                     // Scatter the block

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -190,12 +190,16 @@ impl PlanFragment {
                     for i in 0..values.num_rows {
                         indices.push((i % num_executors) as u32);
                     }
+                    #[cfg(debug_assertions)]
+                    block.check_valid().unwrap();
                     let blocks = block.scatter(&indices, num_executors)?;
                     for (executor, block) in executors.iter().zip(blocks) {
+                        #[cfg(debug_assertions)]
+                        block.check_valid().unwrap();
                         let columns = block
                             .columns()
                             .iter()
-                            .map(|entry| entry.to_column())
+                            .map(BlockEntry::to_column)
                             .collect::<Vec<Column>>();
                         let source = DataSource::ConstTable(ConstTableColumn {
                             columns,

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -195,7 +195,7 @@ impl PlanFragment {
                         let columns = block
                             .columns()
                             .iter()
-                            .map(|entry| entry.to_column(block.num_columns()))
+                            .map(|entry| entry.to_column())
                             .collect::<Vec<Column>>();
                         let source = DataSource::ConstTable(ConstTableColumn {
                             columns,

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -190,12 +190,8 @@ impl PlanFragment {
                     for i in 0..values.num_rows {
                         indices.push((i % num_executors) as u32);
                     }
-                    #[cfg(debug_assertions)]
-                    block.check_valid().unwrap();
                     let blocks = block.scatter(&indices, num_executors)?;
                     for (executor, block) in executors.iter().zip(blocks) {
-                        #[cfg(debug_assertions)]
-                        block.check_valid().unwrap();
                         let columns = block
                             .columns()
                             .iter()

--- a/src/query/service/src/servers/http/v1/query/page_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/page_manager.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 use databend_common_base::base::tokio;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_io::prelude::FormatSettings;
@@ -151,7 +152,7 @@ impl PageManager {
         let columns = block
             .columns()
             .iter()
-            .map(|entry| entry.to_column(block.num_rows()))
+            .map(BlockEntry::to_column)
             .collect_vec();
 
         let block_memory_size = block.memory_size();

--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -246,9 +246,9 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
 
                     let columns = block
                         .consume_convert_to_full()
-                        .columns()
-                        .iter()
-                        .map(|column| column.value.clone().into_column().unwrap())
+                        .take_columns()
+                        .into_iter()
+                        .map(|column| column.into_column().unwrap())
                         .collect::<Vec<_>>();
 
                     for row_index in 0..num_rows {

--- a/src/query/service/src/spillers/serialize.rs
+++ b/src/query/service/src/spillers/serialize.rs
@@ -82,10 +82,10 @@ impl BlocksEncoder {
             } else {
                 DataBlock::concat(&std::mem::take(&mut blocks)).unwrap()
             };
-            let num_rows = block.num_rows();
-            let columns_layout = std::iter::once(self.size())
+            let columns_layout = Some(self.size())
+                .into_iter()
                 .chain(block.take_columns().into_iter().map(|entry| {
-                    let column = entry.to_column(num_rows);
+                    let column = entry.to_column();
                     write_column(&column, &mut self.buf).unwrap();
                     self.size()
                 }))

--- a/src/query/service/src/spillers/serialize.rs
+++ b/src/query/service/src/spillers/serialize.rs
@@ -85,7 +85,7 @@ impl BlocksEncoder {
             let num_rows = block.num_rows();
             let columns_layout = std::iter::once(self.size())
                 .chain(block.take_columns().into_iter().map(|entry| {
-                    let column = entry.value.into_full_column(&entry.data_type, num_rows);
+                    let column = entry.to_column(num_rows);
                     write_column(&column, &mut self.buf).unwrap();
                     self.size()
                 }))
@@ -118,7 +118,7 @@ fn fake_data_schema(block: &DataBlock) -> DataSchema {
         .columns()
         .iter()
         .enumerate()
-        .map(|(idx, arg)| DataField::new(&format!("arg{}", idx + 1), arg.data_type.clone()))
+        .map(|(idx, arg)| DataField::new(&format!("arg{}", idx + 1), arg.data_type()))
         .collect::<Vec<_>>();
     DataSchema::new(fields)
 }

--- a/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
+++ b/src/query/service/src/table_functions/inspect_parquet/inspect_parquet_table.rs
@@ -260,15 +260,19 @@ impl AsyncSource for InspectParquetSource {
         }
         let block = DataBlock::new(
             vec![
-                BlockEntry::from_arg_scalar::<StringType>(created),
-                BlockEntry::from_arg_scalar::<UInt64Type>(num_columns),
-                BlockEntry::from_arg_scalar::<UInt64Type>(
+                BlockEntry::new_const_column_arg::<StringType>(created, 1),
+                BlockEntry::new_const_column_arg::<UInt64Type>(num_columns, 1),
+                BlockEntry::new_const_column_arg::<UInt64Type>(
                     parquet_schema.file_metadata().num_rows() as _,
+                    1,
                 ),
-                BlockEntry::from_arg_scalar::<UInt64Type>(parquet_schema.num_row_groups() as _),
-                BlockEntry::from_arg_scalar::<UInt64Type>(serialized_size),
-                BlockEntry::from_arg_scalar::<Int64Type>(max_compressed),
-                BlockEntry::from_arg_scalar::<Int64Type>(max_uncompressed),
+                BlockEntry::new_const_column_arg::<UInt64Type>(
+                    parquet_schema.num_row_groups() as _,
+                    1,
+                ),
+                BlockEntry::new_const_column_arg::<UInt64Type>(serialized_size, 1),
+                BlockEntry::new_const_column_arg::<Int64Type>(max_compressed, 1),
+                BlockEntry::new_const_column_arg::<Int64Type>(max_uncompressed, 1),
             ],
             1,
         );

--- a/src/query/service/src/table_functions/others/license_info.rs
+++ b/src/query/service/src/table_functions/others/license_info.rs
@@ -28,15 +28,14 @@ use databend_common_catalog::table_function::TableFunction;
 use databend_common_exception::ErrorCode;
 pub use databend_common_exception::Result;
 use databend_common_exception::ToErrorCode;
-use databend_common_expression::types::DataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::TimestampType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_common_license::license::Feature;
 use databend_common_license::license::LicenseInfo;
 use databend_common_license::license_manager::LicenseManagerSwitch;
@@ -153,44 +152,28 @@ impl LicenseInfoSource {
         let feature_str = info.custom.display_features();
         Ok(DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(
-                        info.issuer.clone().unwrap_or("".to_string()),
-                    )),
+                BlockEntry::new_const_column_arg::<StringType>(
+                    info.issuer.clone().unwrap_or("".to_string()),
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(
-                        info.custom.r#type.clone().unwrap_or("".to_string()),
-                    )),
+                BlockEntry::new_const_column_arg::<StringType>(
+                    info.custom.r#type.clone().unwrap_or("".to_string()),
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(
-                        info.custom.org.clone().unwrap_or("".to_string()),
-                    )),
+                BlockEntry::new_const_column_arg::<StringType>(
+                    info.custom.org.clone().unwrap_or("".to_string()),
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::Timestamp,
-                    Value::Scalar(Scalar::Timestamp(
-                        info.issued_at.unwrap_or_default().as_micros() as i64,
-                    )),
+                BlockEntry::new_const_column_arg::<TimestampType>(
+                    info.issued_at.unwrap_or_default().as_micros() as i64,
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::Timestamp,
-                    Value::Scalar(Scalar::Timestamp(
-                        info.expires_at.unwrap_or_default().as_micros() as i64,
-                    )),
+                BlockEntry::new_const_column_arg::<TimestampType>(
+                    info.expires_at.unwrap_or_default().as_micros() as i64,
+                    1,
                 ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(human_readable_available_time)),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(feature_str.to_string())),
-                ),
+                BlockEntry::new_const_column_arg::<StringType>(human_readable_available_time, 1),
+                BlockEntry::new_const_column_arg::<StringType>(feature_str.to_string(), 1),
             ],
             1,
         ))

--- a/src/query/service/src/table_functions/others/tenant_quota.rs
+++ b/src/query/service/src/table_functions/others/tenant_quota.rs
@@ -183,10 +183,10 @@ impl TenantQuotaSource {
     fn to_block(&self, quota: &TenantQuota) -> Result<DataBlock> {
         Ok(DataBlock::new(
             vec![
-                BlockEntry::from_arg_scalar::<UInt32Type>(quota.max_databases),
-                BlockEntry::from_arg_scalar::<UInt32Type>(quota.max_tables_per_database),
-                BlockEntry::from_arg_scalar::<UInt32Type>(quota.max_stages),
-                BlockEntry::from_arg_scalar::<UInt32Type>(quota.max_files_per_stage),
+                BlockEntry::new_const_column_arg::<UInt32Type>(quota.max_databases, 1),
+                BlockEntry::new_const_column_arg::<UInt32Type>(quota.max_tables_per_database, 1),
+                BlockEntry::new_const_column_arg::<UInt32Type>(quota.max_stages, 1),
+                BlockEntry::new_const_column_arg::<UInt32Type>(quota.max_files_per_stage, 1),
             ],
             1,
         ))

--- a/src/query/service/src/test_kits/fuse.rs
+++ b/src/query/service/src/test_kits/fuse.rs
@@ -298,8 +298,7 @@ pub async fn query_count(result_stream: SendableDataBlockStream) -> Result<u64> 
     let blocks: Vec<DataBlock> = result_stream.try_collect().await?;
     let mut count: u64 = 0;
     for block in blocks {
-        let value = &block.get_by_offset(0).value;
-        let value = unsafe { value.index_unchecked(0) };
+        let value = unsafe { block.get_by_offset(0).index_unchecked(0) };
         if let ScalarRef::Number(NumberScalar::UInt64(v)) = value {
             count += v;
         }

--- a/src/query/service/tests/it/pipelines/filter/filter_executor.rs
+++ b/src/query/service/tests/it/pipelines/filter/filter_executor.rs
@@ -73,8 +73,8 @@ pub fn test_filter_executor() -> databend_common_exception::Result<()> {
             let columns_1 = block_1.columns();
             let columns_2 = block_2.columns();
             for idx in 0..columns_1.len() {
-                assert_eq!(columns_1[idx].data_type, columns_2[idx].data_type);
-                assert_eq!(columns_1[idx].value, columns_2[idx].value);
+                assert_eq!(columns_1[idx].data_type(), columns_2[idx].data_type());
+                assert_eq!(columns_1[idx].value(), columns_2[idx].value());
             }
         }
     }

--- a/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
@@ -25,7 +25,7 @@ fn create_pipeline(
 ) -> Result<(Arc<QueryPipelineExecutor>, Receiver<Result<DataBlock>>)> {
     let mut pipeline = Pipeline::create();
 
-    let data_type = data[0][0].get_by_offset(0).data_type.clone();
+    let data_type = data[0][0].data_type(0);
     let source_pipe = create_source_pipe(ctx, data)?;
     pipeline.add_pipe(source_pipe);
 

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -62,7 +62,7 @@ async fn test_spill_with_partition() -> Result<()> {
     assert_eq!(block.num_rows(), 100);
     assert_eq!(block.num_columns(), 2);
     for (col_idx, col) in block.columns().iter().enumerate() {
-        for (idx, cell) in col.to_column(100).iter().enumerate() {
+        for (idx, cell) in col.to_column().iter().enumerate() {
             assert_eq!(
                 cell,
                 ScalarRef::Number(NumberScalar::Int32((col_idx + idx) as i32))

--- a/src/query/service/tests/it/spillers/spiller.rs
+++ b/src/query/service/tests/it/spillers/spiller.rs
@@ -17,9 +17,7 @@ use std::assert_matches::assert_matches;
 use databend_common_base::base::tokio;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
-use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
@@ -64,12 +62,7 @@ async fn test_spill_with_partition() -> Result<()> {
     assert_eq!(block.num_rows(), 100);
     assert_eq!(block.num_columns(), 2);
     for (col_idx, col) in block.columns().iter().enumerate() {
-        for (idx, cell) in col
-            .value
-            .convert_to_full_column(&DataType::Number(NumberDataType::Int32), 100)
-            .iter()
-            .enumerate()
-        {
+        for (idx, cell) in col.to_column(100).iter().enumerate() {
             assert_eq!(
                 cell,
                 ScalarRef::Number(NumberScalar::Int32((col_idx + idx) as i32))

--- a/src/query/service/tests/it/sql/expr/block_operator.rs
+++ b/src/query/service/tests/it/sql/expr/block_operator.rs
@@ -45,7 +45,7 @@ fn test_cse() {
                 RawExpr::ColumnRef {
                     span: None,
                     id: 0usize,
-                    data_type: schema.field(0).data_type().clone(),
+                    data_type: schema.field(0).data_type(),
                     display_name: schema.field(0).name().clone(),
                 },
                 RawExpr::Constant {
@@ -68,7 +68,7 @@ fn test_cse() {
                         RawExpr::ColumnRef {
                             span: None,
                             id: 0usize,
-                            data_type: schema.field(0).data_type().clone(),
+                            data_type: schema.field(0).data_type(),
                             display_name: schema.field(0).name().clone(),
                         },
                         RawExpr::Constant {

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -219,12 +219,12 @@ impl AppendRow for TestFixture {
 
 async fn check_count(result_stream: SendableDataBlockStream) -> Result<u64> {
     let blocks: Vec<DataBlock> = result_stream.try_collect().await?;
-    match &blocks[0].get_by_offset(0).value {
+    match &blocks[0].get_by_offset(0).value() {
         Value::Scalar(Scalar::Number(NumberScalar::UInt64(s))) => Ok(*s),
         Value::Column(Column::Number(NumberColumn::UInt64(c))) => Ok(c[0]),
         _ => Err(ErrorCode::BadDataValueType(format!(
             "Expected UInt64, but got {:?}",
-            blocks[0].get_by_offset(0).value
+            blocks[0].get_by_offset(0).value()
         ))),
     }
 }
@@ -731,9 +731,9 @@ impl CompactSegmentTestFixture {
                     } else {
                         cluster_key_id.map(|v| {
                             let val = block.get_by_offset(0);
-                            let left = vec![unsafe { val.value.index_unchecked(0) }.to_owned()];
+                            let left = vec![unsafe { val.value().index_unchecked(0) }.to_owned()];
                             let right =
-                                vec![unsafe { val.value.index_unchecked(val.value.len() - 1) }
+                                vec![unsafe { val.index_unchecked(val.value().len() - 1) }
                                     .to_owned()];
                             let level = if left.eq(&right)
                                 && block.num_rows() >= thresholds.block_per_segment

--- a/src/query/sql/src/evaluator/block_operator.rs
+++ b/src/query/sql/src/evaluator/block_operator.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use databend_common_catalog::plan::AggIndexMeta;
 use databend_common_exception::Result;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
@@ -70,9 +69,7 @@ impl BlockOperator {
                     for expr in exprs {
                         let evaluator = Evaluator::new(&input, func_ctx, &BUILTIN_FUNCTIONS);
                         let result = evaluator.run(expr)?;
-                        let entry = BlockEntry::new(expr.data_type().clone(), result);
-
-                        input.add_entry(entry);
+                        input.add_value(result, expr.data_type().clone());
                     }
                     match projections {
                         Some(projections) => Ok(input.project(projections)),

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -562,7 +562,7 @@ impl<'a> SelectRewriter<'a> {
             }
             let columns = block.columns();
             for row in 0..block.num_rows() {
-                match columns[0].value.index(row).unwrap() {
+                match columns[0].index(row).unwrap() {
                     ScalarRef::String(s) => {
                         let literal = Expr::Literal {
                             span,

--- a/src/query/sql/src/planner/binder/expr_values.rs
+++ b/src/query/sql/src/planner/binder/expr_values.rs
@@ -172,7 +172,7 @@ impl BindContext {
             .columns()
             .iter()
             .skip(1)
-            .map(|col| unsafe { col.value.index_unchecked(0).to_owned() })
+            .map(|col| unsafe { col.index_unchecked(0).to_owned() })
             .collect();
         Ok(scalars)
     }

--- a/src/query/sql/src/planner/binder/expr_values.rs
+++ b/src/query/sql/src/planner/binder/expr_values.rs
@@ -18,14 +18,11 @@ use databend_common_ast::ast::Expr as AExpr;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
-use databend_common_expression::types::NumberDataType;
-use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::UInt8Type;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_pipeline_transforms::processors::Transform;
 
 use crate::binder::wrap_cast;
@@ -155,13 +152,8 @@ impl BindContext {
             projections: None,
         }];
 
-        let one_row_chunk = DataBlock::new(
-            vec![BlockEntry::new(
-                DataType::Number(NumberDataType::UInt8),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt8(1))),
-            )],
-            1,
-        );
+        let one_row_chunk =
+            DataBlock::new(vec![BlockEntry::new_const_column_arg::<UInt8Type>(1, 1)], 1);
         let func_ctx = ctx.get_function_context()?;
         let mut expression_transform = CompoundBlockOperator {
             operators,

--- a/src/query/sql/src/planner/execution/stream_column.rs
+++ b/src/query/sql/src/planner/execution/stream_column.rs
@@ -180,7 +180,7 @@ impl StreamContext {
         let mut new_block = block;
         for stream_column in self.stream_columns.iter() {
             let entry = stream_column.generate_column_values(meta, num_rows);
-            new_block.add_column(entry);
+            new_block.add_entry(entry);
         }
 
         self.operators

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -29,6 +29,7 @@ use databend_common_expression::types::DateType;
 use databend_common_expression::types::Int16Type;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::Int8Type;
+use databend_common_expression::types::MapType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::types::StringType;
@@ -106,30 +107,26 @@ fn test_base(file: &mut impl Write) {
     let blocks = [
         DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt8),
-                    Value::Scalar(Scalar::Number(NumberScalar::UInt8(1))),
+                BlockEntry::new_const_column_arg::<UInt8Type>(1, 2),
+                BlockEntry::new_const_column_arg::<StringType>("a".to_string(), 2),
+                BlockEntry::new_const_column_arg::<MapType<UInt8Type, StringType>>(
+                    KvColumn {
+                        keys: vec![1, 2].into(),
+                        values: ["a", "b"].into_iter().map(String::from).collect(),
+                    },
+                    2,
                 ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String("a".to_string())),
-                ),
-                BlockEntry::new(
-                    map_ty1.clone(),
-                    Value::Scalar(Scalar::Map(Column::Tuple(vec![
-                        UInt8Type::from_data(vec![1, 2]),
-                        StringType::from_data(vec!["a", "b"]),
-                    ]))),
-                ),
-                BlockEntry::new(
-                    map_ty2.clone(),
-                    Value::Scalar(Scalar::Map(Column::Tuple(vec![
-                        StringType::from_data(vec!["a", "b"]),
-                        VariantType::from_data(vec![
+                BlockEntry::new_const_column_arg::<MapType<StringType, VariantType>>(
+                    KvColumn {
+                        keys: ["a", "b"].into_iter().map(String::from).collect(),
+                        values: VariantType::from_data(vec![
                             jsonb::parse_value(r#""abc""#.as_bytes()).unwrap().to_vec(),
                             jsonb::parse_value(r#"100"#.as_bytes()).unwrap().to_vec(),
-                        ]),
-                    ]))),
+                        ])
+                        .into_variant()
+                        .unwrap(),
+                    },
+                    2,
                 ),
             ],
             2,

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -583,7 +583,7 @@ fn eval_index_expr(
         .enumerate()
         .filter_map(|(i, entry)| {
             let field = bloom_columns.get(&i)?;
-            let column = entry.value.as_column().unwrap();
+            let column = entry.as_column().unwrap();
             let null_count = column
                 .as_nullable()
                 .map(|nullable| nullable.validity.null_count())

--- a/src/query/storages/common/table_meta/src/meta/column_oriented_segment/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/column_oriented_segment/segment.rs
@@ -200,10 +200,7 @@ impl ColumnOrientedSegment {
 
     pub fn col_by_name(&self, name: &[&str]) -> Option<Column> {
         let (index, field) = self.segment_schema.column_with_name(name[0])?;
-        let column = self
-            .block_metas
-            .get_by_offset(index)
-            .to_column(self.block_metas.num_rows());
+        let column = self.block_metas.get_by_offset(index).to_column();
         if name.len() == 1 {
             Some(column)
         } else {

--- a/src/query/storages/delta/src/table_source.rs
+++ b/src/query/storages/delta/src/table_source.rs
@@ -213,28 +213,30 @@ fn check_block_schema(schema: &DataSchema, mut block: DataBlock) -> Result<DataB
 
     for (col, field) in block.columns_mut().iter_mut().zip(schema.fields().iter()) {
         // If the actual data is nullable, the field must be nullbale.
-        if col.data_type.is_nullable_or_null() && !field.is_nullable() {
+        if col.data_type().is_nullable_or_null() && !field.is_nullable() {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column is nullable, but schema field is not nullable",
                 field.name()
             )));
         }
         // The inner type of the data and field should be the same.
-        let data_type = col.data_type.remove_nullable();
+        let data_type = col.data_type().remove_nullable();
         let schema_type = field.data_type().remove_nullable();
         if data_type != schema_type {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column type is {:?}, but schema field type is {:?}",
                 field.name(),
-                col.data_type,
+                col.data_type(),
                 field.data_type()
             )));
         }
         // If the field is nullable but the actual data is not nullable,
         // we should wrap nullable for the data.
-        if field.is_nullable() && !col.data_type.is_nullable_or_null() {
-            col.data_type = col.data_type.wrap_nullable();
-            col.value = col.value.clone().wrap_nullable(None);
+        if field.is_nullable() && !col.data_type().is_nullable_or_null() {
+            *col = BlockEntry::new(
+                col.data_type().wrap_nullable(),
+                col.value().wrap_nullable(None),
+            );
         }
     }
 

--- a/src/query/storages/delta/src/table_source.rs
+++ b/src/query/storages/delta/src/table_source.rs
@@ -22,13 +22,14 @@ use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::FieldIndex;
+use databend_common_expression::Scalar;
 use databend_common_expression::TableField;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
@@ -65,7 +66,7 @@ pub struct DeltaTableSource {
 
     // Per partition
     stream: Option<ParquetRecordBatchStream<ParquetFileReader>>,
-    partition_block_entries: Vec<BlockEntry>,
+    partition_block_scalars: Vec<(DataType, Scalar)>,
 }
 
 impl DeltaTableSource {
@@ -99,7 +100,7 @@ impl DeltaTableSource {
             stream: None,
             generated_data: None,
             is_finished: false,
-            partition_block_entries: vec![],
+            partition_block_scalars: vec![],
         })))
     }
 }
@@ -154,11 +155,16 @@ impl Processor for DeltaTableSource {
                 .read_block_from_stream(&mut stream)
                 .await?
                 .map(|b| {
-                    let mut columns = b.columns().to_vec();
+                    let num_rows = b.num_rows();
+                    let mut entries = b.take_columns();
                     for (fi, pi) in self.output_partition_columns.iter() {
-                        columns.insert(*fi, self.partition_block_entries[*pi].clone());
+                        let (data_type, scalar) = self.partition_block_scalars[*pi].clone();
+                        entries.insert(
+                            *fi,
+                            BlockEntry::new_const_column(data_type, scalar, num_rows),
+                        );
                     }
-                    DataBlock::new(columns, b.num_rows())
+                    DataBlock::new(entries, num_rows)
                 })
                 .map(|b| check_block_schema(&self.output_schema, b))
                 .transpose()?
@@ -179,11 +185,9 @@ impl Processor for DeltaTableSource {
                         .cloned()
                         .zip(part.partition_values.iter().cloned())
                         .collect::<Vec<_>>();
-                    self.partition_block_entries = partition_fields
+                    self.partition_block_scalars = partition_fields
                         .iter()
-                        .map(|(f, v)| {
-                            BlockEntry::new(f.data_type().into(), Value::Scalar(v.clone()))
-                        })
+                        .map(|(f, v)| (f.data_type().into(), v.clone()))
                         .collect::<Vec<_>>();
                     let stream = self
                         .parquet_reader
@@ -211,32 +215,36 @@ fn check_block_schema(schema: &DataSchema, mut block: DataBlock) -> Result<DataB
         )));
     }
 
-    for (col, field) in block.columns_mut().iter_mut().zip(schema.fields().iter()) {
+    for (entry, field) in block.columns_mut().iter_mut().zip(schema.fields().iter()) {
         // If the actual data is nullable, the field must be nullbale.
-        if col.data_type().is_nullable_or_null() && !field.is_nullable() {
+        if entry.data_type().is_nullable_or_null() && !field.is_nullable() {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column is nullable, but schema field is not nullable",
                 field.name()
             )));
         }
         // The inner type of the data and field should be the same.
-        let data_type = col.data_type().remove_nullable();
+        let data_type = entry.data_type().remove_nullable();
         let schema_type = field.data_type().remove_nullable();
         if data_type != schema_type {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column type is {:?}, but schema field type is {:?}",
                 field.name(),
-                col.data_type(),
+                entry.data_type(),
                 field.data_type()
             )));
         }
         // If the field is nullable but the actual data is not nullable,
         // we should wrap nullable for the data.
-        if field.is_nullable() && !col.data_type().is_nullable_or_null() {
-            *col = BlockEntry::new(
-                col.data_type().wrap_nullable(),
-                col.value().wrap_nullable(None),
-            );
+        if field.is_nullable() && !entry.data_type().is_nullable_or_null() {
+            match entry {
+                BlockEntry::Const(_, data_type, _) => {
+                    *data_type = data_type.wrap_nullable();
+                }
+                BlockEntry::Column(column) => {
+                    *column = column.clone().wrap_nullable(None);
+                }
+            }
         }
     }
 

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
@@ -114,7 +114,7 @@ impl AggIndexReader {
         // 2. Compute the output block
         // Fill dummy columns first.
         let mut output_columns = vec![
-            BlockEntry::new(DataType::Null, Value::Scalar(Scalar::Null),);
+            BlockEntry::new(DataType::Null, Value::Scalar(Scalar::Null));
             self.actual_table_field_len
         ];
         let evaluator = Evaluator::new(&block, &self.func_ctx, &BUILTIN_FUNCTIONS);

--- a/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
+++ b/src/query/storages/fuse/src/io/read/agg_index/agg_index_reader.rs
@@ -114,17 +114,14 @@ impl AggIndexReader {
         // 2. Compute the output block
         // Fill dummy columns first.
         let mut output_columns = vec![
-            BlockEntry {
-                data_type: DataType::Null,
-                value: Value::Scalar(Scalar::Null),
-            };
+            BlockEntry::new(DataType::Null, Value::Scalar(Scalar::Null),);
             self.actual_table_field_len
         ];
         let evaluator = Evaluator::new(&block, &self.func_ctx, &BUILTIN_FUNCTIONS);
         for (expr, offset) in self.selection.iter() {
             let data_type = expr.data_type().clone();
             let value = evaluator.run(expr)?;
-            let col = BlockEntry { data_type, value };
+            let col = BlockEntry::new(data_type, value);
 
             if let Some(pos) = offset {
                 output_columns[*pos] = col;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native.rs
@@ -223,11 +223,7 @@ impl BlockReader {
         let mut entries = Vec::with_capacity(self.project_column_nodes.len());
         for (index, _) in self.project_column_nodes.iter().enumerate() {
             if let Some(column) = columns.iter().find(|c| c.0 == index).map(|c| c.1.clone()) {
-                let data_type: DataType = self.projected_schema.field(index).data_type().into();
-                entries.push(BlockEntry::new(
-                    data_type.clone(),
-                    Value::Column(column.clone()),
-                ));
+                entries.push(column.clone().into());
                 match nums_rows {
                     Some(rows) => {
                         debug_assert_eq!(rows, column.len(), "Column lengths are not equal")

--- a/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_native_deserialize.rs
@@ -144,17 +144,17 @@ impl BlockReader {
             )?
         } else {
             debug_assert!(chunk_arrays.len() == self.projected_schema.num_fields());
-            let cols = chunk_arrays
+            let entries = chunk_arrays
                 .into_iter()
                 .zip(self.data_schema().fields())
                 .map(|(arr, f)| {
                     let data_type = f.data_type();
                     Value::from_arrow_rs(arr, data_type)
-                        .map(|val| BlockEntry::new(data_type.clone(), val))
+                        .map(|val| BlockEntry::new(val, || (data_type.clone(), num_rows)))
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            DataBlock::new(cols, num_rows)
+            DataBlock::new(entries, num_rows)
         };
 
         // populate cache if necessary

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -58,7 +58,7 @@ impl BlockReader {
             &column_chunks,
             compression,
         )?;
-        let mut columns = Vec::with_capacity(self.projected_schema.fields.len());
+        let mut entries = Vec::with_capacity(self.projected_schema.fields.len());
         let name_paths = column_name_paths(&self.projection, &self.original_schema);
 
         let array_cache = if self.put_cache {
@@ -116,9 +116,9 @@ impl BlockReader {
                 }
                 None => Value::Scalar(self.default_vals[i].clone()),
             };
-            columns.push(BlockEntry::new(data_type, value));
+            entries.push(BlockEntry::new(value, || (data_type, num_rows)));
         }
-        Ok(DataBlock::new(columns, num_rows))
+        Ok(DataBlock::new(entries, num_rows))
     }
 }
 

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
@@ -205,7 +205,7 @@ impl VirtualColumnReader {
                 .index_of(&virtual_column_field.source_name)
                 .unwrap();
             let source = data_block.get_by_offset(src_index);
-            let src_arg = (source.value.clone(), source.data_type.clone());
+            let src_arg = (source.value(), source.data_type());
             let path_arg = (
                 Value::Scalar(virtual_column_field.key_paths.clone()),
                 DataType::String,

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
@@ -178,7 +178,7 @@ impl VirtualColumnReader {
             {
                 let orig_field = orig_schema.field_with_name(&name).unwrap();
                 let orig_type: DataType = orig_field.data_type().into();
-                let value = Value::Column(Column::from_arrow_rs(arrow_array, &orig_type)?);
+                let column = Column::from_arrow_rs(arrow_array, &orig_type)?;
                 let data_type: DataType = virtual_column_field.data_type.as_ref().into();
                 let entry = if orig_type != data_type {
                     let cast_func_name = format!(
@@ -188,14 +188,14 @@ impl VirtualColumnReader {
                     let (cast_value, cast_data_type) = eval_function(
                         None,
                         &cast_func_name,
-                        [(value, orig_type)],
+                        [(Value::Column(column), orig_type)],
                         &func_ctx,
                         data_block.num_rows(),
                         &BUILTIN_FUNCTIONS,
                     )?;
                     BlockEntry::new(cast_data_type, cast_value)
                 } else {
-                    BlockEntry::new(data_type, value)
+                    column.into()
                 };
                 data_block.add_entry(entry);
                 continue;

--- a/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
+++ b/src/query/storages/fuse/src/io/read/virtual_column/virtual_column_reader_parquet.rs
@@ -180,7 +180,7 @@ impl VirtualColumnReader {
                 let orig_type: DataType = orig_field.data_type().into();
                 let value = Value::Column(Column::from_arrow_rs(arrow_array, &orig_type)?);
                 let data_type: DataType = virtual_column_field.data_type.as_ref().into();
-                let column = if orig_type != data_type {
+                let entry = if orig_type != data_type {
                     let cast_func_name = format!(
                         "to_{}",
                         data_type.remove_nullable().to_string().to_lowercase()
@@ -197,7 +197,7 @@ impl VirtualColumnReader {
                 } else {
                     BlockEntry::new(data_type, value)
                 };
-                data_block.add_column(column);
+                data_block.add_entry(entry);
                 continue;
             }
             let src_index = self
@@ -220,7 +220,7 @@ impl VirtualColumnReader {
                 &BUILTIN_FUNCTIONS,
             )?;
 
-            let column = if let Some(cast_func_name) = &virtual_column_field.cast_func_name {
+            let entry = if let Some(cast_func_name) = &virtual_column_field.cast_func_name {
                 let (cast_value, cast_data_type) = eval_function(
                     None,
                     cast_func_name,
@@ -233,7 +233,7 @@ impl VirtualColumnReader {
             } else {
                 BlockEntry::new(data_type, value)
             };
-            data_block.add_column(column);
+            data_block.add_entry(entry);
         }
 
         Ok(data_block)

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -97,7 +97,7 @@ pub fn serialize_block(
             let batch: Vec<Column> = block
                 .take_columns()
                 .into_iter()
-                .map(|x| x.value.into_column().unwrap())
+                .map(|x| x.into_column().unwrap())
                 .collect();
 
             writer.start()?;

--- a/src/query/storages/fuse/src/io/write/bloom_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/bloom_index_writer.rs
@@ -64,7 +64,7 @@ impl BloomIndexState {
             let mut ngram_size = 0;
             for i in ngram_indexes {
                 let column = index_block.get_by_offset(*i);
-                ngram_size += column.value.memory_size() as u64;
+                ngram_size += column.value().memory_size() as u64;
             }
             Some(ngram_size)
         } else {

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -275,11 +275,10 @@ impl InvertedIndexWriter {
 
         let inverted_index_schema = TableSchema::new(fields);
 
-        let mut index_columns = Vec::with_capacity(values.len());
-        for value in values.into_iter() {
-            let index_value = Value::Scalar(value);
-            index_columns.push(BlockEntry::new(DataType::Binary, index_value));
-        }
+        let index_columns = values
+            .into_iter()
+            .map(|v| BlockEntry::new(DataType::Binary, Value::Scalar(v)))
+            .collect();
         let inverted_index_block = DataBlock::new(index_columns, 1);
 
         let mut data = Vec::with_capacity(DEFAULT_BLOCK_INDEX_BUFFER_SIZE);

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -217,7 +217,7 @@ impl InvertedIndexWriter {
             for (j, (field_index, ty)) in field_indexes.iter().enumerate() {
                 let field = Field::from_field_id(j as u32);
                 let column = block.get_by_offset(*field_index);
-                match unsafe { column.value.index_unchecked(i) } {
+                match unsafe { column.index_unchecked(i) } {
                     ScalarRef::String(text) => doc.add_text(field, text),
                     ScalarRef::Variant(jsonb_val) => {
                         // only support object JSON, other JSON type will not add index.
@@ -311,7 +311,7 @@ fn block_to_inverted_index(
 ) -> Result<()> {
     let mut offsets = Vec::with_capacity(block.num_columns());
     for column in block.columns() {
-        let value: Value<BinaryType> = column.value.try_downcast().unwrap();
+        let value: Value<BinaryType> = column.value().try_downcast().unwrap();
         write_buffer.extend_from_slice(value.as_scalar().unwrap());
         let offset = write_buffer.len() as u32;
         offsets.push(offset);

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -277,7 +277,7 @@ impl InvertedIndexWriter {
 
         let index_columns = values
             .into_iter()
-            .map(|v| BlockEntry::new(DataType::Binary, Value::Scalar(v)))
+            .map(|v| BlockEntry::new_const_column(DataType::Binary, v, 1))
             .collect();
         let inverted_index_block = DataBlock::new(index_columns, 1);
 

--- a/src/query/storages/fuse/src/io/write/stream/block_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/block_builder.rs
@@ -100,7 +100,7 @@ impl BlockWriter for BlockWriterImpl {
                 let batch: Vec<Column> = block
                     .take_columns()
                     .into_iter()
-                    .map(|x| x.value.into_column().unwrap())
+                    .map(|x| x.into_column().unwrap())
                     .collect();
                 writer.write(&batch)?;
             }

--- a/src/query/storages/fuse/src/io/write/stream/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/io/write/stream/cluster_statistics.rs
@@ -129,7 +129,7 @@ impl ClusterStatisticsState {
             .builder
             .cluster_key_index
             .iter()
-            .map(|&i| block.get_by_offset(i).to_column(num_rows))
+            .map(|&i| block.get_by_offset(i).to_column())
             .collect();
         let tuple = Column::Tuple(cols);
         let (min, _) = eval_aggr("min", vec![], &[tuple.clone()], num_rows, vec![])?;

--- a/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
+++ b/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
@@ -29,7 +29,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::UInt64Type;
 use databend_common_expression::types::VariantType;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
@@ -38,7 +37,6 @@ use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_common_expression::VariantDataType;
 use databend_common_expression::VIRTUAL_COLUMNS_LIMIT;
 use databend_common_io::constants::DEFAULT_BLOCK_INDEX_BUFFER_SIZE;
@@ -228,7 +226,7 @@ impl VirtualColumnBuilder {
                     _ => todo!(),
                 };
                 let virtual_table_type = infer_schema_type(&virtual_type).unwrap();
-                virtual_columns.push(BlockEntry::new(virtual_type, Value::Column(column)));
+                virtual_columns.push(column.into());
 
                 let mut key_name = String::new();
                 for path in key_paths {

--- a/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
+++ b/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
@@ -140,7 +140,7 @@ impl VirtualColumnBuilder {
 
             let mut virtual_values = BTreeMap::new();
             for row in 0..sample_rows {
-                let val = unsafe { column.value.index_unchecked(row) };
+                let val = unsafe { column.index_unchecked(row) };
                 if let ScalarRef::Variant(jsonb_bytes) = val {
                     let val = from_slice(jsonb_bytes).unwrap();
                     paths.clear();
@@ -157,7 +157,7 @@ impl VirtualColumnBuilder {
                 continue;
             }
             for row in sample_rows..num_rows {
-                let val = unsafe { column.value.index_unchecked(row) };
+                let val = unsafe { column.index_unchecked(row) };
                 if let ScalarRef::Variant(jsonb_bytes) = val {
                     let val = from_slice(jsonb_bytes).unwrap();
                     paths.clear();

--- a/src/query/storages/fuse/src/lib.rs
+++ b/src/query/storages/fuse/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(box_patterns)]
 #![allow(clippy::large_enum_variant)]
 #![recursion_limit = "256"]
+#![feature(try_blocks)]
 
 mod constants;
 mod fuse_column;

--- a/src/query/storages/fuse/src/operations/agg_index_sink.rs
+++ b/src/query/storages/fuse/src/operations/agg_index_sink.rs
@@ -71,7 +71,7 @@ impl AggIndexSink {
 
     fn process_block(&mut self, block: &mut DataBlock) {
         let col = block.get_by_offset(self.block_name_offset);
-        let block_name_col = col.value.try_downcast::<StringType>().unwrap();
+        let block_name_col = col.value().try_downcast::<StringType>().unwrap();
         let block_id = self.blocks.len();
         for i in 0..block.num_rows() {
             let location = block_name_col.index(i).unwrap().to_string();

--- a/src/query/storages/fuse/src/operations/agg_index_sink.rs
+++ b/src/query/storages/fuse/src/operations/agg_index_sink.rs
@@ -81,15 +81,20 @@ impl AggIndexSink {
                 .and_modify(|idx_vec| idx_vec.push((block_id as u32, i as u32, 1)))
                 .or_insert(vec![(block_id as u32, i as u32, 1)]);
         }
-        let mut result = DataBlock::new(vec![], block.num_rows());
 
-        for (idx, col) in block.columns().iter().enumerate() {
-            if !self.keep_block_name_col && idx == self.block_name_offset {
-                continue;
-            }
-            result.add_column(col.clone());
-        }
-
+        let entries = block
+            .columns()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| {
+                if self.keep_block_name_col || idx != self.block_name_offset {
+                    Some(entry.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let result = DataBlock::new(entries, block.num_rows());
         self.blocks.push(result);
     }
 }

--- a/src/query/storages/fuse/src/operations/gc.rs
+++ b/src/query/storages/fuse/src/operations/gc.rs
@@ -844,10 +844,7 @@ impl TryFrom<Arc<ColumnOrientedSegment>> for LocationTuple {
             .segment_schema
             .column_with_name(BLOOM_FILTER_INDEX_LOCATION)
             .unwrap();
-        let column = value
-            .block_metas
-            .get_by_offset(index)
-            .to_column(value.block_metas.num_rows());
+        let column = value.block_metas.get_by_offset(index).to_column();
         for value in column.iter() {
             match value {
                 ScalarRef::Null => {}

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
@@ -15,12 +15,12 @@
 use databend_common_exception::Result;
 use databend_common_expression::types::BooleanType;
 use databend_common_expression::types::DataType;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Constant;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::Scalar;
 use databend_common_expression::Value;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_sql::executor::cast_expr_to_non_null_boolean;
@@ -147,13 +147,12 @@ impl DeleteByExprMutator {
 
                 let const_expr = Expr::Constant(Constant {
                     span: None,
-                    scalar: databend_common_expression::Scalar::Boolean(false),
+                    scalar: Scalar::Boolean(false),
                     data_type: DataType::Boolean,
                 });
 
                 let const_predicates = expr2prdicate(&evaluator, &const_expr)?;
-
-                res_block.add_entry(BlockEntry::from_arg_value(const_predicates));
+                res_block.add_value(const_predicates.upcast(), DataType::Boolean);
 
                 Ok((res_block, self.get_row_id_block(filtered_block)))
             }

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
@@ -69,7 +69,7 @@ impl DeleteByExprMutator {
     ) -> Result<(Value<BooleanType>, Value<BooleanType>)> {
         // filter rows that's is not processed
         let filter_entry = data_block.get_by_offset(data_block.num_columns() - 1);
-        let old_filter: Value<BooleanType> = filter_entry.value.try_downcast().unwrap();
+        let old_filter: Value<BooleanType> = filter_entry.value().try_downcast().unwrap();
         // false means this row is not processed, so use `not` to reverse it.
         let (filter_not, _) = get_not(old_filter.clone(), &self.func_ctx, data_block.num_rows())?;
         let filter_not = filter_not.try_downcast().unwrap();

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/delete_by_expr_mutator.rs
@@ -153,7 +153,7 @@ impl DeleteByExprMutator {
 
                 let const_predicates = expr2prdicate(&evaluator, &const_expr)?;
 
-                res_block.add_column(BlockEntry::from_arg_value(const_predicates));
+                res_block.add_entry(BlockEntry::from_arg_value(const_predicates));
 
                 Ok((res_block, self.get_row_id_block(filtered_block)))
             }

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -184,7 +184,7 @@ impl MatchedAggregator {
         debug_assert!(
             row_id_col.data_type().remove_nullable() == DataType::Number(NumberDataType::UInt64)
         );
-        let row_ids = row_id_col.to_column(data_block.num_rows());
+        let row_ids = row_id_col.to_column();
         let row_id_kind = RowIdKind::downcast_ref_from(data_block.get_meta().unwrap()).unwrap();
         match row_id_kind {
             RowIdKind::Update => {

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -182,11 +182,9 @@ impl MatchedAggregator {
         // that's row_id
         let row_id_col = data_block.get_by_offset(0);
         debug_assert!(
-            row_id_col.data_type.remove_nullable() == DataType::Number(NumberDataType::UInt64)
+            row_id_col.data_type().remove_nullable() == DataType::Number(NumberDataType::UInt64)
         );
-        let row_ids = row_id_col
-            .value
-            .convert_to_full_column(&row_id_col.data_type, data_block.num_rows());
+        let row_ids = row_id_col.to_column(data_block.num_rows());
         let row_id_kind = RowIdKind::downcast_ref_from(data_block.get_meta().unwrap()).unwrap();
         match row_id_kind {
             RowIdKind::Update => {

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -398,7 +398,7 @@ impl AggregationContext {
         let origin_num_rows = origin_data_block.num_rows();
         if self.stream_ctx.is_some() {
             let row_num = build_origin_block_row_num(origin_num_rows);
-            origin_data_block.add_column(row_num);
+            origin_data_block.add_entry(row_num);
         }
 
         // apply delete

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_split_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/merge_into_split_mutator.rs
@@ -44,7 +44,7 @@ impl MutationSplitMutator {
         }
 
         let filter = match split_entry.as_column().unwrap() {
-            Column::Nullable(nullable_column) => nullable_column.validity_ref().clone(),
+            Column::Nullable(nullable_column) => nullable_column.validity().clone(),
             _ => {
                 return Err(ErrorCode::InvalidRowIdIndex(
                     "row id column should be a nullable column, but it's a normal column",

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
@@ -97,7 +97,7 @@ impl UpdateByExprMutator {
         let mut data_block = data_block.clone();
         let (last_filter, origin_block) = if has_filter {
             let filter_entry = data_block.get_by_offset(data_block.num_columns() - 1);
-            let old_filter: Value<BooleanType> = filter_entry.value.try_downcast().unwrap();
+            let old_filter = filter_entry.value().try_downcast().unwrap();
             // pop filter
             data_block.pop_columns(1);
             // has pop old filter
@@ -178,10 +178,7 @@ impl UpdateByExprMutator {
             }
         }
         // add filter
-        block_entries.push(BlockEntry {
-            data_type: DataType::Boolean,
-            value: last_filter,
-        });
+        block_entries.push(BlockEntry::new(DataType::Boolean, last_filter));
 
         Ok(DataBlock::new(block_entries, data_block.num_rows()))
     }

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/update_by_expr_mutator.rs
@@ -117,9 +117,8 @@ impl UpdateByExprMutator {
 
             predicates = res.try_downcast().unwrap();
 
-            data_block.add_column(BlockEntry::new(
-                DataType::Boolean,
-                Value::upcast(predicates.clone()),
+            data_block.add_entry(BlockEntry::from_arg_value::<BooleanType>(
+                predicates.clone(),
             ));
             let (last_filter, _) = get_or(
                 old_filter,
@@ -131,9 +130,8 @@ impl UpdateByExprMutator {
             (last_filter, origin_block)
         } else {
             let origin_block = data_block.clone();
-            data_block.add_column(BlockEntry::new(
-                DataType::Boolean,
-                Value::upcast(predicates.clone()),
+            data_block.add_entry(BlockEntry::from_arg_value::<BooleanType>(
+                predicates.clone(),
             ));
             (Value::upcast(predicates), origin_block)
         };

--- a/src/query/storages/fuse/src/operations/merge_into/processors/processor_merge_into_matched_and_split.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/processor_merge_into_matched_and_split.rs
@@ -386,7 +386,7 @@ impl Processor for MatchedSplitProcessor {
 
                 let filter: Value<BooleanType> = current_block
                     .get_by_offset(current_block.num_columns() - 1)
-                    .value
+                    .value()
                     .try_downcast()
                     .unwrap();
                 current_block = current_block.filter_boolean_value(&filter)?;
@@ -454,7 +454,7 @@ impl MatchedSplitProcessor {
                         expr: Box::new(RawExpr::ColumnRef {
                             span: None,
                             id: idx,
-                            data_type: col.data_type.clone(),
+                            data_type: col.data_type(),
                             display_name: "".to_string(),
                         }),
                         dest_type: self.target_table_schema.fields[idx].data_type().clone(),

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -25,7 +25,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::BooleanType;
 use databend_common_expression::types::DataType;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
@@ -249,7 +248,7 @@ impl Processor for MutationSource {
                             }
 
                             MutationAction::Update => {
-                                data_block.add_entry(BlockEntry::from_arg_value(predicates));
+                                data_block.add_value(predicates.upcast(), DataType::Boolean);
                                 if self.remain_reader.is_none() {
                                     self.state = State::PerformOperator(
                                         data_block,

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -227,7 +227,7 @@ impl Processor for MutationSource {
                                 } else {
                                     if self.block_reader.update_stream_columns {
                                         let row_num = build_origin_block_row_num(rows);
-                                        data_block.add_column(row_num);
+                                        data_block.add_entry(row_num);
                                     }
 
                                     let predicate_col = predicates.into_column().unwrap();
@@ -249,7 +249,7 @@ impl Processor for MutationSource {
                             }
 
                             MutationAction::Update => {
-                                data_block.add_column(BlockEntry::from_arg_value(predicates));
+                                data_block.add_entry(BlockEntry::from_arg_value(predicates));
                                 if self.remain_reader.is_none() {
                                     self.state = State::PerformOperator(
                                         data_block,
@@ -301,9 +301,7 @@ impl Processor for MutationSource {
                         remain_block
                     };
 
-                    for col in remain_block.columns() {
-                        data_block.add_column(col.clone());
-                    }
+                    data_block.merge_block(remain_block)
                 } else {
                     return Err(ErrorCode::Internal("It's a bug. Need remain reader"));
                 };

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -168,13 +168,13 @@ where F: RowsFetcher + Send + Sync + 'static
     async fn transform(&mut self, data: DataBlock) -> Result<Option<DataBlock>> {
         let num_rows = data.num_rows();
         let entry = &data.columns()[self.row_id_col_offset];
-        let value = entry.to_column(num_rows);
+        let column = entry.to_column();
         let row_id_column = if matches!(entry.data_type(), DataType::Number(NumberDataType::UInt64))
         {
-            value.into_number().unwrap().into_u_int64().unwrap()
+            column.into_number().unwrap().into_u_int64().unwrap()
         } else {
             // From merge into matched data, the row id column is nullable but has no null value.
-            let value = *value.into_nullable().unwrap();
+            let value = *column.into_nullable().unwrap();
             debug_assert!(value.validity.null_count() == 0);
             value.column.into_number().unwrap().into_u_int64().unwrap()
         };

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -263,11 +263,11 @@ where F: RowsFetcher + Send + Sync + 'static
         // We ensure it in transform method
         self.fetcher.clear_cache();
 
-        for col in fetched_block.columns().iter() {
+        for entry in fetched_block.take_columns() {
             if self.need_wrap_nullable {
-                data.add_column(wrap_true_validity(col, num_rows));
+                data.add_entry(wrap_true_validity(&entry, num_rows));
             } else {
-                data.add_column(col.clone());
+                data.add_entry(entry);
             }
         }
 

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -30,7 +30,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::ProcessorPtr;
@@ -288,7 +287,6 @@ fn wrap_true_validity(column: &BlockEntry, num_rows: usize) -> BlockEntry {
     if matches!(col, Column::Null { .. }) || col.as_nullable().is_some() {
         column.clone()
     } else {
-        let col = NullableColumn::new_column(col, Bitmap::new_trued(num_rows));
-        BlockEntry::new(data_type.wrap_nullable(), Value::Column(col))
+        NullableColumn::new_column(col, Bitmap::new_trued(num_rows)).into()
     }
 }

--- a/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
@@ -383,7 +383,7 @@ impl NativeDeserializeDataTransform {
                     .map(|index| {
                         let data_type = self.src_schema.field(*index).data_type().clone();
                         let default_val = &self.block_reader.default_vals[*index];
-                        BlockEntry::new(data_type, Value::Scalar(default_val.to_owned()))
+                        BlockEntry::new_const_column(data_type, default_val.to_owned(), 1)
                     })
                     .collect::<Vec<_>>();
 

--- a/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_source_deserializer.rs
@@ -405,10 +405,10 @@ impl NativeDeserializeDataTransform {
                         let part = FuseBlockPartInfo::from_part(&self.parts[0])?;
                         let num_rows = part.nums_rows;
 
-                        let data_type = self.src_schema.field(*index).data_type().clone();
+                        let data_type = self.src_schema.field(*index).data_type();
                         let default_val = self.block_reader.default_vals[*index].clone();
                         let value = Value::Scalar(default_val);
-                        let col = value.convert_to_full_column(&data_type, num_rows);
+                        let col = value.convert_to_full_column(data_type, num_rows);
                         let mut bitmap = MutableBitmap::from_len_set(num_rows);
                         sorter.push_column(&col, &mut bitmap);
                     }

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -162,7 +162,7 @@ impl DeserializeDataTransform {
         for (idx, filter) in self.cached_runtime_filter.as_ref().unwrap().iter() {
             let mut bitmap = MutableBitmap::from_len_zeroed(data_block.num_rows());
             let probe_block_entry = data_block.get_by_offset(*idx);
-            let probe_column = probe_block_entry.to_column(data_block.num_rows());
+            let probe_column = probe_block_entry.to_column();
 
             // Apply bloom filter
             ExprBloomFilter::new(filter.clone()).apply(probe_column, &mut bitmap)?;

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -162,9 +162,7 @@ impl DeserializeDataTransform {
         for (idx, filter) in self.cached_runtime_filter.as_ref().unwrap().iter() {
             let mut bitmap = MutableBitmap::from_len_zeroed(data_block.num_rows());
             let probe_block_entry = data_block.get_by_offset(*idx);
-            let probe_column = probe_block_entry
-                .value
-                .convert_to_full_column(&probe_block_entry.data_type, data_block.num_rows());
+            let probe_column = probe_block_entry.to_column(data_block.num_rows());
 
             // Apply bloom filter
             ExprBloomFilter::new(filter.clone()).apply(probe_column, &mut bitmap)?;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -456,7 +456,7 @@ impl AggregationContext {
         let mut columns = Vec::with_capacity(on_conflict_fields.len());
         for (field, _) in on_conflict_fields.iter().enumerate() {
             let on_conflict_field_index = field;
-            columns.push(&key_columns_data
+            let entry_value = key_columns_data
                 .columns()
                 .get(on_conflict_field_index)
                 .ok_or_else(|| {
@@ -465,8 +465,10 @@ impl AggregationContext {
                         on_conflict_field_index, segment_index, block_index
                     ))
                 })?
-                .value);
+                .value();
+            columns.push(entry_value);
         }
+        let columns: Vec<_> = columns.iter().collect();
 
         let mut bitmap = MutableBitmap::new();
         for row in 0..num_rows {

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -26,11 +26,8 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::MutableBitmap;
-use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::UInt64Type;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnId;
 use databend_common_expression::ComputedExpr;
@@ -38,7 +35,6 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::FromData;
 use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_metrics::storage::*;
 use databend_common_sql::evaluator::BlockOperator;
 use databend_common_sql::executor::physical_plans::OnConflictField;
@@ -528,9 +524,7 @@ impl AggregationContext {
                     remain_columns_data.filter_with_bitmap(&bitmap)?;
 
                 // merge the remaining columns
-                for col in remain_columns_data_after_deletion.columns() {
-                    key_columns_data_after_deletion.add_column(col.clone());
-                }
+                key_columns_data_after_deletion.merge_block(remain_columns_data_after_deletion);
 
                 // resort the block
                 let col_indexes = self
@@ -553,11 +547,8 @@ impl AggregationContext {
             for i in 0..num_rows {
                 row_ids.push(i as u64);
             }
-            let value = Value::Column(Column::filter(&UInt64Type::from_data(row_ids), &bitmap));
-            let row_num = BlockEntry::new(
-                DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
-                value.wrap_nullable(None),
-            );
+            let row_num =
+                Column::filter(&UInt64Type::from_data(row_ids), &bitmap).wrap_nullable(None);
             new_block.add_column(row_num);
 
             let stream_meta = gen_mutation_stream_meta(None, &block_meta.location.0)?;

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -119,12 +119,12 @@ impl ClusterStatsGenerator {
 
         for key in self.cluster_key_index.iter() {
             let val = data_block.get_by_offset(*key);
-            let left = unsafe { val.value.index_unchecked(0) }.to_owned();
+            let left = unsafe { val.index_unchecked(0) }.to_owned();
             min.push(left);
 
             // The maximum in cluster statistics neednot larger than the non-trimmed one.
             // So we use trim_min directly.
-            let right = unsafe { val.value.index_unchecked(val.value.len() - 1) }.to_owned();
+            let right = unsafe { val.index_unchecked(val.value().len() - 1) }.to_owned();
             max.push(right);
         }
 
@@ -144,7 +144,7 @@ impl ClusterStatsGenerator {
                 let mut tuple_values = Vec::with_capacity(self.cluster_key_index.len());
                 for key in self.cluster_key_index.iter() {
                     let val = data_block.get_by_offset(*key);
-                    let left = unsafe { val.value.index_unchecked(start) };
+                    let left = unsafe { val.index_unchecked(start) };
                     tuple_values.push(left.to_owned());
                 }
                 values.push(Scalar::Tuple(tuple_values));

--- a/src/query/storages/fuse/src/statistics/traverse.rs
+++ b/src/query/storages/fuse/src/statistics/traverse.rs
@@ -34,13 +34,14 @@ pub type TraverseResult =
 pub fn traverse_values_dfs(columns: &[BlockEntry], fields: &[TableField]) -> TraverseResult {
     let mut leaves = vec![];
     for (entry, field) in columns.iter().zip(fields) {
-        let data_type = &entry.data_type();
         let mut next_column_id = field.column_id;
-        if let Some(c) = entry.as_column() {
-            traverse_column_recursive(c, data_type, &mut next_column_id, &mut leaves)?;
-        } else {
-            let s = entry.as_scalar().unwrap();
-            traverse_scalar_recursive(s, data_type, &mut next_column_id, &mut leaves)?;
+        match entry {
+            BlockEntry::Const(s, data_type, _) => {
+                traverse_scalar_recursive(s, data_type, &mut next_column_id, &mut leaves)?;
+            }
+            BlockEntry::Column(c) => {
+                traverse_column_recursive(c, &c.data_type(), &mut next_column_id, &mut leaves)?;
+            }
         }
     }
     Ok(leaves)

--- a/src/query/storages/fuse/src/statistics/traverse.rs
+++ b/src/query/storages/fuse/src/statistics/traverse.rs
@@ -34,15 +34,13 @@ pub type TraverseResult =
 pub fn traverse_values_dfs(columns: &[BlockEntry], fields: &[TableField]) -> TraverseResult {
     let mut leaves = vec![];
     for (entry, field) in columns.iter().zip(fields) {
-        let data_type = &entry.data_type;
+        let data_type = &entry.data_type();
         let mut next_column_id = field.column_id;
-        match &entry.value {
-            Value::Scalar(s) => {
-                traverse_scalar_recursive(s, data_type, &mut next_column_id, &mut leaves)?;
-            }
-            Value::Column(c) => {
-                traverse_column_recursive(c, data_type, &mut next_column_id, &mut leaves)?;
-            }
+        if let Some(c) = entry.as_column() {
+            traverse_column_recursive(c, data_type, &mut next_column_id, &mut leaves)?;
+        } else {
+            let s = entry.as_scalar().unwrap();
+            traverse_scalar_recursive(s, data_type, &mut next_column_id, &mut leaves)?;
         }
     }
     Ok(leaves)

--- a/src/query/storages/fuse/src/table_functions/clustering_statistics.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_statistics.rs
@@ -20,11 +20,9 @@ use databend_common_catalog::table_args::TableArgs;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::string::StringColumnBuilder;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
@@ -34,7 +32,6 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 
@@ -229,30 +226,12 @@ impl<'a> ClusteringStatisticsImpl<'a> {
 
         Ok(DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(StringType::from_data(segment_name)),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(block_name.build())),
-                ),
-                BlockEntry::new(
-                    DataType::String.wrap_nullable(),
-                    Value::Column(StringType::from_opt_data(min)),
-                ),
-                BlockEntry::new(
-                    DataType::String.wrap_nullable(),
-                    Value::Column(StringType::from_opt_data(max)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::Int32).wrap_nullable(),
-                    Value::Column(Int32Type::from_opt_data(level)),
-                ),
-                BlockEntry::new(
-                    DataType::String.wrap_nullable(),
-                    Value::Column(StringType::from_opt_data(pages)),
-                ),
+                StringType::from_data(segment_name).into(),
+                Column::String(block_name.build()).into(),
+                StringType::from_opt_data(min).into(),
+                StringType::from_opt_data(max).into(),
+                Int32Type::from_opt_data(level).into(),
+                StringType::from_opt_data(pages).into(),
             ],
             row_num,
         ))

--- a/src/query/storages/fuse/src/table_functions/fuse_column.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_column.rs
@@ -18,20 +18,19 @@ use std::sync::Arc;
 use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
 use databend_common_expression::types::string::StringColumnBuilder;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::TimestampType;
 use databend_common_expression::types::UInt32Type;
 use databend_common_expression::types::UInt64Type;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractBlockMeta;
 use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractSegment;
 use databend_storages_common_table_meta::meta::TableSnapshot;
@@ -114,7 +113,7 @@ impl FuseColumn {
 
         let segments_io = SegmentsIO::create(ctx.clone(), tbl.operator.clone(), tbl.schema());
 
-        let mut row_num = 0;
+        let mut num_rows = 0;
         let chunk_size =
             std::cmp::min(ctx.get_settings().get_max_threads()? as usize * 4, len).max(1);
 
@@ -147,9 +146,9 @@ impl FuseColumn {
                             block_offset.push(offset);
                             bytes_compressed.push(length);
 
-                            row_num += 1;
+                            num_rows += 1;
 
-                            if row_num >= limit {
+                            if num_rows >= limit {
                                 break 'FOR;
                             }
                         }
@@ -160,49 +159,19 @@ impl FuseColumn {
 
         Ok(DataBlock::new(
             vec![
-                BlockEntry::new(DataType::String, Value::Scalar(Scalar::String(snapshot_id))),
-                BlockEntry::new(
-                    DataType::Timestamp,
-                    Value::Scalar(Scalar::Timestamp(timestamp)),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(block_location.build())),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(UInt64Type::from_data(block_size)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(UInt64Type::from_data(file_size)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(UInt64Type::from_data(row_count)),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(column_name.build())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(column_type.build())),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt32),
-                    Value::Column(UInt32Type::from_data(column_id)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(UInt64Type::from_data(block_offset)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(UInt64Type::from_data(bytes_compressed)),
-                ),
+                BlockEntry::new_const_column_arg::<StringType>(snapshot_id, num_rows),
+                BlockEntry::new_const_column_arg::<TimestampType>(timestamp, num_rows),
+                Column::String(block_location.build()).into(),
+                UInt64Type::from_data(block_size).into(),
+                UInt64Type::from_data(file_size).into(),
+                UInt64Type::from_data(row_count).into(),
+                Column::String(column_name.build()).into(),
+                Column::String(column_type.build()).into(),
+                UInt32Type::from_data(column_id).into(),
+                UInt64Type::from_data(block_offset).into(),
+                UInt64Type::from_data(bytes_compressed).into(),
             ],
-            row_num,
+            num_rows,
         ))
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
@@ -25,11 +25,9 @@ use databend_common_expression::expr::*;
 use databend_common_expression::types::nullable::NullableColumnBuilder;
 use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_expression::types::BooleanType;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::UInt32Type;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
@@ -43,7 +41,6 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_native::read::reader::NativeReader;
 use databend_common_native::stat::stat_simple;
@@ -277,35 +274,14 @@ impl<'a> FuseEncodingImpl<'a> {
 
         Ok(DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(table_name.build())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(column_name.build())),
-                ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(Column::String(column_type.build())),
-                ),
-                BlockEntry::new(
-                    DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt32))),
-                    Value::Column(UInt32Type::from_opt_data(validity_size)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt32),
-                    Value::Column(UInt32Type::from_data(compressed_size)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt32),
-                    Value::Column(UInt32Type::from_data(uncompressed_size)),
-                ),
-                BlockEntry::new(DataType::String, Value::Column(Column::String(l1.build()))),
-                BlockEntry::new(
-                    DataType::Nullable(Box::new(DataType::String)),
-                    Value::Column(Column::Nullable(Box::new(l2.build().upcast()))),
-                ),
+                Column::String(table_name.build()).into(),
+                Column::String(column_name.build()).into(),
+                Column::String(column_type.build()).into(),
+                UInt32Type::from_opt_data(validity_size).into(),
+                UInt32Type::from_data(compressed_size).into(),
+                UInt32Type::from_data(uncompressed_size).into(),
+                Column::String(l1.build()).into(),
+                Column::Nullable(Box::new(l2.build().upcast())).into(),
             ],
             all_num_rows,
         ))

--- a/src/query/storages/hive/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/hive/src/hive_table_source.rs
@@ -22,13 +22,14 @@ use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::FieldIndex;
+use databend_common_expression::Scalar;
 use databend_common_expression::TableField;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
@@ -64,7 +65,7 @@ pub struct HiveTableSource {
 
     // Per partition
     stream: Option<ParquetRecordBatchStream<ParquetFileReader>>,
-    partition_block_entries: Vec<BlockEntry>,
+    partition_block_scalars: Vec<(DataType, Scalar)>,
 }
 
 impl HiveTableSource {
@@ -98,7 +99,7 @@ impl HiveTableSource {
             stream: None,
             generated_data: None,
             is_finished: false,
-            partition_block_entries: vec![],
+            partition_block_scalars: vec![],
         })))
     }
 }
@@ -153,11 +154,16 @@ impl Processor for HiveTableSource {
                 .read_block_from_stream(&mut stream)
                 .await?
                 .map(|b| {
-                    let mut columns = b.columns().to_vec();
+                    let num_rows = b.num_rows();
+                    let mut entries = b.take_columns();
                     for (fi, pi) in self.output_partition_columns.iter() {
-                        columns.insert(*fi, self.partition_block_entries[*pi].clone());
+                        let (data_type, scalar) = self.partition_block_scalars[*pi].clone();
+                        entries.insert(
+                            *fi,
+                            BlockEntry::new_const_column(data_type, scalar, num_rows),
+                        );
                     }
-                    DataBlock::new(columns, b.num_rows())
+                    DataBlock::new(entries, num_rows)
                 })
                 .map(|b| check_block_schema(&self.output_schema, b))
                 .transpose()?
@@ -176,10 +182,10 @@ impl Processor for HiveTableSource {
                 .cloned()
                 .zip(part.partitions.iter().cloned())
                 .collect::<Vec<_>>();
-            self.partition_block_entries = partition_fields
+            self.partition_block_scalars = partition_fields
                 .iter()
-                .map(|(f, v)| BlockEntry::new(f.data_type().into(), Value::Scalar(v.clone())))
-                .collect::<Vec<_>>();
+                .map(|(f, v)| (f.data_type().into(), v.clone()))
+                .collect();
             let stream = self
                 .parquet_reader
                 .prepare_data_stream(&part.filename, part.filesize, Some(&partition_fields))
@@ -203,32 +209,41 @@ fn check_block_schema(schema: &DataSchema, mut block: DataBlock) -> Result<DataB
         )));
     }
 
-    for (col, field) in block.columns_mut().iter_mut().zip(schema.fields().iter()) {
+    for (entry, field) in block.columns_mut().iter_mut().zip(schema.fields().iter()) {
         // If the actual data is nullable, the field must be nullbale.
-        if col.data_type().is_nullable_or_null() && !field.is_nullable() {
+        if entry.data_type().is_nullable_or_null() && !field.is_nullable() {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column is nullable, but schema field is not nullable",
                 field.name()
             )));
         }
         // The inner type of the data and field should be the same.
-        let data_type = col.data_type().remove_nullable();
+        let data_type = entry.data_type().remove_nullable();
         let schema_type = field.data_type().remove_nullable();
         if data_type != schema_type {
             return Err(ErrorCode::TableSchemaMismatch(format!(
                 "Data schema mismatched (col name: {}). Data column type is {:?}, but schema field type is {:?}",
                 field.name(),
-                col.data_type(),
+                entry.data_type(),
                 field.data_type()
             )));
         }
         // If the field is nullable but the actual data is not nullable,
         // we should wrap nullable for the data.
-        if field.is_nullable() && !col.data_type().is_nullable_or_null() {
-            *col = BlockEntry::new(
-                col.data_type().wrap_nullable(),
-                col.value().wrap_nullable(None),
-            );
+        if field.is_nullable() && !entry.data_type().is_nullable_or_null() {
+            *entry = match entry {
+                BlockEntry::Const(scalar, data_type, n) => BlockEntry::new_const_column(
+                    data_type.wrap_nullable(),
+                    scalar.clone(),
+                    n.unwrap(),
+                ),
+                BlockEntry::Column(column) => todo!(),
+            };
+
+            //  BlockEntry::new(
+            //     col.data_type().wrap_nullable(),
+            //     col.value().wrap_nullable(None),
+            // );
         }
     }
 

--- a/src/query/storages/hive/hive/src/hive_table_source.rs
+++ b/src/query/storages/hive/hive/src/hive_table_source.rs
@@ -231,19 +231,12 @@ fn check_block_schema(schema: &DataSchema, mut block: DataBlock) -> Result<DataB
         // If the field is nullable but the actual data is not nullable,
         // we should wrap nullable for the data.
         if field.is_nullable() && !entry.data_type().is_nullable_or_null() {
-            *entry = match entry {
-                BlockEntry::Const(scalar, data_type, n) => BlockEntry::new_const_column(
-                    data_type.wrap_nullable(),
-                    scalar.clone(),
-                    n.unwrap(),
-                ),
-                BlockEntry::Column(column) => todo!(),
+            match entry {
+                BlockEntry::Const(_, data_type, _) => {
+                    *data_type = data_type.wrap_nullable();
+                }
+                BlockEntry::Column(column) => *column = column.clone().wrap_nullable(None),
             };
-
-            //  BlockEntry::new(
-            //     col.data_type().wrap_nullable(),
-            //     col.value().wrap_nullable(None),
-            // );
         }
     }
 

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -351,9 +351,9 @@ impl MemoryTableSource {
             return Ok(entry.clone());
         }
 
-        match &entry.data_type {
+        match entry.data_type() {
             DataType::Tuple(inner_tys) => {
-                let col = entry.value.clone().into_column().unwrap();
+                let col = entry.as_column().unwrap().clone();
                 let inner_columns = col.into_tuple().unwrap();
                 let mut values = Vec::with_capacity(inner_tys.len());
                 for (col, ty) in inner_columns.iter().zip(inner_tys.iter()) {

--- a/src/query/storages/memory/src/memory_table.rs
+++ b/src/query/storages/memory/src/memory_table.rs
@@ -35,7 +35,6 @@ use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
@@ -356,8 +355,8 @@ impl MemoryTableSource {
                 let col = entry.as_column().unwrap().clone();
                 let inner_columns = col.into_tuple().unwrap();
                 let mut values = Vec::with_capacity(inner_tys.len());
-                for (col, ty) in inner_columns.iter().zip(inner_tys.iter()) {
-                    values.push(BlockEntry::new(ty.clone(), Value::Column(col.clone())));
+                for col in inner_columns.iter() {
+                    values.push(col.clone().into());
                 }
                 Self::traverse_paths(&values[..], &path[1..])
             }

--- a/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
+++ b/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
@@ -163,7 +163,7 @@ impl StripeDecoderForCopy {
                     unreachable!("expect value: array of tuple")
                 }
             }
-            let entry = BlockEntry::from_value(evaluator.run(expr)?, || {
+            let entry = BlockEntry::new(evaluator.run(expr)?, || {
                 (field.data_type().clone(), num_rows)
             });
             entries.push(entry);

--- a/src/query/storages/parquet/src/copy_into_table/projection.rs
+++ b/src/query/storages/parquet/src/copy_into_table/projection.rs
@@ -37,7 +37,7 @@ impl CopyProjectionEvaluator {
         let mut entries = Vec::with_capacity(projection.len());
         let num_rows = block.num_rows();
         for (field, expr) in self.schema.fields().iter().zip(projection.iter()) {
-            let entry = BlockEntry::from_value(evaluator.run(expr)?, || {
+            let entry = BlockEntry::new(evaluator.run(expr)?, || {
                 (field.data_type().clone(), num_rows)
             });
             entries.push(entry);

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/predicate_and_topk.rs
@@ -185,7 +185,7 @@ impl ReadPolicyBuilder for PredicateAndTopkPolicyBuilder {
                 num_rows,
             )?;
             debug_assert_eq!(block.num_columns(), 1);
-            let topk_col = block.columns()[0].value.as_column().unwrap();
+            let topk_col = block.columns()[0].as_column().unwrap();
             if sorter.never_match_any(topk_col) {
                 // All rows in current row group are filtered out.
                 return Ok(None);

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/topk_only.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/topk_only.rs
@@ -239,7 +239,7 @@ impl ReadPolicy for TopkOnlyPolicy {
                 transform_record_batch(&self.remain_schema, &batch, &self.remain_field_paths)?;
             if let Some(q) = self.prefetched.as_mut() {
                 let prefetched = q.pop_front().unwrap();
-                block.add_column(prefetched);
+                block.add_entry(prefetched);
             }
             let block = block.resort(&self.src_schema, &self.dst_schema)?;
             Ok(Some(block))

--- a/src/query/storages/parquet/src/parquet_reader/read_policy/utils.rs
+++ b/src/query/storages/parquet/src/parquet_reader/read_policy/utils.rs
@@ -50,7 +50,7 @@ pub fn evaluate_topk(
 ) -> Result<Option<DataBlock>> {
     debug_assert!(block.num_columns() >= 1);
     // The topk column must be the first column.
-    let topk_col = block.columns()[0].value.as_column().unwrap();
+    let topk_col = block.columns()[0].as_column().unwrap();
     let num_rows = topk_col.len();
     let filter = topk.evaluate_column(topk_col, sorter);
     if filter.null_count() == num_rows {

--- a/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
@@ -320,8 +320,7 @@ impl RowGroupReader {
         let mut positional_deletes = Vec::new();
 
         while let Some(block) = reader.read_block_from_stream(&mut stream).await? {
-            let num_rows = block.num_rows();
-            let column = block.columns()[0].to_column(num_rows);
+            let column = block.get_by_offset(0).to_column();
             let column = column.as_number().unwrap().as_int64().unwrap();
 
             positional_deletes.extend_from_slice(column.as_slice())

--- a/src/query/storages/parquet/src/parquet_variant_table/recordbatch_to_variant.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/recordbatch_to_variant.rs
@@ -15,12 +15,10 @@
 use arrow_array::RecordBatch;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::variant::cast_scalar_to_variant;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchema;
 use databend_common_expression::TableDataType;
-use databend_common_expression::Value;
 use jiff::tz::TimeZone;
 
 pub fn read_record_batch(
@@ -54,9 +52,8 @@ pub fn record_batch_to_block(
     read_record_batch(record_batch, &mut builder, tz, typ)?;
     let column = builder.build();
     let num_rows = column.len();
-    let entry = BlockEntry::new(
-        databend_common_expression::types::DataType::Variant,
-        Value::Column(Column::Variant(column)),
-    );
-    Ok(DataBlock::new(vec![entry], num_rows))
+    Ok(DataBlock::new(
+        vec![Column::Variant(column).into()],
+        num_rows,
+    ))
 }

--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -29,13 +29,11 @@ use databend_common_exception::Result;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberColumnBuilder;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableSchema;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
@@ -380,10 +378,7 @@ fn add_internal_columns(
     for c in internal_columns {
         match c {
             InternalColumnType::FileName => {
-                b.add_entry(BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(path.clone())),
-                ));
+                b.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
             InternalColumnType::FileRowNumber => {
                 let end_row = (*start_row) + b.num_rows() as u64;

--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -29,7 +29,6 @@ use databend_common_exception::Result;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberColumnBuilder;
-use databend_common_expression::types::NumberDataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
@@ -381,19 +380,15 @@ fn add_internal_columns(
     for c in internal_columns {
         match c {
             InternalColumnType::FileName => {
-                b.add_column(BlockEntry::new(
+                b.add_entry(BlockEntry::new(
                     DataType::String,
                     Value::Scalar(Scalar::String(path.clone())),
                 ));
             }
             InternalColumnType::FileRowNumber => {
                 let end_row = (*start_row) + b.num_rows() as u64;
-                b.add_column(BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(Column::Number(
-                        NumberColumnBuilder::UInt64(((*start_row)..end_row).collect::<Vec<_>>())
-                            .build(),
-                    )),
+                b.add_column(Column::Number(
+                    NumberColumnBuilder::UInt64(((*start_row)..end_row).collect()).build(),
                 ));
                 *start_row = end_row;
             }

--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -366,8 +366,10 @@ pub fn read_small_file(
     }
     let column = builder.build();
     let num_rows = column.len();
-    let entry = BlockEntry::new(DataType::Variant, Value::Column(Column::Variant(column)));
-    Ok(DataBlock::new(vec![entry], num_rows))
+    Ok(DataBlock::new(
+        vec![Column::Variant(column).into()],
+        num_rows,
+    ))
 }
 
 fn add_internal_columns(

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -32,13 +32,11 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberColumnBuilder;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::TopKSorter;
-use databend_common_expression::Value;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::Processor;
@@ -478,10 +476,7 @@ fn add_internal_columns(
     for c in internal_columns {
         match c {
             InternalColumnType::FileName => {
-                b.add_entry(BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String(path.clone())),
-                ));
+                b.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
             InternalColumnType::FileRowNumber => {
                 let end_row = (*start_row) + b.num_rows() as u64;

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -32,7 +32,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberColumnBuilder;
-use databend_common_expression::types::NumberDataType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
@@ -486,13 +485,13 @@ fn add_internal_columns(
             }
             InternalColumnType::FileRowNumber => {
                 let end_row = (*start_row) + b.num_rows() as u64;
-                b.add_column(BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(Column::Number(
+                b.add_column(
+                    Column::Number(
                         NumberColumnBuilder::UInt64(((*start_row)..end_row).collect::<Vec<_>>())
                             .build(),
-                    )),
-                ));
+                    )
+                    .into(),
+                );
                 *start_row = end_row;
             }
             _ => {

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -478,20 +478,16 @@ fn add_internal_columns(
     for c in internal_columns {
         match c {
             InternalColumnType::FileName => {
-                b.add_column(BlockEntry::new(
+                b.add_entry(BlockEntry::new(
                     DataType::String,
                     Value::Scalar(Scalar::String(path.clone())),
                 ));
             }
             InternalColumnType::FileRowNumber => {
                 let end_row = (*start_row) + b.num_rows() as u64;
-                b.add_column(
-                    Column::Number(
-                        NumberColumnBuilder::UInt64(((*start_row)..end_row).collect::<Vec<_>>())
-                            .build(),
-                    )
-                    .into(),
-                );
+                b.add_column(Column::Number(
+                    NumberColumnBuilder::UInt64(((*start_row)..end_row).collect()).build(),
+                ));
                 *start_row = end_row;
             }
             _ => {

--- a/src/query/storages/random/src/random_table.rs
+++ b/src/query/storages/random/src/random_table.rs
@@ -26,12 +26,10 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
-use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::RandomOptions;
 use databend_common_expression::TableSchemaRef;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_pipeline_core::processors::OutputPort;
 use databend_common_pipeline_core::processors::ProcessorPtr;
@@ -270,12 +268,7 @@ impl SyncSource for RandomSource {
             .iter()
             .map(|f| {
                 let data_type = f.data_type().into();
-                let value = Value::Column(Column::random(
-                    &data_type,
-                    self.rows,
-                    Some(self.random_options.clone()),
-                ));
-                BlockEntry::new(data_type, value)
+                Column::random(&data_type, self.rows, Some(self.random_options.clone())).into()
             })
             .collect();
 

--- a/src/query/storages/random/src/random_table.rs
+++ b/src/query/storages/random/src/random_table.rs
@@ -152,8 +152,7 @@ impl Table for RandomTable {
             .iter()
             .map(|f| {
                 let data_type: DataType = f.data_type().into();
-                let column = Column::random(&data_type, 1, Some(self.random_options.clone()));
-                BlockEntry::new(data_type.clone(), Value::Column(column))
+                Column::random(&data_type, 1, Some(self.random_options.clone())).into()
             })
             .collect::<Vec<_>>();
         let block = DataBlock::new(columns, 1);

--- a/src/query/storages/stage/src/append/output.rs
+++ b/src/query/storages/stage/src/append/output.rs
@@ -75,11 +75,12 @@ impl DataSummary {
         let values = &block
             .columns()
             .iter()
-            .map(|x| match x.value {
-                Value::Scalar(Scalar::Number(NumberScalar::UInt64(n))) => n,
-                _ => {
-                    unreachable!()
-                }
+            .map(|x| {
+                x.as_scalar()
+                    .and_then(|x| x.as_number())
+                    .and_then(|x| x.as_u_int64())
+                    .copied()
+                    .unwrap()
             })
             .collect::<Vec<u64>>();
         DataSummary {

--- a/src/query/storages/stage/src/append/output.rs
+++ b/src/query/storages/stage/src/append/output.rs
@@ -13,16 +13,11 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
-use databend_common_expression::types::NumberDataType;
-use databend_common_expression::types::NumberScalar;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::UInt64Type;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::Scalar;
-use databend_common_expression::Value;
 use databend_common_pipeline_transforms::processors::AccumulatingTransform;
 
 #[derive(Default)]
@@ -49,22 +44,9 @@ impl DataSummary {
 
     pub fn to_block(&self) -> DataBlock {
         let entries = vec![
-            BlockEntry::new(
-                DataType::Number(NumberDataType::UInt64),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt64(self.row_counts as u64))),
-            ),
-            BlockEntry::new(
-                DataType::Number(NumberDataType::UInt64),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt64(
-                    self.input_bytes as u64,
-                ))),
-            ),
-            BlockEntry::new(
-                DataType::Number(NumberDataType::UInt64),
-                Value::Scalar(Scalar::Number(NumberScalar::UInt64(
-                    self.output_bytes as u64,
-                ))),
-            ),
+            BlockEntry::new_const_column_arg::<UInt64Type>(self.row_counts as _, 1),
+            BlockEntry::new_const_column_arg::<UInt64Type>(self.input_bytes as _, 1),
+            BlockEntry::new_const_column_arg::<UInt64Type>(self.output_bytes as _, 1),
         ];
         DataBlock::new(entries, 1)
     }

--- a/src/query/storages/stage/src/transform_null_if.rs
+++ b/src/query/storages/stage/src/transform_null_if.rs
@@ -190,7 +190,7 @@ impl Transform for TransformNullIf {
         let evaluator = Evaluator::new(&data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
         let num_rows = data_block.num_rows();
         for (field, expr) in self.schema.fields().iter().zip(self.exprs.iter()) {
-            let entry = BlockEntry::from_value(evaluator.run(expr)?, || {
+            let entry = BlockEntry::new(evaluator.run(expr)?, || {
                 (field.data_type().clone(), num_rows)
             });
             entries.push(entry);

--- a/src/query/storages/stage/src/transform_null_if.rs
+++ b/src/query/storages/stage/src/transform_null_if.rs
@@ -186,13 +186,15 @@ impl Transform for TransformNullIf {
     const NAME: &'static str = "NullIfTransform";
 
     fn transform(&mut self, data_block: DataBlock) -> Result<DataBlock> {
-        let mut columns = Vec::with_capacity(self.exprs.len());
+        let mut entries = Vec::with_capacity(self.exprs.len());
         let evaluator = Evaluator::new(&data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let num_rows = data_block.num_rows();
         for (field, expr) in self.schema.fields().iter().zip(self.exprs.iter()) {
-            let value = evaluator.run(expr)?;
-            let column = BlockEntry::new(field.data_type().clone(), value);
-            columns.push(column);
+            let entry = BlockEntry::from_value(evaluator.run(expr)?, || {
+                (field.data_type().clone(), num_rows)
+            });
+            entries.push(entry);
         }
-        Ok(DataBlock::new(columns, data_block.num_rows()))
+        Ok(DataBlock::new(entries, data_block.num_rows()))
     }
 }

--- a/src/query/storages/system/src/malloc_stats_table.rs
+++ b/src/query/storages/system/src/malloc_stats_table.rs
@@ -19,14 +19,12 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
+use databend_common_expression::types::VariantType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
-use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
@@ -85,9 +83,9 @@ impl MallocStatsTable {
         tikv_jemalloc_ctl::stats_print::stats_print(&mut buf, options)?;
         let json_value: serde_json::Value = serde_json::from_slice(&buf)?;
         let jsonb_value: jsonb::Value = (&json_value).into();
-        Ok(vec![BlockEntry::new(
-            DataType::Variant,
-            Value::Scalar(Scalar::Variant(jsonb_value.to_vec())),
+        Ok(vec![BlockEntry::new_const_column_arg::<VariantType>(
+            jsonb_value.to_vec(),
+            1,
         )])
     }
 }

--- a/src/query/storages/system/src/table.rs
+++ b/src/query/storages/system/src/table.rs
@@ -368,11 +368,7 @@ impl<TTable: 'static + AsyncSystemTable> AsyncSource for SystemTableAsyncSource<
         {
             use databend_common_expression::types::DataType;
             let table_info = self.inner.get_table_info();
-            let data_types: Vec<DataType> = block
-                .columns()
-                .iter()
-                .map(|v| v.data_type.clone())
-                .collect();
+            let data_types: Vec<DataType> = block.columns().iter().map(|v| v.data_type()).collect();
 
             let table_info_types: Vec<DataType> = table_info
                 .schema()

--- a/src/query/storages/system/src/temp_files_table.rs
+++ b/src/query/storages/system/src/temp_files_table.rs
@@ -25,7 +25,6 @@ use databend_common_catalog::table::DistributionLevel;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberType;
 use databend_common_expression::types::StringType;
@@ -33,12 +32,10 @@ use databend_common_expression::types::TimestampType;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
-use databend_common_expression::Scalar;
 use databend_common_expression::SendableDataBlockStream;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRefExt;
-use databend_common_expression::Value;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
@@ -181,18 +178,15 @@ impl TempFilesTable {
         file_lens: Vec<u64>,
         file_last_modifieds: Vec<Option<i64>>,
     ) -> DataBlock {
-        let row_number = names.len();
+        let num_rows = names.len();
         DataBlock::new(
             vec![
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Scalar(Scalar::String("Spill".to_string())),
-                ),
+                BlockEntry::new_const_column_arg::<StringType>("Spill".to_string(), num_rows),
                 StringType::from_data(names).into(),
                 NumberType::from_data(file_lens).into(),
                 TimestampType::from_opt_data(file_last_modifieds).into(),
             ],
-            row_number,
+            num_rows,
         )
     }
 

--- a/src/query/storages/system/src/temp_files_table.rs
+++ b/src/query/storages/system/src/temp_files_table.rs
@@ -188,18 +188,9 @@ impl TempFilesTable {
                     DataType::String,
                     Value::Scalar(Scalar::String("Spill".to_string())),
                 ),
-                BlockEntry::new(
-                    DataType::String,
-                    Value::Column(StringType::from_data(names)),
-                ),
-                BlockEntry::new(
-                    DataType::Number(NumberDataType::UInt64),
-                    Value::Column(NumberType::from_data(file_lens)),
-                ),
-                BlockEntry::new(
-                    DataType::Timestamp.wrap_nullable(),
-                    Value::Column(TimestampType::from_opt_data(file_last_modifieds)),
-                ),
+                StringType::from_data(names).into(),
+                NumberType::from_data(file_lens).into(),
+                TimestampType::from_opt_data(file_last_modifieds).into(),
             ],
             row_number,
         )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Previously, `BlockEntry` did not include length information, which was extremely inconvenient in scenarios such as aggregate functions, and was usually mitigated by copying it as a `Column`. This PR optimizes this problem.

```rust
// before
pub enum Value<T: AccessType> {
    Scalar(T::Scalar),
    Column(T::Column),
}

pub struct BlockEntry {
    pub data_type: DataType,
    pub value: Value<AnyType>,
}

// after
pub enum BlockEntry {
    Const(Scalar, DataType, usize),
    Column(Column),
}
```


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18131)
<!-- Reviewable:end -->
