### PR TITLE
fix(query): table `system.query_execution` output data type does not match definition

### DIFF
--- a/src/query/storages/system/src/query_execution_table.rs
+++ b/src/query/storages/system/src/query_execution_table.rs
@@ -24,7 +24,7 @@ use databend_common_exception::Result;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::TimestampType;
-use databend_common_expression::types::UInt32Type;
+use databend_common_expression::types::UInt64Type;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FromData;
@@ -183,8 +183,8 @@ impl QueryExecutionTable {
                 nodes.push(local_id.clone());
                 timestamps.push(timestamp as i64 * 1_000_000);
                 query_ids.push(query_id.clone());
-                process_rows.push(rows_for_timestamp.get(query_id).copied().unwrap_or(0));
-                process_times.push(times_for_timestamp.get(query_id).copied().unwrap_or(0));
+                process_rows.push(rows_for_timestamp.get(query_id).copied().unwrap_or(0) as u64);
+                process_times.push(times_for_timestamp.get(query_id).copied().unwrap_or(0) as u64);
             }
         }
 
@@ -192,8 +192,8 @@ impl QueryExecutionTable {
             StringType::from_data(nodes),
             TimestampType::from_data(timestamps),
             StringType::from_data(query_ids),
-            UInt32Type::from_data(process_rows),
-            UInt32Type::from_data(process_times),
+            UInt64Type::from_data(process_rows),
+            UInt64Type::from_data(process_times),
         ])
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

table `system.query_execution` output data type does not match definition

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test debug_assertions

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18554)
<!-- Reviewable:end -->
