### PR TITLE
fix(query): only account_admin role can modify setting network_policy

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -1359,6 +1359,13 @@ impl AccessChecker for PrivilegeAccess {
             Plan::Set(plan) => {
                 use databend_common_ast::ast::SetType;
                 if let SetType::SettingsGlobal = plan.set_type {
+                    plan.idents.iter()
+                        .try_for_each(|setting| {
+                            if setting.eq_ignore_ascii_case("network_policy") && !self.ctx.get_current_user()?.is_account_admin() {
+                                return Err(ErrorCode::PermissionDenied("Permission Denied: Setting of network_policy is restricted to account_admin role".to_string()));
+                            }
+                            Ok(())
+                        })?;
                     self.validate_access(&GrantObject::Global, UserPrivilegeType::Super, false, false)
                         .await?;
                 }
@@ -1366,6 +1373,14 @@ impl AccessChecker for PrivilegeAccess {
             Plan::Unset(plan) => {
                 use databend_common_ast::ast::SetType;
                 if let SetType::SettingsGlobal = plan.unset_type {
+                    plan.vars.iter()
+                        .try_for_each(|setting| {
+                            if setting.eq_ignore_ascii_case("network_policy") && !self.ctx.get_current_user()?.is_account_admin() {
+                                    return Err(ErrorCode::PermissionDenied("Permission Denied: Setting of network_policy is restricted to account_admin role".to_string()));
+                            }
+                            Ok(())
+                            }
+                        )?;
                     self.validate_access(&GrantObject::Global, UserPrivilegeType::Super, false, false)
                         .await?;
                 }

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.result
@@ -36,6 +36,9 @@ test -- insert overwrite
 test -- optimize table
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [Super] is required on 'default'.'default'.'t20_0012' for user 'test-user'@'%' with roles [public,test-role1,test-role2]
 true
+=== NETWORK_POLICY SETTING ===
+Error: APIError: QueryFailed: [1063]Permission Denied: Setting of network_policy is restricted to account_admin role
+Error: APIError: QueryFailed: [1063]Permission Denied: Setting of network_policy is restricted to account_admin role
 test -- select
 1
 1

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -92,6 +92,13 @@ echo "set data_retention_time_in_days=0; optimize table t20_0012 all" | $TEST_US
 ## verify
 echo "select count(*)>=1 from fuse_snapshot('default', 't20_0012')" | $TEST_USER_CONNECT
 
+echo "=== NETWORK_POLICY SETTING ==="
+echo "drop network policy if exists test_user_without_account_admin"  | $TEST_USER_CONNECT
+echo "create network policy test_user_without_account_admin allowed_ip_list=('127.0.0.0/24')"  | $TEST_USER_CONNECT
+echo "set global network_policy='test_user_without_account_admin'"  | $TEST_USER_CONNECT
+echo "unset global network_policy"  | $TEST_USER_CONNECT
+echo "drop network policy if exists test_user_without_account_admin"  | $TEST_USER_CONNECT
+
 ## select data
 echo "select 'test -- select'" | $TEST_USER_CONNECT
 ## Init tables


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

only account_admin role can modify setting network_policy

User a without account_admin role should return error.

```sql
a@localhost:8000/default/default> SET global NETWORK_POLICY = '';
error: APIError: QueryFailed: [1063]Permission Denied: Setting of network_policy is restricted to account_admin role
a@localhost:8000/default/default> UNSET global NETWORK_POLICY;
error: APIError: QueryFailed: [1063]Permission Denied: Setting of network_policy is restricted to account_admin role
```

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->
- fixes: #18454
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18456)
<!-- Reviewable:end -->
