### PR TITLE
refactor: replace find_database_table_filter to extract_leveled_strings

### DIFF
--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -49,7 +49,7 @@ use log::warn;
 use crate::generate_catalog_meta;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
-use crate::util::find_database_table_filters;
+use crate::util::extract_leveled_strings;
 
 pub struct ColumnsTable {
     table_info: TableInfo,
@@ -326,7 +326,7 @@ pub(crate) async fn dump_tables(
         if let Some(filter) = push_downs.filters.as_ref().map(|f| &f.filter) {
             let expr = filter.as_expr(&BUILTIN_FUNCTIONS);
             (filtered_db_names, filtered_table_names) =
-                find_database_table_filters(&expr, &func_ctx)?;
+                extract_leveled_strings(&expr, &["database", "table"], &func_ctx)?;
         }
     }
 

--- a/src/query/storages/system/src/indexes_table.rs
+++ b/src/query/storages/system/src/indexes_table.rs
@@ -36,7 +36,7 @@ use log::warn;
 
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
-use crate::util::find_database_table_filters;
+use crate::util::extract_leveled_strings;
 
 const POINT_GET_TABLE_LIMIT: usize = 20;
 
@@ -64,7 +64,7 @@ impl AsyncSystemTable for IndexesTable {
         if let Some(filters) = push_downs.and_then(|info| info.filters) {
             let expr = filters.filter.as_expr(&BUILTIN_FUNCTIONS);
             (filtered_db_names, filtered_table_names) =
-                find_database_table_filters(&expr, &func_ctx)?;
+                extract_leveled_strings(&expr, &["database", "table"], &func_ctx)?;
         }
 
         let filtered_db_names = if filtered_db_names.is_empty() {

--- a/tests/sqllogictests/suites/tpch_iceberg/utils.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/utils.test
@@ -20,6 +20,10 @@ show catalogs where name='ctl';
 ----
 ctl
 
+statement ok
+create or replace database default.system_db_test;
+
+## should not display system_db_test
 query T
 show databases from ctl;
 ----
@@ -27,6 +31,9 @@ information_schema
 system
 test
 tpch
+
+statement ok
+drop database if exists default.system_db_test;
 
 statement error 1003
 use aa;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. delete find_eq_filter
2. replace find_database_table_filter to extract_leveled_strings
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Just refactor, contain all ci passed

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18297)
<!-- Reviewable:end -->
