### PR TITLE
fix: improve error handling in history table

### DIFF
--- a/src/common/tracing/src/predefined_tables/history_tables.toml
+++ b/src/common/tracing/src/predefined_tables/history_tables.toml
@@ -3,7 +3,7 @@
 name = "log_history"
 target = ""
 create = "CREATE TABLE IF NOT EXISTS system_history.log_history (timestamp TIMESTAMP NULL, path STRING NULL, target STRING NULL, log_level STRING NULL, cluster_id STRING NULL, node_id STRING NULL, warehouse_id STRING NULL, query_id STRING NULL, message STRING NULL, fields VARIANT NULL, batch_number Int64) CLUSTER BY LINEAR(timestamp, query_id)"
-transform = "settings (timezone='Etc/UTC') COPY INTO system_history.log_history FROM (SELECT timestamp, path, target, log_level, cluster_id,node_id, warehouse_id, query_id, message, fields, {batch_number} FROM @{stage_name}) file_format = (TYPE = PARQUET) PURGE = TRUE"
+transform = "settings (timezone='Etc/UTC') COPY INTO system_history.log_history FROM (SELECT timestamp, path, target, log_level, cluster_id,node_id, warehouse_id, query_id, message, fields, {batch_number} FROM @{stage_name}) file_format = (TYPE = PARQUET) PURGE = TRUE MAX_FILES = 5000"
 delete = "DELETE FROM system_history.log_history WHERE timestamp < subtract_hours(NOW(), {retention_hours})"
 
 [[tables]]

--- a/src/query/service/src/history_tables/global_history_log.rs
+++ b/src/query/service/src/history_tables/global_history_log.rs
@@ -178,7 +178,8 @@ impl GlobalHistoryLog {
                             if is_temp_error(&e) {
                                 // If the error is temporary, we will retry with exponential backoff
                                 // The max backoff time is 10 minutes
-                                let backoff_second = min(2u64.pow(temp_error_cnt), 10 * 60);
+                                let backoff_second =
+                                    min(2u64.saturating_pow(temp_error_cnt), 10 * 60);
                                 temp_error_cnt += 1;
                                 warn!(
                                     "[HISTORY-TABLES] {} log transform failed with temporary error {}, count {}, next retry in {} seconds",

--- a/src/query/service/src/history_tables/global_history_log.rs
+++ b/src/query/service/src/history_tables/global_history_log.rs
@@ -198,6 +198,7 @@ impl GlobalHistoryLog {
                                     );
                                     return;
                                 }
+                                sleep(sleep_time).await;
                             }
                         }
                     }

--- a/src/query/service/src/history_tables/global_history_log.rs
+++ b/src/query/service/src/history_tables/global_history_log.rs
@@ -46,6 +46,7 @@ use futures_util::future::join_all;
 use futures_util::TryStreamExt;
 use log::error;
 use log::info;
+use log::warn;
 use opendal::raw::normalize_root;
 use parking_lot::Mutex;
 use rand::random;
@@ -161,30 +162,42 @@ impl GlobalHistoryLog {
             let meta_key = format!("{}/history_log_transform", self.tenant_id).clone();
             let log = GlobalHistoryLog::instance();
             let handle = spawn(async move {
-                let mut consecutive_error = 0;
+                let mut persistent_error_cnt = 0;
+                let mut temp_error_cnt = 0;
                 loop {
                     match log.transform(&table_clone, &meta_key).await {
                         Ok(acquired_lock) => {
                             if acquired_lock {
-                                consecutive_error = 0;
+                                persistent_error_cnt = 0;
+                                temp_error_cnt = 0;
                             }
+                            sleep(sleep_time).await;
                         }
                         Err(e) => {
                             error!(
-                                "[HISTORY-TABLES] {} log transform failed due to {}, retry {}",
-                                table_clone.name, e, consecutive_error
+                                "[HISTORY-TABLES] {} log transform failed with persistent error {}, retry count {}",
+                                table_clone.name, e, persistent_error_cnt
                             );
-                            consecutive_error += 1;
-                            if consecutive_error > 3 {
-                                error!(
-                                    "[HISTORY-TABLES] {} log transform failed too many times, exit",
-                                    table_clone.name
+                            if is_temp_error(&e) {
+                                let backoff_second = 2u64.pow(temp_error_cnt);
+                                temp_error_cnt += 1;
+                                warn!(
+                                    "[HISTORY-TABLES] {} log transform failed with temporary error {}, next retry in {} seconds",
+                                    table_clone.name, e, temp_error_cnt
                                 );
-                                break;
+                                sleep(Duration::from_secs(backoff_second)).await;
+                            } else {
+                                persistent_error_cnt += 1;
+                                if persistent_error_cnt > 3 {
+                                    error!(
+                                        "[HISTORY-TABLES] {} log transform failed too many times, giving up",
+                                        table_clone.name
+                                    );
+                                    return;
+                                }
                             }
                         }
                     }
-                    sleep(sleep_time).await;
                 }
             });
             handles.push(handle);
@@ -432,4 +445,23 @@ pub async fn setup_operator(params: &Option<StorageParams>) -> Result<()> {
     };
     GlobalLogger::instance().set_operator(op).await;
     Ok(())
+}
+
+/// Check if the error is a temporary error,
+/// We will use this to determine if we should retry the operation.
+fn is_temp_error(e: &ErrorCode) -> bool {
+    let code = e.code();
+    let message = e.message();
+    // Storage and I/O errors are considered temporary errors
+    let storage = code == ErrorCode::STORAGE_NOT_FOUND
+        || code == ErrorCode::STORAGE_PERMISSION_DENIED
+        || code == ErrorCode::STORAGE_UNAVAILABLE
+        || code == ErrorCode::STORAGE_UNSUPPORTED
+        || code == ErrorCode::STORAGE_INSECURE
+        || code == ErrorCode::INVALID_OPERATION
+        || code == ErrorCode::STORAGE_OTHER;
+    // If acquire semaphore failed, we consider it a temporary error
+    let meta = code == ErrorCode::INTERNAL && message.contains("acquire semaphore failed");
+    let transaction = code == ErrorCode::UNRESOLVABLE_CONFLICT;
+    storage || transaction || meta
 }

--- a/src/query/service/src/history_tables/meta.rs
+++ b/src/query/service/src/history_tables/meta.rs
@@ -90,7 +90,7 @@ impl HistoryMetaHandle {
             Duration::from_secs(3),
         ))
         .await
-        .map_err(|_e| "acquire semaphore failed from GlobalHistoryLog")?;
+        .map_err(|e| format!("acquire semaphore failed from GlobalHistoryLog {}", e))?;
         if interval == 0 {
             return Ok(Some(acquired_guard));
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

**fix: improve error handling in history table**

As a logging service, the history table should avoid exiting on recoverable errors. For issues such as storage being full or temporary network problems with storage, the system should keep retrying until the external service is healthy again.

**fix: `COPY INTO` should with `MAX_FILES` copy option**

If a lot of intermediate logging files stored in stage, the `COPY INTO` operation should enable a `MAX_FILES` option to avoid error: `Commit limit reached: 15,000 files for 'copy into table'`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18504)
<!-- Reviewable:end -->
