### PR TITLE
fix(storage): Fix presign is not spawned on IO runtime

### DIFF
--- a/src/common/storage/src/runtime_layer.rs
+++ b/src/common/storage/src/runtime_layer.rs
@@ -25,12 +25,14 @@ use opendal::raw::LayeredAccess;
 use opendal::raw::OpCreateDir;
 use opendal::raw::OpDelete;
 use opendal::raw::OpList;
+use opendal::raw::OpPresign;
 use opendal::raw::OpRead;
 use opendal::raw::OpStat;
 use opendal::raw::OpWrite;
 use opendal::raw::RpCreateDir;
 use opendal::raw::RpDelete;
 use opendal::raw::RpList;
+use opendal::raw::RpPresign;
 use opendal::raw::RpRead;
 use opendal::raw::RpStat;
 use opendal::raw::RpWrite;
@@ -174,6 +176,15 @@ impl<A: Access> LayeredAccess for RuntimeAccessor<A> {
                 let r = RuntimeIO::new(r, self.runtime.clone());
                 (rp, r)
             })
+    }
+
+    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+        let op = self.inner.clone();
+        let path = path.to_string();
+        self.runtime
+            .spawn(async move { op.presign(&path, args).await })
+            .await
+            .expect("join must success")
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/src/common/storage/src/runtime_layer.rs
+++ b/src/common/storage/src/runtime_layer.rs
@@ -96,7 +96,7 @@ impl<A: Access> LayeredAccess for RuntimeAccessor<A> {
     type BlockingWriter = A::BlockingWriter;
     type Lister = RuntimeIO<A::Lister>;
     type BlockingLister = A::BlockingLister;
-    type Deleter = RuntimeIO<RuntimeIO<A::Deleter>>;
+    type Deleter = RuntimeIO<A::Deleter>;
     type BlockingDeleter = A::BlockingDeleter;
 
     fn inner(&self) -> &Self::Inner {
@@ -155,10 +155,6 @@ impl<A: Access> LayeredAccess for RuntimeAccessor<A> {
             .spawn(async move { op.delete().await })
             .await
             .expect("join must success")
-            .map(|(rp, r)| {
-                let r = RuntimeIO::new(r, self.runtime.clone());
-                (rp, r)
-            })
             .map(|(rp, r)| {
                 let r = RuntimeIO::new(r, self.runtime.clone());
                 (rp, r)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Presign is not spwaned on IO runtime before. This can lead to our SQL hang sometimes. This PR fixed it.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18149)
<!-- Reviewable:end -->
