### PR TITLE
fix: unload to zip support file larger than 4GB.

### DIFF
--- a/src/common/compress/src/encode.rs
+++ b/src/common/compress/src/encode.rs
@@ -192,6 +192,7 @@ impl CompressCodec {
         let mut zip = ZipWriter::new(&mut cursor);
         let options: FileOptions<()> = FileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated)
+            .large_file(to_compress.len() as u64 >= u32::MAX as u64)
             .unix_permissions(0o644);
 
         // zip for archive files


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix https://github.com/databendlabs/databend/issues/18484

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - the test require 4GB server memory and takes long to run (6 min locally, longer in CI)


<img width="1790" height="257" alt="image" src="https://github.com/user-attachments/assets/27e3b8f7-e40b-4bea-a50f-afb5cd706f03" />

the SQL can reproduce the bug, and passed after this pr.


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18485)
<!-- Reviewable:end -->
