### PR TITLE
feat(meta-service): add timing monitoring for Raft-Log IO

### DIFF
--- a/src/meta/raft-store/src/raft_log_v004/io_desc.rs
+++ b/src/meta/raft-store/src/raft_log_v004/io_desc.rs
@@ -14,26 +14,66 @@
 
 use std::error::Error;
 use std::fmt;
+use std::time::Duration;
+use std::time::SystemTime;
 
 use databend_common_meta_types::anyerror::AnyError;
 use databend_common_meta_types::raft_types::ErrorSubject;
 use databend_common_meta_types::raft_types::ErrorVerb;
 use databend_common_meta_types::raft_types::StorageError;
+use display_more::DisplayUnixTimeStampExt;
 use log::debug;
 use log::error;
 
 use crate::raft_log_v004::io_phase::IOPhase;
 
 /// Describe an IO operation.
+#[derive(Clone)]
 pub struct IODesc {
     pub subject: ErrorSubject,
     pub verb: ErrorVerb,
     pub ctx: String,
+
+    /// Unix timestamp when this IO operation started.
+    pub start_time: Duration,
+
+    /// Unix timestamp when the flush request is sent.
+    pub flush_time: Option<Duration>,
+
+    /// Unix timestamp when the flush request is completed.
+    pub flush_done_time: Option<Duration>,
+
+    /// Unix timestamp when the IO operation is done.
+    pub done_time: Option<Duration>,
 }
 
 impl fmt::Display for IODesc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: ({}-{:?})", self.ctx, self.verb, self.subject)
+        write!(
+            f,
+            "IODesc({}): ({}-{:?})",
+            self.ctx, self.verb, self.subject
+        )?;
+
+        let start_time = self.start_time;
+        write!(f, "[start: {}", start_time.display_unix_timestamp_short())?;
+
+        if let Some(flush_time) = self.flush_time {
+            let elapsed = flush_time.saturating_sub(start_time);
+            write!(f, ", flush: +{:?}", elapsed,)?;
+
+            if let Some(flushed_time) = self.flush_done_time {
+                let elapsed = flushed_time.saturating_sub(flush_time);
+                write!(f, ", flushed: +{:?}", elapsed,)?;
+            }
+        }
+
+        if let Some(done_time) = self.done_time {
+            let elapsed = done_time.saturating_sub(self.start_time);
+            write!(f, ", total: {:?}", elapsed)?;
+        }
+
+        write!(f, "]")
     }
 }
 
@@ -45,7 +85,38 @@ impl IODesc {
             subject,
             verb,
             ctx: s,
+            start_time: Self::since_epoch(),
+            flush_time: None,
+            flush_done_time: None,
+            done_time: None,
         }
+    }
+
+    pub fn set_flush_time(&mut self) {
+        self.flush_time = Some(Self::since_epoch());
+    }
+
+    pub fn set_flush_done_time(&mut self) {
+        self.flush_done_time = Some(Self::since_epoch());
+    }
+
+    pub fn set_done_time(&mut self) {
+        self.done_time = Some(Self::since_epoch());
+    }
+
+    pub fn total_duration(&self) -> Option<Duration> {
+        self.flush_done_time
+            .map(|flushed_time| flushed_time.saturating_sub(self.start_time))
+    }
+
+    fn since_epoch() -> Duration {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+    }
+
+    pub fn unknown(ctx: impl ToString) -> Self {
+        Self::start(ErrorSubject::None, ErrorVerb::Write, ctx)
     }
 
     pub fn save_vote(ctx: impl ToString) -> Self {
@@ -112,5 +183,42 @@ impl IODesc {
 
     pub fn err_recv_flush_cb(&self, err: impl Error + 'static) -> StorageError {
         self.to_storage_error(IOPhase::ReceiveFlushCallback, err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        let now_us = 1754708580036171;
+
+        let mut desc = IODesc::start(ErrorSubject::Logs, ErrorVerb::Write, "test");
+        assert!(desc.start_time.as_secs() > 0);
+        desc.start_time = Duration::from_micros(now_us);
+
+        assert_eq!(
+            format!("{}", desc),
+            "IODesc(test): (Write-Logs)[start: 2025-08-09T03:03:00.036]"
+        );
+
+        desc.flush_time = Some(Duration::from_micros(now_us + 1_000_000));
+        assert_eq!(
+            format!("{}", desc),
+            "IODesc(test): (Write-Logs)[start: 2025-08-09T03:03:00.036, flush: +1s]"
+        );
+
+        desc.flush_done_time = Some(Duration::from_micros(now_us + 2_000_000));
+        assert_eq!(
+            format!("{}", desc),
+            "IODesc(test): (Write-Logs)[start: 2025-08-09T03:03:00.036, flush: +1s, flushed: +1s]"
+        );
+
+        desc.done_time = Some(Duration::from_micros(now_us + 3_000_000));
+        assert_eq!(
+            format!("{}", desc),
+            "IODesc(test): (Write-Logs)[start: 2025-08-09T03:03:00.036, flush: +1s, flushed: +1s, total: 3s]"
+        );
     }
 }

--- a/src/meta/raft-store/src/raft_log_v004/util.rs
+++ b/src/meta/raft-store/src/raft_log_v004/util.rs
@@ -18,11 +18,12 @@ use raft_log::api::raft_log_writer::RaftLogWriter;
 use tokio::sync::oneshot;
 
 use crate::raft_log_v004::callback::Callback;
+use crate::raft_log_v004::IODesc;
 use crate::raft_log_v004::RaftLogV004;
 
 pub async fn blocking_flush(rl: &mut RaftLogV004) -> Result<(), io::Error> {
     let (tx, rx) = oneshot::channel();
-    let callback = Callback::new_oneshot(tx, "blocking_flush");
+    let callback = Callback::new_oneshot(tx, IODesc::unknown("blocking_flush(RaftLogV004)"));
 
     rl.flush(callback)?;
     rx.await


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta-service): add timing monitoring for Raft-Log IO

Enhance `IODesc` with timing fields to track operation phases:
- Add `start_time`, `flush_time`, `flush_done_time`, `done_time` fields
- Update Callback constructors to accept `IODesc` instead of string context
- Add slow operation warnings for flush operations > 50ms
- Improve logging with detailed timing information display

This provides better observability for raft log performance debugging
and helps identify slow IO operations in production systems.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18509)
<!-- Reviewable:end -->
