### PR TITLE
feat(metactl): add lua subcommand with file and stdin support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.101",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -5209,6 +5209,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
+ "mlua",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6305,6 +6306,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -9975,6 +9982,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "548.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bc4bd1f1d5c65b30717333cbec4fa7aa378978940a1bca62f404498d423233"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.6.1+f9140a6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813bd31f2759443affa687c0d9c5eb5cf6cb0e898810ab197408431d746054bf"
+dependencies = [
+ "cc",
+ "which 7.0.3",
+]
+
+[[package]]
 name = "lz4"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10248,6 +10274,34 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mlua"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de25fc513588ac1273aa8c6dc0fffee6d32c12f38dc75f5cdc74547121a107ef"
+dependencies = [
+ "bstr",
+ "either",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot 0.12.3",
+ "rustc-hash 2.1.1",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdf7c9e260ca82aaa32ac11148941952b856bb8c69aa5a9e65962f21fcb8637"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -12113,7 +12167,7 @@ dependencies = [
  "protobuf-support",
  "tempfile",
  "thiserror 1.0.69",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -16726,6 +16780,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17325,6 +17391,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,6 +387,7 @@ match-template = "0.0.1"
 md-5 = "0.10.5"
 memchr = { version = "2", default-features = false }
 micromarshal = "0.7.0"
+mlua = { version = "0.11", features = ["lua54", "vendored"] }
 mockall = "0.11.2"
 mysql_async = { version = "0.34", default-features = false, features = ["native-tls-tls"] }
 naive-cityhash = "0.2.0"

--- a/src/meta/binaries/Cargo.toml
+++ b/src/meta/binaries/Cargo.toml
@@ -47,6 +47,7 @@ display-more = { workspace = true }
 fastrace = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
+mlua = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/control/src/args.rs
+++ b/src/meta/control/src/args.rs
@@ -263,3 +263,10 @@ pub struct TriggerSnapshotArgs {
     #[clap(long, default_value = "127.0.0.1:28101")]
     pub admin_api_address: String,
 }
+
+#[derive(Debug, Clone, Deserialize, Args)]
+pub struct LuaArgs {
+    /// Path to the Lua script file. If not provided, script is read from stdin
+    #[clap(long)]
+    pub file: Option<String>,
+}

--- a/tests/metactl/subcommands/cmd_lua.py
+++ b/tests/metactl/subcommands/cmd_lua.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+import os
+from metactl_utils import metactl_bin
+from utils import print_title
+
+
+def test_lua_file():
+    """Test lua subcommand with file input."""
+    print_title("Test lua subcommand with file")
+
+    # Create a temporary Lua script
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.lua', delete=False) as f:
+        f.write('print(2 + 3)\n')
+        lua_file = f.name
+
+    print("file name:", lua_file)
+    with open(lua_file, 'r') as ff:
+        print("file content:", ff.read())
+
+    # Run metactl lua with file
+    result = subprocess.run([
+        metactl_bin, "lua",
+        "--file", lua_file
+    ], capture_output=True, text=True, check=True)
+
+    output = result.stdout.strip()
+    assert "5" == output
+    print("✓ Lua file execution test passed")
+
+
+
+def test_lua_stdin():
+    """Test lua subcommand with stdin input."""
+    print_title("Test lua subcommand with stdin")
+
+    lua_script = 'print("Hello from stdin!")\nprint(5 * 6)\n'
+
+    # Run metactl lua with stdin
+    result = subprocess.run([
+        metactl_bin, "lua"
+    ], input=lua_script, capture_output=True, text=True, check=True)
+
+    output = result.stdout.strip()
+    assert "Hello from stdin!" in output
+    assert "30" in output
+    print("✓ Lua stdin execution test passed")
+
+
+def main():
+    """Main function to run all lua tests."""
+    test_lua_file()
+    test_lua_stdin()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(metactl): add lua subcommand with file and stdin support

Add new `lua` subcommand to databend-metactl that executes Lua scripts
from either files or stdin input. This enables scripting capabilities
for meta service operations and automation.

- Add mlua dependency with Lua 5.4 and vendored features
- Implement LuaArgs struct with optional file parameter
- Add lua subcommand handler with error handling
- Create comprehensive lua test suite with file and stdin tests
- Enhance test runner with selective test execution support

Usage examples:
  databend-metactl lua --file script.lua
  echo 'print("hello")' | databend-metactl lua
  python test_all_subcommands.py lua

`databend-metactl lua` will be used for complicated benchmark scripting.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18437)
<!-- Reviewable:end -->
