### PR TITLE
fix(query): ignore group_by_shuffle_mode in grouping set query

### DIFF
--- a/src/query/sql/src/executor/physical_plans/physical_aggregate_final.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_aggregate_final.rs
@@ -227,7 +227,11 @@ impl PhysicalPlanBuilder {
                     .collect::<Result<_>>()?;
 
                 let settings = self.ctx.get_settings();
-                let group_by_shuffle_mode = settings.get_group_by_shuffle_mode()?;
+                let mut group_by_shuffle_mode = settings.get_group_by_shuffle_mode()?;
+                if agg.grouping_sets.is_some() {
+                    group_by_shuffle_mode = "before_merge".to_string();
+                }
+
                 let enable_experimental_aggregate_hashtable =
                     settings.get_enable_experimental_aggregate_hashtable()?;
 

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -89,6 +89,14 @@ impl Aggregate {
             self.group_items
                 .iter()
                 .enumerate()
+                .filter(|(_, item)| {
+                    // skip _grouping_id column cause this column is generated in expansion
+                    if let ScalarExpr::BoundColumnRef(c) = &item.scalar {
+                        c.column.column_name != "_grouping_id"
+                    } else {
+                        true
+                    }
+                })
                 .map(|(index, item)| item.bound_column_expr(format!("_group_item_{}", index)))
                 .collect()
         } else {

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -89,14 +89,6 @@ impl Aggregate {
             self.group_items
                 .iter()
                 .enumerate()
-                .filter(|(_, item)| {
-                    // skip _grouping_id column cause this column is generated in expansion
-                    if let ScalarExpr::BoundColumnRef(c) = &item.scalar {
-                        c.column.column_name != "_grouping_id"
-                    } else {
-                        true
-                    }
-                })
                 .map(|(index, item)| item.bound_column_expr(format!("_group_item_{}", index)))
                 .collect()
         } else {
@@ -347,7 +339,14 @@ impl Operator for Aggregate {
                     let settings = ctx.get_settings();
 
                     // Group aggregation, enforce `Hash` distribution
-                    match settings.get_group_by_shuffle_mode()?.as_str() {
+                    let mut group_by_shuffle_mode = settings.get_group_by_shuffle_mode()?;
+
+                    // Grouping set must be merged before_merge
+                    if self.grouping_sets.is_some() {
+                        group_by_shuffle_mode = "before_merge".to_string();
+                    }
+
+                    match group_by_shuffle_mode.as_str() {
                         "before_partial" => {
                             children_required.push(vec![RequiredProperty {
                                 distribution: Distribution::Hash(self.get_distribution_keys(true)?),

--- a/tests/sqllogictests/suites/tpcds/tpcds_agg.test
+++ b/tests/sqllogictests/suites/tpcds/tpcds_agg.test
@@ -1,0 +1,13 @@
+statement ok
+set sandbox_tenant = 'test_tenant';
+
+statement ok
+use tpcds;
+
+statement ok
+set group_by_shuffle_mode = 'before_partial';
+
+include ./Q5
+
+statement ok
+UNSET group_by_shuffle_mode;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The patch makes the following changes:

1. aggregate.rs Modifications:
ignore group_by_shuffle_mode in grouping set query

2. New Test File: tpcds_agg.test:
Created a new test file at tests/sqllogictests/suites/tpcds/tpcds_agg.test.
The test includes setting a sandbox_tenant, using the tpcds database, setting the group_by_shuffle_mode to before_partial, including the Q5 test, and unsetting the group_by_shuffle_mode.

These changes enhance the Aggregate implementation by ignoring specific generated columns and introduce a new test to validate this behavior.


closes #18338

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18508)
<!-- Reviewable:end -->
