### PR TITLE
feat(meta): Add conflict-free sequence generator v1

### DIFF
--- a/src/meta/api/src/lib.rs
+++ b/src/meta/api/src/lib.rs
@@ -37,6 +37,7 @@ pub mod util;
 
 pub mod crud;
 mod sequence_api_impl;
+pub(crate) mod sequence_nextval_impl;
 
 pub use data_mask_api::DatamaskApi;
 pub use schema_api::SchemaApi;

--- a/src/meta/api/src/sequence_api_impl.rs
+++ b/src/meta/api/src/sequence_api_impl.rs
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+
 use databend_common_meta_app::app_error::AppError;
-use databend_common_meta_app::app_error::OutofSequenceRange;
 use databend_common_meta_app::app_error::SequenceError;
+use databend_common_meta_app::app_error::UnsupportedSequenceStorageVersion;
 use databend_common_meta_app::app_error::WrongSequenceCount;
+use databend_common_meta_app::primitive::Id;
+use databend_common_meta_app::schema::sequence_storage::SequenceStorageIdent;
+use databend_common_meta_app::schema::sequence_storage::SequenceStorageValue;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateSequenceReply;
 use databend_common_meta_app::schema::CreateSequenceReq;
@@ -28,7 +33,7 @@ use databend_common_meta_app::schema::SequenceMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::DirName;
-use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::ConditionResult;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::TxnRequest;
@@ -36,14 +41,15 @@ use fastrace::func_name;
 use futures::TryStreamExt;
 use log::debug;
 
-use crate::databend_common_meta_types::With;
 use crate::kv_app_error::KVAppError;
 use crate::kv_pb_api::KVPbApi;
-use crate::kv_pb_api::UpsertPB;
 use crate::send_txn;
+use crate::sequence_nextval_impl::NextVal;
 use crate::txn_backoff::txn_backoff;
 use crate::txn_cond_eq_seq;
-use crate::util::txn_op_put_pb;
+use crate::txn_cond_seq;
+use crate::txn_op_del;
+use crate::util::txn_put_pb;
 use crate::SequenceApi;
 
 #[async_trait::async_trait]
@@ -57,31 +63,34 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
 
         let meta: SequenceMeta = req.clone().into();
 
-        let seq = MatchSeq::from(req.create_option);
-        let key = req.ident.clone();
-        let reply = self
-            .upsert_pb(&UpsertPB::update(key, meta).with(seq))
-            .await?;
+        let storage_ident = SequenceStorageIdent::new_from(req.ident.clone());
+        let storage_value = Id::new_typed(SequenceStorageValue(1));
 
-        debug!(
-            ident :?= (req.ident),
-            prev :? = (reply.prev),
-            is_changed = reply.is_changed();
-            "create_sequence"
-        );
-
-        if !reply.is_changed() {
-            match req.create_option {
-                CreateOption::Create => Err(KVAppError::AppError(AppError::SequenceError(
-                    SequenceError::SequenceAlreadyExists(req.ident.exist_error(func_name!())),
-                ))),
-                CreateOption::CreateIfNotExists => Ok(CreateSequenceReply {}),
-                CreateOption::CreateOrReplace => {
-                    unreachable!("CreateOrReplace should always success")
-                }
-            }
+        let conditions = if req.create_option == CreateOption::CreateOrReplace {
+            vec![]
         } else {
-            Ok(CreateSequenceReply {})
+            vec![txn_cond_eq_seq(&req.ident, 0)]
+        };
+
+        let txn = TxnRequest::new(conditions, vec![
+            txn_put_pb(&req.ident, &meta)?,
+            txn_put_pb(&storage_ident, &storage_value)?,
+        ]);
+
+        let (succ, _response) = send_txn(self, txn).await?;
+
+        if succ {
+            return Ok(CreateSequenceReply {});
+        }
+
+        match req.create_option {
+            CreateOption::Create => Err(KVAppError::AppError(AppError::SequenceError(
+                SequenceError::SequenceAlreadyExists(req.ident.exist_error(func_name!())),
+            ))),
+            CreateOption::CreateIfNotExists => Ok(CreateSequenceReply {}),
+            CreateOption::CreateOrReplace => {
+                unreachable!("CreateOrReplace should always success")
+            }
         }
     }
 
@@ -91,7 +100,24 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
     ) -> Result<Option<SeqV<SequenceMeta>>, MetaError> {
         debug!(req :? =name_ident; "SchemaApi: {}", func_name!());
         let seq_meta = self.get_pb(name_ident).await?;
-        Ok(seq_meta)
+
+        let Some(mut seq_meta) = seq_meta else {
+            return Ok(None);
+        };
+
+        if seq_meta.data.storage_version == 0 {
+            return Ok(Some(seq_meta));
+        }
+
+        // V1 sequence stores the value in a separate key.
+
+        let storage_ident = SequenceStorageIdent::new_from(name_ident.clone());
+        let x = self.get_pb(&storage_ident).await?;
+
+        let next_available = x.map(|seqv| *seqv.data.deref()).unwrap_or(0);
+
+        seq_meta.data.current = next_available;
+        Ok(Some(seq_meta))
     }
 
     #[logcall::logcall]
@@ -101,11 +127,40 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
         tenant: &Tenant,
     ) -> Result<Vec<(String, SequenceMeta)>, MetaError> {
         let dir_name = DirName::new(SequenceIdent::new(tenant, "dummy"));
-        self.list_pb(&dir_name)
+
+        let ident_metas = self
+            .list_pb(&dir_name)
             .await?
-            .map_ok(|itm| (itm.key.name().to_string(), itm.seqv.data))
+            .map_ok(|itm| (itm.key, itm.seqv.data))
             .try_collect::<Vec<_>>()
-            .await
+            .await?;
+
+        let storage_idents = ident_metas
+            .iter()
+            .map(|(ident, _)| SequenceStorageIdent::new_from(ident.clone()));
+
+        let storage_values = self
+            .get_pb_values(storage_idents)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let key_metas = ident_metas
+            .into_iter()
+            .zip(storage_values)
+            .map(|((k, mut meta), sto)| {
+                // For version==1  sequence, load the current value from the external storage.
+                if meta.storage_version == 1 {
+                    if let Some(seq_storage_value) = sto {
+                        meta.current = seq_storage_value.data.into_inner().0;
+                    }
+                }
+
+                (k.name().to_string(), meta)
+            })
+            .collect::<Vec<_>>();
+
+        Ok(key_metas)
     }
 
     async fn get_sequence_next_value(
@@ -132,47 +187,37 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
                 ))
                 .into());
             };
-            let sequence_seq = seq_meta.seq;
-            let mut sequence_meta = seq_meta.data;
+            let sequence_meta = seq_meta.data.clone();
 
-            let start = sequence_meta.current;
-            let count = req.count;
-            if u64::MAX - sequence_meta.current < count {
-                return Err(KVAppError::AppError(AppError::SequenceError(
-                    SequenceError::OutofSequenceRange(OutofSequenceRange::new(
-                        sequence_name,
-                        format!(
-                            "{:?}: current: {}, count: {}",
-                            sequence_name, sequence_meta.current, count
+            let next_val = NextVal {
+                kv_api: self,
+                ident: req.ident.clone(),
+                sequence_meta: seq_meta.clone(),
+            };
+
+            let response = match sequence_meta.storage_version {
+                0 => next_val.next_val_v0(req.count).await?,
+                1 => next_val.next_val_v1(req.count).await?,
+                _ => {
+                    return Err(KVAppError::AppError(AppError::SequenceError(
+                        SequenceError::UnsupportedSequenceStorageVersion(
+                            UnsupportedSequenceStorageVersion::new(sequence_meta.storage_version),
                         ),
-                    )),
-                )));
-            }
+                    )));
+                }
+            };
 
-            // update meta
-            sequence_meta.current += count;
-
-            let condition = vec![txn_cond_eq_seq(&ident, sequence_seq)];
-            let if_then = vec![
-                txn_op_put_pb(&ident, &sequence_meta, None)?, // name -> meta
-            ];
-
-            let txn_req = TxnRequest::new(condition, if_then);
-
-            let (succ, _responses) = send_txn(self, txn_req).await?;
-
-            debug!(
-                current :? =(&sequence_meta.current),
-                ident :?= (req.ident),
-                succ = succ;
-                "get_sequence_next_values"
-            );
-            if succ {
-                return Ok(GetSequenceNextValueReply {
-                    start,
-                    step: sequence_meta.step,
-                    end: sequence_meta.current - 1,
-                });
+            match response {
+                Ok((start, end)) => {
+                    return Ok(GetSequenceNextValueReply {
+                        start,
+                        step: sequence_meta.step,
+                        end,
+                    });
+                }
+                Err(_e) => {
+                    // continue
+                }
             }
         }
     }
@@ -180,19 +225,13 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
     async fn drop_sequence(&self, req: DropSequenceReq) -> Result<DropSequenceReply, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
-        let key = req.ident.clone();
-        let reply = self.upsert_pb(&UpsertPB::delete(key)).await?;
-
-        debug!(
-            ident :?= (req.ident),
-            prev :? = (reply.prev),
-            is_changed = reply.is_changed();
-            "drop_sequence"
+        let storage_ident = SequenceStorageIdent::new_from(req.ident.clone());
+        let txn = TxnRequest::new(
+            vec![txn_cond_seq(&req.ident, ConditionResult::Gt, 0)],
+            vec![txn_op_del(&req.ident), txn_op_del(&storage_ident)],
         );
+        let (success, _response) = send_txn(self, txn).await?;
 
-        // return prev if drop success
-        let prev = reply.prev.map(|prev| prev.seq);
-
-        Ok(DropSequenceReply { prev })
+        Ok(DropSequenceReply { success })
     }
 }

--- a/src/meta/api/src/sequence_nextval_impl.rs
+++ b/src/meta/api/src/sequence_nextval_impl.rs
@@ -1,0 +1,152 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::OutOfSequenceRange;
+use databend_common_meta_app::app_error::SequenceError;
+use databend_common_meta_app::schema::sequence_storage::SequenceStorageIdent;
+use databend_common_meta_app::schema::SequenceIdent;
+use databend_common_meta_app::schema::SequenceMeta;
+use databend_common_meta_kvapi::kvapi;
+use databend_common_meta_kvapi::kvapi::Key;
+use databend_common_meta_types::MetaError;
+use databend_common_meta_types::SeqV;
+use databend_common_meta_types::TxnOp;
+use databend_common_meta_types::TxnRequest;
+use fastrace::func_name;
+use log::debug;
+
+use crate::kv_app_error::KVAppError;
+use crate::send_txn;
+use crate::txn_cond_eq_seq;
+use crate::util::txn_op_put_pb;
+
+/// The implementation of `next_val` for sequence number.
+///
+/// The implementation is different for different storage versions:
+///
+/// - v0: `current` field of `SequenceMeta`.
+/// - v1: standalone key that support `FetchAddU64` to get next value.
+pub(crate) struct NextVal<'a, KV>
+where KV: kvapi::KVApi<Error = MetaError> + ?Sized
+{
+    pub(crate) kv_api: &'a KV,
+    pub(crate) ident: SequenceIdent,
+    pub(crate) sequence_meta: SeqV<SequenceMeta>,
+}
+
+impl<'a, KV> NextVal<'a, KV>
+where KV: kvapi::KVApi<Error = MetaError> + ?Sized
+{
+    /// Sequence number v0 stores the value in `current` field of `SequenceMeta`.
+    /// The update is a clientside CAS.
+    pub(crate) async fn next_val_v0(
+        mut self,
+        count: u64,
+    ) -> Result<Result<(u64, u64), &'static str>, KVAppError> {
+        debug!("{}", func_name!());
+
+        let sequence_seq = self.sequence_meta.seq;
+
+        let start = self.sequence_meta.current;
+        if u64::MAX - start < count {
+            return Err(KVAppError::AppError(AppError::SequenceError(
+                SequenceError::OutOfSequenceRange(OutOfSequenceRange::new(
+                    self.ident.name(),
+                    format!(
+                        "{:?}: current: {}, count: {}",
+                        self.ident.name(),
+                        start,
+                        count
+                    ),
+                )),
+            )));
+        }
+
+        // update meta
+        self.sequence_meta.current += count;
+
+        let condition = vec![txn_cond_eq_seq(&self.ident, sequence_seq)];
+        let if_then = vec![
+            txn_op_put_pb(&self.ident, &self.sequence_meta.data, None)?, // name -> meta
+        ];
+
+        let txn_req = TxnRequest::new(condition, if_then);
+
+        let (succ, _responses) = send_txn(self.kv_api, txn_req).await?;
+
+        debug!(
+            "{} txn result: succ: {succ}, ident: {}, update seq to {}",
+            func_name!(),
+            self.ident,
+            self.sequence_meta.current
+        );
+
+        if succ {
+            Ok(Ok((start, self.sequence_meta.current)))
+        } else {
+            Ok(Err("transaction conflict"))
+        }
+    }
+
+    /// Sequence number v1 stores the value in standalone key that support `FetchAddU64`.
+    pub(crate) async fn next_val_v1(
+        self,
+        count: u64,
+    ) -> Result<Result<(u64, u64), &'static str>, KVAppError> {
+        debug!("{}", func_name!());
+
+        // Key for the sequence number value.
+        let storage_ident = SequenceStorageIdent::new_from(self.ident.clone());
+        let storage_key = storage_ident.to_string_key();
+
+        let sequence_seq = self.sequence_meta.seq;
+        let sequence_meta = self.sequence_meta.data.clone();
+
+        let delta = count * (self.sequence_meta.step as u64);
+
+        let txn = TxnRequest::new(vec![txn_cond_eq_seq(&self.ident, sequence_seq)], vec![
+            TxnOp::fetch_add_u64(&storage_key, delta as i64),
+        ]);
+
+        let (succ, responses) = send_txn(self.kv_api, txn).await?;
+
+        debug!(
+            "{} txn result: succ: {succ}, ident: {}, update seq by {delta}",
+            func_name!(),
+            self.ident,
+        );
+
+        if succ {
+            let resp = responses[0].try_as_fetch_add_u64().unwrap();
+
+            let got_delta = resp.delta();
+
+            if got_delta < delta {
+                return Err(KVAppError::AppError(AppError::SequenceError(
+                        SequenceError::OutOfSequenceRange(OutOfSequenceRange::new(
+                            self.ident.name(),
+                            format!(
+                                "{sequence_meta}: count: {count}; expected delta: {delta}, but got: {resp}",
+                            ),
+                        )),
+                    )));
+            }
+
+            Ok(Ok((resp.before, resp.after)))
+        } else {
+            Ok(Err("transaction conflict"))
+        }
+    }
+}

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -31,6 +31,7 @@ pub mod marked_deleted_index_id;
 pub mod marked_deleted_index_ident;
 pub mod marked_deleted_table_index_id;
 pub mod marked_deleted_table_index_ident;
+pub mod sequence_storage;
 pub mod table_lock_ident;
 pub mod table_niv;
 

--- a/src/meta/app/src/schema/sequence.rs
+++ b/src/meta/app/src/schema/sequence.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use chrono::DateTime;
 use chrono::Utc;
 pub use kvapi_impl::SequenceRsc;
@@ -30,6 +32,22 @@ pub struct SequenceMeta {
     pub comment: Option<String>,
     pub step: i64,
     pub current: u64,
+
+    /// Storage version:
+    ///
+    /// - By default the version is 0, which stores the value in `current` field.
+    /// - With version == 1, it stores the value of the sequence in standalone key that support `FetchAddU64`.
+    pub storage_version: u64,
+}
+
+impl fmt::Display for SequenceMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SequenceMeta{{ create_on={:?} update_on={:?} comment={:?} step={} current={} }}",
+            self.create_on, self.update_on, self.comment, self.step, self.current
+        )
+    }
 }
 
 impl From<CreateSequenceReq> for SequenceMeta {
@@ -40,6 +58,7 @@ impl From<CreateSequenceReq> for SequenceMeta {
             update_on: p.create_on,
             step: 1,
             current: 1,
+            storage_version: p.storage_version,
         }
     }
 }
@@ -50,6 +69,9 @@ pub struct CreateSequenceReq {
     pub ident: SequenceIdent,
     pub create_on: DateTime<Utc>,
     pub comment: Option<String>,
+
+    /// See: [`SequenceMeta::storage_version`]
+    pub storage_version: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -61,11 +83,16 @@ pub struct GetSequenceNextValueReq {
     pub count: u64,
 }
 
+/// The collection of sequence value in range `[start, end)`, e.g.:
+/// `start + i * step` where `start + i + step < end`,
+/// or `[start + 0 * step, start + 1 * step, ...)`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetSequenceNextValueReply {
+    /// The first value in the sequence, inclusive.
     pub start: u64,
     // step has no use until now
     pub step: i64,
+    /// The right bound, exclusive.
     pub end: u64,
 }
 
@@ -97,8 +124,8 @@ pub struct DropSequenceReq {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DropSequenceReply {
-    // return prev seq if drop success
-    pub prev: Option<u64>,
+    // Whether it is dropped
+    pub success: bool,
 }
 
 mod kvapi_impl {

--- a/src/meta/app/src/schema/sequence_storage.rs
+++ b/src/meta/app/src/schema/sequence_storage.rs
@@ -1,0 +1,79 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use kvapi_impl::SequenceStorageRsc;
+pub use kvapi_impl::SequenceStorageValue;
+
+use crate::tenant_key::ident::TIdent;
+
+/// Defines the meta-service key for sequence.
+pub type SequenceStorageIdent = TIdent<SequenceStorageRsc>;
+
+mod kvapi_impl {
+
+    use databend_common_meta_kvapi::kvapi;
+
+    use crate::primitive::Id;
+    use crate::tenant_key::resource::TenantResource;
+
+    /// Defines the storage for sequence generator.
+    ///
+    /// [`SequenceRsc`] just stores the metadata of sequence but not the counter.
+    /// This key stores the counter for the sequence number.
+    pub struct SequenceStorageRsc;
+    impl TenantResource for SequenceStorageRsc {
+        const PREFIX: &'static str = "__fd_sequence_storage";
+        const HAS_TENANT: bool = true;
+        type ValueType = Id<SequenceStorageValue>;
+    }
+
+    impl kvapi::Value for Id<SequenceStorageValue> {
+        type KeyType = super::SequenceStorageIdent;
+        fn dependency_keys(&self, _key: &Self::KeyType) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+
+    #[derive(
+        Debug,
+        Clone,
+        Copy,
+        Default,
+        PartialEq,
+        Eq,
+        derive_more::From,
+        derive_more::Deref,
+        derive_more::DerefMut,
+    )]
+    pub struct SequenceStorageValue(pub u64);
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use crate::schema::sequence_storage::SequenceStorageIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_sequence_storage_ident() {
+        let tenant = Tenant::new_literal("dummy");
+        let ident = SequenceStorageIdent::new_generic(tenant, "3".to_string());
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_sequence_storage/dummy/3");
+
+        assert_eq!(ident, SequenceStorageIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/proto-conv/src/sequence_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/sequence_from_to_protobuf_impl.rs
@@ -38,8 +38,10 @@ impl FromToProto for SequenceMeta {
             comment: p.comment.clone(),
             create_on: DateTime::<Utc>::from_pb(p.create_on)?,
             update_on: DateTime::<Utc>::from_pb(p.update_on)?,
+            #[allow(deprecated)]
             current: p.current,
             step: p.step,
+            storage_version: p.storage_version,
         };
         Ok(v)
     }
@@ -51,8 +53,10 @@ impl FromToProto for SequenceMeta {
             comment: self.comment.clone(),
             create_on: self.create_on.to_pb()?,
             update_on: self.update_on.to_pb()?,
+            #[allow(deprecated)]
             current: self.current,
             step: self.step,
+            storage_version: self.storage_version,
         };
         Ok(p)
     }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -163,6 +163,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (131, "2025-06-24: Add: add use_logic_type in ParquetFileFormatParam and AvroFileFormatParam"),
     (132, "2025-06-25: Remove: SequenceMeta.start"),
     (133, "2025-06-25: Add: Add new StageFileCompression Zip"),
+    (134, "2025-06-27: Add: SequenceMeta.storage_version"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -125,3 +125,4 @@ mod v130_udf_imports_packages;
 mod v131_avro_and_parquet_file_format_params;
 mod v132_remove_sequence_meta_start;
 mod v133_stage_file_compression;
+mod v134_add_sequence_meta_storage_version;

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -83,7 +83,9 @@ fn new_sequence_meta() -> mt::SequenceMeta {
         update_on: DateTime::<Utc>::from_timestamp(10267, 0).unwrap(),
         comment: Some("seq".to_string()),
         step: 1,
+        #[allow(deprecated)]
         current: 10,
+        storage_version: 0,
     }
 }
 

--- a/src/meta/proto-conv/tests/it/v132_remove_sequence_meta_start.rs
+++ b/src/meta/proto-conv/tests/it/v132_remove_sequence_meta_start.rs
@@ -33,6 +33,7 @@ fn test_decode_v132_remove_sequence_meta_step() -> anyhow::Result<()> {
         comment: Some("seq".to_string()),
         step: 5,
         current: 10,
+        storage_version: 0,
     };
     common::test_pb_from_to(func_name!(), want())?;
     common::test_load_old(func_name!(), sequence_meta_v132.as_slice(), 132, want())?;

--- a/src/meta/proto-conv/tests/it/v134_add_sequence_meta_storage_version.rs
+++ b/src/meta/proto-conv/tests/it/v134_add_sequence_meta_storage_version.rs
@@ -20,23 +20,23 @@ use fastrace::func_name;
 use crate::common;
 
 #[test]
-fn test_decode_v88_sequence_meta() -> anyhow::Result<()> {
-    let sequence_meta_v88 = vec![
+fn test_decode_v134_add_sequence_meta_storage_version() -> anyhow::Result<()> {
+    let sequence_meta_v134 = vec![
         10, 23, 49, 57, 55, 48, 45, 48, 49, 45, 48, 49, 32, 48, 50, 58, 53, 49, 58, 48, 55, 32, 85,
         84, 67, 18, 23, 49, 57, 55, 48, 45, 48, 49, 45, 48, 49, 32, 48, 50, 58, 53, 49, 58, 48, 55,
-        32, 85, 84, 67, 26, 3, 115, 101, 113, 32, 1, 40, 1, 48, 10, 160, 6, 88, 168, 6, 24,
+        32, 85, 84, 67, 26, 3, 115, 101, 113, 40, 5, 48, 10, 56, 2, 160, 6, 134, 1, 168, 6, 24,
     ];
 
     let want = || mt::SequenceMeta {
         create_on: DateTime::<Utc>::from_timestamp(10267, 0).unwrap(),
         update_on: DateTime::<Utc>::from_timestamp(10267, 0).unwrap(),
         comment: Some("seq".to_string()),
-        step: 1,
+        step: 5,
         current: 10,
-        storage_version: 0,
+        storage_version: 2,
     };
     common::test_pb_from_to(func_name!(), want())?;
-    common::test_load_old(func_name!(), sequence_meta_v88.as_slice(), 88, want())?;
+    common::test_load_old(func_name!(), sequence_meta_v134.as_slice(), 134, want())?;
 
     Ok(())
 }

--- a/src/meta/protos/proto/sequence.proto
+++ b/src/meta/protos/proto/sequence.proto
@@ -29,5 +29,14 @@ message SequenceMeta {
   reserved 4;
 
   int64 step = 5;
+
+  // Not used for storage_version==1, use externally stored sequence with FetchAddU64
+  // 2025-06-26
   uint64 current = 6;
+
+  // Storage version:
+  //
+  // - By default the version is 0, which stores the value in `current` field.
+  // - With version == 1, it stores the value of the sequence in standalone key that support `FetchAddU64`.
+  uint64 storage_version = 7;
 }

--- a/src/meta/types/src/proto_display/mod.rs
+++ b/src/meta/types/src/proto_display/mod.rs
@@ -361,8 +361,13 @@ impl Display for FetchAddU64Response {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "FetchAddU64Response key={} before=(seq={} {}), after=(seq={} {})",
-            self.key, self.before_seq, self.before, self.after_seq, self.after
+            "FetchAddU64Response{{ key={} before=(seq={} {}), after=(seq={} {}), delta={} }}",
+            self.key,
+            self.before_seq,
+            self.before,
+            self.after_seq,
+            self.after,
+            self.delta()
         )
     }
 }
@@ -497,7 +502,7 @@ mod tests {
         };
         assert_eq!(
             resp.to_string(),
-            "FetchAddU64Response key=k1 before=(seq=1 3), after=(seq=2 4)"
+            "FetchAddU64Response{ key=k1 before=(seq=1 3), after=(seq=2 4), delta=1 }"
         );
     }
 }

--- a/src/meta/types/src/proto_ext/txn_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_ext.rs
@@ -455,9 +455,16 @@ impl pb::ConditionalOperation {
     }
 }
 
+impl pb::FetchAddU64Response {
+    pub fn delta(&self) -> u64 {
+        self.after.saturating_sub(self.before)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::protobuf::BooleanExpression;
+    use crate::protobuf::FetchAddU64Response;
     use crate::TxnCondition;
 
     #[test]
@@ -559,5 +566,18 @@ mod tests {
                 "((a == seq(1) OR b == seq(2)) AND (c == seq(3) OR d == seq(4))) OR ((e == seq(5) OR f == seq(6)) AND (g == seq(7) OR h == seq(8)))"
             );
         }
+    }
+
+    #[test]
+    fn test_fetch_add_u64_response() {
+        let resp = FetchAddU64Response {
+            key: "test_key".to_string(),
+            before_seq: 10,
+            before: 100,
+            after_seq: 20,
+            after: 200,
+        };
+
+        assert_eq!(resp.delta(), 100);
     }
 }

--- a/src/query/service/src/interpreters/interpreter_sequence_create.rs
+++ b/src/query/service/src/interpreters/interpreter_sequence_create.rs
@@ -52,6 +52,7 @@ impl Interpreter for CreateSequenceInterpreter {
             ident: self.plan.ident.clone(),
             comment: self.plan.comment.clone(),
             create_on: Utc::now(),
+            storage_version: 0,
         };
         let catalog = self.ctx.get_default_catalog()?;
         let _reply = catalog.create_sequence(req).await?;

--- a/src/query/service/src/interpreters/interpreter_sequence_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_sequence_drop.rs
@@ -53,7 +53,8 @@ impl Interpreter for DropSequenceInterpreter {
         };
         let catalog = self.ctx.get_default_catalog()?;
         let reply = catalog.drop_sequence(req).await?;
-        if reply.prev.is_none() && !self.plan.if_exists {
+
+        if !reply.success && !self.plan.if_exists {
             return Err(ErrorCode::UnknownSequence(format!(
                 "unknown sequence {:?}",
                 self.plan.ident.name()


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta): Add conflict-free sequence generator v1

Introduce a new conflict-free sequence generator (storage version 1)
alongside the existing version 0 generator. The v1 generator eliminates
conflicts during concurrent sequence number generation by using a new
`FetchAddU64` operation instead of check-and-set semantics.

Key changes:
- V1 generator stores sequence values in external standalone keys
- Uses atomic FetchAddU64 operation for conflict-free updates
- V0 generator remains unchanged for backward compatibility

The FetchAddU64 operation performs in-place atomic updates without
requiring metadata assertions, eliminating conflicts between concurrent
sequence requests and improving throughput for sequence generation
workloads.

Both storage versions coexist, allowing gradual migration from the
conflict-prone v0 implementation to the high-concurrency v1 design.

**Non-Breaking**:

This Commit just add this function but does not used anywhere.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18273)
<!-- Reviewable:end -->
