### PR TITLE
feat(metactl): add lua grpc client functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10284,11 +10284,15 @@ checksum = "de25fc513588ac1273aa8c6dc0fffee6d32c12f38dc75f5cdc74547121a107ef"
 dependencies = [
  "bstr",
  "either",
+ "erased-serde",
+ "futures-util",
  "mlua-sys",
  "num-traits",
  "parking_lot 0.12.3",
  "rustc-hash 2.1.1",
  "rustversion",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]
@@ -13712,6 +13716,16 @@ checksum = "c68119a0846249fd6f4b38561b4b4727dbc4fd9fea074f1253bca7d50440ce58"
 dependencies = [
  "anyhow",
  "log",
+ "serde",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ match-template = "0.0.1"
 md-5 = "0.10.5"
 memchr = { version = "2", default-features = false }
 micromarshal = "0.7.0"
-mlua = { version = "0.11", features = ["lua54", "vendored"] }
+mlua = { version = "0.11", features = ["lua54", "vendored", "async", "serialize"] }
 mockall = "0.11.2"
 mysql_async = { version = "0.34", default-features = false, features = ["native-tls-tls"] }
 naive-cityhash = "0.2.0"

--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -54,6 +54,10 @@ use databend_meta::version::METASRV_COMMIT_VERSION;
 use display_more::DisplayOptionExt;
 use futures::stream::TryStreamExt;
 use mlua::Lua;
+use mlua::LuaSerdeExt;
+use mlua::UserData;
+use mlua::UserDataMethods;
+use mlua::Value;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Parser)]
@@ -233,6 +237,34 @@ impl App {
     async fn run_lua(&self, args: &LuaArgs) -> anyhow::Result<()> {
         let lua = Lua::new();
 
+        // Register new_grpc_client function
+        let new_grpc_client = lua
+            .create_function(|_lua, address: String| {
+                let client = MetaGrpcClient::try_create(
+                    vec![address],
+                    "root",
+                    "xxx",
+                    Some(Duration::from_secs(2)),
+                    Some(Duration::from_secs(1)),
+                    None,
+                )
+                .map_err(|e| {
+                    mlua::Error::external(format!("Failed to create gRPC client: {}", e))
+                })?;
+
+                Ok(LuaGrpcClient::new(client))
+            })
+            .map_err(|e| anyhow::anyhow!("Failed to create new_grpc_client function: {}", e))?;
+
+        lua.globals()
+            .set("new_grpc_client", new_grpc_client)
+            .map_err(|e| anyhow::anyhow!("Failed to register new_grpc_client: {}", e))?;
+
+        // Export NULL constant to Lua environment
+        lua.globals()
+            .set("NULL", Value::NULL)
+            .map_err(|e| anyhow::anyhow!("Failed to register NULL constant: {}", e))?;
+
         let script = match &args.file {
             Some(path) => std::fs::read_to_string(path)?,
             None => {
@@ -242,7 +274,7 @@ impl App {
             }
         };
 
-        if let Err(e) = lua.load(&script).exec() {
+        if let Err(e) = lua.load(&script).exec_async().await {
             return Err(anyhow::anyhow!("Lua execution error: {}", e));
         }
         Ok(())
@@ -261,6 +293,44 @@ impl App {
             Some(Duration::from_secs(1)),
             None,
         )
+    }
+}
+
+struct LuaGrpcClient {
+    client: Arc<ClientHandle>,
+}
+
+impl LuaGrpcClient {
+    fn new(client: Arc<ClientHandle>) -> Self {
+        Self { client }
+    }
+}
+
+impl UserData for LuaGrpcClient {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_async_method("get", |lua, this, key: String| async move {
+            match this.client.get_kv(&key).await {
+                Ok(result) => match lua.to_value(&result) {
+                    Ok(lua_value) => Ok((Some(lua_value), None::<String>)),
+                    Err(e) => Ok((None::<Value>, Some(format!("Lua conversion error: {}", e)))),
+                },
+                Err(e) => Ok((None::<Value>, Some(format!("gRPC error: {}", e)))),
+            }
+        });
+
+        methods.add_async_method(
+            "upsert",
+            |lua, this, (key, value): (String, String)| async move {
+                let upsert = UpsertKV::update(key, value.as_bytes());
+                match this.client.request(upsert).await {
+                    Ok(result) => match lua.to_value(&result) {
+                        Ok(lua_value) => Ok((Some(lua_value), None::<String>)),
+                        Err(e) => Ok((None::<Value>, Some(format!("Lua conversion error: {}", e)))),
+                    },
+                    Err(e) => Ok((None::<Value>, Some(format!("gRPC error: {}", e)))),
+                }
+            },
+        );
     }
 }
 

--- a/tests/metactl/lua_util.lua
+++ b/tests/metactl/lua_util.lua
@@ -1,0 +1,145 @@
+-- Function to check if a value is NULL (mlua NULL constant)
+function is_null(value)
+    return value == NULL
+end
+
+-- Function to normalize NULL values to nil for easier handling
+function normalize_value(value)
+    if is_null(value) then
+        return nil
+    end
+    return value
+end
+
+-- Function to check if a table represents a bytes vector and convert it to string
+function bytes_vector_to_string(value)
+    -- Check if table represents a bytes vector (integer indices starting from 1, u8 values)
+    local max_index = 0
+    local min_index = math.huge
+    
+    -- First pass: check if all keys are integers and find range
+    for k, v in pairs(value) do
+        if type(k) ~= "number" or k ~= math.floor(k) or k < 1 then
+            return nil -- Not a bytes vector
+        end
+        if type(v) ~= "number" or v ~= math.floor(v) or v < 0 or v > 255 then
+            return nil -- Not u8 values
+        end
+        max_index = math.max(max_index, k)
+        min_index = math.min(min_index, k)
+    end
+    
+    -- Check if indices are consecutive starting from 1
+    if min_index == 1 then
+        local expected_length = max_index
+        local actual_length = 0
+        for _ in pairs(value) do
+            actual_length = actual_length + 1
+        end
+        if actual_length == expected_length then
+            -- Check size limit to prevent memory exhaustion (max 1MB)
+            if max_index > 1048576 then
+                return '"<bytes vector too large: ' .. max_index .. ' bytes>"'
+            end
+            
+            -- Convert bytes vector to string
+            local chars = {}
+            for i = 1, max_index do
+                chars[i] = string.char(value[i])
+            end
+            return '"' .. table.concat(chars) .. '"'
+        end
+    end
+    
+    return nil -- Not a valid bytes vector
+end
+
+-- Function to convert a value or table into a single-line string recursively
+function to_string(value)
+    if value == nil then
+        return "nil"
+    end
+    
+    if is_null(value) then
+        return "NULL"
+    end
+
+    if type(value) == "boolean" then
+        return tostring(value)
+    end
+
+    if type(value) == "number" then
+        return tostring(value)
+    end
+
+    if type(value) == "string" then
+        -- Escape quotes in the string
+        return '"' .. string.gsub(value, '"', '\\"') .. '"'
+    end
+
+    if type(value) == "table" then
+        -- Check if it's a bytes vector first
+        local bytes_string = bytes_vector_to_string(value)
+        if bytes_string then
+            return bytes_string
+        end
+        
+        -- Regular table processing
+        local result = "{"
+        local keys = {}
+
+        -- Collect all keys
+        for k in pairs(value) do
+            table.insert(keys, k)
+        end
+
+        -- Sort keys if they're all strings or numbers
+        local can_sort = true
+        for _, k in ipairs(keys) do
+            if type(k) ~= "string" and type(k) ~= "number" then
+                can_sort = false
+                break
+            end
+        end
+
+        if can_sort then
+            table.sort(keys, function(a, b)
+                if type(a) == type(b) then
+                    return a < b
+                else
+                    -- Put numbers before strings
+                    return type(a) == "number"
+                end
+            end)
+        end
+
+        -- Process each key-value pair
+        local first = true
+        for _, k in ipairs(keys) do
+            local v = value[k]
+            
+            -- Skip nil and NULL values
+            if v ~= nil and not is_null(v) then
+                if not first then
+                    result = result .. ","
+                end
+                first = false
+
+                local key_str
+                if type(k) == "string" then
+                    key_str = '"' .. string.gsub(k, '"', '\\"') .. '"'
+                else
+                    key_str = "[" .. tostring(k) .. "]"
+                end
+
+                result = result .. key_str .. "=" .. to_string(v)
+            end
+        end
+
+        result = result .. "}"
+        return result
+    end
+
+    -- Handle function, userdata, thread
+    return "<" .. type(value) .. ">"
+end

--- a/tests/metactl/subcommands/cmd_lua_grpc.py
+++ b/tests/metactl/subcommands/cmd_lua_grpc.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+import os
+import shutil
+import json
+from metactl_utils import metactl_bin
+from utils import print_title, kill_databend_meta, start_meta_node
+
+def load_lua_util():
+    with open("tests/metactl/lua_util.lua", 'r') as f:
+        return f.read()
+
+
+def setup_test_environment():
+    """Setup meta service for testing."""
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+    start_meta_node(1, False)
+    return "127.0.0.1:9191"
+
+
+def test_lua_grpc_client():
+    """Test lua subcommand with gRPC client functionality."""
+    print_title("Test lua subcommand with gRPC client")
+
+    # Setup meta service
+    grpc_addr = setup_test_environment()
+
+    lua_util_str = load_lua_util()
+
+    # Create a Lua script that uses the gRPC client
+    lua_script = f'''
+{lua_util_str}
+
+local client = new_grpc_client("{grpc_addr}")
+
+-- Test upsert operation
+local upsert_result, upsert_err = client:upsert("test_key", "test_value")
+if upsert_err then
+    print("Upsert error:", upsert_err)
+else
+    print("Upsert result:", to_string(upsert_result))
+end
+
+-- Test get operation
+local get_result, get_err = client:get("test_key")
+if get_err then
+    print("Get error:", get_err)
+else
+    print("Get result:", to_string(get_result))
+end
+
+-- Test get non-existent key
+local get_null, get_null_err = client:get("nonexistent_key")
+if get_null_err then
+    print("Get null error:", get_null_err)
+else
+    print("Get null result:", to_string(get_null))
+end
+'''
+
+    # Run metactl lua with gRPC client script
+    result = subprocess.run([
+        metactl_bin, "lua"
+    ], input=lua_script, capture_output=True, text=True, check=True)
+
+    output = result.stdout.strip()
+    print("output:", output)
+
+    expected_output = '''Upsert result:\t{"result"={"data"="test_value","seq"=1}}
+Get result:\t{"data"="test_value","seq"=1}
+Get null result:\tNULL'''
+    print("expect:", expected_output)
+
+    # Check if entire output matches expected value
+    assert output == expected_output, f"Expected:\n{expected_output}\n\nActual:\n{output}"
+
+    print("✓ Lua gRPC client test passed")
+
+    # Only cleanup on success
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+
+
+def test_lua_grpc_from_file():
+    """Test lua subcommand with gRPC client using file input."""
+    print_title("Test lua subcommand with gRPC client from file")
+
+    # Setup meta service
+    grpc_addr = setup_test_environment()
+
+    lua_util_str = load_lua_util()
+
+    # Create a temporary Lua script file
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.lua', delete=False) as f:
+        f.write(f'''
+{lua_util_str}
+
+local client = new_grpc_client("{grpc_addr}")
+
+-- Upsert multiple key-value pairs
+local upsert1_result, upsert1_err = client:upsert("key1", "value1")
+if upsert1_err then
+    print("Key1 upsert error:", upsert1_err)
+end
+
+local upsert2_result, upsert2_err = client:upsert("key2", "value2")
+if upsert2_err then
+    print("Key2 upsert error:", upsert2_err)
+end
+
+-- Get and print the values
+local result1, err1 = client:get("key1")
+if err1 then
+    print("Key1 error:", err1)
+else
+    print("Key1 result:", to_string(result1))
+end
+
+local result2, err2 = client:get("key2")
+if err2 then
+    print("Key2 error:", err2)
+else
+    print("Key2 result:", to_string(result2))
+end
+''')
+        lua_file = f.name
+
+    # Run metactl lua with file
+    result = subprocess.run([
+        metactl_bin, "lua",
+        "--file", lua_file
+    ], capture_output=True, text=True, check=True)
+
+    output = result.stdout.strip()
+    print("output:", output)
+
+    expected_output = '''Key1 result:\t{"data"="value1","seq"=1}
+Key2 result:\t{"data"="value2","seq"=2}'''
+
+    # Check if entire output matches expected value
+    assert output == expected_output, f"Expected:\n{expected_output}\n\nActual:\n{output}"
+
+    print("✓ Lua gRPC client file test passed")
+
+    # Only cleanup on success
+    os.unlink(lua_file)
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+
+
+def main():
+    """Main function to run all lua gRPC tests."""
+    test_lua_grpc_client()
+    test_lua_grpc_from_file()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/metactl/test_all_subcommands.py
+++ b/tests/metactl/test_all_subcommands.py
@@ -28,6 +28,7 @@ from subcommands import cmd_export_from_raft_dir
 from subcommands import cmd_import
 from subcommands import cmd_transfer_leader
 from subcommands import cmd_lua
+from subcommands import cmd_lua_grpc
 
 
 def cleanup_environment():
@@ -61,6 +62,7 @@ def main():
         ("import", cmd_import.main),
         ("transfer_leader", cmd_transfer_leader.main),
         ("lua", cmd_lua.main),
+        ("lua_grpc", cmd_lua_grpc.main),
     ]
 
     # Filter tests based on command line arguments


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(metactl): add lua grpc client functionality

Extend lua subcommand with gRPC client capabilities for meta operations:
- Add new_grpc_client() function to create gRPC client instances
- Implement async get() and upsert() methods with tuple error handling
- Export NULL constant to Lua environment for proper null handling
- Add comprehensive test suite for gRPC client functionality
- Support both stdin and file input modes for Lua scripts

The gRPC client returns (result, error) tuples following Lua conventions
and converts Rust structures to native Lua tables for better usability.

Example usage:
```lua
local client = new_grpc_client("127.0.0.1:9191")

-- Store a key-value pair
local result, err = client:upsert("my_key", "my_value")
if err then
    print("Error:", err)
else
    print("Stored:", to_string(result))
end

-- Retrieve the value
local value, err = client:get("my_key")
if err then
    print("Error:", err)
else
    print("Retrieved:", to_string(value))
end
```

Run with: `databend-metactl lua --file script.lua`
Or pipe: `echo 'script content' | databend-metactl lua`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18438)
<!-- Reviewable:end -->
