### PR TITLE
feat(meta-service): add metrics for stream access operations

### DIFF
--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -152,6 +152,14 @@ impl MetaGrpcReadReq {
 
         Ok(raft_request)
     }
+
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            MetaGrpcReadReq::GetKV(_) => "get",
+            MetaGrpcReadReq::MGetKV(_) => "mget",
+            MetaGrpcReadReq::ListKV(_) => "list",
+        }
+    }
 }
 
 impl RequestFor for GetKVReq {

--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -690,6 +690,7 @@ pub mod network_metrics {
     use std::time::Duration;
 
     use databend_common_meta_types::protobuf::WatchResponse;
+    use log::error;
     use prometheus_client::metrics::counter::Counter;
     use prometheus_client::metrics::gauge::Gauge;
     use prometheus_client::metrics::histogram::Histogram;
@@ -717,6 +718,15 @@ pub mod network_metrics {
 
         /// Number of items sent when data changes in a watch stream.
         watch_change_item_sent: Counter,
+
+        /// Number of items sent in a stream get response.
+        stream_get_item_sent: Counter,
+
+        /// Number of items sent in a stream mget response.
+        stream_mget_item_sent: Counter,
+
+        /// Number of items sent in a stream list response.
+        stream_list_item_sent: Counter,
     }
 
     impl NetworkMetrics {
@@ -743,6 +753,10 @@ pub mod network_metrics {
 
                 watch_initialization_item_sent: Counter::default(),
                 watch_change_item_sent: Counter::default(),
+
+                stream_get_item_sent: Counter::default(),
+                stream_mget_item_sent: Counter::default(),
+                stream_list_item_sent: Counter::default(),
             };
 
             let mut registry = load_global_registry();
@@ -779,6 +793,22 @@ pub mod network_metrics {
                 key!("watch_change"),
                 "Number of items sent when data changes in a watch stream",
                 metrics.watch_change_item_sent.clone(),
+            );
+
+            registry.register(
+                key!("stream_get_item_sent"),
+                "Number of items sent in a stream get response",
+                metrics.stream_get_item_sent.clone(),
+            );
+            registry.register(
+                key!("stream_mget_item_sent"),
+                "Number of items sent in a stream mget response",
+                metrics.stream_mget_item_sent.clone(),
+            );
+            registry.register(
+                key!("stream_list_item_sent"),
+                "Number of items sent in a stream list response",
+                metrics.stream_list_item_sent.clone(),
             );
 
             metrics
@@ -829,6 +859,23 @@ pub mod network_metrics {
 
     pub fn incr_watch_sent_change_item() {
         NETWORK_METRICS.watch_change_item_sent.inc();
+    }
+
+    pub fn incr_stream_sent_item(typ: &'static str) {
+        match typ {
+            "get" => {
+                NETWORK_METRICS.stream_get_item_sent.inc();
+            }
+            "mget" => {
+                NETWORK_METRICS.stream_mget_item_sent.inc();
+            }
+            "list" => {
+                NETWORK_METRICS.stream_list_item_sent.inc();
+            }
+            _ => {
+                error!("Unknown stream item type: {}", typ);
+            }
+        }
     }
 }
 

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -285,5 +285,10 @@ async fn test_metrics() -> anyhow::Result<()> {
     assert!(metric_keys.contains("metasrv_meta_network_watch_initialization_total"));
     assert!(metric_keys.contains("metasrv_meta_network_watch_change_total"));
 
+    // Stream metrics
+    assert!(metric_keys.contains("metasrv_meta_network_stream_get_item_sent_total"));
+    assert!(metric_keys.contains("metasrv_meta_network_stream_mget_item_sent_total"));
+    assert!(metric_keys.contains("metasrv_meta_network_stream_list_item_sent_total"));
+
     Ok(())
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add metrics for stream access operations

Previously, stream-based operations like `mget` and `list` were only counted
as single RPCs in our metrics system, despite potentially sending large
volumes of data. For example, a single `list` RPC fetching a large directory
would appear the same as a simple operation in our metrics.

This commit adds granular metrics to track the actual number of items sent
in stream operations with the following counters:

```
metasrv_meta_network_stream_get_item_sent_total
metasrv_meta_network_stream_mget_item_sent_total
metasrv_meta_network_stream_list_item_sent_total
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18210)
<!-- Reviewable:end -->
