### PR TITLE
feat(storage): capture only changed rows in standard stream

### DIFF
--- a/scripts/selfhost/check_bad_tables.sh
+++ b/scripts/selfhost/check_bad_tables.sh
@@ -6,7 +6,7 @@ SHOW_HELP=false
 
 # Function to display help
 display_help() {
-    cat <<EOF
+	cat <<EOF
 Usage: $0 [OPTIONS]
 
 Options:
@@ -32,86 +32,93 @@ EOF
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --dsn) DSN="$2"; shift ;;
-        --help) SHOW_HELP=true ;;
-        *) echo "Error: Unknown parameter: $1"; display_help; exit 1 ;;
-    esac
-    shift
+	case $1 in
+	--dsn)
+		DSN="$2"
+		shift
+		;;
+	--help) SHOW_HELP=true ;;
+	*)
+		echo "Error: Unknown parameter: $1"
+		display_help
+		exit 1
+		;;
+	esac
+	shift
 done
 
 # Show help if requested
 if [ "$SHOW_HELP" = true ]; then
-    display_help
-    exit 0
+	display_help
+	exit 0
 fi
 
 # Check for DSN in environment variable if not specified via command line
 if [ -z "$DSN" ] && [ -n "$BENDSQL_DSN" ]; then
-    DSN="$BENDSQL_DSN"
+	DSN="$BENDSQL_DSN"
 fi
 
 # Function to execute bendsql query and handle errors
 execute_query() {
-    local query="$1"
-    local result
-    local bendsql_cmd="bendsql"
+	local query="$1"
+	local result
+	local bendsql_cmd="bendsql"
 
-    # Add DSN if specified
-    if [ -n "$DSN" ]; then
-        bendsql_cmd="$bendsql_cmd --dsn=\"$DSN\""
-    fi
+	# Add DSN if specified
+	if [ -n "$DSN" ]; then
+		bendsql_cmd="$bendsql_cmd --dsn=\"$DSN\""
+	fi
 
-    bendsql_cmd="$bendsql_cmd --query=\"$query\""
+	bendsql_cmd="$bendsql_cmd --query=\"$query\""
 
-    # Use eval to properly handle quotes in the command
-    result=$(eval "$bendsql_cmd" 2>&1)
-    if [ $? -ne 0 ]; then
-        return 1
-    fi
-    echo "$result" | tail -n +2  # Skip header row
+	# Use eval to properly handle quotes in the command
+	result=$(eval "$bendsql_cmd" 2>&1)
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+	echo "$result" | tail -n +2 # Skip header row
 }
 
 # Get all databases
 echo "Fetching list of databases..."
 databases=$(execute_query "SELECT name FROM system.databases")
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to get databases list" >&2
-    exit 1
+	echo "Error: Failed to get databases list" >&2
+	exit 1
 fi
 
 # Process each database
 while IFS= read -r db; do
-    if [ -z "$db" ]; then
-        continue
-    fi
+	if [ -z "$db" ]; then
+		continue
+	fi
 
-    echo "Processing database: $db"
+	echo "Processing database: $db"
 
-    # Try to get columns directly
-    columns_query="SELECT * FROM system.columns WHERE database = '$db'"
-    if ! execute_query "$columns_query" >/dev/null 2>&1; then
-        # If error, get tables first
-        tables=$(execute_query "SELECT name FROM system.tables WHERE database = '$db'")
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to get tables for database '$db'" >&2
-            continue
-        fi
+	# Try to get columns directly
+	columns_query="SELECT * FROM system.columns WHERE database = '$db'"
+	if ! execute_query "$columns_query" >/dev/null 2>&1; then
+		# If error, get tables first
+		tables=$(execute_query "SELECT name FROM system.tables WHERE database = '$db'")
+		if [ $? -ne 0 ]; then
+			echo "Error: Failed to get tables for database '$db'" >&2
+			continue
+		fi
 
-        # Process each table
-        while IFS= read -r table; do
-            if [ -z "$table" ]; then
-                continue
-            fi
+		# Process each table
+		while IFS= read -r table; do
+			if [ -z "$table" ]; then
+				continue
+			fi
 
-            echo "  Processing table: $table"
-            # Try to get columns for this table
-            table_columns_query="SELECT * FROM system.columns WHERE database = '$db' AND table = '$table'"
-            if ! execute_query "$table_columns_query" >/dev/null 2>&1; then
-                echo "Error encountered for database: '$db', table: '$table'"
-            fi
-        done <<< "$tables"
-    fi
-done <<< "$databases"
+			echo "  Processing table: $table"
+			# Try to get columns for this table
+			table_columns_query="SELECT * FROM system.columns WHERE database = '$db' AND table = '$table'"
+			if ! execute_query "$table_columns_query" >/dev/null 2>&1; then
+				echo "Error encountered for database: '$db', table: '$table'"
+			fi
+		done <<<"$tables"
+	fi
+done <<<"$databases"
 
 echo "Processing complete."

--- a/scripts/selfhost/fetch_log.sh
+++ b/scripts/selfhost/fetch_log.sh
@@ -2,7 +2,7 @@
 
 # Configuration
 DEFAULT_OUTPUT_DIR="."
-VERBOSITY=0  # 0=normal, 1=verbose, 2=debug
+VERBOSITY=0 # 0=normal, 1=verbose, 2=debug
 
 # Initialize variables
 DSN=""
@@ -12,25 +12,25 @@ FORMATTED_DATE=""
 
 # Logging functions
 log() {
-    local level="$1"
-    local message="$2"
+	local level="$1"
+	local message="$2"
 
-    case "$level" in
-        DEBUG)
-            [[ $VERBOSITY -ge 2 ]] && echo "[DEBUG] $message" >&2
-            ;;
-        INFO)
-            [[ $VERBOSITY -ge 1 ]] && echo "[INFO] $message" >&2
-            ;;
-        ERROR)
-            echo "[ERROR] $message" >&2
-            ;;
-    esac
+	case "$level" in
+	DEBUG)
+		[[ $VERBOSITY -ge 2 ]] && echo "[DEBUG] $message" >&2
+		;;
+	INFO)
+		[[ $VERBOSITY -ge 1 ]] && echo "[INFO] $message" >&2
+		;;
+	ERROR)
+		echo "[ERROR] $message" >&2
+		;;
+	esac
 }
 
 # Show help information
 show_help() {
-    cat << EOF
+	cat <<EOF
 Usage: $0 [OPTIONS] YYYYMMDD
 
 Download Databend system data for the specified date.
@@ -66,278 +66,302 @@ EOF
 
 # Convert YYYYMMDD to YYYY-MM-DD
 format_date() {
-    local input_date="$1"
-    FORMATTED_DATE="${input_date:0:4}-${input_date:4:2}-${input_date:6:2}"
-    log DEBUG "Formatted date: $FORMATTED_DATE"
+	local input_date="$1"
+	FORMATTED_DATE="${input_date:0:4}-${input_date:4:2}-${input_date:6:2}"
+	log DEBUG "Formatted date: $FORMATTED_DATE"
 }
 
 parse_arguments() {
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            -h|--help)
-                show_help
-                exit 0
-                ;;
-            --dsn)
-                DSN="$2"
-                shift 2
-                ;;
-            --output_dir)
-                OUTPUT_DIR="$2"
-                shift 2
-                ;;
-            -v)
-                VERBOSITY=1
-                shift
-                ;;
-            -vv)
-                VERBOSITY=2
-                shift
-                ;;
-            *)
-                if [[ -z "$DATE" ]]; then
-                    DATE="$1"
-                    shift
-                else
-                    log ERROR "Unexpected argument: $1"
-                    echo "Use -h or --help for usage information." >&2
-                    exit 1
-                fi
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-h | --help)
+			show_help
+			exit 0
+			;;
+		--dsn)
+			DSN="$2"
+			shift 2
+			;;
+		--output_dir)
+			OUTPUT_DIR="$2"
+			shift 2
+			;;
+		-v)
+			VERBOSITY=1
+			shift
+			;;
+		-vv)
+			VERBOSITY=2
+			shift
+			;;
+		*)
+			if [[ -z "$DATE" ]]; then
+				DATE="$1"
+				shift
+			else
+				log ERROR "Unexpected argument: $1"
+				echo "Use -h or --help for usage information." >&2
+				exit 1
+			fi
+			;;
+		esac
+	done
 
-    # Set DSN from environment variable if not provided via command line
-    if [[ -z "$DSN" && -n "$BENDSQL_DSN" ]]; then
-        DSN="$BENDSQL_DSN"
-        log DEBUG "Using DSN from environment variable BENDSQL_DSN"
-    fi
+	# Set DSN from environment variable if not provided via command line
+	if [[ -z "$DSN" && -n "$BENDSQL_DSN" ]]; then
+		DSN="$BENDSQL_DSN"
+		log DEBUG "Using DSN from environment variable BENDSQL_DSN"
+	fi
 
-    OUTPUT_DIR="${OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
-    
-    if [[ -n "$DATE" ]]; then
-        format_date "$DATE"
-    fi
+	OUTPUT_DIR="${OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
+
+	if [[ -n "$DATE" ]]; then
+		format_date "$DATE"
+	fi
 }
 
 validate_arguments() {
-    if [[ -z "$DATE" ]]; then
-        log ERROR "Missing required date parameter"
-        echo "Use -h or --help for usage information." >&2
-        exit 1
-    fi
+	if [[ -z "$DATE" ]]; then
+		log ERROR "Missing required date parameter"
+		echo "Use -h or --help for usage information." >&2
+		exit 1
+	fi
 
-    if [[ ! "$DATE" =~ ^[0-9]{8}$ ]]; then
-        log ERROR "Invalid date format: $DATE (expected YYYYMMDD)"
-        echo "Use -h or --help for usage information." >&2
-        exit 1
-    fi
+	if [[ ! "$DATE" =~ ^[0-9]{8}$ ]]; then
+		log ERROR "Invalid date format: $DATE (expected YYYYMMDD)"
+		echo "Use -h or --help for usage information." >&2
+		exit 1
+	fi
 
-    if [[ -z "$DSN" ]]; then
-        log ERROR "No DSN provided. Set BENDSQL_DSN environment variable or use --dsn option."
-        echo "Use -h or --help for usage information." >&2
-        exit 1
-    fi
+	if [[ -z "$DSN" ]]; then
+		log ERROR "No DSN provided. Set BENDSQL_DSN environment variable or use --dsn option."
+		echo "Use -h or --help for usage information." >&2
+		exit 1
+	fi
 }
 
 build_base_command() {
-    BASE_CMD="bendsql"
-    [[ -n "$DSN" ]] && BASE_CMD+=" --dsn \"$DSN\""
-    log INFO "Using command: $BASE_CMD"
+	BASE_CMD="bendsql"
+	[[ -n "$DSN" ]] && BASE_CMD+=" --dsn \"$DSN\""
+	log INFO "Using command: $BASE_CMD"
 }
 
 execute_query() {
-    local sql="$1"
-    log DEBUG "Executing: ${sql:0:60}..."
+	local sql="$1"
+	log DEBUG "Executing: ${sql:0:60}..."
 
-    eval "$BASE_CMD --quote-style never --query=\"$sql\""
-    local retval=$?
+	eval "$BASE_CMD --quote-style never --query=\"$sql\""
+	local retval=$?
 
-    [[ $retval -ne 0 ]] && { log ERROR "Query failed"; exit $retval; }
+	[[ $retval -ne 0 ]] && {
+		log ERROR "Query failed"
+		exit $retval
+	}
 }
 
 download_file() {
-    local filename="$1"
-    local download_dir="$2"
+	local filename="$1"
+	local download_dir="$2"
 
-    log INFO "Processing file: $filename"
+	log INFO "Processing file: $filename"
 
-    presign_result=$(execute_query "PRESIGN DOWNLOAD @a5c7667401c0c728c2ef9703bdaea66d9ae2d906/$filename")
-    presign_url=$(echo "$presign_result" | awk '{print $3}')
+	presign_result=$(execute_query "PRESIGN DOWNLOAD @a5c7667401c0c728c2ef9703bdaea66d9ae2d906/$filename")
+	presign_url=$(echo "$presign_result" | awk '{print $3}')
 
-    [[ -z "$presign_url" ]] && { log ERROR "Empty presigned URL"; return 1; }
-    [[ "$presign_url" =~ ^https?:// ]] || { log ERROR "Invalid URL format"; return 1; }
+	[[ -z "$presign_url" ]] && {
+		log ERROR "Empty presigned URL"
+		return 1
+	}
+	[[ "$presign_url" =~ ^https?:// ]] || {
+		log ERROR "Invalid URL format"
+		return 1
+	}
 
-    log DEBUG "Downloading from: $presign_url"
-    if curl -k -L -s -S -f -o "$download_dir/$filename" "$presign_url"; then
-        log INFO "Downloaded: $filename ($(du -h "$download_dir/$filename" | cut -f1))"
-        return 0
-    else
-        log ERROR "Download failed"
-        rm -f "$download_dir/$filename" 2>/dev/null
-        return 1
-    fi
+	log DEBUG "Downloading from: $presign_url"
+	if curl -k -L -s -S -f -o "$download_dir/$filename" "$presign_url"; then
+		log INFO "Downloaded: $filename ($(du -h "$download_dir/$filename" | cut -f1))"
+		return 0
+	else
+		log ERROR "Download failed"
+		rm -f "$download_dir/$filename" 2>/dev/null
+		return 1
+	fi
 }
 
 create_archive() {
-    local date_str="$1"
-    shift
-    local dirs=("$@")
-    local deleted_files=0
-    local temp_log=$(mktemp)
+	local date_str="$1"
+	shift
+	local dirs=("$@")
+	local deleted_files=0
+	local temp_log=$(mktemp)
 
-    local archive_name="data_${date_str}.tar.gz"
+	local archive_name="data_${date_str}.tar.gz"
 
-    local missing_dirs=()
-    for dir in "${dirs[@]}"; do
-        if [[ ! -d "$dir" ]]; then
-            missing_dirs+=("$dir")
-        elif [[ ! -r "$dir" ]]; then
-            log WARN "[WARN] Directory exists but not readable: $dir"
-        fi
-    done
+	local missing_dirs=()
+	for dir in "${dirs[@]}"; do
+		if [[ ! -d "$dir" ]]; then
+			missing_dirs+=("$dir")
+		elif [[ ! -r "$dir" ]]; then
+			log WARN "[WARN] Directory exists but not readable: $dir"
+		fi
+	done
 
-    if [[ ${#missing_dirs[@]} -gt 0 ]]; then
-        log ERROR "[ERROR] Missing directories: ${missing_dirs[*]}"
-        return 1
-    fi
+	if [[ ${#missing_dirs[@]} -gt 0 ]]; then
+		log ERROR "[ERROR] Missing directories: ${missing_dirs[*]}"
+		return 1
+	fi
 
-    local file_list
-    file_list=$(mktemp)
-    find "${dirs[@]}" -type f -print > "$file_list" 2>/dev/null
+	local file_list
+	file_list=$(mktemp)
+	find "${dirs[@]}" -type f -print >"$file_list" 2>/dev/null
 
-    log INFO "[INFO] Creating archive $archive_name from ${#dirs[@]} directories..."
-    if ! tar -czf "$archive_name" --files-from="$file_list" 2>>"$temp_log"; then
-      log ERROR "[ERROR] Create archive failure, for details:"
-      cat "$temp_log" >&2
-      rm -f "$file_list" "$temp_log" "$archive_name"
-      return 1
-    fi
+	log INFO "[INFO] Creating archive $archive_name from ${#dirs[@]} directories..."
+	if ! tar -czf "$archive_name" --files-from="$file_list" 2>>"$temp_log"; then
+		log ERROR "[ERROR] Create archive failure, for details:"
+		cat "$temp_log" >&2
+		rm -f "$file_list" "$temp_log" "$archive_name"
+		return 1
+	fi
 
-    if ! tar -tzf "$archive_name" &>/dev/null; then
-      log ERROR "[ERROR] Create archive failure"
-      rm -f "$archive_name"
-      return 1
-    fi
+	if ! tar -tzf "$archive_name" &>/dev/null; then
+		log ERROR "[ERROR] Create archive failure"
+		rm -f "$archive_name"
+		return 1
+	fi
 
-    log INFO "[INFO] Clean temp files..."
-    while IFS= read -r file; do
-        if rm -f "$file" 2>>"$temp_log"; then
-            ((deleted_files++))
-        else
-          log WARN "[WARN] remove file failure: $file"
-        fi
-    done < "$file_list"
+	log INFO "[INFO] Clean temp files..."
+	while IFS= read -r file; do
+		if rm -f "$file" 2>>"$temp_log"; then
+			((deleted_files++))
+		else
+			log WARN "[WARN] remove file failure: $file"
+		fi
+	done <"$file_list"
 
-    rm -f "$file_list" "$temp_log"
-    return 0
+	rm -f "$file_list" "$temp_log"
+	return 0
 }
 
 extract_first_column() {
-    sed 's/[[:space:]]\{1,\}/\t/g' | \
-    sed -e 's/^[[:space:]]*//' \
-        -e 's/[[:space:]]*$//' \
-        -e 's/"//g' | \
-    awk -F '\t' 'NF>0 {print $1}'
+	sed 's/[[:space:]]\{1,\}/\t/g' |
+		sed -e 's/^[[:space:]]*//' \
+			-e 's/[[:space:]]*$//' \
+			-e 's/"//g' |
+		awk -F '\t' 'NF>0 {print $1}'
 }
 
 main() {
-    parse_arguments "$@"
-    validate_arguments
-    build_base_command
+	parse_arguments "$@"
+	validate_arguments
+	build_base_command
 
-    mkdir -p "$OUTPUT_DIR"
-    log INFO "Output directory: $OUTPUT_DIR"
+	mkdir -p "$OUTPUT_DIR"
+	log INFO "Output directory: $OUTPUT_DIR"
 
-    execute_query "DROP STAGE IF EXISTS a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
-    execute_query "CREATE STAGE a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	execute_query "DROP STAGE IF EXISTS a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	execute_query "CREATE STAGE a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-    log INFO "Fetch columns info..."
-    execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM system.columns;"
+	log INFO "Fetch columns info..."
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM system.columns;"
 
-    file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
-    [[ -z "$file_list" ]] && { log ERROR "No files found"; exit 1; }
+	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
+	[[ -z "$file_list" ]] && {
+		log ERROR "No files found"
+		exit 1
+	}
 
-    total=0
-    success=0
+	total=0
+	success=0
 
-    mkdir -p "$OUTPUT_DIR/columns"
-    while IFS= read -r filename; do
-        ((total++))
-        download_file "$filename" "$OUTPUT_DIR/columns" && ((success++))
-    done <<< "$file_list"
+	mkdir -p "$OUTPUT_DIR/columns"
+	while IFS= read -r filename; do
+		((total++))
+		download_file "$filename" "$OUTPUT_DIR/columns" && ((success++))
+	done <<<"$file_list"
 
-    log INFO "Fetch Databend user functions..."
-    execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	log INFO "Fetch Databend user functions..."
+	execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-    execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system.user_functions);"
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system.user_functions);"
 
-    file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
-    [[ -z "$file_list" ]] && { log ERROR "No files found"; exit 1; }
+	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
+	[[ -z "$file_list" ]] && {
+		log ERROR "No files found"
+		exit 1
+	}
 
-    mkdir -p "$OUTPUT_DIR/user_functions"
-    while IFS= read -r filename; do
-        ((total++))
-        download_file "$filename" "$OUTPUT_DIR/user_functions" && ((success++))
-    done <<< "$file_list"
+	mkdir -p "$OUTPUT_DIR/user_functions"
+	while IFS= read -r filename; do
+		((total++))
+		download_file "$filename" "$OUTPUT_DIR/user_functions" && ((success++))
+	done <<<"$file_list"
 
-    log INFO "Fetch Databend query logs..."
-    execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	log INFO "Fetch Databend query logs..."
+	execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-    execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.query_history WHERE event_date = '$FORMATTED_DATE');"
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.query_history WHERE event_date = '$FORMATTED_DATE');"
 
-    file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
-    [[ -z "$file_list" ]] && { log ERROR "No files found"; exit 1; }
+	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
+	[[ -z "$file_list" ]] && {
+		log ERROR "No files found"
+		exit 1
+	}
 
-    mkdir -p "$OUTPUT_DIR/query_logs"
-    while IFS= read -r filename; do
-        ((total++))
-        download_file "$filename" "$OUTPUT_DIR/query_logs" && ((success++))
-    done <<< "$file_list"
+	mkdir -p "$OUTPUT_DIR/query_logs"
+	while IFS= read -r filename; do
+		((total++))
+		download_file "$filename" "$OUTPUT_DIR/query_logs" && ((success++))
+	done <<<"$file_list"
 
-    log INFO "Fetch Databend query raw logs..."
-    execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	log INFO "Fetch Databend query raw logs..."
+	execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-    execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.log_history WHERE to_date(timestamp) = '$FORMATTED_DATE');"
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.log_history WHERE to_date(timestamp) = '$FORMATTED_DATE');"
 
-    file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
-    [[ -z "$file_list" ]] && { log ERROR "No files found"; exit 1; }
+	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
+	[[ -z "$file_list" ]] && {
+		log ERROR "No files found"
+		exit 1
+	}
 
-    mkdir -p "$OUTPUT_DIR/query_raw_logs"
-    while IFS= read -r filename; do
-        ((total++))
-        download_file "$filename" "$OUTPUT_DIR/query_raw_logs" && ((success++))
-    done <<< "$file_list"
+	mkdir -p "$OUTPUT_DIR/query_raw_logs"
+	while IFS= read -r filename; do
+		((total++))
+		download_file "$filename" "$OUTPUT_DIR/query_raw_logs" && ((success++))
+	done <<<"$file_list"
 
-    log INFO "Fetch Databend query profile logs..."
-    execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
+	log INFO "Fetch Databend query profile logs..."
+	execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-    execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.profile_history WHERE to_date(timestamp) = '$FORMATTED_DATE');"
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.profile_history WHERE to_date(timestamp) = '$FORMATTED_DATE');"
 
-    file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
-    [[ -z "$file_list" ]] && { log ERROR "No files found"; exit 1; }
+	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
+	[[ -z "$file_list" ]] && {
+		log ERROR "No files found"
+		exit 1
+	}
 
-    mkdir -p "$OUTPUT_DIR/query_profile_logs"
-    while IFS= read -r filename; do
-        ((total++))
-        download_file "$filename" "$OUTPUT_DIR/query_profile_logs" && ((success++))
-    done <<< "$file_list"
+	mkdir -p "$OUTPUT_DIR/query_profile_logs"
+	while IFS= read -r filename; do
+		((total++))
+		download_file "$filename" "$OUTPUT_DIR/query_profile_logs" && ((success++))
+	done <<<"$file_list"
 
-    echo "Summary:"
-    echo "Files processed: $total"
-    echo "Successfully downloaded: $success"
-    echo "Failed: $((total - success))"
+	echo "Summary:"
+	echo "Files processed: $total"
+	echo "Successfully downloaded: $success"
+	echo "Failed: $((total - success))"
 
-    if [[ $success -gt 0 ]]; then
-      if create_archive "$FORMATTED_DATE" "$OUTPUT_DIR/columns" "$OUTPUT_DIR/user_functions" "$OUTPUT_DIR/query_logs" "$OUTPUT_DIR/query_raw_logs" "$OUTPUT_DIR/query_profile_logs" ; then
-        echo "Operation completed successfully"
-        exit 0
-      else
-        exit 1
-      fi
-    else
-      exit 1
-    fi
+	if [[ $success -gt 0 ]]; then
+		if create_archive "$FORMATTED_DATE" "$OUTPUT_DIR/columns" "$OUTPUT_DIR/user_functions" "$OUTPUT_DIR/query_logs" "$OUTPUT_DIR/query_raw_logs" "$OUTPUT_DIR/query_profile_logs"; then
+			echo "Operation completed successfully"
+			exit 0
+		else
+			exit 1
+		fi
+	else
+		exit 1
+	fi
 }
 
 main "$@"

--- a/src/query/catalog/src/plan/stream_column.rs
+++ b/src/query/catalog/src/plan/stream_column.rs
@@ -38,7 +38,6 @@ use databend_common_expression::Value;
 use databend_common_expression::ORIGIN_BLOCK_ID_COLUMN_ID;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COLUMN_ID;
 use databend_common_expression::ORIGIN_VERSION_COLUMN_ID;
-use databend_common_expression::ROW_VERSION_COLUMN_ID;
 use databend_storages_common_table_meta::meta::try_extract_uuid_str_from_path;
 
 use crate::plan::PartInfo;
@@ -132,7 +131,6 @@ pub enum StreamColumnType {
     OriginVersion,
     OriginBlockId,
     OriginRowNum,
-    RowVersion,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -168,7 +166,6 @@ impl StreamColumn {
             StreamColumnType::OriginRowNum => {
                 TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::UInt64)))
             }
-            StreamColumnType::RowVersion => TableDataType::Number(NumberDataType::UInt64),
         }
     }
 
@@ -186,13 +183,12 @@ impl StreamColumn {
             StreamColumnType::OriginVersion => ORIGIN_VERSION_COLUMN_ID,
             StreamColumnType::OriginBlockId => ORIGIN_BLOCK_ID_COLUMN_ID,
             StreamColumnType::OriginRowNum => ORIGIN_BLOCK_ROW_NUM_COLUMN_ID,
-            StreamColumnType::RowVersion => ROW_VERSION_COLUMN_ID,
         }
     }
 
     pub fn generate_column_values(&self, meta: &StreamColumnMeta, num_rows: usize) -> BlockEntry {
         match &self.column_type {
-            StreamColumnType::OriginVersion | StreamColumnType::RowVersion => unreachable!(),
+            StreamColumnType::OriginVersion => unreachable!(),
             StreamColumnType::OriginBlockId => {
                 BlockEntry::new(meta.build_origin_block_id(), || {
                     (

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -80,14 +80,13 @@ pub const FILE_ROW_NUMBER_COLUMN_NAME: &str = "metadata$file_row_number";
 pub const ORIGIN_BLOCK_ROW_NUM_COLUMN_ID: u32 = u32::MAX - 10;
 pub const ORIGIN_BLOCK_ID_COLUMN_ID: u32 = u32::MAX - 11;
 pub const ORIGIN_VERSION_COLUMN_ID: u32 = u32::MAX - 12;
-pub const ROW_VERSION_COLUMN_ID: u32 = u32::MAX - 13;
+
 pub const FILENAME_COLUMN_ID: u32 = u32::MAX - 14;
 pub const FILE_ROW_NUMBER_COLUMN_ID: u32 = u32::MAX - 15;
 // stream column name.
 pub const ORIGIN_VERSION_COL_NAME: &str = "_origin_version";
 pub const ORIGIN_BLOCK_ID_COL_NAME: &str = "_origin_block_id";
 pub const ORIGIN_BLOCK_ROW_NUM_COL_NAME: &str = "_origin_block_row_num";
-pub const ROW_VERSION_COL_NAME: &str = "_row_version";
 
 // The change$row_id might be expended to the computation of
 // the ORIGIN_BLOCK_ROW_NUM_COL_NAME and BASE_ROW_ID_COL_NAME.
@@ -108,7 +107,6 @@ pub static INTERNAL_COLUMNS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| 
         ORIGIN_VERSION_COL_NAME,
         ORIGIN_BLOCK_ID_COL_NAME,
         ORIGIN_BLOCK_ROW_NUM_COL_NAME,
-        ROW_VERSION_COL_NAME,
         FILENAME_COLUMN_NAME,
         FILE_ROW_NUMBER_COLUMN_NAME,
     ])
@@ -127,17 +125,14 @@ pub fn is_internal_column(column_name: &str) -> bool {
 
 #[inline]
 pub fn is_stream_column_id(column_id: ColumnId) -> bool {
-    (ROW_VERSION_COLUMN_ID..=ORIGIN_BLOCK_ROW_NUM_COLUMN_ID).contains(&column_id)
+    (ORIGIN_VERSION_COLUMN_ID..=ORIGIN_BLOCK_ROW_NUM_COLUMN_ID).contains(&column_id)
 }
 
 #[inline]
 pub fn is_stream_column(column_name: &str) -> bool {
     matches!(
         column_name,
-        ORIGIN_VERSION_COL_NAME
-            | ORIGIN_BLOCK_ID_COL_NAME
-            | ORIGIN_BLOCK_ROW_NUM_COL_NAME
-            | ROW_VERSION_COL_NAME
+        ORIGIN_VERSION_COL_NAME | ORIGIN_BLOCK_ID_COL_NAME | ORIGIN_BLOCK_ROW_NUM_COL_NAME
     )
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/transform_resort_addon_without_source_schema.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_resort_addon_without_source_schema.rs
@@ -26,7 +26,6 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Scalar;
 use databend_common_expression::SourceSchemaIndex;
-use databend_common_expression::ROW_VERSION_COL_NAME;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline_transforms::processors::Transform;
 use databend_common_sql::evaluator::BlockOperator;
@@ -73,10 +72,7 @@ pub fn build_expression_transform(
                 // 2. (a int), we give null
                 // but for pg or snowflake, if a field is non-null, it will return
                 // a non-null error (it means they will give a null as the default value).
-
-                // The type of stream column _row_version is UInt64, and the default value is 0.
-                // skip check for _row_version.
-                if !f.is_nullable() && f.name() != ROW_VERSION_COL_NAME {
+                if !f.is_nullable() {
                     // if we have a user-specified default expr, it must satisfy the non-null constraint
                     // in table-create phase. So we just consider default_expr is none.
                     return Err(ErrorCode::BadArguments(format!(

--- a/src/query/sql/src/executor/physical_plans/physical_add_stream_column.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_add_stream_column.rs
@@ -116,7 +116,6 @@ impl AddStreamColumn {
                         .build(),
                     })
                 }
-                StreamColumnType::RowVersion => unreachable!(),
             };
 
             let new_stream_column_scalar_expr = ScalarExpr::FunctionCall(FunctionCall {

--- a/src/query/sql/src/planner/binder/stream_column_factory.rs
+++ b/src/query/sql/src/planner/binder/stream_column_factory.rs
@@ -20,7 +20,6 @@ use databend_common_catalog::plan::StreamColumnType;
 use databend_common_expression::ORIGIN_BLOCK_ID_COL_NAME;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COL_NAME;
 use databend_common_expression::ORIGIN_VERSION_COL_NAME;
-use databend_common_expression::ROW_VERSION_COL_NAME;
 
 #[ctor]
 pub static STREAM_COLUMN_FACTORY: StreamColumnFactory = StreamColumnFactory::init();
@@ -47,10 +46,6 @@ impl StreamColumnFactory {
                 ORIGIN_BLOCK_ROW_NUM_COL_NAME,
                 StreamColumnType::OriginRowNum,
             ),
-        );
-        stream_columns.insert(
-            ROW_VERSION_COL_NAME.to_string(),
-            StreamColumn::new(ROW_VERSION_COL_NAME, StreamColumnType::RowVersion),
         );
 
         StreamColumnFactory { stream_columns }

--- a/src/query/sql/src/planner/execution/stream_column.rs
+++ b/src/query/sql/src/planner/execution/stream_column.rs
@@ -114,7 +114,6 @@ impl StreamContext {
                         .build(),
                     })
                 }
-                StreamColumnType::RowVersion => unreachable!(),
             };
 
             let new_stream_column_scalar_expr = ScalarExpr::FunctionCall(FunctionCall {

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -3776,7 +3776,7 @@ impl<'a> TypeChecker<'a> {
                         distinct: false,
                         name: Identifier::from_name(span, "ifnull"),
                         args: vec![eq_expr, Expr::Literal {
-                            span: span,
+                            span,
                             value: Literal::Boolean(false),
                         }],
                         params: vec![],

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -54,7 +54,6 @@ use databend_common_expression::TableSchema;
 use databend_common_expression::ORIGIN_BLOCK_ID_COL_NAME;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COL_NAME;
 use databend_common_expression::ORIGIN_VERSION_COL_NAME;
-use databend_common_expression::ROW_VERSION_COL_NAME;
 use databend_common_expression::SEARCH_SCORE_COLUMN_ID;
 use databend_common_io::constants::DEFAULT_BLOCK_BUFFER_SIZE;
 use databend_common_io::constants::DEFAULT_BLOCK_COMPRESSED_SIZE;
@@ -805,9 +804,6 @@ impl Table for FuseTable {
                     .unwrap(),
                 STREAM_COLUMN_FACTORY
                     .get_stream_column(ORIGIN_BLOCK_ROW_NUM_COL_NAME)
-                    .unwrap(),
-                STREAM_COLUMN_FACTORY
-                    .get_stream_column(ROW_VERSION_COL_NAME)
                     .unwrap(),
             ]
         } else {

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -125,13 +125,6 @@ impl FuseTable {
         table_desc: String,
         seq: u64,
     ) -> Result<String> {
-        let cols = self
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| f.name().clone())
-            .collect::<Vec<_>>();
-
         let suffix = format!("{:08x}", Utc::now().timestamp());
 
         let optimized_mode = self.optimize_stream_mode(mode, base_location).await?;
@@ -153,22 +146,33 @@ impl FuseTable {
                 )
             }
             StreamMode::Standard => {
+                let schema = self.schema();
+                let fields = schema.fields();
                 let quote = ctx.get_settings().get_sql_dialect()?.default_ident_quote();
 
                 let a_table_alias = format!("_change_insert${}", suffix);
                 let d_table_alias = format!("_change_delete${}", suffix);
 
-                let mut a_cols_vec = Vec::with_capacity(cols.len());
-                let mut d_alias_vec = Vec::with_capacity(cols.len());
-                let mut d_cols_vec = Vec::with_capacity(cols.len());
-                for col in cols {
-                    a_cols_vec.push(format!("{quote}{col}{quote}"));
-                    d_alias_vec.push(format!("{quote}{col}{quote} as d_{col}"));
-                    d_cols_vec.push(format!("d_{col}"));
+                let mut a_cols_vec = Vec::with_capacity(fields.len());
+                let mut d_alias_vec = Vec::with_capacity(fields.len());
+                let mut d_cols_vec = Vec::with_capacity(fields.len());
+                let mut exprs_vec = Vec::with_capacity(fields.len());
+                for field in fields {
+                    let name = field.name();
+                    a_cols_vec.push(format!("{quote}{name}{quote}"));
+                    d_alias_vec.push(format!("{quote}{name}{quote} as d_{name}"));
+                    d_cols_vec.push(format!("d_{name}"));
+
+                    if field.data_type().is_nullable_or_null() {
+                        exprs_vec.push(format!("not(equal_null({quote}{name}{quote}, d_{name}))"));
+                    } else {
+                        exprs_vec.push(format!("{quote}{name}{quote} <> d_{name}"));
+                    }
                 }
                 let a_cols = a_cols_vec.join(", ");
                 let d_cols_alias = d_alias_vec.join(", ");
                 let d_cols = d_cols_vec.join(", ");
+                let exprs = exprs_vec.join(" or ");
 
                 let cte_name = format!("_change${}", suffix);
                 format!(
@@ -177,7 +181,6 @@ impl FuseTable {
                         select * \
                         from ( \
                             select {a_cols}, \
-                                    _row_version, \
                                     'INSERT' as a_change$action, \
                                     if(is_not_null(_origin_block_id), \
                                         concat(to_uuid(_origin_block_id), lpad(hex(_origin_block_row_num), 6, '0')), \
@@ -187,7 +190,6 @@ impl FuseTable {
                         ) as A \
                         FULL OUTER JOIN ( \
                             select {d_cols_alias}, \
-                                    _row_version, \
                                     'DELETE' as d_change$action, \
                                     if(is_not_null(_origin_block_id), \
                                         concat(to_uuid(_origin_block_id), lpad(hex(_origin_block_row_num), 6, '0')), \
@@ -196,7 +198,7 @@ impl FuseTable {
                             from {table_desc} as {d_table_alias} \
                         ) as D \
                         on A.a_change$row_id = D.d_change$row_id \
-                        where A.a_change$row_id is null or D.d_change$row_id is null or A._row_version > D._row_version \
+                        where A.a_change$row_id is null or D.d_change$row_id is null or {exprs} \
                     ) \
                     select {a_cols}, \
                             a_change$action as change$action, \

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -36,7 +36,6 @@ use databend_common_expression::BASE_ROW_ID_COLUMN_ID;
 use databend_common_expression::ORIGIN_BLOCK_ID_COL_NAME;
 use databend_common_expression::ORIGIN_BLOCK_ROW_NUM_COL_NAME;
 use databend_common_expression::ORIGIN_VERSION_COL_NAME;
-use databend_common_expression::ROW_VERSION_COL_NAME;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_pipeline_core::Pipeline;
@@ -367,9 +366,6 @@ impl Table for StreamTable {
                 .unwrap(),
             STREAM_COLUMN_FACTORY
                 .get_stream_column(ORIGIN_BLOCK_ROW_NUM_COL_NAME)
-                .unwrap(),
-            STREAM_COLUMN_FACTORY
-                .get_stream_column(ROW_VERSION_COL_NAME)
                 .unwrap(),
         ]
     }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0011_change_tracking.test
@@ -14,7 +14,7 @@ statement ok
 insert into t values(1),(2)
 
 statement error 1065
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 
 statement ok
 alter table t set options(change_tracking = true)
@@ -22,23 +22,23 @@ alter table t set options(change_tracking = true)
 statement ok
 insert into t values(3),(4)
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 1 1 NULL 0
-2 1 1 NULL 0
-3 1 1 NULL 0
-4 1 1 NULL 0
+1 1 1 NULL
+2 1 1 NULL
+3 1 1 NULL
+4 1 1 NULL
 
 statement ok
 delete from t where a = 3
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 1 1 NULL 0
-2 1 1 NULL 0
-4 0 0 1 0
+1 1 1 NULL
+2 1 1 NULL
+4 0 0 1
 
 statement ok
 update t set a = 3 where a = 4
@@ -46,12 +46,12 @@ update t set a = 3 where a = 4
 statement ok
 optimize table t compact
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 0 0 0 0
-2 0 0 1 0
-3 0 0 1 1
+1 0 0 0
+2 0 0 1
+3 0 0 1
 
 statement ok
 insert into t values(5)
@@ -62,14 +62,14 @@ insert into t values(6)
 statement ok
 alter table t recluster
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 0 0 0 0
-2 0 0 1 0
-3 0 0 1 1
-5 0 0 0 0
-6 0 0 0 0
+1 0 0 0
+2 0 0 1
+3 0 0 1
+5 0 0 0
+6 0 0 0
 
 statement error 1065
 select change$is_update from t
@@ -77,15 +77,15 @@ select change$is_update from t
 statement ok
 replace into t on(a) values(6),(7)
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 0 0 0 0
-2 0 0 1 0
-3 0 0 1 1
-5 0 0 0 0
-6 1 1 NULL 0
-7 1 1 NULL 0
+1 0 0 0
+2 0 0 1
+3 0 0 1
+5 0 0 0
+6 1 1 NULL
+7 1 1 NULL
 
 statement ok
 create table t2(a int)
@@ -98,15 +98,15 @@ merge into t using t2 on t.a = t2.a when matched and t2.a = 1 then update set t.
 ----
 1 1 1
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-0 1 1 NULL 0
-3 0 0 1 1
-5 0 0 0 0
-6 1 1 NULL 0
-7 1 1 NULL 0
-8 0 0 0 1
+0 1 1 NULL
+3 0 0 1
+5 0 0 0
+6 1 1 NULL
+7 1 1 NULL
+8 0 0 0
 
 statement ok
 set enable_compact_after_write = 1;
@@ -128,15 +128,15 @@ merge into t using t1 on t.a = t1.a when matched and t1.a = 0 then update set t.
 ----
 2
 
-query IBBII
-select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a
+query IBBI
+select a, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a
 ----
-1 0 0 0 1
-2 0 0 1 2
-5 0 0 0 0
-6 0 0 0 0
-7 0 0 1 0
-8 0 0 0 1
+1 0 0 0
+2 0 0 1
+5 0 0 0
+6 0 0 0
+7 0 0 1
+8 0 0 0
 
 ###############
 # issue 14955 #
@@ -181,13 +181,13 @@ merge into t3 using t4 on t3.a = t4.a when matched and t4.a = 4 then delete when
 1 1 1
 
 
-query IIBBII
-select a, b, _row_version from t3 order by a
+query II
+select a, b from t3 order by a
 ----
-0 0 0
-1 1 0
-2 2 1
-3 3 1
+0 0
+1 1
+2 2
+3 3
 
 statement ok
 drop table t4 all
@@ -214,10 +214,10 @@ merge into db1.test_select t1 using (select * from db1.test_select) t2 on t1.id 
 ----
 1
 
-query ITI
-select id, name, _row_version from test_select
+query IT
+select id, name from test_select
 ----
-1 {} 1
+1 {}
 
 statement ok
 drop table test_select all

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -320,13 +320,13 @@ update t3 set a = 6 where b = 5
 statement ok
 optimize table t3 compact
 
-query IIBBII
-select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t3 order by a
+query IIBBI
+select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t3 order by a
 ----
-0 1 0 0 0 1
-3 3 0 0 2 0
-4 4 0 0 0 0
-6 5 0 0 1 1
+0 1 0 0 0
+3 3 0 0 2
+4 4 0 0 0
+6 5 0 0 1
 
 query IITB
 select a, b, change$action, change$is_update from s3 order by a
@@ -506,12 +506,12 @@ select a, b, change$action, change$is_update from s7 order by a, change$action
 3 3 DELETE 0
 4 4 INSERT 0
 
-query IIBBII
-select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t7 order by a
+query IIBBI
+select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t7 order by a
 ----
-1 1 0 0 0 0
-2 2 0 0 0 0
-4 4 0 0 1 0
+1 1 0 0 0
+2 2 0 0 0
+4 4 0 0 1
 
 statement ok
 create stream s7_1 on table t7 at(stream => s7)

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -660,6 +660,44 @@ statement ok
 drop stream s3
 
 statement ok
+create or replace table t9 (id int not null, c1 varchar);
+
+statement ok
+create or replace table t9_v1 like t9; 
+
+statement ok
+create or replace stream stream_t9 on table t9 append_only=false;
+
+query II
+merge into t9 a using (select 10,'a') b(id,c1) on a.id=b.id when matched then update set a.c1=b.c1 when not matched then insert *;
+----
+1 0
+
+query T
+select id, c1, change$action, change$is_update from stream_t9;
+----
+10 a INSERT 0
+
+query I
+insert into t9_v1 select id,c1 from stream_t9;
+----
+1
+
+query IT
+select * from t9_v1;
+----
+10 a
+
+query II
+merge into t9 a using (select 10,'a') b(id,c1) on a.id=b.id when matched then update set a.c1=b.c1 when not matched then insert *;
+----
+0 1
+
+query T
+select * from stream_t9;
+----
+
+statement ok
 drop table t3 all
 
 statement ok
@@ -670,6 +708,15 @@ drop table t5 all
 
 statement ok
 drop table t6 all
+
+statement ok
+drop table t9 all
+
+statement ok
+drop table t9_v1 all
+
+statement ok
+drop stream stream_t9
 
 statement ok
 create table replace_t1(a int);

--- a/tests/sqllogictests/suites/ee/07_hilbert_clustering/07_0001_change_tracking.test
+++ b/tests/sqllogictests/suites/ee/07_hilbert_clustering/07_0001_change_tracking.test
@@ -30,24 +30,24 @@ alter table t set options(change_tracking = true);
 statement ok
 insert into t values(2, 2), (4, 4);
 
-query IIBBII
-select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a;
+query IIBBI
+select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a;
 ----
-1 1 1 1 NULL 0
-2 2 1 1 NULL 0
-3 3 1 1 NULL 0
-4 4 1 1 NULL 0
+1 1 1 1 NULL
+2 2 1 1 NULL
+3 3 1 1 NULL
+4 4 1 1 NULL
 
 statement ok
 alter table t recluster;
 
-query IIBBII
-select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num, _row_version from t order by a;
+query IIBBI
+select a, b, _origin_version is null, _origin_block_id is null, _origin_block_row_num from t order by a;
 ----
-1 1 0 0 0 0
-2 2 0 0 0 0
-3 3 0 0 1 0
-4 4 0 0 1 0
+1 1 0 0 0
+2 2 0 0 0
+3 3 0 0 1
+4 4 0 0 1
 
 statement ok
 drop table t all;

--- a/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
+++ b/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
@@ -1181,3 +1181,8 @@ query T
 select id from t where id not like '%_SIP'
 ----
 IRxxSIPD
+
+query BBB
+select equal_null(1, 1), equal_null(1,null), equal_null(null,null), equal_null(1,0)
+----
+1 0 1 0

--- a/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
+++ b/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
@@ -1182,7 +1182,7 @@ select id from t where id not like '%_SIP'
 ----
 IRxxSIPD
 
-query BBB
-select equal_null(1, 1), equal_null(1,null), equal_null(null,null), equal_null(1,0)
+query BBBB
+select equal_null(1, 1), equal_null(1, null), equal_null(null, null), equal_null(1, 0)
 ----
 1 0 1 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. **Added `equal_null` function**: A new function that simplify NULL value comparisons. Users can now use this function in SQL queries to easily compare NULL values, improving code readability and simplicity.
```sql
> select equal_null(1, 1), equal_null(1,null), equal_null(null,null), equal_null(1,0);
╭────────────────────────────────────────────────────────────────────────────────────╮
│ equal_null(1, 1) │ equal_null(1, NULL) │ equal_null(NULL, NULL) │ equal_null(1, 0) │
│      Boolean     │       Boolean       │         Boolean        │      Boolean     │
├──────────────────┼─────────────────────┼────────────────────────┼──────────────────┤
│ true             │ false               │ true                   │ false            │
╰────────────────────────────────────────────────────────────────────────────────────╯
1 row read in 0.029 sec. Processed 1 row, 1 B (34.48 rows/s, 34 B/s)
```

2. Improvements to the **CDC logic** of the **Standard Stream** in Databend. The unnecessary `row_version` field has been removed, and now the system captures rows in the stream only when actual changes occur by comparing each column's data. Previously, all `UPDATE` operations would capture rows, but now only rows with actual changes in their field values will be recorded. This change reduces redundant data and improves the efficiency of stream storage and processing.
```sql
root@localhost:8000/default/default> create table t9 (id int not null, c1 varchar);

root@localhost:8000/default/default> create table t9_v1 like t9; 

root@localhost:8000/default/default> create stream stream_t9 on table t9 append_only=false;

root@localhost:8000/default/default> merge into t9 a using (select 10,'a') b(id,c1) on a.id=b.id when matched then update set a.c1=b.c1 when not matched then insert *;
╭──────────────────────────────────────────────────╮
│ number of rows inserted │ number of rows updated │
│          UInt64         │         UInt64         │
├─────────────────────────┼────────────────────────┤
│                       1 │                      0 │
╰──────────────────────────────────────────────────╯
1 row read in 0.221 sec. Processed 1 row, 1 B (4.52 rows/s, 4 B/s)

root@localhost:8000/default/default> select * from stream_t9;
╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│   id  │        c1        │ change$action │ change$is_update │               change$row_id              │
│ Int32 │ Nullable(String) │     String    │      Boolean     │             Nullable(String)             │
├───────┼──────────────────┼───────────────┼──────────────────┼──────────────────────────────────────────┤
│    10 │ 'a'              │ 'INSERT'      │ false            │ '0197f0007e2e7692a27b2994dc95e8a9000000' │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
1 row read in 0.164 sec. Processed 1 row, 18 B (6.1 rows/s, 109 B/s)

root@localhost:8000/default/default> insert into t9_v1  select id,c1 from stream_t9;
╭─────────────────────────╮
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                       1 │
╰─────────────────────────╯
1 row written in 0.216 sec. Processed 1 row, 18 B (4.63 rows/s, 83 B/s)

root@localhost:8000/default/default> merge into t9 a using (select 10,'a') b(id,c1) on a.id=b.id when matched then update set a.c1=b.c1 when not matched then insert *;
╭──────────────────────────────────────────────────╮
│ number of rows inserted │ number of rows updated │
│          UInt64         │         UInt64         │
├─────────────────────────┼────────────────────────┤
│                       0 │                      1 │
╰──────────────────────────────────────────────────╯
1 row read in 0.263 sec. Processed 2 row, 5 B (7.6 rows/s, 19 B/s)

root@localhost:8000/default/default> select * from stream_t9;
0 row read in 0.410 sec. Processed 2 row, 62 B (4.88 rows/s, 151 B/s)
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18330)
<!-- Reviewable:end -->
