### PR TITLE
refactor: make queries executor lazy init

### DIFF
--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -19,8 +19,6 @@ io-uring = [
     "databend-common-meta-store/io-uring",
 ]
 
-enable_queries_executor = []
-
 [dependencies]
 anyhow = { workspace = true }
 arrow-array = { workspace = true }

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -50,8 +50,6 @@ use crate::catalogs::IcebergCreator;
 use crate::clusters::ClusterDiscovery;
 use crate::history_tables::GlobalHistoryLog;
 use crate::locks::LockManager;
-#[cfg(feature = "enable_queries_executor")]
-use crate::pipelines::executor::GlobalQueriesExecutor;
 use crate::servers::flight::v1::exchange::DataExchangeManager;
 use crate::servers::http::v1::ClientSessionManager;
 use crate::servers::http::v1::HttpQueryManager;
@@ -161,11 +159,6 @@ impl GlobalServices {
 
         if let Some(addr) = config.query.cloud_control_grpc_server_address.clone() {
             CloudControlApiProvider::init(addr, config.query.cloud_control_grpc_timeout).await?;
-        }
-
-        #[cfg(feature = "enable_queries_executor")]
-        {
-            GlobalQueriesExecutor::init()?;
         }
 
         if !ee_mode {

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -442,9 +442,12 @@ impl ExecutingGraph {
 
     /// Checks if a task can be performed in the current epoch, consuming a point if possible.
     pub fn can_perform_task(&self, global_epoch: u32) -> bool {
+        // Load the maximum points this query can have per epoch
         let max_points = self.max_points.load(Ordering::SeqCst);
         let mut expected_value = 0;
         let mut desired_value = 0;
+
+        // Use compare-and-swap loop to atomically update points and epoch
         loop {
             match self.points.compare_exchange_weak(
                 expected_value,
@@ -453,20 +456,30 @@ impl ExecutingGraph {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
+                    // Successfully updated the atomic value. Check if the final epoch matches global epoch.
+                    // Return true only if we're executing in the correct epoch (task can proceed)
                     return (desired_value & EPOCH_MASK) as u32 == global_epoch;
                 }
                 Err(new_expected) => {
+                    // Extract points and epoch from the 64-bit atomic value
                     let remain_points = (new_expected & POINTS_MASK) >> 32;
                     let epoch = new_expected & EPOCH_MASK;
 
                     expected_value = new_expected;
+
                     if epoch > global_epoch as u64 {
+                        // Query epoch is ahead of global epoch - don't execute, keep current state
                         desired_value = new_expected;
                     } else if epoch < global_epoch as u64 {
+                        // Query epoch is behind global epoch - refill points and consume one
+                        // This happens when the query was idle and needs to catch up
                         desired_value = (max_points - 1) << 32 | global_epoch as u64;
                     } else if remain_points >= 1 {
+                        // Same epoch and have points available - consume one point
                         desired_value = (remain_points - 1) << 32 | epoch;
                     } else {
+                        // Same epoch but no points left - advance to next epoch with full points
+                        // Task will need to wait as it cannot execute in current epoch
                         desired_value = max_points << 32 | (epoch + 1);
                     }
                 }

--- a/src/query/service/src/pipelines/executor/global_queries_executor.rs
+++ b/src/query/service/src/pipelines/executor/global_queries_executor.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::OnceLock;
 
-use databend_common_base::base::GlobalInstance;
 use databend_common_base::runtime::Thread;
 use databend_common_exception::Result;
 use log::info;
@@ -23,19 +23,29 @@ use crate::pipelines::executor::QueriesPipelineExecutor;
 
 pub struct GlobalQueriesExecutor(pub QueriesPipelineExecutor);
 
+static GLOBAL_QUERIES_EXECUTOR: OnceLock<Arc<QueriesPipelineExecutor>> = OnceLock::new();
+
 impl GlobalQueriesExecutor {
-    pub fn init() -> Result<()> {
+    fn init_once() -> Result<Arc<QueriesPipelineExecutor>> {
         let num_cpus = num_cpus::get();
-        GlobalInstance::set(QueriesPipelineExecutor::create(num_cpus)?);
-        Thread::spawn(|| {
-            if let Err(e) = Self::instance().execute() {
+        let executor = QueriesPipelineExecutor::create(num_cpus)?;
+        let executor_clone = executor.clone();
+        Thread::named_spawn(Some("GlobalQueriesExecutor".to_string()), move || {
+            if let Err(e) = executor.execute() {
                 info!("Executor finished with error: {:?}", e);
             }
         });
-        Ok(())
+        Ok(executor_clone)
     }
 
     pub fn instance() -> Arc<QueriesPipelineExecutor> {
-        GlobalInstance::get()
+        GLOBAL_QUERIES_EXECUTOR
+            .get_or_init(|| match Self::init_once() {
+                Ok(executor) => executor,
+                Err(e) => {
+                    panic!("Failed to initialize GlobalQueriesExecutor: {:?}", e);
+                }
+            })
+            .clone()
     }
 }

--- a/src/query/service/src/pipelines/executor/queries_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/queries_pipeline_executor.rs
@@ -109,7 +109,7 @@ impl QueriesPipelineExecutor {
         for thread_num in 0..threads {
             let this = self.clone();
             #[allow(unused_mut)]
-            let mut name = format!("PipelineExecutor-{}", thread_num);
+            let mut name = format!("QueriesPipelineExecutor-{}", thread_num);
 
             #[cfg(debug_assertions)]
             {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Remove compile flag `enable_queries_executor`
- Make queries executor lazy init, control by settings

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - No logic change

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
