### PR TITLE
fix: Bloom filter not updated after refresh

### DIFF
--- a/src/query/ee/tests/it/ngram_index/index_refresh.rs
+++ b/src/query/ee/tests/it/ngram_index/index_refresh.rs
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use databend_common_base::base::tokio;
 use databend_common_exception::Result;
 use databend_common_storage::DataOperator;
-use databend_common_storages_fuse::index::BloomIndexMeta;
-use databend_common_storages_fuse::io::read::bloom::block_filter_reader::load_index_meta;
+use databend_common_storages_fuse::io::read::bloom::block_filter_reader::load_bloom_filter_by_columns;
 use databend_enterprise_query::test_kits::context::EESetup;
+use databend_query::storages::index::filters::BlockFilter;
 use databend_query::test_kits::TestFixture;
-use databend_storages_common_table_meta::meta::SingleColumnMeta;
 use futures_util::StreamExt;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -45,48 +42,70 @@ async fn test_fuse_do_refresh_ngram_index() -> Result<()> {
         .execute_command("CREATE NGRAM INDEX idx2 ON default.t3(d);")
         .await?;
 
-    let meta_0 = get_bloom_index_meta(&fixture).await?;
-    assert_eq!(meta_0.columns.len(), 5);
+    let block_filter_0 = get_block_filter(&fixture, &[
+        "Bloom(0)".to_string(),
+        "Bloom(1)".to_string(),
+        "Bloom(2)".to_string(),
+        "Bloom(3)".to_string(),
+        "Bloom(4)".to_string(),
+    ])
+    .await?;
+    assert_eq!(block_filter_0.filter_schema.fields().len(), 5);
+    assert_eq!(block_filter_0.filters.len(), 5);
     fixture
         .execute_command("REFRESH NGRAM INDEX idx2 ON default.t3;")
         .await?;
-    let meta_1 = get_bloom_index_meta(&fixture).await?;
+    let block_filter_1 = get_block_filter(&fixture, &[
+        "Bloom(0)".to_string(),
+        "Bloom(1)".to_string(),
+        "Bloom(2)".to_string(),
+        "Bloom(3)".to_string(),
+        "Bloom(4)".to_string(),
+        "Ngram(3)_3_1048576".to_string(),
+    ])
+    .await?;
+    assert_eq!(block_filter_1.filter_schema.fields().len(), 6);
+    assert_eq!(block_filter_1.filters.len(), 6);
 
-    assert_eq!(&meta_0.columns[..], &meta_1.columns[..5]);
-    assert_eq!(meta_1.columns.len(), 6);
     assert_eq!(
-        &meta_1.columns[5],
-        &("Ngram(3)_3_1048576".to_string(), SingleColumnMeta {
-            offset: 424,
-            len: 1048644,
-            num_values: 1,
-        })
+        &block_filter_0.filter_schema.fields()[..],
+        &block_filter_1.filter_schema.fields()[..5]
     );
+    if &block_filter_0.filters[..] != &block_filter_1.filters[..5] {
+        unreachable!()
+    }
 
     fixture
         .execute_command("DROP NGRAM INDEX idx2 ON default.t3;")
         .await?;
     fixture
-        .execute_command("CREATE NGRAM INDEX idx2 ON default.t3(d) gram_size = 5;")
+        .execute_command(
+            "CREATE NGRAM INDEX idx2 ON default.t3(d) gram_size = 8 bloom_size = 1048570;",
+        )
         .await?;
     fixture
         .execute_command("REFRESH NGRAM INDEX idx2 ON default.t3;")
         .await?;
-    let meta_2 = get_bloom_index_meta(&fixture).await?;
-    assert_eq!(meta_2.columns.len(), 6);
-    assert_eq!(
-        &meta_2.columns[5],
-        &("Ngram(3)_5_1048576".to_string(), SingleColumnMeta {
-            offset: 424,
-            len: 1048644,
-            num_values: 1,
-        })
-    );
+    let block_filter_2 = get_block_filter(&fixture, &[
+        "Bloom(0)".to_string(),
+        "Bloom(1)".to_string(),
+        "Bloom(2)".to_string(),
+        "Bloom(3)".to_string(),
+        "Bloom(4)".to_string(),
+        "Ngram(3)_8_1048570".to_string(),
+    ])
+    .await?;
+    assert_eq!(block_filter_2.filter_schema.fields().len(), 6);
+    assert_eq!(block_filter_2.filters.len(), 6);
+
+    if &block_filter_1.filters[5] == &block_filter_2.filters[5] {
+        unreachable!()
+    }
 
     Ok(())
 }
 
-async fn get_bloom_index_meta(fixture: &TestFixture) -> Result<Arc<BloomIndexMeta>> {
+async fn get_block_filter(fixture: &TestFixture, columns: &[String]) -> Result<BlockFilter> {
     let block = fixture
         .execute_query(
             "select bloom_filter_location, bloom_filter_size from fuse_block('default', 't3');",
@@ -101,8 +120,9 @@ async fn get_bloom_index_meta(fixture: &TestFixture) -> Result<Arc<BloomIndexMet
     let length = block.columns()[1].to_column();
     let length_scalar = length.as_number().unwrap().index(0).unwrap();
 
-    load_index_meta(
+    load_bloom_filter_by_columns(
         DataOperator::instance().operator(),
+        columns,
         path_scalar,
         *length_scalar.as_u_int64().unwrap(),
     )

--- a/src/query/ee/tests/it/ngram_index/index_refresh.rs
+++ b/src/query/ee/tests/it/ngram_index/index_refresh.rs
@@ -71,7 +71,7 @@ async fn test_fuse_do_refresh_ngram_index() -> Result<()> {
         &block_filter_0.filter_schema.fields()[..],
         &block_filter_1.filter_schema.fields()[..5]
     );
-    if &block_filter_0.filters[..] != &block_filter_1.filters[..5] {
+    if block_filter_0.filters[..] != block_filter_1.filters[..5] {
         unreachable!()
     }
 
@@ -98,7 +98,7 @@ async fn test_fuse_do_refresh_ngram_index() -> Result<()> {
     assert_eq!(block_filter_2.filter_schema.fields().len(), 6);
     assert_eq!(block_filter_2.filters.len(), 6);
 
-    if &block_filter_1.filters[5] == &block_filter_2.filters[5] {
+    if block_filter_1.filters[5] == block_filter_2.filters[5] {
         unreachable!()
     }
 

--- a/src/query/storages/common/index/src/filters/bloom_filter.rs
+++ b/src/query/storages/common/index/src/filters/bloom_filter.rs
@@ -89,7 +89,7 @@ impl FilterBuilder for BloomBuilder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BloomFilter {
     size: u64,
     hashes: u64,

--- a/src/query/storages/common/index/src/filters/xor8/mod.rs
+++ b/src/query/storages/common/index/src/filters/xor8/mod.rs
@@ -31,6 +31,7 @@ pub use crate::filters::bloom_filter::BloomFilter;
 use crate::filters::Filter;
 use crate::filters::FilterBuilder;
 
+#[derive(PartialEq)]
 pub enum FilterImpl {
     Xor(Xor8Filter),
     Ngram(BloomFilter),

--- a/src/query/storages/common/index/src/filters/xor8/xor8_filter.rs
+++ b/src/query/storages/common/index/src/filters/xor8/xor8_filter.rs
@@ -36,6 +36,7 @@ pub struct Xor8Builder {
     builder: xorfilter::Xor8Builder,
 }
 
+#[derive(Clone, Default, PartialEq)]
 pub struct Xor8Filter {
     pub filter: Xor8,
 }

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -50,7 +50,6 @@ pub use write::CachedMetaWriter;
 pub use write::InvertedIndexBuilder;
 pub use write::InvertedIndexWriter;
 pub use write::MetaWriter;
-pub use write::NewNgramIndexColumn;
 pub(crate) use write::StreamBlockBuilder;
 pub(crate) use write::StreamBlockProperties;
 pub use write::VirtualColumnBuilder;

--- a/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
@@ -118,9 +118,10 @@ pub async fn load_bloom_filter_by_columns<'a>(
 
     let futs = col_metas
         .iter()
-        .map(|(idx, (_, col_chunk_meta))| {
+        .map(|(idx, (name, col_chunk_meta))| {
             load_column_bloom_filter(
                 *idx,
+                name,
                 col_chunk_meta,
                 index_path,
                 &dal,
@@ -150,6 +151,7 @@ pub async fn load_bloom_filter_by_columns<'a>(
 #[fastrace::trace]
 async fn load_column_bloom_filter<'a>(
     idx: ColumnId,
+    filter_name: &str,
     col_chunk_meta: &'a SingleColumnMeta,
     index_path: &'a str,
     dal: &'a Operator,
@@ -160,6 +162,7 @@ async fn load_column_bloom_filter<'a>(
         let column_data_reader = BloomColumnFilterReader::new(
             index_path.to_owned(),
             idx,
+            filter_name,
             col_chunk_meta,
             dal.clone(),
             bloom_index_schema_desc,

--- a/src/query/storages/fuse/src/io/read/bloom/column_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/column_filter_reader.rs
@@ -49,11 +49,12 @@ impl BloomColumnFilterReader {
     pub fn new(
         index_path: String,
         column_id: ColumnId,
+        filter_name: &str,
         column_chunk_meta: &SingleColumnMeta,
         operator: Operator,
         schema_desc: SchemaDescPtr,
     ) -> Self {
-        let cache_key = format!("{index_path}-{column_id}");
+        let cache_key = format!("{index_path}-{filter_name}");
 
         let SingleColumnMeta {
             offset,

--- a/src/query/storages/fuse/src/io/write/mod.rs
+++ b/src/query/storages/fuse/src/io/write/mod.rs
@@ -27,7 +27,6 @@ pub use block_writer::BlockSerialization;
 pub use block_writer::BlockWriter;
 pub use bloom_index_writer::BloomIndexRebuilder;
 pub use bloom_index_writer::BloomIndexState;
-pub use bloom_index_writer::NewNgramIndexColumn;
 pub(crate) use inverted_index_writer::create_index_schema;
 pub(crate) use inverted_index_writer::create_inverted_index_builders;
 pub(crate) use inverted_index_writer::create_tokenizer_manager;

--- a/src/query/storages/fuse/src/io/write/stream/block_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/block_builder.rs
@@ -279,7 +279,6 @@ impl StreamBlockBuilder {
             Some(BloomIndexState::from_bloom_index(
                 &bloom_index,
                 bloom_index_location,
-                None,
             )?)
         } else {
             None


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: 
- Refresh ngram index only evicts the meta cache before
- The cache key does not distinguish between bloom index and ngram index.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18170)
<!-- Reviewable:end -->
