### PR TITLE
ci: test_private_tasks uses 8c32g for testing

### DIFF
--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -190,7 +190,6 @@ jobs:
       - X64
       - Linux
       - 8c32g
-      - aws
       - "${{ inputs.runner_provider }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -189,7 +189,8 @@ jobs:
       - self-hosted
       - X64
       - Linux
-      - 2c8g
+      - 8c32g
+      - aws
       - "${{ inputs.runner_provider }}"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`test_private_tasks` always fails in 2c8g, so try to improve the configuration

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): ci config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18406)
<!-- Reviewable:end -->
