### PR TITLE
feat(meta-service): Add comprehensive snapshot database metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13088,9 +13088,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6e7717a92f1a74cd17a166a7e3972016b306dfea7d43186728d982838c5f32"
+checksum = "068a45a83c2ce7d6bdad6ba83719ff08ba9818d210b613af13647ea33ab7d23c"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,7 +466,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.2.6", features = [] }
+rotbl = { version = "0.2.7", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -577,7 +577,8 @@ impl MetaService for MetaServiceImpl {
                 wal_closed_chunk_sizes: status.raft_log.wal_closed_chunk_sizes,
             }),
 
-            snapshot_key_count: status.snapshot_key_count as u64,
+            snapshot_key_count: status.snapshot_key_count,
+
             state: status.state,
             is_leader: status.is_leader,
             current_term: status.current_term,

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -53,6 +53,7 @@ use databend_common_meta_types::raft_types::MembershipNode;
 use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::raft_types::RaftMetrics;
 use databend_common_meta_types::raft_types::TypeConfig;
+use databend_common_meta_types::snapshot_db::DBStat;
 use databend_common_meta_types::AppliedState;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::Endpoint;
@@ -487,6 +488,19 @@ impl MetaNode {
                     )
                 }
 
+                {
+                    let db_stat = meta_node.get_snapshot_db_stat().await;
+                    let snapshot = server_metrics::snapshot();
+                    snapshot.block_count.set(db_stat.block_num as i64);
+                    snapshot.data_size.set(db_stat.data_size as i64);
+                    snapshot.index_size.set(db_stat.index_size as i64);
+                    snapshot.avg_block_size.set(db_stat.avg_block_size as i64);
+                    snapshot
+                        .avg_keys_per_block
+                        .set(db_stat.avg_keys_per_block as i64);
+                    snapshot.read_block.set(db_stat.read_block as i64);
+                }
+
                 last_leader = mm.current_leader;
             }
 
@@ -896,6 +910,10 @@ impl MetaNode {
 
     async fn get_snapshot_key_space_stat(&self) -> BTreeMap<String, u64> {
         self.raft_store.get_snapshot_key_space_stat().await
+    }
+
+    async fn get_snapshot_db_stat(&self) -> DBStat {
+        self.raft_store.get_snapshot_db_stat().await
     }
 
     pub async fn get_status(&self) -> Result<MetaNodeStatus, MetaError> {

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -43,6 +43,7 @@ use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::raft_types::Snapshot;
 use databend_common_meta_types::raft_types::SnapshotMeta;
 use databend_common_meta_types::raft_types::StorageError;
+use databend_common_meta_types::snapshot_db::DBStat;
 use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::MetaNetworkError;
@@ -308,6 +309,15 @@ impl RaftStoreInner {
             return Default::default();
         };
         db.sys_data().key_counts().clone()
+    }
+
+    /// Get the statistics of the snapshot database.
+    pub(crate) async fn get_snapshot_db_stat(&self) -> DBStat {
+        let sm = self.state_machine.read().await;
+        let Some(db) = sm.levels().persisted() else {
+            return Default::default();
+        };
+        db.db_stat()
     }
 
     /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -109,62 +109,62 @@ async fn test_metrics() -> anyhow::Result<()> {
     // metasrv_meta_network_watch_initialization_total 0
     // metasrv_raft_network_active_peers{id="1",addr="127.0.0.1:29003"} 1
     // metasrv_raft_network_active_peers{id="2",addr="127.0.0.1:29006"} 1
-    // metasrv_raft_network_append_sent_seconds_bucket{le="+Inf",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="+Inf",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="+Inf",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.001",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.001",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.001",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.002",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.002",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.002",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.004",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.004",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.004",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.008",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.008",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.008",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.016",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.016",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.016",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.032",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.032",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.032",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.064",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.064",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.064",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.128",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.128",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.128",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.256",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.256",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.256",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="0.512",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="0.512",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="0.512",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="1.024",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="1.024",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="1.024",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="131.072",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="131.072",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="131.072",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="16.384",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="16.384",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="16.384",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="2.048",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="2.048",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="2.048",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="262.144",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="262.144",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="262.144",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="32.768",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="32.768",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="32.768",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="4.096",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="4.096",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="4.096",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="524.288",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="524.288",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="524.288",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="65.536",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="65.536",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="65.536",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_bucket{le="8.192",to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_bucket{le="8.192",to="1"} 9
     // metasrv_raft_network_append_sent_seconds_bucket{le="8.192",to="2"} 6
-    // metasrv_raft_network_append_sent_seconds_count{to="1"} 8
+    // metasrv_raft_network_append_sent_seconds_count{to="1"} 9
     // metasrv_raft_network_append_sent_seconds_count{to="2"} 6
     // metasrv_raft_network_append_sent_seconds_sum{to="1"} 0.0
     // metasrv_raft_network_append_sent_seconds_sum{to="2"} 0.0
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57382"} 1830
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57384"} 809
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57385"} 1764
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57387"} 537
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57388"} 338
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57389"} 533
-    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:57390"} 673
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62962"} 1794
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62964"} 797
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62965"} 1728
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62967"} 537
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62968"} 537
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62969"} 533
+    // metasrv_raft_network_recv_bytes_total{from="127.0.0.1:62970"} 673
     // metasrv_raft_network_recv_bytes_total{from="addr"} 1
-    // metasrv_raft_network_sent_bytes_total{to="1"} 3650
-    // metasrv_raft_network_sent_bytes_total{to="2"} 2834
+    // metasrv_raft_network_sent_bytes_total{to="1"} 3661
+    // metasrv_raft_network_sent_bytes_total{to="2"} 2938
     // metasrv_raft_storage_raft_store_write_failed_total{func="fun"} 1
     // metasrv_raft_storage_snapshot_building 0
     // metasrv_raft_storage_snapshot_written_entries_total 0
@@ -180,16 +180,24 @@ async fn test_metrics() -> anyhow::Result<()> {
     // metasrv_server_proposals_failed_total 0
     // metasrv_server_proposals_pending 0
     // metasrv_server_raft_log_cache_items 10
-    // metasrv_server_raft_log_cache_used_size 867
-    // metasrv_server_raft_log_size 1712
+    // metasrv_server_raft_log_cache_used_size 771
+    // metasrv_server_raft_log_size 1694
     // metasrv_server_raft_log_wal_closed_chunk_count 0
     // metasrv_server_raft_log_wal_closed_chunk_total_size 0
-    // metasrv_server_raft_log_wal_offset 1712
-    // metasrv_server_raft_log_wal_open_chunk_size 1712
+    // metasrv_server_raft_log_wal_offset 1694
+    // metasrv_server_raft_log_wal_open_chunk_size 1694
     // metasrv_server_read_failed_total 0
+    // metasrv_server_snapshot_avg_block_size 0
+    // metasrv_server_snapshot_avg_keys_per_block 0
+    // metasrv_server_snapshot_block_count 0
+    // metasrv_server_snapshot_data_size 0
     // metasrv_server_snapshot_expire_index_count 0
+    // metasrv_server_snapshot_index_size 0
     // metasrv_server_snapshot_key_count 0
     // metasrv_server_snapshot_primary_index_count 0
+    // metasrv_server_snapshot_read_block 0
+    // metasrv_server_snapshot_read_block_from_cache 0
+    // metasrv_server_snapshot_read_block_from_disk 0
     // metasrv_server_watchers 0
 
     let b = response.take_body();
@@ -257,6 +265,16 @@ async fn test_metrics() -> anyhow::Result<()> {
     assert!(metric_keys.contains("metasrv_server_snapshot_key_count"));
     assert!(metric_keys.contains("metasrv_server_snapshot_primary_index_count"));
     assert!(metric_keys.contains("metasrv_server_snapshot_expire_index_count"));
+
+    // Server snapshot internal metrics
+    assert!(metric_keys.contains("metasrv_server_snapshot_block_count"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_data_size"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_index_size"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_avg_block_size"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_avg_keys_per_block"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_read_block"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_read_block_from_cache"));
+    assert!(metric_keys.contains("metasrv_server_snapshot_read_block_from_disk"));
 
     // Meta network metrics
     assert!(metric_keys.contains("metasrv_meta_network_recv_bytes_total"));

--- a/src/meta/types/src/snapshot_db.rs
+++ b/src/meta/types/src/snapshot_db.rs
@@ -105,6 +105,26 @@ impl DB {
         self.rotbl.file_size()
     }
 
+    /// Get the statistics of the snapshot database.
+    pub fn db_stat(&self) -> DBStat {
+        let stat = self.stat();
+        let access_stat = self.rotbl.access_stat();
+
+        let divider_block_num = std::cmp::max(stat.block_num as u64, 1);
+
+        DBStat {
+            block_num: stat.block_num as u64,
+            key_num: stat.key_num,
+            data_size: stat.data_size,
+            index_size: stat.index_size,
+            avg_block_size: stat.data_size / divider_block_num,
+            avg_keys_per_block: stat.key_num / divider_block_num,
+            read_block: access_stat.read_block(),
+            read_block_from_cache: access_stat.read_block_from_cache(),
+            read_block_from_disk: access_stat.read_block_from_disk(),
+        }
+    }
+
     pub fn stat(&self) -> &RotblStat {
         self.rotbl.stat()
     }
@@ -112,4 +132,34 @@ impl DB {
     pub fn sys_data(&self) -> &SysData {
         &self.sys_data
     }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DBStat {
+    /// Total number of blocks.
+    pub block_num: u64,
+
+    /// Total number of keys.
+    pub key_num: u64,
+
+    /// Size of all user data(in blocks) in bytes.
+    pub data_size: u64,
+
+    /// Size of serialized block index in bytes.
+    pub index_size: u64,
+
+    /// Average size in bytes of a block.
+    pub avg_block_size: u64,
+
+    /// Average number of keys per block.
+    pub avg_keys_per_block: u64,
+
+    /// Total number of read block from cache or from disk.
+    pub read_block: u64,
+
+    /// Total number of read block from cache.
+    pub read_block_from_cache: u64,
+
+    /// Total number of read block from disk.
+    pub read_block_from_disk: u64,
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): Add comprehensive snapshot database metrics

Add detailed snapshot database metrics to monitor storage performance and statistics:
- Block count, data size, index size metrics
- Average block size and keys per block calculations
- Block read statistics (total, from cache, from disk)
- Upgrade rotbl dependency to 0.2.7 for enhanced access statistics

These metrics provide visibility into snapshot storage efficiency and cache performance.

All metrics are `gauge` type:

```config
# number of keys in the last snapshot.
metasrv_server_snapshot_key_count 0

# number of primary keys in the last snapshot.
metasrv_server_snapshot_primary_index_count 0

# number of expire index keys in the last snapshot.
metasrv_server_snapshot_expire_index_count 0

# number of blocks in the last snapshot.
metasrv_server_snapshot_block_count 0

# size of data section in the last snapshot.
metasrv_server_snapshot_data_size 0

# size of index section in the last snapshot.
metasrv_server_snapshot_index_size 0

# average size of a block in the last snapshot.
metasrv_server_snapshot_avg_block_size 0

# average number of keys per block in the last snapshot.
metasrv_server_snapshot_avg_keys_per_block 0

# total number of read block from cache or from disk.
metasrv_server_snapshot_read_block 0

# total number of read block from cache.
metasrv_server_snapshot_read_block_from_cache 0

# total number of read block from disk.
metasrv_server_snapshot_read_block_from_disk 0
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18422)
<!-- Reviewable:end -->
