### PR TITLE
fix(query): the workload_group sort spill needs to be able to be forced to be turned off

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/sort/merge_sort.rs
+++ b/src/query/service/src/pipelines/processors/transforms/sort/merge_sort.rs
@@ -105,6 +105,7 @@ where
         order_col_generated: bool,
         memory_settings: MemorySettings,
     ) -> Result<Self> {
+        assert!(max_block_size > 0);
         let sort_row_offset = schema.fields().len() - 1;
         let row_converter = C::create(&sort_desc, schema.clone())?;
         let (name, inner, limit) = match limit {

--- a/src/query/service/src/pipelines/processors/transforms/sort/sort_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/sort/sort_builder.rs
@@ -83,7 +83,7 @@ impl TransformSortBuilder {
             output_order_col: false,
             enable_loser_tree: false,
             limit: None,
-            memory_settings: MemorySettings::disable_spill(),
+            memory_settings: MemorySettings::builder().build(),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

the workload_group sort spill needs to be able to be forced to be turned off

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18561)
<!-- Reviewable:end -->
