### PR TITLE
fix: maybe panic by divide by zero

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_sort_merge_base.rs
@@ -44,10 +44,14 @@ impl SortSpillParams {
         max_block_rows: usize,
     ) -> Self {
         // We use the first memory calculation to estimate the batch size and the number of merge.
-        let block = usize::max(
-            (bytes.0).div_ceil(spill_unit_size.0) as _,
-            rows.div_ceil(max_block_rows),
-        );
+        let block = if spill_unit_size.0 > 0 {
+            usize::max(
+                bytes.0.div_ceil(spill_unit_size.0),
+                rows.div_ceil(max_block_rows),
+            )
+        } else {
+            rows.div_ceil(max_block_rows)
+        };
         let batch_rows = (rows / block).max(1);
 
         /// The memory will be doubled during merging.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

spill_unit_size maybe 0, when the sort spill is disabled.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18553)
<!-- Reviewable:end -->
