### PR TITLE
feat: support the `to_binary` with format

### DIFF
--- a/tests/sqllogictests/suites/base/03_common/03_0041_insert_into_binary.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0041_insert_into_binary.test
@@ -11,10 +11,10 @@ statement ok
 CREATE TABLE IF NOT EXISTS t1(id Int, v binary) Engine = Fuse
 
 statement ok
-INSERT INTO t1 (id, v) VALUES(1, to_binary('aaa')),(2, from_hex('616161')),(3, from_base64('YWFh'))
+INSERT INTO t1 (id, v) VALUES(1, to_binary('aaa')),(2, from_hex('616161')),(3, from_base64('YWFh')),(4, to_binary('aaa', 'utf-8')),(5, to_binary('616161', 'hex')),(6, to_binary('YWFh', 'base64'))
 
 statement ok
-INSERT INTO t1 (id, v) VALUES(4, 'aaa')
+INSERT INTO t1 (id, v) VALUES(7, 'aaa')
 
 query IT
 SELECT id, v FROM t1 order by id
@@ -23,6 +23,9 @@ SELECT id, v FROM t1 order by id
 2 616161
 3 616161
 4 616161
+5 616161
+6 616161
+7 616161
 
 statement ok
 ALTER TABLE t1 MODIFY COLUMN v string

--- a/tests/sqllogictests/suites/query/functions/02_0019_function_strings_hex.test
+++ b/tests/sqllogictests/suites/query/functions/02_0019_function_strings_hex.test
@@ -18,3 +18,12 @@ select hex(null)
 ----
 NULL
 
+query T
+SELECT FROM_HEX(TO_HEX('abc'))::STRING
+----
+abc
+
+query T
+SELECT HEX_DECODE_STRING(TO_HEX('abc'))
+----
+abc

--- a/tests/sqllogictests/suites/query/functions/02_0024_function_strings_base_64.test
+++ b/tests/sqllogictests/suites/query/functions/02_0024_function_strings_base_64.test
@@ -9,6 +9,11 @@ SELECT FROM_BASE64(TO_BASE64('abc'))::STRING
 abc
 
 query T
+SELECT BASE64_DECODE_STRING(TO_BASE64('abc'))
+----
+abc
+
+query T
 SELECT TO_BASE64(NULL)
 ----
 NULL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- support function `to_bianry` with `format`
  - 'hex'
  - 'base64'
  - 'utf-8'
- add alias for encode/decode function
  - 'hex_encode' -> `to_hex`
  - 'hex_decode_binary' -> 'from_hex'
  - 'try_hex_decode_binary' -> 'try_from_hex'
  - 'hex_decode_string' -> 'from_hex' + cast to string
  - 'try_hex_decode_string' -> 'try_from_hex' + cast to string
  - 'base64_encode' -> 'to_base64'
  - 'base64_decode_binary' -> 'from_base64'
  - 'try_base64_decode_binary' -> 'try_from_base64'
  - 'base64_decode_string' -> 'from_base64' + cast to string
  - 'try_base64_decode_string' -> 'try_from_base64' + cast to string

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
