### PR TITLE
fix(query): add find_leveled_eq_filters function

### DIFF
--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -78,9 +78,11 @@ impl FilterHelpers {
                                         data_type,
                                     }))
                                 } else {
+                                    // for other values, we just ignore it
                                     None
                                 }
                             } else {
+                                // for other columns, we just ignore it
                                 None
                             }
                         });
@@ -101,30 +103,18 @@ impl FilterHelpers {
                     let mut results_all_used = true;
                     // let's check or function that
                     // for the equality columns set,let's call `ecs`
-                    // if both side of `or` of the name columns are all in `ecs`, it's valid
+                    // if any side of `or` of the name columns is not in `ecs`, it's valid
                     // otherwise, it's invalid
-
                     expr.visit_func("or", &mut |call| {
-                        let mut left_ecs = HashSet::new();
-                        let mut right_ecs = HashSet::new();
-
-                        if call.args.len() != 2 {
-                            results_all_used = false;
-                            return;
-                        }
-
-                        for (i, arg) in call.args.iter().enumerate() {
+                        for arg in call.args.iter() {
+                            let mut ecs = HashSet::new();
                             arg.find_function_literals("eq", &mut |col_name, _scalar, _| {
-                                if i == 0 {
-                                    left_ecs.insert(col_name.name());
-                                } else {
-                                    right_ecs.insert(col_name.name());
-                                }
+                                ecs.insert(col_name.name());
                             });
-                        }
 
-                        if !left_ecs.contains(*name) || !right_ecs.contains(*name) {
-                            results_all_used = false;
+                            if !ecs.contains(*name) {
+                                results_all_used = false;
+                            }
                         }
                     });
                     if results_all_used {

--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -101,8 +101,8 @@ impl FilterHelpers {
                     let mut results_all_used = true;
                     // let's check or function that
                     // for the equality columns set,let's call `ecs`
-                    // `ecs` of the left child must be subset of  `ecs` of the right child
-                    // if not, it's invalid
+                    // if both side of `or` of the name columns are all in `ecs`, it's valid
+                    // otherwise, it's invalid
 
                     expr.visit_func("or", &mut |call| {
                         let mut left_ecs = HashSet::new();

--- a/src/query/functions/tests/it/type_check.rs
+++ b/src/query/functions/tests/it/type_check.rs
@@ -204,6 +204,22 @@ fn test_find_leveled_eq_filters() {
             ],
             vec![],
         ),
+
+        (
+            "catalog = 'x' and (database = 'a' or database = 'b' or table = 'b') and c like '%xxxx%'",
+            vec![Scalar::String("x".to_string())],
+            vec![
+            ],
+            vec![],
+        ),
+         (
+            "catalog = 'x' and (database = 'a' or database = 'b') and database = 'c' and c like '%xxxx%'",
+            vec![Scalar::String("x".to_string())],
+            vec![
+             Scalar::String("c".to_string())
+            ],
+            vec![],
+        ),
     ];
 
     let cols = vec![

--- a/src/query/functions/tests/it/type_check.rs
+++ b/src/query/functions/tests/it/type_check.rs
@@ -223,7 +223,7 @@ fn test_find_leveled_eq_filters() {
         let func_ctx = FunctionContext::default();
         let scalars = FilterHelpers::find_leveled_eq_filters(
             &expr,
-            &vec!["catalog", "database", "table"],
+            &["catalog", "database", "table"],
             &func_ctx,
             &BUILTIN_FUNCTIONS,
         )

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -352,9 +352,6 @@ pub(crate) async fn dump_tables(
                     }
                 }
             }
-
-            dbg!(&leveld_results);
-            dbg!(&filtered_db_names, &filtered_table_names);
         }
     }
 

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -396,9 +396,9 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
 
                             let s = check_string::<usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)?;
                             match i {
-                                1 => catalog_name.push(s),
-                                2 => db_name.push(s),
-                                3 => {
+                                0 => catalog_name.push(s),
+                                1 => db_name.push(s),
+                                2 => {
                                     let _ = tables_names.insert(s);
                                 }
                                 _ => unreachable!(),

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -378,13 +378,11 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
                                 data_type: r.as_ref().infer_data_type(),
                             });
 
-                            let s = check_number::<u64, usize>(
-                                None,
-                                &func_ctx,
-                                &e,
-                                &BUILTIN_FUNCTIONS,
-                            )?;
-                            tables_ids.push(s);
+                            if let Ok(s) =
+                                check_number::<u64, usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)
+                            {
+                                tables_ids.push(s);
+                            }
                         }
                     } else {
                         for r in scalars.iter() {
@@ -394,14 +392,17 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
                                 data_type: r.as_ref().infer_data_type(),
                             });
 
-                            let s = check_string::<usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)?;
-                            match i {
-                                0 => catalog_name.push(s),
-                                1 => db_name.push(s),
-                                2 => {
-                                    let _ = tables_names.insert(s);
+                            if let Ok(s) =
+                                check_string::<usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)
+                            {
+                                match i {
+                                    0 => catalog_name.push(s),
+                                    1 => db_name.push(s),
+                                    2 => {
+                                        let _ = tables_names.insert(s);
+                                    }
+                                    _ => unreachable!(),
                                 }
-                                _ => unreachable!(),
                             }
                         }
                     }

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use databend_common_catalog::catalog_kind::CATALOG_DEFAULT;
 use databend_common_exception::Result;
 use databend_common_expression::expr::*;
+use databend_common_expression::ConstantFolder;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::FunctionRegistry;
 use databend_common_expression::Scalar;
 use databend_common_meta_app::schema::CatalogMeta;
 use databend_common_meta_app::schema::CatalogOption;
@@ -135,117 +140,4 @@ pub fn find_lt_filter(expr: &Expr<String>, visitor: &mut impl FnMut(&str, &Scala
             }
         }
     }
-}
-
-pub fn find_eq_or_filter(
-    expr: &Expr<String>,
-    visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>,
-    mut invalid_optimize: bool,
-) -> bool {
-    if invalid_optimize {
-        return true;
-    }
-
-    fn inner(
-        expr: &Expr<String>,
-        visitor: &mut impl FnMut(&str, &Scalar) -> Result<()>,
-        invalid_optimize: &mut bool,
-    ) {
-        match expr {
-            Expr::Constant(_) | Expr::ColumnRef(_) => {}
-            Expr::Cast(Cast { expr, .. }) => inner(expr, visitor, invalid_optimize),
-            Expr::FunctionCall(FunctionCall { function, args, .. }) => {
-                // Like: select * from (select * from system.tables where database='default') where name='t'
-                // push downs: [filters: [and_filters(and_filters(tables.database (#1) = 'default', tables.name (#2) = 't'), tables.database (#1) = 'default')], limit: NONE]
-                // database generate twice, so when call find_eq_filter, should check uniq.
-                match function.signature.name.as_str() {
-                    "eq" => {
-                        if let [Expr::ColumnRef(ColumnRef { id, .. }), Expr::Constant(Constant { scalar, .. })]
-                        | [Expr::Constant(Constant { scalar, .. }), Expr::ColumnRef(ColumnRef { id, .. })] =
-                            args.as_slice()
-                        {
-                            let _ = visitor(id, scalar);
-                        }
-                    }
-                    "and_filters" => {
-                        for arg in args {
-                            inner(arg, visitor, invalid_optimize);
-                            if *invalid_optimize {
-                                return;
-                            }
-                        }
-                    }
-                    "or" => {
-                        // Check for conflicting column references in "or" conditions.
-                        if args.windows(2).any(|w| {
-                            match (&w[0], &w[1]) {
-                                // e.g. will get all tables
-                                // database = 'a' or name = 't'
-                                // name = 't' or table_id = 123
-                               (Expr::FunctionCall(FunctionCall {
-                                        function: lfunc,
-                                        args: largs,
-                                        ..
-                                    }),
-                                    Expr::FunctionCall(FunctionCall {
-                                        function: rfunc,
-                                        args: rargs,
-                                        ..
-                                    }),
-                                ) => {
-                                    if lfunc.signature.name == "eq" && rfunc.signature.name == "eq" {
-                                        match (largs.as_slice(), rargs.as_slice()) {
-                                            (
-                                                [Expr::ColumnRef (ColumnRef{ id, .. }), Expr::Constant(_)]
-                                                | [Expr::Constant(_), Expr::ColumnRef (ColumnRef{ id, .. })],
-                                                [Expr::ColumnRef(ColumnRef { id: rid, .. }), Expr::Constant(_)]
-                                                | [Expr::Constant(_), Expr::ColumnRef(ColumnRef { id: rid, .. })],
-                                            ) => id != rid,
-                                            _ => false,
-                                        }
-                                    } else {
-                                        false
-                                    }
-                                }
-                                _ => false,
-                            }
-                        }) {
-                            *invalid_optimize = true;
-                            return;
-                        }
-
-                        for arg in args {
-                            inner(arg, visitor, invalid_optimize);
-                            if *invalid_optimize {
-                                return;
-                            }
-                        }
-                    }
-                    // show drop tables will specific is_not_null(dropped_on)
-                    "is_not_null" => {
-                        if let Expr::ColumnRef(ColumnRef { id, .. }) = args[0].clone() {
-                            if id != "dropped_on" {
-                                *invalid_optimize = true;
-                            }
-                        }
-                    }
-                    _ => {
-                        // Any other function makes it invalid.
-                        *invalid_optimize = true;
-                    }
-                }
-            }
-            Expr::LambdaFunctionCall(LambdaFunctionCall { args, .. }) => {
-                for arg in args {
-                    inner(arg, visitor, invalid_optimize);
-                    if *invalid_optimize {
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    inner(expr, visitor, &mut invalid_optimize);
-    invalid_optimize
 }

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-
 use databend_common_catalog::catalog_kind::CATALOG_DEFAULT;
 use databend_common_exception::Result;
 use databend_common_expression::expr::*;
-use databend_common_expression::ConstantFolder;
-use databend_common_expression::FunctionContext;
-use databend_common_expression::FunctionRegistry;
 use databend_common_expression::Scalar;
 use databend_common_meta_app::schema::CatalogMeta;
 use databend_common_meta_app::schema::CatalogOption;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): add find_leveled_eq_filters function

For filter in system tables like 

```
where catalog = 'x' and (database = 'a' or database = 'b' ) and table = 'c' and c like '%xxxx%'
```
 We need to find that we only need to scan catalog "c"  and database "a" and "b"  and table "c" which improve the query performance by reducing meta key scan.



## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18264)
<!-- Reviewable:end -->
