### PR TITLE
fix: remove temp table from global when drop m_cte temp tables.

### DIFF
--- a/src/query/service/src/servers/http/v1/session/client_session_manager.rs
+++ b/src/query/service/src/servers/http/v1/session/client_session_manager.rs
@@ -157,8 +157,8 @@ impl ClientSessionManager {
 
             if !(remained.is_empty() && num_expired == 0) {
                 info!(
-                    "[TEMP TABLE] cleanup {num_expired} sessions in {} secs, {} remained: {:?}",
-                    elapsed.as_secs(),
+                    "[TEMP TABLE] cleanup {num_expired} sessions in {} millisecond, {} remained: {:?}",
+                    elapsed.as_millis(),
                     remained.len(),
                     remained
                 );


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix waning logs like:

```
[TEMP TABLE] session={client_session_id} empty temp_tbl_mgr in ClientSessionManager.
```

the affect of the bug not very harmful：a empty TempTableMgr occupy a entry in  ClientSessionManager until timeout after 4h or overwritten by another insert when creating temp table.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
