### PR TITLE
fix: transient should ignore retention period settings and table options

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -491,7 +491,9 @@ impl FuseTable {
     ///   1. Number of snapshots to keep (from table option or setting)
     ///   2. Time-based retention period (if snapshot count is not specified)
     pub fn get_data_retention_policy(&self, ctx: &dyn TableContext) -> Result<RetentionPolicy> {
-        let policy =
+        let policy = if self.is_transient() {
+            RetentionPolicy::ByNumOfSnapshotsToKeep(1)
+        } else {
             // Try to get number of snapshots to keep
             if let Some(num_snapshots) = self.try_get_policy_by_num_snapshots_to_keep(ctx)? {
                 RetentionPolicy::ByNumOfSnapshotsToKeep(num_snapshots as usize)
@@ -499,7 +501,8 @@ impl FuseTable {
                 // Fall back to time-based retention policy
                 let duration = self.get_data_retention_period(ctx)?;
                 RetentionPolicy::ByTimePeriod(duration)
-            };
+            }
+        };
 
         Ok(policy)
     }

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0018_transient_table.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0018_transient_table.test
@@ -1,41 +1,140 @@
 statement ok
-DROP DATABASE IF EXISTS db1
+create or replace database ee_vacuum_03_0018;
 
 statement ok
-CREATE DATABASE db1
+use ee_vacuum_03_0018;
 
 statement ok
-USE db1
+CREATE OR REPLACE TRANSIENT TABLE test_tbl(a int);
+
+####################################################################################
+# transient tables should ignore the data_retention_num_snapshots_to_keep settings #
+####################################################################################
 
 statement ok
-CREATE TRANSIENT TABLE IF NOT EXISTS t09_0016(a int)
+set data_retention_num_snapshots_to_keep = 20;
 
 statement ok
-INSERT INTO t09_0016 VALUES(1)
+INSERT INTO test_tbl VALUES(1)
 
 statement ok
-INSERT INTO t09_0016 VALUES(2)
+INSERT INTO test_tbl VALUES(2)
 
 statement ok
-INSERT INTO t09_0016 VALUES(3)
+INSERT INTO test_tbl VALUES(3)
 
 query I
-select * from t09_0016 order by a
+select * from test_tbl order by a
 ----
 1
 2
 3
 
 query B
-select count(*)=1 from fuse_snapshot('db1', 't09_0016')
+select count(*)=1 from fuse_snapshot('ee_vacuum_03_0018', 'test_tbl')
+----
+1
+
+###############################################################################
+#  test data_retention_time_in_days setting does not affect transient tables  #
+###############################################################################
+
+# reset data_retention_num_snapshots_to_keep to default value
+statement ok
+unset data_retention_num_snapshots_to_keep
+
+statement ok
+CREATE OR REPLACE TRANSIENT TABLE test_tbl(a int);
+
+# transient tables should ignore the data_retention_time_in_days settings
+statement ok
+set data_retention_time_in_days = 20;
+
+statement ok
+INSERT INTO test_tbl VALUES(1)
+
+statement ok
+INSERT INTO test_tbl VALUES(2)
+
+statement ok
+INSERT INTO test_tbl VALUES(3)
+
+query I
+select * from test_tbl order by a
+----
+1
+2
+3
+
+query B
+select count(*)=1 from fuse_snapshot('ee_vacuum_03_0018', 'test_tbl')
+----
+1
+
+######################################################################################
+#  test table option data_retention_period_in_hours does not affect transient tables  #
+######################################################################################
+
+# reset data_retention_time_in_days to default value
+statement ok
+unset data_retention_time_in_days;
+
+# transient tables should ignore the data_retention_period_in_hours table option
+statement ok
+CREATE OR REPLACE TRANSIENT TABLE test_tbl(a int) data_retention_period_in_hours = 1;
+
+statement ok
+unset data_retention_num_snapshots_to_keep;
+
+statement ok
+INSERT INTO test_tbl VALUES(1)
+
+statement ok
+INSERT INTO test_tbl VALUES(2)
+
+statement ok
+INSERT INTO test_tbl VALUES(3)
+
+query I
+select * from test_tbl order by a
+----
+1
+2
+3
+
+query B
+select count(*)=1 from fuse_snapshot('ee_vacuum_03_0018', 'test_tbl')
+----
+1
+
+######################################################################################
+#  test table option data_retention_num_snapshots_to_keep does not affect transient tables  #
+######################################################################################
+
+# transient tables should ignore the data_retention_num_snapshots_to_keep table option
+statement ok
+CREATE OR REPLACE TRANSIENT TABLE test_tbl(a int) data_retention_num_snapshots_to_keep = 100;
+
+statement ok
+INSERT INTO test_tbl VALUES(1)
+
+statement ok
+INSERT INTO test_tbl VALUES(2)
+
+statement ok
+INSERT INTO test_tbl VALUES(3)
+
+query I
+select * from test_tbl order by a
+----
+1
+2
+3
+
+query B
+select count(*)=1 from fuse_snapshot('ee_vacuum_03_0018', 'test_tbl')
 ----
 1
 
 
-
-statement ok
-DROP TABLE t09_0016
-
-statement ok
-DROP DATABASE db1
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


Currently transient table only ignores setting `data_retention_time_in_days`, it should ignore other retention period settings and table options as well:

- settings: `data_retention_num_snapshots_to_keep` 
- table options: `data_retention_period_in_hours` and `data_retention_num_snapshots_to_keep`



- fixes: #18293


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18295)
<!-- Reviewable:end -->
