### PR TITLE
fix: Use async lock in reqsign to prevent concurrent update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12766,9 +12766,9 @@ checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "reqsign"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9323c0afb30e54f793f4705b10c890395bccc87c6e6ea62c4e7e82d09a380dc6"
+checksum = "0e81996ab38ccfb2e295ecd3250c0fb7717e29ab8814d4bc0fd6097338d87518"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12793,6 +12793,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tokio",
 ]
 
 [[package]]

--- a/src/common/storage/src/lib.rs
+++ b/src/common/storage/src/lib.rs
@@ -39,7 +39,6 @@ mod http_client;
 pub use http_client::StorageHttpClient;
 
 mod operator;
-pub use operator::build_operator;
 pub use operator::check_operator;
 pub use operator::init_operator;
 pub use operator::DataOperator;

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -146,10 +146,7 @@ pub(crate) fn init_operator_uncached(cfg: &StorageParams) -> Result<Operator> {
 /// ```
 ///
 /// Please balance the performance and compile time.
-pub fn build_operator<B: Builder>(
-    builder: B,
-    cfg: Option<&StorageNetworkParams>,
-) -> Result<Operator> {
+fn build_operator<B: Builder>(builder: B, cfg: Option<&StorageNetworkParams>) -> Result<Operator> {
     let ob = Operator::new(builder)?
         // Timeout layer is required to be the first layer so that internal
         // futures can be cancelled safely when the timeout is reached.
@@ -558,24 +555,8 @@ impl DataOperator {
         Ok(())
     }
 
-    /// Create a new data operator without check.
-    pub fn try_new(
-        conf: &StorageConfig,
-        spill_params: Option<StorageParams>,
-    ) -> databend_common_exception::Result<DataOperator> {
-        let operator = init_operator(&conf.params)?;
-        let spill_operator = spill_params.as_ref().map(init_operator).transpose()?;
-
-        Ok(DataOperator {
-            operator,
-            params: conf.params.clone(),
-            spill_operator,
-            spill_params,
-        })
-    }
-
     #[async_backtrace::framed]
-    pub async fn try_create(
+    async fn try_create(
         conf: &StorageConfig,
         spill_params: Option<StorageParams>,
     ) -> databend_common_exception::Result<DataOperator> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR brings a fix from upstream crate `reqsign`: https://github.com/Xuanwo/reqsign/pull/572

In this PR, we use async lock instead to prevent concurrent update which lead to huge amount of STS requests been send while performing large queries.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18265)
<!-- Reviewable:end -->
