### PR TITLE
feat(query): add rule_deduplicated_sort

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
@@ -18,6 +18,7 @@ use databend_common_exception::Result;
 
 use crate::optimizer::optimizers::rule::RuleCommuteJoin;
 use crate::optimizer::optimizers::rule::RuleCommuteJoinBaseTable;
+use crate::optimizer::optimizers::rule::RuleDeduplicateSort;
 use crate::optimizer::optimizers::rule::RuleEagerAggregation;
 use crate::optimizer::optimizers::rule::RuleEliminateEvalScalar;
 use crate::optimizer::optimizers::rule::RuleEliminateFilter;
@@ -114,6 +115,7 @@ impl RuleFactory {
             RuleID::PushDownPrewhere => Ok(Box::new(RulePushDownPrewhere::new(metadata))),
             RuleID::TryApplyAggIndex => Ok(Box::new(RuleTryApplyAggIndex::new(metadata))),
             RuleID::EliminateSort => Ok(Box::new(RuleEliminateSort::new())),
+            RuleID::DeduplicateSort => Ok(Box::new(RuleDeduplicateSort::new())),
             RuleID::SemiToInnerJoin => Ok(Box::new(RuleSemiToInnerJoin::new())),
             RuleID::MergeFilterIntoMutation => {
                 Ok(Box::new(RuleMergeFilterIntoMutation::new(metadata)))

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
@@ -27,6 +27,7 @@ use crate::optimizer::optimizers::rule::TransformResult;
 pub static DEFAULT_REWRITE_RULES: LazyLock<Vec<RuleID>> = LazyLock::new(|| {
     vec![
         RuleID::EliminateSort,
+        RuleID::DeduplicateSort,
         RuleID::EliminateUnion,
         RuleID::MergeEvalScalar,
         // Filter
@@ -113,6 +114,7 @@ pub enum RuleID {
     EliminateEvalScalar,
     EliminateFilter,
     EliminateSort,
+    DeduplicateSort,
     MergeEvalScalar,
     MergeFilter,
     GroupingSetsToUnion,
@@ -158,6 +160,7 @@ impl Display for RuleID {
             RuleID::EliminateEvalScalar => write!(f, "EliminateEvalScalar"),
             RuleID::EliminateFilter => write!(f, "EliminateFilter"),
             RuleID::EliminateSort => write!(f, "EliminateSort"),
+            RuleID::DeduplicateSort => write!(f, "DeduplicateSort"),
             RuleID::MergeEvalScalar => write!(f, "MergeEvalScalar"),
             RuleID::MergeFilter => write!(f, "MergeFilter"),
             RuleID::NormalizeScalarFilter => write!(f, "NormalizeScalarFilter"),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/mod.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod rule_deduplicate_sort;
 mod rule_eliminate_sort;
 
+pub use rule_deduplicate_sort::RuleDeduplicateSort;
 pub use rule_eliminate_sort::RuleEliminateSort;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_deduplicate_sort.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_deduplicate_sort.rs
@@ -1,0 +1,105 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+
+use crate::optimizer::ir::Matcher;
+use crate::optimizer::ir::SExpr;
+use crate::optimizer::optimizers::rule::Rule;
+use crate::optimizer::optimizers::rule::RuleID;
+use crate::optimizer::optimizers::rule::TransformResult;
+use crate::plans::RelOp;
+use crate::plans::Sort;
+
+/// Rule to remove duplicate sort items in ORDER BY clause.
+/// 
+/// For example, transforms:
+/// ORDER BY x ASC NULLS LAST, x ASC NULLS LAST
+/// into:
+/// ORDER BY x ASC NULLS LAST
+/// 
+/// This optimization is valid because duplicate sort fields don't contribute
+/// additional ordering and only add unnecessary computational overhead.
+pub struct RuleDeduplicateSort {
+    id: RuleID,
+    matchers: Vec<Matcher>,
+}
+
+impl RuleDeduplicateSort {
+    pub fn new() -> Self {
+        Self {
+            id: RuleID::DeduplicateSort,
+            // Sort
+            //  \
+            //   *
+            matchers: vec![Matcher::MatchOp {
+                op_type: RelOp::Sort,
+                children: vec![Matcher::Leaf],
+            }],
+        }
+    }
+}
+
+impl Rule for RuleDeduplicateSort {
+    fn id(&self) -> RuleID {
+        self.id
+    }
+
+    fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
+        let sort: Sort = s_expr.plan().clone().try_into()?;
+        
+        if sort.items.len() <= 1 {
+            return Ok(());
+        }
+        
+        // Deduplicate sort items while preserving order
+        let mut deduplicated_items = Vec::with_capacity(sort.items.len());
+        let mut seen = std::collections::HashSet::with_capacity(sort.items.len());
+        
+        for item in &sort.items {
+            if seen.insert(item.clone()) {
+                deduplicated_items.push(item.clone());
+            }
+        }
+        
+        // Only apply transformation if we actually removed duplicates
+        if deduplicated_items.len() == sort.items.len() {
+            return Ok(());
+        }
+
+        let new_sort = Sort {
+            items: deduplicated_items,
+            limit: sort.limit,
+            after_exchange: sort.after_exchange,
+            pre_projection: sort.pre_projection,
+            window_partition: sort.window_partition,
+        };
+        
+        let mut result = s_expr.replace_plan(std::sync::Arc::new(new_sort.into()));
+        result.set_applied_rule(&self.id);
+        state.add_result(result);
+        
+        Ok(())
+    }
+
+    fn matchers(&self) -> &[Matcher] {
+        &self.matchers
+    }
+}
+
+impl Default for RuleDeduplicateSort {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_deduplicate_sort.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_deduplicate_sort.test
@@ -1,0 +1,41 @@
+-- Test for RuleDeduplicateSort optimization
+-- This test verifies that duplicate sort items are removed from ORDER BY clause
+
+statement ok
+CREATE TABLE emp (deptno INT, job STRING, sal INT);
+
+statement ok
+INSERT INTO emp VALUES 
+(10, 'MANAGER', 5000),
+(10, 'CLERK', 3000),
+(20, 'MANAGER', 6000),
+(20, 'ANALYST', 4000);
+
+-- Test: Comprehensive duplicate sort field scenarios
+-- This query tests multiple cases:
+-- 1. Simple duplicates: deptno, deptno -> should become just deptno
+-- 2. Different directions: job ASC, job DESC -> should keep both
+-- 3. Different null handling: sal NULLS FIRST, sal NULLS LAST -> should keep both
+-- 4. Mixed duplicates: deptno appears again -> should deduplicate
+query T
+EXPLAIN SELECT deptno AS d, job, sal 
+FROM emp 
+ORDER BY deptno, d, job ASC, job DESC, sal NULLS FIRST, sal NULLS LAST, deptno;
+----
+Sort(Single)
+├── output columns: [emp.deptno (#0), emp.job (#1), emp.sal (#2)]
+├── sort keys: [deptno ASC NULLS LAST, job ASC NULLS LAST, job DESC NULLS LAST, sal ASC NULLS FIRST, sal ASC NULLS LAST]
+├── estimated rows: 4.00
+└── TableScan
+    ├── table: default.db.emp
+    ├── output columns: [deptno (#0), job (#1), sal (#2)]
+    ├── read rows: 4
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
+    ├── push downs: [filters: [], limit: NONE]
+    └── estimated rows: 4.00
+
+statement ok
+DROP TABLE emp;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->
Eg.
```
EXPLAIN SELECT deptno AS d, job, sal 
FROM emp 
ORDER BY deptno, d, job ASC, job DESC, sal NULLS FIRST, sal NULLS LAST, deptno;
```
into 
```
EXPLAIN SELECT deptno AS d, job, sal 
FROM emp 
ORDER BY deptno, job ASC, job DESC, sal NULLS FIRST, sal NULLS LAST;
```
The plan is
```
Sort(Single)
├── output columns: [emp.deptno (#0), emp.job (#1), emp.sal (#2)]
├── sort keys: [deptno ASC NULLS LAST, job ASC NULLS LAST, job DESC NULLS LAST, sal ASC NULLS FIRST, sal ASC NULLS LAST]
├── estimated rows: 4.00
└── TableScan
    ├── table: default.db.emp
    ├── output columns: [deptno (#0), job (#1), sal (#2)]
    ├── read rows: 4
    ├── read size: < 1 KiB
    ├── partitions total: 1
    ├── partitions scanned: 1
    ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
    ├── push downs: [filters: [], limit: NONE]
    └── estimated rows: 4.00
```
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
