### PR TITLE
refactor(meta): add state machine lock guards with debugging

### DIFF
--- a/src/meta/control/src/import.rs
+++ b/src/meta/control/src/import.rs
@@ -201,7 +201,7 @@ async fn init_new_cluster(
     let mut sto = RaftStore::open(&raft_config).await?;
 
     let last_applied = {
-        let sm2 = sto.get_state_machine().await;
+        let sm2 = sto.get_state_machine_write("get-last-applied").await;
         *sm2.sys_data_ref().last_applied_ref()
     };
 
@@ -213,7 +213,9 @@ async fn init_new_cluster(
 
     // Update snapshot: Replace nodes set and membership config.
     {
-        let mut sm2 = sto.get_state_machine().await;
+        let mut sm2 = sto
+            .get_state_machine_write("init_new_cluster-get-last-membership")
+            .await;
 
         *sm2.sys_data_mut().nodes_mut() = nodes.clone();
 

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -457,10 +457,10 @@ impl MetaService for MetaServiceImpl {
         // This approach prevents race conditions and guarantees that no events will be
         // delivered out of order to the watcher.
         let stream = {
-            let sm = &mn.raft_store.state_machine;
-            let sm = sm.write().await;
-
-            info!("enter sm write lock for watch {}", watch);
+            let sm = mn
+                .raft_store
+                .get_state_machine_read("new-watch-stream")
+                .await;
 
             let sender = mn.new_watch_sender(watch, tx.clone())?;
             let sender_str = sender.to_string();

--- a/src/meta/service/src/api/http/v1/features.rs
+++ b/src/meta/service/src/api/http/v1/features.rs
@@ -114,7 +114,10 @@ pub async fn set(
 
 pub async fn features_state(meta_node: &Arc<MetaNode>) -> FeatureResponse {
     let enabled = {
-        let mut sm = meta_node.raft_store.state_machine.write().await;
+        let mut sm = meta_node
+            .raft_store
+            .get_state_machine_write("get-state-machine-features")
+            .await;
         let x = sm.sys_data_mut().features();
         x.iter().cloned().collect()
     };

--- a/src/meta/service/src/meta_service/meta_node.rs
+++ b/src/meta/service/src/meta_service/meta_node.rs
@@ -180,7 +180,7 @@ impl MetaNodeBuilder {
             move |change| h.send_change(change)
         };
 
-        sto.get_state_machine()
+        sto.get_state_machine_write("set_on_change_applied-hook")
             .await
             .set_on_change_applied(Box::new(on_change_applied));
 
@@ -775,7 +775,10 @@ impl MetaNode {
     ///   Only when the membership is committed, this node can be sure it is in a cluster.
     async fn is_in_cluster(&self) -> Result<Result<String, String>, MetaStorageError> {
         let membership = {
-            let sm = self.raft_store.get_state_machine().await;
+            let sm = self
+                .raft_store
+                .get_state_machine_write("is_in_cluster-get-membership")
+                .await;
             sm.sys_data_ref().last_membership_ref().membership().clone()
         };
         info!("is_in_cluster: membership: {:?}", membership);
@@ -879,7 +882,7 @@ impl MetaNode {
     pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         // inconsistent get: from local state machine
 
-        let sm = self.raft_store.state_machine.read().await;
+        let sm = self.raft_store.get_state_machine_read("get-node").await;
         let n = sm.sys_data_ref().nodes_ref().get(node_id).cloned();
         n
     }
@@ -888,7 +891,7 @@ impl MetaNode {
     pub async fn get_nodes(&self) -> Vec<Node> {
         // inconsistent get: from local state machine
 
-        let sm = self.raft_store.state_machine.read().await;
+        let sm = self.raft_store.get_state_machine_read("get-nodes").await;
         let nodes = sm
             .sys_data_ref()
             .nodes_ref()
@@ -976,7 +979,7 @@ impl MetaNode {
     }
 
     pub(crate) async fn get_last_seq(&self) -> u64 {
-        let sm = self.raft_store.state_machine.read().await;
+        let sm = self.raft_store.get_state_machine_read("get-last-seq").await;
         sm.sys_data_ref().curr_seq()
     }
 
@@ -985,7 +988,10 @@ impl MetaNode {
         // Maybe stale get: from local state machine
 
         let nodes = {
-            let sm = self.raft_store.state_machine.read().await;
+            let sm = self
+                .raft_store
+                .get_state_machine_read("get-grpc-advertise-addrs")
+                .await;
             sm.sys_data_ref()
                 .nodes_ref()
                 .values()

--- a/src/meta/service/src/store/lock_guards.rs
+++ b/src/meta/service/src/store/lock_guards.rs
@@ -1,0 +1,122 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::time::Instant;
+
+use log::info;
+use tokio::sync::RwLockReadGuard;
+use tokio::sync::RwLockWriteGuard;
+
+#[derive(Debug)]
+pub struct WriteGuard<'a, T: ?Sized> {
+    acquired: Instant,
+    purpose: String,
+    inner: RwLockWriteGuard<'a, T>,
+}
+
+impl<'a, T> WriteGuard<'a, T> {
+    pub fn new(purpose: impl ToString, inner: RwLockWriteGuard<'a, T>) -> Self {
+        Self {
+            acquired: Instant::now(),
+            purpose: purpose.to_string(),
+            inner,
+        }
+    }
+}
+
+impl<T> Deref for WriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<T> DerefMut for WriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.deref_mut()
+    }
+}
+
+impl<T> fmt::Display for WriteGuard<'_, T>
+where T: fmt::Display
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StateMachineLock-Write-Guard({}): {}",
+            self.purpose, self.inner
+        )
+    }
+}
+
+impl<T: ?Sized> Drop for WriteGuard<'_, T> {
+    fn drop(&mut self) {
+        let elapsed = self.acquired.elapsed();
+        info!(
+            "StateMachineLock-Write-Guard({}) released after {:?}",
+            self.purpose, elapsed
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadGuard<'a, T: ?Sized> {
+    acquired: Instant,
+    purpose: String,
+    inner: RwLockReadGuard<'a, T>,
+}
+
+impl<'a, T> ReadGuard<'a, T> {
+    pub fn new(purpose: impl ToString, inner: RwLockReadGuard<'a, T>) -> Self {
+        Self {
+            acquired: Instant::now(),
+            purpose: purpose.to_string(),
+            inner,
+        }
+    }
+}
+
+impl<T> Deref for ReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<T> fmt::Display for ReadGuard<'_, T>
+where T: fmt::Display
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StateMachineLock-Read-Guard({}): {}",
+            self.purpose, self.inner
+        )
+    }
+}
+
+impl<T: ?Sized> Drop for ReadGuard<'_, T> {
+    fn drop(&mut self) {
+        let elapsed = self.acquired.elapsed();
+        info!(
+            "StateMachineLock-Read-Guard({}) released after {:?}",
+            self.purpose, elapsed
+        );
+    }
+}

--- a/src/meta/service/src/store/mod.rs
+++ b/src/meta/service/src/store/mod.rs
@@ -18,5 +18,7 @@ mod raft_state_machine_impl;
 mod store;
 mod store_inner;
 
+pub mod lock_guards;
+
 pub use store::RaftStore;
 pub use store_inner::RaftStoreInner;

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fs;
 use std::io;
 use std::io::ErrorKind;
@@ -20,7 +21,7 @@ use std::sync::Arc;
 
 use anyerror::AnyError;
 use databend_common_base::base::tokio::sync::RwLock;
-use databend_common_base::base::tokio::sync::RwLockWriteGuard;
+use databend_common_base::future::TimedFutureExt;
 use databend_common_meta_raft_store::config::RaftConfig;
 use databend_common_meta_raft_store::key_spaces::RaftStoreEntry;
 use databend_common_meta_raft_store::leveled_store::db_exporter::DBExporter;
@@ -57,6 +58,8 @@ use raft_log::api::raft_log_writer::RaftLogWriter;
 
 use crate::metrics::raft_metrics;
 use crate::metrics::SnapshotBuilding;
+use crate::store::lock_guards::ReadGuard;
+use crate::store::lock_guards::WriteGuard;
 
 /// This is the inner store that implements the raft log storage API.
 pub struct RaftStoreInner {
@@ -179,9 +182,41 @@ impl RaftStoreInner {
         Ok(sm)
     }
 
-    /// Get a handle to the state machine for testing purposes.
-    pub async fn get_state_machine(&self) -> RwLockWriteGuard<'_, SMV003> {
-        self.state_machine.write().await
+    pub async fn get_state_machine_read(&self, for_what: impl ToString) -> ReadGuard<'_, SMV003> {
+        let for_what = for_what.to_string();
+
+        let g = self
+            .state_machine
+            .read()
+            .with_timing(|_output, total, busy| {
+                info!(
+                    "StateMachineLock-Read-Acquire-Elapsed: total: {:?}, busy: {:?}; {}",
+                    total, busy, &for_what
+                );
+            })
+            .await;
+
+        ReadGuard::new(for_what, g)
+    }
+
+    pub async fn get_state_machine_write(
+        &self,
+        for_what: impl fmt::Display,
+    ) -> WriteGuard<'_, SMV003> {
+        let for_what = for_what.to_string();
+
+        let g = self
+            .state_machine
+            .write()
+            .with_timing(|_output, total, busy| {
+                info!(
+                    "StateMachineLock-Write-Acquire-Elapsed: total: {:?}, busy: {:?}; {}",
+                    total, busy, &for_what
+                );
+            })
+            .await;
+
+        WriteGuard::new(for_what, g)
     }
 
     #[fastrace::trace]
@@ -195,7 +230,9 @@ impl RaftStoreInner {
         let permit = self.new_compactor_acquirer().await.acquire().await;
 
         let mut compactor = {
-            let mut w = self.state_machine.write().await;
+            let mut w = self
+                .get_state_machine_write("do_build_snapshot-new-compactor")
+                .await;
             w.freeze_writable();
             w.new_compactor(permit)
         };
@@ -272,7 +309,7 @@ impl RaftStoreInner {
             snapshot_stat :% = db.stat(); "do_build_snapshot complete");
 
         {
-            let mut sm = self.state_machine.write().await;
+            let mut sm = self.get_state_machine_write("do_build_snapshot").await;
             sm.levels_mut()
                 .replace_with_compacted(compactor, db.clone());
         }
@@ -291,7 +328,9 @@ impl RaftStoreInner {
     ///
     /// It returns None if there is no snapshot or there is an error parsing snapshot meta or id.
     pub(crate) async fn try_get_snapshot_key_count(&self) -> Option<u64> {
-        let sm = self.state_machine.read().await;
+        let sm = self
+            .get_state_machine_read("try_get_snapshot_key_count")
+            .await;
         let db = sm.levels().persisted()?;
         Some(db.stat().key_num)
     }
@@ -304,7 +343,9 @@ impl RaftStoreInner {
     ///
     /// Returns an empty map if no snapshot exists.
     pub(crate) async fn get_snapshot_key_space_stat(&self) -> BTreeMap<String, u64> {
-        let sm = self.state_machine.read().await;
+        let sm = self
+            .get_state_machine_read("get_snapshot_key_space_stat")
+            .await;
         let Some(db) = sm.levels().persisted() else {
             return Default::default();
         };
@@ -313,7 +354,7 @@ impl RaftStoreInner {
 
     /// Get the statistics of the snapshot database.
     pub(crate) async fn get_snapshot_db_stat(&self) -> DBStat {
-        let sm = self.state_machine.read().await;
+        let sm = self.get_state_machine_read("get_snapshot_db_stat").await;
         let Some(db) = sm.levels().persisted() else {
             return Default::default();
         };
@@ -323,7 +364,7 @@ impl RaftStoreInner {
     /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.
     #[fastrace::trace]
     pub async fn do_install_snapshot(&self, db: DB) -> Result<(), MetaStorageError> {
-        let mut sm = self.state_machine.write().await;
+        let mut sm = self.get_state_machine_write("do_install_snapshot").await;
         sm.install_snapshot_v003(db).await.map_err(|e| {
             MetaStorageError(
                 AnyError::new(&e).add_context(|| "replacing state-machine with snapshot"),
@@ -356,7 +397,9 @@ impl RaftStoreInner {
         let permit = self.new_compactor_acquirer().await.acquire().await;
 
         let compactor = {
-            let sm_read = self.state_machine.read().await;
+            let sm_read = self
+                .get_state_machine_read("new-compactor-for-export")
+                .await;
             sm_read.new_compactor(permit)
         };
 
@@ -436,7 +479,7 @@ impl RaftStoreInner {
     }
 
     pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
-        let sm = self.state_machine.read().await;
+        let sm = self.get_state_machine_read("get_node").await;
         let n = sm.sys_data_ref().nodes_ref().get(node_id).cloned();
         n
     }
@@ -446,7 +489,7 @@ impl RaftStoreInner {
         &self,
         list_ids: impl Fn(&Membership) -> Vec<NodeId>,
     ) -> Vec<Node> {
-        let sm = self.state_machine.read().await;
+        let sm = self.get_state_machine_read("get-nodes").await;
         let membership = sm.sys_data_ref().last_membership_ref().membership();
 
         debug!("in-statemachine membership: {:?}", membership);
@@ -484,7 +527,7 @@ impl RaftStoreInner {
     }
 
     async fn new_compactor_acquirer(&self) -> CompactorAcquirer {
-        let sm = self.state_machine.read().await;
+        let sm = self.get_state_machine_read("new_compactor_acquirer").await;
         sm.new_compactor_acquirer()
     }
 }

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -114,7 +114,10 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     // This way on every node applying a log always get the same result.
     info!("--- get updated kv with new expire, assert the updated value");
     {
-        let sm = learner.raft_store.state_machine.read().await;
+        let sm = learner
+            .raft_store
+            .get_state_machine_read("test_meta_node_replicate_kv_with_expire")
+            .await;
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
         assert_eq!(

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -138,7 +138,10 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
 
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
-        let sm = mn1.raft_store.get_state_machine().await;
+        let sm = mn1
+            .raft_store
+            .get_state_machine_write("test_meta_node_snapshot_replication")
+            .await;
         let got = sm.get_maybe_expired_kv(&key).await?;
         match got {
             None => {

--- a/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
+++ b/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
@@ -126,8 +126,7 @@ async fn write_two_logs(
     // Check final state
     let result = meta_node
         .raft_store
-        .state_machine
-        .read()
+        .get_state_machine_read("write_two_logs")
         .await
         .kv_api()
         .get_kv("k1")

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -197,7 +197,10 @@ async fn test_meta_store_build_snapshot() -> anyhow::Result<()> {
     let (logs, want) = snapshot_logs();
 
     sto.blocking_append(logs.clone()).await?;
-    sto.state_machine.write().await.apply_entries(logs).await?;
+    sto.get_state_machine_write("test_meta_store_build_snapshot")
+        .await
+        .apply_entries(logs)
+        .await?;
 
     let curr_snap = sto.build_snapshot().await?;
     assert_eq!(Some(new_log_id(1, 0, 9)), curr_snap.meta.last_log_id);
@@ -246,7 +249,9 @@ async fn test_meta_store_current_snapshot() -> anyhow::Result<()> {
 
     sto.blocking_append(logs.clone()).await?;
     {
-        let mut sm = sto.state_machine.write().await;
+        let mut sm = sto
+            .get_state_machine_write("test_meta_store_current_snapshot")
+            .await;
         sm.apply_entries(logs).await?;
     }
 
@@ -290,7 +295,10 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
         info!("--- feed logs and state machine");
 
         sto.blocking_append(logs.clone()).await?;
-        sto.state_machine.write().await.apply_entries(logs).await?;
+        sto.get_state_machine_write("test_meta_store_install_snapshot")
+            .await
+            .apply_entries(logs)
+            .await?;
 
         snap = sto.build_snapshot().await?;
     }
@@ -311,8 +319,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
         info!("--- check installed meta");
         {
             let mem = sto
-                .state_machine
-                .write()
+                .get_state_machine_write("test_meta_store_install_snapshot")
                 .await
                 .sys_data_ref()
                 .last_membership_ref()
@@ -327,8 +334,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
             );
 
             let last_applied = *sto
-                .state_machine
-                .write()
+                .get_state_machine_write("test_meta_store_install_snapshot")
                 .await
                 .sys_data_ref()
                 .last_applied_ref();


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): add state machine lock guards with debugging

Replace direct RwLock access with tracked guards that log lock
acquisition timing and purpose for better debugging visibility.

Key changes:
- Add new lock_guards.rs with WriteGuard and ReadGuard wrappers
- Replace state_machine.read/write() calls with get_state_machine_read/write()
- Add timing instrumentation with purpose tracking for all lock acquisitions
- Update all meta service components to use new guard pattern

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18534)
<!-- Reviewable:end -->
