### PR TITLE
refactor: simply management of tmp table in session.

### DIFF
--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -173,6 +173,7 @@ mod util;
 
 pub use access::ManagementModeAccess;
 pub use common::InterpreterQueryLog;
+pub use hook::vacuum_hook::hook_clear_m_cte_temp_table;
 pub use hook::HookOperator;
 pub use interpreter::interpreter_plan_sql;
 pub use interpreter::Interpreter;

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -27,7 +27,6 @@ use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Scalar;
 use databend_common_io::prelude::FormatSettings;
 use databend_common_settings::Settings;
-use databend_storages_common_session::TempTblMgrRef;
 use databend_storages_common_session::TxnManagerRef;
 use futures::StreamExt;
 use log::debug;
@@ -156,7 +155,6 @@ pub struct ExecutorSessionState {
     pub secondary_roles: Option<Vec<String>>,
     pub settings: Arc<Settings>,
     pub txn_manager: TxnManagerRef,
-    pub temp_tbl_mgr: TempTblMgrRef,
     pub variables: HashMap<String, Scalar>,
     pub last_query_ids: Vec<String>,
     pub last_query_result_cache_key: String,
@@ -182,7 +180,6 @@ impl ExecutorSessionState {
             secondary_roles: session.get_secondary_roles(),
             settings: session.get_settings(),
             txn_manager: session.txn_mgr(),
-            temp_tbl_mgr: session.temp_tbl_mgr(),
             variables: session.get_all_variables(),
             last_query_ids,
             last_query_result_cache_key,

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -785,6 +785,9 @@ impl HttpQuery {
                 .with_context(|| "failed to start query")
                 .flatten()
                 {
+                    crate::interpreters::hook_clear_m_cte_temp_table(&query_context)
+                        .inspect_err(|e| warn!("clear_m_cte_temp_table fail: {e}"))
+                        .ok();
                     let state = ExecuteStopped {
                         stats: Progresses::default(),
                         schema: vec![],

--- a/src/query/service/src/servers/http/v1/session/client_session_manager.rs
+++ b/src/query/service/src/servers/http/v1/session/client_session_manager.rs
@@ -34,7 +34,6 @@ use databend_storages_common_session::drop_all_temp_tables;
 use databend_storages_common_session::TempTblMgrRef;
 use log::error;
 use log::info;
-use log::warn;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use sha2::Digest;
@@ -59,13 +58,8 @@ fn hash_token(token: &[u8]) -> String {
     hex::encode_upper(Sha256::digest(token))
 }
 
-enum QueryState {
-    InUse(String),
-    Idle(Instant),
-}
-
 struct SessionState {
-    pub query_state: QueryState,
+    pub last_access: Instant,
     pub temp_tbl_mgr: TempTblMgrRef,
 }
 
@@ -86,7 +80,7 @@ pub struct ClientSessionManager {
     ///
     /// # Ops
     /// add:
-    /// - write temp table
+    /// - create temp table
     ///
     /// rm:
     ///  - all temp table deleted
@@ -94,8 +88,7 @@ pub struct ClientSessionManager {
     ///  - timeout
     ///
     /// refresh:
-    ///  - query start/stop
-    ///  - /session/refresh
+    ///  - auth (with min interval)
     session_state: Mutex<BTreeMap<String, SessionState>>,
 }
 
@@ -125,23 +118,15 @@ impl ClientSessionManager {
     async fn check_timeout(self: Arc<Self>) {
         loop {
             let now = Instant::now();
-            let mut in_use = vec![];
-            let mut idle = vec![];
+            let mut remained = vec![];
             let mut expired = vec![];
             {
                 let guard = self.session_state.lock();
                 for (key, session_state) in &*guard {
-                    match session_state.query_state {
-                        QueryState::InUse(_) => {
-                            in_use.push(key.clone());
-                        }
-                        QueryState::Idle(t) => {
-                            if (now - t) > self.session_token_ttl {
-                                expired.push((key.clone(), session_state.temp_tbl_mgr.clone()));
-                            } else {
-                                idle.push(key.clone());
-                            }
-                        }
+                    if (now - session_state.last_access) > self.session_token_ttl {
+                        expired.push((key.clone(), session_state.temp_tbl_mgr.clone()));
+                    } else {
+                        remained.push(key.clone());
                     }
                 }
             };
@@ -155,9 +140,12 @@ impl ClientSessionManager {
                 drop_all_temp_tables_with_logging(&key, mgr, "idle").await;
             }
 
-            if !(in_use.is_empty() && idle.is_empty()) {
-                info!("[TEMP TABLE] sessions after cleanup, {} idle {} in use, idle sessions: {:?}, in use sessions: {:?}",
-                idle.len(), in_use.len(), idle, in_use);
+            if !(remained.is_empty()) {
+                info!(
+                    "[TEMP TABLE] sessions after cleanup, {} remained: {:?}",
+                    remained.len(),
+                    remained
+                );
             }
             tokio::time::sleep(self.session_token_ttl / 4).await;
         }
@@ -174,7 +162,7 @@ impl ClientSessionManager {
             .upsert_client_session_id(
                 client_session_id,
                 &user_name,
-                REFRESH_TOKEN_TTL + TTL_GRACE_PERIOD_META + STATE_REFRESH_INTERVAL_META,
+                REFRESH_TOKEN_TTL + TTL_GRACE_PERIOD_META + MIN_STATE_REFRESH_INTERVAL,
             )
             .await?;
         Ok(())
@@ -378,56 +366,32 @@ impl ClientSessionManager {
         }
     }
 
-    pub fn on_query_start(
-        &self,
-        client_session_id: &str,
-        user_name: &str,
-        session: &Arc<Session>,
-        query_id: &str,
-    ) {
+    pub fn on_query_start(&self, client_session_id: &str, user_name: &str, session: &Arc<Session>) {
         let key = Self::state_key(client_session_id, user_name);
         let mut guard = self.session_state.lock();
         guard.entry(key).and_modify(|e| {
-            if let QueryState::InUse(old_id) = &e.query_state {
-                warn!(
-                    "[TEMP TABLE] session = {client_session_id} last query {old_id} not finished."
-                )
-            }
-            e.query_state = QueryState::InUse(query_id.to_string());
             session.set_temp_tbl_mgr(e.temp_tbl_mgr.clone());
         });
     }
-    pub fn on_query_finish(
-        &self,
-        client_session_id: &str,
-        user_name: &str,
-        temp_tbl_mgr: TempTblMgrRef,
-        is_empty: bool,
-        just_changed: bool,
-    ) {
-        let key = Self::state_key(client_session_id, user_name);
-        if !is_empty || just_changed {
-            let mut guard = self.session_state.lock();
-            match guard.entry(key) {
-                Entry::Vacant(e) => {
-                    if !is_empty {
-                        e.insert(SessionState {
-                            query_state: QueryState::Idle(Instant::now()),
-                            temp_tbl_mgr,
-                        });
-                        info!("[TEMP-TABLE] session={client_session_id} added to ClientSessionManager");
-                    }
-                }
-                Entry::Occupied(mut e) => {
-                    if !is_empty {
-                        e.get_mut().query_state = QueryState::Idle(Instant::now())
-                    } else {
-                        e.remove();
-                        // all temp table dropped by user, data should have been removed when executing drop.
-                        info!("[TEMP-TABLE] session={client_session_id} removed from ClientSessionManager");
-                    }
-                }
-            }
+
+    pub fn add_temp_tbl_mgr(&self, prefix: String, temp_tbl_mgr: TempTblMgrRef) {
+        let mut guard = self.session_state.lock();
+        let state = SessionState {
+            last_access: Instant::now(),
+            temp_tbl_mgr,
+        };
+        if guard.insert(prefix.clone(), state).is_none() {
+            info!("[TEMP TABLE] session={prefix} added to ClientSessionManager");
+        }
+    }
+
+    pub fn remove_temp_tbl_mgr(&self, prefix: String, temp_tbl_mgr: TempTblMgrRef) {
+        let mut guard = self.session_state.lock();
+        let is_empty = temp_tbl_mgr.lock().is_empty();
+        if is_empty {
+            guard.remove(&prefix);
+            // all temp table dropped by user, data should have been removed when executing drop.
+            info!("[TEMP TABLE] session={prefix} removed from ClientSessionManager");
         }
     }
 

--- a/src/query/service/src/servers/http/v1/session/client_session_manager.rs
+++ b/src/query/service/src/servers/http/v1/session/client_session_manager.rs
@@ -460,14 +460,14 @@ pub async fn drop_all_temp_tables_with_logging(
         Ok(_) => {
             let duration = start.elapsed().as_millis();
             info!(
-                "[TEMP-TABLE] session={} clean up completed in {}ms",
+                "[TEMP TABLE] session={} clean up completed in {}ms",
                 user_name_session_id, duration
             );
         }
         Err(e) => {
             let duration = start.elapsed().as_millis();
             error!(
-                "[TEMP-TABLE] session={} clean up failed after {}ms: error={:?}",
+                "[TEMP TABLE] session={} clean up failed after {}ms: error={:?}",
                 user_name_session_id, duration, e
             );
         }

--- a/src/query/service/src/servers/http/v1/session/consts.rs
+++ b/src/query/service/src/servers/http/v1/session/consts.rs
@@ -27,4 +27,3 @@ pub const TTL_GRACE_PERIOD_QUERY: Duration = Duration::from_secs(600);
 /// only required for refresh token.
 /// e.g. /session/refresh still need the token for auth when retrying.
 pub const TOMBSTONE_TTL: Duration = Duration::from_secs(90);
-pub const MIN_STATE_REFRESH_INTERVAL: Duration = Duration::from_secs(300);

--- a/src/query/service/src/servers/http/v1/session/consts.rs
+++ b/src/query/service/src/servers/http/v1/session/consts.rs
@@ -27,5 +27,4 @@ pub const TTL_GRACE_PERIOD_QUERY: Duration = Duration::from_secs(600);
 /// only required for refresh token.
 /// e.g. /session/refresh still need the token for auth when retrying.
 pub const TOMBSTONE_TTL: Duration = Duration::from_secs(90);
-pub const STATE_REFRESH_INTERVAL_META: Duration = Duration::from_secs(300);
-pub const STATE_REFRESH_INTERVAL_MEMORY: Duration = Duration::from_secs(60);
+pub const MIN_STATE_REFRESH_INTERVAL: Duration = Duration::from_secs(300);

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1538,7 +1538,6 @@ async fn test_affect() -> Result<()> {
                 database: Some("default".to_string()),
                 role: Some("account_admin".to_string()),
                 secondary_roles: None,
-                keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([
                     ("max_threads".to_string(), "1".to_string()),
                     ("timezone".to_string(), "Asia/Shanghai".to_string()),
@@ -1564,7 +1563,6 @@ async fn test_affect() -> Result<()> {
                 database: Some("default".to_string()),
                 role: Some("account_admin".to_string()),
                 secondary_roles: None,
-                keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
                     "6".to_string(),
@@ -1585,7 +1583,6 @@ async fn test_affect() -> Result<()> {
                 database: Some("default".to_string()),
                 role: Some("account_admin".to_string()),
                 secondary_roles: None,
-                keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
                     "6".to_string(),
@@ -1608,7 +1605,6 @@ async fn test_affect() -> Result<()> {
                 database: Some("db2".to_string()),
                 role: Some("account_admin".to_string()),
                 secondary_roles: None,
-                keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "max_threads".to_string(),
                     "6".to_string(),
@@ -1633,7 +1629,6 @@ async fn test_affect() -> Result<()> {
                 database: Some("default".to_string()),
                 role: Some("account_admin".to_string()),
                 secondary_roles: None,
-                keep_server_session_secs: None,
                 settings: Some(BTreeMap::from([(
                     "timezone".to_string(),
                     "Asia/Shanghai".to_string(),

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -321,7 +321,7 @@ pub async fn drop_table_by_id(
 ) -> Result<Option<DropTableReply>> {
     let DropTableByIdReq { tb_id, engine, .. } = &req;
     info!(
-        "[TEMP-TABLE] session={} dropping {} table {tb_id}.",
+        "[TEMP TABLE] session={} dropping {} table {tb_id}.",
         req.temp_prefix,
         engine.as_str()
     );
@@ -412,7 +412,7 @@ pub async fn drop_all_temp_tables(
     let num_mem_table = mem_tbl_ids.len();
 
     info!(
-        "[TEMP-TABLE] session={user_name_session_id} starting cleanup, reason = {reason}, {} fuse table, {} mem table."
+        "[TEMP TABLE] session={user_name_session_id} starting cleanup, reason = {reason}, {} fuse table, {} mem table."
         , num_fuse_table, num_mem_table
     );
 

--- a/tests/suites/1_stateful/09_http_handler/09_0009_cookie.py
+++ b/tests/suites/1_stateful/09_http_handler/09_0009_cookie.py
@@ -47,7 +47,7 @@ def test_simple():
     # print(client.cookies)
     sid = client.cookies.get("session_id", path="/")
 
-    last_access_time1 = int(client.cookies.get("last_access_time"))
+    last_access_time1 = int(client.cookies.get("last_refresh_time"))
     # print(last_access_time1)
     assert time.time() - 10 < last_access_time1 <= time.time()
 
@@ -58,9 +58,9 @@ def test_simple():
     assert resp.json()["data"] == [["1"]], resp.text
     sid2 = client.cookies.get("session_id")
     # print(client.cookies)
-    last_access_time2 = int(client.cookies.get("last_access_time"))
+    last_access_time2 = int(client.cookies.get("last_refresh_time"))
     assert sid2 == sid
-    assert last_access_time1 < last_access_time2 <= time.time()
+    assert last_access_time1 == last_access_time2 <= time.time()
 
 
 def test_temp_table():

--- a/tests/suites/1_stateful/09_http_handler/09_0011_concurrent_query.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0011_concurrent_query.result
@@ -1,0 +1,11 @@
+2
+null
+false
+
+10
+null
+false
+
+2
+null
+null

--- a/tests/suites/1_stateful/09_http_handler/09_0011_concurrent_query.sh
+++ b/tests/suites/1_stateful/09_http_handler/09_0011_concurrent_query.sh
@@ -1,0 +1,20 @@
+session_id="065142ee-68e8-470b-a4d6-2ed67f90e2ae"
+curl -s -u root: -XPOST "http://127.0.0.1:8000/v1/query"  \
+ -H 'x-databend-query-id: qq1' \
+ -H 'Content-Type: application/json' \
+ -d '{"sql": "select * from numbers(10);","pagination": {"max_rows_per_page": 2}}' \
+ -b "cookie_enabled=true;session_id=${session_id}" | jq "(.data | length), .error,.session.need_sticky"
+
+echo
+
+curl -s -u root: -XPOST "http://127.0.0.1:8000/v1/query"  \
+ -H 'x-databend-query-id: qq2' \
+ -H 'Content-Type: application/json' \
+ -d '{"sql": "select * from numbers(10);", "session": {"internal": "{\"variables\": [], \"last_query_result_cache_key\":\"x\"}", "last_query_ids":["qq1"]}}' \
+ -b "cookie_enabled=true;session_id=${session_id}" | jq  "(.data| length), .error, .session.need_sticky"
+
+ echo
+
+# session field should be empty
+curl -s -u root: -XGET  "http://127.0.0.1:8000/v1/query/qq1/page/1"  \
+  -b "cookie_enabled=true;session_id=${session_id}"| jq  "(.data| length), .error,.session"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

## Improved Temporary Table Management and Session State Handling

### Summary
This PR introduces more robust temporary table management and reduces potential session invalidation issues caused by concurrent queries.

### Changes

#### 1. Temporary Table Management Improvements
- **More robust implementation with slight efficiency tradeoff**
- Moved temporary table add/remove operations (to/from manager) to the interpreter level
  - Now occurs immediately after temp table creation/dropping (instead of being handled by HTTP handler)
- Removed `INUSE` session state
  - Rationale: This state indicated a query was running on the session (no refresh needed)
  - Problem: Could lead to permanent cleanup failures if not properly reset in edge cases
  - New approach: Refresh attempted on each request instead

#### 2. Reduced Session Invalidation from Concurrent Queries
- **Problem**: Concurrent queries (when client starts new query while previous is still running) could lead to:
  - Connection state being overwritten by the previous query's response
  - Potential session invalidation
- **Solution**:
  - Only send changed state to clients
-  **Rationale**
  - No problem as long as client check `.session = null` first, already done long time ago.
  - reduce chance of unexpected overwrite:
     - For queries that modify session state: `conn.start_query` blocks until query completion
     - For other queries that might still be running after `conn.start_query`, most are select, no need to update,  the only exception known is that failure in transaction modify txn state.
- **Additional Improvement**:
  - Added logging for concurrent query cases to facilitate debugging of related issues

#### 2. Fix leaking of `m_cte_temp_table`
- **Problem**: `drop_m_cte_temp_table` only called in interpreter,  but may be created in binder, if bind fail, could lead to:
  -  memory leak.
  -  wrong result of next query of stream (dup records)  https://github.com/databendlabs/databend/blob/v1.2.756-nightly/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test#L434 cc @zhyass 
- **Solution**:
  - call  `drop_m_cte_temp_table` if start_query fail

### Impact
- More reliable temporary table handling
- Reduced risk of session corruption from concurrent operations
- Better debuggability for concurrent query scenarios

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18162)
<!-- Reviewable:end -->
