### PR TITLE
fix: insert_stmt allow `;` at the end of SQL.

### DIFF
--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -2989,9 +2989,9 @@ pub fn insert_source_file(i: Input) -> IResult<InsertSource> {
     );
     map(
         rule! {
-           (VALUES ~ #value?)? ~ FROM ~ #at_string ~  #file_format_clause
+           (VALUES ~ #value?)? ~ FROM ~ #at_string ~  #file_format_clause ~ ";"? ~ &EOI
         },
-        |(values, _, location, format_options)| InsertSource::LoadFile {
+        |(values, _, location, format_options, _, _)| InsertSource::LoadFile {
             value: values.map(|(_, value)| value).unwrap_or_default(),
             location,
             format_options,

--- a/tests/suites/1_stateful/09_http_handler/09_0002_sql_ends_semicolon.result
+++ b/tests/suites/1_stateful/09_http_handler/09_0002_sql_ends_semicolon.result
@@ -1,0 +1,10 @@
+>>>> create or replace table t_09_0002 (a int)
+<<<<
+"Succeeded"
+null
+"Succeeded"
+null
+"Succeeded"
+null
+"Succeeded"
+null

--- a/tests/suites/1_stateful/09_http_handler/09_0002_sql_ends_semicolon.sh
+++ b/tests/suites/1_stateful/09_http_handler/09_0002_sql_ends_semicolon.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+query "create or replace table t_09_0002 (a int)"
+
+# insert_stmt
+curl -s --header 'Content-Type: application/json'  --request POST '127.0.0.1:8000/v1/query/'  --data-raw '{"sql": "insert into t_09_0002 from @~/not_exist file_format=(type=csv);", "pagination": { "wait_time_secs": 5}}' -u root: | jq -c ".state",".error"
+curl -s --header 'Content-Type: application/json'  --request POST '127.0.0.1:8000/v1/query/'  --data-raw '{"sql": "insert into t_09_0002 select 1;", "pagination": { "wait_time_secs": 5}}' -u root: | jq -c ".state",".error"
+curl -s --header 'Content-Type: application/json'  --request POST '127.0.0.1:8000/v1/query/'  --data-raw '{"sql": "insert into t_09_0002 values (1);", "pagination": { "wait_time_secs": 5}}' -u root: | jq -c ".state",".error"
+
+# statement
+curl -s --header 'Content-Type: application/json'  --request POST '127.0.0.1:8000/v1/query/'  --data-raw '{"sql": "select 1;", "pagination": { "wait_time_secs": 2}}' -u root:  | jq -c ".state",".error"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix error like

```
 unable to parse rest of the sql, rest tokens:  [SemiColon(62..63), EOI(63..63), EOI(63..63)] \n\n"}
```

when `insert ... file_format ... ` ends with `;`


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18399)
<!-- Reviewable:end -->
