### PR TITLE
docs(meta): add Lua API documentation and benchmarking tools

### DIFF
--- a/src/meta/control/LUA_API.md
+++ b/src/meta/control/LUA_API.md
@@ -1,0 +1,262 @@
+# Databend Meta Control Lua API Documentation
+
+This document describes the Lua runtime API available in `databend-metactl lua` command.
+
+## Overview
+
+The Lua runtime provides access to meta service operations through the `metactl` namespace. All functions and utilities are available in the global `metactl` table.
+
+## Core Functions
+
+### metactl.new_grpc_client(address)
+
+Creates a new gRPC client for communicating with the meta service.
+
+**Parameters:**
+- `address` (string): The gRPC address of the meta service (e.g., "127.0.0.1:9191")
+
+**Returns:**
+- A gRPC client object with methods for meta operations
+
+**Example:**
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+```
+
+### metactl.spawn(function)
+
+Spawns an asynchronous task that runs concurrently.
+
+**Parameters:**
+- `function`: A Lua function to execute asynchronously
+
+**Returns:**
+- A task handle that can be awaited with `join()`
+
+**Example:**
+```lua
+local task = metactl.spawn(function()
+    metactl.sleep(1.0)
+    print("Task completed")
+end)
+task:join()
+```
+
+### metactl.sleep(seconds)
+
+Asynchronously sleeps for the specified duration.
+
+**Parameters:**
+- `seconds` (number): Duration to sleep in seconds (supports fractional values)
+
+**Example:**
+```lua
+metactl.sleep(0.5)  -- Sleep for 500ms
+metactl.sleep(2.0)  -- Sleep for 2 seconds
+```
+
+### metactl.to_string(value)
+
+Converts any Lua value to a human-readable string representation.
+
+**Parameters:**
+- `value`: Any Lua value (nil, boolean, number, string, table, etc.)
+
+**Returns:**
+- String representation of the value
+
+**Features:**
+- Handles nested tables recursively
+- Detects and converts byte vectors to strings
+- Sorts table keys for consistent output
+- Handles NULL values from meta service
+- Escapes quotes in strings
+- Single-line output format
+
+**Example:**
+```lua
+print(metactl.to_string({key="value", data={1,2,3}}))
+-- Output: {"data"={1,2,3},"key"="value"}
+
+print(metactl.to_string(metactl.NULL))
+-- Output: NULL
+```
+
+## Constants
+
+### metactl.NULL
+
+A special constant representing NULL values returned from the meta service.
+
+**Example:**
+```lua
+local result, err = client:get("nonexistent_key") 
+if result == metactl.NULL then
+    print("Key not found")
+end
+```
+
+## gRPC Client Methods
+
+The client object returned by `metactl.new_grpc_client()` provides these methods:
+
+### client:get(key)
+
+Retrieves a value from the meta service.
+
+**Parameters:**
+- `key` (string): The key to retrieve
+
+**Returns:**
+- `result`: The retrieved value or `metactl.NULL` if not found
+- `error`: Error message string if operation failed, nil otherwise
+
+**Example:**
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+local result, err = client:get("my_key")
+if err then
+    print("Error:", err)
+else
+    print("Value:", metactl.to_string(result))
+end
+```
+
+### client:upsert(key, value)
+
+Inserts or updates a key-value pair in the meta service.
+
+**Parameters:**
+- `key` (string): The key to upsert
+- `value` (string): The value to store
+
+**Returns:**
+- `result`: Operation result containing sequence number and other metadata
+- `error`: Error message string if operation failed, nil otherwise
+
+**Example:**
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+local result, err = client:upsert("my_key", "my_value")
+if err then
+    print("Error:", err)
+else
+    print("Upsert result:", metactl.to_string(result))
+end
+```
+
+## Task Handling
+
+### task:join()
+
+Waits for a spawned task to complete and returns its result.
+
+**Returns:**
+- The return value of the spawned function
+
+**Example:**
+```lua
+local task = metactl.spawn(function()
+    return "task result"
+end)
+
+local result = task:join()
+print(result)  -- Output: task result
+```
+
+## Usage Patterns
+
+### Basic Key-Value Operations
+
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+
+-- Store a value
+local upsert_result, err = client:upsert("config/timeout", "30")
+if not err then
+    print("Stored successfully:", metactl.to_string(upsert_result))
+end
+
+-- Retrieve a value
+local get_result, err = client:get("config/timeout")
+if not err then
+    if get_result == metactl.NULL then
+        print("Key not found")
+    else
+        print("Retrieved:", metactl.to_string(get_result))
+    end
+end
+```
+
+### Concurrent Operations
+
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+
+local task1 = metactl.spawn(function()
+    client:upsert("key1", "value1")
+    print("Task 1 completed")
+end)
+
+local task2 = metactl.spawn(function()
+    metactl.sleep(0.1)
+    local result, _ = client:get("key1")
+    print("Task 2 got:", metactl.to_string(result))
+end)
+
+task1:join()
+task2:join()
+```
+
+### Error Handling
+
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+
+local result, err = client:get("some_key")
+if err then
+    print("Operation failed:", err)
+    return
+end
+
+if result == metactl.NULL then
+    print("Key does not exist")
+else
+    print("Key value:", metactl.to_string(result))
+end
+```
+
+## Data Types
+
+The meta service returns structured data that can be processed using `metactl.to_string()`:
+
+```lua
+-- Typical get response structure:
+{
+    "data" = "actual_value",  -- The stored value as byte array
+    "seq" = 1                 -- Sequence number
+}
+
+-- Typical upsert response structure:
+{
+    "result" = {
+        "data" = "stored_value",
+        "seq" = 1
+    }
+}
+```
+
+## Best Practices
+
+1. **Always check for errors**: Both `get` and `upsert` operations can fail
+2. **Handle NULL values**: Use `metactl.NULL` comparison for missing keys
+3. **Use concurrent operations**: Leverage `metactl.spawn()` for parallel processing
+4. **Format output**: Use `metactl.to_string()` for readable data display
+5. **Clean resource usage**: Ensure tasks are properly joined
+
+## Examples
+
+See the test files in `tests/metactl/subcommands/` for comprehensive usage examples:
+- `cmd_lua_grpc.py` - Basic gRPC operations
+- `cmd_lua_spawn_grpc.py` - Concurrent gRPC operations
+- `cmd_lua_spawn_concurrent.py` - Task spawning patterns

--- a/src/meta/control/lua_util.lua
+++ b/src/meta/control/lua_util.lua
@@ -1,10 +1,10 @@
 -- Function to check if a value is NULL (mlua NULL constant)
-function is_null(value)
-    return value == NULL
+local function is_null(value)
+    return value == metactl.NULL
 end
 
 -- Function to normalize NULL values to nil for easier handling
-function normalize_value(value)
+local function normalize_value(value)
     if is_null(value) then
         return nil
     end
@@ -12,11 +12,11 @@ function normalize_value(value)
 end
 
 -- Function to check if a table represents a bytes vector and convert it to string
-function bytes_vector_to_string(value)
+local function bytes_vector_to_string(value)
     -- Check if table represents a bytes vector (integer indices starting from 1, u8 values)
     local max_index = 0
     local min_index = math.huge
-    
+
     -- First pass: check if all keys are integers and find range
     for k, v in pairs(value) do
         if type(k) ~= "number" or k ~= math.floor(k) or k < 1 then
@@ -28,7 +28,7 @@ function bytes_vector_to_string(value)
         max_index = math.max(max_index, k)
         min_index = math.min(min_index, k)
     end
-    
+
     -- Check if indices are consecutive starting from 1
     if min_index == 1 then
         local expected_length = max_index
@@ -41,7 +41,7 @@ function bytes_vector_to_string(value)
             if max_index > 1048576 then
                 return '"<bytes vector too large: ' .. max_index .. ' bytes>"'
             end
-            
+
             -- Convert bytes vector to string
             local chars = {}
             for i = 1, max_index do
@@ -50,16 +50,16 @@ function bytes_vector_to_string(value)
             return '"' .. table.concat(chars) .. '"'
         end
     end
-    
+
     return nil -- Not a valid bytes vector
 end
 
 -- Function to convert a value or table into a single-line string recursively
-function to_string(value)
+local function to_string(value)
     if value == nil then
         return "nil"
     end
-    
+
     if is_null(value) then
         return "NULL"
     end
@@ -83,7 +83,7 @@ function to_string(value)
         if bytes_string then
             return bytes_string
         end
-        
+
         -- Regular table processing
         local result = "{"
         local keys = {}
@@ -117,7 +117,7 @@ function to_string(value)
         local first = true
         for _, k in ipairs(keys) do
             local v = value[k]
-            
+
             -- Skip nil and NULL values
             if v ~= nil and not is_null(v) then
                 if not first then
@@ -143,3 +143,6 @@ function to_string(value)
     -- Handle function, userdata, thread
     return "<" .. type(value) .. ">"
 end
+
+-- Register to_string function in metactl namespace
+metactl.to_string = to_string

--- a/tests/metactl/benchmark/databend_meta_benchmark.lua
+++ b/tests/metactl/benchmark/databend_meta_benchmark.lua
@@ -1,0 +1,171 @@
+local GRPC_ADDR = "127.0.0.1:9191"
+local UPSERT_WORKERS = 4
+local GET_WORKERS = 4
+local OPERATIONS_PER_WORKER = 10000
+local KEY_PREFIX = "bench_key_"
+local VALUE_PREFIX = "bench_value_"
+local PROGRESS_INTERVAL = 2.0
+
+local stats = {
+    upsert_ops = 0,
+    get_ops = 0,
+    upsert_errors = 0,
+    get_errors = 0,
+    start_time = nil,
+    end_time = nil
+}
+
+local function generate_key(worker_id, op_id)
+    return KEY_PREFIX .. worker_id .. "_" .. op_id
+end
+
+local function generate_value(worker_id, op_id)
+    return VALUE_PREFIX .. worker_id .. "_" .. op_id .. "_data_" .. string.rep("x", 32)
+end
+
+local function atomic_inc(field)
+    stats[field] = stats[field] + 1
+end
+
+local function upsert_worker(worker_id)
+    local client = metactl.new_grpc_client(GRPC_ADDR)
+
+    for i = 1, OPERATIONS_PER_WORKER do
+        local key = generate_key(worker_id, i)
+        local value = generate_value(worker_id, i)
+
+        local result, err = client:upsert(key, value)
+        if err then
+            atomic_inc("upsert_errors")
+        else
+            atomic_inc("upsert_ops")
+        end
+
+        metactl.sleep(0.001)
+    end
+
+    print("Upsert worker " .. worker_id .. " completed")
+end
+
+local function get_worker(worker_id)
+    local client = metactl.new_grpc_client(GRPC_ADDR)
+
+    metactl.sleep(0.1)
+
+    for i = 1, OPERATIONS_PER_WORKER do
+        local target_worker = (worker_id + i) % UPSERT_WORKERS + 1
+        local target_op = (i % OPERATIONS_PER_WORKER) + 1
+        local key = generate_key(target_worker, target_op)
+
+        local result, err = client:get(key)
+        if err then
+            atomic_inc("get_errors")
+        else
+            atomic_inc("get_ops")
+        end
+
+        metactl.sleep(0.001)
+    end
+
+    print("Get worker " .. worker_id .. " completed")
+end
+
+local function print_config()
+    print("=== Databend Meta Benchmark Configuration ===")
+    print("gRPC Address: " .. GRPC_ADDR)
+    print("Upsert Workers: " .. UPSERT_WORKERS)
+    print("Get Workers: " .. GET_WORKERS)
+    print("Operations per Worker: " .. OPERATIONS_PER_WORKER)
+    print("Total Upsert Operations: " .. (UPSERT_WORKERS * OPERATIONS_PER_WORKER))
+    print("Total Get Operations: " .. (GET_WORKERS * OPERATIONS_PER_WORKER))
+    print("============================================")
+    print("")
+end
+
+local function print_results()
+    local elapsed = stats.end_time - stats.start_time
+    local total_ops = stats.upsert_ops + stats.get_ops
+    local total_errors = stats.upsert_errors + stats.get_errors
+
+    print("")
+    print("=== Benchmark Results ===")
+    print("Duration: " .. string.format("%.2f", elapsed) .. " seconds")
+    print("")
+    print("Upsert Operations:")
+    print("  Successful: " .. stats.upsert_ops)
+    print("  Errors: " .. stats.upsert_errors)
+    print("  Rate: " .. string.format("%.1f", stats.upsert_ops / elapsed) .. " ops/sec")
+    print("")
+    print("Get Operations:")
+    print("  Successful: " .. stats.get_ops)
+    print("  Errors: " .. stats.get_errors)
+    print("  Rate: " .. string.format("%.1f", stats.get_ops / elapsed) .. " ops/sec")
+    print("")
+    print("Total Operations:")
+    print("  Successful: " .. total_ops)
+    print("  Errors: " .. total_errors)
+    print("  Overall Rate: " .. string.format("%.1f", total_ops / elapsed) .. " ops/sec")
+    print("  Success Rate: " .. string.format("%.2f", (total_ops / (total_ops + total_errors)) * 100) .. "%")
+    print("========================")
+end
+
+local function progress_reporter()
+    local last_upsert_ops = 0
+    local last_get_ops = 0
+
+    while true do
+        metactl.sleep(PROGRESS_INTERVAL)
+        local current_upsert_ops = stats.upsert_ops
+        local current_get_ops = stats.get_ops
+        local current_upsert_errors = stats.upsert_errors
+        local current_get_errors = stats.get_errors
+
+        local upsert_qps = (current_upsert_ops - last_upsert_ops) / PROGRESS_INTERVAL
+        local get_qps = (current_get_ops - last_get_ops) / PROGRESS_INTERVAL
+
+        print(string.format("Progress: Upsert %d ops (%d err, %.1f qps), Get %d ops (%d err, %.1f qps)",
+              current_upsert_ops, current_upsert_errors, upsert_qps,
+              current_get_ops, current_get_errors, get_qps))
+
+        last_upsert_ops = current_upsert_ops
+        last_get_ops = current_get_ops
+    end
+end
+
+local function run_benchmark()
+    print_config()
+
+    stats.start_time = os.clock()
+
+    local progress_task = metactl.spawn(progress_reporter)
+
+    local upsert_tasks = {}
+    for i = 1, UPSERT_WORKERS do
+        upsert_tasks[i] = metactl.spawn(function() upsert_worker(i) end)
+    end
+
+    local get_tasks = {}
+    for i = 1, GET_WORKERS do
+        get_tasks[i] = metactl.spawn(function() get_worker(i) end)
+    end
+
+    print("All workers started, waiting for completion...")
+
+    for i = 1, UPSERT_WORKERS do
+        upsert_tasks[i]:join()
+    end
+    print("All upsert workers completed")
+
+    for i = 1, GET_WORKERS do
+        get_tasks[i]:join()
+    end
+    print("All get workers completed")
+
+    stats.end_time = os.clock()
+
+    print_results()
+end
+
+print("Starting Databend Meta Benchmark...")
+run_benchmark()
+print("Benchmark completed!")

--- a/tests/metactl/benchmark/run_lua_benchmark.py
+++ b/tests/metactl/benchmark/run_lua_benchmark.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+import subprocess
+import select
+from pathlib import Path
+from metactl_utils import metactl_bin
+from utils import print_title, print_step, kill_databend_meta, start_meta_node
+
+
+def setup_meta_service():
+    """Setup meta service for benchmarking."""
+    print_step("Setting up meta service")
+
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+    start_meta_node(1, False)
+
+    print_step("Meta service ready at 127.0.0.1:9191")
+    return "127.0.0.1:9191"
+
+
+def run_lua_script(script_path):
+    """Run the Lua script with metactl."""
+    print_step(f"Running Lua script: {script_path}")
+
+    script_file = Path(script_path)
+    if not script_file.exists():
+        raise FileNotFoundError(f"Lua script not found: {script_path}")
+
+    try:
+        process = subprocess.Popen([
+            metactl_bin, "lua", "--file", str(script_file)
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=0)
+
+        while process.poll() is None:
+            ready, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
+            
+            for stream in ready:
+                line = stream.readline()
+                if line:
+                    if stream == process.stdout:
+                        print(line.rstrip())
+                    else:
+                        print("STDERR:", line.rstrip(), file=sys.stderr)
+        
+        for line in process.stdout:
+            print(line.rstrip())
+        for line in process.stderr:
+            print("STDERR:", line.rstrip(), file=sys.stderr)
+
+        return_code = process.wait()
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, [metactl_bin, "lua", "--file", str(script_file)])
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error running Lua script: {e}")
+        raise
+
+
+def main():
+    """Main function to run Lua benchmark with meta service setup."""
+    if len(sys.argv) != 2:
+        print("Usage: python run_lua_benchmark.py <lua_script_file>")
+        print("Example: python run_lua_benchmark.py databend_meta_benchmark.lua")
+        sys.exit(1)
+
+    script_path = sys.argv[1]
+    script_name = Path(script_path).name
+
+    print_title(f"Running Lua Benchmark: {script_name}")
+
+    grpc_addr = setup_meta_service()
+    run_lua_script(script_path)
+
+    print_step("Benchmark completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/metactl/metactl_utils.py
+++ b/tests/metactl/metactl_utils.py
@@ -12,10 +12,6 @@ from utils import print_step, BUILD_PROFILE, run_command
 metactl_bin = f"./target/{BUILD_PROFILE}/databend-metactl"
 
 
-def load_lua_util():
-    """Load lua utility functions from lua_util.lua file."""
-    with open("tests/metactl/lua_util.lua", 'r') as f:
-        return f.read()
 
 
 def metactl_run_lua(lua_script=None, lua_filename=None):

--- a/tests/metactl/subcommands/cmd_lua_grpc.py
+++ b/tests/metactl/subcommands/cmd_lua_grpc.py
@@ -8,9 +8,6 @@ import json
 from metactl_utils import metactl_bin
 from utils import print_title, kill_databend_meta, start_meta_node
 
-def load_lua_util():
-    with open("tests/metactl/lua_util.lua", 'r') as f:
-        return f.read()
 
 
 def setup_test_environment():
@@ -28,20 +25,16 @@ def test_lua_grpc_client():
     # Setup meta service
     grpc_addr = setup_test_environment()
 
-    lua_util_str = load_lua_util()
-
     # Create a Lua script that uses the gRPC client
     lua_script = f'''
-{lua_util_str}
-
-local client = new_grpc_client("{grpc_addr}")
+local client = metactl.new_grpc_client("{grpc_addr}")
 
 -- Test upsert operation
 local upsert_result, upsert_err = client:upsert("test_key", "test_value")
 if upsert_err then
     print("Upsert error:", upsert_err)
 else
-    print("Upsert result:", to_string(upsert_result))
+    print("Upsert result:", metactl.to_string(upsert_result))
 end
 
 -- Test get operation
@@ -49,7 +42,7 @@ local get_result, get_err = client:get("test_key")
 if get_err then
     print("Get error:", get_err)
 else
-    print("Get result:", to_string(get_result))
+    print("Get result:", metactl.to_string(get_result))
 end
 
 -- Test get non-existent key
@@ -57,7 +50,7 @@ local get_null, get_null_err = client:get("nonexistent_key")
 if get_null_err then
     print("Get null error:", get_null_err)
 else
-    print("Get null result:", to_string(get_null))
+    print("Get null result:", metactl.to_string(get_null))
 end
 '''
 

--- a/tests/metactl/subcommands/cmd_lua_sleep.py
+++ b/tests/metactl/subcommands/cmd_lua_sleep.py
@@ -11,7 +11,7 @@ def test_lua_sleep():
 
     lua_script = '''
 print("Before sleep")
-sleep(0.5)
+metactl.sleep(0.5)
 print("After sleep")
 '''
 

--- a/tests/metactl/subcommands/cmd_lua_spawn_concurrent.py
+++ b/tests/metactl/subcommands/cmd_lua_spawn_concurrent.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import os
 import shutil
-from metactl_utils import metactl_bin, load_lua_util, metactl_run_lua
+from metactl_utils import metactl_bin, metactl_run_lua
 from utils import print_title, kill_databend_meta, start_meta_node
 
 
@@ -12,22 +12,18 @@ def test_spawn_basic():
     """Test basic spawn functionality without gRPC."""
     print_title("Test basic spawn functionality")
 
-    lua_util_str = load_lua_util()
-
     lua_script = f'''
-{lua_util_str}
-
 print("Testing basic spawn functionality...")
 
-local task1 = spawn(function()
+local task1 = metactl.spawn(function()
     print("Task 1: Starting")
-    sleep(0.1)
+    metactl.sleep(0.1)
     print("Task 1: Finished")
 end)
 
-local task2 = spawn(function()
+local task2 = metactl.spawn(function()
     print("Task 2: Starting")
-    sleep(0.2)
+    metactl.sleep(0.2)
     print("Task 2: Finished")
 end)
 

--- a/tests/metactl/subcommands/cmd_lua_spawn_grpc.py
+++ b/tests/metactl/subcommands/cmd_lua_spawn_grpc.py
@@ -2,7 +2,7 @@
 
 import subprocess
 import shutil
-from metactl_utils import metactl_bin, load_lua_util
+from metactl_utils import metactl_bin
 from utils import print_title, kill_databend_meta, start_meta_node
 
 
@@ -19,39 +19,36 @@ def test_grpc_cross_task_access():
     print_title("Test gRPC cross-task key access")
 
     grpc_addr = setup_test_environment()
-    lua_util_str = load_lua_util()
 
     lua_script = f'''
-{lua_util_str}
-
-local task1 = spawn(function()
-    local client = new_grpc_client("{grpc_addr}")
+local task1 = metactl.spawn(function()
+    local client = metactl.new_grpc_client("{grpc_addr}")
     
     client:upsert("k1", "v1")
     print("Task 1: Upserted k1")
     
-    sleep(0.5)
+    metactl.sleep(0.5)
     
     local result, err = client:get("k2")
     if not err then
-        print("Task 1: Got k2:", to_string(result))
+        print("Task 1: Got k2:", metactl.to_string(result))
     end
 end)
 
-local task2 = spawn(function()
-    local client = new_grpc_client("{grpc_addr}")
+local task2 = metactl.spawn(function()
+    local client = metactl.new_grpc_client("{grpc_addr}")
 
     -- Let task1 run first
-    sleep(0.2)
+    metactl.sleep(0.2)
     
     client:upsert("k2", "v2")
     print("Task 2: Upserted k2")
     
-    sleep(0.5)
+    metactl.sleep(0.5)
     
     local result, err = client:get("k1")
     if not err then
-        print("Task 2: Got k1:", to_string(result))
+        print("Task 2: Got k1:", metactl.to_string(result))
     end
 end)
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### docs(meta): add Lua API documentation and benchmarking tools

Add comprehensive documentation for the metactl Lua runtime API,
including all available functions, client methods, and usage patterns.
Add benchmark script and runner for performance testing of concurrent
meta operations.

- Complete API documentation with examples and best practices
- Benchmark script with configurable concurrent workers
- Python test runner with meta service setup automation


##### refactor(meta): move Lua functions to metactl namespace

Move all Lua functions from global scope to metactl namespace
to prevent conflicts with other Lua libraries:

- metactl.new_grpc_client() replaces new_grpc_client()
- metactl.spawn() replaces spawn()
- metactl.sleep() replaces sleep()
- metactl.NULL replaces NULL

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues