### PR TITLE
refactor(executor): add max rows/bytes limit when schedule executor task

### DIFF
--- a/src/query/pipeline/core/src/processors/block_limit.rs
+++ b/src/query/pipeline/core/src/processors/block_limit.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+
+/// DataBlock limit in rows and bytes
+pub struct BlockLimit {
+    rows: AtomicU64,
+    bytes: AtomicU64,
+}
+
+impl BlockLimit {
+    pub fn new(rows: u64, bytes: u64) -> Self {
+        BlockLimit {
+            rows: AtomicU64::new(rows),
+            bytes: AtomicU64::new(bytes),
+        }
+    }
+}
+
+impl Default for BlockLimit {
+    fn default() -> Self {
+        BlockLimit {
+            rows: AtomicU64::new(u64::MAX),
+            bytes: AtomicU64::new(u64::MAX),
+        }
+    }
+}

--- a/src/query/pipeline/core/src/processors/mod.rs
+++ b/src/query/pipeline/core/src/processors/mod.rs
@@ -15,6 +15,7 @@
 mod port;
 mod processor;
 
+mod block_limit;
 mod duplicate_processor;
 mod port_trigger;
 mod profile;
@@ -22,6 +23,7 @@ mod resize_processor;
 mod sequence_group;
 mod shuffle_processor;
 
+pub use block_limit::BlockLimit;
 pub use duplicate_processor::DuplicateProcessor;
 pub use port::connect;
 pub use port::InputPort;

--- a/src/query/pipeline/core/src/processors/port.rs
+++ b/src/query/pipeline/core/src/processors/port.rs
@@ -21,6 +21,7 @@ use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_base::runtime::ExecutorStats;
 use databend_common_base::runtime::QueryTimeSeriesProfile;
+use databend_common_base::runtime::ThreadTracker;
 use databend_common_base::runtime::TimeSeriesProfileName;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
@@ -230,6 +231,7 @@ impl InputPort {
             let remaining_data = Box::new(SharedData(Ok(remaining_block)));
             self.shared.swap(Box::into_raw(remaining_data), 0, 0);
 
+            ThreadTracker::has_remaining_data().store(true, Ordering::SeqCst);
             ExecutorStats::record_thread_tracker(taken_block.num_rows());
             Some(Ok(taken_block))
         } else {

--- a/src/query/pipeline/core/src/processors/port_trigger.rs
+++ b/src/query/pipeline/core/src/processors/port_trigger.rs
@@ -33,6 +33,7 @@ unsafe impl Send for UpdateList {}
 
 unsafe impl Sync for UpdateList {}
 
+#[derive(Debug, Clone)]
 pub enum DirectedEdge {
     Source(EdgeIndex),
     Target(EdgeIndex),

--- a/src/query/pipeline/core/src/processors/resize_processor.rs
+++ b/src/query/pipeline/core/src/processors/resize_processor.rs
@@ -17,6 +17,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
+use log::info;
 
 use crate::pipe::PipeItem;
 use crate::processors::Event;
@@ -110,6 +111,10 @@ impl Processor for ResizeProcessor {
                 }
             }
         }
+        info!(
+            "[resize] event_with_cause: {:?}, input port {:?} output port {:?}",
+            &cause, &self.waiting_inputs, &self.waiting_outputs
+        );
 
         while !self.waiting_outputs.is_empty() && !self.waiting_inputs.is_empty() {
             let output_index = self.waiting_outputs.pop_front().unwrap();
@@ -159,6 +164,10 @@ impl Processor for ResizeProcessor {
 
             return Ok(Event::Finished);
         }
+        info!(
+            "[resize] event_with_cause: {:?}, input port {:?} output port {:?}",
+            &cause, &self.waiting_inputs, &self.waiting_outputs
+        );
 
         match self.waiting_outputs.is_empty() {
             true => Ok(Event::NeedConsume),

--- a/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
@@ -44,8 +44,16 @@ async fn test_duplicate_output_finish() -> Result<()> {
 
         unsafe {
             connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
-            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+            connect(
+                &downstream_input1,
+                &output1,
+                Arc::new(BlockLimit::default()),
+            );
+            connect(
+                &downstream_input2,
+                &output2,
+                Arc::new(BlockLimit::default()),
+            );
         }
 
         downstream_input1.set_need_data();
@@ -72,8 +80,16 @@ async fn test_duplicate_output_finish() -> Result<()> {
 
         unsafe {
             connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
-            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+            connect(
+                &downstream_input1,
+                &output1,
+                Arc::new(BlockLimit::default()),
+            );
+            connect(
+                &downstream_input2,
+                &output2,
+                Arc::new(BlockLimit::default()),
+            );
         }
 
         downstream_input1.finish();
@@ -98,8 +114,16 @@ async fn test_duplicate_output_finish() -> Result<()> {
 
         unsafe {
             connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
-            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+            connect(
+                &downstream_input1,
+                &output1,
+                Arc::new(BlockLimit::default()),
+            );
+            connect(
+                &downstream_input2,
+                &output2,
+                Arc::new(BlockLimit::default()),
+            );
         }
 
         downstream_input1.finish();
@@ -124,8 +148,16 @@ async fn test_duplicate_processor() -> Result<()> {
 
     unsafe {
         connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
-        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+        connect(
+            &downstream_input1,
+            &output1,
+            Arc::new(BlockLimit::default()),
+        );
+        connect(
+            &downstream_input2,
+            &output2,
+            Arc::new(BlockLimit::default()),
+        );
     }
 
     downstream_input1.set_need_data();

--- a/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/duplicate.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use databend_common_exception::Result;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::DuplicateProcessor;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
@@ -40,9 +43,9 @@ async fn test_duplicate_output_finish() -> Result<()> {
         let downstream_input2 = InputPort::create();
 
         unsafe {
-            connect(&input, &upstream_output);
-            connect(&downstream_input1, &output1);
-            connect(&downstream_input2, &output2);
+            connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
         }
 
         downstream_input1.set_need_data();
@@ -68,9 +71,9 @@ async fn test_duplicate_output_finish() -> Result<()> {
         let downstream_input2 = InputPort::create();
 
         unsafe {
-            connect(&input, &upstream_output);
-            connect(&downstream_input1, &output1);
-            connect(&downstream_input2, &output2);
+            connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
         }
 
         downstream_input1.finish();
@@ -94,9 +97,9 @@ async fn test_duplicate_output_finish() -> Result<()> {
         let downstream_input2 = InputPort::create();
 
         unsafe {
-            connect(&input, &upstream_output);
-            connect(&downstream_input1, &output1);
-            connect(&downstream_input2, &output2);
+            connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+            connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+            connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
         }
 
         downstream_input1.finish();
@@ -120,9 +123,9 @@ async fn test_duplicate_processor() -> Result<()> {
     let downstream_input2 = InputPort::create();
 
     unsafe {
-        connect(&input, &upstream_output);
-        connect(&downstream_input1, &output1);
-        connect(&downstream_input2, &output2);
+        connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
     }
 
     downstream_input1.set_need_data();

--- a/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
@@ -22,6 +22,7 @@ use databend_common_expression::local_block_meta_serde;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
 
@@ -60,7 +61,7 @@ async fn test_port_drop() -> Result<()> {
         let input = InputPort::create();
         let output = OutputPort::create();
 
-        connect(&input, &output);
+        connect(&input, &output, Arc::new(BlockLimit::default()));
         output.push_data(Ok(DataBlock::empty_with_meta(meta.clone_self())));
         assert_eq!(meta.ref_count(), 2);
     }
@@ -98,7 +99,7 @@ async fn test_input_and_output_port() -> Result<()> {
         let output = OutputPort::create();
         let barrier = Arc::new(Barrier::new(2));
 
-        connect(&input, &output);
+        connect(&input, &output, Arc::new(BlockLimit::default()));
         let thread_1 = Thread::spawn(input_port(input, barrier.clone()));
         let thread_2 = Thread::spawn(output_port(output, barrier));
 
@@ -114,7 +115,7 @@ async fn test_input_and_output_flags() -> Result<()> {
         let input = InputPort::create();
         let output = OutputPort::create();
 
-        connect(&input, &output);
+        connect(&input, &output, Arc::new(BlockLimit::default()));
 
         output.finish();
         assert!(input.is_finished());

--- a/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/port_test.rs
@@ -19,8 +19,10 @@ use databend_common_base::runtime::Thread;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::local_block_meta_serde;
+use databend_common_expression::types::Int32Type;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
 use databend_common_pipeline_core::processors::connect;
 use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::InputPort;
@@ -126,5 +128,95 @@ async fn test_input_and_output_flags() -> Result<()> {
     // assert_eq!(output.can_push());
     // input.set_need_data();
     // assert_eq!(!output.can_push());
+    Ok(())
+}
+
+#[test]
+fn test_block_limit_splitting() -> Result<()> {
+    unsafe {
+        let input = InputPort::create();
+        let output = OutputPort::create();
+
+        // Create a BlockLimit with small row limit to trigger splitting
+        let block_limit = Arc::new(BlockLimit::new(10, 1024 * 1024)); // 10 rows max, 1MB bytes
+        connect(&input, &output, block_limit);
+
+        // Create a block with 30 rows
+        let mut data = Vec::with_capacity(30);
+        for i in 0..30 {
+            data.push(i);
+        }
+        let col = Int32Type::from_data(data);
+        let block = DataBlock::new_from_columns(vec![col]);
+
+        // Push the large block
+        output.push_data(Ok(block.clone()));
+
+        // First pull should get 10 rows
+        input.set_need_data();
+        assert!(input.has_data());
+        let pulled_block = input.pull_data().unwrap()?;
+        assert_eq!(pulled_block.num_rows(), 10);
+
+        // After first pull, should still have data (remaining 20 rows)
+        assert!(input.has_data());
+
+        // Second pull should get another 10 rows
+        let pulled_block = input.pull_data().unwrap()?;
+        assert_eq!(pulled_block.num_rows(), 10);
+
+        // Should still have data (remaining 10 rows)
+        assert!(input.has_data());
+
+        // Third pull should get the last 10 rows
+        let pulled_block = input.pull_data().unwrap()?;
+        assert_eq!(pulled_block.num_rows(), 10);
+
+        // Now should have no data
+        assert!(!input.has_data());
+
+        // Trying to pull again should return None
+        let result = input.pull_data();
+        assert!(result.is_none());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_block_limit_no_splitting() -> Result<()> {
+    unsafe {
+        let input = InputPort::create();
+        let output = OutputPort::create();
+
+        // Create a BlockLimit with large limits (no splitting should occur)
+        let block_limit = Arc::new(BlockLimit::new(1000, 10 * 1024 * 1024)); // 1000 rows, 10MB
+        connect(&input, &output, block_limit);
+
+        // Create a small block with 30 rows
+        let mut data = Vec::with_capacity(30);
+        for i in 0..30 {
+            data.push(i);
+        }
+        let col = Int32Type::from_data(data);
+        let block = DataBlock::new_from_columns(vec![col]);
+
+        // Push the block
+        output.push_data(Ok(block.clone()));
+
+        // Pull should get all 30 rows at once
+        input.set_need_data();
+        assert!(input.has_data());
+        let pulled_block = input.pull_data().unwrap().unwrap();
+        assert_eq!(pulled_block.num_rows(), 30);
+
+        // Should have no more data
+        assert!(!input.has_data());
+
+        // Trying to pull again should return None
+        let result = input.pull_data();
+        assert!(result.is_none());
+    }
+
     Ok(())
 }

--- a/src/query/pipeline/core/tests/it/pipelines/processors/resize.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/resize.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::EventCause;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -61,7 +62,7 @@ fn connect_inputs(inputs: Vec<Arc<InputPort>>) -> Vec<Arc<OutputPort>> {
     unsafe {
         for input in inputs {
             let output = OutputPort::create();
-            connect(&input, &output);
+            connect(&input, &output, Arc::new(BlockLimit::default()));
             outputs.push(output);
         }
     }
@@ -75,7 +76,7 @@ fn connect_outputs(outputs: Vec<Arc<OutputPort>>) -> Vec<Arc<InputPort>> {
     unsafe {
         for output in outputs {
             let input = InputPort::create();
-            connect(&input, &output);
+            connect(&input, &output, Arc::new(BlockLimit::default()));
             inputs.push(input);
         }
     }

--- a/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
@@ -48,8 +48,16 @@ async fn test_shuffle_output_finish() -> Result<()> {
     unsafe {
         connect(&input1, &upstream_output1, Arc::new(BlockLimit::default()));
         connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
-        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+        connect(
+            &downstream_input1,
+            &output1,
+            Arc::new(BlockLimit::default()),
+        );
+        connect(
+            &downstream_input2,
+            &output2,
+            Arc::new(BlockLimit::default()),
+        );
     }
 
     downstream_input1.finish();
@@ -113,10 +121,26 @@ async fn test_shuffle_processor() -> Result<()> {
         connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
         connect(&input3, &upstream_output3, Arc::new(BlockLimit::default()));
         connect(&input4, &upstream_output4, Arc::new(BlockLimit::default()));
-        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
-        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
-        connect(&downstream_input3, &output3, Arc::new(BlockLimit::default()));
-        connect(&downstream_input4, &output4, Arc::new(BlockLimit::default()));
+        connect(
+            &downstream_input1,
+            &output1,
+            Arc::new(BlockLimit::default()),
+        );
+        connect(
+            &downstream_input2,
+            &output2,
+            Arc::new(BlockLimit::default()),
+        );
+        connect(
+            &downstream_input3,
+            &output3,
+            Arc::new(BlockLimit::default()),
+        );
+        connect(
+            &downstream_input4,
+            &output4,
+            Arc::new(BlockLimit::default()),
+        );
     }
 
     let col1 = Int32Type::from_data(vec![1]);

--- a/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
+++ b/src/query/pipeline/core/tests/it/pipelines/processors/shuffle.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use databend_common_exception::Result;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::EventCause;
 use databend_common_pipeline_core::processors::InputPort;
@@ -43,10 +46,10 @@ async fn test_shuffle_output_finish() -> Result<()> {
     let downstream_input2 = InputPort::create();
 
     unsafe {
-        connect(&input1, &upstream_output1);
-        connect(&input2, &upstream_output2);
-        connect(&downstream_input1, &output1);
-        connect(&downstream_input2, &output2);
+        connect(&input1, &upstream_output1, Arc::new(BlockLimit::default()));
+        connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
+        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
     }
 
     downstream_input1.finish();
@@ -106,14 +109,14 @@ async fn test_shuffle_processor() -> Result<()> {
     let downstream_input4 = InputPort::create();
 
     unsafe {
-        connect(&input1, &upstream_output1);
-        connect(&input2, &upstream_output2);
-        connect(&input3, &upstream_output3);
-        connect(&input4, &upstream_output4);
-        connect(&downstream_input1, &output1);
-        connect(&downstream_input2, &output2);
-        connect(&downstream_input3, &output3);
-        connect(&downstream_input4, &output4);
+        connect(&input1, &upstream_output1, Arc::new(BlockLimit::default()));
+        connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
+        connect(&input3, &upstream_output3, Arc::new(BlockLimit::default()));
+        connect(&input4, &upstream_output4, Arc::new(BlockLimit::default()));
+        connect(&downstream_input1, &output1, Arc::new(BlockLimit::default()));
+        connect(&downstream_input2, &output2, Arc::new(BlockLimit::default()));
+        connect(&downstream_input3, &output3, Arc::new(BlockLimit::default()));
+        connect(&downstream_input4, &output4, Arc::new(BlockLimit::default()));
     }
 
     let col1 = Int32Type::from_data(vec![1]);

--- a/src/query/pipeline/sinks/tests/it/async_mpsc_sink.rs
+++ b/src/query/pipeline/sinks/tests/it/async_mpsc_sink.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -73,8 +74,8 @@ async fn test_async_mpsc_sink() -> Result<()> {
     let upstream_output2 = OutputPort::create();
 
     unsafe {
-        connect(&input1, &upstream_output1);
-        connect(&input2, &upstream_output2);
+        connect(&input1, &upstream_output1, Arc::new(BlockLimit::default()));
+        connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
     }
 
     upstream_output1.push_data(Ok(DataBlock::new(vec![], 1)));

--- a/src/query/pipeline/sinks/tests/it/sync_mpsc_sink.rs
+++ b/src/query/pipeline/sinks/tests/it/sync_mpsc_sink.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline_core::processors::connect;
+use databend_common_pipeline_core::processors::BlockLimit;
 use databend_common_pipeline_core::processors::Event;
 use databend_common_pipeline_core::processors::InputPort;
 use databend_common_pipeline_core::processors::OutputPort;
@@ -71,8 +72,8 @@ async fn test_sync_mpsc_sink() -> Result<()> {
     let upstream_output2 = OutputPort::create();
 
     unsafe {
-        connect(&input1, &upstream_output1);
-        connect(&input2, &upstream_output2);
+        connect(&input1, &upstream_output1, Arc::new(BlockLimit::default()));
+        connect(&input2, &upstream_output2, Arc::new(BlockLimit::default()));
     }
 
     upstream_output1.push_data(Ok(DataBlock::new(vec![], 1)));

--- a/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sort/k_way_merge_sort_partition.rs
@@ -245,4 +245,8 @@ pub struct SortTaskMeta {
 }
 
 #[typetag::serde(name = "sort_task")]
-impl BlockMetaInfo for SortTaskMeta {}
+impl BlockMetaInfo for SortTaskMeta {
+    fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
+        Box::new(*self)
+    }
+}

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -368,7 +368,7 @@ impl ExecutingGraph {
         graph: &Arc<RunningGraph>,
     ) -> Result<()> {
         // info!("[schedule] ------------new--------------");
-        let node = &locker.graph[index];
+        let _node = &locker.graph[index];
         // info!("[schedule] Node {:?} trigger schedule", node);
         let mut need_schedule_nodes = VecDeque::new();
         let mut need_schedule_edges = VecDeque::new();

--- a/src/query/service/src/pipelines/executor/executor_settings.rs
+++ b/src/query/service/src/pipelines/executor/executor_settings.rs
@@ -49,7 +49,10 @@ impl ExecutorSettings {
 
         let max_block_rows = settings.get_max_block_size()?;
         let max_block_bytes = settings.get_max_block_bytes()?;
-        let block_limit = Arc::new(BlockLimit::new(max_block_rows, max_block_bytes));
+        let block_limit = Arc::new(BlockLimit::new(
+            max_block_rows as usize,
+            max_block_bytes as usize,
+        ));
 
         Ok(ExecutorSettings {
             enable_queries_executor,

--- a/src/query/service/src/pipelines/executor/executor_settings.rs
+++ b/src/query/service/src/pipelines/executor/executor_settings.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
+use databend_common_pipeline_core::processors::BlockLimit;
 
 #[derive(Clone)]
 pub struct ExecutorSettings {
@@ -26,6 +27,7 @@ pub struct ExecutorSettings {
     pub enable_queries_executor: bool,
     pub max_execute_time_in_seconds: Duration,
     pub executor_node_id: String,
+    pub block_limit: Arc<BlockLimit>,
 }
 
 impl ExecutorSettings {
@@ -45,12 +47,17 @@ impl ExecutorSettings {
             config_enable_queries_executor
         };
 
+        let max_block_rows = settings.get_max_block_size()?;
+        let max_block_bytes = settings.get_max_block_bytes()?;
+        let block_limit = Arc::new(BlockLimit::new(max_block_rows, max_block_bytes));
+
         Ok(ExecutorSettings {
             enable_queries_executor,
             query_id: Arc::new(query_id),
             max_execute_time_in_seconds: Duration::from_secs(max_execute_time_in_seconds),
             max_threads,
             executor_node_id: ctx.get_cluster().local_id.clone(),
+            block_limit,
         })
     }
 }

--- a/src/query/service/src/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_executor.rs
@@ -75,9 +75,9 @@ impl PipelineExecutor {
 
             let graph = RunningGraph::create(
                 pipeline,
-                1,
                 settings.query_id.clone(),
                 Some(finish_condvar.clone()),
+                settings.block_limit.clone(),
             )?;
 
             Ok(PipelineExecutor::QueriesPipelineExecutor(QueryWrapper {
@@ -130,9 +130,9 @@ impl PipelineExecutor {
 
             let graph = RunningGraph::from_pipelines(
                 pipelines,
-                1,
                 settings.query_id.clone(),
                 Some(finish_condvar.clone()),
+                settings.block_limit.clone(),
             )?;
 
             Ok(PipelineExecutor::QueriesPipelineExecutor(QueryWrapper {

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -84,7 +84,12 @@ impl QueryPipelineExecutor {
         let mut on_finished_chain = pipeline.take_on_finished();
         let lock_guards = pipeline.take_lock_guards();
 
-        match RunningGraph::create(pipeline, 1, settings.query_id.clone(), None) {
+        match RunningGraph::create(
+            pipeline,
+            settings.query_id.clone(),
+            None,
+            settings.block_limit.clone(),
+        ) {
             Err(cause) => {
                 let info = ExecutionInfo::create(Err(cause.clone()), HashMap::new());
                 let _ = on_finished_chain.apply(info);
@@ -149,7 +154,12 @@ impl QueryPipelineExecutor {
             .flat_map(|x| x.take_lock_guards())
             .collect::<Vec<_>>();
 
-        match RunningGraph::from_pipelines(pipelines, 1, settings.query_id.clone(), None) {
+        match RunningGraph::from_pipelines(
+            pipelines,
+            settings.query_id.clone(),
+            None,
+            settings.block_limit.clone(),
+        ) {
             Err(cause) => {
                 let info = ExecutionInfo::create(Err(cause.clone()), HashMap::new());
                 let _ignore_res = finished_chain.apply(info);

--- a/src/query/service/src/pipelines/processors/transforms/sort/sort_merge_stream.rs
+++ b/src/query/service/src/pipelines/processors/transforms/sort/sort_merge_stream.rs
@@ -296,6 +296,7 @@ mod tests {
     use databend_common_expression::types::Int32Type;
     use databend_common_expression::FromData;
     use databend_common_pipeline_core::processors::connect;
+    use databend_common_pipeline_core::processors::BlockLimit;
     use databend_common_pipeline_transforms::sort::SimpleRowsAsc;
 
     use super::*;
@@ -315,7 +316,7 @@ mod tests {
         let output = OutputPort::create();
         let input = InputPort::create();
         unsafe {
-            connect(&input, &output);
+            connect(&input, &output, Arc::new(BlockLimit::default()));
         }
 
         let stream = BoundedInputStream {

--- a/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/transform_window.rs
@@ -1364,6 +1364,7 @@ mod tests {
     use databend_common_expression::FromData;
     use databend_common_functions::aggregates::AggregateFunctionFactory;
     use databend_common_pipeline_core::processors::connect;
+    use databend_common_pipeline_core::processors::BlockLimit;
     use databend_common_pipeline_core::processors::Event;
     use databend_common_pipeline_core::processors::InputPort;
     use databend_common_pipeline_core::processors::OutputPort;
@@ -2305,8 +2306,8 @@ mod tests {
             )?;
 
             unsafe {
-                connect(&input, &upstream_output);
-                connect(&downstream_input, &output);
+                connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+                connect(&downstream_input, &output, Arc::new(BlockLimit::default()));
             }
 
             downstream_input.set_need_data();
@@ -2380,8 +2381,8 @@ mod tests {
             )?;
 
             unsafe {
-                connect(&input, &upstream_output);
-                connect(&downstream_input, &output);
+                connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+                connect(&downstream_input, &output, Arc::new(BlockLimit::default()));
             }
 
             downstream_input.set_need_data();
@@ -2477,8 +2478,8 @@ mod tests {
             )?;
 
             unsafe {
-                connect(&input, &upstream_output);
-                connect(&downstream_input, &output);
+                connect(&input, &upstream_output, Arc::new(BlockLimit::default()));
+                connect(&downstream_input, &output, Arc::new(BlockLimit::default()));
             }
 
             downstream_input.set_need_data();

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -456,7 +456,12 @@ fn create_simple_pipeline(ctx: Arc<QueryContext>) -> Result<Arc<RunningGraph>> {
     pipeline.add_pipe(create_transform_pipe(1)?);
     pipeline.add_pipe(sink_pipe);
 
-    RunningGraph::create(pipeline, 1, Arc::new("".to_string()), None)
+    RunningGraph::create(
+        pipeline,
+        Arc::new("".to_string()),
+        None,
+        Arc::new(Default::default()),
+    )
 }
 
 fn create_parallel_simple_pipeline(ctx: Arc<QueryContext>) -> Result<Arc<RunningGraph>> {
@@ -468,7 +473,12 @@ fn create_parallel_simple_pipeline(ctx: Arc<QueryContext>) -> Result<Arc<Running
     pipeline.add_pipe(create_transform_pipe(2)?);
     pipeline.add_pipe(sink_pipe);
 
-    RunningGraph::create(pipeline, 1, Arc::new("".to_string()), None)
+    RunningGraph::create(
+        pipeline,
+        Arc::new("".to_string()),
+        None,
+        Arc::new(Default::default()),
+    )
 }
 
 fn create_resize_pipeline(ctx: Arc<QueryContext>) -> Result<Arc<RunningGraph>> {
@@ -484,7 +494,12 @@ fn create_resize_pipeline(ctx: Arc<QueryContext>) -> Result<Arc<RunningGraph>> {
     pipeline.try_resize(2)?;
     pipeline.add_pipe(sink_pipe);
 
-    RunningGraph::create(pipeline, 1, Arc::new("".to_string()), None)
+    RunningGraph::create(
+        pipeline,
+        Arc::new("".to_string()),
+        None,
+        Arc::new(Default::default()),
+    )
 }
 
 fn create_source_pipe(
@@ -562,6 +577,7 @@ async fn create_executor_with_simple_pipeline(
         enable_queries_executor: false,
         max_threads: 8,
         executor_node_id: "".to_string(),
+        block_limit: Arc::new(Default::default()),
     };
     QueryPipelineExecutor::create(pipeline, settings)
 }

--- a/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
@@ -47,6 +47,7 @@ async fn test_always_call_on_finished() -> Result<()> {
         enable_queries_executor: false,
         max_threads: 8,
         executor_node_id: "".to_string(),
+        block_limit: Arc::new(Default::default()),
     };
 
     {

--- a/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
@@ -57,6 +57,7 @@ fn create_pipeline(
         enable_queries_executor: false,
         max_threads: 8,
         executor_node_id: "".to_string(),
+        block_limit: Arc::new(Default::default()),
     };
     let executor = QueryPipelineExecutor::create(pipeline, settings)?;
     Ok((executor, rx))

--- a/src/query/service/tests/it/storages/fuse/pruning_column_oriented_segment.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_column_oriented_segment.rs
@@ -123,6 +123,7 @@ async fn apply_snapshot_pruning(
         enable_queries_executor: false,
         max_threads: 8,
         executor_node_id: "".to_string(),
+        block_limit: Arc::new(Default::default()),
     };
     let executor = QueryPipelineExecutor::create(prune_pipeline, settings)?;
 

--- a/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
@@ -124,6 +124,7 @@ async fn apply_snapshot_pruning(
         enable_queries_executor: false,
         max_threads: 8,
         executor_node_id: "".to_string(),
+        block_limit: Arc::new(Default::default()),
     };
     let executor = QueryPipelineExecutor::create(prune_pipeline, settings)?;
 

--- a/tests/sqllogictests/suites/query/join/left_outer.test
+++ b/tests/sqllogictests/suites/query/join/left_outer.test
@@ -285,7 +285,7 @@ INSERT INTO t2 VALUES(2, 2), (2, 4), (2, 6), (2, 8), (2, 10);
 statement ok
 set max_block_size = 2;
 
-query I
+query I rowsort
 SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a;
 ----
 2 3 2 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

introduces configurable (via settings) limits for the maximum number of rows and bytes per scheduled task.

Imposing these limits prevents oversized data blocks from causing excessively long processing times. 

This is a preparatory step for implementing task scheduling priorities with workload groups in an upcoming pull request. (part of #18277 )



## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18433)
<!-- Reviewable:end -->
