### PR TITLE
fix(query): decimal64 not correct shrink_scalar

### DIFF
--- a/src/query/expression/src/utils/mod.rs
+++ b/src/query/expression/src/utils/mod.rs
@@ -127,6 +127,7 @@ pub fn shrink_scalar(scalar: Scalar) -> Scalar {
         Scalar::Number(NumberScalar::Int16(n)) => shrink_i64(n as i64),
         Scalar::Number(NumberScalar::Int32(n)) => shrink_i64(n as i64),
         Scalar::Number(NumberScalar::Int64(n)) => shrink_i64(n),
+        Scalar::Decimal(DecimalScalar::Decimal64(d, size)) => shrink_d256(d.into(), size),
         Scalar::Decimal(DecimalScalar::Decimal128(d, size)) => shrink_d256(d.into(), size),
         Scalar::Decimal(DecimalScalar::Decimal256(d, size)) => shrink_d256(d, size),
         Scalar::Tuple(mut fields) => {
@@ -199,5 +200,37 @@ fn shrink_d256(decimal: i256, size: DecimalSize) -> Scalar {
             Scalar::Decimal(DecimalScalar::Decimal128(decimal.as_i128(), size))
         }
         DecimalDataKind::Decimal256 => Scalar::Decimal(DecimalScalar::Decimal256(decimal, size)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shrink_scalar() {
+        let tests = [
+            (
+                Scalar::Decimal(DecimalScalar::Decimal64(
+                    50,
+                    DecimalSize::new_unchecked(10, 1),
+                )),
+                Scalar::Decimal(DecimalScalar::Decimal64(
+                    50,
+                    DecimalSize::new_unchecked(2, 1),
+                )),
+            ),
+            (
+                Scalar::Decimal(DecimalScalar::Decimal64(
+                    50,
+                    DecimalSize::new_unchecked(10, 0),
+                )),
+                Scalar::Number(NumberScalar::UInt8(50)),
+            ),
+        ];
+
+        for (t, want) in tests {
+            assert_eq!(shrink_scalar(t), want);
+        }
     }
 }

--- a/src/query/functions/tests/it/scalars/arithmetic.rs
+++ b/src/query/functions/tests/it/scalars/arithmetic.rs
@@ -24,8 +24,6 @@ use databend_common_expression::FromData;
 use goldenfile::Mint;
 
 use super::run_ast;
-use super::run_ast_with_context;
-use super::TestContext;
 
 #[test]
 fn test_arithmetic() {
@@ -312,17 +310,11 @@ fn test_decimal() {
         ),
     ];
 
-    run_ast_with_context(
+    run_ast(
         file,
         "l_extendedprice + (1 - l_discount) - l_quantity",
-        TestContext {
-            columns: &columns,
-            ..Default::default()
-        },
+        &columns,
     );
 
-    run_ast_with_context(file, "1964831797.0000 - 0.0214642400000", TestContext {
-        columns: &columns,
-        ..Default::default()
-    })
+    run_ast(file, "1964831797.0000 - 0.0214642400000", &columns);
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

decimal64 not correct shrink_scalar

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18267)
<!-- Reviewable:end -->
