### PR TITLE
refactor: implement cooperative state machine for range/list operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16527,8 +16527,8 @@ dependencies = [
 
 [[package]]
 name = "watcher"
-version = "0.4.1"
-source = "git+https://github.com/databendlabs/watcher?tag=v0.4.1#70d512a0beeccc7d7e1ce588a6e90b8ad6b875db"
+version = "0.4.2"
+source = "git+https://github.com/databendlabs/watcher?tag=v0.4.2#38e5109dd07a0fd496a48646dddd7de43242d75d"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -535,7 +535,7 @@ url = "2.5.4"
 uuid = { version = "1.10.0", features = ["std", "serde", "v4", "v7"] }
 volo-thrift = "0.10"
 walkdir = "2.3.2"
-watcher = { version = "0.4.1" }
+watcher = { version = "0.4.2" }
 wiremock = "0.6"
 wkt = "0.11.1"
 xorf = { version = "0.11.0", default-features = false, features = ["binary-fuse"] }
@@ -661,5 +661,5 @@ sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" 
 tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370" }
 tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370", package = "tantivy-common" }
 tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "0e300e9" }
-watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.4.1" }
+watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.4.2" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }

--- a/src/meta/raft-store/src/leveled_store/leveled_map/compacting_data.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/compacting_data.rs
@@ -33,6 +33,7 @@ use crate::leveled_store::rotbl_codec::RotblCodec;
 use crate::leveled_store::util;
 use crate::marked::Marked;
 use crate::state_machine::ExpireKey;
+use crate::utils::add_cooperative_yielding;
 
 /// The data to compact.
 ///
@@ -140,6 +141,8 @@ impl<'a> CompactingData<'a> {
 
         // Filter out tombstone
         let normal_strm = coalesce.try_filter(|(_k, v)| future::ready(v.is_normal()));
+
+        let normal_strm = add_cooperative_yielding(normal_strm, "compact");
 
         Ok((sys_data, normal_strm.boxed()))
     }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: implement cooperative state machine for range/list operations

Fix blocking issue during initialization data transmission.

Problem:

When establishing a watch stream, the meta-service sends large amounts of
initialization data to the client. During this transmission, other events
are blocked until completion, including add-watcher commands.

This creates a deadlock: if initialization data is large, it blocks all
subsequent Dispatcher operations. When a second watch request arrives,
it must wait for the first one to complete sending all initialization data.
Since adding a new watcher requires holding the state machine lock,
multiple concurrent watch requests will block the state machine entirely,
causing timeouts for other requests.

Solution:

Make the process cooperative by not waiting for watch stream transmission
to complete. Instead, queue the add-watcher command and return immediately.
This allows subsequent watch requests to proceed without waiting for previous
initialization data transmissions to finish.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18204)
<!-- Reviewable:end -->
