### PR TITLE
chore(query): mark the 'create as select' query as heavy

### DIFF
--- a/src/query/service/tests/it/sessions/queue_mgr.rs
+++ b/src/query/service/tests/it/sessions/queue_mgr.rs
@@ -382,6 +382,10 @@ async fn test_heavy_actions() -> Result<()> {
             // MERGE INTO
             add_to_queue: true,
         },
+        Query {
+            sql: "CREATE TABLE test_heavy_create AS SELECT 1",
+            add_to_queue: true,
+        }
     ];
 
     let fixture = TestFixture::setup().await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

chore(query): mark the 'create as select' query as heavy

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
