### PR TITLE
fix(meta): export should log large chunk of snapshot cache data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,6 +3965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "state-machine-api",
+ "tempfile",
  "thiserror 1.0.69",
  "tonic",
  "tonic-build",

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -35,6 +35,7 @@ tonic-build = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+tempfile = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["num-derive", "prost"]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix(meta): export should log large chunk of snapshot cache data

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues