### PR TITLE
fix: String type parameters will result in double quotes and the query will be empty

### DIFF
--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
@@ -31,6 +31,7 @@ use databend_common_catalog::table_args::TableArgs;
 use databend_common_catalog::table_function::TableFunction;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::display::scalar_ref_to_string;
 use databend_common_expression::types::convert_to_type_name;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::FunctionKind;
@@ -101,11 +102,13 @@ impl Binder {
                         span: *span,
                         expr: Box::new(Expr::Literal {
                             span: *span,
-                            value: Literal::String(self.table_args.positioned[pos].to_string()),
+                            value: Literal::String(scalar_ref_to_string(
+                                &self.table_args.positioned[pos].as_ref(),
+                            )),
                         }),
                         target_type: convert_to_type_name(ty),
                         pg_style: false,
-                    }
+                    };
                 }
             }
         }

--- a/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
@@ -242,3 +242,17 @@ create or replace function invalid_udtf_0 () RETURNS TABLE (c1_string string, c2
 
 statement error
 select * from invalid_udtf_0();
+
+statement ok
+create or replace table t2 (c1 string);
+
+statement ok
+insert into t2 values('hello'), ('databend');
+
+statement ok
+create or replace function filter_t2 (arg0 string) RETURNS TABLE (c1_string string) as $$ select * from t2 where c1 = arg0 $$;
+
+query T
+select * from filter_t2('hello');
+----
+hello


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`scalar::to_string` will add extra quotes to the String type, Replace it with `scalar_ref_to_string` and it will work fine.
```sql
explain
SELECT
  *
FROM
  get_employees_by_dept('Engineering')

-[ EXPLAIN ]-----------------------------------
EvalScalar
├── output columns: [id (#3), name (#4), department (#5)]
├── expressions: [employees.id (#0), employees.name (#1), employees.department (#2)]
├── estimated rows: 0.00
└── Filter
    ├── output columns: [employees.id (#0), employees.name (#1), employees.department (#2)]
    ├── filters: [is_true(employees.department (#2) = '\'Engineering\'')]
    ├── estimated rows: 0.00
    └── TableScan
        ├── table: default.default.employees
        ├── output columns: [id (#0), name (#1), department (#2)]
        ├── read rows: 0
        ├── read size: 0
        ├── partitions total: 1
        ├── partitions scanned: 0
        ├── pruning stats: [segments: <range pruning: 1 to 0>]
        ├── push downs: [filters: [is_true(employees.department (#2) = '\'Engineering\'')], limit: NONE]
        └── estimated rows: 2.00
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
