### PR TITLE
chore: bump databend-common-ast to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "databend-common-ast"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "databend_educe",
  "derive-visitor",

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databend-common-ast"
-version = "0.2.1"
+version = "0.2.2"
 publish = true
 description = "SQL parser for Databend"
 authors = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Parse for updating BendSQL to solve the issue: https://github.com/databendlabs/databend/issues/18449


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18457)
<!-- Reviewable:end -->
