### PR TITLE
chore: improve logging for FUSE change tracking and partitions pruning

### DIFF
--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -299,6 +299,12 @@ impl FuseTable {
         let bloom_index_cols = self.bloom_index_cols();
         let ngram_args =
             Self::create_ngram_index_args(&self.table_info.meta, &self.table_info.meta.schema)?;
+
+        info!(
+            "[FUSE-CHANGE-TRACKING] prune snapshot block start, at node {}",
+            ctx.get_cluster().local_id,
+        );
+
         let mut pruner = FusePruner::create_with_pages(
             &ctx,
             self.get_operator(),
@@ -315,9 +321,10 @@ impl FuseTable {
         let pruning_stats = pruner.pruning_stats();
 
         info!(
-            "prune snapshot block end, final block numbers:{}, cost:{:?}",
+            "[FUSE-CHANGE-TRACKING] prune snapshot block end, final block numbers:{}, cost:{:?}, at node {}",
             block_metas.len(),
-            start.elapsed()
+            start.elapsed(),
+            ctx.get_cluster().local_id,
         );
 
         let block_metas = block_metas

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -345,10 +345,12 @@ impl FuseTable {
         segments_location: Vec<SegmentLocation>,
         summary: usize,
     ) -> Result<(PartStatistics, Partitions)> {
+        let num_segments_to_prune = segments_location.len();
         let start = Instant::now();
         info!(
-            "segment numbers" = segments_location.len();
-            "prune snapshot block start"
+            "[FUSE-PARTITIONS] prune snapshot block start, {} segment to be processed, at node {}",
+            num_segments_to_prune,
+            ctx.get_cluster().local_id,
         );
 
         let dal = self.operator.clone();
@@ -378,9 +380,11 @@ impl FuseTable {
         let pruning_stats = pruner.pruning_stats();
 
         info!(
-            "[FUSE-PARTITIONS] prune snapshot block end, final block numbers:{}, cost:{:?}",
+            "[FUSE-PARTITIONS] prune snapshot block end, final block numbers:{}, out of {} segments, cost:{:?}, at node {}",
             block_metas.len(),
-            start.elapsed()
+            num_segments_to_prune,
+            start.elapsed(),
+            ctx.get_cluster().local_id,
         );
 
         let block_metas = block_metas


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 Improve logging for FUSE partitions pruning
- Add node ID and segment count  to pruning log messages for better traceability in distributed environments
- Tweak log prefix tags ([FUSE-CHANGE-TRACKING], [FUSE-PARTITIONS]) for easier log filtering

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Just tweaking log message

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18229)
<!-- Reviewable:end -->
