### PR TITLE
refactor(query): Gracefully handle unknown GrantEntry objects in UserGrantSet::from_pb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,6 +4096,7 @@ dependencies = [
  "databend-common-protos",
  "enumflags2",
  "fastrace",
+ "log",
  "maplit",
  "num",
  "pretty_assertions",

--- a/src/meta/proto-conv/Cargo.toml
+++ b/src/meta/proto-conv/Cargo.toml
@@ -16,6 +16,7 @@ databend-common-meta-types = { workspace = true }
 databend-common-protos = { workspace = true }
 enumflags2 = { workspace = true }
 fastrace = { workspace = true }
+log = { workspace = true }
 num = { workspace = true }
 prost = { workspace = true }
 thiserror = { workspace = true }

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -160,7 +160,7 @@ impl FromToProto for mt::principal::GrantObject {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let Some(object) = p.object else {
-            return Err(Incompatible::new("GrantObject cannot be None".to_string()));
+            return Err(Incompatible::new(format!("Incompatible GrantObject type: Data contains an unrecognized variant for {} version", p.ver)));
         };
 
         match object {

--- a/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/user_from_to_protobuf_impl.rs
@@ -295,7 +295,13 @@ impl FromToProto for mt::principal::UserGrantSet {
 
         let mut entries = Vec::new();
         for entry in p.entries.iter() {
-            entries.push(mt::principal::GrantEntry::from_pb(entry.clone())?);
+            // If we add new GrantObject in new version
+            // Rollback to old version, GrantEntry.object will be None
+            // GrantEntry::from_pb will return err so user can not login in old version.
+            match mt::principal::GrantEntry::from_pb(entry.clone()) {
+                Ok(entry) => entries.push(entry),
+                Err(e) => log::error!("GrantEntry::from_pb with error : {e}"),
+            }
         }
         let mut roles = HashSet::new();
         for role in p.roles.iter() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When an older version of the application processes `UserGrantSet` data that contains `GrantEntry` objects with newly introduced `GrantObject` types, the `GrantEntry::from_pb` conversion can fail for those specific entries.

This commit modifies the `UserGrantSet::from_pb` function to gracefully handle such scenarios. If `GrantEntry::from_pb` returns an error (e.g., due to an unknown `GrantObject`), the error is now logged, and the problematic grant entry is skipped instead of causing the entire conversion to fail.

This ensures that users on older versions can still log in and use their available grants, providing better forward compatibility and robustness against evolving data schemas.
Without this, a user attempting to log in with data containing new `GrantObject` types would be prevented from logging in on an older client.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test : keep ci passed

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18400)
<!-- Reviewable:end -->
