### PR TITLE
feat(meta-service): add metrics for watch stream

### DIFF
--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -464,6 +464,13 @@ impl MetaService for MetaServiceImpl {
 
             let stream = WatchStream::new(rx, Box::new(on_drop));
 
+            let stream = stream.map(move |item| {
+                if let Ok(ref resp) = item {
+                    network_metrics::incr_watch_sent(resp);
+                }
+                item
+            });
+
             if flush {
                 let ctx = "watch-Dispatcher";
                 let snk = new_initialization_sink::<WatchTypes>(tx.clone(), ctx);

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -281,5 +281,9 @@ async fn test_metrics() -> anyhow::Result<()> {
     // Raft storage metrics
     assert!(metric_keys.contains("metasrv_raft_storage_raft_store_write_failed_total"));
 
+    // Watch
+    assert!(metric_keys.contains("metasrv_meta_network_watch_initialization_total"));
+    assert!(metric_keys.contains("metasrv_meta_network_watch_change_total"));
+
     Ok(())
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add metrics for watch stream

Add two metrics:
- the number of items sent when sending watch stream initialization
  data(all existent key-values),
- and the number of items sent when a key-value changed

```
metasrv_meta_network_watch_initialization_total 2753400
metasrv_meta_network_watch_change_total         2753394
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18209)
<!-- Reviewable:end -->
