### PR TITLE
feat(meta-service): add FetchAddU64 command to txn

### DIFF
--- a/src/meta/app/src/data_id.rs
+++ b/src/meta/app/src/data_id.rs
@@ -31,7 +31,7 @@ use crate::tenant_key::resource::TenantResource;
 /// e.g. TableId, DatabaseId as a value.
 ///
 /// `DataId<R>` can be dereferenced to `u64`.
-/// `DataId<R>` will take place of `Id<T>` in future.
+/// `DataId<R>` will take place of `Id<T>` in the future.
 ///
 /// When an id is used as a key in a key-value store,
 /// it is serialized in another way to keep order.

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -150,6 +150,9 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-06-11: since 1.2.756
 ///   🖥 server: add `TxnPutResponse::current`
 ///
+/// - 2025-06-24: since TODO: add when merge
+///   🖥 server: add `FetchAddU64` operation to the `TxnOp`
+///
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -213,6 +213,7 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
             }
             Request::Delete(_) => {}
             Request::DeleteByPrefix(_) => {}
+            Request::FetchAddU64(_) => {}
         }
 
         Ok(TxnOp { request: Some(req) })

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -154,6 +154,14 @@ fn build_proto() {
             "TxnRequest.operations",
             r#"#[serde(skip_serializing_if = "Vec::is_empty")] #[serde(default)]"#,
         )
+        .type_attribute(
+            "FetchAddU64",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
+        )
+        .type_attribute(
+            "FetchAddU64Response",
+            "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
+        )
         .compile_protos_with_config(config, &protos, &[&proto_dir])
         .unwrap();
 }

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -182,6 +182,8 @@ message TxnOp {
     TxnPutRequest put = 2;
     TxnDeleteRequest delete = 3;
     TxnDeleteByPrefixRequest delete_by_prefix = 4;
+
+    FetchAddU64 fetch_add_u64 = 5;
   }
 }
 
@@ -191,6 +193,8 @@ message TxnOpResponse {
     TxnPutResponse put = 2;
     TxnDeleteResponse delete = 3;
     TxnDeleteByPrefixResponse delete_by_prefix = 4;
+
+    FetchAddU64Response fetch_add_u64 = 5;
   }
 }
 

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -37,6 +37,38 @@ message TxnGetResponse {
   optional SeqV value = 2;
 }
 
+// Return the value by key, then add the delta to the key.
+//
+// This operation assume the value bytes is a json encoded `uint64`,
+// e.g. `1025` in bytes is `b"1025"`.
+// If the result is negative, it will be set to zero.
+message FetchAddU64 {
+
+  // The key to fetch and add the delta.
+  string key = 1;
+
+  // The delta to add to the value.
+  int64 delta = 2;
+}
+
+// Response for FetchAddU64, contains the value before and after `add`
+message FetchAddU64Response {
+
+  string key = 1;
+
+  // The seq number of the record before update. `0` if the key does not exist.
+  uint64 before_seq = 2;
+
+  // The value before update.
+  uint64 before = 3;
+
+  // The seq number of the record after update. It should always be greater than `before_seq`.
+  uint64 after_seq = 4;
+
+  // The value after update.
+  uint64 after = 5;
+}
+
 // Put request and response
 message TxnPutRequest {
   string key = 1;

--- a/src/meta/types/src/proto_display/mod.rs
+++ b/src/meta/types/src/proto_display/mod.rs
@@ -27,6 +27,8 @@ use num_traits::FromPrimitive;
 use crate::protobuf::boolean_expression::CombiningOperator;
 use crate::protobuf::BooleanExpression;
 use crate::protobuf::ConditionalOperation;
+use crate::protobuf::FetchAddU64;
+use crate::protobuf::FetchAddU64Response;
 use crate::txn_condition::Target;
 use crate::txn_op;
 use crate::txn_op::Request;
@@ -165,6 +167,9 @@ impl Display for txn_op::Request {
             Request::DeleteByPrefix(r) => {
                 write!(f, "DeleteByPrefix({})", r)
             }
+            Request::FetchAddU64(r) => {
+                write!(f, "FetchAddU64({})", r)
+            }
         }
     }
 }
@@ -251,6 +256,9 @@ impl Display for Response {
             }
             Response::DeleteByPrefix(r) => {
                 write!(f, "DeleteByPrefix: {}", r)
+            }
+            Response::FetchAddU64(r) => {
+                write!(f, "FetchAddU64: {}", r)
             }
         }
     }
@@ -339,9 +347,27 @@ impl Display for ConditionalOperation {
     }
 }
 
+impl Display for FetchAddU64 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FetchAddU64 key={} delta={}", self.key, self.delta)
+    }
+}
+
+impl Display for FetchAddU64Response {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "FetchAddU64Response key={} before=(seq={} {}), after=(seq={} {})",
+            self.key, self.before_seq, self.before, self.after_seq, self.after
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::protobuf::BooleanExpression;
+    use crate::protobuf::FetchAddU64;
+    use crate::protobuf::FetchAddU64Response;
     use crate::protobuf::TxnCondition;
     use crate::TxnOp;
 
@@ -433,6 +459,30 @@ mod tests {
         assert_eq!(
             format!("{}", req),
            "TxnRequest{{ if:(k1 == seq(1) AND k2 == seq(2)) then:[Put(Put key=k1),Put(Put key=k2)] }, if:[k1 == seq(1),k2 == seq(2)] then:[Put(Put key=k1),Put(Put key=k2)] else:[Put(Put key=k3)]}",
+        );
+    }
+
+    #[test]
+    fn test_display_fetch_add_u64() {
+        let req = FetchAddU64 {
+            key: "k1".to_string(),
+            delta: 1,
+        };
+        assert_eq!(req.to_string(), "FetchAddU64 key=k1 delta=1");
+    }
+
+    #[test]
+    fn test_display_fetch_add_u64_response() {
+        let resp = FetchAddU64Response {
+            key: "k1".to_string(),
+            before_seq: 1,
+            before: 3,
+            after_seq: 2,
+            after: 4,
+        };
+        assert_eq!(
+            resp.to_string(),
+            "FetchAddU64Response key=k1 before=(seq=1 3), after=(seq=2 4)"
         );
     }
 }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -312,6 +312,15 @@ impl pb::TxnOp {
             })),
         }
     }
+
+    pub fn fetch_add_u64(key: impl ToString, delta: i64) -> Self {
+        pb::TxnOp {
+            request: Some(pb::txn_op::Request::FetchAddU64(pb::FetchAddU64 {
+                key: key.to_string(),
+                delta,
+            })),
+        }
+    }
 }
 
 impl pb::TxnOpResponse {
@@ -343,6 +352,26 @@ impl pb::TxnOpResponse {
         }
     }
 
+    pub fn fetch_add_u64(
+        key: impl ToString,
+        before_seq: u64,
+        before: u64,
+        after_seq: u64,
+        after: u64,
+    ) -> Self {
+        pb::TxnOpResponse {
+            response: Some(pb::txn_op_response::Response::FetchAddU64(
+                pb::FetchAddU64Response {
+                    key: key.to_string(),
+                    before_seq,
+                    before,
+                    after_seq,
+                    after,
+                },
+            )),
+        }
+    }
+
     pub fn get(key: impl ToString, value: Option<SeqV>) -> Self {
         pb::TxnOpResponse {
             response: Some(pb::txn_op_response::Response::Get(pb::TxnGetResponse {
@@ -368,6 +397,13 @@ impl pb::TxnOpResponse {
     pub fn try_as_get(&self) -> Option<&pb::TxnGetResponse> {
         match &self.response {
             Some(pb::txn_op_response::Response::Get(resp)) => Some(resp),
+            _ => None,
+        }
+    }
+
+    pub fn try_as_fetch_add_u64(&self) -> Option<&pb::FetchAddU64Response> {
+        match &self.response {
+            Some(pb::txn_op_response::Response::FetchAddU64(resp)) => Some(resp),
             _ => None,
         }
     }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add FetchAddU64 command to txn

`FetchAddU64` fetch the `u64` value of a key and add provided delta to
it, in one RPC.

The response `FetchAddU64Response` returns the key, the value before
update and the value after update.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18243)
<!-- Reviewable:end -->
