### PR TITLE
refactor(meta-service): optimize state machine block loading with early cache checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13235,9 +13235,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068a45a83c2ce7d6bdad6ba83719ff08ba9818d210b613af13647ea33ab7d23c"
+checksum = "9659467da3a686edc86248421dcebabf2971fbba3ad4679e1da2d63c57f8d5dc"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -467,7 +467,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.2.7", features = [] }
+rotbl = { version = "0.2.8", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }

--- a/src/meta/raft-store/src/sm_v003/writer_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/writer_v003.rs
@@ -19,7 +19,6 @@ use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::sys_data::SysData;
 use futures::Stream;
 use futures_util::TryStreamExt;
-use log::debug;
 use log::info;
 use rotbl::v001::SeqMarked;
 use tokio::sync::mpsc;
@@ -93,7 +92,7 @@ impl WriterV003 {
         mut kv_rx: mpsc::Receiver<WriteEntry<(String, SeqMarked), (MetaSnapshotId, SysData)>>,
     ) -> Result<DB, io::Error> {
         while let Some(ent) = kv_rx.blocking_recv() {
-            debug!(entry :? =(&ent); "write kv");
+            // debug!(entry :? =(&ent); "write kv");
 
             let (k, v) = match ent {
                 WriteEntry::Data(ent) => ent,

--- a/src/meta/service/src/store/lock_guards.rs
+++ b/src/meta/service/src/store/lock_guards.rs
@@ -58,8 +58,8 @@ where T: fmt::Display
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "StateMachineLock-Write-Guard({}): {}",
-            self.purpose, self.inner
+            "StateMachineLock-Write-Guard: {} {}",
+            self.inner, self.purpose,
         )
     }
 }
@@ -68,8 +68,8 @@ impl<T: ?Sized> Drop for WriteGuard<'_, T> {
     fn drop(&mut self) {
         let elapsed = self.acquired.elapsed();
         info!(
-            "StateMachineLock-Write-Guard({}) released after {:?}",
-            self.purpose, elapsed
+            "StateMachineLock-Write-Release: total: {:?}; {}",
+            elapsed, self.purpose,
         );
     }
 }
@@ -105,8 +105,8 @@ where T: fmt::Display
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "StateMachineLock-Read-Guard({}): {}",
-            self.purpose, self.inner
+            "StateMachineLock-Read-Guard: {} {}",
+            self.inner, self.purpose
         )
     }
 }
@@ -115,8 +115,8 @@ impl<T: ?Sized> Drop for ReadGuard<'_, T> {
     fn drop(&mut self) {
         let elapsed = self.acquired.elapsed();
         info!(
-            "StateMachineLock-Read-Guard({}) released after {:?}",
-            self.purpose, elapsed
+            "StateMachineLock-Read-Release: total: {:?}; {}",
+            elapsed, self.purpose,
         );
     }
 }

--- a/src/meta/service/src/store/store_inner.rs
+++ b/src/meta/service/src/store/store_inner.rs
@@ -190,7 +190,7 @@ impl RaftStoreInner {
             .read()
             .with_timing(|_output, total, busy| {
                 info!(
-                    "StateMachineLock-Read-Acquire-Elapsed: total: {:?}, busy: {:?}; {}",
+                    "StateMachineLock-Read-Acquire: total: {:?}, busy: {:?}; {}",
                     total, busy, &for_what
                 );
             })
@@ -210,7 +210,7 @@ impl RaftStoreInner {
             .write()
             .with_timing(|_output, total, busy| {
                 info!(
-                    "StateMachineLock-Write-Acquire-Elapsed: total: {:?}, busy: {:?}; {}",
+                    "StateMachineLock-Write-Acquire: total: {:?}, busy: {:?}; {}",
                     total, busy, &for_what
                 );
             })


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service): optimize state machine block loading with early cache checks

Restructure load_block method to check cache before acquiring locks,
reducing contention and improving concurrent access performance.

- Add early cache check before lock acquisition
- Reduce lock scope to only critical sections

These changes improve cache hit performance and reduce lock contention
in multi-threaded scenarios.

Other changes:

- Refine state-machine locking log

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18541)
<!-- Reviewable:end -->
