### PR TITLE
fix(query): AsyncFunctionCall::display_name should respect quota

### DIFF
--- a/tests/sqllogictests/suites/stage/sequence_as_default.test
+++ b/tests/sqllogictests/suites/stage/sequence_as_default.test
@@ -2,10 +2,10 @@ statement ok
 create or replace sequence seq
 
 statement ok
-create or replace sequence seq1
+create or replace sequence `seq1_测试`
 
 statement ok
-create or replace table tmp (seq int default nextval(seq), a int, seq1 bigint not null default nextval(seq1));
+create or replace table tmp (seq int default nextval(seq), a int, seq1 bigint not null default nextval(`seq1_测试`));
 
 statement ok
 set sequence_step_size = 1;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

During the semantic analysis phase of the `nextval` function, the logic for generating `display_name` might not have fully considered SQL identifier quoting rules. If the sequence name was a reserved keyword or contained special characters, the generated `display_name` might not conform to SQL syntax, leading to inaccurate display or potential issues.

This change constructs the `display_name` by leveraging the `to_string()` method of the `ident` object returned by `normalize_identifier`. The `ident.to_string()` method already incorporates the logic for necessary identifier quoting according to SQL rules.

In main this will be failed:

```
root@localhost:8000/default/default> create or replace table mytest (seq int default nextval(`测试`));
error: APIError: QueryFailed: [1001]fail to parse default expr `CAST(nextval(测试) AS Int32 NULL)` (string length = 35) of field seq, SyntaxException. Code: 1005, Text = unable to recognize the rest tokens.
```

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18412)
<!-- Reviewable:end -->
