### PR TITLE
feat(meta-service): return current seq-value in txn-put response

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -144,8 +144,12 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-05-08: since 1.2.736
 ///   🖥 server: add `WatchResponse::is_initialization`,
 ///
-/// - 2025-06-09: since TODO: update when merged
+/// - 2025-06-09: since 1.2.755
 ///   🖥 server: remove `TxnReply::error`
+///
+/// - 2025-06-11: since TODO: update when merge
+///   🖥 server: add `TxnPutResponse::current`
+///
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -521,6 +521,7 @@ impl kvapi::TestSuite {
             response: Some(txn_op_response::Response::Put(TxnPutResponse {
                 key: txn_key.clone(),
                 prev_value: None,
+                current: Some(pb::SeqV::new(1, b"new_v1".to_vec())),
             })),
         }];
 
@@ -659,6 +660,7 @@ impl kvapi::TestSuite {
                 response: Some(txn_op_response::Response::Put(TxnPutResponse {
                     key: txn_key.clone(),
                     prev_value: Some(pb::SeqV::from(SeqV::new(1, val1.clone()))),
+                    current: Some(pb::SeqV::new(2, b("new_v1"))),
                 })),
             }];
 
@@ -766,14 +768,16 @@ impl kvapi::TestSuite {
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Put(TxnPutResponse {
                         key: txn_key1.clone(),
-                        prev_value: Some(pb::SeqV::from(SeqV::new(4, val1.clone()))),
+                        prev_value: Some(pb::SeqV::new(4, val1.clone())),
+                        current: Some(pb::SeqV::new(7, val1_new.clone())),
                     })),
                 },
                 // change k2
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Put(TxnPutResponse {
                         key: txn_key2.clone(),
-                        prev_value: Some(pb::SeqV::from(SeqV::new(5, val2.clone()))),
+                        prev_value: Some(pb::SeqV::new(5, val2.clone())),
+                        current: Some(pb::SeqV::new(8, b("new_v2").clone())),
                     })),
                 },
                 // get k1
@@ -872,7 +876,11 @@ impl kvapi::TestSuite {
             let resp = kv.transaction(txn).await?;
 
             let expected: Vec<TxnOpResponse> = vec![
-                TxnOpResponse::put(k1, Some(pb::SeqV::new(8, b("v1")))),
+                TxnOpResponse::put(
+                    k1,
+                    Some(pb::SeqV::new(8, b("v1"))),
+                    Some(pb::SeqV::new(9, b("v2"))),
+                ),
                 TxnOpResponse::get(k1, Some(SeqV::new(9, b("v2")))),
             ];
 
@@ -906,7 +914,11 @@ impl kvapi::TestSuite {
             let resp = kv.transaction(txn).await?;
 
             let expected: Vec<TxnOpResponse> = vec![
-                TxnOpResponse::put(k1, Some(pb::SeqV::new(9, b("v2")))),
+                TxnOpResponse::put(
+                    k1,
+                    Some(pb::SeqV::new(9, b("v2"))),
+                    Some(pb::SeqV::new(10, b("v3"))),
+                ),
                 TxnOpResponse::get(k1, Some(SeqV::new(10, b("v3")))),
             ];
 
@@ -940,7 +952,11 @@ impl kvapi::TestSuite {
             let resp = kv.transaction(txn).await?;
 
             let expected: Vec<TxnOpResponse> = vec![
-                TxnOpResponse::put(k1, Some(pb::SeqV::new(10, b("v3")))),
+                TxnOpResponse::put(
+                    k1,
+                    Some(pb::SeqV::new(10, b("v3"))),
+                    Some(pb::SeqV::new(11, b("v4"))),
+                ),
                 TxnOpResponse::get(k1, Some(SeqV::new(11, b("v4")))),
             ];
 
@@ -974,7 +990,11 @@ impl kvapi::TestSuite {
             let resp = kv.transaction(txn).await?;
 
             let expected: Vec<TxnOpResponse> = vec![
-                TxnOpResponse::put(k1, Some(pb::SeqV::new(11, b("v4")))),
+                TxnOpResponse::put(
+                    k1,
+                    Some(pb::SeqV::new(11, b("v4"))),
+                    Some(pb::SeqV::new(12, b("v5"))),
+                ),
                 TxnOpResponse::get(k1, Some(SeqV::new(12, b("v5")))),
             ];
 
@@ -1008,7 +1028,11 @@ impl kvapi::TestSuite {
             let resp = kv.transaction(txn).await?;
 
             let expected: Vec<TxnOpResponse> = vec![
-                TxnOpResponse::put(k1, Some(pb::SeqV::new(12, b("v5")))),
+                TxnOpResponse::put(
+                    k1,
+                    Some(pb::SeqV::new(12, b("v5"))),
+                    Some(pb::SeqV::new(13, b("v6"))),
+                ),
                 TxnOpResponse::get(k1, Some(SeqV::new(13, b("v6")))),
             ];
 

--- a/src/meta/raft-store/src/applier.rs
+++ b/src/meta/raft-store/src/applier.rs
@@ -470,11 +470,12 @@ where SM: StateMachineApi + 'static
             put.ttl_ms.map(Interval::from_millis),
         ));
 
-        let (prev, _result) = self.upsert_kv(&upsert).await?;
+        let (prev, result) = self.upsert_kv(&upsert).await?;
 
         let put_resp = TxnPutResponse {
             key: put.key.clone(),
             prev_value: prev.map(pb::SeqV::from),
+            current: result.map(pb::SeqV::from),
         };
 
         resp.responses.push(TxnOpResponse {

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -59,7 +59,12 @@ message TxnPutRequest {
 
 message TxnPutResponse {
   string key = 1;
+
+  // The value before put
   optional SeqV prev_value = 2;
+
+  // The value after put
+  optional SeqV current = 3;
 }
 
 // Delete request and response
@@ -124,7 +129,7 @@ message TxnDeleteResponse {
 }
 
 // Delete by prefix request and response
-message TxnDeleteByPrefixRequest { string prefix = 1; }
+message TxnDeleteByPrefixRequest {string prefix = 1;}
 
 message TxnDeleteByPrefixResponse {
   string prefix = 1;

--- a/src/meta/types/src/proto_display/mod.rs
+++ b/src/meta/types/src/proto_display/mod.rs
@@ -270,9 +270,10 @@ impl Display for TxnPutResponse {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Put-resp: key={}, prev_seq={:?}",
+            "Put-resp: key={}, prev_seq={}, current_seq={}",
             self.key,
-            self.prev_value.as_ref().map(|x| x.seq)
+            self.prev_value.as_ref().map(|x| x.seq).display(),
+            self.current.as_ref().map(|x| x.seq).display()
         )
     }
 }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -329,11 +329,16 @@ impl pb::TxnOpResponse {
     }
 
     /// Create a new `TxnOpResponse` of a `Put` operation.
-    pub fn put(key: impl ToString, prev_value: Option<pb::SeqV>) -> Self {
+    pub fn put(
+        key: impl ToString,
+        prev_value: Option<pb::SeqV>,
+        current: Option<pb::SeqV>,
+    ) -> Self {
         pb::TxnOpResponse {
             response: Some(pb::txn_op_response::Response::Put(pb::TxnPutResponse {
                 key: key.to_string(),
                 prev_value,
+                current,
             })),
         }
     }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): return current seq-value in txn-put response

TxnPutResponse now returns both the value before and after the put
operation. Each returned value is a `SeqV` struct containing the
sequence number and value in bytes.

This is a backward-compatible change as protobuf-based clients
will ignore the new field.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18136)
<!-- Reviewable:end -->
