### PR TITLE
feat(meta-service): add FetchAddU64.match_seq

### DIFF
--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -153,6 +153,8 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-06-24: since TODO: add when merge
 ///   🖥 server: add `FetchAddU64` operation to the `TxnOp`
 ///
+/// - 2025-06-26: since TODO: add when merge
+///   🖥 server: add `FetchAddU64.match_seq`
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/kvapi/src/kvapi/test_suite.rs
+++ b/src/meta/kvapi/src/kvapi/test_suite.rs
@@ -93,6 +93,10 @@ impl kvapi::TestSuite {
         self.kv_mget(&builder.build().await).await?;
         self.kv_txn_absent_seq_0(&builder.build().await).await?;
         self.kv_transaction(&builder.build().await).await?;
+        self.kv_transaction_fetch_add_u64(&builder.build().await)
+            .await?;
+        self.kv_transaction_fetch_add_u64_match_seq(&builder.build().await)
+            .await?;
         self.kv_transaction_with_ttl(&builder.build().await).await?;
         self.kv_transaction_delete_match_seq_none(&builder.build().await)
             .await?;
@@ -1074,7 +1078,7 @@ impl kvapi::TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                resp.responses[1].try_as_fetch_add_u64().unwrap(),
                 &FetchAddU64Response {
                     key: "k2".to_string(),
                     before_seq: 0,
@@ -1105,7 +1109,7 @@ impl kvapi::TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                resp.responses[1].try_as_fetch_add_u64().unwrap(),
                 &FetchAddU64Response {
                     key: "k2".to_string(),
                     before_seq: 2,
@@ -1137,13 +1141,131 @@ impl kvapi::TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                resp.responses[1].try_as_fetch_add_u64().unwrap(),
                 &FetchAddU64Response {
                     key: "k2".to_string(),
                     before_seq: 4,
                     before: 6,
+                    after_seq: 6,
+                    after: u64::MAX / 2 + 6,
+                }
+            );
+            assert_eq!(
+                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k2".to_string(),
+                    before_seq: 6,
+                    before: u64::MAX / 2 + 6,
                     after_seq: 7,
                     after: u64::MAX,
+                }
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Tests match_seq must match the record seq to take place the operation.
+    #[fastrace::trace]
+    pub async fn kv_transaction_fetch_add_u64_match_seq<KV: kvapi::KVApi>(
+        &self,
+        kv: &KV,
+    ) -> anyhow::Result<()> {
+        // - Add a record via transaction with ttl
+
+        info!("--- {}", func_path!());
+
+        info!("--- match_seq zero");
+        {
+            let txn = TxnRequest::new(vec![], vec![
+                TxnOp::fetch_add_u64("k1", 2).match_seq(Some(0)),
+                TxnOp::fetch_add_u64("k1", 3).match_seq(Some(0)),
+                TxnOp::fetch_add_u64("k1", 4),
+                TxnOp::fetch_add_u64("k2", 5),
+            ]);
+
+            let resp = kv.transaction(txn).await?;
+
+            assert_eq!(
+                resp.responses[0].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 0,
+                    before: 0,
+                    after_seq: 1,
+                    after: 2,
+                }
+            );
+            assert_eq!(
+                resp.responses[1].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 1,
+                    before: 2,
+                    after_seq: 1,
+                    after: 2,
+                }
+            );
+            assert_eq!(
+                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 1,
+                    before: 2,
+                    after_seq: 2,
+                    after: 6,
+                }
+            );
+            assert_eq!(
+                resp.responses[3].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k2".to_string(),
+                    before_seq: 0,
+                    before: 0,
+                    after_seq: 3,
+                    after: 5,
+                }
+            );
+        }
+
+        info!("--- match_seq non zero");
+        {
+            let txn = TxnRequest::new(vec![], vec![
+                TxnOp::fetch_add_u64("k1", 2).match_seq(Some(2)),
+                TxnOp::fetch_add_u64("k1", 3).match_seq(Some(2)),
+                TxnOp::fetch_add_u64("k1", 4),
+            ]);
+
+            let resp = kv.transaction(txn).await?;
+
+            assert_eq!(
+                resp.responses[0].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 2,
+                    before: 6,
+                    after_seq: 4,
+                    after: 8,
+                }
+            );
+            assert_eq!(
+                resp.responses[1].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 4,
+                    before: 8,
+                    after_seq: 4,
+                    after: 8,
+                }
+            );
+            assert_eq!(
+                resp.responses[2].try_as_fetch_add_u64().unwrap(),
+                &FetchAddU64Response {
+                    key: "k1".to_string(),
+                    before_seq: 4,
+                    before: 8,
+                    after_seq: 5,
+                    after: 12,
                 }
             );
         }

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -47,6 +47,11 @@ message FetchAddU64 {
   // The key to fetch and add the delta.
   string key = 1;
 
+  // Assert the seq number of the record before update.
+  // - If it does not match, no update will be made and the record seq number won't change.
+  // - If it is None, the update will always be made.
+  optional uint64 match_seq = 3;
+
   // The delta to add to the value.
   int64 delta = 2;
 }

--- a/src/meta/types/src/proto_display/mod.rs
+++ b/src/meta/types/src/proto_display/mod.rs
@@ -349,7 +349,11 @@ impl Display for ConditionalOperation {
 
 impl Display for FetchAddU64 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FetchAddU64 key={} delta={}", self.key, self.delta)
+        write!(f, "FetchAddU64 key={} delta={}", self.key, self.delta)?;
+        if let Some(match_seq) = self.match_seq {
+            write!(f, " match_seq: {}", match_seq)?;
+        }
+        Ok(())
     }
 }
 
@@ -466,9 +470,20 @@ mod tests {
     fn test_display_fetch_add_u64() {
         let req = FetchAddU64 {
             key: "k1".to_string(),
+            match_seq: None,
             delta: 1,
         };
         assert_eq!(req.to_string(), "FetchAddU64 key=k1 delta=1");
+
+        let req_with_seq = FetchAddU64 {
+            key: "k1".to_string(),
+            match_seq: Some(10),
+            delta: 1,
+        };
+        assert_eq!(
+            req_with_seq.to_string(),
+            "FetchAddU64 key=k1 delta=1 match_seq: 10"
+        );
     }
 
     #[test]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add FetchAddU64.match_seq

If `match_seq: Option<64>` is specified, the record seq number must
match the provided value to proceed `FetchAddU64` operation.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18258)
<!-- Reviewable:end -->
