### PR TITLE
refactor(meta-service): upgrade snapshot storage(rotbl)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13058,18 +13058,18 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751d6483053228f9e4102fb1e3054ac727b3bde446c4abf02663220cd1bab332"
+checksum = "c41ec40750140065f1a499e159781712b5688a84600fafc6708ee1101037596e"
 dependencies = [
- "anyhow",
  "bincode 2.0.1",
  "byteorder",
  "bytes",
  "clap",
- "crc32fast",
+ "codeq",
  "futures",
  "futures-async-stream",
+ "log",
  "lru-cache-map",
  "num-format",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,7 +464,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.1.2", features = [] }
+rotbl = { version = "0.2.1", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }

--- a/src/meta/raft-store/src/leveled_store/db_builder.rs
+++ b/src/meta/raft-store/src/leveled_store/db_builder.rs
@@ -22,6 +22,7 @@ use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::sys_data::SysData;
 use futures::Stream;
 use futures_util::TryStreamExt;
+use rotbl::storage::impls::fs::FsStorage;
 use rotbl::v001::Rotbl;
 use rotbl::v001::RotblMeta;
 use rotbl::v001::SeqMarked;
@@ -31,37 +32,32 @@ use crate::leveled_store::leveled_map::LeveledMap;
 /// Builds a snapshot from series of key-value in `(String, SeqMarked)`
 pub(crate) struct DBBuilder {
     path: String,
-    rotbl_builder: rotbl::v001::Builder,
+    rotbl_builder: rotbl::v001::Builder<FsStorage>,
 }
 
 impl DBBuilder {
     pub fn new<P: AsRef<Path>>(
-        path: P,
+        storage_path: P,
+        rel_path: &str,
         rotbl_config: rotbl::v001::Config,
     ) -> Result<Self, io::Error> {
-        let p = path.as_ref().to_str().ok_or_else(|| {
+        let storage = FsStorage::new(storage_path.as_ref().to_path_buf());
+
+        let base_path = storage_path.as_ref().to_str().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("invalid path: {:?}", path.as_ref()),
+                format!("invalid path: {:?}", storage_path.as_ref()),
             )
         })?;
 
-        let inner = rotbl::v001::Builder::new(rotbl_config, path.as_ref())?;
+        let inner = rotbl::v001::Builder::new(storage, rotbl_config, rel_path)?;
 
         let b = Self {
-            path: p.to_string(),
+            path: format!("{}/{}", base_path, rel_path),
             rotbl_builder: inner,
         };
 
         Ok(b)
-    }
-
-    /// This method is only used for test.
-    #[allow(dead_code)]
-    pub fn new_with_default_config<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
-        let mut config = rotbl::v001::Config::default();
-        config.fill_default_values();
-        Self::new(path, config)
     }
 
     /// Append a key-value pair to the builder, the keys must be sorted.

--- a/src/meta/raft-store/src/leveled_store/db_builder.rs
+++ b/src/meta/raft-store/src/leveled_store/db_builder.rs
@@ -31,7 +31,8 @@ use crate::leveled_store::leveled_map::LeveledMap;
 
 /// Builds a snapshot from series of key-value in `(String, SeqMarked)`
 pub(crate) struct DBBuilder {
-    path: String,
+    storage_path: String,
+    rel_path: String,
     rotbl_builder: rotbl::v001::Builder<FsStorage>,
 }
 
@@ -50,10 +51,13 @@ impl DBBuilder {
             )
         })?;
 
-        let inner = rotbl::v001::Builder::new(storage, rotbl_config, rel_path)?;
+        let rel_path = rel_path.to_string();
+
+        let inner = rotbl::v001::Builder::new(storage, rotbl_config, &rel_path)?;
 
         let b = Self {
-            path: format!("{}/{}", base_path, rel_path),
+            storage_path: base_path.to_string(),
+            rel_path,
             rotbl_builder: inner,
         };
 
@@ -78,8 +82,11 @@ impl DBBuilder {
         Ok(())
     }
 
-    /// Flush the data to disk and return a read-only table [`Rotbl`] instance.
-    pub fn flush(self, sys_data: SysData) -> Result<(String, Rotbl), io::Error> {
+    /// Flush the data to disk and return:
+    /// - storage path,
+    /// - relative path of the db,
+    /// - and a read-only table [`Rotbl`] instance.
+    pub fn flush(self, sys_data: SysData) -> Result<(String, String, Rotbl), io::Error> {
         let meta = serde_json::to_string(&sys_data).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -91,7 +98,7 @@ impl DBBuilder {
         let rotbl_meta = RotblMeta::new(0, meta);
 
         let r = self.rotbl_builder.commit(rotbl_meta)?;
-        Ok((self.path, r))
+        Ok((self.storage_path, self.rel_path, r))
     }
 
     /// Build a [`DB`] from a leveled map.
@@ -112,8 +119,8 @@ impl DBBuilder {
         self.append_kv_stream(strm).await?;
 
         let snapshot_id = make_snapshot_id(&sys_data);
-        let (path, r) = self.flush(sys_data)?;
-        let db = DB::new(path, snapshot_id, Arc::new(r))?;
+        let (storage_path, rel_path, r) = self.flush(sys_data)?;
+        let db = DB::new(storage_path, rel_path, snapshot_id, Arc::new(r))?;
 
         Ok(db)
     }

--- a/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
+++ b/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
@@ -57,9 +57,8 @@ async fn test_db_map_api_ro() -> anyhow::Result<()> {
 
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path();
-        let path = path.join("temp-db");
 
-        let db_builder = DBBuilder::new_with_default_config(path)?;
+        let db_builder = DBBuilder::new(path, "temp-db", rotbl::v001::Config::default())?;
         db_builder
             .build_from_leveled_map(lm, |_| "1-1-1-1".to_string())
             .await?

--- a/src/meta/raft-store/src/leveled_store/db_open_snapshot_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/db_open_snapshot_impl.rs
@@ -42,7 +42,7 @@ impl OpenSnapshot for DB {
 
         info!("Opened snapshot at {storage_path}/{rel_path}");
 
-        let db = Self::new(storage_path, snapshot_id, Arc::new(r))?;
+        let db = Self::new(storage_path, rel_path, snapshot_id, Arc::new(r))?;
         Ok(db)
     }
 }

--- a/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
@@ -156,8 +156,12 @@ async fn test_compact() -> anyhow::Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let path = temp_dir.path();
-    let path = path.join("temp-compacted");
-    compact(&mut lm, path.as_os_str().to_str().unwrap()).await?;
+    compact(
+        &mut lm,
+        path.as_os_str().to_str().unwrap(),
+        "temp-compacted",
+    )
+    .await?;
 
     let db = lm.persisted().unwrap();
 
@@ -208,8 +212,12 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
     let temp_dir = tempfile::tempdir()?;
     let path = temp_dir.path();
-    let path = path.join("temp-compacted");
-    compact(&mut lm, path.as_os_str().to_str().unwrap()).await?;
+    compact(
+        &mut lm,
+        path.as_os_str().to_str().unwrap(),
+        "temp-compacted",
+    )
+    .await?;
 
     let db = lm.persisted().unwrap();
 
@@ -359,8 +367,7 @@ async fn build_3_levels() -> anyhow::Result<(LeveledMap, impl Drop)> {
     // Move the bottom level to db
     let temp_dir = tempfile::tempdir()?;
     let path = temp_dir.path();
-    let path = path.join("temp-db");
-    move_bottom_to_db(&mut lm, path.to_str().unwrap()).await?;
+    move_bottom_to_db(&mut lm, path.to_str().unwrap(), "temp-db").await?;
 
     Ok((lm, temp_dir))
 }
@@ -393,13 +400,16 @@ async fn build_sm_with_expire() -> anyhow::Result<(SMV003, impl Drop)> {
 
     let temp_dir = tempfile::tempdir()?;
     let path = temp_dir.path();
-    let path = path.join("temp-db");
-    move_bottom_to_db(lm, path.to_str().unwrap()).await?;
+    move_bottom_to_db(lm, path.to_str().unwrap(), "temp-db").await?;
     Ok((sm, temp_dir))
 }
 
 /// Build a DB from the bottom level of the immutable levels.
-async fn move_bottom_to_db(lm: &mut LeveledMap, path: &str) -> Result<(), io::Error> {
+async fn move_bottom_to_db(
+    lm: &mut LeveledMap,
+    base_path: &str,
+    rel_path: &str,
+) -> Result<(), io::Error> {
     let mut immutables = lm.immutable_levels_ref().clone();
     let bottom = immutables.levels().remove(0);
     lm.replace_immutable_levels(immutables);
@@ -408,14 +418,14 @@ async fn move_bottom_to_db(lm: &mut LeveledMap, path: &str) -> Result<(), io::Er
     let mut lm2 = LeveledMap::default();
     lm2.replace_immutable_levels(bottom);
 
-    compact(&mut lm2, path).await?;
+    compact(&mut lm2, base_path, rel_path).await?;
 
     *lm.persisted_mut() = lm2.persisted_mut().clone();
     Ok(())
 }
 
-async fn compact(lm: &mut LeveledMap, path: &str) -> Result<(), io::Error> {
-    let db_builder = DBBuilder::new_with_default_config(path)?;
+async fn compact(lm: &mut LeveledMap, base_path: &str, rel_path: &str) -> Result<(), io::Error> {
+    let db_builder = DBBuilder::new(base_path, rel_path, rotbl::v001::Config::default())?;
 
     let db = db_builder
         .build_from_leveled_map(lm, |_sys_data| "1-1-1-1.snap".to_string())

--- a/src/meta/raft-store/src/sm_v003/open_snapshot.rs
+++ b/src/meta/raft-store/src/sm_v003/open_snapshot.rs
@@ -18,8 +18,10 @@ use crate::config::RaftConfig;
 
 /// A trait for opening a snapshot.
 pub trait OpenSnapshot {
+    /// Open a snapshot at `<storage_path>/<rel_path>`
     fn open_snapshot(
-        path: impl ToString,
+        storage_path: impl ToString,
+        rel_path: impl ToString,
         snapshot_id: SnapshotId,
         raft_config: &RaftConfig,
     ) -> Result<Self, std::io::Error>

--- a/src/meta/raft-store/src/sm_v003/received.rs
+++ b/src/meta/raft-store/src/sm_v003/received.rs
@@ -23,7 +23,9 @@ pub struct Received {
     pub format: String,
     pub vote: Vote,
     pub snapshot_meta: SnapshotMeta,
-    pub temp_path: String,
+
+    pub storage_path: String,
+    pub temp_rel_path: String,
 
     pub remote_addr: String,
 

--- a/src/meta/raft-store/src/sm_v003/receiver_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/receiver_v003.rs
@@ -58,7 +58,7 @@ impl ReceiverV003 {
         temp_f: File,
     ) -> Self {
         let remote_addr = remote_addr.to_string();
-        info!("Begin receiving snapshot v2 stream from: {}", remote_addr);
+        info!("Begin receiving snapshot v003 stream from: {}", remote_addr);
 
         ReceiverV003 {
             remote_addr,

--- a/src/meta/raft-store/src/sm_v003/receiver_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/receiver_v003.rs
@@ -33,7 +33,9 @@ use crate::sm_v003::received::Received;
 pub struct ReceiverV003 {
     remote_addr: String,
 
-    temp_path: String,
+    storage_path: String,
+
+    temp_rel_path: String,
 
     temp_file: Option<BufWriter<File>>,
 
@@ -49,13 +51,19 @@ pub struct ReceiverV003 {
 
 impl ReceiverV003 {
     /// Create a new snapshot receiver with an empty snapshot.
-    pub(crate) fn new(remote_addr: impl ToString, temp_path: impl ToString, temp_f: File) -> Self {
+    pub(crate) fn new(
+        remote_addr: impl ToString,
+        storage_path: impl ToString,
+        temp_rel_path: impl ToString,
+        temp_f: File,
+    ) -> Self {
         let remote_addr = remote_addr.to_string();
         info!("Begin receiving snapshot v2 stream from: {}", remote_addr);
 
         ReceiverV003 {
             remote_addr,
-            temp_path: temp_path.to_string(),
+            storage_path: storage_path.to_string(),
+            temp_rel_path: temp_rel_path.to_string(),
             temp_file: Some(BufWriter::with_capacity(64 * 1024 * 1024, temp_f)),
             on_recv: None,
             n_received: 0,
@@ -118,26 +126,25 @@ impl ReceiverV003 {
         chunk: SnapshotChunkRequestV003,
     ) -> Result<Option<Received>, io::Error> {
         let remote_addr = self.remote_addr.clone();
-        let temp_path = self.temp_path.clone();
 
         fn invalid_input<E>(e: E) -> io::Error
         where E: Into<Box<dyn std::error::Error + Send + Sync>> {
             io::Error::new(io::ErrorKind::InvalidInput, e)
         }
 
+        // 1. update stat
+        self.update_stat(&chunk);
+
         // Add context info to io::Error
         let ctx = |e: io::Error, context: &str| -> io::Error {
             io::Error::new(
                 e.kind(),
                 format!(
-                    "{} while:(ReceiverV003::receive(): {}; remote_addr: {}; temp_path: {})",
-                    e, context, remote_addr, temp_path
+                    "{} while:(ReceiverV003::receive(): {}; remote_addr: {}; temp_path: {}/{})",
+                    e, context, remote_addr, self.storage_path, self.temp_rel_path
                 ),
             )
         };
-
-        // 1. update stat
-        self.update_stat(&chunk);
 
         // 2. write chunk to local snapshot_data
         {
@@ -163,8 +170,8 @@ impl ReceiverV003 {
             };
 
             info!(
-                "snapshot from {} is completely received, format: {}, vote: {:?}, meta: {:?}, size: {}; path: {}",
-                self.remote_addr, format, vote, snapshot_meta, self.size_received, self.temp_path
+                "snapshot from {} is completely received, format: {}, vote: {:?}, meta: {:?}, size: {}; path: {}/{}",
+                self.remote_addr, format, vote, snapshot_meta, self.size_received, self.storage_path, self.temp_rel_path
             );
 
             if format != "rotbl::v001" {
@@ -198,7 +205,8 @@ impl ReceiverV003 {
                 format,
                 vote,
                 snapshot_meta,
-                temp_path: self.temp_path.clone(),
+                storage_path: self.storage_path.clone(),
+                temp_rel_path: self.temp_rel_path.clone(),
                 remote_addr: self.remote_addr.clone(),
                 n_received: self.n_received,
                 size_received: self.size_received,
@@ -214,15 +222,15 @@ impl ReceiverV003 {
         debug!(
             len = data_len,
             total_len = self.size_received;
-            "received {}-th snapshot chunk from {}; path: {}",
-            self.n_received, self.remote_addr, self.temp_path
+            "received {}-th snapshot chunk from {}; path: {}/{}",
+            self.n_received, self.remote_addr, self.storage_path, self.temp_rel_path
         );
 
         if self.n_received % 100 == 0 {
             info!(
                 total_len = self.size_received;
-                "received {}-th snapshot chunk from {}; path: {}",
-                self.n_received, self.remote_addr, self.temp_path
+                "received {}-th snapshot chunk from {}; path: {}/{}",
+                self.n_received, self.remote_addr, self.storage_path, self.temp_rel_path
             );
         }
 

--- a/src/meta/raft-store/src/sm_v003/snapshot_loader.rs
+++ b/src/meta/raft-store/src/sm_v003/snapshot_loader.rs
@@ -71,16 +71,17 @@ where SD: OpenSnapshot
             .ensure_snapshot_dir()
             .map_err(SnapshotStoreError::write)?;
 
-        let path = self.snapshot_config.snapshot_path(snapshot_id);
+        let (storage_path, rel_path) = self.snapshot_config.snapshot_dir_fn(snapshot_id);
 
         let d = SD::open_snapshot(
-            path.clone(),
+            storage_path.clone(),
+            rel_path,
             snapshot_id.clone(),
             self.snapshot_config.raft_config(),
         )
         .map_err(|e| {
-            error!("failed to open snapshot file({}): {}", path, e);
-            SnapshotStoreError::read(e).with_meta("opening snapshot file", path)
+            error!("failed to open snapshot file({}): {}", storage_path, e);
+            SnapshotStoreError::read(e).with_meta("opening snapshot file", storage_path)
         })?;
 
         Ok(d)

--- a/src/meta/raft-store/src/sm_v003/snapshot_store_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/snapshot_store_v003.rs
@@ -84,7 +84,8 @@ impl SnapshotStoreV004 {
     pub fn new_receiver(&self, remote_addr: impl ToString) -> Result<ReceiverV003, io::Error> {
         self.snapshot_config.ensure_snapshot_dir()?;
 
-        let temp_path = self.snapshot_config.snapshot_temp_path();
+        let (storage_path, temp_rel_path) = self.snapshot_config.snapshot_temp_dir_fn();
+        let temp_path = format!("{}/{}", storage_path, temp_rel_path);
 
         let f = fs::OpenOptions::new()
             .create_new(true)
@@ -99,7 +100,7 @@ impl SnapshotStoreV004 {
                 )
             })?;
 
-        let r = ReceiverV003::new(remote_addr, temp_path, f);
+        let r = ReceiverV003::new(remote_addr, storage_path, temp_rel_path, f);
         Ok(r)
     }
 

--- a/src/meta/raft-store/src/sm_v003/temp_snapshot_data.rs
+++ b/src/meta/raft-store/src/sm_v003/temp_snapshot_data.rs
@@ -25,7 +25,8 @@ use crate::snapshot_config::SnapshotConfig;
 
 /// A typed temporary snapshot data.
 pub struct TempSnapshotDataV003 {
-    path: String,
+    storage_path: String,
+    rel_path: String,
     snapshot_config: SnapshotConfig,
     inner: Arc<Rotbl>,
 }
@@ -39,18 +40,25 @@ impl Deref for TempSnapshotDataV003 {
 }
 
 impl TempSnapshotDataV003 {
-    pub fn new(path: impl ToString, snapshot_config: SnapshotConfig, r: Arc<Rotbl>) -> Self {
+    pub fn new(
+        storage_path: impl ToString,
+        rel_path: impl ToString,
+        snapshot_config: SnapshotConfig,
+        r: Arc<Rotbl>,
+    ) -> Self {
         Self {
-            path: path.to_string(),
+            storage_path: storage_path.to_string(),
+            rel_path: rel_path.to_string(),
             snapshot_config,
             inner: r,
         }
     }
 
     pub fn move_to_final_path(self, snapshot_id: SnapshotId) -> Result<DB, io::Error> {
+        let final_path = format!("{}/{}", self.storage_path, self.rel_path);
         let (storage_path, rel_path) = self
             .snapshot_config
-            .move_to_final_path(&self.path, snapshot_id.clone())?;
+            .move_to_final_path(&final_path, snapshot_id.clone())?;
 
         let db = DB::open_snapshot(
             storage_path,
@@ -61,7 +69,7 @@ impl TempSnapshotDataV003 {
         Ok(db)
     }
 
-    pub fn path(&self) -> &str {
-        &self.path
+    pub fn path(&self) -> String {
+        format!("{}/{}", self.storage_path, self.rel_path)
     }
 }

--- a/src/meta/raft-store/src/sm_v003/temp_snapshot_data.rs
+++ b/src/meta/raft-store/src/sm_v003/temp_snapshot_data.rs
@@ -48,11 +48,16 @@ impl TempSnapshotDataV003 {
     }
 
     pub fn move_to_final_path(self, snapshot_id: SnapshotId) -> Result<DB, io::Error> {
-        let final_path = self
+        let (storage_path, rel_path) = self
             .snapshot_config
             .move_to_final_path(&self.path, snapshot_id.clone())?;
 
-        let db = DB::open_snapshot(final_path, snapshot_id, self.snapshot_config.raft_config())?;
+        let db = DB::open_snapshot(
+            storage_path,
+            rel_path,
+            snapshot_id,
+            self.snapshot_config.raft_config(),
+        )?;
         Ok(db)
     }
 

--- a/src/meta/raft-store/src/sm_v003/writer_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/writer_v003.rs
@@ -122,8 +122,9 @@ impl WriterV003 {
     ///
     /// This method consumes the writer, thus the writer will not be used after commit.
     pub fn flush(self, sys_data: SysData) -> Result<TempSnapshotDataV003, io::Error> {
-        let (path, r) = self.db_builder.flush(sys_data)?;
-        let t = TempSnapshotDataV003::new(path, self.snapshot_config, Arc::new(r));
+        let (storage_path, rel_path, r) = self.db_builder.flush(sys_data)?;
+        let t =
+            TempSnapshotDataV003::new(storage_path, rel_path, self.snapshot_config, Arc::new(r));
         Ok(t)
     }
 

--- a/src/meta/raft-store/src/sm_v003/writer_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/writer_v003.rs
@@ -43,10 +43,11 @@ pub struct WriterV003 {
 impl WriterV003 {
     /// Create a singleton writer for the snapshot.
     pub fn new(snapshot_config: &SnapshotConfig) -> Result<Self, io::Error> {
-        let temp_path = snapshot_config.snapshot_temp_path();
+        let (storage_path, temp_rel_path) = snapshot_config.snapshot_temp_dir_fn();
 
         let db_builder = DBBuilder::new(
-            temp_path.clone(),
+            storage_path.clone(),
+            &temp_rel_path,
             snapshot_config.raft_config().to_rotbl_config(),
         )?;
 

--- a/src/meta/raft-store/src/snapshot_config.rs
+++ b/src/meta/raft-store/src/snapshot_config.rs
@@ -62,6 +62,11 @@ impl SnapshotConfig {
         )
     }
 
+    /// Return a two element tuple of snapshot dir and fn
+    pub fn snapshot_dir_fn(&self, snapshot_id: &SnapshotId) -> (String, String) {
+        (self.snapshot_dir(), Self::snapshot_fn(snapshot_id))
+    }
+
     pub fn snapshot_path(&self, snapshot_id: &SnapshotId) -> String {
         format!("{}/{}", self.snapshot_dir(), Self::snapshot_fn(snapshot_id))
     }
@@ -70,6 +75,14 @@ impl SnapshotConfig {
         format!("{}.snap", snapshot_id)
     }
 
+    // TODO: remvoe this
+    /// Return a two elements tuple of snapshot dir and temp fn
+    pub fn snapshot_temp_dir_fn(&self) -> (String, String) {
+        let temp_snapshot_id = self.temp_snapshot_id();
+        (self.snapshot_dir(), temp_snapshot_id)
+    }
+
+    // TODO: remvoe this
     pub fn snapshot_temp_path(&self) -> String {
         let temp_snapshot_id = self.temp_snapshot_id();
         format!("{}/{}", self.snapshot_dir(), temp_snapshot_id)
@@ -105,13 +118,14 @@ impl SnapshotConfig {
     ///
     /// So that it is visible and can be loaded.
     ///
-    /// It returns the final path.
+    /// It returns the final storage path and rel path.
     pub fn move_to_final_path(
         &self,
         temp_path: &str,
         snapshot_id: SnapshotId,
-    ) -> Result<String, io::Error> {
-        let final_path = self.snapshot_path(&snapshot_id);
+    ) -> Result<(String, String), io::Error> {
+        let (storage_path, rel_path) = self.snapshot_dir_fn(&snapshot_id);
+        let final_path = format!("{storage_path}/{rel_path}");
         fs::rename(temp_path, &final_path)?;
 
         info!(
@@ -119,7 +133,7 @@ impl SnapshotConfig {
             snapshot_id, final_path
         );
 
-        Ok(final_path)
+        Ok((storage_path, rel_path))
     }
 }
 

--- a/src/meta/raft-store/src/snapshot_config.rs
+++ b/src/meta/raft-store/src/snapshot_config.rs
@@ -126,6 +126,7 @@ impl SnapshotConfig {
     ) -> Result<(String, String), io::Error> {
         let (storage_path, rel_path) = self.snapshot_dir_fn(&snapshot_id);
         let final_path = format!("{storage_path}/{rel_path}");
+
         fs::rename(temp_path, &final_path)?;
 
         info!(

--- a/src/meta/service/src/meta_service/raft_service_impl.rs
+++ b/src/meta/service/src/meta_service/raft_service_impl.rs
@@ -82,19 +82,25 @@ impl RaftServiceImpl {
         let Received {
             vote: req_vote,
             snapshot_meta,
-            temp_path,
+            storage_path,
+            temp_rel_path,
             ..
         } = received;
 
         let raft_config = &self.meta_node.raft_store.config;
 
-        let db = DB::open_snapshot(&temp_path, snapshot_meta.snapshot_id.clone(), raft_config)
-            .map_err(|e| {
-                Status::internal(format!(
-                    "Fail to open snapshot: {:?}, snapshot_meta:{:?} path: {}",
-                    e, &snapshot_meta, temp_path
-                ))
-            })?;
+        let db = DB::open_snapshot(
+            &storage_path,
+            &temp_rel_path,
+            snapshot_meta.snapshot_id.clone(),
+            raft_config,
+        )
+        .map_err(|e| {
+            Status::internal(format!(
+                "Fail to open snapshot: {:?}, snapshot_meta:{:?} path: {}/{}",
+                e, &snapshot_meta, storage_path, temp_rel_path
+            ))
+        })?;
 
         let snapshot = Snapshot {
             meta: snapshot_meta,

--- a/src/meta/service/src/store/raft_state_machine_impl.rs
+++ b/src/meta/service/src/store/raft_state_machine_impl.rs
@@ -99,13 +99,18 @@ impl RaftStateMachine<TypeConfig> for RaftStore {
         let sig = meta.signature();
 
         let ss_store = SnapshotStoreV004::new(self.inner.config.clone());
-        let final_path = ss_store
+        let (storage_path, rel_path) = ss_store
             .snapshot_config()
             .move_to_final_path(&snapshot.path, meta.snapshot_id.clone())
             .map_err(|e| StorageError::write_snapshot(Some(sig.clone()), &e))?;
 
-        let db = DB::open_snapshot(final_path, meta.snapshot_id.clone(), &self.inner.config)
-            .map_err(|e| StorageError::read_snapshot(Some(sig.clone()), &e))?;
+        let db = DB::open_snapshot(
+            storage_path,
+            rel_path,
+            meta.snapshot_id.clone(),
+            &self.inner.config,
+        )
+        .map_err(|e| StorageError::read_snapshot(Some(sig.clone()), &e))?;
 
         info!("snapshot meta: {:?}", meta);
 

--- a/src/meta/service/src/store/raft_state_machine_impl.rs
+++ b/src/meta/service/src/store/raft_state_machine_impl.rs
@@ -101,7 +101,7 @@ impl RaftStateMachine<TypeConfig> for RaftStore {
         let ss_store = SnapshotStoreV004::new(self.inner.config.clone());
         let (storage_path, rel_path) = ss_store
             .snapshot_config()
-            .move_to_final_path(&snapshot.path, meta.snapshot_id.clone())
+            .move_to_final_path(&snapshot.path(), meta.snapshot_id.clone())
             .map_err(|e| StorageError::write_snapshot(Some(sig.clone()), &e))?;
 
         let db = DB::open_snapshot(


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service): upgrade snapshot storage(rotbl)

# `rotbl` crate Changelog

## Version 0.2.1

**What's Changed for Users:**

- **Storage is now pluggable** - You'll need to provide a storage instance when creating or opening Rotbl files. This change makes it possible to use different storage backends beyond just the filesystem
- **Codec functionality moved** - The encoding/decoding features have been moved to a separate `codeq` library, which means better code sharing across projects
- **Better async support** - Fixed thread safety issues so Rotbl works more reliably in async applications
- **Improved backwards compatibility** - Added extensive testing to ensure your existing data files will always work with newer versions

**New Capabilities:**

- **Flexible storage backends** - The new Storage trait means we can add support for cloud storage, databases, or other backends in the future
- **Better testing infrastructure** - Completely rebuilt our test system to work across different storage types
- **Runtime configuration** - Config values are now calculated when you need them rather than upfront, making the library more efficient

**What We Removed:**

- Some internal APIs that weren't being used
- Redundant configuration methods that were causing confusion

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18326)
<!-- Reviewable:end -->
