### PR TITLE
chore: extend the short_sql_max_length to 2048

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1165,7 +1165,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("short_sql_max_length", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(128),
+                    value: UserSettingValue::UInt64(2048),
                     desc: "Sets the maximum length for truncating SQL queries in short_sql function.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

* Extend the default `short_sql_max_length` settings value from 128 to 2048

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - For query log

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18390)
<!-- Reviewable:end -->
