### PR TITLE
chore: limit num of threads used by streaming load.

### DIFF
--- a/src/query/storages/stage/src/streaming_load.rs
+++ b/src/query/storages/stage/src/streaming_load.rs
@@ -75,7 +75,7 @@ pub fn build_streaming_load_pipeline(
     let max_threads = settings.get_max_threads()? as usize;
 
     // since there are only one source, a few processor is fast enough and avoid both OOM and small DataBlocks.
-    let max_threads = max_threads.max(4);
+    let max_threads = max_threads.min(4);
 
     let file_format_options_ext = FileFormatOptionsExt::create_from_settings(&settings, false)?;
 

--- a/src/query/storages/stage/src/streaming_load.rs
+++ b/src/query/storages/stage/src/streaming_load.rs
@@ -74,6 +74,9 @@ pub fn build_streaming_load_pipeline(
 
     let max_threads = settings.get_max_threads()? as usize;
 
+    // since there are only ony source, a few processor is fast enough.
+    let max_threads = max_threads.max(4);
+
     let file_format_options_ext = FileFormatOptionsExt::create_from_settings(&settings, false)?;
 
     let load_ctx = Arc::new(LoadContext::try_create(

--- a/src/query/storages/stage/src/streaming_load.rs
+++ b/src/query/storages/stage/src/streaming_load.rs
@@ -74,7 +74,7 @@ pub fn build_streaming_load_pipeline(
 
     let max_threads = settings.get_max_threads()? as usize;
 
-    // since there are only ony source, a few processor is fast enough.
+    // since there are only one source, a few processor is fast enough and avoid both OOM and small DataBlocks.
     let max_threads = max_threads.max(4);
 
     let file_format_options_ext = FileFormatOptionsExt::create_from_settings(&settings, false)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

since there are only one source, a few processor is fast enough and avoid both oom and small DataBlocks.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18147)
<!-- Reviewable:end -->
