### PR TITLE
refactor: polish handling of fail in transaction

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -748,7 +748,7 @@ impl HttpQuery {
         );
 
         if is_stopped
-            && txn_state != TxnState::AutoCommit
+            && txn_state == TxnState::Active
             && !self.is_txn_mgr_saved.load(Ordering::Relaxed)
             && self
                 .is_txn_mgr_saved
@@ -764,7 +764,7 @@ impl HttpQuery {
                 .await;
         }
 
-        let need_sticky = txn_state != TxnState::AutoCommit || has_temp_table;
+        let need_sticky = txn_state == TxnState::Active || has_temp_table;
         let need_keep_alive = need_sticky;
 
         Ok(HttpSessionConf {

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -101,8 +101,14 @@ impl HttpQueryRequest {
             } else {
                 s.txn_state.clone()
             };
+            let need_sticky = match &s.internal {
+                Some(internal) => internal.has_temp_table,
+                None => false,
+            };
             HttpSessionConf {
                 txn_state,
+                need_sticky,
+                need_keep_alive: need_sticky,
                 ..s.clone()
             }
         });

--- a/src/query/storages/common/session/src/transaction.rs
+++ b/src/query/storages/common/session/src/transaction.rs
@@ -167,7 +167,7 @@ impl TxnManager {
 
     pub fn set_fail(&mut self) {
         if let TxnState::Active = self.state {
-            self.state = TxnState::Fail;
+            self.force_set_fail()
         }
     }
 
@@ -177,6 +177,8 @@ impl TxnManager {
 
     pub fn force_set_fail(&mut self) {
         self.state = TxnState::Fail;
+        self.txn_buffer.clear();
+        // keep the txn_id until commit/abort for tracing
     }
 
     pub fn is_fail(&self) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

when execution fails, do the following at once, instead of waiting for commit/abort:

1.  release buffer memory
2. session leave the state of `sticky` 


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18497)
<!-- Reviewable:end -->
