### PR TITLE
fix(query): fix incorrect pushdown for grouping sets

### DIFF
--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
@@ -32,6 +32,11 @@ NULL 0
 NULL 1
 NULL 2
 
+query T
+select * from (select number % 3 a, number % 4 b, count() from range(1, 1000)t(number) group by cube(a,b))  where a is null and b is null;
+----
+NULL NULL 999
+
 query TT
 select number % 2 as a, number % 3 as b from numbers(24) group by grouping sets ((1,2), (1), (2)) order by a,b;
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): fix incorrect pushdown for grouping sets

If all used columns in predicate are in group columns
 we can push down the predicate, otherwise we need to keep the predicate
 eg: 

```
 select * from (select number % 3 a, number % 4 b from
 range(1, 1000)t(number) group by cube(a,b))  where a is null and b is null;
```

 we can't push down the predicate cause filter will remove all rows
 but we can't remove the predicate cause the null will be generated
 by group by cube

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
