### PR TITLE
fix: panic when the `string_agg` parameter is not of type string

### DIFF
--- a/src/query/expression/src/types.rs
+++ b/src/query/expression/src/types.rs
@@ -62,6 +62,7 @@ pub use self::bitmap::BitmapType;
 pub use self::boolean::Bitmap;
 pub use self::boolean::BooleanType;
 pub use self::boolean::MutableBitmap;
+pub use self::compute_view::StringConvert;
 pub use self::date::DateType;
 pub use self::decimal::*;
 pub use self::empty_array::EmptyArrayType;

--- a/src/query/expression/src/types/compute_view.rs
+++ b/src/query/expression/src/types/compute_view.rs
@@ -19,7 +19,7 @@ use std::ops::Range;
 
 use num_traits::AsPrimitive;
 
-use super::AccessType;
+use super::{AccessType, NumberType};
 use super::AnyType;
 use super::ArgType;
 use super::StringColumn;
@@ -27,7 +27,6 @@ use super::StringType;
 use crate::display::scalar_ref_to_string;
 use crate::types::string::StringDomain;
 use crate::types::string::StringIterator;
-use crate::types::CoreNumber;
 use crate::types::Number;
 use crate::types::SimpleDomain;
 use crate::Column;
@@ -151,19 +150,19 @@ where
 }
 
 /// For number convert
-pub type NumberConvertView<F, T> = ComputeView<NumberConvert<F, T>, CoreNumber<F>, CoreNumber<T>>;
+pub type NumberConvertView<F, T> = ComputeView<NumberConvert<F, T>, NumberType<F>, NumberType<T>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NumberConvert<F, T>(std::marker::PhantomData<(F, T)>);
 
-impl<F, T> Compute<CoreNumber<F>, CoreNumber<T>> for NumberConvert<F, T>
+impl<F, T> Compute<NumberType<F>, NumberType<T>> for NumberConvert<F, T>
 where
     F: Number + AsPrimitive<T>,
     T: Number,
 {
     fn compute<'a>(
-        value: <CoreNumber<F> as AccessType>::ScalarRef<'a>,
-    ) -> <CoreNumber<T> as AccessType>::ScalarRef<'a> {
+        value: <NumberType<F> as AccessType>::ScalarRef<'a>,
+    ) -> <NumberType<T> as AccessType>::ScalarRef<'a> {
         value.as_()
     }
 

--- a/src/query/expression/src/types/compute_view.rs
+++ b/src/query/expression/src/types/compute_view.rs
@@ -17,37 +17,42 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Range;
 
-use databend_common_column::buffer::Buffer;
 use num_traits::AsPrimitive;
 
-use super::simple_type::SimpleType;
 use super::AccessType;
+use super::AnyType;
+use super::ArgType;
+use super::StringColumn;
+use super::StringType;
+use crate::types::string::StringDomain;
+use crate::types::string::StringIterator;
 use crate::types::CoreNumber;
 use crate::types::Number;
 use crate::types::SimpleDomain;
 use crate::Column;
+use crate::display::scalar_ref_to_string;
 use crate::Domain;
 use crate::ScalarRef;
 
 pub trait Compute<F, T>: Debug + Clone + PartialEq + 'static
 where
-    F: SimpleType,
-    T: SimpleType,
+    F: AccessType,
+    T: AccessType,
 {
-    fn compute(value: &F::Scalar) -> T::Scalar;
+    fn compute<'a>(value: F::ScalarRef<'a>) -> T::ScalarRef<'a>;
 
     fn compute_domain(domain: &F::Domain) -> T::Domain;
 }
 
 impl<T> Compute<T, T> for T
-where T: SimpleType
+where T: AccessType
 {
-    fn compute(value: &T::Scalar) -> T::Scalar {
-        *value
+    fn compute<'a>(value: T::ScalarRef<'a>) -> T::ScalarRef<'a> {
+        value
     }
 
     fn compute_domain(domain: &T::Domain) -> T::Domain {
-        *domain
+        domain.to_owned()
     }
 }
 
@@ -56,56 +61,56 @@ pub struct ComputeView<C, F, T>(PhantomData<(C, F, T)>);
 
 impl<C, F, T> AccessType for ComputeView<C, F, T>
 where
-    F: SimpleType,
-    T: SimpleType,
+    F: AccessType,
+    T: AccessType,
     C: Compute<F, T>,
 {
     type Scalar = T::Scalar;
-    type ScalarRef<'a> = T::Scalar;
-    type Column = Buffer<F::Scalar>;
+    type ScalarRef<'a> = T::ScalarRef<'a>;
+    type Column = F::Column;
     type Domain = T::Domain;
     type ColumnIterator<'a> =
-        std::iter::Map<std::slice::Iter<'a, F::Scalar>, fn(&'a F::Scalar) -> T::Scalar>;
+        std::iter::Map<F::ColumnIterator<'a>, fn(F::ScalarRef<'a>) -> T::ScalarRef<'a>>;
 
     fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
-        scalar
+        T::to_owned_scalar(scalar)
     }
 
     fn to_scalar_ref(scalar: &Self::Scalar) -> Self::ScalarRef<'_> {
-        *scalar
+        T::to_scalar_ref(scalar)
     }
 
     fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
-        F::downcast_scalar(scalar).map(|v| C::compute(&v))
+        F::try_downcast_scalar(scalar).map(|v| C::compute(v))
     }
 
     fn try_downcast_column(col: &Column) -> Option<Self::Column> {
-        F::downcast_column(col)
+        F::try_downcast_column(col)
     }
 
     fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
-        F::downcast_domain(domain).map(|domain| C::compute_domain(&domain))
+        F::try_downcast_domain(domain).map(|domain| C::compute_domain(&domain))
     }
 
     fn column_len(col: &Self::Column) -> usize {
-        col.len()
+        F::column_len(col)
     }
 
     fn index_column(col: &Self::Column, index: usize) -> Option<Self::ScalarRef<'_>> {
-        col.get(index).map(C::compute)
+        F::index_column(col, index).map(C::compute)
     }
 
     unsafe fn index_column_unchecked(col: &Self::Column, index: usize) -> Self::ScalarRef<'_> {
-        debug_assert!(index < col.len());
-        C::compute(col.get_unchecked(index))
+        let scalar = F::index_column_unchecked(col, index);
+        C::compute(scalar)
     }
 
     fn slice_column(col: &Self::Column, range: Range<usize>) -> Self::Column {
-        col.clone().sliced(range.start, range.end - range.start)
+        F::slice_column(col, range)
     }
 
     fn iter_column(col: &Self::Column) -> Self::ColumnIterator<'_> {
-        col.iter().map(C::compute as fn(&F::Scalar) -> T::Scalar)
+        F::iter_column(col).map(C::compute)
     }
 
     fn scalar_memory_size(_: &Self::ScalarRef<'_>) -> usize {
@@ -113,35 +118,35 @@ where
     }
 
     fn column_memory_size(col: &Self::Column) -> usize {
-        col.len() * std::mem::size_of::<F>()
+        F::column_len(col) * std::mem::size_of::<F>()
     }
 
     fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
-        T::compare(&lhs, &rhs)
+        T::compare(lhs, rhs)
     }
 
     fn equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        left == right
+        T::equal(left, right)
     }
 
     fn not_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        left != right
+        T::not_equal(left, right)
     }
 
     fn greater_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        T::greater_than(&left, &right)
+        T::greater_than(left, right)
     }
 
     fn less_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        T::less_than(&left, &right)
+        T::less_than(left, right)
     }
 
     fn greater_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        T::greater_than_equal(&left, &right)
+        T::greater_than_equal(left, right)
     }
 
     fn less_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
-        T::less_than_equal(&left, &right)
+        T::less_than_equal(left, right)
     }
 }
 
@@ -156,7 +161,9 @@ where
     F: Number + AsPrimitive<T>,
     T: Number,
 {
-    fn compute(value: &F) -> T {
+    fn compute<'a>(
+        value: <CoreNumber<F> as AccessType>::ScalarRef<'a>,
+    ) -> <CoreNumber<T> as AccessType>::ScalarRef<'a> {
         value.as_()
     }
 
@@ -164,5 +171,118 @@ where
         let min = domain.min.as_();
         let max = domain.max.as_();
         SimpleDomain { min, max }
+    }
+}
+
+/// For number convert
+pub type StringConvertView = ComputeView<StringConvert, AnyType, OwnedStringType>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedStringType;
+
+impl AccessType for OwnedStringType {
+    type Scalar = String;
+    type ScalarRef<'a> = String;
+    type Column = StringColumn;
+    type Domain = StringDomain;
+    type ColumnIterator<'a> = std::iter::Map<StringIterator<'a>, fn(&str) -> String>;
+
+    fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
+        scalar.to_string()
+    }
+
+    fn to_scalar_ref(scalar: &Self::Scalar) -> Self::ScalarRef<'_> {
+        scalar.clone()
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
+        scalar.as_string().map(|s| s.to_string())
+    }
+
+    fn try_downcast_column(col: &Column) -> Option<Self::Column> {
+        col.as_string().cloned()
+    }
+
+    fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
+        domain.as_string().cloned()
+    }
+
+    fn column_len(col: &Self::Column) -> usize {
+        col.len()
+    }
+
+    fn index_column(col: &Self::Column, index: usize) -> Option<Self::ScalarRef<'_>> {
+        col.index(index).map(str::to_string)
+    }
+
+    #[inline]
+    unsafe fn index_column_unchecked(col: &Self::Column, index: usize) -> Self::ScalarRef<'_> {
+        col.value_unchecked(index).to_string()
+    }
+
+    fn slice_column(col: &Self::Column, range: Range<usize>) -> Self::Column {
+        col.clone().sliced(range.start, range.end - range.start)
+    }
+
+    fn iter_column(col: &Self::Column) -> Self::ColumnIterator<'_> {
+        col.iter().map(str::to_string)
+    }
+
+    fn scalar_memory_size(scalar: &Self::ScalarRef<'_>) -> usize {
+        scalar.len()
+    }
+
+    fn column_memory_size(col: &Self::Column) -> usize {
+        col.memory_size()
+    }
+
+    #[inline(always)]
+    fn compare(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> Ordering {
+        left.cmp(&right)
+    }
+
+    #[inline(always)]
+    fn equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left == right
+    }
+
+    #[inline(always)]
+    fn not_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left != right
+    }
+
+    #[inline(always)]
+    fn greater_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left > right
+    }
+
+    #[inline(always)]
+    fn greater_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left >= right
+    }
+
+    #[inline(always)]
+    fn less_than(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left < right
+    }
+
+    #[inline(always)]
+    fn less_than_equal(left: Self::ScalarRef<'_>, right: Self::ScalarRef<'_>) -> bool {
+        left <= right
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringConvert;
+
+impl Compute<AnyType, OwnedStringType> for StringConvert {
+    fn compute<'a>(
+        value: <AnyType as AccessType>::ScalarRef<'a>,
+    ) -> <OwnedStringType as AccessType>::ScalarRef<'a> {
+        scalar_ref_to_string(&value)
+    }
+
+    fn compute_domain(_: &<AnyType as AccessType>::Domain) -> StringDomain {
+        StringType::full_domain()
     }
 }

--- a/src/query/expression/src/types/compute_view.rs
+++ b/src/query/expression/src/types/compute_view.rs
@@ -24,13 +24,13 @@ use super::AnyType;
 use super::ArgType;
 use super::StringColumn;
 use super::StringType;
+use crate::display::scalar_ref_to_string;
 use crate::types::string::StringDomain;
 use crate::types::string::StringIterator;
 use crate::types::CoreNumber;
 use crate::types::Number;
 use crate::types::SimpleDomain;
 use crate::Column;
-use crate::display::scalar_ref_to_string;
 use crate::Domain;
 use crate::ScalarRef;
 

--- a/src/query/expression/src/types/compute_view.rs
+++ b/src/query/expression/src/types/compute_view.rs
@@ -19,9 +19,10 @@ use std::ops::Range;
 
 use num_traits::AsPrimitive;
 
-use super::{AccessType, NumberType};
+use super::AccessType;
 use super::AnyType;
 use super::ArgType;
+use super::NumberType;
 use super::StringColumn;
 use super::StringType;
 use crate::display::scalar_ref_to_string;

--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -51,13 +51,12 @@ use serde::Serialize;
 
 use super::compute_view::Compute;
 use super::compute_view::ComputeView;
-use super::AccessType;
+use super::{AccessType, NumberType};
 use super::AnyType;
 use super::SimpleDomain;
 use super::SimpleType;
 use super::SimpleValueType;
 use super::ValueType;
-use crate::types::CoreNumber;
 use crate::types::DataType;
 use crate::types::F64;
 use crate::utils::arrow::buffer_into_mut;
@@ -3030,7 +3029,7 @@ impl Ord for i256 {
 
 pub type DecimalView<F, T> = ComputeView<DecimalConvert<F, T>, CoreDecimal<F>, CoreDecimal<T>>;
 pub type DecimalF64View<F> =
-    ComputeView<DecimalConvert<F, F64>, CoreScalarDecimal<F>, CoreNumber<F64>>;
+    ComputeView<DecimalConvert<F, F64>, CoreScalarDecimal<F>, NumberType<F64>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DecimalConvert<F, T>(std::marker::PhantomData<(F, T)>);
@@ -3055,13 +3054,13 @@ where
     }
 }
 
-impl<F> Compute<CoreScalarDecimal<F>, CoreNumber<F64>> for DecimalConvert<F, F64>
+impl<F> Compute<CoreScalarDecimal<F>, NumberType<F64>> for DecimalConvert<F, F64>
 where F: Decimal
 {
     #[inline]
     fn compute<'a>(
         value: <CoreScalarDecimal<F> as AccessType>::ScalarRef<'a>,
-    ) -> <CoreNumber<F64> as AccessType>::ScalarRef<'a> {
+    ) -> <NumberType<F64> as AccessType>::ScalarRef<'a> {
         value.0.to_float64(value.1.scale()).into()
     }
 

--- a/src/query/expression/src/types/decimal.rs
+++ b/src/query/expression/src/types/decimal.rs
@@ -51,8 +51,9 @@ use serde::Serialize;
 
 use super::compute_view::Compute;
 use super::compute_view::ComputeView;
-use super::{AccessType, NumberType};
+use super::AccessType;
 use super::AnyType;
+use super::NumberType;
 use super::SimpleDomain;
 use super::SimpleType;
 use super::SimpleValueType;

--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -34,7 +34,6 @@ use serde::Serialize;
 
 use super::decimal::DecimalSize;
 use crate::property::Domain;
-use crate::types::AccessType;
 use crate::types::ArgType;
 use crate::types::DataType;
 use crate::types::SimpleType;
@@ -103,58 +102,6 @@ pub type Float32Type = NumberType<F32>;
 pub type Float64Type = NumberType<F64>;
 
 pub type NumberType<T> = SimpleValueType<CoreNumber<T>>;
-
-impl<Num: Number> AccessType for CoreNumber<Num> {
-    type Scalar = Num;
-    type ScalarRef<'a> = Num;
-    type Column = Buffer<Num>;
-    type Domain = SimpleDomain<Num>;
-    type ColumnIterator<'a> = std::iter::Copied<std::slice::Iter<'a, Num>>;
-
-    fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
-        scalar
-    }
-
-    fn to_scalar_ref(scalar: &Self::Scalar) -> Self::ScalarRef<'_> {
-        *scalar
-    }
-
-    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
-        Num::try_downcast_scalar(scalar.as_number()?)
-    }
-
-    fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
-        Num::try_downcast_domain(domain.as_number()?)
-    }
-
-    fn try_downcast_column(col: &Column) -> Option<Self::Column> {
-        Num::try_downcast_column(col.as_number()?).cloned()
-    }
-
-    fn column_len(col: &Self::Column) -> usize {
-        col.len()
-    }
-
-    fn index_column(col: &Self::Column, index: usize) -> Option<Self::ScalarRef<'_>> {
-        col.get(index).copied()
-    }
-
-    unsafe fn index_column_unchecked(col: &Self::Column, index: usize) -> Self::ScalarRef<'_> {
-        *col.get_unchecked(index)
-    }
-
-    fn slice_column(col: &Self::Column, range: Range<usize>) -> Self::Column {
-        col.clone().sliced(range.start, range.end - range.start)
-    }
-
-    fn iter_column(col: &Self::Column) -> Self::ColumnIterator<'_> {
-        col.iter().copied()
-    }
-
-    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
-        lhs.cmp(&rhs)
-    }
-}
 
 impl<Num: Number> SimpleType for CoreNumber<Num> {
     type Scalar = Num;

--- a/src/query/expression/src/types/number.rs
+++ b/src/query/expression/src/types/number.rs
@@ -34,6 +34,7 @@ use serde::Serialize;
 
 use super::decimal::DecimalSize;
 use crate::property::Domain;
+use crate::types::AccessType;
 use crate::types::ArgType;
 use crate::types::DataType;
 use crate::types::SimpleType;
@@ -102,6 +103,58 @@ pub type Float32Type = NumberType<F32>;
 pub type Float64Type = NumberType<F64>;
 
 pub type NumberType<T> = SimpleValueType<CoreNumber<T>>;
+
+impl<Num: Number> AccessType for CoreNumber<Num> {
+    type Scalar = Num;
+    type ScalarRef<'a> = Num;
+    type Column = Buffer<Num>;
+    type Domain = SimpleDomain<Num>;
+    type ColumnIterator<'a> = std::iter::Copied<std::slice::Iter<'a, Num>>;
+
+    fn to_owned_scalar(scalar: Self::ScalarRef<'_>) -> Self::Scalar {
+        scalar
+    }
+
+    fn to_scalar_ref(scalar: &Self::Scalar) -> Self::ScalarRef<'_> {
+        *scalar
+    }
+
+    fn try_downcast_scalar<'a>(scalar: &ScalarRef<'a>) -> Option<Self::ScalarRef<'a>> {
+        Num::try_downcast_scalar(scalar.as_number()?)
+    }
+
+    fn try_downcast_domain(domain: &Domain) -> Option<Self::Domain> {
+        Num::try_downcast_domain(domain.as_number()?)
+    }
+
+    fn try_downcast_column(col: &Column) -> Option<Self::Column> {
+        Num::try_downcast_column(col.as_number()?).cloned()
+    }
+
+    fn column_len(col: &Self::Column) -> usize {
+        col.len()
+    }
+
+    fn index_column(col: &Self::Column, index: usize) -> Option<Self::ScalarRef<'_>> {
+        col.get(index).copied()
+    }
+
+    unsafe fn index_column_unchecked(col: &Self::Column, index: usize) -> Self::ScalarRef<'_> {
+        *col.get_unchecked(index)
+    }
+
+    fn slice_column(col: &Self::Column, range: Range<usize>) -> Self::Column {
+        col.clone().sliced(range.start, range.end - range.start)
+    }
+
+    fn iter_column(col: &Self::Column) -> Self::ColumnIterator<'_> {
+        col.iter().copied()
+    }
+
+    fn compare(lhs: Self::ScalarRef<'_>, rhs: Self::ScalarRef<'_>) -> Ordering {
+        lhs.cmp(&rhs)
+    }
+}
 
 impl<Num: Number> SimpleType for CoreNumber<Num> {
     type Scalar = Num;

--- a/src/query/functions/src/scalars/decimal/src/arithmetic.rs
+++ b/src/query/functions/src/scalars/decimal/src/arithmetic.rs
@@ -223,16 +223,16 @@ where
                 // round_div(-5, -2) --> 3
                 if std::intrinsics::unlikely(b == zero) {
                     ctx.set_error(result.len(), "divided by zero");
-                    result.push(C::compute(&one));
+                    result.push(C::compute(one));
                 } else {
                     match a.do_round_div(b, scale_mul) {
-                        Some(t) => result.push(C::compute(&t)),
+                        Some(t) => result.push(C::compute(t)),
                         None => {
                             ctx.set_error(
                                 result.len(),
                                 concat!("Decimal div overflow at line : ", line!()),
                             );
-                            result.push(C::compute(&one));
+                            result.push(C::compute(one));
                         }
                     }
                 }
@@ -248,20 +248,20 @@ where
             let scale_mul = scale_a + scale_b - return_size.scale();
 
             if scale_mul == 0 {
-                vectorize_2_arg::<L, R, DecimalType<U>>(|a, b, _| C::compute(&op.calc(a, b)))(
+                vectorize_2_arg::<L, R, DecimalType<U>>(|a, b, _| C::compute(op.calc(a, b)))(
                     a, b, ctx,
                 )
             } else {
                 let func = |a: T, b: T, result: &mut Vec<U>, ctx: &mut EvalContext| match a
                     .do_round_mul(b, scale_mul as u32, overflow)
                 {
-                    Some(t) => result.push(C::compute(&t)),
+                    Some(t) => result.push(C::compute(t)),
                     None => {
                         ctx.set_error(
                             result.len(),
                             concat!("Decimal multiply overflow at line : ", line!()),
                         );
-                        result.push(C::compute(&one));
+                        result.push(C::compute(one));
                     }
                 };
 
@@ -282,15 +282,15 @@ where
                             result.len(),
                             concat!("Decimal overflow at line : ", line!()),
                         );
-                        result.push(C::compute(&one));
+                        result.push(C::compute(one));
                     } else {
-                        result.push(C::compute(&t));
+                        result.push(C::compute(t));
                     }
                 };
 
                 vectorize_with_builder_2_arg::<L, R, DecimalType<U>>(func)(a, b, ctx)
             } else {
-                vectorize_2_arg::<L, R, DecimalType<U>>(|l, r, _| C::compute(&op.calc(l, r)))(
+                vectorize_2_arg::<L, R, DecimalType<U>>(|l, r, _| C::compute(op.calc(l, r)))(
                     a, b, ctx,
                 )
             }

--- a/src/query/functions/src/scalars/decimal/src/cast.rs
+++ b/src/query/functions/src/scalars/decimal/src/cast.rs
@@ -811,7 +811,7 @@ where
         Ordering::Equal => vectorize_with_builder_1_arg::<DecimalType<F>, DecimalType<T>>(
             |x: F, builder: &mut Vec<T>, ctx: &mut EvalContext| {
                 if x <= max && x >= min {
-                    builder.push(C::compute(&x));
+                    builder.push(C::compute(x));
                 } else {
                     ctx.set_error(
                         builder.len(),
@@ -827,7 +827,7 @@ where
             vectorize_with_builder_1_arg::<DecimalType<F>, DecimalType<T>>(
                 |x: F, builder: &mut Vec<T>, ctx: &mut EvalContext| match x.checked_mul(factor) {
                     Some(x) if x <= max && x >= min => {
-                        builder.push(C::compute(&x));
+                        builder.push(C::compute(x));
                     }
                     _ => {
                         ctx.set_error(
@@ -854,7 +854,7 @@ where
                     scale_diff,
                     ctx.func_ctx.rounding_mode,
                 ) {
-                    Some(y) => builder.push(C::compute(&y)),
+                    Some(y) => builder.push(C::compute(y)),
                     None => {
                         ctx.set_error(
                             builder.len(),

--- a/src/query/functions/src/scalars/decimal/src/math.rs
+++ b/src/query/functions/src/scalars/decimal/src/math.rs
@@ -169,7 +169,7 @@ where
         } else {
             (a + addition) / power_of_ten
         };
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 
@@ -201,7 +201,7 @@ where
             a + addition
         };
         let res = a / divide_power_of_ten * multiply_power_of_ten;
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 
@@ -220,7 +220,7 @@ where
     let power_of_ten = T::e((source_scale - target_scale) as u8);
     vectorize_1_arg::<DecimalType<T>, DecimalType<U>>(|a, _| {
         let res = a / power_of_ten;
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 
@@ -246,7 +246,7 @@ where
 
     vectorize_1_arg::<DecimalType<T>, DecimalType<U>>(|a, _| {
         let res = a / divide_power_of_ten * multiply_power_of_ten;
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 
@@ -275,7 +275,7 @@ where
         } else {
             a / power_of_ten
         };
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 
@@ -303,7 +303,7 @@ where
         } else {
             ((a - T::one()) / power_of_ten) + T::one()
         };
-        C::compute(&res)
+        C::compute(res)
     })(value, ctx)
 }
 

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -561,6 +561,30 @@ select k, mode(v) from aggr group by k order by k;
 3 NULL
 
 statement ok
+CREATE OR REPLACE TABLE convert_string (
+    c1 STRING,
+    c2 INT,
+    c3 INT
+);
+
+statement ok
+INSERT INTO convert_string (c1, c2, c3) VALUES
+('a', 1, 1),
+('a', 2, 1),
+('b', 1, 1),
+('b', 2, 1),
+('a', 1, 1),
+('a', 1, 2),
+('a', 2, 2),
+('b', 1, 2);
+
+query IT
+select c1, string_agg(json_object('col', c2, 'no2', c3), ',') from convert_string group by c1;
+----
+a {"col":1,"no2":1},{"col":2,"no2":1},{"col":1,"no2":1},{"col":1,"no2":2},{"col":2,"no2":2}
+b {"col":1,"no2":1},{"col":2,"no2":1},{"col":1,"no2":2}
+
+statement ok
 DROP TABLE aggr
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

```
select c1, string_agg(json_object('col', c2, 'no2', c3), ',') from convert_string group by c1;
----
a {"col":1,"no2":1},{"col":2,"no2":1},{"col":1,"no2":1},{"col":1,"no2":2},{"col":2,"no2":2}
b {"col":1,"no2":1},{"col":2,"no2":1},{"col":1,"no2":2}
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18416)
<!-- Reviewable:end -->
