### PR TITLE
fix(bind): disable the shrink constant when it is a generic type argument of a function

### DIFF
--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -1461,16 +1461,14 @@ fn normalize_txn_response(vs: Vec<TxnOpResponse>) -> Vec<TxnOpResponse> {
                 _ => {}
             }
 
-            match &mut v.response {
-                Some(Response::Put(TxnPutResponse {
-                    current: Some(pb::SeqV { meta, .. }),
-                    ..
-                })) => {
-                    if *meta == Some(pb::KvMeta { expire_at: None }) {
-                        *meta = None;
-                    }
+            if let Some(Response::Put(TxnPutResponse {
+                current: Some(pb::SeqV { meta, .. }),
+                ..
+            })) = &mut v.response
+            {
+                if *meta == Some(pb::KvMeta { expire_at: None }) {
+                    *meta = None;
                 }
-                _ => {}
             }
 
             v

--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -35,6 +35,7 @@ use crate::types::decimal::MAX_DECIMAL256_PRECISION;
 use crate::types::i256;
 use crate::types::AnyType;
 use crate::types::DataType;
+use crate::types::Decimal;
 use crate::types::DecimalDataKind;
 use crate::types::DecimalSize;
 use crate::types::NumberScalar;
@@ -180,7 +181,7 @@ fn shrink_d256(decimal: i256, size: DecimalSize) -> Scalar {
     let log10_2 = std::f64::consts::LOG10_2;
     let mut precision = ((valid_bits as f64) * log10_2).floor() as u8;
 
-    if decimal.saturating_abs() >= i256::from(10).pow(precision as u32) {
+    if decimal.saturating_abs() >= i256::e(precision) {
         precision += 1;
     }
 

--- a/tests/sqllogictests/suites/query/functions/02_0058_function_ifnull.test
+++ b/tests/sqllogictests/suites/query/functions/02_0058_function_ifnull.test
@@ -87,6 +87,12 @@ NULL 0 0
 NULL 1 1
 NULL NULL NULL
 
+query R
+select ifnull(number::string, 0) from numbers(3);
+----
+0.00000
+1.00000
+2.00000
+
 statement ok
 DROP TABLE t
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

disable the shrink constant when it is a generic type argument of a function

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18145)
<!-- Reviewable:end -->
