### PR TITLE
chore: remove materialized keyword for standard stream

### DIFF
--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -207,8 +207,8 @@ impl Display for CreateTableStmt {
         }
         match self.table_type {
             TableType::Normal => {}
-            TableType::Transient => write!(f, " TRANSIENT ")?,
-            TableType::Temporary => write!(f, " TEMPORARY ")?,
+            TableType::Transient => write!(f, " TRANSIENT")?,
+            TableType::Temporary => write!(f, " TEMPORARY")?,
         };
         write!(f, " TABLE")?;
         if let CreateOption::CreateIfNotExists = self.create_option {

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -15001,7 +15001,7 @@ AlterPasswordPolicy(
 ---------- Input ----------
 CREATE TEMPORARY TABLE t (a INT COMMENT 'col comment')
 ---------- Output ---------
-CREATE TEMPORARY  TABLE t (a Int32 COMMENT 'col comment')
+CREATE TEMPORARY TABLE t (a Int32 COMMENT 'col comment')
 ---------- AST ------------
 CreateTable(
     CreateTableStmt {

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -172,7 +172,7 @@ impl FuseTable {
 
                 let cte_name = format!("_change${}", suffix);
                 format!(
-                    "with {cte_name} as materialized \
+                    "with {cte_name} as \
                     ( \
                         select * \
                         from ( \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

With the introduction of the `auto_materialize_cte` optimization, Common Table Expressions (CTEs) in standard streams will now be automatically materialized, making the use of the materialized keyword unnecessary. 

In case of encountering the error `"can not use temp table in HTTP handler if cookie is not enabled"`, users can resolve the issue by disabling the `enable_auto_materialize_cte` setting.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18327)
<!-- Reviewable:end -->
