### PR TITLE
chore(query): make async function works within local counters

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_async_function.rs
+++ b/src/query/service/src/pipelines/builders/builder_async_function.rs
@@ -24,11 +24,15 @@ impl PipelineBuilder {
         self.build_pipeline(&async_function.input)?;
 
         let operators = TransformAsyncFunction::init_operators(&async_function.async_func_descs)?;
+        let sequence_counters =
+            TransformAsyncFunction::create_sequence_counters(async_function.async_func_descs.len());
+
         self.main_pipeline.add_async_transformer(|| {
             TransformAsyncFunction::new(
                 self.ctx.clone(),
                 async_function.async_func_descs.clone(),
                 operators.clone(),
+                sequence_counters.clone(),
             )
         });
 

--- a/src/query/service/src/pipelines/builders/builder_fill_missing_columns.rs
+++ b/src/query/service/src/pipelines/builders/builder_fill_missing_columns.rs
@@ -52,11 +52,15 @@ impl PipelineBuilder {
                 default_expr_binder
                     .split_async_default_exprs(source_schema.clone(), default_schema.clone())?
             {
+                let sequence_counters =
+                    TransformAsyncFunction::create_sequence_counters(async_funcs.len());
+
                 pipeline.try_add_async_transformer(|| {
                     Ok(TransformAsyncFunction::new(
                         ctx.clone(),
                         async_funcs.clone(),
                         BTreeMap::new(),
+                        sequence_counters.clone(),
                     ))
                 })?;
                 if new_default_schema != new_default_schema_no_cast {

--- a/src/query/service/src/pipelines/processors/transforms/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/mod.rs
@@ -50,6 +50,7 @@ pub use transform_add_computed_columns::TransformAddComputedColumns;
 pub use transform_add_const_columns::TransformAddConstColumns;
 pub use transform_add_internal_columns::TransformAddInternalColumns;
 pub use transform_add_stream_columns::TransformAddStreamColumns;
+pub use transform_async_function::SequenceCounters;
 pub use transform_async_function::TransformAsyncFunction;
 pub use transform_branched_async_function::AsyncFunctionBranch;
 pub use transform_branched_async_function::TransformBranchedAsyncFunction;

--- a/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use databend_common_base::base::tokio::sync::RwLock;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_expression::types::UInt64Type;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
@@ -30,34 +32,182 @@ use crate::sessions::QueryContext;
 use crate::sql::executor::physical_plans::AsyncFunctionDesc;
 use crate::sql::plans::AsyncFunctionArgument;
 
+// Structure to manage sequence numbers in batches
+pub struct SequenceCounter {
+    // Current sequence number
+    current: AtomicU64,
+    // Maximum sequence number in the current batch
+    max: AtomicU64,
+}
+
+impl SequenceCounter {
+    fn new() -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            max: AtomicU64::new(0),
+        }
+    }
+
+    // Try to reserve a range of sequence numbers
+    fn try_reserve(&self, count: u64) -> Option<(u64, u64)> {
+        if self.current.load(Ordering::Relaxed) == 0 {
+            return None;
+        }
+
+        let current = self.current.load(Ordering::Relaxed);
+        let max = self.max.load(Ordering::Relaxed);
+
+        // Check if we have enough sequence numbers in the current batch
+        if current + count <= max {
+            let new_current = current + count;
+            if self
+                .current
+                .compare_exchange(current, new_current, Ordering::SeqCst, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Successfully reserved the range
+                return Some((current, new_current));
+            }
+        }
+
+        // Failed to reserve
+        None
+    }
+
+    // Update the counter with a new batch of sequence numbers
+    fn update_batch(&self, start: u64, count: u64) {
+        self.current.store(start, Ordering::SeqCst);
+        self.max.store(start + count, Ordering::SeqCst);
+    }
+}
+
+// Shared sequence counters type
+pub type SequenceCounters = Vec<Arc<RwLock<SequenceCounter>>>;
+
+// Minimum batch size for fetching sequence numbers
+const MIN_SEQUENCE_BATCH_SIZE: u64 = 65536;
+
 pub struct TransformAsyncFunction {
     ctx: Arc<QueryContext>,
     // key is the index of async_func_desc
     pub(crate) operators: BTreeMap<usize, Arc<DictionaryOperator>>,
     async_func_descs: Vec<AsyncFunctionDesc>,
+    // Shared map of sequence name to sequence counter
+    pub(crate) sequence_counters: SequenceCounters,
 }
 
 impl TransformAsyncFunction {
+    // New constructor that accepts a shared sequence counters map
     pub(crate) fn new(
         ctx: Arc<QueryContext>,
         async_func_descs: Vec<AsyncFunctionDesc>,
         operators: BTreeMap<usize, Arc<DictionaryOperator>>,
+        sequence_counters: SequenceCounters,
     ) -> Self {
         Self {
             ctx,
             async_func_descs,
             operators,
+            sequence_counters,
         }
     }
 
+    // Create a new shared sequence counters map
+    pub(crate) fn create_sequence_counters(size: usize) -> SequenceCounters {
+        (0..size)
+            .map(|_| Arc::new(RwLock::new(SequenceCounter::new())))
+            .collect()
+    }
+
     // transform add sequence nextval column.
-    async fn transform_sequence(
-        &self,
+    pub async fn transform_sequence(
+        ctx: Arc<QueryContext>,
         data_block: &mut DataBlock,
+        counter_lock: Arc<RwLock<SequenceCounter>>,
         sequence_name: &String,
-        data_type: &DataType,
     ) -> Result<()> {
-        transform_sequence(&self.ctx, data_block, sequence_name, data_type).await
+        let count = data_block.num_rows() as u64;
+        let column = if count == 0 {
+            UInt64Type::from_data(vec![])
+        } else {
+            // Get or create the sequence counter
+            let counter = counter_lock.read().await;
+
+            // Try to reserve sequence numbers from the counter
+            if let Some((start, _end)) = counter.try_reserve(count) {
+                // We have enough sequence numbers in the current batch
+                let range = start..start + count;
+                UInt64Type::from_data(range.collect::<Vec<u64>>())
+            } else {
+                // drop the read lock and get the write lock
+                drop(counter);
+                let counter = counter_lock.write().await;
+                {
+                    // try reserve again
+                    if let Some((start, _end)) = counter.try_reserve(count) {
+                        // We have enough sequence numbers in the current batch
+                        let range = start..start + count;
+                        UInt64Type::from_data(range.collect::<Vec<u64>>())
+                    } else {
+                        // We need to fetch more sequence numbers
+                        let tenant = ctx.get_tenant();
+                        let catalog = ctx.get_default_catalog()?;
+
+                        // Get current state of the counter
+                        let current = counter.current.load(Ordering::Relaxed);
+                        let max = counter.max.load(Ordering::Relaxed);
+                        // Calculate how many sequence numbers we need to fetch
+                        // If there are remaining numbers, we'll use them first
+                        let remaining = if max > current { max - current } else { 0 };
+                        let to_fetch = count.saturating_sub(remaining);
+                        let batch_size = to_fetch.max(MIN_SEQUENCE_BATCH_SIZE);
+
+                        // Calculate batch size - take the larger of count or MIN_SEQUENCE_BATCH_SIZE
+                        let req = GetSequenceNextValueReq {
+                            ident: SequenceIdent::new(&tenant, sequence_name),
+                            count: batch_size,
+                        };
+
+                        let resp = catalog.get_sequence_next_value(req).await?;
+                        let start = resp.start;
+
+                        // If we have remaining numbers, use them first
+                        if remaining > 0 {
+                            // Then add the new batch after the remaining numbers
+                            counter.update_batch(start, batch_size);
+
+                            // Return a combined range: first the remaining numbers, then the new ones
+                            let mut numbers = Vec::with_capacity(count as usize);
+
+                            // Add the remaining numbers
+                            let remaining_to_use = remaining.min(count);
+                            numbers.extend(
+                                (current..current + remaining_to_use).collect::<Vec<u64>>(),
+                            );
+
+                            // Add numbers from the new batch if needed
+                            if remaining_to_use < count {
+                                let new_needed = count - remaining_to_use;
+                                numbers.extend((start..start + new_needed).collect::<Vec<u64>>());
+                                // Update the counter to reflect that we've used some of the new batch
+                                counter.current.store(start + new_needed, Ordering::SeqCst);
+                            }
+
+                            UInt64Type::from_data(numbers)
+                        } else {
+                            // No remaining numbers, just use the new batch
+                            counter.update_batch(start + count, batch_size - count);
+                            // Return the sequence numbers needed for this request
+                            let range = start..start + count;
+                            UInt64Type::from_data(range.collect::<Vec<u64>>())
+                        }
+                    }
+                }
+            }
+        };
+
+        data_block.add_column(column);
+        Ok(())
     }
 }
 
@@ -70,10 +220,11 @@ impl AsyncTransform for TransformAsyncFunction {
         for (i, async_func_desc) in self.async_func_descs.iter().enumerate() {
             match &async_func_desc.func_arg {
                 AsyncFunctionArgument::SequenceFunction(sequence_name) => {
-                    self.transform_sequence(
+                    Self::transform_sequence(
+                        self.ctx.clone(),
                         &mut data_block,
+                        self.sequence_counters[i].clone(),
                         sequence_name,
-                        &async_func_desc.data_type,
                     )
                     .await?;
                 }
@@ -91,29 +242,4 @@ impl AsyncTransform for TransformAsyncFunction {
         }
         Ok(data_block)
     }
-}
-
-pub async fn transform_sequence(
-    ctx: &Arc<QueryContext>,
-    data_block: &mut DataBlock,
-    sequence_name: &String,
-    _data_type: &DataType,
-) -> Result<()> {
-    let count = data_block.num_rows() as u64;
-    let column = if count == 0 {
-        UInt64Type::from_data(vec![])
-    } else {
-        let tenant = ctx.get_tenant();
-        let catalog = ctx.get_default_catalog()?;
-        let req = GetSequenceNextValueReq {
-            ident: SequenceIdent::new(&tenant, sequence_name),
-            count,
-        };
-        let resp = catalog.get_sequence_next_value(req).await?;
-        let range = resp.start..resp.start + count;
-        UInt64Type::from_data(range.collect::<Vec<u64>>())
-    };
-    data_block.add_column(column);
-
-    Ok(())
 }

--- a/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
@@ -158,7 +158,7 @@ impl TransformAsyncFunction {
                         let max = counter.max.load(Ordering::Relaxed);
                         // Calculate how many sequence numbers we need to fetch
                         // If there are remaining numbers, we'll use them first
-                        let remaining = if max > current { max - current } else { 0 };
+                        let remaining = max.saturating_sub(current);
                         let to_fetch = count.saturating_sub(remaining);
                         let batch_size = to_fetch.max(MIN_SEQUENCE_BATCH_SIZE);
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_async_function.rs
@@ -84,9 +84,6 @@ impl SequenceCounter {
 // Shared sequence counters type
 pub type SequenceCounters = Vec<Arc<RwLock<SequenceCounter>>>;
 
-// Minimum batch size for fetching sequence numbers
-const MIN_SEQUENCE_BATCH_SIZE: u64 = 65536;
-
 pub struct TransformAsyncFunction {
     ctx: Arc<QueryContext>,
     // key is the index of async_func_desc
@@ -160,9 +157,11 @@ impl TransformAsyncFunction {
                         // If there are remaining numbers, we'll use them first
                         let remaining = max.saturating_sub(current);
                         let to_fetch = count.saturating_sub(remaining);
-                        let batch_size = to_fetch.max(MIN_SEQUENCE_BATCH_SIZE);
 
-                        // Calculate batch size - take the larger of count or MIN_SEQUENCE_BATCH_SIZE
+                        let step_size = ctx.get_settings().get_sequence_step_size()?;
+                        let batch_size = to_fetch.max(step_size);
+
+                        // Calculate batch size - take the larger of count or step_size
                         let req = GetSequenceNextValueReq {
                             ident: SequenceIdent::new(&tenant, sequence_name),
                             count: batch_size,

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -150,6 +150,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(1..=u64::MAX)),
                 }),
+                ("sequence_step_size", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(65536),
+                    desc: "Sets the sequence step size for nextval function.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(1..=u64::MAX)),
+                }),
                 ("week_start", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Specifies the first day of the week.(Used by week-related date functions)",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -192,6 +192,11 @@ impl Settings {
         self.try_set_u64("max_block_size", val)
     }
 
+    // Get sequence_step_size.
+    pub fn get_sequence_step_size(&self) -> Result<u64> {
+        self.try_get_u64("sequence_step_size")
+    }
+
     // Max block size for parquet reader
     pub fn get_parquet_max_block_size(&self) -> Result<u64> {
         self.try_get_u64("parquet_max_block_size")

--- a/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
@@ -37,6 +37,10 @@ CREATE TABLE tmp2(a uint64);
 statement ok
 CREATE TABLE tmp3(a int, b uint64, c int);
 
+
+statement ok
+set sequence_step_size = 1;
+
 statement ok
 INSERT INTO tmp1 values(nextval(seq));
 
@@ -102,6 +106,9 @@ query I
 select sum(nextval(seq)) from numbers(10);
 ----
 205
+
+statement ok
+unset sequence_step_size;
 
 statement ok
 INSERT INTO tmp select nextval(seq) from numbers(1000000);

--- a/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
@@ -111,6 +111,22 @@ select count(*) from tmp;
 ----
 1000000
 
+
+query I
+select uniq(nextval(seq)) from numbers(10000000);
+----
+10000000
+
+query I
+select uniq(nextval(seq)) from numbers(10000000);
+----
+10000000
+
+query I
+select uniq(nextval(seq)) from numbers(10000000);
+----
+10000000
+
 statement ok
 DESC SEQUENCE SEQ
 

--- a/tests/sqllogictests/suites/stage/sequence_as_default.test
+++ b/tests/sqllogictests/suites/stage/sequence_as_default.test
@@ -8,6 +8,9 @@ statement ok
 create or replace table tmp (seq int default nextval(seq), a int, seq1 bigint not null default nextval(seq1));
 
 statement ok
+set sequence_step_size = 1;
+
+statement ok
 INSERT INTO tmp(seq, a) values (-1, 11),(-2, 22);
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): 

1. make async function works within local counters
2. add settings `sequence_step_size`, default to 65536

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18178)
<!-- Reviewable:end -->
