### PR TITLE
fix(query): fix update set with udf and filter

### DIFF
--- a/tests/sqllogictests/suites/udf_server/udf_server_test.test
+++ b/tests/sqllogictests/suites/udf_server/udf_server_test.test
@@ -579,6 +579,19 @@ SELECT * FROM test_update_udf;
 databend.com 12
 databend.cn 11
 
+statement ok
+INSERT INTO test_update_udf (url) VALUES('databend.com'),('databend.cn');
+
+statement ok
+UPDATE test_update_udf SET length = url_len(url) WHERE length IS NULL;
+
+query TI
+SELECT * FROM test_update_udf ORDER BY url;
+----
+databend.cn 11
+databend.cn 11
+databend.com 12
+databend.com 12
 
 statement ok
 CREATE OR REPLACE TABLE test_update_udf_1(url STRING, a INT64,b INT64,c INT64);
@@ -632,19 +645,13 @@ SELECT embedding_4('databend.com')::vector(4);
 ----
 [1.1,1.2,1.3,1.4]
 
-statement ok
-CREATE OR REPLACE TABLE test(url STRING, length INT64);
-
-statement ok
-INSERT INTO test (url) VALUES('databend.com'),('databend.cn');
-
 query T
-SELECT embedding_4('databend.com')::vector(4) fro
+SELECT embedding_4('databend.com')::vector(4)
 ----
 [1.1,1.2,1.3,1.4]
 
 query T
-SELECT embedding_4(url)::vector(4) FROM test;
+SELECT embedding_4(url)::vector(4) FROM test_update_udf_1;
 ----
 [1.1,1.2,1.3,1.4]
 [1.1,1.2,1.3,1.4]
@@ -672,4 +679,5 @@ query I
 select sum((value::Int)::Int) from system.metrics where metric = 'external_running_requests_total';
 ----
 0
+
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fix the bug when executing the udf function for update with WHERE filter condition

```sql
CREATE OR REPLACE FUNCTION url_len (VARCHAR) RETURNS BIGINT LANGUAGE python IMMUTABLE HANDLER = 'url_len' ADDRESS = 'http://0.0.0.0:8815';
CREATE OR REPLACE TABLE test(url STRING, length INT64);
INSERT INTO test (url) VALUES('databend.com'),('databend.cn');
UPDATE test SET length = url_len(url) WHERE length IS NULL;
error: APIError: QueryFailed: [1001]The number of columns in the data block does not match the number of fields in the table schema, block_columns: 3, table_schema_fields: 2
```

- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18487)
<!-- Reviewable:end -->
