### PR TITLE
refactor(meta-service): merge `Marked` and `SeqMarked` into one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ dependencies = [
  "rmp-serde",
  "rotbl",
  "semver",
+ "seq-marked",
  "serde",
  "serde_json",
  "stream-more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10025,8 +10025,8 @@ dependencies = [
 
 [[package]]
 name = "map-api"
-version = "0.2.4"
-source = "git+https://github.com/databendlabs/map-api?tag=v0.2.4#758985f34b2dd6515bff59f3dcd8a5c5ec5de417"
+version = "0.2.6"
+source = "git+https://github.com/databendlabs/map-api?tag=v0.2.6#015e10b3d22a0bf217ddc31f98b76a864ae60a4e"
 dependencies = [
  "async-trait",
  "deepsize",
@@ -13069,9 +13069,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7977f6ea3719f39a3353dc80f4dff5dc7d659a362c8473e97ad59db2c662474"
+checksum = "1f6e7717a92f1a74cd17a166a7e3972016b306dfea7d43186728d982838c5f32"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -13603,9 +13603,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "seq-marked"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468ff34ed0c96a19dd56758e4da24b496af88752fcd46351c577031c1e55afee"
+checksum = "5d45380716df592d2c8393158bd0fd805dd95223d3abef08ebf4e3222f55550c"
 dependencies = [
  "bincode 2.0.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10025,14 +10025,15 @@ dependencies = [
 
 [[package]]
 name = "map-api"
-version = "0.2.3"
-source = "git+https://github.com/databendlabs/map-api?tag=v0.2.3#e4de1786b63d2c401413413ac8069f305c849c06"
+version = "0.2.4"
+source = "git+https://github.com/databendlabs/map-api?tag=v0.2.4#758985f34b2dd6515bff59f3dcd8a5c5ec5de417"
 dependencies = [
  "async-trait",
  "deepsize",
  "futures",
  "futures-util",
  "log",
+ "seq-marked",
  "serde",
  "stream-more",
  "thiserror 1.0.69",
@@ -13068,9 +13069,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beb0fdccf6ea5cfe13a80e00090e71e80e35c6399946a8eb7a8d5e604e5b561"
+checksum = "e7977f6ea3719f39a3353dc80f4dff5dc7d659a362c8473e97ad59db2c662474"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -13082,7 +13083,7 @@ dependencies = [
  "log",
  "lru-cache-map",
  "num-format",
- "seqmarked",
+ "seq-marked",
  "serde",
  "serde_json",
  "tokio",
@@ -13601,10 +13602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
-name = "seqmarked"
-version = "0.1.1"
+name = "seq-marked"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359ec9c6a7073d99a286620ee39c370449f4a87c7faeee6424f9b600f6e7cc40"
+checksum = "468ff34ed0c96a19dd56758e4da24b496af88752fcd46351c577031c1e55afee"
 dependencies = [
  "bincode 2.0.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,7 @@ logforth = { git = "https://github.com/datafuse-extras/logforth", branch = "glob
     'fastrace',
 ] }
 lz4 = "1.24.0"
-map-api = { version = "0.2.3" }
+map-api = { version = "0.2.4" }
 maplit = "1.0.2"
 match-template = "0.0.1"
 md-5 = "0.10.5"
@@ -466,7 +466,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.2.3", features = [] }
+rotbl = { version = "0.2.4", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }
@@ -657,7 +657,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 display-more = { git = "https://github.com/databendlabs/display-more", tag = "v0.2.0" }
-map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.2.3" }
+map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.2.4" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.9" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "d82aa6d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ rustyline = "14"
 scroll = "0.12.0"
 self_cell = "1.2.0"
 semver = "1.0.14"
-seq-marked = { version = "0.3.1", features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
+seq-marked = { version = "0.3.1", features = ["seq-marked-serde", "seq-marked-bincode", "seqv-serde"] }
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 serde_derive = "1"
 serde_ignored = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,6 +476,7 @@ rustyline = "14"
 scroll = "0.12.0"
 self_cell = "1.2.0"
 semver = "1.0.14"
+seq-marked = { version = "0.3.1", features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 serde_derive = "1"
 serde_ignored = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,7 @@ logforth = { git = "https://github.com/datafuse-extras/logforth", branch = "glob
     'fastrace',
 ] }
 lz4 = "1.24.0"
-map-api = { version = "0.2.4" }
+map-api = { version = "0.2.5" }
 maplit = "1.0.2"
 match-template = "0.0.1"
 md-5 = "0.10.5"
@@ -466,7 +466,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.2.4", features = [] }
+rotbl = { version = "0.2.6", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }
@@ -657,7 +657,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 display-more = { git = "https://github.com/databendlabs/display-more", tag = "v0.2.0" }
-map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.2.4" }
+map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.2.6" }
 openai_api_rust = { git = "https://github.com/datafuse-extras/openai-api", rev = "819a0ed" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.9" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "d82aa6d" }

--- a/src/meta/api/src/kv_pb_api/codec.rs
+++ b/src/meta/api/src/kv_pb_api/codec.rs
@@ -86,7 +86,7 @@ where
     let x: Result<_, PbDecodeError> = try {
         let p: T::PB = prost::Message::decode(buf.as_ref())?;
         let v: T = FromToProto::from_pb(p)?;
-        SeqV::with_meta(seqv.seq, seqv.meta, v)
+        SeqV::new_with_meta(seqv.seq, seqv.meta, v)
     };
 
     x.map_err(|e| e.with_context(context()))

--- a/src/meta/api/src/util.rs
+++ b/src/meta/api/src/util.rs
@@ -89,7 +89,7 @@ where
     if let Some(pb_seqv) = resp.value {
         let seqv = SeqV::from(pb_seqv);
         let value = deserialize_struct::<K::ValueType>(&seqv.data)?;
-        let seqv = SeqV::with_meta(seqv.seq, seqv.meta, value);
+        let seqv = SeqV::new_with_meta(seqv.seq, seqv.meta, value);
         Ok((key, Some(seqv)))
     } else {
         Ok((key, None))
@@ -111,7 +111,7 @@ where K: kvapi::Key {
     if let Some(pb_seqv) = resp.value {
         let seqv = SeqV::from(pb_seqv);
         let id = deserialize_u64(&seqv.data)?;
-        let seqv = SeqV::with_meta(seqv.seq, seqv.meta, id);
+        let seqv = SeqV::new_with_meta(seqv.seq, seqv.meta, id);
         Ok((key, Some(seqv)))
     } else {
         Ok((key, None))

--- a/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
+++ b/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::time::Duration;
+use std::time::SystemTime;
 
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_types::protobuf as pb;
@@ -281,7 +282,7 @@ impl TestSuite {
             assert!(res.is_none(), "got expired");
         }
 
-        let now_sec = SeqV::<()>::now_sec();
+        let now_sec = since_epoch_secs();
 
         info!("--- expired entry act as if it does not exist, an ADD op should apply");
         {
@@ -362,7 +363,7 @@ impl TestSuite {
 
         info!("--- expired in milliseconds");
         {
-            let now_sec = SeqV::<()>::now_sec();
+            let now_sec = since_epoch_secs();
 
             // expire time in milliseconds
             kv.upsert_kv(
@@ -451,7 +452,7 @@ impl TestSuite {
 
         let test_key = "test_key_for_update_meta";
 
-        let now_sec = SeqV::<()>::now_sec();
+        let now_sec = since_epoch_secs();
 
         let r = kv.upsert_kv(UpsertKV::update(test_key, b"v1")).await?;
         assert_eq!(Some(SeqV::new(1, b("v1"))), r.result);
@@ -872,7 +873,7 @@ impl TestSuite {
                 TxnOpResponse {
                     response: Some(txn_op_response::Response::Get(TxnGetResponse {
                         key: txn_key1.clone(),
-                        value: Some(pb::SeqV::from(SeqV::with_meta(
+                        value: Some(pb::SeqV::from(SeqV::new_with_meta(
                             6,
                             Some(KVMeta::default()),
                             val1_new.clone(),
@@ -884,7 +885,7 @@ impl TestSuite {
                     response: Some(txn_op_response::Response::Delete(TxnDeleteResponse {
                         key: txn_key1.clone(),
                         success: true,
-                        prev_value: Some(pb::SeqV::from(SeqV::with_meta(
+                        prev_value: Some(pb::SeqV::from(SeqV::new_with_meta(
                             6,
                             Some(KVMeta::default()),
                             val1_new.clone(),
@@ -1427,7 +1428,7 @@ impl TestSuite {
 
         info!("--- {}", func_path!());
 
-        let now_ms = SeqV::<()>::now_ms();
+        let now_ms = since_epoch_millis();
 
         let txn = TxnRequest::new(vec![], vec![
             TxnOp::put_sequential("k1/", "seq1", b("v1")).with_expires_at_ms(Some(now_ms + 1000)),
@@ -1905,4 +1906,18 @@ fn normalize_txn_response(vs: Vec<TxnOpResponse>) -> Vec<TxnOpResponse> {
 
 fn b(x: impl ToString) -> Vec<u8> {
     x.to_string().as_bytes().to_vec()
+}
+
+fn since_epoch_secs() -> u64 {
+    since_epoch().as_secs()
+}
+
+fn since_epoch_millis() -> u64 {
+    since_epoch().as_millis() as u64
+}
+
+fn since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
 }

--- a/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
+++ b/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
@@ -294,7 +294,7 @@ impl TestSuite {
                         .with(MetaSpec::new_expire(now_sec - 1)),
                 )
                 .await?;
-            // dbg!("update expired k1", _res);
+            // dbg!("update on expired k1", _res);
 
             let _res = kv
                 .upsert_kv(
@@ -306,8 +306,14 @@ impl TestSuite {
             // dbg!("update non expired k2", _res);
 
             info!("--- mget should not return expired");
-            let mut res = kv.mget_kv(&["k1".to_string(), "k2".to_string()]).await?;
             {
+                // let got = kv.get_kv("k1").await?;
+                // dbg!("k1", got);
+                // let got = kv.get_kv("k2").await?;
+                // dbg!("k2", got);
+
+                let mut res = kv.mget_kv(&["k1".to_string(), "k2".to_string()]).await?;
+                // dbg!(&res);
                 assert_eq!(res[0], None);
 
                 let v2 = res.remove(1).unwrap();

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { workspace = true }
 [dev-dependencies]
 databend-common-base = { workspace = true }
 pretty_assertions = { workspace = true }
+seq-marked = { workspace = true, features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -42,7 +42,7 @@ raft-log = { workspace = true }
 rmp-serde = { workspace = true }
 rotbl = { workspace = true }
 semver = { workspace = true }
-seq-marked = { workspace = true, features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
+seq-marked = { workspace = true, features = ["seq-marked-serde", "seq-marked-bincode", "seqv-serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 stream-more = { workspace = true }

--- a/src/meta/raft-store/Cargo.toml
+++ b/src/meta/raft-store/Cargo.toml
@@ -42,6 +42,7 @@ raft-log = { workspace = true }
 rmp-serde = { workspace = true }
 rotbl = { workspace = true }
 semver = { workspace = true }
+seq-marked = { workspace = true, features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 stream-more = { workspace = true }
@@ -53,7 +54,6 @@ tokio = { workspace = true }
 [dev-dependencies]
 databend-common-base = { workspace = true }
 pretty_assertions = { workspace = true }
-seq-marked = { workspace = true, features = [ "seq-marked-serde", "seq-marked-bincode", "seqv-serde" ] }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/src/meta/raft-store/src/applier/mod.rs
+++ b/src/meta/raft-store/src/applier/mod.rs
@@ -675,6 +675,7 @@ where SM: StateMachineApi + 'static
 
         for (expire_key, key) in to_clean {
             let curr = self.sm.get_maybe_expired_kv(&key).await?;
+
             if let Some(seq_v) = &curr {
                 assert_eq!(expire_key.seq, seq_v.seq);
                 info!("clean expired: {}, {}", key, expire_key);

--- a/src/meta/raft-store/src/leveled_store/db_exporter.rs
+++ b/src/meta/raft-store/src/leveled_store/db_exporter.rs
@@ -102,11 +102,14 @@ impl<'a> DBExporter<'a> {
 
         // kv
 
-        let strm = MapView(self.db).str_map().range(..).await?;
-        let kv_strm = strm.try_filter_map(|(str_k, marked)| {
+        let strm = MapView(self.db).user_map().range(..).await?;
+        let kv_strm = strm.try_filter_map(|(user_key, seq_marked)| {
             // Tombstone will be converted to None and be ignored.
-            let seqv: Option<SeqV<_>> = marked.into();
-            let ent = seqv.map(|value| SMEntry::GenericKV { key: str_k, value });
+            let seqv: Option<SeqV<_>> = seq_marked.into();
+            let ent = seqv.map(|value| SMEntry::GenericKV {
+                key: user_key.to_string(),
+                value,
+            });
             future::ready(Ok(ent))
         });
 

--- a/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
+++ b/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
@@ -18,11 +18,11 @@ use databend_common_meta_types::seq_value::KVMeta;
 use databend_common_meta_types::UpsertKV;
 use futures_util::TryStreamExt;
 use map_api::map_api_ro::MapApiRO;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::db_builder::DBBuilder;
 use crate::leveled_store::db_map_api_ro_impl::MapView;
 use crate::leveled_store::map_api::AsMap;
-use crate::marked::SeqMarked;
 use crate::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;

--- a/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
+++ b/src/meta/raft-store/src/leveled_store/db_map_api_ro_test.rs
@@ -22,9 +22,10 @@ use map_api::map_api_ro::MapApiRO;
 use crate::leveled_store::db_builder::DBBuilder;
 use crate::leveled_store::db_map_api_ro_impl::MapView;
 use crate::leveled_store::map_api::AsMap;
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 use crate::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_db_map_api_ro() -> anyhow::Result<()> {
@@ -67,32 +68,32 @@ async fn test_db_map_api_ro() -> anyhow::Result<()> {
     // Test kv map
 
     let binding = MapView(&db);
-    let smap = binding.str_map();
+    let smap = binding.user_map();
     assert_eq!(
-        Marked::new_with_meta(4, b("a1"), Some(KVMeta::new(Some(15)))),
-        smap.get(&s("a")).await?
+        SeqMarked::new_normal(4, (Some(KVMeta::new(Some(15))), b("a1"))),
+        smap.get(&user_key("a")).await?
     );
     assert_eq!(
-        Marked::empty(),
-        smap.get(&s("b")).await?,
+        SeqMarked::new_not_found(),
+        smap.get(&user_key("b")).await?,
         "no tombstone is stored"
     );
     assert_eq!(
-        Marked::new_with_meta(3, b("c0"), Some(KVMeta::new(Some(20)))),
-        smap.get(&s("c")).await?
+        SeqMarked::new_normal(3, (Some(KVMeta::new(Some(20))), b("c0"))),
+        smap.get(&user_key("c")).await?
     );
-    assert_eq!(Marked::empty(), smap.get(&s("d")).await?);
+    assert_eq!(SeqMarked::new_not_found(), smap.get(&user_key("d")).await?);
 
     let got = smap.range(..).await?.try_collect::<Vec<_>>().await?;
     assert_eq!(
         vec![
             (
-                s("a"),
-                Marked::new_with_meta(4, b("a1"), Some(KVMeta::new(Some(15)))),
+                user_key("a"),
+                SeqMarked::new_normal(4, (Some(KVMeta::new(Some(15))), b("a1"))),
             ),
             (
-                s("c"),
-                Marked::new_with_meta(3, b("c0"), Some(KVMeta::new(Some(20)))),
+                user_key("c"),
+                SeqMarked::new_normal(3, (Some(KVMeta::new(Some(20))), b("c0"))),
             )
         ],
         got
@@ -104,20 +105,23 @@ async fn test_db_map_api_ro() -> anyhow::Result<()> {
     let emap = binding.expire_map();
 
     assert_eq!(
-        Marked::new_normal(4, s("a")),
+        SeqMarked::new_normal(4, s("a")),
         emap.get(&ExpireKey::new(15_000, 4)).await?
     );
     assert_eq!(
-        Marked::new_normal(3, s("c")),
+        SeqMarked::new_normal(3, s("c")),
         emap.get(&ExpireKey::new(20_000, 3)).await?
     );
-    assert_eq!(Marked::empty(), emap.get(&ExpireKey::new(5_000, 2)).await?);
+    assert_eq!(
+        SeqMarked::new_not_found(),
+        emap.get(&ExpireKey::new(5_000, 2)).await?
+    );
 
     let got = emap.range(..).await?.try_collect::<Vec<_>>().await?;
     assert_eq!(
         vec![
-            (ExpireKey::new(15_000, 4), Marked::new_normal(4, s("a"))),
-            (ExpireKey::new(20_000, 3), Marked::new_normal(3, s("c"))),
+            (ExpireKey::new(15_000, 4), SeqMarked::new_normal(4, s("a"))),
+            (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
         ],
         got
     );
@@ -130,4 +134,7 @@ fn s(x: impl ToString) -> String {
 }
 fn b(x: impl ToString) -> Vec<u8> {
     x.to_string().as_bytes().to_vec()
+}
+fn user_key(s: impl ToString) -> UserKey {
+    UserKey::new(s)
 }

--- a/src/meta/raft-store/src/leveled_store/immutable.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use map_api::map_api_ro::MapApiRO;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::level::Level;
 use crate::leveled_store::level_index::LevelIndex;
@@ -29,7 +30,6 @@ use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapKV;
 use crate::leveled_store::map_api::SeqMarkedOf;
 use crate::marked::MetaValue;
-use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;
 

--- a/src/meta/raft-store/src/leveled_store/immutable.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use databend_common_meta_types::KVMeta;
 use map_api::map_api_ro::MapApiRO;
 
 use crate::leveled_store::level::Level;
@@ -28,8 +27,11 @@ use crate::leveled_store::level_index::LevelIndex;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapKV;
-use crate::leveled_store::map_api::MarkedOf;
+use crate::leveled_store::map_api::SeqMarkedOf;
+use crate::marked::MetaValue;
+use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 /// A single **immutable** level of state machine data.
 ///
@@ -86,10 +88,10 @@ impl Deref for Immutable {
 
 impl Immutable {
     /// Build a static stream that yields key values for primary index
-    #[futures_async_stream::try_stream(boxed, ok = MapKV<String>, error = io::Error)]
+    #[futures_async_stream::try_stream(boxed, ok = MapKV<UserKey>, error = io::Error)]
     async fn str_range<Q, R>(self: Immutable, range: R)
     where
-        String: Borrow<Q>,
+        UserKey: Borrow<Q>,
         Q: Ord + Send + Sync + ?Sized,
         R: RangeBounds<Q> + Clone + Send + Sync + 'static,
     {
@@ -117,22 +119,22 @@ impl Immutable {
 }
 
 #[async_trait::async_trait]
-impl MapApiRO<String, KVMeta> for Immutable {
-    async fn get(&self, key: &String) -> Result<MarkedOf<String>, io::Error> {
+impl MapApiRO<UserKey> for Immutable {
+    async fn get(&self, key: &UserKey) -> Result<SeqMarked<MetaValue>, io::Error> {
         // get() is just delegated
-        self.as_ref().str_map().get(key).await
+        self.as_ref().user_map().get(key).await
     }
 
-    async fn range<R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
-    where R: RangeBounds<String> + Clone + Send + Sync + 'static {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<UserKey>, io::Error>
+    where R: RangeBounds<UserKey> + Clone + Send + Sync + 'static {
         let strm = self.clone().str_range(range);
         Ok(strm)
     }
 }
 
 #[async_trait::async_trait]
-impl MapApiRO<ExpireKey, KVMeta> for Immutable {
-    async fn get(&self, key: &ExpireKey) -> Result<MarkedOf<ExpireKey>, io::Error> {
+impl MapApiRO<ExpireKey> for Immutable {
+    async fn get(&self, key: &ExpireKey) -> Result<SeqMarkedOf<ExpireKey>, io::Error> {
         // get() is just delegated
         self.as_ref().expire_map().get(key).await
     }

--- a/src/meta/raft-store/src/leveled_store/immutable_levels.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable_levels.rs
@@ -18,6 +18,7 @@ use std::ops::RangeBounds;
 use map_api::compact::compacted_get;
 use map_api::compact::compacted_range;
 use map_api::map_api_ro::MapApiRO;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::immutable::Immutable;
 use crate::leveled_store::level::Level;
@@ -25,7 +26,6 @@ use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapKey;
 use crate::leveled_store::map_api::MapKeyDecode;
 use crate::leveled_store::map_api::MapKeyEncode;
-use crate::marked::SeqMarked;
 
 /// A readonly leveled map that owns the data.
 #[derive(Debug, Default, Clone)]

--- a/src/meta/raft-store/src/leveled_store/immutable_levels.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable_levels.rs
@@ -15,7 +15,6 @@
 use std::io;
 use std::ops::RangeBounds;
 
-use databend_common_meta_types::KVMeta;
 use map_api::compact::compacted_get;
 use map_api::compact::compacted_range;
 use map_api::map_api_ro::MapApiRO;
@@ -26,7 +25,7 @@ use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::MapKey;
 use crate::leveled_store::map_api::MapKeyDecode;
 use crate::leveled_store::map_api::MapKeyEncode;
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 
 /// A readonly leveled map that owns the data.
 #[derive(Debug, Default, Clone)]
@@ -69,22 +68,22 @@ impl ImmutableLevels {
 }
 
 #[async_trait::async_trait]
-impl<K> MapApiRO<K, KVMeta> for ImmutableLevels
+impl<K> MapApiRO<K> for ImmutableLevels
 where
-    K: MapKey<KVMeta>,
+    K: MapKey,
     K: MapKeyEncode,
     K: MapKeyDecode,
-    Level: MapApiRO<K, KVMeta>,
-    Immutable: MapApiRO<K, KVMeta>,
+    Level: MapApiRO<K>,
+    Immutable: MapApiRO<K>,
 {
-    async fn get(&self, key: &K) -> Result<Marked<K::V>, io::Error> {
+    async fn get(&self, key: &K) -> Result<SeqMarked<K::V>, io::Error> {
         let levels = self.iter_immutable_levels();
-        compacted_get::<_, _, _, Immutable>(key, levels, []).await
+        compacted_get::<_, _, Immutable>(key, levels, []).await
     }
 
     async fn range<R>(&self, range: R) -> Result<KVResultStream<K>, io::Error>
     where R: RangeBounds<K> + Clone + Send + Sync + 'static {
         let levels = self.iter_immutable_levels();
-        compacted_range::<_, _, _, Level, _, Level>(range, None, levels, []).await
+        compacted_range::<_, _, Level, _, Level>(range, None, levels, []).await
     }
 }

--- a/src/meta/raft-store/src/leveled_store/level.rs
+++ b/src/meta/raft-store/src/leveled_store/level.rs
@@ -23,13 +23,13 @@ use map_api::map_api::MapApi;
 use map_api::map_api_ro::MapApiRO;
 use map_api::map_key::MapKey;
 use map_api::BeforeAfter;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::KVResultStream;
 use crate::leveled_store::map_api::SeqMarkedOf;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
 use crate::marked::MetaValue;
-use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;
 

--- a/src/meta/raft-store/src/leveled_store/level.rs
+++ b/src/meta/raft-store/src/leveled_store/level.rs
@@ -16,7 +16,6 @@ use std::collections::BTreeMap;
 use std::io;
 use std::ops::RangeBounds;
 
-use databend_common_meta_types::seq_value::KVMeta;
 use databend_common_meta_types::sys_data::SysData;
 use futures_util::StreamExt;
 use log::warn;
@@ -27,10 +26,12 @@ use map_api::BeforeAfter;
 
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::KVResultStream;
-use crate::leveled_store::map_api::MarkedOf;
+use crate::leveled_store::map_api::SeqMarkedOf;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
-use crate::marked::Marked;
+use crate::marked::MetaValue;
+use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 /// A single level of state machine data.
 ///
@@ -41,10 +42,10 @@ pub struct Level {
     pub(crate) sys_data: SysData,
 
     /// Generic Key-value store.
-    pub(crate) kv: BTreeMap<String, Marked<Vec<u8>>>,
+    pub(crate) kv: BTreeMap<UserKey, SeqMarked<MetaValue>>,
 
     /// The expiration queue of generic kv.
-    pub(crate) expire: BTreeMap<ExpireKey, Marked<String>>,
+    pub(crate) expire: BTreeMap<ExpireKey, SeqMarked<String>>,
 }
 
 impl Level {
@@ -69,25 +70,29 @@ impl Level {
     }
 
     /// Replace the kv store with a new one.
-    pub(crate) fn replace_kv(&mut self, kv: BTreeMap<String, Marked<Vec<u8>>>) {
+    pub(crate) fn replace_kv(&mut self, kv: BTreeMap<UserKey, SeqMarked<MetaValue>>) {
         self.kv = kv;
     }
 
-    /// Replace the expire queue with a new one.
-    pub(crate) fn replace_expire(&mut self, expire: BTreeMap<ExpireKey, Marked<String>>) {
+    /// Replace the expiry queue with a new one.
+    pub(crate) fn replace_expire(&mut self, expire: BTreeMap<ExpireKey, SeqMarked<String>>) {
         self.expire = expire;
     }
 }
 
 #[async_trait::async_trait]
-impl MapApiRO<String, KVMeta> for Level {
-    async fn get(&self, key: &String) -> Result<MarkedOf<String>, io::Error> {
-        let got = self.kv.get(key).cloned().unwrap_or(Marked::empty());
+impl MapApiRO<UserKey> for Level {
+    async fn get(&self, key: &UserKey) -> Result<SeqMarked<MetaValue>, io::Error> {
+        let got = self
+            .kv
+            .get(key)
+            .cloned()
+            .unwrap_or(SeqMarked::new_not_found());
         Ok(got)
     }
 
-    async fn range<R>(&self, range: R) -> Result<KVResultStream<String>, io::Error>
-    where R: RangeBounds<String> + Clone + Send + Sync + 'static {
+    async fn range<R>(&self, range: R) -> Result<KVResultStream<UserKey>, io::Error>
+    where R: RangeBounds<UserKey> + Clone + Send + Sync + 'static {
         // Level is borrowed. It has to copy the result to make the returning stream static.
         let vec = self
             .kv
@@ -97,7 +102,7 @@ impl MapApiRO<String, KVMeta> for Level {
 
         if vec.len() > 1000 {
             warn!(
-                "Level::<String>::range() returns big range of len={}",
+                "Level::<UserKey>::range() returns big range of len={}",
                 vec.len()
             );
         }
@@ -108,34 +113,38 @@ impl MapApiRO<String, KVMeta> for Level {
 }
 
 #[async_trait::async_trait]
-impl MapApi<String, KVMeta> for Level {
+impl MapApi<UserKey> for Level {
     async fn set(
         &mut self,
-        key: String,
-        value: Option<(<String as MapKey<KVMeta>>::V, Option<KVMeta>)>,
-    ) -> Result<BeforeAfter<MarkedOf<String>>, io::Error> {
+        key: UserKey,
+        value: Option<MetaValue>,
+    ) -> Result<BeforeAfter<SeqMarked<MetaValue>>, io::Error> {
         // The chance it is the bottom level is very low in a loaded system.
         // Thus, we always tombstone the key if it is None.
 
-        let marked = if let Some((v, meta)) = value {
+        let marked = if let Some(meta_v) = value {
             let seq = self.sys_data_mut().next_seq();
-            Marked::new_with_meta(seq, v, meta)
+            SeqMarked::new_normal(seq, meta_v)
         } else {
             // Do not increase the sequence number, just use the max seq for all tombstone.
             let seq = self.curr_seq();
-            Marked::new_tombstone(seq)
+            SeqMarked::new_tombstone(seq)
         };
 
-        let prev = (*self).str_map().get(&key).await?;
+        let prev = (*self).user_map().get(&key).await?;
         self.kv.insert(key, marked.clone());
         Ok((prev, marked))
     }
 }
 
 #[async_trait::async_trait]
-impl MapApiRO<ExpireKey, KVMeta> for Level {
-    async fn get(&self, key: &ExpireKey) -> Result<MarkedOf<ExpireKey>, io::Error> {
-        let got = self.expire.get(key).cloned().unwrap_or(Marked::empty());
+impl MapApiRO<ExpireKey> for Level {
+    async fn get(&self, key: &ExpireKey) -> Result<SeqMarkedOf<ExpireKey>, io::Error> {
+        let got = self
+            .expire
+            .get(key)
+            .cloned()
+            .unwrap_or(SeqMarked::new_not_found());
         Ok(got)
     }
 
@@ -161,18 +170,18 @@ impl MapApiRO<ExpireKey, KVMeta> for Level {
 }
 
 #[async_trait::async_trait]
-impl MapApi<ExpireKey, KVMeta> for Level {
+impl MapApi<ExpireKey> for Level {
     async fn set(
         &mut self,
         key: ExpireKey,
-        value: Option<(<ExpireKey as MapKey<KVMeta>>::V, Option<KVMeta>)>,
-    ) -> Result<BeforeAfter<MarkedOf<ExpireKey>>, io::Error> {
+        value: Option<<ExpireKey as MapKey>::V>,
+    ) -> Result<BeforeAfter<SeqMarkedOf<ExpireKey>>, io::Error> {
         let seq = self.curr_seq();
 
-        let marked = if let Some((v, meta)) = value {
-            Marked::from((seq, v, meta))
+        let marked = if let Some(v) = value {
+            SeqMarked::new_normal(seq, v)
         } else {
-            Marked::TombStone { internal_seq: seq }
+            SeqMarked::new_tombstone(seq)
         };
 
         let prev = (*self).expire_map().get(&key).await?;

--- a/src/meta/raft-store/src/leveled_store/leveled_map/compacting_data.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/compacting_data.rs
@@ -22,6 +22,7 @@ use futures_util::StreamExt;
 use futures_util::TryStreamExt;
 use map_api::map_api_ro::MapApiRO;
 use map_api::IOResultStream;
+use map_api::MapKV;
 use rotbl::v001::SeqMarked;
 use stream_more::KMerge;
 use stream_more::StreamMore;
@@ -31,8 +32,8 @@ use crate::leveled_store::immutable_levels::ImmutableLevels;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::rotbl_codec::RotblCodec;
 use crate::leveled_store::util;
-use crate::marked::Marked;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 use crate::utils::add_cooperative_yielding;
 
 /// The data to compact.
@@ -75,7 +76,7 @@ impl<'a> CompactingData<'a> {
         data.replace_expire(bt);
 
         // Copy all kv data and keep tombstone.
-        let strm = (*immutable_levels).str_map().range(..).await?;
+        let strm = (*immutable_levels).user_map().range(..).await?;
         let bt = strm.try_collect().await?;
         data.replace_kv(bt);
 
@@ -110,7 +111,7 @@ impl<'a> CompactingData<'a> {
         // expire index: prefix `exp-/`.
 
         let strm = (*self.immutable_levels).expire_map().range(..).await?;
-        let expire_strm = strm.map(|item: Result<(ExpireKey, Marked<String>), io::Error>| {
+        let expire_strm = strm.map(|item: Result<(ExpireKey, SeqMarked<String>), io::Error>| {
             let (expire_key, marked_string) = item?;
 
             RotblCodec::encode_key_seq_marked(&expire_key, marked_string)
@@ -119,8 +120,8 @@ impl<'a> CompactingData<'a> {
 
         // kv: prefix: `kv--/`
 
-        let strm = (*self.immutable_levels).str_map().range(..).await?;
-        let kv_strm = strm.map(|item: Result<(String, Marked), io::Error>| {
+        let strm = (*self.immutable_levels).user_map().range(..).await?;
+        let kv_strm = strm.map(|item: Result<MapKV<UserKey>, io::Error>| {
             let (k, v) = item?;
 
             RotblCodec::encode_key_seq_marked(&k, v).map_err(|e| with_context(e, &k))

--- a/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
@@ -500,9 +500,9 @@ async fn test_2_level_same_tombstone() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
-            "a=Normal { internal_seq: 1, value: [97, 48], meta: None }",
-            "b=TombStone { internal_seq: 3 }",
-            "c=Normal { internal_seq: 4, value: [99, 49], meta: None }"
+            "a=SeqMarked { seq: 1, marked: Normal((None, [97, 48])) }",
+            "b=SeqMarked { seq: 3, marked: TombStone }",
+            "c=SeqMarked { seq: 4, marked: Normal((None, [99, 49])) }"
         ],
         got
     );

--- a/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
@@ -16,52 +16,59 @@ use databend_common_meta_types::seq_value::KVMeta;
 use futures_util::TryStreamExt;
 use map_api::map_api::MapApi;
 use map_api::map_api_ro::MapApiRO;
+use map_api::SeqMarked;
 
 use crate::leveled_store::leveled_map::LeveledMap;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::MapApiExt;
-use crate::marked::Marked;
+use crate::state_machine::UserKey;
 
 #[tokio::test]
 async fn test_freeze() -> anyhow::Result<()> {
     let mut l = LeveledMap::default();
 
     // Insert an entry at level 0
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b0"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(0));
-    assert_eq!(result, Marked::new_with_meta(1, b("b0"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a1"), Some((None, b("b0"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(0));
+    assert_eq!(result, SeqMarked::new_normal(1, (None, b("b0"))));
 
     // Insert the same entry at level 1
     l.freeze_writable();
 
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(1, b("b0"), None));
-    assert_eq!(result, Marked::new_with_meta(2, b("b1"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a1"), Some((None, b("b1"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(1, (None, b("b0"))));
+    assert_eq!(result, SeqMarked::new_normal(2, (None, b("b1"))));
 
     // Listing entries from all levels see the latest
     let got = l
-        .str_map()
-        .range(s("")..)
+        .user_map()
+        .range(user_key("")..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(2, b("b1"), None)),
+        (user_key("a1"), SeqMarked::new_normal(2, (None, b("b1")))),
     ]);
 
     // Listing from the base level sees the old value.
     let immutables = l.immutable_levels_ref();
 
     let got = immutables
-        .str_map()
-        .range(s("")..)
+        .user_map()
+        .range(user_key("")..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(1, b("b0"), None)),
+        (user_key("a1"), SeqMarked::new_normal(1, (None, b("b0")))),
     ]);
 
     Ok(())
@@ -72,55 +79,73 @@ async fn test_single_level() -> anyhow::Result<()> {
     let mut l = LeveledMap::default();
 
     // Write a1
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(0));
-    assert_eq!(result, Marked::new_with_meta(1, b("b1"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a1"), Some((None, b("b1"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(0));
+    assert_eq!(result, SeqMarked::new_normal(1, (None, b("b1"))));
 
     // Write more
-    let (_prev, result) = l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await?;
-    assert_eq!(result, Marked::new_with_meta(2, b("b2"), None));
+    let (_prev, result) = l
+        .user_map_mut()
+        .set(user_key("a2"), Some((None, b("b2"))))
+        .await?;
+    assert_eq!(result, SeqMarked::new_normal(2, (None, b("b2"))));
 
-    let (_prev, result) = l.str_map_mut().set(s("a3"), Some((b("b3"), None))).await?;
-    assert_eq!(result, Marked::new_with_meta(3, b("b3"), None));
+    let (_prev, result) = l
+        .user_map_mut()
+        .set(user_key("a3"), Some((None, b("b3"))))
+        .await?;
+    assert_eq!(result, SeqMarked::new_normal(3, (None, b("b3"))));
 
-    let (_prev, result) = l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await?;
-    assert_eq!(result, Marked::new_with_meta(4, b("y1"), None));
+    let (_prev, result) = l
+        .user_map_mut()
+        .set(user_key("x1"), Some((None, b("y1"))))
+        .await?;
+    assert_eq!(result, SeqMarked::new_normal(4, (None, b("y1"))));
 
-    let (_prev, result) = l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await?;
-    assert_eq!(result, Marked::new_with_meta(5, b("y2"), None));
+    let (_prev, result) = l
+        .user_map_mut()
+        .set(user_key("x2"), Some((None, b("y2"))))
+        .await?;
+    assert_eq!(result, SeqMarked::new_normal(5, (None, b("y2"))));
 
     // Override a1
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(1, b("b1"), None));
-    assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a1"), Some((None, b("b1"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(1, (None, b("b1"))));
+    assert_eq!(result, SeqMarked::new_normal(6, (None, b("b1"))));
 
     // Delete a3
-    let (prev, result) = l.str_map_mut().set(s("a3"), None).await?;
-    assert_eq!(prev, Marked::new_with_meta(3, b("b3"), None));
+    let (prev, result) = l.user_map_mut().set(user_key("a3"), None).await?;
+    assert_eq!(prev, SeqMarked::new_normal(3, (None, b("b3"))));
     assert_eq!(
         result,
-        Marked::new_tombstone(6),
+        SeqMarked::new_tombstone(6),
         "NOTE: single level data also creates a tombstone"
     );
 
     // Range
-    let strm = l.str_map().range(s("")..).await?;
+    let strm = l.user_map().range(user_key("")..).await?;
     let got = strm.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(6, b("b1"), None)),
-        (s("a2"), Marked::new_with_meta(2, b("b2"), None)),
-        (s("a3"), Marked::new_tombstone(6)),
-        (s("x1"), Marked::new_with_meta(4, b("y1"), None)),
-        (s("x2"), Marked::new_with_meta(5, b("y2"), None)),
+        (user_key("a1"), SeqMarked::new_normal(6, (None, b("b1")))),
+        (user_key("a2"), SeqMarked::new_normal(2, (None, b("b2")))),
+        (user_key("a3"), SeqMarked::new_tombstone(6)),
+        (user_key("x1"), SeqMarked::new_normal(4, (None, b("y1")))),
+        (user_key("x2"), SeqMarked::new_normal(5, (None, b("y2")))),
     ]);
 
     // Get
-    let got = l.str_map().get(&s("a2")).await?;
-    assert_eq!(got, Marked::new_with_meta(2, b("b2"), None));
+    let got = l.user_map().get(&user_key("a2")).await?;
+    assert_eq!(got, SeqMarked::new_normal(2, (None, b("b2"))));
 
-    let got = l.str_map().get(&s("a3")).await?;
-    assert_eq!(got, Marked::new_tombstone(6));
+    let got = l.user_map().get(&user_key("a3")).await?;
+    assert_eq!(got, SeqMarked::new_tombstone(6));
     Ok(())
 }
 
@@ -130,19 +155,27 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     let mut l = LeveledMap::default();
 
-    l.str_map_mut().set(s("a1"), Some((b("b1"), None))).await?;
-    l.str_map_mut().set(s("a2"), Some((b("b2"), None))).await?;
-    l.str_map_mut().set(s("x1"), Some((b("y1"), None))).await?;
-    l.str_map_mut().set(s("x2"), Some((b("y2"), None))).await?;
+    l.user_map_mut()
+        .set(user_key("a1"), Some((None, b("b1"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("a2"), Some((None, b("b2"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("x1"), Some((None, b("y1"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("x2"), Some((None, b("y2"))))
+        .await?;
 
-    let it = l.str_map().range(s("")..).await?;
+    let it = l.user_map().range(user_key("")..).await?;
     let got = it.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(1, b("b1"), None)),
-        (s("a2"), Marked::new_with_meta(2, b("b2"), None)),
-        (s("x1"), Marked::new_with_meta(3, b("y1"), None)),
-        (s("x2"), Marked::new_with_meta(4, b("y2"), None)),
+        (user_key("a1"), SeqMarked::new_normal(1, (None, b("b1")))),
+        (user_key("a2"), SeqMarked::new_normal(2, (None, b("b2")))),
+        (user_key("x1"), SeqMarked::new_normal(3, (None, b("y1")))),
+        (user_key("x2"), SeqMarked::new_normal(4, (None, b("y2")))),
     ]);
 
     // Create a new level
@@ -150,59 +183,68 @@ async fn test_two_levels() -> anyhow::Result<()> {
     l.freeze_writable();
 
     // Override
-    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b3"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(2, b("b2"), None));
-    assert_eq!(result, Marked::new_with_meta(5, b("b3"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a2"), Some((None, b("b3"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(2, (None, b("b2"))));
+    assert_eq!(result, SeqMarked::new_normal(5, (None, b("b3"))));
 
     // Override again
-    let (prev, result) = l.str_map_mut().set(s("a2"), Some((b("b4"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(5, b("b3"), None));
-    assert_eq!(result, Marked::new_with_meta(6, b("b4"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a2"), Some((None, b("b4"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(5, (None, b("b3"))));
+    assert_eq!(result, SeqMarked::new_normal(6, (None, b("b4"))));
 
     // Delete by adding a tombstone
-    let (prev, result) = l.str_map_mut().set(s("a1"), None).await?;
-    assert_eq!(prev, Marked::new_with_meta(1, b("b1"), None));
-    assert_eq!(result, Marked::new_tombstone(6));
+    let (prev, result) = l.user_map_mut().set(user_key("a1"), None).await?;
+    assert_eq!(prev, SeqMarked::new_normal(1, (None, b("b1"))));
+    assert_eq!(result, SeqMarked::new_tombstone(6));
 
     // Override tombstone
-    let (prev, result) = l.str_map_mut().set(s("a1"), Some((b("b5"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(6));
-    assert_eq!(result, Marked::new_with_meta(7, b("b5"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a1"), Some((None, b("b5"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(6));
+    assert_eq!(result, SeqMarked::new_normal(7, (None, b("b5"))));
 
     // Range
-    let it = l.str_map().range(s("")..).await?;
+    let it = l.user_map().range(user_key("")..).await?;
     let got = it.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(7, b("b5"), None)),
-        (s("a2"), Marked::new_with_meta(6, b("b4"), None)),
-        (s("x1"), Marked::new_with_meta(3, b("y1"), None)),
-        (s("x2"), Marked::new_with_meta(4, b("y2"), None)),
+        (user_key("a1"), SeqMarked::new_normal(7, (None, b("b5")))),
+        (user_key("a2"), SeqMarked::new_normal(6, (None, b("b4")))),
+        (user_key("x1"), SeqMarked::new_normal(3, (None, b("y1")))),
+        (user_key("x2"), SeqMarked::new_normal(4, (None, b("y2")))),
     ]);
 
     // Get
 
-    let got = l.str_map().get(&s("a1")).await?;
-    assert_eq!(got, Marked::new_with_meta(7, b("b5"), None));
+    let got = l.user_map().get(&user_key("a1")).await?;
+    assert_eq!(got, SeqMarked::new_normal(7, (None, b("b5"))));
 
-    let got = l.str_map().get(&s("a2")).await?;
-    assert_eq!(got, Marked::new_with_meta(6, b("b4"), None));
+    let got = l.user_map().get(&user_key("a2")).await?;
+    assert_eq!(got, SeqMarked::new_normal(6, (None, b("b4"))));
 
-    let got = l.str_map().get(&s("w1")).await?;
-    assert_eq!(got, Marked::new_tombstone(0));
+    let got = l.user_map().get(&user_key("w1")).await?;
+    assert_eq!(got, SeqMarked::new_tombstone(0));
 
     // Check base level
 
     let immutables = l.immutable_levels_ref();
 
-    let strm = immutables.str_map().range(s("")..).await?;
+    let strm = immutables.user_map().range(user_key("")..).await?;
     let got = strm.try_collect::<Vec<_>>().await?;
     assert_eq!(got, vec![
         //
-        (s("a1"), Marked::new_with_meta(1, b("b1"), None)),
-        (s("a2"), Marked::new_with_meta(2, b("b2"), None)),
-        (s("x1"), Marked::new_with_meta(3, b("y1"), None)),
-        (s("x2"), Marked::new_with_meta(4, b("y2"), None)),
+        (user_key("a1"), SeqMarked::new_normal(1, (None, b("b1")))),
+        (user_key("a2"), SeqMarked::new_normal(2, (None, b("b2")))),
+        (user_key("x1"), SeqMarked::new_normal(3, (None, b("y1")))),
+        (user_key("x2"), SeqMarked::new_normal(4, (None, b("y2")))),
     ]);
 
     Ok(())
@@ -218,21 +260,35 @@ async fn test_two_levels() -> anyhow::Result<()> {
 async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
     // internal_seq: 0
-    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
-    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
-    l.str_map_mut().set(s("d"), Some((b("d0"), None))).await?;
+    l.user_map_mut()
+        .set(user_key("a"), Some((None, b("a0"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("b"), Some((None, b("b0"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("c"), Some((None, b("c0"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("d"), Some((None, b("d0"))))
+        .await?;
 
     l.freeze_writable();
     // internal_seq: 4
-    l.str_map_mut().set(s("b"), None).await?;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
-    l.str_map_mut().set(s("e"), Some((b("e1"), None))).await?;
+    l.user_map_mut().set(user_key("b"), None).await?;
+    l.user_map_mut()
+        .set(user_key("c"), Some((None, b("c1"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("e"), Some((None, b("e1"))))
+        .await?;
 
     l.freeze_writable();
     // internal_seq: 6
-    l.str_map_mut().set(s("c"), None).await?;
-    l.str_map_mut().set(s("d"), Some((b("d2"), None))).await?;
+    l.user_map_mut().set(user_key("c"), None).await?;
+    l.user_map_mut()
+        .set(user_key("d"), Some((None, b("d2"))))
+        .await?;
 
     Ok(l)
 }
@@ -241,37 +297,37 @@ async fn build_3_levels() -> anyhow::Result<LeveledMap> {
 async fn test_three_levels_get_range() -> anyhow::Result<()> {
     let l = build_3_levels().await?;
 
-    let got = l.str_map().get(&s("a")).await?;
-    assert_eq!(got, Marked::new_with_meta(1, b("a0"), None));
+    let got = l.user_map().get(&user_key("a")).await?;
+    assert_eq!(got, SeqMarked::new_normal(1, (None, b("a0"))));
 
-    let got = l.str_map().get(&s("b")).await?;
-    assert_eq!(got, Marked::new_tombstone(4));
+    let got = l.user_map().get(&user_key("b")).await?;
+    assert_eq!(got, SeqMarked::new_tombstone(4));
 
-    let got = l.str_map().get(&s("c")).await?;
-    assert_eq!(got, Marked::new_tombstone(6));
+    let got = l.user_map().get(&user_key("c")).await?;
+    assert_eq!(got, SeqMarked::new_tombstone(6));
 
-    let got = l.str_map().get(&s("d")).await?;
-    assert_eq!(got, Marked::new_with_meta(7, b("d2"), None));
+    let got = l.user_map().get(&user_key("d")).await?;
+    assert_eq!(got, SeqMarked::new_normal(7, (None, b("d2"))));
 
-    let got = l.str_map().get(&s("e")).await?;
-    assert_eq!(got, Marked::new_with_meta(6, b("e1"), None));
+    let got = l.user_map().get(&user_key("e")).await?;
+    assert_eq!(got, SeqMarked::new_normal(6, (None, b("e1"))));
 
-    let got = l.str_map().get(&s("f")).await?;
-    assert_eq!(got, Marked::new_tombstone(0));
+    let got = l.user_map().get(&user_key("f")).await?;
+    assert_eq!(got, SeqMarked::new_tombstone(0));
 
     let got = l
-        .str_map()
-        .range(s("")..)
+        .user_map()
+        .range(user_key("")..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_with_meta(1, b("a0"), None)),
-        (s("b"), Marked::new_tombstone(4)),
-        (s("c"), Marked::new_tombstone(6)),
-        (s("d"), Marked::new_with_meta(7, b("d2"), None)),
-        (s("e"), Marked::new_with_meta(6, b("e1"), None)),
+        (user_key("a"), SeqMarked::new_normal(1, (None, b("a0")))),
+        (user_key("b"), SeqMarked::new_tombstone(4)),
+        (user_key("c"), SeqMarked::new_tombstone(6)),
+        (user_key("d"), SeqMarked::new_normal(7, (None, b("d2")))),
+        (user_key("e"), SeqMarked::new_normal(6, (None, b("e1")))),
     ]);
 
     Ok(())
@@ -281,44 +337,62 @@ async fn test_three_levels_get_range() -> anyhow::Result<()> {
 async fn test_three_levels_override() -> anyhow::Result<()> {
     let mut l = build_3_levels().await?;
 
-    let (prev, result) = l.str_map_mut().set(s("a"), Some((b("x"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(1, b("a0"), None));
-    assert_eq!(result, Marked::new_with_meta(8, b("x"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("a"), Some((None, b("x"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(1, (None, b("a0"))));
+    assert_eq!(result, SeqMarked::new_normal(8, (None, b("x"))));
 
-    let (prev, result) = l.str_map_mut().set(s("b"), Some((b("y"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(4));
-    assert_eq!(result, Marked::new_with_meta(9, b("y"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("b"), Some((None, b("y"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(4));
+    assert_eq!(result, SeqMarked::new_normal(9, (None, b("y"))));
 
-    let (prev, result) = l.str_map_mut().set(s("c"), Some((b("z"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(6));
-    assert_eq!(result, Marked::new_with_meta(10, b("z"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("c"), Some((None, b("z"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(6));
+    assert_eq!(result, SeqMarked::new_normal(10, (None, b("z"))));
 
-    let (prev, result) = l.str_map_mut().set(s("d"), Some((b("u"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(7, b("d2"), None));
-    assert_eq!(result, Marked::new_with_meta(11, b("u"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("d"), Some((None, b("u"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(7, (None, b("d2"))));
+    assert_eq!(result, SeqMarked::new_normal(11, (None, b("u"))));
 
-    let (prev, result) = l.str_map_mut().set(s("e"), Some((b("v"), None))).await?;
-    assert_eq!(prev, Marked::new_with_meta(6, b("e1"), None));
-    assert_eq!(result, Marked::new_with_meta(12, b("v"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("e"), Some((None, b("v"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_normal(6, (None, b("e1"))));
+    assert_eq!(result, SeqMarked::new_normal(12, (None, b("v"))));
 
-    let (prev, result) = l.str_map_mut().set(s("f"), Some((b("w"), None))).await?;
-    assert_eq!(prev, Marked::new_tombstone(0));
-    assert_eq!(result, Marked::new_with_meta(13, b("w"), None));
+    let (prev, result) = l
+        .user_map_mut()
+        .set(user_key("f"), Some((None, b("w"))))
+        .await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(0));
+    assert_eq!(result, SeqMarked::new_normal(13, (None, b("w"))));
 
     let got = l
-        .str_map()
-        .range(s("")..)
+        .user_map()
+        .range(user_key("")..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_with_meta(8, b("x"), None)),
-        (s("b"), Marked::new_with_meta(9, b("y"), None)),
-        (s("c"), Marked::new_with_meta(10, b("z"), None)),
-        (s("d"), Marked::new_with_meta(11, b("u"), None)),
-        (s("e"), Marked::new_with_meta(12, b("v"), None)),
-        (s("f"), Marked::new_with_meta(13, b("w"), None)),
+        (user_key("a"), SeqMarked::new_normal(8, (None, b("x")))),
+        (user_key("b"), SeqMarked::new_normal(9, (None, b("y")))),
+        (user_key("c"), SeqMarked::new_normal(10, (None, b("z")))),
+        (user_key("d"), SeqMarked::new_normal(11, (None, b("u")))),
+        (user_key("e"), SeqMarked::new_normal(12, (None, b("v")))),
+        (user_key("f"), SeqMarked::new_normal(13, (None, b("w")))),
     ]);
 
     Ok(())
@@ -328,43 +402,43 @@ async fn test_three_levels_override() -> anyhow::Result<()> {
 async fn test_three_levels_delete() -> anyhow::Result<()> {
     let mut l = build_3_levels().await?;
 
-    let (prev, result) = l.str_map_mut().set(s("a"), None).await?;
-    assert_eq!(prev, Marked::new_with_meta(1, b("a0"), None));
-    assert_eq!(result, Marked::new_tombstone(7));
+    let (prev, result) = l.user_map_mut().set(user_key("a"), None).await?;
+    assert_eq!(prev, SeqMarked::new_normal(1, (None, b("a0"))));
+    assert_eq!(result, SeqMarked::new_tombstone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("b"), None).await?;
-    assert_eq!(prev, Marked::new_tombstone(4));
-    assert_eq!(result, Marked::new_tombstone(7));
+    let (prev, result) = l.user_map_mut().set(user_key("b"), None).await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(4));
+    assert_eq!(result, SeqMarked::new_tombstone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("c"), None).await?;
-    assert_eq!(prev, Marked::new_tombstone(6));
-    assert_eq!(result, Marked::new_tombstone(7));
+    let (prev, result) = l.user_map_mut().set(user_key("c"), None).await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(6));
+    assert_eq!(result, SeqMarked::new_tombstone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("d"), None).await?;
-    assert_eq!(prev, Marked::new_with_meta(7, b("d2"), None));
-    assert_eq!(result, Marked::new_tombstone(7));
+    let (prev, result) = l.user_map_mut().set(user_key("d"), None).await?;
+    assert_eq!(prev, SeqMarked::new_normal(7, (None, b("d2"))));
+    assert_eq!(result, SeqMarked::new_tombstone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("e"), None).await?;
-    assert_eq!(prev, Marked::new_with_meta(6, b("e1"), None));
-    assert_eq!(result, Marked::new_tombstone(7));
+    let (prev, result) = l.user_map_mut().set(user_key("e"), None).await?;
+    assert_eq!(prev, SeqMarked::new_normal(6, (None, b("e1"))));
+    assert_eq!(result, SeqMarked::new_tombstone(7));
 
-    let (prev, result) = l.str_map_mut().set(s("f"), None).await?;
-    assert_eq!(prev, Marked::new_tombstone(0));
-    assert_eq!(result, Marked::new_tombstone(0));
+    let (prev, result) = l.user_map_mut().set(user_key("f"), None).await?;
+    assert_eq!(prev, SeqMarked::new_tombstone(0));
+    assert_eq!(result, SeqMarked::new_tombstone(0));
 
     let got = l
-        .str_map()
-        .range(s("")..)
+        .user_map()
+        .range(user_key("")..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_tombstone(7)),
-        (s("b"), Marked::new_tombstone(7)),
-        (s("c"), Marked::new_tombstone(7)),
-        (s("d"), Marked::new_tombstone(7)),
-        (s("e"), Marked::new_tombstone(7)),
+        (user_key("a"), SeqMarked::new_tombstone(7)),
+        (user_key("b"), SeqMarked::new_tombstone(7)),
+        (user_key("c"), SeqMarked::new_tombstone(7)),
+        (user_key("d"), SeqMarked::new_tombstone(7)),
+        (user_key("e"), SeqMarked::new_tombstone(7)),
     ]);
 
     Ok(())
@@ -378,21 +452,34 @@ async fn build_2_level_with_meta() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
 
     // internal_seq: 0
-    l.str_map_mut()
-        .set(s("a"), Some((b("a0"), Some(KVMeta::new_expires_at(1)))))
+    l.user_map_mut()
+        .set(
+            user_key("a"),
+            Some((Some(KVMeta::new_expires_at(1)), b("a0"))),
+        )
         .await?;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
-    l.str_map_mut()
-        .set(s("c"), Some((b("c0"), Some(KVMeta::new_expires_at(2)))))
+    l.user_map_mut()
+        .set(user_key("b"), Some((None, b("b0"))))
+        .await?;
+    l.user_map_mut()
+        .set(
+            user_key("c"),
+            Some((Some(KVMeta::new_expires_at(2)), b("c0"))),
+        )
         .await?;
 
     l.freeze_writable();
 
     // internal_seq: 3
-    l.str_map_mut()
-        .set(s("b"), Some((b("b1"), Some(KVMeta::new_expires_at(10)))))
+    l.user_map_mut()
+        .set(
+            user_key("b"),
+            Some((Some(KVMeta::new_expires_at(10)), b("b1"))),
+        )
         .await?;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
+    l.user_map_mut()
+        .set(user_key("c"), Some((None, b("c1"))))
+        .await?;
 
     Ok(l)
 }
@@ -402,7 +489,7 @@ async fn build_2_level_with_meta() -> anyhow::Result<LeveledMap> {
 #[tokio::test]
 async fn test_2_level_same_tombstone() -> anyhow::Result<()> {
     let lm = build_2_level_consecutive_delete().await?;
-    let strm = lm.str_map().range(..).await?;
+    let strm = lm.user_map().range(..).await?;
 
     let got = strm.try_collect::<Vec<_>>().await?;
 
@@ -432,16 +519,24 @@ async fn build_2_level_consecutive_delete() -> anyhow::Result<LeveledMap> {
     let mut l = LeveledMap::default();
 
     // internal_seq: 0
-    l.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
-    l.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
-    l.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
-    l.str_map_mut().set(s("b"), None).await?;
+    l.user_map_mut()
+        .set(user_key("a"), Some((None, b("a0"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("b"), Some((None, b("b0"))))
+        .await?;
+    l.user_map_mut()
+        .set(user_key("c"), Some((None, b("c0"))))
+        .await?;
+    l.user_map_mut().set(user_key("b"), None).await?;
 
     l.freeze_writable();
 
     // internal_seq: 3
-    l.str_map_mut().set(s("b"), None).await?;
-    l.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
+    l.user_map_mut().set(user_key("b"), None).await?;
+    l.user_map_mut()
+        .set(user_key("c"), Some((None, b("c1"))))
+        .await?;
 
     Ok(l)
 }
@@ -452,20 +547,20 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
     {
         let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("a"), b("a1")).await?;
+        let (prev, result) = MapApiExt::upsert_value(&mut l, user_key("a"), b("a1")).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expires_at(1)))
+            SeqMarked::new_normal(1, (Some(KVMeta::new_expires_at(1)), b("a0")))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expires_at(1)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(1)), b("a1")))
         );
 
-        let got = l.str_map().get(&s("a")).await?;
+        let got = l.user_map().get(&user_key("a")).await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a1"), Some(KVMeta::new_expires_at(1)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(1)), b("a1")))
         );
     }
 
@@ -473,20 +568,20 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
     {
         let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("b"), b("x1")).await?;
+        let (prev, result) = MapApiExt::upsert_value(&mut l, user_key("b"), b("x1")).await?;
         assert_eq!(
             prev,
-            Marked::new_normal(4, b("b1")).with_meta(Some(KVMeta::new_expires_at(10)))
+            SeqMarked::new_normal(4, (Some(KVMeta::new_expires_at(10)), b("b1")))
         );
         assert_eq!(
             result,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expires_at(10)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(10)), b("x1")))
         );
 
-        let got = l.str_map().get(&s("b")).await?;
+        let got = l.user_map().get(&user_key("b")).await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("x1")).with_meta(Some(KVMeta::new_expires_at(10)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(10)), b("x1")))
         );
     }
 
@@ -494,12 +589,12 @@ async fn test_two_level_update_value() -> anyhow::Result<()> {
     {
         let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::upsert_value(&mut l, s("d"), b("d1")).await?;
-        assert_eq!(prev, Marked::new_tombstone(0));
-        assert_eq!(result, Marked::new_with_meta(6, b("d1"), None));
+        let (prev, result) = MapApiExt::upsert_value(&mut l, user_key("d"), b("d1")).await?;
+        assert_eq!(prev, SeqMarked::new_tombstone(0));
+        assert_eq!(result, SeqMarked::new_normal(6, (None, b("d1"))));
 
-        let got = l.str_map().get(&s("d")).await?;
-        assert_eq!(got, Marked::new_with_meta(6, b("d1"), None));
+        let got = l.user_map().get(&user_key("d")).await?;
+        assert_eq!(got, SeqMarked::new_normal(6, (None, b("d1"))));
     }
 
     Ok(())
@@ -512,20 +607,21 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("a"), Some(KVMeta::new_expires_at(2))).await?;
+            MapApiExt::update_meta(&mut l, user_key("a"), Some(KVMeta::new_expires_at(2))).await?;
+
         assert_eq!(
             prev,
-            Marked::new_with_meta(1, b("a0"), Some(KVMeta::new_expires_at(1)))
+            SeqMarked::new_normal(1, (Some(KVMeta::new_expires_at(1)), b("a0")))
         );
         assert_eq!(
             result,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expires_at(2)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(2)), b("a0")))
         );
 
-        let got = l.str_map().get(&s("a")).await?;
+        let got = l.user_map().get(&user_key("a")).await?;
         assert_eq!(
             got,
-            Marked::new_with_meta(6, b("a0"), Some(KVMeta::new_expires_at(2)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(2)), b("a0")))
         );
     }
 
@@ -533,15 +629,15 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
     {
         let mut l = build_2_level_with_meta().await?;
 
-        let (prev, result) = MapApiExt::update_meta(&mut l, s("b"), None).await?;
+        let (prev, result) = MapApiExt::update_meta(&mut l, user_key("b"), None).await?;
         assert_eq!(
             prev,
-            Marked::new_with_meta(4, b("b1"), Some(KVMeta::new_expires_at(10)))
+            SeqMarked::new_normal(4, (Some(KVMeta::new_expires_at(10)), b("b1"),))
         );
-        assert_eq!(result, Marked::new_with_meta(6, b("b1"), None));
+        assert_eq!(result, SeqMarked::new_normal(6, (None, b("b1"))));
 
-        let got = l.str_map().get(&s("b")).await?;
-        assert_eq!(got, Marked::new_with_meta(6, b("b1"), None));
+        let got = l.user_map().get(&user_key("b")).await?;
+        assert_eq!(got, SeqMarked::new_normal(6, (None, b("b1"))));
     }
 
     // Update meta for c.
@@ -549,17 +645,17 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("c"), Some(KVMeta::new_expires_at(20))).await?;
-        assert_eq!(prev, Marked::new_with_meta(5, b("c1"), None));
+            MapApiExt::update_meta(&mut l, user_key("c"), Some(KVMeta::new_expires_at(20))).await?;
+        assert_eq!(prev, SeqMarked::new_normal(5, (None, b("c1"))));
         assert_eq!(
             result,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expires_at(20)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(20)), b("c1")))
         );
 
-        let got = l.str_map().get(&s("c")).await?;
+        let got = l.user_map().get(&user_key("c")).await?;
         assert_eq!(
             got,
-            Marked::new_normal(6, b("c1")).with_meta(Some(KVMeta::new_expires_at(20)))
+            SeqMarked::new_normal(6, (Some(KVMeta::new_expires_at(20)), b("c1")))
         );
     }
 
@@ -568,19 +664,19 @@ async fn test_two_level_update_meta() -> anyhow::Result<()> {
         let mut l = build_2_level_with_meta().await?;
 
         let (prev, result) =
-            MapApiExt::update_meta(&mut l, s("d"), Some(KVMeta::new_expires_at(2))).await?;
-        assert_eq!(prev, Marked::new_tombstone(0));
-        assert_eq!(result, Marked::new_tombstone(0));
+            MapApiExt::update_meta(&mut l, user_key("d"), Some(KVMeta::new_expires_at(2))).await?;
+        assert_eq!(prev, SeqMarked::new_tombstone(0));
+        assert_eq!(result, SeqMarked::new_tombstone(0));
 
-        let got = l.str_map().get(&s("d")).await?;
-        assert_eq!(got, Marked::new_tombstone(0));
+        let got = l.user_map().get(&user_key("d")).await?;
+        assert_eq!(got, SeqMarked::new_tombstone(0));
     }
 
     Ok(())
 }
 
-fn s(x: impl ToString) -> String {
-    x.to_string()
+fn user_key(s: impl ToString) -> UserKey {
+    UserKey::new(s)
 }
 
 fn b(x: impl ToString) -> Vec<u8> {

--- a/src/meta/raft-store/src/leveled_store/leveled_map/map_api_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/map_api_impl.rs
@@ -21,6 +21,7 @@ use map_api::compact::compacted_range;
 use map_api::map_api::MapApi;
 use map_api::map_api_ro::MapApiRO;
 use map_api::BeforeAfter;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::db_map_api_ro_impl::MapView;
 use crate::leveled_store::immutable::Immutable;
@@ -31,7 +32,6 @@ use crate::leveled_store::map_api::MapKey;
 use crate::leveled_store::map_api::MapKeyDecode;
 use crate::leveled_store::map_api::MapKeyEncode;
 use crate::leveled_store::map_api::SeqMarkedOf;
-use crate::marked::SeqMarked;
 
 #[async_trait::async_trait]
 impl<K> MapApiRO<K> for LeveledMap

--- a/src/meta/raft-store/src/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/leveled_store/map_api.rs
@@ -25,9 +25,9 @@ pub use map_api::map_key::MapKey;
 pub use map_api::map_value::MapValue;
 pub use map_api::BeforeAfter;
 pub use map_api::IOResultStream;
+use seq_marked::SeqMarked;
 
 use crate::marked::MetaValue;
-use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;
 

--- a/src/meta/raft-store/src/leveled_store/map_api.rs
+++ b/src/meta/raft-store/src/leveled_store/map_api.rs
@@ -26,8 +26,10 @@ pub use map_api::map_value::MapValue;
 pub use map_api::BeforeAfter;
 pub use map_api::IOResultStream;
 
-use crate::marked::Marked;
+use crate::marked::MetaValue;
+use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 pub type MapKeyPrefix = &'static str;
 
@@ -47,10 +49,10 @@ pub trait MapKeyDecode: Sized {
 }
 
 /// A Marked value type of key type.
-pub(crate) type MarkedOf<K> = Marked<<K as MapKey<KVMeta>>::V>;
+pub(crate) type SeqMarkedOf<K> = SeqMarked<<K as MapKey>::V>;
 
 /// A key-value pair used in a map.
-pub(crate) type MapKV<K> = (K, MarkedOf<K>);
+pub(crate) type MapKV<K> = (K, SeqMarkedOf<K>);
 
 /// A stream of result of key-value returned by `range()`.
 pub(crate) type KVResultStream<K> = IOResultStream<MapKV<K>>;
@@ -59,34 +61,34 @@ pub(crate) type KVResultStream<K> = IOResultStream<MapKV<K>>;
 #[allow(dead_code)]
 pub trait AsMap {
     /// Use Self as an implementation of the [`MapApiRO`] (Read-Only) interface.
-    fn as_map<K: MapKey<KVMeta>>(&self) -> &impl MapApiRO<K, KVMeta>
-    where Self: MapApiRO<K, KVMeta> + Sized {
+    fn as_map<K: MapKey>(&self) -> &impl MapApiRO<K>
+    where Self: MapApiRO<K> + Sized {
         self
     }
 
     /// Use Self as an implementation of the [`MapApi`] interface, allowing for mutation.
-    fn as_map_mut<K: MapKey<KVMeta>>(&mut self) -> &mut impl MapApi<K, KVMeta>
-    where Self: MapApi<K, KVMeta> + Sized {
+    fn as_map_mut<K: MapKey>(&mut self) -> &mut impl MapApi<K>
+    where Self: MapApi<K> + Sized {
         self
     }
 
-    fn str_map(&self) -> &impl MapApiRO<String, KVMeta>
-    where Self: MapApiRO<String, KVMeta> + Sized {
+    fn user_map(&self) -> &impl MapApiRO<UserKey>
+    where Self: MapApiRO<UserKey> + Sized {
         self
     }
 
-    fn expire_map(&self) -> &impl MapApiRO<ExpireKey, KVMeta>
-    where Self: MapApiRO<ExpireKey, KVMeta> + Sized {
+    fn expire_map(&self) -> &impl MapApiRO<ExpireKey>
+    where Self: MapApiRO<ExpireKey> + Sized {
         self
     }
 
-    fn str_map_mut(&mut self) -> &mut impl MapApi<String, KVMeta>
-    where Self: MapApi<String, KVMeta> + Sized {
+    fn user_map_mut(&mut self) -> &mut impl MapApi<UserKey>
+    where Self: MapApi<UserKey> + Sized {
         self
     }
 
-    fn expire_map_mut(&mut self) -> &mut impl MapApi<ExpireKey, KVMeta>
-    where Self: MapApi<ExpireKey, KVMeta> + Sized {
+    fn expire_map_mut(&mut self) -> &mut impl MapApi<ExpireKey>
+    where Self: MapApi<ExpireKey> + Sized {
         self
     }
 }
@@ -98,15 +100,13 @@ pub(crate) struct MapApiExt;
 impl MapApiExt {
     /// Update only the meta associated to an entry and keeps the value unchanged.
     /// If the entry does not exist, nothing is done.
-    pub(crate) async fn update_meta<K, T>(
+    pub(crate) async fn update_meta<T>(
         s: &mut T,
-        key: K,
+        key: UserKey,
         meta: Option<KVMeta>,
-    ) -> Result<BeforeAfter<MarkedOf<K>>, io::Error>
+    ) -> Result<BeforeAfter<SeqMarked<MetaValue>>, io::Error>
     where
-        K: MapKey<KVMeta>,
-        K: MapKeyEncode,
-        T: MapApi<K, KVMeta>,
+        T: MapApi<UserKey>,
     {
         //
         let got = s.get(&key).await?;
@@ -115,32 +115,28 @@ impl MapApiExt {
         }
 
         // Safe unwrap(), got is Normal
-        let (v, _) = got.unpack_ref().unwrap();
+        let (_meta, v) = got.into_data().unwrap();
 
-        s.set(key, Some((v.clone(), meta))).await
+        s.set(key, Some((meta, v))).await
     }
 
     /// Update only the value and keeps the meta unchanged.
     /// If the entry does not exist, create one.
     #[allow(dead_code)]
-    pub(crate) async fn upsert_value<K, T>(
+    pub(crate) async fn upsert_value<T>(
         s: &mut T,
-        key: K,
-        value: K::V,
-    ) -> Result<BeforeAfter<MarkedOf<K>>, io::Error>
+        key: UserKey,
+        value: Vec<u8>,
+    ) -> Result<BeforeAfter<SeqMarked<MetaValue>>, io::Error>
     where
-        K: MapKey<KVMeta>,
-        K: MapKeyEncode,
-        T: MapApi<K, KVMeta>,
+        T: MapApi<UserKey>,
     {
         let got = s.get(&key).await?;
 
-        let meta = if let Some((_, meta)) = got.unpack_ref() {
-            meta
-        } else {
-            None
-        };
+        let d = got.into_data();
 
-        s.set(key, Some((value, meta.cloned()))).await
+        let meta = if let Some((meta, _)) = d { meta } else { None };
+
+        s.set(key, Some((meta, value))).await
     }
 }

--- a/src/meta/raft-store/src/leveled_store/rotbl_seq_mark_impl.rs
+++ b/src/meta/raft-store/src/leveled_store/rotbl_seq_mark_impl.rs
@@ -13,26 +13,28 @@
 // limitations under the License.
 
 //! Implement the conversion between `rotbl::SeqMarked` and `Marked` that is used by this crate.
+//!
+//! `UserKey`
+//! `SeqV <-> SeqMarked<(Option<KVMeta>, bytes)> <-> SeqMarked`
+//!
+//! `ExpireKey`
+//! `ExpireValue <-> SeqMarked<String> <-> SeqMarked`
 
 use std::io;
 
 use databend_common_meta_types::seq_value::KVMeta;
+use rotbl::v001::Marked;
 use rotbl::v001::SeqMarked;
 
 use crate::leveled_store::value_convert::ValueConvert;
-use crate::marked::Marked;
+use crate::marked::MetaValue;
 
-impl ValueConvert<SeqMarked> for Marked {
+impl ValueConvert<SeqMarked> for SeqMarked<MetaValue> {
     fn conv_to(self) -> Result<SeqMarked, io::Error> {
-        // internal_seq() is the storage seq of the record.
-        // seq() returns seq for user, which 0 for a tombstone.
-        let seq_marked = match self {
-            Marked::TombStone { internal_seq } => SeqMarked::new_tombstone(internal_seq),
-            Marked::Normal {
-                internal_seq,
-                value,
-                meta,
-            } => {
+        let (seq, data) = self.into_parts();
+        let seq_marked = match data {
+            Marked::TombStone => SeqMarked::new_tombstone(seq),
+            Marked::Normal((meta, value)) => {
                 let kv_meta_str = serde_json::to_string(&meta).map_err(|e| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -50,17 +52,20 @@ impl ValueConvert<SeqMarked> for Marked {
                     )
                 })?;
 
-                SeqMarked::new_normal(internal_seq, d)
+                SeqMarked::new_normal(seq, d)
             }
         };
         Ok(seq_marked)
     }
 
     fn conv_from(seq_marked: SeqMarked) -> Result<Self, io::Error> {
-        let seq = seq_marked.seq();
+        let (seq, data) = seq_marked.into_parts();
 
-        let Some(data) = seq_marked.into_data() else {
-            return Ok(Marked::new_tombstone(seq));
+        let data = match data {
+            Marked::TombStone => {
+                return Ok(SeqMarked::new_tombstone(seq));
+            }
+            Marked::Normal(bytes) => bytes,
         };
 
         // version, meta, value
@@ -97,20 +102,31 @@ impl ValueConvert<SeqMarked> for Marked {
             )
         })?;
 
-        let marked = Marked::new_with_meta(seq, value, kv_meta);
+        let marked = SeqMarked::new_normal(seq, (kv_meta, value));
         Ok(marked)
     }
 }
 
-impl ValueConvert<SeqMarked> for Marked<String> {
+/// Conversion for ExpireValue
+impl ValueConvert<SeqMarked> for SeqMarked<String> {
     fn conv_to(self) -> Result<SeqMarked, io::Error> {
-        let marked = Marked::<Vec<u8>>::from(self);
+        let marked = self.map(|s| (None::<KVMeta>, s.into_bytes()));
+
         marked.conv_to()
     }
 
     fn conv_from(seq_marked: SeqMarked) -> Result<Self, io::Error> {
-        let marked = Marked::<Vec<u8>>::conv_from(seq_marked)?;
-        Marked::<String>::try_from(marked)
+        let marked = SeqMarked::<(Option<KVMeta>, Vec<u8>)>::conv_from(seq_marked)?;
+        let marked = marked.try_map(|(_meta, value)| {
+            String::from_utf8(value).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("fail to decode String from bytes: {}", e),
+                )
+            })
+        })?;
+
+        Ok(marked)
     }
 }
 
@@ -128,54 +144,46 @@ mod tests {
     #[test]
     fn test_marked_of_string_try_from_seq_marked() -> io::Result<()> {
         t_string_try_from(
-            Marked::<String>::new_with_meta(1, s("hello"), None),
+            SeqMarked::<String>::new_normal(1, s("hello")),
             SeqMarked::new_normal(1, b("\x01\x04null\x05hello")),
         );
 
         t_string_try_from(
-            Marked::<String>::new_with_meta(1, s("hello"), Some(KVMeta::new_expires_at(20))),
-            SeqMarked::new_normal(1, b("\x01\x10{\"expire_at\":20}\x05hello")),
-        );
-
-        t_string_try_from(
-            Marked::<String>::new_tombstone(2),
+            SeqMarked::<String>::new_tombstone(2),
             SeqMarked::new_tombstone(2),
         );
         Ok(())
     }
 
-    fn t_string_try_from(marked: Marked<String>, seq_marked: SeqMarked) {
+    fn t_string_try_from(marked: SeqMarked<String>, seq_marked: SeqMarked) {
         let got: SeqMarked = marked.clone().conv_to().unwrap();
         assert_eq!(seq_marked, got);
 
-        let got = Marked::<String>::conv_from(got).unwrap();
+        let got = SeqMarked::<String>::conv_from(got).unwrap();
         assert_eq!(marked, got);
     }
 
     #[test]
     fn test_marked_try_from_seq_marked() -> io::Result<()> {
         t_try_from(
-            Marked::new_with_meta(1, b("hello"), None),
+            SeqMarked::new_normal(1, (None, b("hello"))),
             SeqMarked::new_normal(1, b("\x01\x04null\x05hello")),
         );
 
         t_try_from(
-            Marked::new_with_meta(1, b("hello"), Some(KVMeta::new_expires_at(20))),
+            SeqMarked::new_normal(1, (Some(KVMeta::new_expires_at(20)), b("hello"))),
             SeqMarked::new_normal(1, b("\x01\x10{\"expire_at\":20}\x05hello")),
         );
 
-        t_try_from(
-            Marked::<Vec<u8>>::new_tombstone(2),
-            SeqMarked::new_tombstone(2),
-        );
+        t_try_from(SeqMarked::new_tombstone(2), SeqMarked::new_tombstone(2));
         Ok(())
     }
 
-    fn t_try_from(marked: Marked, seq_marked: SeqMarked) {
+    fn t_try_from(marked: SeqMarked<MetaValue>, seq_marked: SeqMarked) {
         let got: SeqMarked = marked.clone().conv_to().unwrap();
         assert_eq!(seq_marked, got);
 
-        let got = Marked::conv_from(got).unwrap();
+        let got = SeqMarked::conv_from(got).unwrap();
         assert_eq!(marked, got);
     }
 
@@ -203,7 +211,7 @@ mod tests {
     }
 
     fn t_invalid(seq_mark: SeqMarked, want_err: impl ToString) {
-        let res = Marked::<Vec<u8>>::conv_from(seq_mark);
+        let res = SeqMarked::<(Option<KVMeta>, Vec<u8>)>::conv_from(seq_mark);
         let err = res.unwrap_err();
         assert_eq!(want_err.to_string(), err.to_string());
     }

--- a/src/meta/raft-store/src/leveled_store/util.rs
+++ b/src/meta/raft-store/src/leveled_store/util.rs
@@ -51,7 +51,7 @@ pub(crate) fn rotbl_choose_greater(
 }
 
 fn seq_marked_max(a: SeqMarked, b: SeqMarked) -> SeqMarked {
-    if a.seq() > b.seq() {
+    if a.internal_seq() > b.internal_seq() {
         a
     } else {
         b

--- a/src/meta/raft-store/src/marked/marked_test.rs
+++ b/src/meta/raft-store/src/marked/marked_test.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 use crate::state_machine::ExpireValue;
 
 // Test From<ExpireValue> for Marked<String>
 #[test]
 fn test_from_expire_value_for_marked() -> anyhow::Result<()> {
-    let m = Marked::new_with_meta(1, "2".to_string(), None);
+    let m = SeqMarked::new_normal(1, "2".to_string());
     let s = ExpireValue::new("2", 1);
     assert_eq!(m, s.into());
 
@@ -28,11 +28,11 @@ fn test_from_expire_value_for_marked() -> anyhow::Result<()> {
 // Test From<Marked<String>> for Option<ExpireValue>
 #[test]
 fn test_from_marked_for_option_expire_value() -> anyhow::Result<()> {
-    let m = Marked::new_with_meta(1, "2".to_string(), None);
+    let m = SeqMarked::new_normal(1, "2".to_string());
     let s: Option<ExpireValue> = Some(ExpireValue::new("2".to_string(), 1));
     assert_eq!(s, ExpireValue::from_marked(m));
 
-    let m = Marked::new_tombstone(1);
+    let m = SeqMarked::new_tombstone(1);
     let s: Option<ExpireValue> = None;
     assert_eq!(s, ExpireValue::from_marked(m));
 

--- a/src/meta/raft-store/src/marked/mod.rs
+++ b/src/meta/raft-store/src/marked/mod.rs
@@ -19,10 +19,9 @@
 mod marked_test;
 
 use databend_common_meta_types::KVMeta;
+use seq_marked::SeqMarked;
 
 use crate::state_machine::ExpireValue;
-
-pub type SeqMarked<T = Vec<u8>> = map_api::SeqMarked<T>;
 
 pub type MetaValue<T = Vec<u8>> = (Option<KVMeta>, T);
 

--- a/src/meta/raft-store/src/marked/mod.rs
+++ b/src/meta/raft-store/src/marked/mod.rs
@@ -18,14 +18,16 @@
 #[cfg(test)]
 mod marked_test;
 
-use databend_common_meta_types::seq_value::KVMeta;
+use databend_common_meta_types::KVMeta;
 
 use crate::state_machine::ExpireValue;
 
-pub type Marked<T = Vec<u8>> = map_api::marked::Marked<KVMeta, T>;
+pub type SeqMarked<T = Vec<u8>> = map_api::SeqMarked<T>;
 
-impl From<ExpireValue> for Marked<String> {
+pub type MetaValue<T = Vec<u8>> = (Option<KVMeta>, T);
+
+impl From<ExpireValue> for SeqMarked<String> {
     fn from(value: ExpireValue) -> Self {
-        Marked::new_with_meta(value.seq, value.key, None)
+        SeqMarked::new_normal(value.seq, value.key)
     }
 }

--- a/src/meta/raft-store/src/sm_v003/adapter.rs
+++ b/src/meta/raft-store/src/sm_v003/adapter.rs
@@ -23,8 +23,8 @@ use rotbl::v001::SeqMarked;
 
 use crate::key_spaces::SMEntry;
 use crate::leveled_store::rotbl_codec::RotblCodec;
-use crate::marked::Marked;
 use crate::state_machine::StateMachineMetaKey;
+use crate::state_machine::UserKey;
 
 /// Convert V002 snapshot lines in json of [`SMEntry`]
 /// to V004 rotbl key-value pairs. `(String, SeqMarked)`,
@@ -82,13 +82,14 @@ impl SMEntryV002ToV004 {
                     value.seq = 1;
                 }
 
-                let marked = Marked::from(value);
+                let marked = SeqMarked::from(value);
                 let (k, v) = RotblCodec::encode_key_seq_marked(&key, marked)?;
                 return Ok(Some((k, v)));
             }
             SMEntry::GenericKV { key, value } => {
-                let marked = Marked::from(value);
-                let (k, v) = RotblCodec::encode_key_seq_marked(&key, marked)?;
+                let marked = SeqMarked::from(value);
+                let (k, v) =
+                    RotblCodec::encode_key_seq_marked(UserKey::from_string_ref(&key), marked)?;
                 return Ok(Some((k, v)));
             }
             SMEntry::Sequences { key: _, value } => {

--- a/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
@@ -29,9 +29,10 @@ use crate::leveled_store::leveled_map::compacting_data::CompactingData;
 use crate::leveled_store::leveled_map::LeveledMap;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 use crate::sm_v003::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 #[tokio::test]
 async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
@@ -62,14 +63,19 @@ async fn test_compact_copied_value_and_kv() -> anyhow::Result<()> {
         &btreemap! {3=>Node::new("3", Endpoint::new("3", 3))}
     );
 
-    let got = d.str_map().range(..).await?.try_collect::<Vec<_>>().await?;
+    let got = d
+        .user_map()
+        .range(..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_with_meta(1, b("a0"), None)),
-        (s("b"), Marked::new_tombstone(4)),
-        (s("c"), Marked::new_tombstone(6)),
-        (s("d"), Marked::new_with_meta(7, b("d2"), None)),
-        (s("e"), Marked::new_with_meta(6, b("e1"), None)),
+        (user_key("a"), SeqMarked::new_normal(1, (None, b("a0")))),
+        (user_key("b"), SeqMarked::new_tombstone(4)),
+        (user_key("c"), SeqMarked::new_tombstone(6)),
+        (user_key("d"), SeqMarked::new_normal(7, (None, b("d2")))),
+        (user_key("e"), SeqMarked::new_normal(6, (None, b("e1")))),
     ]);
 
     let got = d
@@ -96,20 +102,25 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
 
     let d = compacted.newest().unwrap().as_ref();
 
-    let got = d.str_map().range(..).await?.try_collect::<Vec<_>>().await?;
+    let got = d
+        .user_map()
+        .range(..)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
     assert_eq!(got, vec![
         //
         (
-            s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
+            user_key("a"),
+            SeqMarked::new_normal(4, (Some(KVMeta::new_expires_at(15)), b("a1")))
         ),
         (
-            s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
+            user_key("b"),
+            SeqMarked::new_normal(2, (Some(KVMeta::new_expires_at(5)), b("b0")))
         ),
         (
-            s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
+            user_key("c"),
+            SeqMarked::new_normal(3, (Some(KVMeta::new_expires_at(20)), b("c0")))
         ),
     ]);
 
@@ -121,19 +132,10 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         .await?;
     assert_eq!(got, vec![
         //
-        (
-            ExpireKey::new(5_000, 2),
-            Marked::new_with_meta(2, s("b"), None)
-        ),
-        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
-        (
-            ExpireKey::new(15_000, 4),
-            Marked::new_with_meta(4, s("a"), None)
-        ),
-        (
-            ExpireKey::new(20_000, 3),
-            Marked::new_with_meta(3, s("c"), None)
-        ),
+        (ExpireKey::new(5_000, 2), SeqMarked::new_normal(2, s("b"))),
+        (ExpireKey::new(10_000, 1), SeqMarked::new_tombstone(4)),
+        (ExpireKey::new(15_000, 4), SeqMarked::new_normal(4, s("a"))),
+        (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
     ]);
 
     Ok(())
@@ -214,10 +216,18 @@ async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     *sd.nodes_mut() = btreemap! {1=>Node::new("1", Endpoint::new("1", 1))};
 
     // internal_seq: 0
-    lm.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
-    lm.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
-    lm.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
-    lm.str_map_mut().set(s("d"), Some((b("d0"), None))).await?;
+    lm.user_map_mut()
+        .set(user_key("a"), Some((None, b("a0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("b"), Some((None, b("b0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("c"), Some((None, b("c0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("d"), Some((None, b("d0"))))
+        .await?;
 
     lm.freeze_writable();
     let sd = lm.writable_mut().sys_data_mut();
@@ -230,9 +240,13 @@ async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     *sd.nodes_mut() = btreemap! {2=>Node::new("2", Endpoint::new("2", 2))};
 
     // internal_seq: 4
-    lm.str_map_mut().set(s("b"), None).await?;
-    lm.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
-    lm.str_map_mut().set(s("e"), Some((b("e1"), None))).await?;
+    lm.user_map_mut().set(user_key("b"), None).await?;
+    lm.user_map_mut()
+        .set(user_key("c"), Some((None, b("c1"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("e"), Some((None, b("e1"))))
+        .await?;
 
     lm.freeze_writable();
     let sd = lm.writable_mut().sys_data_mut();
@@ -245,8 +259,10 @@ async fn build_3_levels() -> anyhow::Result<LeveledMap> {
     *sd.nodes_mut() = btreemap! {3=>Node::new("3", Endpoint::new("3", 3))};
 
     // internal_seq: 6
-    lm.str_map_mut().set(s("c"), None).await?;
-    lm.str_map_mut().set(s("d"), Some((b("d2"), None))).await?;
+    lm.user_map_mut().set(user_key("c"), None).await?;
+    lm.user_map_mut()
+        .set(user_key("d"), Some((None, b("d2"))))
+        .await?;
 
     Ok(lm)
 }
@@ -284,4 +300,8 @@ fn s(x: impl ToString) -> String {
 
 fn b(x: impl ToString) -> Vec<u8> {
     x.to_string().as_bytes().to_vec()
+}
+
+fn user_key(s: impl ToString) -> UserKey {
+    UserKey::new(s)
 }

--- a/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_immutable_levels_test.rs
@@ -24,12 +24,12 @@ use map_api::map_api_ro::MapApiRO;
 use maplit::btreemap;
 use openraft::testing::log_id;
 use pretty_assertions::assert_eq;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::leveled_map::compacting_data::CompactingData;
 use crate::leveled_store::leveled_map::LeveledMap;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
-use crate::marked::SeqMarked;
 use crate::sm_v003::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;

--- a/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
@@ -26,6 +26,7 @@ use map_api::map_api_ro::MapApiRO;
 use maplit::btreemap;
 use openraft::testing::log_id;
 use pretty_assertions::assert_eq;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::db_builder::DBBuilder;
 use crate::leveled_store::immutable_levels::ImmutableLevels;
@@ -33,7 +34,6 @@ use crate::leveled_store::leveled_map::LeveledMap;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
 use crate::leveled_store::MapView;
-use crate::marked::SeqMarked;
 use crate::sm_v003::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;

--- a/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
+++ b/src/meta/raft-store/src/sm_v003/compact_with_db_test.rs
@@ -33,9 +33,10 @@ use crate::leveled_store::leveled_map::LeveledMap;
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::sys_data_api::SysDataApiRO;
 use crate::leveled_store::MapView;
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 use crate::sm_v003::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_leveled_query_with_db() -> anyhow::Result<()> {
@@ -56,25 +57,28 @@ async fn test_leveled_query_with_db() -> anyhow::Result<()> {
     );
 
     let got = lm
-        .str_map()
+        .user_map()
         .range(..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_with_meta(1, b("a0"), None)),
-        (s("b"), Marked::new_tombstone(4)),
-        (s("c"), Marked::new_tombstone(6)),
-        (s("d"), Marked::new_with_meta(7, b("d2"), None)),
-        (s("e"), Marked::new_with_meta(6, b("e1"), None)),
+        (user_key("a"), SeqMarked::new_normal(1, (None, b("a0")))),
+        (user_key("b"), SeqMarked::new_tombstone(4)),
+        (user_key("c"), SeqMarked::new_tombstone(6)),
+        (user_key("d"), SeqMarked::new_normal(7, (None, b("d2")))),
+        (user_key("e"), SeqMarked::new_normal(6, (None, b("e1")))),
     ]);
 
     assert_eq!(
-        lm.str_map().get(&s("a")).await?,
-        Marked::new_with_meta(1, b("a0"), None)
+        lm.user_map().get(&user_key("a")).await?,
+        SeqMarked::new_normal(1, (None, b("a0")))
     );
-    assert_eq!(lm.str_map().get(&s("b")).await?, Marked::new_tombstone(4));
+    assert_eq!(
+        lm.user_map().get(&user_key("b")).await?,
+        SeqMarked::new_tombstone(4)
+    );
 
     let got = lm
         .expire_map()
@@ -102,7 +106,7 @@ async fn test_leveled_query_with_expire_index() -> anyhow::Result<()> {
     assert_eq!(lm.nodes_ref(), &btreemap! {});
 
     let got = lm
-        .str_map()
+        .user_map()
         .range(..)
         .await?
         .try_collect::<Vec<_>>()
@@ -110,16 +114,16 @@ async fn test_leveled_query_with_expire_index() -> anyhow::Result<()> {
     assert_eq!(got, vec![
         //
         (
-            s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
+            user_key("a"),
+            SeqMarked::new_normal(4, (Some(KVMeta::new_expires_at(15)), b("a1")))
         ),
         (
-            s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
+            user_key("b"),
+            SeqMarked::new_normal(2, (Some(KVMeta::new_expires_at(5)), b("b0")))
         ),
         (
-            s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
+            user_key("c"),
+            SeqMarked::new_normal(3, (Some(KVMeta::new_expires_at(20)), b("c0")))
         ),
     ]);
 
@@ -131,19 +135,10 @@ async fn test_leveled_query_with_expire_index() -> anyhow::Result<()> {
         .await?;
     assert_eq!(got, vec![
         //
-        (
-            ExpireKey::new(5_000, 2),
-            Marked::new_with_meta(2, s("b"), None)
-        ),
-        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
-        (
-            ExpireKey::new(15_000, 4),
-            Marked::new_with_meta(4, s("a"), None)
-        ),
-        (
-            ExpireKey::new(20_000, 3),
-            Marked::new_with_meta(3, s("c"), None)
-        ),
+        (ExpireKey::new(5_000, 2), SeqMarked::new_normal(2, s("b"))),
+        (ExpireKey::new(10_000, 1), SeqMarked::new_tombstone(4)),
+        (ExpireKey::new(15_000, 4), SeqMarked::new_normal(4, s("a"))),
+        (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
     ]);
 
     Ok(())
@@ -180,16 +175,16 @@ async fn test_compact() -> anyhow::Result<()> {
     );
 
     let got = MapView(db)
-        .str_map()
+        .user_map()
         .range(..)
         .await?
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
         //
-        (s("a"), Marked::new_with_meta(1, b("a0"), None)),
-        (s("d"), Marked::new_with_meta(7, b("d2"), None)),
-        (s("e"), Marked::new_with_meta(6, b("e1"), None)),
+        (user_key("a"), SeqMarked::new_normal(1, (None, b("a0")))),
+        (user_key("d"), SeqMarked::new_normal(7, (None, b("d2")))),
+        (user_key("e"), SeqMarked::new_normal(6, (None, b("e1")))),
     ]);
 
     let got = MapView(db)
@@ -230,7 +225,7 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
     assert_eq!(db.nodes_ref(), &btreemap! {});
 
     let got = MapView(db)
-        .str_map()
+        .user_map()
         .range(..)
         .await?
         .try_collect::<Vec<_>>()
@@ -238,16 +233,16 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
     assert_eq!(got, vec![
         //
         (
-            s("a"),
-            Marked::new_with_meta(4, b("a1"), Some(KVMeta::new_expires_at(15)))
+            user_key("a"),
+            SeqMarked::new_normal(4, (Some(KVMeta::new_expires_at(15)), b("a1")))
         ),
         (
-            s("b"),
-            Marked::new_with_meta(2, b("b0"), Some(KVMeta::new_expires_at(5)))
+            user_key("b"),
+            SeqMarked::new_normal(2, (Some(KVMeta::new_expires_at(5)), b("b0")))
         ),
         (
-            s("c"),
-            Marked::new_with_meta(3, b("c0"), Some(KVMeta::new_expires_at(20)))
+            user_key("c"),
+            SeqMarked::new_normal(3, (Some(KVMeta::new_expires_at(20)), b("c0")))
         ),
     ]);
 
@@ -259,18 +254,9 @@ async fn test_compact_expire_index() -> anyhow::Result<()> {
         .await?;
     assert_eq!(got, vec![
         //
-        (
-            ExpireKey::new(5_000, 2),
-            Marked::new_with_meta(2, s("b"), None)
-        ),
-        (
-            ExpireKey::new(15_000, 4),
-            Marked::new_with_meta(4, s("a"), None)
-        ),
-        (
-            ExpireKey::new(20_000, 3),
-            Marked::new_with_meta(3, s("c"), None)
-        ),
+        (ExpireKey::new(5_000, 2), SeqMarked::new_normal(2, s("b"))),
+        (ExpireKey::new(15_000, 4), SeqMarked::new_normal(4, s("a"))),
+        (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
     ]);
 
     Ok(())
@@ -330,10 +316,18 @@ async fn build_3_levels() -> anyhow::Result<(LeveledMap, impl Drop)> {
     *sd.nodes_mut() = btreemap! {1=>Node::new("1", Endpoint::new("1", 1))};
 
     // internal_seq: 0
-    lm.str_map_mut().set(s("a"), Some((b("a0"), None))).await?;
-    lm.str_map_mut().set(s("b"), Some((b("b0"), None))).await?;
-    lm.str_map_mut().set(s("c"), Some((b("c0"), None))).await?;
-    lm.str_map_mut().set(s("d"), Some((b("d0"), None))).await?;
+    lm.user_map_mut()
+        .set(user_key("a"), Some((None, b("a0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("b"), Some((None, b("b0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("c"), Some((None, b("c0"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("d"), Some((None, b("d0"))))
+        .await?;
 
     lm.freeze_writable();
     let sd = lm.writable_mut().sys_data_mut();
@@ -346,9 +340,13 @@ async fn build_3_levels() -> anyhow::Result<(LeveledMap, impl Drop)> {
     *sd.nodes_mut() = btreemap! {2=>Node::new("2", Endpoint::new("2", 2))};
 
     // internal_seq: 4
-    lm.str_map_mut().set(s("b"), None).await?;
-    lm.str_map_mut().set(s("c"), Some((b("c1"), None))).await?;
-    lm.str_map_mut().set(s("e"), Some((b("e1"), None))).await?;
+    lm.user_map_mut().set(user_key("b"), None).await?;
+    lm.user_map_mut()
+        .set(user_key("c"), Some((None, b("c1"))))
+        .await?;
+    lm.user_map_mut()
+        .set(user_key("e"), Some((None, b("e1"))))
+        .await?;
 
     lm.freeze_writable();
     let sd = lm.writable_mut().sys_data_mut();
@@ -361,8 +359,10 @@ async fn build_3_levels() -> anyhow::Result<(LeveledMap, impl Drop)> {
     *sd.nodes_mut() = btreemap! {3=>Node::new("3", Endpoint::new("3", 3))};
 
     // internal_seq: 6
-    lm.str_map_mut().set(s("c"), None).await?;
-    lm.str_map_mut().set(s("d"), Some((b("d2"), None))).await?;
+    lm.user_map_mut().set(user_key("c"), None).await?;
+    lm.user_map_mut()
+        .set(user_key("d"), Some((None, b("d2"))))
+        .await?;
 
     // Move the bottom level to db
     let temp_dir = tempfile::tempdir()?;
@@ -442,4 +442,8 @@ fn s(x: impl ToString) -> String {
 
 fn b(x: impl ToString) -> Vec<u8> {
     x.to_string().as_bytes().to_vec()
+}
+
+fn user_key(s: impl ToString) -> UserKey {
+    UserKey::new(s)
 }

--- a/src/meta/raft-store/src/sm_v003/sm_v003_kv_api.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003_kv_api.rs
@@ -29,6 +29,7 @@ use futures_util::TryStreamExt;
 
 use crate::sm_v003::SMV003;
 use crate::state_machine_api_ext::StateMachineApiExt;
+use crate::testing::since_epoch_millis;
 
 /// A wrapper that implements KVApi **readonly** methods for the state machine.
 pub struct SMV003KVApi<'a> {
@@ -44,7 +45,7 @@ impl kvapi::KVApi for SMV003KVApi<'_> {
     }
 
     async fn get_kv_stream(&self, keys: &[String]) -> Result<KVStream<Self::Error>, Self::Error> {
-        let local_now_ms = SeqV::<()>::now_ms();
+        let local_now_ms = since_epoch_millis();
 
         let mut items = Vec::with_capacity(keys.len());
 
@@ -58,7 +59,7 @@ impl kvapi::KVApi for SMV003KVApi<'_> {
     }
 
     async fn list_kv(&self, prefix: &str) -> Result<KVStream<Self::Error>, Self::Error> {
-        let local_now_ms = SeqV::<()>::now_ms();
+        let local_now_ms = since_epoch_millis();
 
         let strm = self
             .sm

--- a/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
@@ -21,7 +21,7 @@ use map_api::map_api_ro::MapApiRO;
 use pretty_assertions::assert_eq;
 
 use crate::leveled_store::map_api::AsMap;
-use crate::marked::Marked;
+use crate::marked::SeqMarked;
 use crate::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
 use crate::state_machine_api::StateMachineApi;
@@ -182,19 +182,10 @@ async fn test_internal_expire_index() -> anyhow::Result<()> {
         .try_collect::<Vec<_>>()
         .await?;
     assert_eq!(got, vec![
-        (
-            ExpireKey::new(5_000, 2),
-            Marked::new_with_meta(2, s("b"), None)
-        ),
-        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
-        (
-            ExpireKey::new(15_000, 4),
-            Marked::new_with_meta(4, s("a"), None)
-        ),
-        (
-            ExpireKey::new(20_000, 3),
-            Marked::new_with_meta(3, s("c"), None)
-        ),
+        (ExpireKey::new(5_000, 2), SeqMarked::new_normal(2, s("b"))),
+        (ExpireKey::new(10_000, 1), SeqMarked::new_tombstone(4)),
+        (ExpireKey::new(15_000, 4), SeqMarked::new_normal(4, s("a"))),
+        (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
     ]);
 
     Ok(())
@@ -292,16 +283,10 @@ async fn test_inserting_expired_becomes_deleting() -> anyhow::Result<()> {
         .await?;
     assert_eq!(got, vec![
         //
-        (
-            ExpireKey::new(5_000, 2),
-            Marked::new_with_meta(2, s("b"), None)
-        ),
-        (ExpireKey::new(10_000, 1), Marked::new_tombstone(4)),
-        (ExpireKey::new(15_000, 4), Marked::new_tombstone(5),),
-        (
-            ExpireKey::new(20_000, 3),
-            Marked::new_with_meta(3, s("c"), None)
-        ),
+        (ExpireKey::new(5_000, 2), SeqMarked::new_normal(2, s("b"))),
+        (ExpireKey::new(10_000, 1), SeqMarked::new_tombstone(4)),
+        (ExpireKey::new(15_000, 4), SeqMarked::new_tombstone(5),),
+        (ExpireKey::new(20_000, 3), SeqMarked::new_normal(3, s("c"))),
     ]);
 
     Ok(())

--- a/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
@@ -19,9 +19,9 @@ use databend_common_meta_types::UpsertKV;
 use futures_util::TryStreamExt;
 use map_api::map_api_ro::MapApiRO;
 use pretty_assertions::assert_eq;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::map_api::AsMap;
-use crate::marked::SeqMarked;
 use crate::sm_v003::SMV003;
 use crate::state_machine::ExpireKey;
 use crate::state_machine_api::StateMachineApi;

--- a/src/meta/raft-store/src/state_machine/expire.rs
+++ b/src/meta/raft-store/src/state_machine/expire.rs
@@ -32,8 +32,7 @@ use databend_common_meta_sled_store::SledBytesError;
 use databend_common_meta_sled_store::SledOrderedSerde;
 use databend_common_meta_sled_store::SledSerde;
 use rotbl::v001::Marked;
-
-use crate::marked::SeqMarked;
+use seq_marked::SeqMarked;
 
 /// The identifier of the index for kv with expiration.
 ///

--- a/src/meta/raft-store/src/state_machine/mod.rs
+++ b/src/meta/raft-store/src/state_machine/mod.rs
@@ -20,12 +20,14 @@ pub use log_meta::LogMetaValue;
 pub use snapshot_id::MetaSnapshotId;
 pub use state_machine_meta::StateMachineMetaKey;
 pub use state_machine_meta::StateMachineMetaValue;
+pub use user_key::UserKey;
 
 pub mod client_last_resp;
 mod expire;
 pub mod log_meta;
 mod snapshot_id;
 pub mod state_machine_meta;
+mod user_key;
 
 // will be accessed by other crate, can not cfg(test)
 pub mod testing;

--- a/src/meta/raft-store/src/state_machine/user_key.rs
+++ b/src/meta/raft-store/src/state_machine/user_key.rs
@@ -1,0 +1,196 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::ops::Deref;
+
+/// Key for the user data in state machine
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct UserKey {
+    pub key: String,
+}
+
+impl Deref for UserKey {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.key
+    }
+}
+
+impl AsRef<UserKey> for String {
+    fn as_ref(&self) -> &UserKey {
+        // SAFETY: UserKey is a transparent wrapper around String
+        // This is safe because:
+        // 1. UserKey is marked as #[repr(transparent)]
+        // 2. UserKey contains only a single String field
+        // 3. The memory layout of UserKey is identical to String
+        // 4. Both &String and &UserKey are references of the same size
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl fmt::Display for UserKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.key)
+    }
+}
+
+impl UserKey {
+    pub fn new(key: impl ToString) -> Self {
+        Self {
+            key: key.to_string(),
+        }
+    }
+
+    /// Create a reference to a UserKey from a &str
+    pub fn from_string_ref(key: &String) -> &Self {
+        // SAFETY: UserKey is a transparent wrapper around String
+        // This is safe because:
+        // 1. UserKey is marked as #[repr(transparent)]
+        // 2. UserKey contains only a single String field
+        // 3. The memory layout of UserKey is identical to String
+        unsafe { std::mem::transmute(key) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_key_new() {
+        let key = UserKey::new("test_key");
+        assert_eq!(key.key, "test_key");
+
+        let key_from_int = UserKey::new(42);
+        assert_eq!(key_from_int.key, "42");
+    }
+
+    #[test]
+    fn test_user_key_default() {
+        let key = UserKey::default();
+        assert_eq!(key.key, "");
+        assert!(key.key.is_empty());
+    }
+
+    #[test]
+    fn test_user_key_deref() {
+        let key = UserKey::new("test_deref");
+
+        // Test deref functionality
+        assert_eq!(*key, "test_deref");
+        assert_eq!(key.len(), 10);
+        assert_eq!(key.chars().count(), 10);
+    }
+
+    #[test]
+    fn test_user_key_clone() {
+        let key1 = UserKey::new("clone_test");
+        let key2 = key1.clone();
+
+        assert_eq!(key1, key2);
+        assert_eq!(key1.key, key2.key);
+    }
+
+    #[test]
+    fn test_user_key_equality() {
+        let key1 = UserKey::new("same_key");
+        let key2 = UserKey::new("same_key");
+        let key3 = UserKey::new("different_key");
+
+        assert_eq!(key1, key2);
+        assert_ne!(key1, key3);
+        assert_ne!(key2, key3);
+    }
+
+    #[test]
+    fn test_user_key_ordering() {
+        let key_a = UserKey::new("a");
+        let key_b = UserKey::new("b");
+        let key_c = UserKey::new("c");
+
+        assert!(key_a < key_b);
+        assert!(key_b < key_c);
+        assert!(key_a < key_c);
+
+        let mut keys = vec![key_c.clone(), key_a.clone(), key_b.clone()];
+        keys.sort();
+        assert_eq!(keys, vec![key_a, key_b, key_c]);
+    }
+
+    #[test]
+    fn test_user_key_debug() {
+        let key = UserKey::new("debug_test");
+        let debug_str = format!("{:?}", key);
+        assert!(debug_str.contains("UserKey"));
+        assert!(debug_str.contains("debug_test"));
+    }
+
+    #[test]
+    fn test_string_as_ref_user_key() {
+        let s = "test_string".to_string();
+        let user_key_ref: &UserKey = s.as_ref();
+
+        // Test that the reference points to the same data
+        assert_eq!(user_key_ref.key, "test_string");
+    }
+
+    #[test]
+    fn test_string_as_ref_user_key_memory_layout() {
+        let s = "memory_test".to_string();
+        let user_key_ref: &UserKey = s.as_ref();
+
+        // Test that the memory addresses are the same
+        let string_ptr = &s as *const String as *const u8;
+        let user_key_ptr = &user_key_ref.key as *const String as *const u8;
+        assert_eq!(string_ptr, user_key_ptr);
+
+        // Test that the data is identical
+        assert_eq!(user_key_ref.key.as_ptr(), s.as_ptr());
+        assert_eq!(user_key_ref.key.len(), s.len());
+        assert_eq!(user_key_ref.key.capacity(), s.capacity());
+    }
+
+    #[test]
+    fn test_user_key_partial_ord() {
+        let key1 = UserKey::new("apple");
+        let key2 = UserKey::new("banana");
+        let key3 = UserKey::new("cherry");
+
+        assert!(key1.partial_cmp(&key2) == Some(std::cmp::Ordering::Less));
+        assert!(key2.partial_cmp(&key3) == Some(std::cmp::Ordering::Less));
+        assert!(key1.partial_cmp(&key1) == Some(std::cmp::Ordering::Equal));
+        assert!(key3.partial_cmp(&key1) == Some(std::cmp::Ordering::Greater));
+    }
+
+    #[test]
+    fn test_user_key_from_str() {
+        let a = String::from("test_from_str");
+        let key = UserKey::from_string_ref(&a);
+        assert_eq!(key.key, "test_from_str");
+    }
+
+    #[test]
+    fn test_to_string() {
+        let key = UserKey::new("to_string_test");
+        let string_representation = key.to_string();
+        assert_eq!(string_representation, "to_string_test");
+
+        // Test with an empty key
+        let empty_key = UserKey::default();
+        assert_eq!(empty_key.to_string(), "");
+    }
+}

--- a/src/meta/raft-store/src/state_machine_api.rs
+++ b/src/meta/raft-store/src/state_machine_api.rs
@@ -16,12 +16,12 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use databend_common_meta_types::sys_data::SysData;
-use databend_common_meta_types::KVMeta;
 use databend_common_meta_types::SeqV;
 use futures::future::BoxFuture;
 use map_api::map_api::MapApi;
 
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 
 /// Send a key-value change event to subscribers.
 pub trait SMEventSender: Debug + Sync + Send {
@@ -48,7 +48,7 @@ where T: SMEventSender
 /// The state machine is responsible for managing the application's persistent state,
 /// including application kv data and expired key data.
 pub trait StateMachineApi: Send + Sync {
-    type Map: MapApi<String, KVMeta> + MapApi<ExpireKey, KVMeta> + 'static;
+    type Map: MapApi<UserKey> + MapApi<ExpireKey> + 'static;
 
     /// Returns a reference to the map that stores application data.
     ///

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -32,11 +32,11 @@ use log::warn;
 use map_api::map_api::MapApi;
 use map_api::map_api_ro::MapApiRO;
 use map_api::IOResultStream;
+use seq_marked::SeqMarked;
 
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::MapApiExt;
 use crate::marked::MetaValue;
-use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
 use crate::state_machine::UserKey;
 use crate::state_machine_api::StateMachineApi;

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -35,9 +35,10 @@ use map_api::IOResultStream;
 
 use crate::leveled_store::map_api::AsMap;
 use crate::leveled_store::map_api::MapApiExt;
-use crate::leveled_store::map_api::MarkedOf;
-use crate::marked::Marked;
+use crate::marked::MetaValue;
+use crate::marked::SeqMarked;
 use crate::state_machine::ExpireKey;
+use crate::state_machine::UserKey;
 use crate::state_machine_api::StateMachineApi;
 use crate::utils::add_cooperative_yielding;
 use crate::utils::prefix_right_bound;
@@ -49,10 +50,15 @@ pub trait StateMachineApiExt: StateMachineApi {
         &mut self,
         upsert_kv: &UpsertKV,
         cmd_ctx: &CmdContext,
-    ) -> Result<(Marked<Vec<u8>>, Marked<Vec<u8>>), io::Error> {
+    ) -> Result<(SeqMarked<MetaValue>, SeqMarked<MetaValue>), io::Error> {
         let kv_meta = upsert_kv.value_meta.as_ref().map(|m| m.to_kv_meta(cmd_ctx));
 
-        let prev = self.map_ref().str_map().get(&upsert_kv.key).await?.clone();
+        let prev = self
+            .map_ref()
+            .user_map()
+            .get(upsert_kv.key.as_ref())
+            .await?
+            .clone();
 
         if upsert_kv.seq.match_seq(&prev.seq()).is_err() {
             return Ok((prev.clone(), prev));
@@ -61,14 +67,25 @@ pub trait StateMachineApiExt: StateMachineApi {
         let (prev, mut result) = match &upsert_kv.value {
             Operation::Update(v) => {
                 self.map_mut()
-                    .set(upsert_kv.key.clone(), Some((v.clone(), kv_meta.clone())))
+                    .set(
+                        UserKey::new(&upsert_kv.key),
+                        Some((kv_meta.clone(), v.clone())),
+                    )
                     .await?
             }
-            Operation::Delete => self.map_mut().set(upsert_kv.key.clone(), None).await?,
+            Operation::Delete => {
+                self.map_mut()
+                    .set(UserKey::new(&upsert_kv.key), None)
+                    .await?
+            }
             #[allow(deprecated)]
             Operation::AsIs => {
-                MapApiExt::update_meta(self.map_mut(), upsert_kv.key.clone(), kv_meta.clone())
-                    .await?
+                MapApiExt::update_meta(
+                    self.map_mut(),
+                    UserKey::new(&upsert_kv.key),
+                    kv_meta.clone(),
+                )
+                .await?
             }
         };
 
@@ -87,7 +104,10 @@ pub trait StateMachineApiExt: StateMachineApi {
             // Note that it must update first then delete,
             // in order to keep compatibility with the old state machine.
             // Old SM will just insert an expired record, and that causes the system seq increase by 1.
-            let (_p, r) = self.map_mut().set(upsert_kv.key.clone(), None).await?;
+            let (_p, r) = self
+                .map_mut()
+                .set(UserKey::new(&upsert_kv.key), None)
+                .await?;
             result = r;
         };
 
@@ -106,9 +126,12 @@ pub trait StateMachineApiExt: StateMachineApi {
         let p = prefix.to_string();
 
         let strm = if let Some(right) = prefix_right_bound(&p) {
-            self.map_ref().str_map().range(p.clone()..right).await?
+            self.map_ref()
+                .user_map()
+                .range(UserKey::new(&p)..UserKey::new(right))
+                .await?
         } else {
-            self.map_ref().str_map().range(p.clone()..).await?
+            self.map_ref().user_map().range(UserKey::new(&p)..).await?
         };
 
         let strm = strm
@@ -117,23 +140,23 @@ pub trait StateMachineApiExt: StateMachineApi {
 
         let strm = add_cooperative_yielding(strm, format!("list_kv: {prefix}"))
             // Skip tombstone
-            .try_filter_map(|(k, marked)| future::ready(Ok(marked_to_seqv(k, marked))));
+            .try_filter_map(|(k, marked)| future::ready(Ok(seq_marked_to_seqv(k, marked))));
 
         Ok(strm.boxed())
     }
 
     /// Return a range of kv entries.
     async fn range_kv<R>(&self, rng: R) -> Result<IOResultStream<(String, SeqV)>, io::Error>
-    where R: RangeBounds<String> + Send + Sync + Clone + 'static {
+    where R: RangeBounds<UserKey> + Send + Sync + Clone + 'static {
         let left = rng.start_bound().cloned();
         let right = rng.end_bound().cloned();
 
         let leveled_map = self.map_ref();
-        let strm = leveled_map.str_map().range(rng).await?;
+        let strm = leveled_map.user_map().range(rng).await?;
 
         let strm = add_cooperative_yielding(strm, format!("range_kv: {left:?} to {right:?}"))
             // Skip tombstone
-            .try_filter_map(|(k, marked)| future::ready(Ok(marked_to_seqv(k, marked))));
+            .try_filter_map(|(k, marked)| future::ready(Ok(seq_marked_to_seqv(k, marked))));
 
         Ok(strm.boxed())
     }
@@ -144,8 +167,8 @@ pub trait StateMachineApiExt: StateMachineApi {
     async fn update_expire_index(
         &mut self,
         key: impl ToString + Send,
-        removed: &Marked<Vec<u8>>,
-        added: &Marked<Vec<u8>>,
+        removed: &SeqMarked<MetaValue>,
+        added: &SeqMarked<MetaValue>,
     ) -> Result<(), io::Error> {
         // No change, no need to update expiration index
         if removed == added {
@@ -163,7 +186,7 @@ pub trait StateMachineApiExt: StateMachineApi {
         if let Some(exp_ms) = added.expires_at_ms_opt() {
             let k = ExpireKey::new(exp_ms, added.order_key().seq());
             let v = key.to_string();
-            self.map_mut().set(k, Some((v, None))).await?;
+            self.map_mut().set(k, Some(v)).await?;
         }
 
         Ok(())
@@ -185,8 +208,8 @@ pub trait StateMachineApiExt: StateMachineApi {
 
         let strm = add_cooperative_yielding(strm, format!("list_expire_index up to {end}"))
             // Return only non-deleted records
-            .try_filter_map(|(k, marked)| {
-                let expire_entry = marked.unpack().map(|(v, _v_meta)| (k, v));
+            .try_filter_map(|(k, seq_marked)| {
+                let expire_entry = seq_marked.into_data().map(|v| (k, v));
                 future::ready(Ok(expire_entry))
             });
 
@@ -197,7 +220,7 @@ pub trait StateMachineApiExt: StateMachineApi {
     ///
     /// It does not check expiration of the returned entry.
     async fn get_maybe_expired_kv(&self, key: &String) -> Result<Option<SeqV>, io::Error> {
-        let got = self.map_ref().str_map().get(key).await?;
+        let got = self.map_ref().user_map().get(key.as_ref()).await?;
         let seqv = Into::<Option<SeqV>>::into(got);
         Ok(seqv)
     }
@@ -205,10 +228,10 @@ pub trait StateMachineApiExt: StateMachineApi {
 
 impl<T> StateMachineApiExt for T where T: StateMachineApi {}
 
-/// Convert internal data to a public API format.
+/// Convert internal data format [`SeqMarked<T>`] containing tombstone to a public API format [`SeqV`] without tombstone.
 ///
 /// A tombstone is converted to None.
-fn marked_to_seqv(k: String, marked: MarkedOf<String>) -> Option<(String, SeqV)> {
+fn seq_marked_to_seqv(k: UserKey, marked: SeqMarked<MetaValue>) -> Option<(String, SeqV)> {
     let seqv = Into::<Option<SeqV>>::into(marked);
-    seqv.map(|x| (k, x))
+    seqv.map(|x| (k.to_string(), x))
 }

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -179,12 +179,12 @@ pub trait StateMachineApiExt: StateMachineApi {
 
         if let Some(exp_ms) = removed.expires_at_ms_opt() {
             self.map_mut()
-                .set(ExpireKey::new(exp_ms, removed.order_key().seq()), None)
+                .set(ExpireKey::new(exp_ms, *removed.internal_seq()), None)
                 .await?;
         }
 
         if let Some(exp_ms) = added.expires_at_ms_opt() {
-            let k = ExpireKey::new(exp_ms, added.order_key().seq());
+            let k = ExpireKey::new(exp_ms, *added.internal_seq());
             let v = key.to_string();
             self.map_mut().set(k, Some(v)).await?;
         }

--- a/src/meta/raft-store/src/testing.rs
+++ b/src/meta/raft-store/src/testing.rs
@@ -12,28 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::uninlined_format_args)]
-#![feature(coroutines)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(try_blocks)]
-#![allow(clippy::diverging_sub_expression)]
+use std::time::Duration;
+use std::time::SystemTime;
 
-pub mod applier;
-pub mod config;
-pub mod key_spaces;
-pub mod leveled_store;
-pub(crate) mod marked;
-pub mod ondisk;
-pub mod raft_log_v004;
-pub mod sm_v003;
-pub mod snapshot_config;
-pub mod state;
-pub mod state_machine;
-pub mod state_machine_api;
-pub mod state_machine_api_ext;
-pub(crate) mod testing;
-pub mod utils;
+#[allow(dead_code)]
+pub(crate) fn since_epoch_secs() -> u64 {
+    since_epoch().as_secs()
+}
 
-mod state_machine_features;
+pub(crate) fn since_epoch_millis() -> u64 {
+    since_epoch().as_millis() as u64
+}
 
-pub use state_machine_features::StateMachineFeature;
+pub(crate) fn since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+}

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::collections::BTreeSet;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use anyerror::AnyError;
 use databend_common_base::base::tokio::sync::RwLockReadGuard;
@@ -27,7 +29,6 @@ use databend_common_meta_types::raft_types::ClientWriteError;
 use databend_common_meta_types::raft_types::MembershipNode;
 use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::raft_types::RaftError;
-use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::AppliedState;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::LogEntry;
@@ -268,7 +269,7 @@ impl<'a> MetaLeader<'a> {
         mut entry: LogEntry,
     ) -> Result<AppliedState, RaftError<ClientWriteError>> {
         // Add consistent clock time to log entry.
-        entry.time_ms = Some(SeqV::<()>::now_ms());
+        entry.time_ms = Some(since_epoch().as_millis() as u64);
 
         // report metrics
         let _guard = ProposalPending::guard();
@@ -317,4 +318,10 @@ impl<'a> MetaLeader<'a> {
     async fn get_state_machine(&self) -> RwLockReadGuard<'_, SMV003> {
         self.sto.state_machine.read().await
     }
+}
+
+fn since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
 }

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -23,7 +23,6 @@ use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_types::protobuf as pb;
-use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::KVMeta;
 use databend_common_meta_types::MetaSpec;
 use databend_common_meta_types::UpsertKV;
@@ -35,12 +34,13 @@ use pretty_assertions::assert_eq;
 use test_harness::test;
 
 use crate::testing::meta_service_test_harness;
+use crate::testing::since_epoch_sec;
 use crate::tests::service::make_grpc_client;
 
 #[test(harness = meta_service_test_harness)]
 #[fastrace::trace]
 async fn test_kv_read_v1_on_leader() -> anyhow::Result<()> {
-    let now_sec = SeqV::<()>::now_sec();
+    let now_sec = since_epoch_sec();
 
     let (tc, _addr) = crate::tests::start_metasrv().await?;
 
@@ -56,7 +56,7 @@ async fn test_kv_read_v1_on_leader() -> anyhow::Result<()> {
 #[test(harness = meta_service_test_harness)]
 #[fastrace::trace]
 async fn test_kv_read_v1_on_follower() -> anyhow::Result<()> {
-    let now_sec = SeqV::<()>::now_sec();
+    let now_sec = since_epoch_sec();
 
     let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
 

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 
 use databend_common_base::base::tokio::time::sleep;
 use databend_common_meta_kvapi::kvapi::KVApi;
-use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::LogEntry;
 use databend_common_meta_types::MatchSeq;
@@ -27,6 +26,7 @@ use log::info;
 use test_harness::test;
 
 use crate::testing::meta_service_test_harness;
+use crate::testing::since_epoch_sec;
 use crate::tests::meta_node::start_meta_node_leader;
 use crate::tests::meta_node::start_meta_node_non_voter;
 
@@ -54,7 +54,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
 
     let key = "expire-kv";
     let value2 = "value2";
-    let now_sec = SeqV::<()>::now_ms() / 1000;
+    let now_sec = since_epoch_sec();
 
     info!("--- write a kv expiring in 3 sec");
     {

--- a/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
+++ b/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
@@ -28,6 +28,7 @@ use test_harness::test;
 use tokio::time::sleep;
 
 use crate::testing::meta_service_test_harness;
+use crate::testing::since_epoch_millis;
 use crate::tests::meta_node::start_meta_node_cluster;
 use crate::tests::meta_node::timeout;
 
@@ -47,7 +48,7 @@ use crate::tests::meta_node::timeout;
 #[test(harness = meta_service_test_harness)]
 #[fastrace::trace]
 async fn test_meta_node_log_time_revert_cross_snapshot_boundary() -> anyhow::Result<()> {
-    let now_ms = SeqV::<()>::now_ms();
+    let now_ms = since_epoch_millis();
 
     // Log with later timestamp (T+180s) - will be included in snapshot
     let log_later = LogEntry {

--- a/src/meta/service/tests/it/testing.rs
+++ b/src/meta/service/tests/it/testing.rs
@@ -14,6 +14,8 @@
 
 use std::collections::BTreeMap;
 use std::sync::Once;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use databend_common_base::base::tokio;
 use databend_common_tracing::closure_name;
@@ -66,4 +68,18 @@ fn setup_test() {
 
 fn shutdown_test() {
     fastrace::flush();
+}
+
+pub fn since_epoch_sec() -> u64 {
+    since_epoch().as_secs()
+}
+
+pub fn since_epoch_millis() -> u64 {
+    since_epoch().as_millis() as u64
+}
+
+pub fn since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
 }

--- a/src/meta/types/src/lib.rs
+++ b/src/meta/types/src/lib.rs
@@ -76,7 +76,7 @@ pub use errors::meta_startup_errors::MetaStartupError;
 pub use errors::rpc_errors::ForwardRPCError;
 pub use grpc_config::GrpcConfig;
 pub use log_entry::LogEntry;
-pub use map_api::expirable::Expirable;
+pub use map_api::Expirable;
 pub mod match_seq {
     pub use map_api::match_seq::errors::ConflictSeq;
     pub use map_api::match_seq::MatchSeq;

--- a/src/meta/types/src/seq_value/kv_meta.rs
+++ b/src/meta/types/src/seq_value/kv_meta.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::time::Duration;
 
 use display_more::DisplayUnixTimeStampExt;
-use map_api::expirable::Expirable;
+use map_api::Expirable;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/src/meta/types/src/seq_value/mod.rs
+++ b/src/meta/types/src/seq_value/mod.rs
@@ -15,6 +15,6 @@
 mod kv_meta;
 
 pub use kv_meta::KVMeta;
-pub use map_api::seq_value::SeqValue;
+pub use map_api::SeqValue;
 
-pub type SeqV<T = Vec<u8>> = map_api::seq_value::SeqV<KVMeta, T>;
+pub type SeqV<T = Vec<u8>> = map_api::SeqV<KVMeta, T>;

--- a/src/query/management/src/quota/quota_mgr.rs
+++ b/src/query/management/src/quota/quota_mgr.rs
@@ -82,7 +82,7 @@ impl<const WRITE_PB: bool> QuotaApi for QuotaMgr<WRITE_PB> {
                     .await?;
 
                     // Keep the original seq.
-                    Ok(SeqV::with_meta(seq_value.seq, seq_value.meta, u.data))
+                    Ok(SeqV::new_with_meta(seq_value.seq, seq_value.meta, u.data))
                 }
             },
         }

--- a/src/query/storages/result_cache/src/write/sink.rs
+++ b/src/query/storages/result_cache/src/write/sink.rs
@@ -14,13 +14,13 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_store::MetaStore;
-use databend_common_meta_types::seq_value::SeqV;
 use databend_common_meta_types::MatchSeq;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::ProcessorPtr;
@@ -91,7 +91,10 @@ impl AsyncMpscSink for WriteResultCacheSink {
         let location = self.cache_writer.write_to_storage().await?;
 
         // 2. Set result cache key-value pair to meta.
-        let now = SeqV::<()>::now_ms() / 1000;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         let ttl_sec = self.meta_mgr.get_ttl();
         let ttl_interval = Duration::from_secs(ttl_sec);
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service): merge `Marked` and `SeqMarked` into one

These two structures provide similar functionality and should be just
one.

Internally, `SeqMarked` is a type for value with sequence number and
tombstone mark. Since this commit it is defined in a shared crate
`seqmarked` and reused by all depending crates:

- `rotbl`: the snapshot storage impl;
- `map-api`: abstract map like API;
- databend raft-store impl

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18350)
<!-- Reviewable:end -->
