### PR TITLE
feat(query): support create or replace role

### DIFF
--- a/.github/actions/test_compat_fuse/action.yml
+++ b/.github/actions/test_compat_fuse/action.yml
@@ -13,12 +13,11 @@ runs:
       run: |
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.46   --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  base
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.241  --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  revoke
-          bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.306  --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  rbac
-          bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.307  --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  rbac
+          bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.311  --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  rbac
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.318  --reader-version  current  --meta-versions  1.2.527  1.2.677  --logictest-path  rbac
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  1.2.680  --reader-version  current  --meta-versions  1.2.527  1.2.680  --logictest-path  udf
 
-          bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  current  --reader-version  1.2.307  --meta-versions  1.2.677           --logictest-path  rbac
+          bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  current  --reader-version  1.2.311  --meta-versions  1.2.677           --logictest-path  rbac
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  current  --reader-version  1.2.318  --meta-versions  1.2.677           --logictest-path  rbac
           bash ./tests/compat_fuse/test_compat_fuse.sh  --writer-version  current  --reader-version  1.2.680  --meta-versions  1.2.680           --logictest-path  udf
     - name: Upload failure

--- a/src/meta/app/src/principal/mod.rs
+++ b/src/meta/app/src/principal/mod.rs
@@ -83,6 +83,7 @@ pub use procedure_id_ident::ProcedureId;
 pub use procedure_id_to_name::ProcedureIdToNameIdent;
 pub use procedure_identity::ProcedureIdentity;
 pub use procedure_name_ident::ProcedureNameIdent;
+pub use role_ident::Resource;
 pub use role_ident::RoleIdent;
 pub use role_ident::RoleIdentRaw;
 pub use role_info::RoleInfo;

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -244,7 +244,7 @@ pub enum Statement {
         show_options: Option<ShowOptions>,
     },
     CreateRole {
-        if_not_exists: bool,
+        create_option: CreateOption,
         role_name: String,
     },
     DropRole {
@@ -875,11 +875,15 @@ impl Display for Statement {
                 write!(f, " {}", user)?;
             }
             Statement::CreateRole {
-                if_not_exists,
+                create_option,
                 role_name: role,
             } => {
-                write!(f, "CREATE ROLE")?;
-                if *if_not_exists {
+                write!(f, "CREATE")?;
+                if let CreateOption::CreateOrReplace = create_option {
+                    write!(f, " OR REPLACE")?;
+                }
+                write!(f, " ROLE")?;
+                if let CreateOption::CreateIfNotExists = create_option {
                     write!(f, " IF NOT EXISTS")?;
                 }
                 write!(f, " {}", QuotedString(role, '\''))?;

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -13055,7 +13055,7 @@ create role test
 CREATE ROLE 'test'
 ---------- AST ------------
 CreateRole {
-    if_not_exists: false,
+    create_option: Create,
     role_name: "test",
 }
 
@@ -13066,7 +13066,7 @@ create role 'test'
 CREATE ROLE 'test'
 ---------- AST ------------
 CreateRole {
-    if_not_exists: false,
+    create_option: Create,
     role_name: "test",
 }
 

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -22,7 +22,7 @@ use databend_common_meta_types::SeqV;
 
 #[async_trait::async_trait]
 pub trait RoleApi: Sync + Send {
-    async fn add_role(&self, role_info: RoleInfo) -> Result<u64>;
+    async fn add_role(&self, role_info: RoleInfo, can_replace: bool) -> Result<()>;
 
     #[allow(clippy::ptr_arg)]
     async fn get_role(&self, role: &String, seq: MatchSeq) -> Result<SeqV<RoleInfo>>;

--- a/src/query/management/src/role/role_api.rs
+++ b/src/query/management/src/role/role_api.rs
@@ -13,16 +13,23 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
+use databend_common_meta_app::principal::role_ident;
 use databend_common_meta_app::principal::OwnershipInfo;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::RoleInfo;
+use databend_common_meta_app::tenant_key::errors::ExistError;
 use databend_common_meta_kvapi::kvapi::ListKVReply;
 use databend_common_meta_types::MatchSeq;
+use databend_common_meta_types::MetaError;
 use databend_common_meta_types::SeqV;
 
 #[async_trait::async_trait]
 pub trait RoleApi: Sync + Send {
-    async fn add_role(&self, role_info: RoleInfo, can_replace: bool) -> Result<()>;
+    async fn add_role(
+        &self,
+        role_info: RoleInfo,
+        can_replace: bool,
+    ) -> std::result::Result<std::result::Result<(), ExistError<role_ident::Resource>>, MetaError>;
 
     #[allow(clippy::ptr_arg)]
     async fn get_role(&self, role: &String, seq: MatchSeq) -> Result<SeqV<RoleInfo>>;

--- a/src/query/service/src/interpreters/interpreter_role_create.rs
+++ b/src/query/service/src/interpreters/interpreter_role_create.rs
@@ -70,7 +70,7 @@ impl Interpreter for CreateRoleInterpreter {
         let tenant = self.ctx.get_tenant();
         let user_mgr = UserApiProvider::instance();
         user_mgr
-            .add_role(&tenant, RoleInfo::new(&role_name), plan.if_not_exists)
+            .add_role(&tenant, RoleInfo::new(&role_name), &plan.create_option)
             .await?;
         RoleCacheManager::instance().force_reload(&tenant).await?;
         Ok(PipelineBuildResult::create())

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -26,6 +26,7 @@ use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateOption::Create;
+use databend_common_meta_app::schema::CreateOption::CreateIfNotExists;
 use databend_common_meta_app::schema::CreateOption::CreateOrReplace;
 use databend_common_meta_app::storage::StorageFsConfig;
 use databend_common_meta_app::storage::StorageParams;
@@ -394,6 +395,15 @@ async fn test_roles_table() -> Result<()> {
             .add_role(&tenant, role_info, &Create)
             .await?;
     }
+
+    {
+        let mut role_info = RoleInfo::new("test1");
+        role_info.grants.grant_role("t2".to_string());
+        UserApiProvider::instance()
+            .add_role(&tenant, role_info, &CreateIfNotExists)
+            .await?;
+    }
+
     let table = RolesTable::create(1);
     let source_plan = table
         .read_plan(ctx.clone(), None, None, false, true)

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -25,6 +25,8 @@ use databend_common_meta_app::principal::AuthType;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserInfo;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::schema::CreateOption::Create;
+use databend_common_meta_app::schema::CreateOption::CreateOrReplace;
 use databend_common_meta_app::storage::StorageFsConfig;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::storage::StorageS3Config;
@@ -381,7 +383,7 @@ async fn test_roles_table() -> Result<()> {
     {
         let role_info = RoleInfo::new("test");
         UserApiProvider::instance()
-            .add_role(&tenant, role_info, false)
+            .add_role(&tenant, role_info, &CreateOrReplace)
             .await?;
     }
 
@@ -389,7 +391,7 @@ async fn test_roles_table() -> Result<()> {
         let mut role_info = RoleInfo::new("test1");
         role_info.grants.grant_role("test".to_string());
         UserApiProvider::instance()
-            .add_role(&tenant, role_info, false)
+            .add_role(&tenant, role_info, &Create)
             .await?;
     }
     let table = RolesTable::create(1);

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -388,7 +388,7 @@ impl Binder {
                 self.bind_show_roles(bind_context, show_options).await?
             }
             Statement::CreateRole {
-                if_not_exists,
+                create_option,
                 role_name,
             } => {
                 if illegal_ident_name(role_name) {
@@ -397,7 +397,7 @@ impl Binder {
                     ));
                 }
                 Plan::CreateRole(Box::new(CreateRolePlan {
-                    if_not_exists: *if_not_exists,
+                    create_option: create_option.clone().into(),
                     role_name: role_name.to_string(),
                 }))
             }

--- a/src/query/sql/src/planner/plans/ddl/account.rs
+++ b/src/query/sql/src/planner/plans/ddl/account.rs
@@ -88,7 +88,7 @@ impl DescUserPlan {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateRolePlan {
-    pub if_not_exists: bool,
+    pub create_option: CreateOption,
     pub role_name: String,
 }
 

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -126,9 +126,15 @@ impl UserApiProvider {
     ) -> Result<()> {
         let can_replace = matches!(create_option, CreateOption::CreateOrReplace);
         let client = self.role_api(tenant);
+        let name = role_info.identity().to_string();
         if let Err(_e) = client.add_role(role_info, can_replace).await? {
             if matches!(create_option, CreateOption::CreateIfNotExists) {
                 return Ok(());
+            } else {
+                return Err(ErrorCode::RoleAlreadyExists(format!(
+                    "Role {} already exists",
+                    name
+                )));
             }
         }
         return Ok(());

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -22,6 +22,7 @@ use databend_common_meta_app::principal::OwnershipInfo;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserPrivilegeSet;
+use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MatchSeq;
 
@@ -121,24 +122,21 @@ impl UserApiProvider {
         &self,
         tenant: &Tenant,
         role_info: RoleInfo,
-        if_not_exists: bool,
-    ) -> Result<u64> {
-        if if_not_exists && self.exists_role(tenant, role_info.name.clone()).await? {
-            return Ok(0);
-        }
-
-        let client = self.role_api(tenant);
-        let add_role = client.add_role(role_info);
-        match add_role.await {
-            Ok(res) => Ok(res),
-            Err(e) => {
-                if if_not_exists && e.code() == ErrorCode::ROLE_ALREADY_EXISTS {
-                    Ok(0)
-                } else {
-                    Err(e.add_message_back("(while add role)"))
-                }
+        create_option: &CreateOption,
+    ) -> Result<()> {
+        if let CreateOption::CreateIfNotExists = create_option {
+            if self.exists_role(tenant, role_info.name.clone()).await? {
+                return Ok(());
             }
         }
+
+        let can_replace = matches!(create_option, CreateOption::CreateOrReplace);
+
+        let client = self.role_api(tenant);
+        client
+            .add_role(role_info, can_replace)
+            .await
+            .map_err(|e| e.add_message_back("(while add role)"))
     }
 
     #[async_backtrace::framed]

--- a/src/query/users/src/user_api.rs
+++ b/src/query/users/src/user_api.rs
@@ -42,6 +42,7 @@ use databend_common_management::UserMgr;
 use databend_common_meta_app::principal::AuthInfo;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserDefinedFunction;
+use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_app::tenant::TenantQuota;
 use databend_common_meta_cache::Cache;
@@ -135,7 +136,9 @@ impl UserApiProvider {
         // We can add account_admin into meta.
         {
             let public = RoleInfo::new(BUILTIN_ROLE_PUBLIC);
-            user_mgr.add_role(tenant, public, true).await?;
+            user_mgr
+                .add_role(tenant, public, &CreateOption::CreateIfNotExists)
+                .await?;
         }
 
         Ok(Arc::new(user_mgr))

--- a/src/query/users/tests/it/role_cache_mgr.rs
+++ b/src/query/users/tests/it/role_cache_mgr.rs
@@ -23,6 +23,7 @@ use databend_common_grpc::RpcClientConf;
 use databend_common_meta_app::principal::GrantObject;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserPrivilegeSet;
+use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::role_util::find_all_related_roles;
 use databend_common_users::RoleCacheManager;
@@ -51,7 +52,9 @@ async fn test_role_cache_mgr() -> Result<()> {
         &GrantObject::Database(CATALOG_DEFAULT.to_owned(), "db1".to_string()),
         UserPrivilegeSet::available_privileges_on_database(false),
     );
-    user_manager.add_role(&tenant, role1, false).await?;
+    user_manager
+        .add_role(&tenant, role1, &CreateOption::CreateOrReplace)
+        .await?;
 
     let mut roles = role_cache_manager
         .find_related_roles(&tenant, &["role1".to_string()])

--- a/src/query/users/tests/it/role_mgr.rs
+++ b/src/query/users/tests/it/role_mgr.rs
@@ -22,6 +22,9 @@ use databend_common_meta_app::principal::GrantObject;
 use databend_common_meta_app::principal::RoleInfo;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
+use databend_common_meta_app::schema::CreateOption::Create;
+use databend_common_meta_app::schema::CreateOption::CreateIfNotExists;
+use databend_common_meta_app::schema::CreateOption::CreateOrReplace;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::UserApiProvider;
 use pretty_assertions::assert_eq;
@@ -46,13 +49,15 @@ async fn test_role_manager() -> Result<()> {
     // add role
     {
         let role_info = RoleInfo::new(&role_name);
-        role_mgr.add_role(&tenant, role_info, false).await?;
+        role_mgr
+            .add_role(&tenant, role_info, &CreateOrReplace)
+            .await?;
     }
 
     // add role again, error
     {
         let role_info = RoleInfo::new(&role_name);
-        let res = role_mgr.add_role(&tenant, role_info, false).await;
+        let res = role_mgr.add_role(&tenant, role_info, &Create).await;
         assert!(res.is_err());
         assert_eq!(res.err().unwrap().code(), ErrorCode::ROLE_ALREADY_EXISTS,);
     }
@@ -60,7 +65,9 @@ async fn test_role_manager() -> Result<()> {
     // add role
     {
         let role_info = RoleInfo::new(&role_name);
-        role_mgr.add_role(&tenant, role_info, true).await?;
+        role_mgr
+            .add_role(&tenant, role_info, &CreateIfNotExists)
+            .await?;
     }
 
     // get role

--- a/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
@@ -23,10 +23,7 @@ statement ok
 CREATE ROLE IF NOT EXISTS `test-a`
 
 statement ok
-DROP ROLE `test-a`
-
-statement ok
-CREATE ROLE IF NOT EXISTS `test-a`
+CREATE or replace ROLE `test-a`
 
 statement ok
 DROP ROLE `test-a`
@@ -49,3 +46,28 @@ create role 'a"a'
 
 statement error 1005
 create role "a'a"
+
+statement ok
+drop role if exists r1;
+
+statement ok
+create role r1;
+
+statement ok
+grant select on *.* to role r1;
+
+query T
+show grants for role r1;
+----
+SELECT *.* NULL ROLE r1 GRANT SELECT ON *.* TO ROLE `r1`
+
+statement ok
+create or replace role r1;
+
+query T
+SELECT count() FROM show_grants('role', 'r1')
+----
+0
+
+statement ok
+drop role r1;

--- a/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0014_ddl_create_role.test
@@ -61,6 +61,25 @@ show grants for role r1;
 ----
 SELECT *.* NULL ROLE r1 GRANT SELECT ON *.* TO ROLE `r1`
 
+## not replace return ok
+statement ok
+create role if not exists r1;
+
+query T
+show grants for role r1;
+----
+SELECT *.* NULL ROLE r1 GRANT SELECT ON *.* TO ROLE `r1`
+
+## not replace return error
+statement error 2216
+CREATE ROLE r1
+
+query T
+show grants for role r1;
+----
+SELECT *.* NULL ROLE r1 GRANT SELECT ON *.* TO ROLE `r1`
+
+## replace return ok
 statement ok
 create or replace role r1;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

support CREATE [ OR REPLACE ] <role_name>

```sql

statement ok
create role r1;

statement ok
grant select on *.* to role r1;

query T
show grants for role r1;
----
SELECT *.* NULL ROLE r1 GRANT SELECT ON *.* TO ROLE `r1`

statement ok
create or replace role r1;

query T
SELECT count() FROM show_grants('role', 'r1')
----
0
```
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

Note:

delete 306 307 and add 311 rbac compat test
    
    In ths pr add replace role, and it's based on PB.
    
    In 306/307(Before version-311) role is serde_json not support PB.


- fixes: #18499

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change :
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18500)
<!-- Reviewable:end -->
