### PR TITLE
ci: ignore upload R2 failure for release

### DIFF
--- a/.github/actions/publish_binary/action.yml
+++ b/.github/actions/publish_binary/action.yml
@@ -41,6 +41,7 @@ runs:
 
     - name: Sync normal release to R2
       shell: bash
+      continue-on-error: true
       if: inputs.category == 'default'
       run: |
         aws s3 cp ${{ steps.name.outputs.name }}.tar.gz s3://repo/databend/${{ inputs.version }}/${{ steps.name.outputs.name }}.tar.gz --no-progress --checksum-algorithm=CRC32

--- a/.github/actions/publish_deb/action.yml
+++ b/.github/actions/publish_deb/action.yml
@@ -56,6 +56,7 @@ runs:
 
     - name: Publish to S3
       shell: bash
+      continue-on-error: true
       working-directory: scripts/distribution/deb
       run: |
         aws s3 sync dists s3://repo/deb/dists --delete --no-progress --checksum-algorithm=CRC32


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

R2 is unstable.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18346)
<!-- Reviewable:end -->
