### PR TITLE
feat: Add Operator Cache for databend 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4207,6 +4207,7 @@ dependencies = [
  "http 1.3.1",
  "iceberg",
  "log",
+ "lru",
  "opendal",
  "parquet",
  "prometheus-client 0.22.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,7 @@ http = "1"
 humantime = "2.1.0"
 hyper = "1"
 hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "tokio", "service"] }
+lru = "0.12"
 
 ## in branch dev
 iceberg = { version = "0.4.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "d5cca1c15f240f3cb04e57569bce648933b1c79b", features = [

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -28,6 +28,7 @@ futures = { workspace = true }
 http = { workspace = true }
 iceberg = { workspace = true }
 log = { workspace = true }
+lru = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
 prometheus-client = { workspace = true }

--- a/src/common/storage/src/lib.rs
+++ b/src/common/storage/src/lib.rs
@@ -42,8 +42,13 @@ mod operator;
 pub use operator::build_operator;
 pub use operator::check_operator;
 pub use operator::init_operator;
+pub use operator::init_operator_with_cache;
 pub use operator::DataOperator;
 pub use operator::OperatorRegistry;
+
+mod operator_cache;
+pub use operator_cache::get_operator_cache;
+pub use operator_cache::OperatorCache;
 
 pub mod metrics;
 pub use crate::metrics::StorageMetrics;

--- a/src/common/storage/src/lib.rs
+++ b/src/common/storage/src/lib.rs
@@ -42,13 +42,10 @@ mod operator;
 pub use operator::build_operator;
 pub use operator::check_operator;
 pub use operator::init_operator;
-pub use operator::init_operator_with_cache;
 pub use operator::DataOperator;
 pub use operator::OperatorRegistry;
 
 mod operator_cache;
-pub use operator_cache::get_operator_cache;
-pub use operator_cache::OperatorCache;
 
 pub mod metrics;
 pub use crate::metrics::StorageMetrics;

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -68,7 +68,6 @@ static METRIC_OPENDAL_RETRIES_COUNT: LazyLock<FamilyCounter<Vec<(&'static str, S
     LazyLock::new(|| register_counter_family("opendal_retries_count"));
 
 /// init_operator will init an opendal operator based on storage config.
-/// This function uses caching to avoid frequent recreation of operators.
 pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
     // Use block_on to run async code in sync context
     databend_common_base::runtime::block_on(async move {
@@ -78,19 +77,6 @@ pub fn init_operator(cfg: &StorageParams) -> Result<Operator> {
             .await
             .map_err(|e| Error::other(anyhow!("Failed to get or create operator: {}", e)))
     })
-}
-
-/// init_operator_with_cache will init an opendal operator with caching support.
-/// This function will check the cache first, and return the cached operator if it exists.
-/// Otherwise, it will create a new operator and cache it.
-///
-/// This is now just an alias for init_operator since it uses caching by default.
-pub async fn init_operator_with_cache(cfg: &StorageParams) -> Result<Operator> {
-    let cache = get_operator_cache();
-    cache
-        .get_or_create(cfg)
-        .await
-        .map_err(|e| Error::other(anyhow!("Failed to get or create operator: {}", e)))
 }
 
 /// init_operator_uncached will init an opendal operator without caching.

--- a/src/common/storage/src/operator_cache.rs
+++ b/src/common/storage/src/operator_cache.rs
@@ -1,0 +1,168 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::Duration;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use databend_common_base::runtime::metrics::register_counter;
+use databend_common_base::runtime::metrics::register_gauge;
+use databend_common_base::runtime::metrics::Counter;
+use databend_common_base::runtime::metrics::Gauge;
+use databend_common_exception::Result as DatabendResult;
+use databend_common_meta_app::storage::StorageParams;
+use log::debug;
+use log::info;
+use opendal::Operator;
+
+use crate::operator::init_operator_uncached;
+
+static CACHE_HIT_COUNT: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("storage_operator_cache_hit_total"));
+static CACHE_MISS_COUNT: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("storage_operator_cache_miss_total"));
+static CACHE_SIZE: LazyLock<Gauge> =
+    LazyLock::new(|| register_gauge("storage_operator_cache_size"));
+
+#[derive(Clone)]
+struct CachedOperator {
+    operator: Operator,
+    created_at: Instant,
+    ttl: Duration,
+}
+
+/// OperatorCache provides caching for storage operators to avoid
+/// frequent recreation and token refresh operations.
+pub struct OperatorCache {
+    cache: Arc<DashMap<u64, CachedOperator>>,
+    default_ttl: Duration,
+}
+
+impl OperatorCache {
+    pub fn new() -> Self {
+        let default_ttl = std::env::var("DATABEND_OPERATOR_CACHE_TTL_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(3000)); // Default 50 minutes
+
+        info!("Initializing operator cache with TTL: {:?}", default_ttl);
+
+        Self {
+            cache: Arc::new(DashMap::new()),
+            default_ttl,
+        }
+    }
+
+    /// Get or create an operator from cache
+    pub async fn get_or_create(&self, params: &StorageParams) -> DatabendResult<Operator> {
+        let cache_key = self.compute_cache_key(params);
+
+        // Check if we have a valid cached operator
+        if let Some(entry) = self.cache.get(&cache_key) {
+            if entry.created_at.elapsed() < entry.ttl {
+                debug!("Operator cache hit for key: {}", cache_key);
+                CACHE_HIT_COUNT.inc();
+                return Ok(entry.operator.clone());
+            } else {
+                debug!("Operator cache expired for key: {}", cache_key);
+                // Remove expired entry
+                drop(entry);
+                self.cache.remove(&cache_key);
+                CACHE_SIZE.dec();
+            }
+        }
+
+        // Cache miss, create new operator
+        debug!("Operator cache miss for key: {}", cache_key);
+        CACHE_MISS_COUNT.inc();
+
+        let operator = init_operator_uncached(params)?;
+
+        // Determine TTL based on storage type
+        let ttl = self.get_ttl_for_params(params);
+
+        let cached = CachedOperator {
+            operator: operator.clone(),
+            created_at: Instant::now(),
+            ttl,
+        };
+
+        self.cache.insert(cache_key, cached);
+        CACHE_SIZE.inc();
+
+        Ok(operator)
+    }
+
+    /// Clear all cached operators
+    pub fn clear(&self) {
+        let size = self.cache.len();
+        self.cache.clear();
+        CACHE_SIZE.set(CACHE_SIZE.get() - size as i64);
+        info!("Cleared {} operators from cache", size);
+    }
+
+    /// Remove specific operator from cache
+    pub fn invalidate(&self, params: &StorageParams) {
+        let cache_key = self.compute_cache_key(params);
+        if self.cache.remove(&cache_key).is_some() {
+            CACHE_SIZE.dec();
+            debug!("Invalidated operator cache for key: {}", cache_key);
+        }
+    }
+
+    /// Get current cache size
+    pub fn size(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Compute a stable hash key for storage params
+    fn compute_cache_key(&self, params: &StorageParams) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        params.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Get TTL for specific storage params
+    fn get_ttl_for_params(&self, params: &StorageParams) -> Duration {
+        match params {
+            // AWS STS tokens typically last 1 hour, cache for 50 minutes
+            StorageParams::S3(cfg) if !cfg.role_arn.is_empty() => Duration::from_secs(3000),
+            // GCS tokens might have different TTL
+            StorageParams::Gcs(_) => Duration::from_secs(3300),
+            // For storage without temporary tokens, cache longer
+            StorageParams::Fs(_) => Duration::from_secs(86400), // 24 hours
+            // Default TTL for other storage types
+            _ => self.default_ttl,
+        }
+    }
+}
+
+impl Default for OperatorCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Global operator cache instance
+pub fn get_operator_cache() -> Arc<OperatorCache> {
+    static INSTANCE: LazyLock<Arc<OperatorCache>> =
+        LazyLock::new(|| Arc::new(OperatorCache::new()));
+    INSTANCE.clone()
+}

--- a/src/common/storage/src/operator_cache.rs
+++ b/src/common/storage/src/operator_cache.rs
@@ -15,12 +15,11 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::LazyLock;
-use std::time::Duration;
-use std::time::Instant;
+use std::sync::Mutex;
 
-use dashmap::DashMap;
 use databend_common_base::runtime::metrics::register_counter;
 use databend_common_base::runtime::metrics::register_gauge;
 use databend_common_base::runtime::metrics::Counter;
@@ -29,10 +28,12 @@ use databend_common_exception::Result as DatabendResult;
 use databend_common_meta_app::storage::StorageParams;
 use log::debug;
 use log::info;
+use lru::LruCache;
 use opendal::Operator;
 
 use crate::operator::init_operator_uncached;
 
+// Internal metrics for monitoring cache effectiveness
 static CACHE_HIT_COUNT: LazyLock<Counter> =
     LazyLock::new(|| register_counter("storage_operator_cache_hit_total"));
 static CACHE_MISS_COUNT: LazyLock<Counter> =
@@ -40,52 +41,41 @@ static CACHE_MISS_COUNT: LazyLock<Counter> =
 static CACHE_SIZE: LazyLock<Gauge> =
     LazyLock::new(|| register_gauge("storage_operator_cache_size"));
 
-#[derive(Clone)]
-struct CachedOperator {
-    operator: Operator,
-    created_at: Instant,
-    ttl: Duration,
-}
+const DEFAULT_CACHE_SIZE: usize = 1024;
 
 /// OperatorCache provides caching for storage operators to avoid
 /// frequent recreation and token refresh operations.
-pub struct OperatorCache {
-    cache: Arc<DashMap<u64, CachedOperator>>,
-    default_ttl: Duration,
+pub(crate) struct OperatorCache {
+    cache: Arc<Mutex<LruCache<u64, Operator>>>,
 }
 
 impl OperatorCache {
-    pub fn new() -> Self {
-        let default_ttl = std::env::var("DATABEND_OPERATOR_CACHE_TTL_SECS")
+    pub(crate) fn new() -> Self {
+        let cache_size = std::env::var("DATABEND_OPERATOR_CACHE_SIZE")
             .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .map(Duration::from_secs)
-            .unwrap_or(Duration::from_secs(3000)); // Default 50 minutes
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CACHE_SIZE);
 
-        info!("Initializing operator cache with TTL: {:?}", default_ttl);
+        info!("Initializing operator cache with size: {}", cache_size);
 
         Self {
-            cache: Arc::new(DashMap::new()),
-            default_ttl,
+            cache: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(cache_size).expect("cache size must be greater than 0"),
+            ))),
         }
     }
 
     /// Get or create an operator from cache
-    pub async fn get_or_create(&self, params: &StorageParams) -> DatabendResult<Operator> {
+    pub(crate) async fn get_or_create(&self, params: &StorageParams) -> DatabendResult<Operator> {
         let cache_key = self.compute_cache_key(params);
 
-        // Check if we have a valid cached operator
-        if let Some(entry) = self.cache.get(&cache_key) {
-            if entry.created_at.elapsed() < entry.ttl {
+        // Check if we have a cached operator
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(operator) = cache.get(&cache_key) {
                 debug!("Operator cache hit for key: {}", cache_key);
                 CACHE_HIT_COUNT.inc();
-                return Ok(entry.operator.clone());
-            } else {
-                debug!("Operator cache expired for key: {}", cache_key);
-                // Remove expired entry
-                drop(entry);
-                self.cache.remove(&cache_key);
-                CACHE_SIZE.dec();
+                return Ok(operator.clone());
             }
         }
 
@@ -95,41 +85,14 @@ impl OperatorCache {
 
         let operator = init_operator_uncached(params)?;
 
-        // Determine TTL based on storage type
-        let ttl = self.get_ttl_for_params(params);
-
-        let cached = CachedOperator {
-            operator: operator.clone(),
-            created_at: Instant::now(),
-            ttl,
-        };
-
-        self.cache.insert(cache_key, cached);
-        CACHE_SIZE.inc();
+        // Insert into cache
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(cache_key, operator.clone());
+            CACHE_SIZE.set(cache.len() as i64);
+        }
 
         Ok(operator)
-    }
-
-    /// Clear all cached operators
-    pub fn clear(&self) {
-        let size = self.cache.len();
-        self.cache.clear();
-        CACHE_SIZE.set(CACHE_SIZE.get() - size as i64);
-        info!("Cleared {} operators from cache", size);
-    }
-
-    /// Remove specific operator from cache
-    pub fn invalidate(&self, params: &StorageParams) {
-        let cache_key = self.compute_cache_key(params);
-        if self.cache.remove(&cache_key).is_some() {
-            CACHE_SIZE.dec();
-            debug!("Invalidated operator cache for key: {}", cache_key);
-        }
-    }
-
-    /// Get current cache size
-    pub fn size(&self) -> usize {
-        self.cache.len()
     }
 
     /// Compute a stable hash key for storage params
@@ -137,20 +100,6 @@ impl OperatorCache {
         let mut hasher = DefaultHasher::new();
         params.hash(&mut hasher);
         hasher.finish()
-    }
-
-    /// Get TTL for specific storage params
-    fn get_ttl_for_params(&self, params: &StorageParams) -> Duration {
-        match params {
-            // AWS STS tokens typically last 1 hour, cache for 50 minutes
-            StorageParams::S3(cfg) if !cfg.role_arn.is_empty() => Duration::from_secs(3000),
-            // GCS tokens might have different TTL
-            StorageParams::Gcs(_) => Duration::from_secs(3300),
-            // For storage without temporary tokens, cache longer
-            StorageParams::Fs(_) => Duration::from_secs(86400), // 24 hours
-            // Default TTL for other storage types
-            _ => self.default_ttl,
-        }
     }
 }
 
@@ -161,7 +110,7 @@ impl Default for OperatorCache {
 }
 
 /// Global operator cache instance
-pub fn get_operator_cache() -> Arc<OperatorCache> {
+pub(crate) fn get_operator_cache() -> Arc<OperatorCache> {
     static INSTANCE: LazyLock<Arc<OperatorCache>> =
         LazyLock::new(|| Arc::new(OperatorCache::new()));
     INSTANCE.clone()

--- a/src/meta/app-storage/src/storage_params.rs
+++ b/src/meta/app-storage/src/storage_params.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 const DEFAULT_DETECT_REGION_TIMEOUT_SEC: u64 = 10;
 
 /// Storage params which contains the detailed storage info.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum StorageParams {
     Azblob(StorageAzblobConfig),
@@ -292,7 +292,7 @@ impl Display for StorageParams {
 }
 
 /// Config for storage backend azblob.
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageAzblobConfig {
     pub endpoint_url: String,
     pub container: String,
@@ -315,7 +315,7 @@ impl Debug for StorageAzblobConfig {
 }
 
 /// Config for storage backend fs.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageFsConfig {
     pub root: String,
 }
@@ -331,7 +331,7 @@ impl Default for StorageFsConfig {
 pub const STORAGE_FTP_DEFAULT_ENDPOINT: &str = "ftps://127.0.0.1";
 
 /// Config for FTP and FTPS data source
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageFtpConfig {
     pub endpoint: String,
     pub root: String,
@@ -366,7 +366,7 @@ impl Debug for StorageFtpConfig {
 pub static STORAGE_GCS_DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com";
 
 /// Config for storage backend GCS.
-#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct StorageGcsConfig {
     pub endpoint_url: String,
     pub bucket: String,
@@ -405,7 +405,7 @@ impl Debug for StorageGcsConfig {
 /// Ideally, we should export this config only when hdfs feature enabled.
 /// But export this struct without hdfs feature is safe and no harm. So we
 /// export it to make crates' lives that depend on us easier.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageHdfsConfig {
     pub name_node: String,
     pub root: String,
@@ -415,7 +415,7 @@ pub struct StorageHdfsConfig {
 pub static STORAGE_S3_DEFAULT_ENDPOINT: &str = "https://s3.amazonaws.com";
 
 /// Config for storage backend s3.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageS3Config {
     pub endpoint_url: String,
     pub region: String,
@@ -489,7 +489,7 @@ impl Debug for StorageS3Config {
 }
 
 /// Config for storage backend http.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageHttpConfig {
     pub endpoint_url: String,
     pub paths: Vec<String>,
@@ -499,7 +499,7 @@ pub struct StorageHttpConfig {
 pub const STORAGE_IPFS_DEFAULT_ENDPOINT: &str = "https://ipfs.io";
 
 /// Config for IPFS storage backend
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageIpfsConfig {
     pub endpoint_url: String,
     pub root: String,
@@ -507,7 +507,7 @@ pub struct StorageIpfsConfig {
 }
 
 /// Config for storage backend obs.
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageObsConfig {
     pub endpoint_url: String,
     pub bucket: String,
@@ -533,7 +533,7 @@ impl Debug for StorageObsConfig {
 }
 
 /// config for Aliyun Object Storage Service
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageOssConfig {
     pub endpoint_url: String,
     pub presign_endpoint_url: String,
@@ -577,7 +577,7 @@ impl Debug for StorageOssConfig {
 }
 
 /// config for Moka Object Storage Service
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageMokaConfig {
     pub max_capacity: u64,
     pub time_to_live: i64,
@@ -599,7 +599,7 @@ impl Default for StorageMokaConfig {
 }
 
 /// config for WebHDFS Storage Service
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageWebhdfsConfig {
     pub endpoint_url: String,
     pub root: String,
@@ -624,7 +624,7 @@ impl Debug for StorageWebhdfsConfig {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageCosConfig {
     pub secret_id: String,
     pub secret_key: String,
@@ -648,7 +648,7 @@ impl Debug for StorageCosConfig {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageHuggingfaceConfig {
     /// repo_id for huggingface repo, looks like `opendal/huggingface-testdata`
     pub repo_id: String,
@@ -698,7 +698,7 @@ pub fn mask_string(s: &str, unmask_len: usize) -> String {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StorageNetworkParams {
     pub retry_timeout: u64,
     pub retry_io_timeout: u64,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add Operator Cache for databend. 

Databend uses OpenDAL to access object storage. When accessing through an IAM role, OpenDAL internally uses reqsign to call AWS's API and obtain a temporary token. However, this API has a ratelimit. If users are frequently creating external tables, this can often cause query failures.

This PR address this by introduce an operator cache which can resuse the same operator if inputs are the same.


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
