### PR TITLE
feat(meta-service): Add millisecond precision for expiration times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ dependencies = [
  "logcall",
  "once_cell",
  "parking_lot 0.12.3",
+ "pretty_assertions",
  "prost",
  "rand 0.8.5",
  "semver",

--- a/src/meta/client/Cargo.toml
+++ b/src/meta/client/Cargo.toml
@@ -41,6 +41,7 @@ tonic = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 databend-common-exception = { workspace = true }
+pretty_assertions = { workspace = true }
 rand = { workspace = true }
 
 [lints]

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -150,14 +150,17 @@ pub static METACLI_COMMIT_SEMVER: LazyLock<Version> = LazyLock::new(|| {
 /// - 2025-06-11: since 1.2.756
 ///   🖥 server: add `TxnPutResponse::current`
 ///
-/// - 2025-06-24: since TODO: add when merge
+/// - 2025-06-24: since 1.2.764
 ///   🖥 server: add `FetchAddU64` operation to the `TxnOp`
 ///
-/// - 2025-06-26: since TODO: add when merge
+/// - 2025-06-26: since 1.2.764
 ///   🖥 server: add `FetchAddU64.match_seq`
 ///
-/// - 2025-07-01: since TODO: add when enables sequence v1
-///   👥 client: new sequence API depends on `FetchAddU64`.
+/// - 2025-07-01: since TODO: add when enables sequence storage v1
+///   👥 client: new sequence API v1: depends on `FetchAddU64`.
+///
+/// - 2025-07-03: since TODO: add when merged
+///   🖥 server: adaptive `expire_at` support both seconds and milliseconds.
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/client/src/required.rs
+++ b/src/meta/client/src/required.rs
@@ -140,34 +140,3 @@ pub fn export() -> &'static [FeatureSpec] {
 
     REQUIRES
 }
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeSet;
-
-    use super::*;
-    use crate::MIN_METASRV_SEMVER;
-
-    /// Ensures the defined std features includes exact all the features that the min required version server provided.
-    #[test]
-    fn test_std_features() {
-        let min_required_server_version = (
-            MIN_METASRV_SEMVER.major,
-            MIN_METASRV_SEMVER.minor,
-            MIN_METASRV_SEMVER.patch,
-        );
-
-        let mut got = BTreeSet::new();
-        for feat in all() {
-            if feat.1 >= min_required_server_version {
-                got.insert(feat);
-            }
-        }
-
-        let defined = std().iter().collect::<BTreeSet<_>>();
-        assert_eq!(
-            got, defined,
-            "The std features should be a subset of all features that are supported by the minimum required server version."
-        );
-    }
-}

--- a/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
@@ -379,18 +379,18 @@ async fn build_2_level_with_meta() -> anyhow::Result<LeveledMap> {
 
     // internal_seq: 0
     l.str_map_mut()
-        .set(s("a"), Some((b("a0"), Some(KVMeta::new_expire(1)))))
+        .set(s("a"), Some((b("a0"), Some(KVMeta::new_expires_at(1)))))
         .await?;
     l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
     l.str_map_mut()
-        .set(s("c"), Some((b("c0"), Some(KVMeta::new_expire(2)))))
+        .set(s("c"), Some((b("c0"), Some(KVMeta::new_expires_at(2)))))
         .await?;
 
     l.freeze_writable();
 
     // internal_seq: 3
     l.str_map_mut()
-        .set(s("b"), Some((b("b1"), Some(KVMeta::new_expire(10)))))
+        .set(s("b"), Some((b("b1"), Some(KVMeta::new_expires_at(10)))))
         .await?;
     l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
 
@@ -455,17 +455,17 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::upsert_value(&mut l, s("a"), b("a1")).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expire(1)))
+            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expires_at(1)))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
+            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expires_at(1)))
         );
 
         let got = l.str_map().get(&s("a")).await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expire(1)))
+            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expires_at(1)))
         );
     }
 
@@ -476,17 +476,17 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::upsert_value(&mut l, s("b"), b("x1")).await?;
         assert_eq!(
             prev,
-            Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta::new_expire(10)))
+            Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta::new_expires_at(10)))
         );
         assert_eq!(
             result,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
+            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expires_at(10)))
         );
 
         let got = l.str_map().get(&s("b")).await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expire(10)))
+            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expires_at(10)))
         );
     }
 
@@ -512,20 +512,20 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta::new_expire(2))).await?;
+            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta::new_expires_at(2))).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expire(1)))
+            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expires_at(1)))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
+            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expires_at(2)))
         );
 
         let got = l.str_map().get(&s("a")).await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expire(2)))
+            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expires_at(2)))
         );
     }
 
@@ -536,7 +536,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let (prev, result) = MapApiExt::update_meta(&mut l, s("b"), None).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(4, b("b1"), Some(KVMeta::new_expire(10)))
+            Marked::new_with_meta(4, b("b1"), Some(KVMeta::new_expires_at(10)))
         );
         assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
 
@@ -549,17 +549,17 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("c"), Some(KVMeta::new_expire(20))).await?;
+            MapApiExt::update_meta(&mut l, s("c"), Some(KVMeta::new_expires_at(20))).await?;
         assert_eq!(prev, Marked::new_with_meta(5, b("c1"), None));
         assert_eq!(
             result,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
+            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expires_at(20)))
         );
 
         let got = l.str_map().get(&s("c")).await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expire(20)))
+            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expires_at(20)))
         );
     }
 
@@ -568,7 +568,7 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta::new_expire(2))).await?;
+            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta::new_expires_at(2))).await?;
         assert_eq!(prev, Marked::new_tombstone(0));
         assert_eq!(result, Marked::new_tombstone(0));
 

--- a/src/meta/raft-store/src/leveled_store/rotbl_seq_mark_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/rotbl_seq_mark_impl.rs
@@ -133,7 +133,7 @@ mod tests {
         );
 
         t_string_try_from(
-            Marked::<String>::new_with_meta(1, s("hello"), Some(KVMeta::new_expire(20))),
+            Marked::<String>::new_with_meta(1, s("hello"), Some(KVMeta::new_expires_at(20))),
             SeqMarked::new_normal(1, b("\x01\x10{\"expire_at\":20}\x05hello")),
         );
 
@@ -160,7 +160,7 @@ mod tests {
         );
 
         t_try_from(
-            Marked::new_with_meta(1, b("hello"), Some(KVMeta::new_expire(20))),
+            Marked::new_with_meta(1, b("hello"), Some(KVMeta::new_expires_at(20))),
             SeqMarked::new_normal(1, b("\x01\x10{\"expire_at\":20}\x05hello")),
         );
 

--- a/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
@@ -101,15 +101,15 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         //
         (
             s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expire(15)))
+            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
         ),
         (
             s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expire(5)))
+            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
         ),
         (
             s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expire(20)))
+            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
         ),
     ]);
 

--- a/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
@@ -111,15 +111,15 @@ async fn test_leveled_query_with_expire_index() -> anyhow::Result<()> {
         //
         (
             s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expire(15)))
+            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
         ),
         (
             s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expire(5)))
+            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
         ),
         (
             s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expire(20)))
+            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
         ),
     ]);
 
@@ -231,15 +231,15 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         //
         (
             s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expire(15)))
+            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
         ),
         (
             s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expire(5)))
+            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
         ),
         (
             s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expire(20)))
+            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
         ),
     ]);
 

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -126,7 +126,6 @@ async fn test_kv_api_restart_cluster_write_read() -> anyhow::Result<()> {
 /// - Test read kv using same grpc client.
 #[test(harness = meta_service_test_harness)]
 #[fastrace::trace]
-#[ignore = "CI FLKAY TEST"]
 async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
     fn make_key(tc: &MetaSrvTestContext, k: impl std::fmt::Display) -> String {
         let x = &tc.config.raft_config;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -25,6 +25,7 @@ use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::KvMeta;
 use databend_common_meta_types::seq_value::SeqV;
+use databend_common_meta_types::KVMeta;
 use databend_common_meta_types::MetaSpec;
 use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::With;
@@ -174,7 +175,9 @@ async fn test_streamed_mget(client: &Arc<ClientHandle>, now_sec: u64) -> anyhow:
         assert_eq!(b("a"), seq_v.data);
         // check meta
         {
-            let KvMeta { expire_at } = seq_v.meta.unwrap();
+            let kv_meta: KVMeta = seq_v.meta.unwrap().into();
+            let expire_at = kv_meta.expires_at_sec_opt();
+
             let want = now_sec + 10;
             assert!((want..want + 3).contains(&expire_at.unwrap()));
         }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -23,7 +23,6 @@ use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_types::protobuf as pb;
-use databend_common_meta_types::protobuf::KvMeta;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::KVMeta;
 use databend_common_meta_types::MetaSpec;

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_watch.rs
@@ -561,15 +561,25 @@ async fn test_watch_expired_events() -> anyhow::Result<()> {
         fn tidy(mut ev: Event) -> Event {
             if let Some(ref mut prev) = ev.prev {
                 if let Some(ref mut meta) = prev.meta {
-                    meta.expire_at = meta.expire_at.map(|x| x / 10 * 10);
+                    meta.expire_at = meta.expire_at.map(tidy_timestamp);
                 }
             }
             if let Some(ref mut current) = ev.current {
                 if let Some(ref mut meta) = current.meta {
-                    meta.expire_at = meta.expire_at.map(|x| x / 10 * 10);
+                    meta.expire_at = meta.expire_at.map(tidy_timestamp);
                 }
             }
             ev
+        }
+
+        fn tidy_timestamp(x: u64) -> u64 {
+            if x > 100_000_000_000 {
+                // tidy the timestamp in millis
+                x / 10_000 * 10_000
+            } else {
+                // tidy the timestamp in seconds
+                x / 10 * 10
+            }
         }
 
         for ev in watch_events {

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 
 use databend_common_base::base::tokio::time::sleep;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_types::seq_value::KVMeta;
 use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::LogEntry;
@@ -70,7 +69,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     let seq = {
         let resp = leader.kv_api().get_kv(key).await?;
         let seq_v = resp.unwrap();
-        assert_eq!(Some(KVMeta::new_expires_at(now_sec + 3)), seq_v.meta);
+        assert_eq!(Some(now_sec + 3), seq_v.meta.unwrap().expires_at_sec_opt());
         seq_v.seq
     };
 
@@ -118,7 +117,10 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
         let sm = learner.raft_store.state_machine.read().await;
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
-        assert_eq!(Some(KVMeta::new_expires_at(now_sec + 1000)), seq_v.meta);
+        assert_eq!(
+            Some(now_sec + 1000),
+            seq_v.meta.unwrap().expires_at_sec_opt()
+        );
         assert_eq!(value2.to_string().into_bytes(), seq_v.data);
     }
 

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -70,7 +70,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     let seq = {
         let resp = leader.kv_api().get_kv(key).await?;
         let seq_v = resp.unwrap();
-        assert_eq!(Some(KVMeta::new_expire(now_sec + 3)), seq_v.meta);
+        assert_eq!(Some(KVMeta::new_expires_at(now_sec + 3)), seq_v.meta);
         seq_v.seq
     };
 
@@ -118,7 +118,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
         let sm = learner.raft_store.state_machine.read().await;
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
-        assert_eq!(Some(KVMeta::new_expire(now_sec + 1000)), seq_v.meta);
+        assert_eq!(Some(KVMeta::new_expires_at(now_sec + 1000)), seq_v.meta);
         assert_eq!(value2.to_string().into_bytes(), seq_v.data);
     }
 

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -17,6 +17,11 @@ syntax = "proto3";
 package meta;
 
 message KVMeta {
+  // Expiration time in **seconds or milliseconds** since Unix epoch (1970-01-01).
+  //
+  // The interpretation depends on the magnitude of the value:
+  // - Values > `1_000_000_000_000`: treated as milliseconds since epoch
+  // - Values ≤ `1_000_000_000_000`: treated as seconds since epoch
   optional uint64 expire_at = 1;
 }
 

--- a/src/meta/types/src/cmd/meta_spec.rs
+++ b/src/meta/types/src/cmd/meta_spec.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use deepsize::Context;
 use display_more::DisplayUnixTimeStampExt;
 
-use crate::adaptable_timestamp_to_duration;
 use crate::cmd::CmdContext;
+use crate::flexible_timestamp_to_duration;
 use crate::seq_value::KVMeta;
 use crate::time::Interval;
 
@@ -66,7 +66,7 @@ impl fmt::Display for MetaSpec {
             write!(
                 f,
                 "expire_at: {} ",
-                adaptable_timestamp_to_duration(expires_at).display_unix_timestamp_short()
+                flexible_timestamp_to_duration(expires_at).display_unix_timestamp_short()
             )?;
         }
         if let Some(ttl) = &self.ttl {

--- a/src/meta/types/src/cmd/meta_spec.rs
+++ b/src/meta/types/src/cmd/meta_spec.rs
@@ -109,7 +109,8 @@ impl MetaSpec {
     pub fn to_kv_meta(&self, cmd_ctx: &CmdContext) -> KVMeta {
         // If `ttl` is set, override `expire_at`
         if let Some(ttl) = self.ttl {
-            return KVMeta::new_expires_at((cmd_ctx.time() + ttl).millis());
+            // TODO: use `.millis()` when there is no direct access to KVMeta.expire_at
+            return KVMeta::new_expires_at((cmd_ctx.time() + ttl).seconds());
         }
 
         // No `ttl`, check if absolute expire time `expire_at` is set.

--- a/src/meta/types/src/cmd/meta_spec.rs
+++ b/src/meta/types/src/cmd/meta_spec.rs
@@ -110,7 +110,8 @@ impl MetaSpec {
         // If `ttl` is set, override `expire_at`
         if let Some(ttl) = self.ttl {
             // TODO: use `.millis()` when there is no direct access to KVMeta.expire_at
-            return KVMeta::new_expires_at((cmd_ctx.time() + ttl).seconds());
+            // return KVMeta::new_expires_at((cmd_ctx.time() + ttl).seconds());
+            return KVMeta::new_expires_at((cmd_ctx.time() + ttl).millis());
         }
 
         // No `ttl`, check if absolute expire time `expire_at` is set.
@@ -129,12 +130,12 @@ mod tests {
 
     #[test]
     fn test_serde() {
-        let meta = MetaSpec::new_expire(100);
+        let meta = MetaSpec::new_expire(1723102819);
         let s = serde_json::to_string(&meta).unwrap();
         assert_eq!(r#"{"expire_at":100}"#, s);
 
         let got: KVMeta = serde_json::from_str(&s).unwrap();
-        assert_eq!(Some(100), got.expire_at);
+        assert_eq!(Some(1723102819), got.expire_at);
 
         let meta = MetaSpec::new_ttl(Duration::from_millis(100));
         let s = serde_json::to_string(&meta).unwrap();

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -111,6 +111,7 @@ pub use seq_num::SeqNum;
 pub use seq_value::KVMeta;
 pub use seq_value::SeqV;
 pub use seq_value::SeqValue;
+pub use time::adaptable_timestamp_to_duration;
 pub use time::Interval;
 pub use time::Time;
 pub use with::With;

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -111,7 +111,7 @@ pub use seq_num::SeqNum;
 pub use seq_value::KVMeta;
 pub use seq_value::SeqV;
 pub use seq_value::SeqValue;
-pub use time::adaptable_timestamp_to_duration;
+pub use time::flexible_timestamp_to_duration;
 pub use time::Interval;
 pub use time::Time;
 pub use with::With;

--- a/src/meta/types/src/proto_display/seqv_display.rs
+++ b/src/meta/types/src/proto_display/seqv_display.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use display_more::DisplayUnixTimeStampExt;
 
+use crate::adaptable_timestamp_to_duration;
 use crate::protobuf::KvMeta;
 use crate::protobuf::SeqV;
 
@@ -30,7 +31,7 @@ impl fmt::Display for KvMeta {
                 write!(
                     f,
                     "[expire={}]",
-                    Duration::from_secs(e).display_unix_timestamp_short()
+                    adaptable_timestamp_to_duration(e).display_unix_timestamp_short()
                 )
             }
         }
@@ -69,6 +70,11 @@ mod tests {
             expire_at: Some(1723102819),
         };
         assert_eq!(meta.to_string(), "[expire=2024-08-08T07:40:19.000]");
+
+        let meta = KvMeta {
+            expire_at: Some(1723102819_000),
+        };
+        assert_eq!(meta.to_string(), "[expire=2024-08-08T07:40:19.000]");
     }
 
     #[test]
@@ -95,7 +101,32 @@ mod tests {
         let seqv = SeqV {
             seq: 1,
             meta: Some(KvMeta {
+                expire_at: Some(1723102819_000),
+            }),
+            data: vec![65, 66, 67],
+        };
+        assert_eq!(
+            seqv.to_string(),
+            "(seq=1 [expire=2024-08-08T07:40:19.000] 'ABC')"
+        );
+
+        let seqv = SeqV {
+            seq: 1,
+            meta: Some(KvMeta {
                 expire_at: Some(1723102819),
+            }),
+            data: vec![0, 159, 146, 150],
+        };
+        assert_eq!(
+            seqv.to_string(),
+            "(seq=1 [expire=2024-08-08T07:40:19.000] [0, 159, 146, 150])"
+        );
+
+        let seqv = SeqV {
+            seq: 1,
+            meta: Some(KvMeta {
+                // in millis
+                expire_at: Some(1723102819_000),
             }),
             data: vec![0, 159, 146, 150],
         };

--- a/src/meta/types/src/proto_display/seqv_display.rs
+++ b/src/meta/types/src/proto_display/seqv_display.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 use std::fmt;
-use std::time::Duration;
 
 use display_more::DisplayUnixTimeStampExt;
 
-use crate::adaptable_timestamp_to_duration;
+use crate::flexible_timestamp_to_duration;
 use crate::protobuf::KvMeta;
 use crate::protobuf::SeqV;
 
@@ -31,7 +30,7 @@ impl fmt::Display for KvMeta {
                 write!(
                     f,
                     "[expire={}]",
-                    adaptable_timestamp_to_duration(e).display_unix_timestamp_short()
+                    flexible_timestamp_to_duration(e).display_unix_timestamp_short()
                 )
             }
         }

--- a/src/meta/types/src/proto_display/seqv_display.rs
+++ b/src/meta/types/src/proto_display/seqv_display.rs
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(meta.to_string(), "[expire=2024-08-08T07:40:19.000]");
 
         let meta = KvMeta {
-            expire_at: Some(1723102819_000),
+            expire_at: Some(1_723_102_819_000),
         };
         assert_eq!(meta.to_string(), "[expire=2024-08-08T07:40:19.000]");
     }
@@ -100,7 +100,7 @@ mod tests {
         let seqv = SeqV {
             seq: 1,
             meta: Some(KvMeta {
-                expire_at: Some(1723102819_000),
+                expire_at: Some(1_723_102_819_000),
             }),
             data: vec![65, 66, 67],
         };
@@ -125,7 +125,7 @@ mod tests {
             seq: 1,
             meta: Some(KvMeta {
                 // in millis
-                expire_at: Some(1723102819_000),
+                expire_at: Some(1_723_102_819_000),
             }),
             data: vec![0, 159, 146, 150],
         };

--- a/src/meta/types/src/proto_display/watch_display.rs
+++ b/src/meta/types/src/proto_display/watch_display.rs
@@ -16,21 +16,8 @@ use std::fmt;
 
 use display_more::DisplayOptionExt;
 
-use crate::protobuf::Event;
 use crate::protobuf::WatchRequest;
 use crate::protobuf::WatchResponse;
-
-impl fmt::Display for Event {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "({}: {} -> {})",
-            self.key,
-            self.prev.display(),
-            self.current.display()
-        )
-    }
-}
 
 impl fmt::Display for WatchResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -62,25 +49,6 @@ mod tests {
     use crate::protobuf::watch_request::FilterType;
     use crate::protobuf::KvMeta;
     use crate::protobuf::SeqV;
-    #[test]
-    fn test_event_display() {
-        let event = Event {
-            key: "test_key".to_string(),
-            prev: Some(SeqV {
-                seq: 1,
-                data: "test_prev".as_bytes().to_vec(),
-                meta: Some(KvMeta {
-                    expire_at: Some(1723102819),
-                }),
-            }),
-            current: Some(SeqV {
-                seq: 2,
-                data: "test_current".as_bytes().to_vec(),
-                meta: None,
-            }),
-        };
-        assert_eq!(event.to_string(), "(test_key: (seq=1 [expire=2024-08-08T07:40:19.000] 'test_prev') -> (seq=2 [] 'test_current'))");
-    }
 
     #[test]
     fn test_watch_response_display() {

--- a/src/meta/types/src/proto_display/watch_display.rs
+++ b/src/meta/types/src/proto_display/watch_display.rs
@@ -46,6 +46,7 @@ impl fmt::Display for WatchRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protobuf as pb;
     use crate::protobuf::watch_request::FilterType;
     use crate::protobuf::KvMeta;
     use crate::protobuf::SeqV;
@@ -53,7 +54,7 @@ mod tests {
     #[test]
     fn test_watch_response_display() {
         let mut watch_response = WatchResponse {
-            event: Some(Event {
+            event: Some(pb::Event {
                 key: "test_key".to_string(),
                 prev: Some(SeqV {
                     seq: 1,

--- a/src/meta/types/src/proto_display/watch_display.rs
+++ b/src/meta/types/src/proto_display/watch_display.rs
@@ -70,7 +70,7 @@ mod tests {
                 seq: 1,
                 data: "test_prev".as_bytes().to_vec(),
                 meta: Some(KvMeta {
-                    expire_at: Some(1000),
+                    expire_at: Some(1723102819),
                 }),
             }),
             current: Some(SeqV {
@@ -79,7 +79,7 @@ mod tests {
                 meta: None,
             }),
         };
-        assert_eq!(event.to_string(), "(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+        assert_eq!(event.to_string(), "(test_key: (seq=1 [expire=2024-08-08T07:40:19.000] 'test_prev') -> (seq=2 [] 'test_current'))");
     }
 
     #[test]
@@ -91,7 +91,7 @@ mod tests {
                     seq: 1,
                     data: "test_prev".as_bytes().to_vec(),
                     meta: Some(KvMeta {
-                        expire_at: Some(1000),
+                        expire_at: Some(1723102819),
                     }),
                 }),
                 current: Some(SeqV {
@@ -102,10 +102,10 @@ mod tests {
             }),
             is_initialization: false,
         };
-        assert_eq!(watch_response.to_string(), "CHANGE:(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+        assert_eq!(watch_response.to_string(), "CHANGE:(test_key: (seq=1 [expire=2024-08-08T07:40:19.000] 'test_prev') -> (seq=2 [] 'test_current'))");
 
         watch_response.is_initialization = true;
-        assert_eq!(watch_response.to_string(), "INIT:(test_key: (seq=1 [expire=1970-01-01T00:16:40.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+        assert_eq!(watch_response.to_string(), "INIT:(test_key: (seq=1 [expire=2024-08-08T07:40:19.000] 'test_prev') -> (seq=2 [] 'test_current'))");
 
         let watch_response = WatchResponse {
             event: None,

--- a/src/meta/types/src/proto_ext/seq_v_ext.rs
+++ b/src/meta/types/src/proto_ext/seq_v_ext.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use map_api::match_seq::errors::ConflictSeq;
 use map_api::match_seq::MatchSeq;
 use map_api::match_seq::MatchSeqExt;
 
+use crate::flexible_timestamp_to_duration;
 use crate::protobuf as pb;
 use crate::seq_value::KVMeta;
 use crate::seq_value::SeqV;
@@ -42,6 +45,27 @@ impl pb::KvMeta {
             expire_at: Some(expire_at),
         }
     }
+
+    /// Returns true if two `KvMeta` instances are close to each other.
+    ///
+    /// If both have no expiration time, returns true.
+    /// If only one has an expiration time, returns false.
+    pub fn close_to(&self, other: &Self, tolerance: Duration) -> bool {
+        let (a, b) = match (self.expire_at, other.expire_at) {
+            (Some(a), Some(b)) => (a, b),
+            (None, None) => return true,
+            _ => return false,
+        };
+
+        let a = flexible_timestamp_to_duration(a);
+        let b = flexible_timestamp_to_duration(b);
+
+        let a = a.as_micros() as u64;
+        let b = b.as_micros() as u64;
+
+        let diff = if a > b { a - b } else { b - a };
+        diff <= tolerance.as_micros() as u64
+    }
 }
 
 impl pb::SeqV {
@@ -59,6 +83,16 @@ impl pb::SeqV {
 
     pub fn seq(&self) -> u64 {
         self.seq
+    }
+
+    pub fn close_to(&self, other: &Self, tolerance: Duration) -> bool {
+        self.seq == other.seq
+            && self.data == other.data
+            && match (&self.meta, &other.meta) {
+                (Some(meta), Some(other_meta)) => meta.close_to(other_meta, tolerance),
+                (None, None) => true,
+                _ => false,
+            }
     }
 }
 
@@ -86,5 +120,27 @@ impl From<pb::SeqV> for SeqV {
 impl MatchSeqExt<pb::SeqV> for MatchSeq {
     fn match_seq(&self, sv: &pb::SeqV) -> Result<(), ConflictSeq> {
         self.match_seq(&sv.seq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_close_to() {
+        let e1 = pb::SeqV::with_meta(1, Some(pb::KvMeta::new_expire(1723102819)), b"".to_vec());
+        let e2 = pb::SeqV::with_meta(1, Some(pb::KvMeta::new_expire(1723102818)), b"".to_vec());
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        let e1 = pb::SeqV::with_meta(1, Some(pb::KvMeta::new_expire(1723102819)), b"".to_vec());
+        let e2 = pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102820_000)),
+            b"".to_vec(),
+        );
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
     }
 }

--- a/src/meta/types/src/proto_ext/seq_v_ext.rs
+++ b/src/meta/types/src/proto_ext/seq_v_ext.rs
@@ -23,7 +23,7 @@ use crate::seq_value::SeqV;
 impl From<KVMeta> for pb::KvMeta {
     fn from(m: KVMeta) -> Self {
         Self {
-            expire_at: m.get_expire_at_ms().map(|x| x / 1000),
+            expire_at: m.expire_at,
         }
     }
 }

--- a/src/meta/types/src/proto_ext/seq_v_ext.rs
+++ b/src/meta/types/src/proto_ext/seq_v_ext.rs
@@ -137,7 +137,7 @@ mod tests {
         let e1 = pb::SeqV::with_meta(1, Some(pb::KvMeta::new_expire(1723102819)), b"".to_vec());
         let e2 = pb::SeqV::with_meta(
             1,
-            Some(pb::KvMeta::new_expire(1723102820_000)),
+            Some(pb::KvMeta::new_expire(1_723_102_820_000)),
             b"".to_vec(),
         );
 

--- a/src/meta/types/src/proto_ext/watch_ext.rs
+++ b/src/meta/types/src/proto_ext/watch_ext.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod event_ext;
+
 use crate::protobuf as pb;
 use crate::protobuf::watch_request::FilterType;
 use crate::protobuf::WatchRequest;

--- a/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
+++ b/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
@@ -45,7 +45,7 @@ impl pb::Event {
 
         match (&self.prev, &other.prev) {
             (Some(prev), Some(other_prev)) => {
-                if !prev.close_to(&other_prev, tolerance) {
+                if !prev.close_to(other_prev, tolerance) {
                     return false;
                 }
             }
@@ -55,7 +55,7 @@ impl pb::Event {
 
         match (&self.current, &other.current) {
             (Some(current), Some(other_current)) => {
-                if !current.close_to(&other_current, tolerance) {
+                if !current.close_to(other_current, tolerance) {
                     return false;
                 }
             }
@@ -213,7 +213,7 @@ mod tests {
             ))
             .with_current(pb::SeqV::with_meta(
                 1,
-                Some(pb::KvMeta::new_expire(1723102821_000)),
+                Some(pb::KvMeta::new_expire(1_723_102_821_000)),
                 b"".to_vec(),
             ));
 

--- a/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
+++ b/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
@@ -144,7 +144,7 @@ mod tests {
         ));
         let e2 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
             1,
-            Some(pb::KvMeta::new_expire(1723102820_000)),
+            Some(pb::KvMeta::new_expire(1_723_102_820_000)),
             b"".to_vec(),
         ));
 
@@ -159,7 +159,7 @@ mod tests {
         ));
         let e2 = pb::Event::new("k1").with_current(pb::SeqV::with_meta(
             1,
-            Some(pb::KvMeta::new_expire(1723102820_000)),
+            Some(pb::KvMeta::new_expire(1_723_102_820_000)),
             b"".to_vec(),
         ));
 
@@ -186,7 +186,7 @@ mod tests {
             ))
             .with_current(pb::SeqV::with_meta(
                 1,
-                Some(pb::KvMeta::new_expire(1723102820_000)),
+                Some(pb::KvMeta::new_expire(1_723_102_820_000)),
                 b"".to_vec(),
             ));
 

--- a/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
+++ b/src/meta/types/src/proto_ext/watch_ext/event_ext.rs
@@ -1,0 +1,222 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::time::Duration;
+
+use display_more::DisplayOptionExt;
+
+use crate::protobuf as pb;
+
+impl pb::Event {
+    pub fn new(key: impl ToString) -> Self {
+        pb::Event {
+            key: key.to_string(),
+            prev: None,
+            current: None,
+        }
+    }
+
+    pub fn with_prev(mut self, prev: pb::SeqV) -> Self {
+        self.prev = Some(prev);
+        self
+    }
+
+    pub fn with_current(mut self, current: pb::SeqV) -> Self {
+        self.current = Some(current);
+        self
+    }
+
+    pub fn close_to(&self, other: &Self, tolerance: Duration) -> bool {
+        if self.key != other.key {
+            return false;
+        }
+
+        match (&self.prev, &other.prev) {
+            (Some(prev), Some(other_prev)) => {
+                if !prev.close_to(&other_prev, tolerance) {
+                    return false;
+                }
+            }
+            (None, None) => {}
+            _ => return false,
+        }
+
+        match (&self.current, &other.current) {
+            (Some(current), Some(other_current)) => {
+                if !current.close_to(&other_current, tolerance) {
+                    return false;
+                }
+            }
+            (None, None) => {}
+            _ => return false,
+        }
+
+        true
+    }
+}
+
+impl fmt::Display for pb::Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "({}: {} -> {})",
+            self.key,
+            self.prev.display(),
+            self.current.display()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_display() {
+        let event = pb::Event {
+            key: "test_key".to_string(),
+            prev: Some(pb::SeqV {
+                seq: 1,
+                data: "test_prev".as_bytes().to_vec(),
+                meta: Some(pb::KvMeta {
+                    expire_at: Some(1723102819),
+                }),
+            }),
+            current: Some(pb::SeqV {
+                seq: 2,
+                data: "test_current".as_bytes().to_vec(),
+                meta: None,
+            }),
+        };
+        assert_eq!(event.to_string(), "(test_key: (seq=1 [expire=2024-08-08T07:40:19.000] 'test_prev') -> (seq=2 [] 'test_current'))");
+    }
+
+    #[test]
+    fn test_event_close_to() {
+        // prev.expire diff -1s
+
+        let e1 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102819)),
+            b"".to_vec(),
+        ));
+        let e2 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102818)),
+            b"".to_vec(),
+        ));
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        // prev.expire diff +1s
+
+        let e1 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102819)),
+            b"".to_vec(),
+        ));
+        let e2 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102820)),
+            b"".to_vec(),
+        ));
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        // prev.expire diff +1000 millis
+
+        let e1 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102819)),
+            b"".to_vec(),
+        ));
+        let e2 = pb::Event::new("k1").with_prev(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102820_000)),
+            b"".to_vec(),
+        ));
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        // current.expire diff +1000 millis
+
+        let e1 = pb::Event::new("k1").with_current(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102819)),
+            b"".to_vec(),
+        ));
+        let e2 = pb::Event::new("k1").with_current(pb::SeqV::with_meta(
+            1,
+            Some(pb::KvMeta::new_expire(1723102820_000)),
+            b"".to_vec(),
+        ));
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        // prev and current.expire diff +1000 millis
+
+        let e1 = pb::Event::new("k1")
+            .with_prev(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1823102819)),
+                b"".to_vec(),
+            ))
+            .with_current(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1723102819)),
+                b"".to_vec(),
+            ));
+        let e2 = pb::Event::new("k1")
+            .with_prev(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1823102818)),
+                b"".to_vec(),
+            ))
+            .with_current(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1723102820_000)),
+                b"".to_vec(),
+            ));
+
+        assert!(e1.close_to(&e2, Duration::from_secs(1)));
+
+        // prev diff 1s current.expire diff +2000 millis
+
+        let e1 = pb::Event::new("k1")
+            .with_prev(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1823102819)),
+                b"".to_vec(),
+            ))
+            .with_current(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1723102819)),
+                b"".to_vec(),
+            ));
+        let e2 = pb::Event::new("k1")
+            .with_prev(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1823102818)),
+                b"".to_vec(),
+            ))
+            .with_current(pb::SeqV::with_meta(
+                1,
+                Some(pb::KvMeta::new_expire(1723102821_000)),
+                b"".to_vec(),
+            ));
+
+        assert!(!e1.close_to(&e2, Duration::from_secs(1)));
+    }
+}

--- a/src/meta/types/src/seq_value/kv_meta.rs
+++ b/src/meta/types/src/seq_value/kv_meta.rs
@@ -20,7 +20,7 @@ use map_api::expirable::Expirable;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::adaptable_timestamp_to_duration;
+use crate::flexible_timestamp_to_duration;
 
 /// The meta data of a record in kv
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
@@ -61,12 +61,12 @@ impl KVMeta {
 
     pub fn expires_at_sec_opt(&self) -> Option<u64> {
         self.expire_at
-            .map(|x| adaptable_timestamp_to_duration(x).as_secs())
+            .map(|x| flexible_timestamp_to_duration(x).as_secs())
     }
 
     /// Return the absolute expire time in since 1970-01-01 00:00:00.
     pub fn expires_at_duration_opt(&self) -> Option<Duration> {
-        self.expire_at.map(adaptable_timestamp_to_duration)
+        self.expire_at.map(flexible_timestamp_to_duration)
     }
 }
 

--- a/src/meta/types/src/seq_value/kv_meta.rs
+++ b/src/meta/types/src/seq_value/kv_meta.rs
@@ -13,41 +13,71 @@
 // limitations under the License.
 
 use std::fmt;
+use std::time::Duration;
 
+use display_more::DisplayUnixTimeStampExt;
 use map_api::expirable::Expirable;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::adaptable_timestamp_to_duration;
+
 /// The meta data of a record in kv
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 pub struct KVMeta {
-    /// expiration time in second since 1970
+    /// Expiration time in **seconds or milliseconds** since Unix epoch (1970-01-01).
+    ///
+    /// The interpretation depends on the magnitude of the value:
+    /// - Values > `100_000_000_000`: treated as milliseconds since epoch
+    /// - Values ≤ `100_000_000_000`: treated as seconds since epoch
+    ///
+    /// See [`adaptable_timestamp_to_duration`]
     pub(crate) expire_at: Option<u64>,
 }
 
 impl KVMeta {
-    /// Create a new KVMeta
-    pub fn new(expire_at: Option<u64>) -> Self {
-        Self { expire_at }
+    /// Create a new KVMeta.
+    ///
+    /// `expire_at_sec_or_ms` can be either seconds or milliseconds.
+    pub fn new(expire_at_sec_or_ms: Option<u64>) -> Self {
+        Self {
+            expire_at: expire_at_sec_or_ms,
+        }
     }
 
-    /// Create a KVMeta with a absolute expiration time in second since 1970-01-01.
-    pub fn new_expire(expire_at: u64) -> Self {
+    /// Create a KVMeta with an absolute expiration time since 1970-01-01.
+    ///
+    /// `expires_at_sec_or_ms` can be either seconds or milliseconds.
+    pub fn new_expires_at(expires_at_sec_or_ms: u64) -> Self {
         Self {
-            expire_at: Some(expire_at),
+            expire_at: Some(expires_at_sec_or_ms),
         }
     }
 
     /// Returns expire time in millisecond since 1970.
     pub fn get_expire_at_ms(&self) -> Option<u64> {
-        self.expire_at.map(|t| t * 1000)
+        self.expires_at_duration_opt().map(|d| d.as_millis() as u64)
+    }
+
+    pub fn expires_at_sec_opt(&self) -> Option<u64> {
+        self.expire_at
+            .map(|x| adaptable_timestamp_to_duration(x).as_secs())
+    }
+
+    /// Return the absolute expire time in since 1970-01-01 00:00:00.
+    pub fn expires_at_duration_opt(&self) -> Option<Duration> {
+        self.expire_at.map(adaptable_timestamp_to_duration)
     }
 }
 
 impl fmt::Display for KVMeta {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.expire_at {
-            Some(expire_at) => write!(f, "(expire_at: {})", expire_at),
+        match self.expires_at_duration_opt() {
+            Some(expire_at) => write!(
+                f,
+                "(expires_at: {})",
+                expire_at.display_unix_timestamp_short()
+            ),
             None => write!(f, "()"),
         }
     }
@@ -55,6 +85,56 @@ impl fmt::Display for KVMeta {
 
 impl Expirable for KVMeta {
     fn expires_at_ms_opt(&self) -> Option<u64> {
-        self.expire_at.map(|t| t * 1000)
+        self.expires_at_duration_opt().map(|d| d.as_millis() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kv_meta_expirable_trait() {
+        let kv_meta = KVMeta::new(Some(100_000_000_000));
+        assert_eq!(kv_meta.expires_at_ms_opt(), Some(100_000_000_000_000));
+
+        let kv_meta = KVMeta::new(Some(100_000_000_001));
+        assert_eq!(kv_meta.expires_at_ms_opt(), Some(100_000_000_001));
+    }
+
+    #[test]
+    fn test_kv_meta_method_get_expire_at_ms() {
+        let kv_meta = KVMeta::new(Some(100_000_000_000));
+        assert_eq!(kv_meta.get_expire_at_ms(), Some(100_000_000_000_000));
+
+        let kv_meta = KVMeta::new(Some(100_000_000_001));
+        assert_eq!(kv_meta.get_expire_at_ms(), Some(100_000_000_001));
+    }
+
+    #[test]
+    fn test_kv_meta_method_expires_at_duration() {
+        let kv_meta = KVMeta::new(Some(100_000_000_000));
+        assert_eq!(
+            kv_meta.expires_at_duration_opt(),
+            Some(Duration::from_secs(100_000_000_000))
+        );
+
+        let kv_meta = KVMeta::new(Some(100_000_000_001));
+        assert_eq!(
+            kv_meta.expires_at_duration_opt(),
+            Some(Duration::from_millis(100_000_000_001))
+        );
+    }
+
+    #[test]
+    fn test_kv_meta_display() {
+        let kv_meta = KVMeta::new(Some(100_000_000_000));
+        assert_eq!(kv_meta.to_string(), "(expires_at: 5138-11-16T09:46:40.000)");
+
+        let kv_meta = KVMeta::new(Some(100_000_000_001));
+        assert_eq!(kv_meta.to_string(), "(expires_at: 1973-03-03T09:46:40.001)");
+
+        let kv_meta = KVMeta::new(None);
+        assert_eq!(kv_meta.to_string(), "()");
     }
 }

--- a/src/meta/types/src/time.rs
+++ b/src/meta/types/src/time.rs
@@ -169,7 +169,7 @@ impl Sub for Time {
 ///
 /// To avoid overflow issues, use timestamps between `1973-03-03 17:46:40`
 /// and `5138-11-16 17:46:40` for reliable behavior across both interpretations.
-pub fn adaptable_timestamp_to_duration(timestamp: u64) -> Duration {
+pub fn flexible_timestamp_to_duration(timestamp: u64) -> Duration {
     if timestamp > 100_000_000_000 {
         // Milliseconds since epoch
         Duration::from_millis(timestamp)
@@ -220,11 +220,11 @@ mod tests {
     #[test]
     fn test_adaptable_timestamp_to_duration() {
         assert_eq!(
-            adaptable_timestamp_to_duration(100_000_000_001),
+            flexible_timestamp_to_duration(100_000_000_001),
             Duration::from_millis(100_000_000_001)
         );
         assert_eq!(
-            adaptable_timestamp_to_duration(100_000_000_000),
+            flexible_timestamp_to_duration(100_000_000_000),
             Duration::from_secs(100_000_000_000)
         );
     }

--- a/src/meta/types/src/time.rs
+++ b/src/meta/types/src/time.rs
@@ -153,10 +153,35 @@ impl Sub for Time {
     }
 }
 
+/// Timestamp in **seconds or milliseconds** since Unix epoch (1970-01-01).
+///
+/// The interpretation depends on the magnitude of the value:
+/// - Values > `100_000_000_000`: treated as milliseconds since epoch
+/// - Values ≤ `100_000_000_000`: treated as seconds since epoch
+///
+/// Examples:
+/// - `100_000_000_001` → `1973-03-03 17:46:40` (milliseconds)
+/// - `100_000_000_000` → `5138-11-16 17:46:40` (seconds)
+///
+/// Valid ranges:
+/// - Seconds: `1970-01-01 00:00:00` to `5138-11-16 17:46:40`
+/// - Milliseconds: `1973-03-03 17:46:40` onwards
+///
+/// To avoid overflow issues, use timestamps between `1973-03-03 17:46:40`
+/// and `5138-11-16 17:46:40` for reliable behavior across both interpretations.
+pub fn adaptable_timestamp_to_duration(timestamp: u64) -> Duration {
+    if timestamp > 100_000_000_000 {
+        // Milliseconds since epoch
+        Duration::from_millis(timestamp)
+    } else {
+        // Seconds since epoch
+        Duration::from_secs(timestamp)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Interval;
-    use crate::time::Time;
+    use super::*;
 
     #[test]
     fn test_interval() {
@@ -190,5 +215,17 @@ mod tests {
         assert_eq!(time - Interval::from_millis(500), Time::from_millis(500));
         assert_eq!(time - Time::from_millis(500), Interval::from_millis(500));
         assert_eq!(time - Time::from_millis(1500), Interval::from_millis(0));
+    }
+
+    #[test]
+    fn test_adaptable_timestamp_to_duration() {
+        assert_eq!(
+            adaptable_timestamp_to_duration(100_000_000_001),
+            Duration::from_millis(100_000_000_001)
+        );
+        assert_eq!(
+            adaptable_timestamp_to_duration(100_000_000_000),
+            Duration::from_secs(100_000_000_000)
+        );
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): Add millisecond precision for expiration times

Extend expiration time support to accept both seconds and milliseconds
while maintaining backward compatibility. The meta-service now stores
both time formats in the existing `expire_at` field and automatically
detects the format based on value magnitude.

Detection logic:
- Values > 100_000_000_000 are treated as milliseconds
- Values ≤ 100_000_000_000 are treated as seconds

This threshold corresponds to timestamps after ~1973, ensuring reliable
differentiation between the two formats while supporting both legacy
second-based expiration times and new millisecond-precision requirements.

This is a non-breaking change that maintains full backward compatibility
with existing configurations using second-based expiration times.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18303)
<!-- Reviewable:end -->
