### PR TITLE
fix(query): to_string(DateColumn, format) should success if date = 9999-12-31

### DIFF
--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -1143,6 +1143,19 @@ select to_date('9999-12-31','%Y-%m-%d');
 ----
 9999-12-31
 
+statement ok
+create or replace table t(c1 date);
+
+statement ok
+insert into t values('9999-12-31');
+
+query T
+select to_string(c1, '%Y'),c1 from t;
+----
+9999 9999-12-31
+
+statement ok
+drop table if exists t;
 
 statement ok
 set timezone='America/Los_Angeles';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. in calc_date_to_timestamp if the date's tomorrow or yesterday can not be calc directly calc ts with offset.

### Example

select * from t;

╭────────────────╮
│       c1       │
│ Nullable(Date) │
├────────────────┤
│ 9999-12-31     │
╰────────────────╯
1 row read in 0.044 sec. Processed 1 row, 5 B (22.73 rows/s, 113 B/s)

In main:
```
root@localhost:8000/default/default> select to_string(c1,'%Y') from t;
error: APIError: QueryFailed: [1006]Calc tomorrow midnight with error parameter 'year' with value 1 is not in the required range of -9999..=9999 while evaluating function `to_timestamp('9999-12-31')` in expr `CAST(t.c1 (#0) AS Timestamp NULL)`, during run expr: `to_string(CAST(t.c1 (#0) AS Timestamp NULL), '%Y')`
```

In pr:

```
select to_string(c,'%Y') from t;

╭────────────────────╮
│ to_string(c, '%Y') │
│  Nullable(String)  │
├────────────────────┤
│ 9999               │
╰────────────────────╯
```

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

- fixes: #18320
- 
## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18321)
<!-- Reviewable:end -->
