### PR TITLE
fix(query): attach table should not collect statistics in system.columns

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -960,6 +960,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_collect_column_statistics", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Collect column statistic in system.columns(enable by default).",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("enable_expand_roles", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Enable expand roles when execute show grants statement(enable by default).",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -548,6 +548,10 @@ impl Settings {
         Ok(self.try_get_u64("enable_experimental_rbac_check")? != 0)
     }
 
+    pub fn get_enable_collect_column_statistics(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_collect_column_statistics")? != 0)
+    }
+
     pub fn get_enable_expand_roles(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_expand_roles")? != 0)
     }

--- a/src/query/storages/system/src/columns_table.rs
+++ b/src/query/storages/system/src/columns_table.rs
@@ -19,6 +19,7 @@ use databend_common_catalog::catalog::CatalogManager;
 use databend_common_catalog::catalog_kind::CATALOG_DEFAULT;
 use databend_common_catalog::database::Database;
 use databend_common_catalog::plan::PushDownInfo;
+use databend_common_catalog::table::DummyColumnStatisticsProvider;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
@@ -40,6 +41,7 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_sql::Planner;
+use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_stream::stream_table::StreamTable;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_storages_view::view_table::QUERY;
@@ -271,10 +273,7 @@ impl ColumnsTable {
                     _ => {
                         let schema = table.schema();
                         let field_comments = table.field_comments();
-                        let columns_statistics =
-                            table.column_statistics_provider(ctx.clone()).await?;
 
-                        let row_count = columns_statistics.num_rows();
                         for (idx, field) in schema.fields().iter().enumerate() {
                             let comment = if field_comments.len() == schema.fields.len()
                                 && !field_comments[idx].is_empty()
@@ -285,6 +284,33 @@ impl ColumnsTable {
                                 "".to_string()
                             };
 
+                            // attach table should not collect statistics, source table column already collect them.
+                            let columns_statistics = if ctx
+                                .get_settings()
+                                .get_enable_collect_column_statistics()?
+                                && !FuseTable::is_table_attached(
+                                    &table.get_table_info().meta.options,
+                                ) {
+                                table
+                                    .column_statistics_provider(ctx.clone())
+                                    .await
+                                    .unwrap_or_else(|e| {
+                                        let msg = format!(
+                                            "Collect {}.{}.{} column statistics with error: {}",
+                                            catalog.name(),
+                                            database,
+                                            table.name(),
+                                            e
+                                        );
+                                        warn!("{}", msg);
+                                        ctx.push_warning(msg);
+                                        Box::new(DummyColumnStatisticsProvider)
+                                    })
+                            } else {
+                                Box::new(DummyColumnStatisticsProvider)
+                            };
+
+                            let row_count = columns_statistics.num_rows();
                             let column_statistics =
                                 columns_statistics.column_statistics(field.column_id);
                             rows.push(TableColumnInfo {

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -30,6 +30,8 @@ storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in
 
 comment "attaching table"
 echo "attach table table_to 's3://testbucket/admin/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+# If failed will return err msg. Expect it success.
+echo "select * from system.columns where table='table_to' ignore_result;" | $BENDSQL_CLIENT_CONNECT
 echo "attach table table_to2 's3://testbucket/admin/data/$storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


**Solution:**

1.  **Disable Column Statistics Collection for Attached Tables by Default:** To improve `system.columns` query performance and prevent collecting statistics based on potentially inaccurate snapshots, we will, by default, disable column statistics collection for attached tables.
2.  **Introduce New Setting `enable_collect_column_statistics`:** This new setting provides granular control over column statistics collection behavior.
    *   **Default Value:** `1` (enables statistics collection, but attached tables remain subject to the aforementioned restriction).
    *   **Disable:** Setting it to `0` will completely stop column statistics collection for all tables within `system.columns` (including non-attached tables), further boosting performance.
    *   **Configuration:** `SET GLOBAL enable_collect_column_statistics = [0|1];`



<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18310)
<!-- Reviewable:end -->
