### PR TITLE
fix(query): view query should not cover the origin query

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -631,6 +631,10 @@ impl QueryContextShared {
     }
 
     pub fn attach_query_str(&self, kind: QueryKind, query: String) {
+        // `create view as view_query` the view_query should not cover create view
+        if !self.get_query_str().is_empty() {
+            return;
+        }
         {
             let mut running_query = self.running_query.write();
             *running_query = Some(short_sql(
@@ -649,14 +653,18 @@ impl QueryContextShared {
 
     pub fn attach_query_hash(&self, text_hash: String, parameterized_hash: String) {
         {
-            let mut running_query_hash = self.running_query_text_hash.write();
-            *running_query_hash = Some(text_hash);
+            if self.get_query_text_hash().is_empty() {
+                let mut running_query_hash = self.running_query_text_hash.write();
+                *running_query_hash = Some(text_hash);
+            }
         }
 
         {
-            let mut running_query_parameterized_hash =
-                self.running_query_parameterized_hash.write();
-            *running_query_parameterized_hash = Some(parameterized_hash);
+            if self.get_query_parameterized_hash().is_empty() {
+                let mut running_query_parameterized_hash =
+                    self.running_query_parameterized_hash.write();
+                *running_query_parameterized_hash = Some(parameterized_hash);
+            }
         }
     }
 


### PR DESCRIPTION
                                                                                                                                 │

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Run `CREATE VIEW c AS SELECT * FROM hits.hits LIMIT `

query the query_history:

```sql
SELECT query_start_time, query_duration_ms, query_id, query_text FROM system_history.query_history;
```

In main :

│ 2025-06-30 04:54:06.178345 │                 0 │ 475d40329f8946fd9cc2310f79de643f │ SELECT * FROM hits.hits LIMIT 1                                                                                                                                                                       │

In pr:

│ 2025-06-30 04:59:20.485635 │                82 │ 04319b72fff94aac8b6c4f72fae01414 │ CREATE VIEW c AS SELECT * FROM hits.hits LIMIT 1                     

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
