### PR TITLE
fix(query): fix find_leveled_eq_filters works with not in

### DIFF
--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -106,7 +106,7 @@ impl FilterHelpers {
                     }
                 }
 
-                values.retain(|v| !results.contains(v) && !invalid_results.contains(v));
+                values.retain(|v| !invalid_results.contains(v));
                 if results.is_empty() && !values.is_empty() {
                     let mut results_all_used = true;
                     // let's check or function that

--- a/src/query/functions/tests/it/type_check.rs
+++ b/src/query/functions/tests/it/type_check.rs
@@ -220,6 +220,21 @@ fn test_find_leveled_eq_filters() {
             ],
             vec![],
         ),
+
+        (
+            "not (database = 'default')",
+            vec![],
+            vec![],
+            vec![],
+        ),
+
+
+        (
+            "not (database = 'default' or database = 'abcd')",
+            vec![],
+            vec![],
+            vec![],
+        ),
     ];
 
     let cols = vec![

--- a/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0001_system_tables.test
@@ -51,6 +51,16 @@ t c
 t100 c
 
 query T
+select count() > 0 from system.tables where database not in ('system', 'default');
+----
+1
+
+query T
+select count() > 0 from system.tables where database not in ('default');
+----
+1
+
+query T
 select name, database from system.tables where database='c' or name ='t' or name like 't10%' order by name, database;
 ----
 t a


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


fix(query): fix find_leveled_eq_filters works with not in
fixes #18332

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18334)
<!-- Reviewable:end -->
