### PR TITLE
feat(query): when decimal is used as an aggregate group by column, decimal64 is used

### DIFF
--- a/src/query/expression/src/aggregate/payload_row.rs
+++ b/src/query/expression/src/aggregate/payload_row.rs
@@ -42,7 +42,7 @@ use crate::InputColumns;
 use crate::Scalar;
 use crate::SelectVector;
 
-pub fn rowformat_size(data_type: &DataType) -> usize {
+pub(super) fn rowformat_size(data_type: &DataType) -> usize {
     match data_type {
         DataType::Null | DataType::EmptyArray | DataType::EmptyMap => 0,
         DataType::Boolean => 1,
@@ -73,7 +73,7 @@ pub fn rowformat_size(data_type: &DataType) -> usize {
 }
 
 /// This serialize column into row format by fixed size
-pub unsafe fn serialize_column_to_rowformat(
+pub(super) unsafe fn serialize_column_to_rowformat(
     arena: &Bump,
     column: &Column,
     select_vector: &SelectVector,
@@ -195,7 +195,7 @@ unsafe fn serialize_fixed_size_column_to_rowformat<T>(
     }
 }
 
-pub unsafe fn row_match_columns(
+pub(super) unsafe fn row_match_columns(
     cols: InputColumns,
     address: &[*const u8],
     select_vector: &mut SelectVector,

--- a/src/query/expression/src/aggregate/payload_row.rs
+++ b/src/query/expression/src/aggregate/payload_row.rs
@@ -21,7 +21,6 @@ use crate::read;
 use crate::store;
 use crate::types::binary::BinaryColumn;
 use crate::types::decimal::DecimalColumn;
-use crate::types::decimal::DecimalType;
 use crate::types::i256;
 use crate::types::AccessType;
 use crate::types::AnyType;
@@ -29,13 +28,14 @@ use crate::types::BinaryType;
 use crate::types::BooleanType;
 use crate::types::DataType;
 use crate::types::DateType;
-use crate::types::Decimal128As256Type;
-use crate::types::Decimal256As128Type;
+use crate::types::DecimalDataKind;
+use crate::types::DecimalView;
 use crate::types::NumberColumn;
 use crate::types::NumberType;
 use crate::types::StringColumn;
 use crate::types::StringType;
 use crate::types::TimestampType;
+use crate::with_decimal_mapped_type;
 use crate::with_number_mapped_type;
 use crate::Column;
 use crate::InputColumns;
@@ -47,8 +47,10 @@ pub fn rowformat_size(data_type: &DataType) -> usize {
         DataType::Null | DataType::EmptyArray | DataType::EmptyMap => 0,
         DataType::Boolean => 1,
         DataType::Number(n) => n.bit_width() as usize / 8,
-        DataType::Decimal(n) => {
-            if n.can_carried_by_128() {
+        DataType::Decimal(size) => {
+            if size.can_carried_by_64() {
+                8
+            } else if size.can_carried_by_128() {
                 16
             } else {
                 32
@@ -89,33 +91,22 @@ pub unsafe fn serialize_column_to_rowformat(
                 }
             }
         }),
-        Column::Decimal(v) => match v {
-            DecimalColumn::Decimal64(_, _) => unimplemented!(),
-            DecimalColumn::Decimal128(buffer, size) => {
-                if size.can_carried_by_128() {
-                    for index in select_vector.iter().take(rows).copied() {
-                        store(&buffer[index], address[index].add(offset) as *mut u8);
-                    }
-                } else {
-                    for index in select_vector.iter().take(rows).copied() {
-                        let val = Decimal128As256Type::index_column_unchecked(buffer, index);
-                        store(&val, address[index].add(offset) as *mut u8);
-                    }
+        Column::Decimal(decimal_column) => {
+            with_decimal_mapped_type!(|F| match decimal_column {
+                DecimalColumn::F(buffer, size) => {
+                    with_decimal_mapped_type!(|T| match size.best_type().data_kind() {
+                        DecimalDataKind::T => {
+                            serialize_fixed_size_column_to_rowformat::<DecimalView<F, T>>(
+                                buffer,
+                                &select_vector[0..rows],
+                                address,
+                                offset,
+                            );
+                        }
+                    });
                 }
-            }
-            DecimalColumn::Decimal256(buffer, size) => {
-                if size.can_carried_by_128() {
-                    for index in select_vector.iter().take(rows).copied() {
-                        let val = Decimal256As128Type::index_column_unchecked(buffer, index);
-                        store(&val, address[index].add(offset) as *mut u8);
-                    }
-                } else {
-                    for index in select_vector.iter().take(rows).copied() {
-                        store(&buffer[index], address[index].add(offset) as *mut u8);
-                    }
-                }
-            }
-        },
+            });
+        }
         Column::Boolean(v) => {
             if v.null_count() == 0 || v.null_count() == v.len() {
                 let val: u8 = if v.null_count() == 0 { 1 } else { 0 };
@@ -190,6 +181,20 @@ pub unsafe fn serialize_column_to_rowformat(
     }
 }
 
+unsafe fn serialize_fixed_size_column_to_rowformat<T>(
+    column: &T::Column,
+    select_vector: &[usize],
+    address: &[*const u8],
+    offset: usize,
+) where
+    T: AccessType<Scalar: Copy>,
+{
+    for index in select_vector.iter().copied() {
+        let val = T::index_column_unchecked_scalar(column, index);
+        store(&val, address[index].add(offset) as *mut u8);
+    }
+}
+
 pub unsafe fn row_match_columns(
     cols: InputColumns,
     address: &[*const u8],
@@ -226,7 +231,7 @@ pub unsafe fn row_match_columns(
     }
 }
 
-pub unsafe fn row_match_column(
+unsafe fn row_match_column(
     col: &Column,
     address: &[*const u8],
     select_vector: &mut SelectVector,
@@ -264,33 +269,28 @@ pub unsafe fn row_match_column(
                 )
             }
         }),
-        Column::Decimal(v) => match v {
-            DecimalColumn::Decimal64(_, _) => unreachable!(),
-            DecimalColumn::Decimal128(_, _) => row_match_column_type::<DecimalType<i128>>(
-                col,
-                validity,
-                address,
-                select_vector,
-                temp_vector,
-                count,
-                validity_offset,
-                col_offset,
-                no_match,
-                no_match_count,
-            ),
-            DecimalColumn::Decimal256(_, _) => row_match_column_type::<DecimalType<i256>>(
-                col,
-                validity,
-                address,
-                select_vector,
-                temp_vector,
-                count,
-                validity_offset,
-                col_offset,
-                no_match,
-                no_match_count,
-            ),
-        },
+        Column::Decimal(decimal_column) => {
+            with_decimal_mapped_type!(|F| match decimal_column {
+                DecimalColumn::F(_, size) => {
+                    with_decimal_mapped_type!(|T| match size.best_type().data_kind() {
+                        DecimalDataKind::T => {
+                            row_match_column_type::<DecimalView<F, T>>(
+                                col,
+                                validity,
+                                address,
+                                select_vector,
+                                temp_vector,
+                                count,
+                                validity_offset,
+                                col_offset,
+                                no_match,
+                                no_match_count,
+                            )
+                        }
+                    });
+                }
+            });
+        }
         Column::Boolean(_) => row_match_column_type::<BooleanType>(
             col,
             validity,

--- a/src/query/expression/src/kernels/group_by_hash/method_fixed_keys.rs
+++ b/src/query/expression/src/kernels/group_by_hash/method_fixed_keys.rs
@@ -104,7 +104,8 @@ where T: Clone
 impl<T> HashMethodFixedKeys<T>
 where T: Clone
 {
-    pub fn deserialize_group_columns(
+    #[expect(dead_code)]
+    fn deserialize_group_columns(
         &self,
         keys: Vec<T>,
         group_items: &[(usize, DataType)],

--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -2815,6 +2815,8 @@ impl Ord for i256 {
     }
 }
 
+pub type DecimalView<F, T> = ComputeView<DecimalConvert<F, T>, CoreDecimal<F>, CoreDecimal<T>>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DecimalConvert<F, T>(std::marker::PhantomData<(F, T)>);
 

--- a/src/query/expression/src/types/nullable.rs
+++ b/src/query/expression/src/types/nullable.rs
@@ -362,7 +362,7 @@ impl<T: ReturnType> NullableColumn<T> {
 impl NullableColumn<AnyType> {
     pub fn new(column: Column, validity: Bitmap) -> Self {
         debug_assert_eq!(column.len(), validity.len());
-        debug_assert!(!column.is_nullable());
+        debug_assert!(!column.is_nullable() && !column.is_null());
         NullableColumn { column, validity }
     }
 }

--- a/src/query/functions/src/aggregates/adaptors/aggregate_sort_adaptor.rs
+++ b/src/query/functions/src/aggregates/adaptors/aggregate_sort_adaptor.rs
@@ -35,8 +35,6 @@ use databend_common_expression::Scalar;
 use databend_common_expression::SortColumnDescription;
 use itertools::Itertools;
 
-use crate::aggregates::borsh_deserialize_state;
-use crate::aggregates::borsh_serialize_state;
 use crate::aggregates::AggregateFunctionSortDesc;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
@@ -119,14 +117,12 @@ impl AggregateFunction for AggregateFunctionSortAdaptor {
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = Self::get_state(place);
-        borsh_serialize_state(writer, state)?;
-
-        Ok(())
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = Self::get_state(place);
-        let rhs: SortAggState = borsh_deserialize_state(reader)?;
+        let rhs = SortAggState::deserialize(reader)?;
 
         Self::merge_states_inner(state, &rhs);
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_arg_min_max.rs
+++ b/src/query/functions/src/aggregates/aggregate_arg_min_max.rs
@@ -40,8 +40,7 @@ use super::aggregate_scalar_state::CmpMin;
 use super::aggregate_scalar_state::TYPE_ANY;
 use super::aggregate_scalar_state::TYPE_MAX;
 use super::aggregate_scalar_state::TYPE_MIN;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::AggregateFunctionRef;
 use super::StateAddr;
 use crate::aggregates::assert_binary_arguments;
@@ -273,12 +272,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs: State = borsh_partial_deserialize(reader)?;
         state.merge_from(rhs)
     }
 

--- a/src/query/functions/src/aggregates/aggregate_array_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_agg.rs
@@ -413,7 +413,7 @@ where
                     self.validity.push(false);
                 }
             }
-        } else if NULLABLE {
+        } else {
             self.validity.extend_constant(*length, true);
         }
         Ok(())
@@ -673,13 +673,7 @@ pub fn try_create_aggregate_array_agg_function(
             }
         }
 
-        DataType::Null => {
-            if is_nullable {
-                ArrayAggrZST::<CoreNull, true>::create(display_name, return_type)
-            } else {
-                ArrayAggrZST::<CoreNull, false>::create(display_name, return_type)
-            }
-        }
+        DataType::Null => ArrayAggrZST::<CoreNull, false>::create(display_name, return_type),
         DataType::EmptyArray => {
             if is_nullable {
                 ArrayAggrZST::<CoreEmptyArray, true>::create(display_name, return_type)

--- a/src/query/functions/src/aggregates/aggregate_array_moving.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_moving.rs
@@ -328,8 +328,7 @@ where T: Decimal
         let size = inner_type.as_decimal().unwrap();
 
         let inner_col = T::upcast_column(sum_values.into(), *size);
-        let array_value = ScalarRef::Array(inner_col);
-        builder.push(array_value);
+        builder.push(ScalarRef::Array(inner_col));
 
         Ok(())
     }
@@ -372,9 +371,9 @@ where T: Decimal
 
         let data_type = builder.data_type();
         let inner_type = data_type.as_array().unwrap();
-        let decimal_type = inner_type.as_decimal().unwrap();
+        let decimal_size = inner_type.as_decimal().unwrap();
 
-        let inner_col = T::upcast_column(avg_values.into(), *decimal_type);
+        let inner_col = T::upcast_column(avg_values.into(), *decimal_size);
         let array_value = ScalarRef::Array(inner_col);
         builder.push(array_value);
 

--- a/src/query/functions/src/aggregates/aggregate_array_moving.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_moving.rs
@@ -49,8 +49,6 @@ use super::aggregate_function::AggregateFunction;
 use super::aggregate_function::AggregateFunctionRef;
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_function_factory::AggregateFunctionSortDesc;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
 use super::extract_number_param;
 use super::StateAddr;
 use crate::aggregates::aggregate_sum::SumState;
@@ -437,12 +435,12 @@ where State: SumState
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs = State::deserialize_reader(reader)?;
 
         state.merge(&rhs)
     }
@@ -613,12 +611,12 @@ where State: SumState
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs = State::deserialize_reader(reader)?;
 
         state.merge(&rhs)
     }

--- a/src/query/functions/src/aggregates/aggregate_covariance.rs
+++ b/src/query/functions/src/aggregates/aggregate_covariance.rs
@@ -37,8 +37,7 @@ use databend_common_expression::InputColumns;
 use databend_common_expression::Scalar;
 use num_traits::AsPrimitive;
 
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::StateAddr;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionDescription;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionSortDesc;
@@ -235,12 +234,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<AggregateCovarianceState>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<AggregateCovarianceState>();
-        let rhs: AggregateCovarianceState = borsh_deserialize_state(reader)?;
+        let rhs: AggregateCovarianceState = borsh_partial_deserialize(reader)?;
         state.merge(&rhs);
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_histogram.rs
+++ b/src/query/functions/src/aggregates/aggregate_histogram.rs
@@ -23,7 +23,6 @@ use borsh::BorshSerialize;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::decimal::*;
-use databend_common_expression::types::i256;
 use databend_common_expression::types::number::*;
 use databend_common_expression::types::*;
 use databend_common_expression::with_number_mapped_type;
@@ -117,20 +116,10 @@ where
         };
 
         let mut buckets = build_histogram(&self.value_map, histogram_data.max_num_buckets);
-        let decimal_size = histogram_data.data_type.as_decimal().copied();
 
         let format_scalar = |scalar| {
             let scalar = T::upcast_scalar_with_type(scalar, &histogram_data.data_type);
-            let scalar = match scalar {
-                Scalar::Decimal(DecimalScalar::Decimal128(value, _)) => {
-                    i128::upcast_scalar(value, decimal_size.unwrap())
-                }
-                Scalar::Decimal(DecimalScalar::Decimal256(value, _)) => {
-                    i256::upcast_scalar(value, decimal_size.unwrap())
-                }
-                _ => scalar,
-            };
-            format!("{}", scalar)
+            format!("{scalar}")
         };
 
         let json_str = serde_json::to_string(

--- a/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
@@ -41,8 +41,7 @@ use jsonb::RawJsonb;
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_function_factory::AggregateFunctionSortDesc;
 use super::aggregate_scalar_state::ScalarStateFunc;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::StateAddr;
 use crate::aggregates::assert_unary_arguments;
 use crate::aggregates::AggrState;
@@ -243,12 +242,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs: State = borsh_partial_deserialize(reader)?;
 
         state.merge(&rhs)
     }

--- a/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
@@ -136,9 +136,11 @@ where
 pub struct AggregateJsonArrayAggFunction<T, State> {
     display_name: String,
     return_type: DataType,
-    _t: PhantomData<T>,
-    _state: PhantomData<State>,
+    _t: PhantomData<(T, State)>,
 }
+
+unsafe impl<T, State> Send for AggregateJsonArrayAggFunction<T, State> {}
+unsafe impl<T, State> Sync for AggregateJsonArrayAggFunction<T, State> {}
 
 impl<T, State> AggregateFunction for AggregateJsonArrayAggFunction<T, State>
 where
@@ -287,8 +289,7 @@ where
         let func = AggregateJsonArrayAggFunction::<T, State> {
             display_name: display_name.to_string(),
             return_type,
-            _t: PhantomData,
-            _state: PhantomData,
+            _t: Default::default(),
         };
         Ok(Arc::new(func))
     }

--- a/src/query/functions/src/aggregates/aggregate_json_object_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_json_object_agg.rs
@@ -42,8 +42,7 @@ use jsonb::RawJsonb;
 
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_function_factory::AggregateFunctionSortDesc;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::StateAddr;
 use crate::aggregates::assert_binary_arguments;
 use crate::aggregates::AggrState;
@@ -296,12 +295,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs: State = borsh_partial_deserialize(reader)?;
 
         state.merge(&rhs)
     }

--- a/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
+++ b/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
@@ -41,8 +41,7 @@ use databend_common_expression::InputColumns;
 
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::assert_unary_arguments;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::extract_number_param;
 use super::AggregateFunction;
 
@@ -114,12 +113,12 @@ impl AggregateFunction for MarkovTarin {
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<MarkovModel>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<MarkovModel>();
-        let mut rhs = borsh_deserialize_state::<MarkovModel>(reader)?;
+        let mut rhs = borsh_partial_deserialize::<MarkovModel>(reader)?;
         state.merge(&mut rhs);
 
         Ok(())

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest.rs
@@ -36,8 +36,7 @@ use databend_common_expression::ScalarRef;
 use itertools::Itertools;
 use num_traits::AsPrimitive;
 
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::get_levels;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionDescription;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionSortDesc;
@@ -361,12 +360,12 @@ where T: Number + AsPrimitive<f64>
     }
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<QuantileTDigestState>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<QuantileTDigestState>();
-        let mut rhs: QuantileTDigestState = borsh_deserialize_state(reader)?;
+        let mut rhs: QuantileTDigestState = borsh_partial_deserialize(reader)?;
         state.merge(&mut rhs)
     }
 

--- a/src/query/functions/src/aggregates/aggregate_quantile_tdigest_weighted.rs
+++ b/src/query/functions/src/aggregates/aggregate_quantile_tdigest_weighted.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use borsh::BorshSerialize;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::types::number::*;
@@ -32,8 +33,7 @@ use databend_common_expression::InputColumns;
 use databend_common_expression::Scalar;
 use num_traits::AsPrimitive;
 
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::get_levels;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionDescription;
 use crate::aggregates::aggregate_function_factory::AggregateFunctionSortDesc;
@@ -145,12 +145,12 @@ where
     }
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<QuantileTDigestState>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<QuantileTDigestState>();
-        let mut rhs: QuantileTDigestState = borsh_deserialize_state(reader)?;
+        let mut rhs: QuantileTDigestState = borsh_partial_deserialize(reader)?;
         state.merge(&mut rhs)
     }
 

--- a/src/query/functions/src/aggregates/aggregate_retention.rs
+++ b/src/query/functions/src/aggregates/aggregate_retention.rs
@@ -35,8 +35,7 @@ use super::aggregate_function::AggregateFunction;
 use super::aggregate_function::AggregateFunctionRef;
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_function_factory::AggregateFunctionSortDesc;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::StateAddr;
 use crate::aggregates::aggregator_common::assert_variadic_arguments;
 use crate::aggregates::AggrState;
@@ -145,12 +144,12 @@ impl AggregateFunction for AggregateRetentionFunction {
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<AggregateRetentionState>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<AggregateRetentionState>();
-        let rhs: AggregateRetentionState = borsh_deserialize_state(reader)?;
+        let rhs: AggregateRetentionState = borsh_partial_deserialize(reader)?;
         state.merge(&rhs);
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_scalar_state.rs
+++ b/src/query/functions/src/aggregates/aggregate_scalar_state.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use databend_common_exception::Result;
+use databend_common_expression::types::AccessType;
 use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::BuilderExt;
 use databend_common_expression::types::DataType;
@@ -138,8 +139,8 @@ impl<T: ValueType> ChangeIf<T> for CmpAny {
     }
 }
 
-pub trait ScalarStateFunc<T: ValueType>:
-    BorshSerialize + BorshDeserialize + Send + Sync + 'static
+pub trait ScalarStateFunc<T: AccessType>:
+    BorshSerialize + BorshDeserialize + Send + 'static
 {
     fn new() -> Self;
     fn mem_size() -> Option<usize> {

--- a/src/query/functions/src/aggregates/aggregate_st_collect.rs
+++ b/src/query/functions/src/aggregates/aggregate_st_collect.rs
@@ -197,13 +197,15 @@ where
 pub struct AggregateStCollectFunction<T, State> {
     display_name: String,
     return_type: DataType,
-    _t: PhantomData<T>,
-    _state: PhantomData<State>,
+    _t: PhantomData<(T, State)>,
 }
+
+unsafe impl<T, State> Send for AggregateStCollectFunction<T, State> {}
+unsafe impl<T, State> Sync for AggregateStCollectFunction<T, State> {}
 
 impl<T, State> AggregateFunction for AggregateStCollectFunction<T, State>
 where
-    T: ValueType + Send + Sync,
+    T: ValueType,
     State: ScalarStateFunc<T>,
 {
     fn name(&self) -> &str {
@@ -346,15 +348,14 @@ impl<T, State> fmt::Display for AggregateStCollectFunction<T, State> {
 
 impl<T, State> AggregateStCollectFunction<T, State>
 where
-    T: ValueType + Send + Sync,
+    T: ValueType,
     State: ScalarStateFunc<T>,
 {
     fn try_create(display_name: &str, return_type: DataType) -> Result<Arc<dyn AggregateFunction>> {
         let func = AggregateStCollectFunction::<T, State> {
             display_name: display_name.to_string(),
             return_type,
-            _t: PhantomData,
-            _state: PhantomData,
+            _t: Default::default(),
         };
         Ok(Arc::new(func))
     }

--- a/src/query/functions/src/aggregates/aggregate_st_collect.rs
+++ b/src/query/functions/src/aggregates/aggregate_st_collect.rs
@@ -49,8 +49,7 @@ use geozero::wkb::Ewkb;
 use super::aggregate_function_factory::AggregateFunctionDescription;
 use super::aggregate_function_factory::AggregateFunctionSortDesc;
 use super::aggregate_scalar_state::ScalarStateFunc;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::StateAddr;
 use crate::aggregates::assert_unary_arguments;
 use crate::aggregates::AggrState;
@@ -309,12 +308,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<State>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<State>();
-        let rhs: State = borsh_deserialize_state(reader)?;
+        let rhs: State = borsh_partial_deserialize(reader)?;
 
         state.merge(&rhs)
     }

--- a/src/query/functions/src/aggregates/aggregate_string_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_string_agg.rs
@@ -37,8 +37,7 @@ use databend_common_expression::Scalar;
 use databend_common_expression::Value;
 
 use super::aggregate_function_factory::AggregateFunctionDescription;
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::AggregateFunctionSortDesc;
 use super::StateAddr;
 use crate::aggregates::assert_variadic_arguments;
@@ -152,13 +151,12 @@ impl AggregateFunction for AggregateStringAggFunction {
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<StringAggState>();
-        borsh_serialize_state(writer, state)?;
-        Ok(())
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<StringAggState>();
-        let rhs: StringAggState = borsh_deserialize_state(reader)?;
+        let rhs: StringAggState = borsh_partial_deserialize(reader)?;
         state.values.push_str(&rhs.values);
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregate_unary.rs
+++ b/src/query/functions/src/aggregates/aggregate_unary.rs
@@ -232,7 +232,7 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state: &mut S = place.get::<S>();
-        Ok(borsh::to_writer(writer, state)?)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {

--- a/src/query/functions/src/aggregates/aggregate_window_funnel.rs
+++ b/src/query/functions/src/aggregates/aggregate_window_funnel.rs
@@ -43,8 +43,7 @@ use databend_common_expression::InputColumns;
 use databend_common_expression::Scalar;
 use num_traits::AsPrimitive;
 
-use super::borsh_deserialize_state;
-use super::borsh_serialize_state;
+use super::borsh_partial_deserialize;
 use super::extract_number_param;
 use super::AggregateFunctionRef;
 use super::AggregateNullVariadicAdaptor;
@@ -281,12 +280,12 @@ where
 
     fn serialize(&self, place: AggrState, writer: &mut Vec<u8>) -> Result<()> {
         let state = place.get::<AggregateWindowFunnelState<T::Scalar>>();
-        borsh_serialize_state(writer, state)
+        Ok(state.serialize(writer)?)
     }
 
     fn merge(&self, place: AggrState, reader: &mut &[u8]) -> Result<()> {
         let state = place.get::<AggregateWindowFunnelState<T::Scalar>>();
-        let mut rhs: AggregateWindowFunnelState<T::Scalar> = borsh_deserialize_state(reader)?;
+        let mut rhs: AggregateWindowFunnelState<T::Scalar> = borsh_partial_deserialize(reader)?;
         state.merge(&mut rhs);
         Ok(())
     }

--- a/src/query/functions/src/aggregates/aggregator_common.rs
+++ b/src/query/functions/src/aggregates/aggregator_common.rs
@@ -15,7 +15,6 @@
 use std::fmt::Display;
 
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use bumpalo::Bump;
 use databend_common_base::runtime::drop_guard;
 use databend_common_exception::ErrorCode;
@@ -197,16 +196,7 @@ pub fn eval_aggr_for_test(
 }
 
 #[inline]
-pub fn borsh_serialize_state<W: std::io::Write, T: BorshSerialize>(
-    writer: &mut W,
-    value: &T,
-) -> Result<()> {
-    borsh::to_writer(writer, value)?;
-    Ok(())
-}
-
-#[inline]
-pub fn borsh_deserialize_state<T: BorshDeserialize>(slice: &mut &[u8]) -> Result<T> {
+pub fn borsh_partial_deserialize<T: BorshDeserialize>(slice: &mut &[u8]) -> Result<T> {
     Ok(T::deserialize(slice)?)
 }
 

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_list.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_list.test
@@ -1,0 +1,9 @@
+query ?
+select list(a), list(b), list(c) from (values(null,[],{})) t(a,b,c), numbers(5);
+----
+[NULL,NULL,NULL,NULL,NULL] [[],[],[],[],[]] [{},{},{},{},{}]
+
+query ?
+select list(a), list(b), list(c) from (values(1::decimal(10,0),1::decimal(20,0),1::decimal(40,0))) t(a,b,c), numbers(5);
+----
+[1,1,1,1,1] [1,1,1,1,1] [1,1,1,1,1]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- When decimal is used as an aggregate group by column (also distinct, union), decimal64 is used.
- Refactored `array_agg` and fixed zst support (since borsh doesn't support zst)

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18171)
<!-- Reviewable:end -->
