### PR TITLE
fix(query): add_months need to respect last day of month

### DIFF
--- a/src/query/functions/src/scalars/timestamp/src/interval.rs
+++ b/src/query/functions/src/scalars/timestamp/src/interval.rs
@@ -117,7 +117,12 @@ fn register_interval_add_sub_mul(registry: &mut FunctionRegistry) {
                     let ts = a
                         .wrapping_add(b.microseconds())
                         .wrapping_add((b.days() as i64).wrapping_mul(86_400_000_000));
-                    match EvalMonthsImpl::eval_timestamp(ts, ctx.func_ctx.tz.clone(), b.months()) {
+                    match EvalMonthsImpl::eval_timestamp(
+                        ts,
+                        ctx.func_ctx.tz.clone(),
+                        b.months(),
+                        false,
+                    ) {
                         Ok(t) => output.push(t),
                         Err(e) => {
                             ctx.set_error(output.len(), e);
@@ -138,7 +143,12 @@ fn register_interval_add_sub_mul(registry: &mut FunctionRegistry) {
                     let ts = a
                         .wrapping_add(b.microseconds())
                         .wrapping_add((b.days() as i64).wrapping_mul(86_400_000_000));
-                    match EvalMonthsImpl::eval_timestamp(ts, ctx.func_ctx.tz.clone(), b.months()) {
+                    match EvalMonthsImpl::eval_timestamp(
+                        ts,
+                        ctx.func_ctx.tz.clone(),
+                        b.months(),
+                        false,
+                    ) {
                         Ok(t) => output.push(t),
                         Err(e) => {
                             ctx.set_error(output.len(), e);
@@ -173,7 +183,12 @@ fn register_interval_add_sub_mul(registry: &mut FunctionRegistry) {
                     let ts = a
                         .wrapping_sub(b.microseconds())
                         .wrapping_sub((b.days() as i64).wrapping_mul(86_400_000_000));
-                    match EvalMonthsImpl::eval_timestamp(ts, ctx.func_ctx.tz.clone(), -b.months()) {
+                    match EvalMonthsImpl::eval_timestamp(
+                        ts,
+                        ctx.func_ctx.tz.clone(),
+                        -b.months(),
+                        false,
+                    ) {
                         Ok(t) => output.push(t),
                         Err(e) => {
                             ctx.set_error(output.len(), e);

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1270,6 +1270,14 @@ Functions overloads:
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
 1 crc32(String NULL) :: UInt32 NULL
+0 date_add_months(Date, Int64) :: Date
+1 date_add_months(Date NULL, Int64 NULL) :: Date NULL
+2 date_add_months(Timestamp, Int64) :: Timestamp
+3 date_add_months(Timestamp NULL, Int64 NULL) :: Timestamp NULL
+0 date_subtract_months(Date, Int64) :: Date
+1 date_subtract_months(Date NULL, Int64 NULL) :: Date NULL
+2 date_subtract_months(Timestamp, Int64) :: Timestamp
+3 date_subtract_months(Timestamp NULL, Int64 NULL) :: Timestamp NULL
 0 dayofweek(Date) :: UInt8
 1 dayofweek(Date NULL) :: UInt8 NULL
 2 dayofweek(Timestamp) :: UInt8

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3283,7 +3283,12 @@ impl<'a> TypeChecker<'a> {
         let func_name = match is_diff {
             Expr::DateDiff { .. } => format!("diff_{}s", interval_kind.to_string().to_lowercase()),
             Expr::DateSub { .. } | Expr::DateAdd { .. } => {
-                format!("add_{}s", interval_kind.to_string().to_lowercase())
+                let interval_kind = interval_kind.to_string().to_lowercase();
+                if interval_kind == "month" {
+                    format!("date_add_{}s", interval_kind.to_string().to_lowercase())
+                } else {
+                    format!("add_{}s", interval_kind.to_string().to_lowercase())
+                }
             }
             Expr::DateBetween { .. } => {
                 format!("between_{}s", interval_kind.to_string().to_lowercase())

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -757,13 +757,13 @@ select add_years(to_datetime('9998-12-30 21:59:59'), 1)
 query T
 select subtract_months(to_date(18321), cast(13, INT16))
 ----
-2019-01-29
+2019-01-31
 
 # 2020-2-29T10:00:00 - (12*10 + 2) months
 query T
 select subtract_months(to_datetime(1582970400000000), cast(122, INT16))
 ----
-2009-12-29 10:00:00.000000
+2009-12-31 10:00:00.000000
 
 
 query T
@@ -1777,3 +1777,23 @@ query T
 select datebetween('microsecond','2019-02-28'::Date, '2020-02-28'::Date), date_between('microsecond','2019-03-01'::Date, '2020-02-28'::Date), date_between('microsecond','2019-02-28 22:00:01'::Timestamp, '2020-02-28 22:00:00'::Timestamp), date_between('microsecond','2020-02-28 22:00:01'::Timestamp, '2019-02-28 22:00:01'::Timestamp);
 ----
 31536000000000 31449600000000 31535999000000 -31536000000000
+
+query T
+select add_months('2020-02-29',12), DATE_ADD(month, 12, '2020-02-29');
+----
+2021-02-28 2021-02-28
+
+query T
+select add_months('2020-02-28',12), DATE_ADD(month, 12, '2020-02-28');
+----
+2021-02-28 2021-02-28
+
+query T
+select add_months('2020-02-27',12), DATE_ADD(month, 12, '2020-02-27');
+----
+2021-02-27 2021-02-27
+
+query T
+select add_months('2025-04-30',1), DATE_ADD(month, 1, '2025-04-30');
+----
+2025-05-31 2025-05-30

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -457,7 +457,7 @@ set timezone = 'UTC'
 query T
 select add_months(to_timestamp(1619822911999000), 1)
 ----
-2021-05-30 22:48:31.999000
+2021-05-31 22:48:31.999000
 
 query T
 select to_timestamp(1583013600000000)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/


## Summary

ADD_MONTHS returns slightly different results than DATEADD used with a MONTH component:

- For both ADD_MONTHS and DATEADD, if the result month has fewer days than the original day, the result day of the month is the last day of the result month.

- For ADD_MONTHS only, if the original day is the last day of the month, the result day of month will be the last day of the result month.

In main:

```sql
select add_months('2025-04-30',1)
----
2025-05-30
```

In PR:

```sql
select add_months('2025-04-30',1)
----
2025-05-31
```

- fixes: https://github.com/databendlabs/databend/issues/18200
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18201)
<!-- Reviewable:end -->
