### PR TITLE
fix: handle Decimal64 properly in `column_update_hll_cardinality`

### DIFF
--- a/src/query/storages/fuse/src/io/write/stream/column_statistics.rs
+++ b/src/query/storages/fuse/src/io/write/stream/column_statistics.rs
@@ -194,6 +194,11 @@ fn column_update_hll_cardinality(col: &Column, ty: &DataType, hll: &mut ColumnDi
         }
         DataType::Decimal(_) => {
             match col {
+                Column::Decimal(DecimalColumn::Decimal64(col, _)) => {
+                    for v in col.iter() {
+                        hll.add_object(v);
+                    }
+                }
                 Column::Decimal(DecimalColumn::Decimal128(col, _)) => {
                     for v in col.iter() {
                         hll.add_object(v);

--- a/tests/sqllogictests/suites/base/issues/issue_18286.test
+++ b/tests/sqllogictests/suites/base/issues/issue_18286.test
@@ -1,0 +1,18 @@
+# https://github.com/datafuselabs/databend/issues/18286
+
+statement ok
+create or replace database issue_18286;
+
+statement ok
+use issue_18286;
+
+statement ok
+create or replace table t( c DECIMAL(10, 2) not null);
+
+statement ok
+insert into t select number / 100 as c from numbers(100);
+
+query T
+select count(*) from t;
+----
+100


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #18286

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18287)
<!-- Reviewable:end -->
