### PR TITLE
fix(script): fetch log script need use the timestamp

### DIFF
--- a/scripts/selfhost/fetch_log.sh
+++ b/scripts/selfhost/fetch_log.sh
@@ -299,7 +299,7 @@ main() {
 	log INFO "Fetch Databend query logs..."
 	execute_query "REMOVE @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;"
 
-	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.query_history WHERE event_date = '$FORMATTED_DATE');"
+	execute_query "COPY INTO @a5c7667401c0c728c2ef9703bdaea66d9ae2d906 FROM (SELECT * FROM system_history.query_history WHERE to_date(event_time) = '$FORMATTED_DATE');"
 
 	file_list=$(execute_query "list @a5c7667401c0c728c2ef9703bdaea66d9ae2d906;" | awk '{print $1}')
 	[[ -z "$file_list" ]] && {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: fetch log script need use the timestamp

The `event_date` field in the `query_history` table not include timezone information. Use `event_time` instead.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Minor fix

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18352)
<!-- Reviewable:end -->
