### PR TITLE
fix(query): Fix vector distance function can not accept array nullable types

### DIFF
--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -1343,9 +1343,13 @@ Functions overloads:
 1 cos(Float64 NULL) :: Float64 NULL
 0 cosine_distance(Array(Float32), Array(Float32)) :: Float32
 1 cosine_distance(Array(Float32) NULL, Array(Float32) NULL) :: Float32 NULL
-2 cosine_distance(Array(Float64), Array(Float64)) :: Float64
-3 cosine_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
-4 cosine_distance FACTORY
+2 cosine_distance(Array(Float32 NULL), Array(Float32 NULL)) :: Float32
+3 cosine_distance(Array(Float32 NULL) NULL, Array(Float32 NULL) NULL) :: Float32 NULL
+4 cosine_distance(Array(Float64), Array(Float64)) :: Float64
+5 cosine_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
+6 cosine_distance(Array(Float64 NULL), Array(Float64 NULL)) :: Float64
+7 cosine_distance(Array(Float64 NULL) NULL, Array(Float64 NULL) NULL) :: Float64 NULL
+8 cosine_distance FACTORY
 0 cot(Float64) :: Float64
 1 cot(Float64 NULL) :: Float64 NULL
 0 crc32(String) :: UInt32
@@ -2235,9 +2239,13 @@ Functions overloads:
 1 inet_ntoa(Int64 NULL) :: String NULL
 0 inner_product(Array(Float32), Array(Float32)) :: Float32
 1 inner_product(Array(Float32) NULL, Array(Float32) NULL) :: Float32 NULL
-2 inner_product(Array(Float64), Array(Float64)) :: Float64
-3 inner_product(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
-4 inner_product FACTORY
+2 inner_product(Array(Float32 NULL), Array(Float32 NULL)) :: Float32
+3 inner_product(Array(Float32 NULL) NULL, Array(Float32 NULL) NULL) :: Float32 NULL
+4 inner_product(Array(Float64), Array(Float64)) :: Float64
+5 inner_product(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
+6 inner_product(Array(Float64 NULL), Array(Float64 NULL)) :: Float64
+7 inner_product(Array(Float64 NULL) NULL, Array(Float64 NULL) NULL) :: Float64 NULL
+8 inner_product FACTORY
 0 insert(String, Int64, Int64, String) :: String
 1 insert(String NULL, Int64 NULL, Int64 NULL, String NULL) :: String NULL
 0 instr(String, String) :: UInt64
@@ -2307,14 +2315,22 @@ Functions overloads:
 1 json_typeof(Variant NULL) :: String NULL
 0 l1_distance(Array(Float32), Array(Float32)) :: Float32
 1 l1_distance(Array(Float32) NULL, Array(Float32) NULL) :: Float32 NULL
-2 l1_distance(Array(Float64), Array(Float64)) :: Float64
-3 l1_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
-4 l1_distance FACTORY
+2 l1_distance(Array(Float32 NULL), Array(Float32 NULL)) :: Float32
+3 l1_distance(Array(Float32 NULL) NULL, Array(Float32 NULL) NULL) :: Float32 NULL
+4 l1_distance(Array(Float64), Array(Float64)) :: Float64
+5 l1_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
+6 l1_distance(Array(Float64 NULL), Array(Float64 NULL)) :: Float64
+7 l1_distance(Array(Float64 NULL) NULL, Array(Float64 NULL) NULL) :: Float64 NULL
+8 l1_distance FACTORY
 0 l2_distance(Array(Float32), Array(Float32)) :: Float32
 1 l2_distance(Array(Float32) NULL, Array(Float32) NULL) :: Float32 NULL
-2 l2_distance(Array(Float64), Array(Float64)) :: Float64
-3 l2_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
-4 l2_distance FACTORY
+2 l2_distance(Array(Float32 NULL), Array(Float32 NULL)) :: Float32
+3 l2_distance(Array(Float32 NULL) NULL, Array(Float32 NULL) NULL) :: Float32 NULL
+4 l2_distance(Array(Float64), Array(Float64)) :: Float64
+5 l2_distance(Array(Float64) NULL, Array(Float64) NULL) :: Float64 NULL
+6 l2_distance(Array(Float64 NULL), Array(Float64 NULL)) :: Float64
+7 l2_distance(Array(Float64 NULL) NULL, Array(Float64 NULL) NULL) :: Float64 NULL
+8 l2_distance FACTORY
 0 left(String, UInt64) :: String
 1 left(String NULL, UInt64 NULL) :: String NULL
 0 length(Variant NULL) :: UInt32 NULL

--- a/src/query/functions/tests/it/scalars/testdata/vector.txt
+++ b/src/query/functions/tests/it/scalars/testdata/vector.txt
@@ -86,6 +86,106 @@ evaluation (internal):
 +--------+---------------------------------------------------+
 
 
+ast            : cosine_distance([a, b], [c, d])
+raw expr       : cosine_distance(array(a::Float32, b::Float32), array(c::Float32, d::Float32))
+checked expr   : cosine_distance<Array(Float32), Array(Float32)>(array<T0=Float32><T0, T0>(a, b), array<T0=Float32><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+--------------+
+|        | a         | b          | c          | d          | Output       |
++--------+-----------+------------+------------+------------+--------------+
+| Type   | Float32   | Float32    | Float32    | Float32    | Float32      |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown      |
+| Row 0  | 1         | 2          | 3          | 4          | 0.01613009   |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 0.0003668666 |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 0.0000377297 |
++--------+-----------+------------+------------+------------+--------------+
+evaluation (internal):
++--------+---------------------------------------------------+
+| Column | Data                                              |
++--------+---------------------------------------------------+
+| a      | Float32([1, 5.1, 9.4])                            |
+| b      | Float32([2, 6.2, 10.6])                           |
+| c      | Float32([3, 7.3, 11.1])                           |
+| d      | Float32([4, 8.4, 12.3])                           |
+| Output | Float32([0.01613009, 0.0003668666, 0.0000377297]) |
++--------+---------------------------------------------------+
+
+
+ast            : cosine_distance([a, b], [c, d])
+raw expr       : cosine_distance(array(a::Float32 NULL, b::Float32 NULL), array(c::Float32 NULL, d::Float32 NULL))
+checked expr   : cosine_distance<Array(Float32 NULL), Array(Float32 NULL)>(array<T0=Float32 NULL><T0, T0>(a, b), array<T0=Float32 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+--------------+
+|        | a            | b            | c            | d            | Output       |
++--------+--------------+--------------+--------------+--------------+--------------+
+| Type   | Float32 NULL | Float32 NULL | Float32 NULL | Float32 NULL | Float32      |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown      |
+| Row 0  | 1            | 2            | 3            | 4            | 0.01613009   |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 0.0003668666 |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 0.0000377297 |
++--------+--------------+--------------+--------------+--------------+--------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float32([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float32([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float32([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float32([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float32([0.01613009, 0.0003668666, 0.0000377297])                          |
++--------+----------------------------------------------------------------------------+
+
+
+ast            : cosine_distance([a, b], [c, d])
+raw expr       : cosine_distance(array(a::Float64, b::Float64), array(c::Float64, d::Float64))
+checked expr   : cosine_distance<Array(Float64), Array(Float64)>(array<T0=Float64><T0, T0>(a, b), array<T0=Float64><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+--------------+
+|        | a         | b          | c          | d          | Output       |
++--------+-----------+------------+------------+------------+--------------+
+| Type   | Float64   | Float64    | Float64    | Float64    | Float64      |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown      |
+| Row 0  | 1         | 2          | 3          | 4          | 0.0161300899 |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 0.0003669116 |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 0.0000377663 |
++--------+-----------+------------+------------+------------+--------------+
+evaluation (internal):
++--------+-----------------------------------------------------+
+| Column | Data                                                |
++--------+-----------------------------------------------------+
+| a      | Float64([1, 5.1, 9.4])                              |
+| b      | Float64([2, 6.2, 10.6])                             |
+| c      | Float64([3, 7.3, 11.1])                             |
+| d      | Float64([4, 8.4, 12.3])                             |
+| Output | Float64([0.0161300899, 0.0003669116, 0.0000377663]) |
++--------+-----------------------------------------------------+
+
+
+ast            : cosine_distance([a, b], [c, d])
+raw expr       : cosine_distance(array(a::Float64 NULL, b::Float64 NULL), array(c::Float64 NULL, d::Float64 NULL))
+checked expr   : cosine_distance<Array(Float64 NULL), Array(Float64 NULL)>(array<T0=Float64 NULL><T0, T0>(a, b), array<T0=Float64 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+--------------+
+|        | a            | b            | c            | d            | Output       |
++--------+--------------+--------------+--------------+--------------+--------------+
+| Type   | Float64 NULL | Float64 NULL | Float64 NULL | Float64 NULL | Float64      |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown      |
+| Row 0  | 1            | 2            | 3            | 4            | 0.0161300899 |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 0.0003669116 |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 0.0000377663 |
++--------+--------------+--------------+--------------+--------------+--------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float64([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float64([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float64([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float64([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float64([0.0161300899, 0.0003669116, 0.0000377663])                        |
++--------+----------------------------------------------------------------------------+
+
+
 ast            : l1_distance([1,2,3], [1,2,3])
 raw expr       : l1_distance(array(1, 2, 3), array(1, 2, 3))
 checked expr   : l1_distance<Array(Float32), Array(Float32)>(CAST<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Float32)), CAST<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Float32)))
@@ -165,6 +265,106 @@ evaluation (internal):
 +--------+-----------------------------+
 
 
+ast            : l1_distance([a, b], [c, d])
+raw expr       : l1_distance(array(a::Float32, b::Float32), array(c::Float32, d::Float32))
+checked expr   : l1_distance<Array(Float32), Array(Float32)>(array<T0=Float32><T0, T0>(a, b), array<T0=Float32><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+----------+
+|        | a         | b          | c          | d          | Output   |
++--------+-----------+------------+------------+------------+----------+
+| Type   | Float32   | Float32    | Float32    | Float32    | Float32  |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown  |
+| Row 0  | 1         | 2          | 3          | 4          | 4        |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 4.4      |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 3.400001 |
++--------+-----------+------------+------------+------------+----------+
+evaluation (internal):
++--------+-----------------------------+
+| Column | Data                        |
++--------+-----------------------------+
+| a      | Float32([1, 5.1, 9.4])      |
+| b      | Float32([2, 6.2, 10.6])     |
+| c      | Float32([3, 7.3, 11.1])     |
+| d      | Float32([4, 8.4, 12.3])     |
+| Output | Float32([4, 4.4, 3.400001]) |
++--------+-----------------------------+
+
+
+ast            : l1_distance([a, b], [c, d])
+raw expr       : l1_distance(array(a::Float32 NULL, b::Float32 NULL), array(c::Float32 NULL, d::Float32 NULL))
+checked expr   : l1_distance<Array(Float32 NULL), Array(Float32 NULL)>(array<T0=Float32 NULL><T0, T0>(a, b), array<T0=Float32 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+----------+
+|        | a            | b            | c            | d            | Output   |
++--------+--------------+--------------+--------------+--------------+----------+
+| Type   | Float32 NULL | Float32 NULL | Float32 NULL | Float32 NULL | Float32  |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown  |
+| Row 0  | 1            | 2            | 3            | 4            | 4        |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 4.4      |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 3.400001 |
++--------+--------------+--------------+--------------+--------------+----------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float32([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float32([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float32([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float32([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float32([4, 4.4, 3.400001])                                                |
++--------+----------------------------------------------------------------------------+
+
+
+ast            : l1_distance([a, b], [c, d])
+raw expr       : l1_distance(array(a::Float64, b::Float64), array(c::Float64, d::Float64))
+checked expr   : l1_distance<Array(Float64), Array(Float64)>(array<T0=Float64><T0, T0>(a, b), array<T0=Float64><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+---------+
+|        | a         | b          | c          | d          | Output  |
++--------+-----------+------------+------------+------------+---------+
+| Type   | Float64   | Float64    | Float64    | Float64    | Float64 |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown |
+| Row 0  | 1         | 2          | 3          | 4          | 4       |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 4.4     |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 3.4     |
++--------+-----------+------------+------------+------------+---------+
+evaluation (internal):
++--------+-------------------------+
+| Column | Data                    |
++--------+-------------------------+
+| a      | Float64([1, 5.1, 9.4])  |
+| b      | Float64([2, 6.2, 10.6]) |
+| c      | Float64([3, 7.3, 11.1]) |
+| d      | Float64([4, 8.4, 12.3]) |
+| Output | Float64([4, 4.4, 3.4])  |
++--------+-------------------------+
+
+
+ast            : l1_distance([a, b], [c, d])
+raw expr       : l1_distance(array(a::Float64 NULL, b::Float64 NULL), array(c::Float64 NULL, d::Float64 NULL))
+checked expr   : l1_distance<Array(Float64 NULL), Array(Float64 NULL)>(array<T0=Float64 NULL><T0, T0>(a, b), array<T0=Float64 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+---------+
+|        | a            | b            | c            | d            | Output  |
++--------+--------------+--------------+--------------+--------------+---------+
+| Type   | Float64 NULL | Float64 NULL | Float64 NULL | Float64 NULL | Float64 |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown |
+| Row 0  | 1            | 2            | 3            | 4            | 4       |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 4.4     |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 3.4     |
++--------+--------------+--------------+--------------+--------------+---------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float64([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float64([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float64([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float64([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float64([4, 4.4, 3.4])                                                     |
++--------+----------------------------------------------------------------------------+
+
+
 ast            : l2_distance([1,2,3], [1,2,3])
 raw expr       : l2_distance(array(1, 2, 3), array(1, 2, 3))
 checked expr   : l2_distance<Array(Float32), Array(Float32)>(CAST<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Float32)), CAST<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(1_u8, 2_u8, 3_u8) AS Array(Float32)))
@@ -242,6 +442,106 @@ evaluation (internal):
 | d      | Float32([4, 8.4, 12.3])                |
 | Output | Float32([2.828427, 3.11127, 2.404163]) |
 +--------+----------------------------------------+
+
+
+ast            : l2_distance([a, b], [c, d])
+raw expr       : l2_distance(array(a::Float32, b::Float32), array(c::Float32, d::Float32))
+checked expr   : l2_distance<Array(Float32), Array(Float32)>(array<T0=Float32><T0, T0>(a, b), array<T0=Float32><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+----------+
+|        | a         | b          | c          | d          | Output   |
++--------+-----------+------------+------------+------------+----------+
+| Type   | Float32   | Float32    | Float32    | Float32    | Float32  |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown  |
+| Row 0  | 1         | 2          | 3          | 4          | 2.828427 |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 3.11127  |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 2.404163 |
++--------+-----------+------------+------------+------------+----------+
+evaluation (internal):
++--------+----------------------------------------+
+| Column | Data                                   |
++--------+----------------------------------------+
+| a      | Float32([1, 5.1, 9.4])                 |
+| b      | Float32([2, 6.2, 10.6])                |
+| c      | Float32([3, 7.3, 11.1])                |
+| d      | Float32([4, 8.4, 12.3])                |
+| Output | Float32([2.828427, 3.11127, 2.404163]) |
++--------+----------------------------------------+
+
+
+ast            : l2_distance([a, b], [c, d])
+raw expr       : l2_distance(array(a::Float32 NULL, b::Float32 NULL), array(c::Float32 NULL, d::Float32 NULL))
+checked expr   : l2_distance<Array(Float32 NULL), Array(Float32 NULL)>(array<T0=Float32 NULL><T0, T0>(a, b), array<T0=Float32 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+----------+
+|        | a            | b            | c            | d            | Output   |
++--------+--------------+--------------+--------------+--------------+----------+
+| Type   | Float32 NULL | Float32 NULL | Float32 NULL | Float32 NULL | Float32  |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown  |
+| Row 0  | 1            | 2            | 3            | 4            | 2.828427 |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 3.11127  |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 2.404163 |
++--------+--------------+--------------+--------------+--------------+----------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float32([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float32([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float32([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float32([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float32([2.828427, 3.11127, 2.404163])                                     |
++--------+----------------------------------------------------------------------------+
+
+
+ast            : l2_distance([a, b], [c, d])
+raw expr       : l2_distance(array(a::Float64, b::Float64), array(c::Float64, d::Float64))
+checked expr   : l2_distance<Array(Float64), Array(Float64)>(array<T0=Float64><T0, T0>(a, b), array<T0=Float64><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+--------------+
+|        | a         | b          | c          | d          | Output       |
++--------+-----------+------------+------------+------------+--------------+
+| Type   | Float64   | Float64    | Float64    | Float64    | Float64      |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown      |
+| Row 0  | 1         | 2          | 3          | 4          | 2.8284271247 |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 3.1112698372 |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 2.404163056  |
++--------+-----------+------------+------------+------------+--------------+
+evaluation (internal):
++--------+----------------------------------------------------+
+| Column | Data                                               |
++--------+----------------------------------------------------+
+| a      | Float64([1, 5.1, 9.4])                             |
+| b      | Float64([2, 6.2, 10.6])                            |
+| c      | Float64([3, 7.3, 11.1])                            |
+| d      | Float64([4, 8.4, 12.3])                            |
+| Output | Float64([2.8284271247, 3.1112698372, 2.404163056]) |
++--------+----------------------------------------------------+
+
+
+ast            : l2_distance([a, b], [c, d])
+raw expr       : l2_distance(array(a::Float64 NULL, b::Float64 NULL), array(c::Float64 NULL, d::Float64 NULL))
+checked expr   : l2_distance<Array(Float64 NULL), Array(Float64 NULL)>(array<T0=Float64 NULL><T0, T0>(a, b), array<T0=Float64 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+--------------+
+|        | a            | b            | c            | d            | Output       |
++--------+--------------+--------------+--------------+--------------+--------------+
+| Type   | Float64 NULL | Float64 NULL | Float64 NULL | Float64 NULL | Float64      |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown      |
+| Row 0  | 1            | 2            | 3            | 4            | 2.8284271247 |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 3.1112698372 |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 2.404163056  |
++--------+--------------+--------------+--------------+--------------+--------------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float64([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float64([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float64([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float64([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float64([2.8284271247, 3.1112698372, 2.404163056])                         |
++--------+----------------------------------------------------------------------------+
 
 
 ast            : inner_product([1,0,0], [1,0,0])
@@ -330,6 +630,106 @@ evaluation (internal):
 | d      | Float32([4, 8.4, 12.3])      |
 | Output | Float32([11, 89.31, 234.72]) |
 +--------+------------------------------+
+
+
+ast            : inner_product([a, b], [c, d])
+raw expr       : inner_product(array(a::Float32, b::Float32), array(c::Float32, d::Float32))
+checked expr   : inner_product<Array(Float32), Array(Float32)>(array<T0=Float32><T0, T0>(a, b), array<T0=Float32><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+---------+
+|        | a         | b          | c          | d          | Output  |
++--------+-----------+------------+------------+------------+---------+
+| Type   | Float32   | Float32    | Float32    | Float32    | Float32 |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown |
+| Row 0  | 1         | 2          | 3          | 4          | 11      |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 89.31   |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 234.72  |
++--------+-----------+------------+------------+------------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| a      | Float32([1, 5.1, 9.4])       |
+| b      | Float32([2, 6.2, 10.6])      |
+| c      | Float32([3, 7.3, 11.1])      |
+| d      | Float32([4, 8.4, 12.3])      |
+| Output | Float32([11, 89.31, 234.72]) |
++--------+------------------------------+
+
+
+ast            : inner_product([a, b], [c, d])
+raw expr       : inner_product(array(a::Float32 NULL, b::Float32 NULL), array(c::Float32 NULL, d::Float32 NULL))
+checked expr   : inner_product<Array(Float32 NULL), Array(Float32 NULL)>(array<T0=Float32 NULL><T0, T0>(a, b), array<T0=Float32 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+---------+
+|        | a            | b            | c            | d            | Output  |
++--------+--------------+--------------+--------------+--------------+---------+
+| Type   | Float32 NULL | Float32 NULL | Float32 NULL | Float32 NULL | Float32 |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown |
+| Row 0  | 1            | 2            | 3            | 4            | 11      |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 89.31   |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 234.72  |
++--------+--------------+--------------+--------------+--------------+---------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float32([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float32([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float32([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float32([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float32([11, 89.31, 234.72])                                               |
++--------+----------------------------------------------------------------------------+
+
+
+ast            : inner_product([a, b], [c, d])
+raw expr       : inner_product(array(a::Float64, b::Float64), array(c::Float64, d::Float64))
+checked expr   : inner_product<Array(Float64), Array(Float64)>(array<T0=Float64><T0, T0>(a, b), array<T0=Float64><T0, T0>(c, d))
+evaluation:
++--------+-----------+------------+------------+------------+---------+
+|        | a         | b          | c          | d          | Output  |
++--------+-----------+------------+------------+------------+---------+
+| Type   | Float64   | Float64    | Float64    | Float64    | Float64 |
+| Domain | {1..=9.4} | {2..=10.6} | {3..=11.1} | {4..=12.3} | Unknown |
+| Row 0  | 1         | 2          | 3          | 4          | 11      |
+| Row 1  | 5.1       | 6.2        | 7.3        | 8.4        | 89.31   |
+| Row 2  | 9.4       | 10.6       | 11.1       | 12.3       | 234.72  |
++--------+-----------+------------+------------+------------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| a      | Float64([1, 5.1, 9.4])       |
+| b      | Float64([2, 6.2, 10.6])      |
+| c      | Float64([3, 7.3, 11.1])      |
+| d      | Float64([4, 8.4, 12.3])      |
+| Output | Float64([11, 89.31, 234.72]) |
++--------+------------------------------+
+
+
+ast            : inner_product([a, b], [c, d])
+raw expr       : inner_product(array(a::Float64 NULL, b::Float64 NULL), array(c::Float64 NULL, d::Float64 NULL))
+checked expr   : inner_product<Array(Float64 NULL), Array(Float64 NULL)>(array<T0=Float64 NULL><T0, T0>(a, b), array<T0=Float64 NULL><T0, T0>(c, d))
+evaluation:
++--------+--------------+--------------+--------------+--------------+---------+
+|        | a            | b            | c            | d            | Output  |
++--------+--------------+--------------+--------------+--------------+---------+
+| Type   | Float64 NULL | Float64 NULL | Float64 NULL | Float64 NULL | Float64 |
+| Domain | {1..=9.4}    | {2..=10.6}   | {3..=11.1}   | {4..=12.3}   | Unknown |
+| Row 0  | 1            | 2            | 3            | 4            | 11      |
+| Row 1  | 5.1          | 6.2          | 7.3          | 8.4          | 89.31   |
+| Row 2  | 9.4          | 10.6         | 11.1         | 12.3         | 234.72  |
++--------+--------------+--------------+--------------+--------------+---------+
+evaluation (internal):
++--------+----------------------------------------------------------------------------+
+| Column | Data                                                                       |
++--------+----------------------------------------------------------------------------+
+| a      | NullableColumn { column: Float64([1, 5.1, 9.4]), validity: [0b_____111] }  |
+| b      | NullableColumn { column: Float64([2, 6.2, 10.6]), validity: [0b_____111] } |
+| c      | NullableColumn { column: Float64([3, 7.3, 11.1]), validity: [0b_____111] } |
+| d      | NullableColumn { column: Float64([4, 8.4, 12.3]), validity: [0b_____111] } |
+| Output | Float64([11, 89.31, 234.72])                                               |
++--------+----------------------------------------------------------------------------+
 
 
 ast            : vector_dims([1,-2]::vector(2))

--- a/src/query/functions/tests/it/scalars/vector.rs
+++ b/src/query/functions/tests/it/scalars/vector.rs
@@ -63,6 +63,54 @@ fn test_vector_cosine_distance(file: &mut impl Write) {
             ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
         ],
     );
+    run_ast(file, "cosine_distance([a, b], [c, d])", &[
+        ("a", Float32Type::from_data(vec![1.0f32, 5.1, 9.4])),
+        ("b", Float32Type::from_data(vec![2.0f32, 6.2, 10.6])),
+        ("c", Float32Type::from_data(vec![3.0f32, 7.3, 11.1])),
+        ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
+    ]);
+    run_ast(file, "cosine_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float32Type::from_data_with_validity(vec![1.0f32, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float32Type::from_data_with_validity(vec![2.0f32, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float32Type::from_data_with_validity(vec![3.0f32, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float32Type::from_data_with_validity(vec![4.0f32, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
+    run_ast(file, "cosine_distance([a, b], [c, d])", &[
+        ("a", Float64Type::from_data(vec![1.0f64, 5.1, 9.4])),
+        ("b", Float64Type::from_data(vec![2.0f64, 6.2, 10.6])),
+        ("c", Float64Type::from_data(vec![3.0f64, 7.3, 11.1])),
+        ("d", Float64Type::from_data(vec![4.0f64, 8.4, 12.3])),
+    ]);
+    run_ast(file, "cosine_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float64Type::from_data_with_validity(vec![1.0f64, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float64Type::from_data_with_validity(vec![2.0f64, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float64Type::from_data_with_validity(vec![3.0f64, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float64Type::from_data_with_validity(vec![4.0f64, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
 }
 
 fn test_vector_l1_distance(file: &mut impl Write) {
@@ -90,6 +138,54 @@ fn test_vector_l1_distance(file: &mut impl Write) {
             ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
         ],
     );
+    run_ast(file, "l1_distance([a, b], [c, d])", &[
+        ("a", Float32Type::from_data(vec![1.0f32, 5.1, 9.4])),
+        ("b", Float32Type::from_data(vec![2.0f32, 6.2, 10.6])),
+        ("c", Float32Type::from_data(vec![3.0f32, 7.3, 11.1])),
+        ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
+    ]);
+    run_ast(file, "l1_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float32Type::from_data_with_validity(vec![1.0f32, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float32Type::from_data_with_validity(vec![2.0f32, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float32Type::from_data_with_validity(vec![3.0f32, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float32Type::from_data_with_validity(vec![4.0f32, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
+    run_ast(file, "l1_distance([a, b], [c, d])", &[
+        ("a", Float64Type::from_data(vec![1.0f64, 5.1, 9.4])),
+        ("b", Float64Type::from_data(vec![2.0f64, 6.2, 10.6])),
+        ("c", Float64Type::from_data(vec![3.0f64, 7.3, 11.1])),
+        ("d", Float64Type::from_data(vec![4.0f64, 8.4, 12.3])),
+    ]);
+    run_ast(file, "l1_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float64Type::from_data_with_validity(vec![1.0f64, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float64Type::from_data_with_validity(vec![2.0f64, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float64Type::from_data_with_validity(vec![3.0f64, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float64Type::from_data_with_validity(vec![4.0f64, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
 }
 
 fn test_vector_l2_distance(file: &mut impl Write) {
@@ -117,6 +213,54 @@ fn test_vector_l2_distance(file: &mut impl Write) {
             ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
         ],
     );
+    run_ast(file, "l2_distance([a, b], [c, d])", &[
+        ("a", Float32Type::from_data(vec![1.0f32, 5.1, 9.4])),
+        ("b", Float32Type::from_data(vec![2.0f32, 6.2, 10.6])),
+        ("c", Float32Type::from_data(vec![3.0f32, 7.3, 11.1])),
+        ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
+    ]);
+    run_ast(file, "l2_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float32Type::from_data_with_validity(vec![1.0f32, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float32Type::from_data_with_validity(vec![2.0f32, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float32Type::from_data_with_validity(vec![3.0f32, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float32Type::from_data_with_validity(vec![4.0f32, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
+    run_ast(file, "l2_distance([a, b], [c, d])", &[
+        ("a", Float64Type::from_data(vec![1.0f64, 5.1, 9.4])),
+        ("b", Float64Type::from_data(vec![2.0f64, 6.2, 10.6])),
+        ("c", Float64Type::from_data(vec![3.0f64, 7.3, 11.1])),
+        ("d", Float64Type::from_data(vec![4.0f64, 8.4, 12.3])),
+    ]);
+    run_ast(file, "l2_distance([a, b], [c, d])", &[
+        (
+            "a",
+            Float64Type::from_data_with_validity(vec![1.0f64, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float64Type::from_data_with_validity(vec![2.0f64, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float64Type::from_data_with_validity(vec![3.0f64, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float64Type::from_data_with_validity(vec![4.0f64, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
 }
 
 fn test_vector_inner_product(file: &mut impl Write) {
@@ -149,6 +293,54 @@ fn test_vector_inner_product(file: &mut impl Write) {
             ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
         ],
     );
+    run_ast(file, "inner_product([a, b], [c, d])", &[
+        ("a", Float32Type::from_data(vec![1.0f32, 5.1, 9.4])),
+        ("b", Float32Type::from_data(vec![2.0f32, 6.2, 10.6])),
+        ("c", Float32Type::from_data(vec![3.0f32, 7.3, 11.1])),
+        ("d", Float32Type::from_data(vec![4.0f32, 8.4, 12.3])),
+    ]);
+    run_ast(file, "inner_product([a, b], [c, d])", &[
+        (
+            "a",
+            Float32Type::from_data_with_validity(vec![1.0f32, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float32Type::from_data_with_validity(vec![2.0f32, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float32Type::from_data_with_validity(vec![3.0f32, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float32Type::from_data_with_validity(vec![4.0f32, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
+    run_ast(file, "inner_product([a, b], [c, d])", &[
+        ("a", Float64Type::from_data(vec![1.0f64, 5.1, 9.4])),
+        ("b", Float64Type::from_data(vec![2.0f64, 6.2, 10.6])),
+        ("c", Float64Type::from_data(vec![3.0f64, 7.3, 11.1])),
+        ("d", Float64Type::from_data(vec![4.0f64, 8.4, 12.3])),
+    ]);
+    run_ast(file, "inner_product([a, b], [c, d])", &[
+        (
+            "a",
+            Float64Type::from_data_with_validity(vec![1.0f64, 5.1, 9.4], vec![true, true, true]),
+        ),
+        (
+            "b",
+            Float64Type::from_data_with_validity(vec![2.0f64, 6.2, 10.6], vec![true, true, true]),
+        ),
+        (
+            "c",
+            Float64Type::from_data_with_validity(vec![3.0f64, 7.3, 11.1], vec![true, true, true]),
+        ),
+        (
+            "d",
+            Float64Type::from_data_with_validity(vec![4.0f64, 8.4, 12.3], vec![true, true, true]),
+        ),
+    ]);
 }
 
 fn test_vector_vector_dims(file: &mut impl Write) {

--- a/tests/sqllogictests/suites/query/functions/02_0063_function_vector.test
+++ b/tests/sqllogictests/suites/query/functions/02_0063_function_vector.test
@@ -59,6 +59,14 @@ select inner_product([1.1,2.2,3]::vector(3), [1,1,1]::vector(3)), inner_product(
 ----
 6.3 41.2
 
+query FFFF
+SELECT COSINE_DISTANCE(parse_json('[0.1,0.2,0.3]')::ARRAY(FLOAT NULL), CAST([0.4,0.5,0.6], ARRAY(FLOAT NULL))),
+       L1_DISTANCE(parse_json('[0.1,0.2,0.3]')::ARRAY(FLOAT NULL), CAST([0.4,0.5,0.6], ARRAY(FLOAT NULL))),
+       L2_DISTANCE(parse_json('[0.1,0.2,0.3]')::ARRAY(FLOAT NULL), CAST([0.4,0.5,0.6], ARRAY(FLOAT NULL))),
+       INNER_PRODUCT(parse_json('[0.1,0.2,0.3]')::ARRAY(FLOAT NULL), CAST([0.4,0.5,0.6], ARRAY(FLOAT NULL)));
+----
+0.025368273 0.90000004 0.51961523 0.32
+
 statement ok
 CREATE OR REPLACE TABLE vectors (a VECTOR(3), b VECTOR(3));
 
@@ -83,3 +91,4 @@ NULL NULL
 
 statement ok
 DROP TABLE vectors;
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fix vector distance function can not accept array nullable types

- fixes: #17990

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
