### PR TITLE
feat(meta): optimize expired key cleanup with time-range filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14536,8 +14536,8 @@ dependencies = [
 
 [[package]]
 name = "state-machine-api"
-version = "0.1.0"
-source = "git+https://github.com/databendlabs/state-machine-api.git?tag=v0.1.0#3c4eb15cb42620f7cdaf331b0fd0a75c6a31f498"
+version = "0.1.1"
+source = "git+https://github.com/databendlabs/state-machine-api.git?tag=v0.1.1#637437b7a78b07bf39adff8bebef270f17c678dc"
 dependencies = [
  "display-more",
  "map-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -503,7 +503,7 @@ socket2 = "0.5.3"
 span-map = { version = "0.2.0" }
 sqlx = { version = "0.8", features = ["mysql", "runtime-tokio"] }
 state = "0.6.0"
-state-machine-api = { version = "0.1.0" }
+state-machine-api = { version = "0.1.1" }
 stream-more = "0.1.3"
 strength_reduce = "0.2.4"
 stringslice = "0.2.0"
@@ -666,7 +666,7 @@ openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-al
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "d82aa6d" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "6af35a1" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
-state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.1.0" }
+state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.1.1" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }
 tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370" }
 tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "7502370", package = "tantivy-common" }

--- a/src/meta/raft-store/src/sm_v003/sm_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 use std::fmt::Formatter;
 use std::io;
+use std::time::Duration;
 
 use databend_common_meta_types::raft_types::Entry;
 use databend_common_meta_types::raft_types::StorageError;
@@ -39,6 +40,9 @@ type OnChange = Box<dyn Fn((String, Option<SeqV>, Option<SeqV>)) + Send + Sync>;
 #[derive(Default)]
 pub struct SMV003 {
     levels: LeveledMap,
+
+    /// Since when to start cleaning expired keys.
+    cleanup_start_time_ms: Duration,
 
     /// Callback when a change is applied to state machine
     pub(crate) on_change_applied: Option<OnChange>,
@@ -75,6 +79,14 @@ impl StateMachineApi<SysData> for SMV003 {
 
     fn expire_map_mut(&mut self) -> &mut Self::ExpireMap {
         &mut self.levels
+    }
+
+    fn cleanup_start_timestamp(&self) -> Duration {
+        self.cleanup_start_time_ms
+    }
+
+    fn set_cleanup_start_timestamp(&mut self, timestamp: Duration) {
+        self.cleanup_start_time_ms = timestamp;
     }
 
     fn sys_data_mut(&mut self) -> &mut SysData {

--- a/src/meta/raft-store/src/utils.rs
+++ b/src/meta/raft-store/src/utils.rs
@@ -31,11 +31,9 @@ where
     T: Send + 'static,
 {
     stream.enumerate().then(move |(index, item)| {
-        // Yield control every 100 items to prevent blocking other tasks
-        let to_yield = if index % 100 == 0 {
-            if index % 5000 == 0 {
-                info!("{stream_name} yield control to allow other tasks to run: index={index}");
-            }
+        // Yield control every n items to prevent blocking other tasks
+        let to_yield = if index > 0 && index % 5000 == 0 {
+            info!("{stream_name} yield control to allow other tasks to run: index={index}");
             true
         } else {
             false


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta): optimize expired key cleanup with time-range filtering

Update state-machine-api from v0.1.0 to v0.1.1 and improve expired
key cleanup efficiency:

- Add `cleanup_start_timestamp` tracking to avoid re-scanning processed
  tombstone entries
- Simplify expired key removal logic by eliminating redundant checks

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18441)
<!-- Reviewable:end -->
