### PR TITLE
fix: should not use array contains to implement inlist runtime filter

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -215,3 +215,93 @@ fn build_bloom_filter(
     let filter = BinaryFuse16::try_from(&hashes_vec)?;
     Ok((probe_key.id.to_string(), filter))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::ColumnBuilder;
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::Constant;
+    use databend_common_expression::ConstantFolder;
+    use databend_common_expression::Domain;
+    use databend_common_expression::Expr;
+    use databend_common_expression::FunctionContext;
+    use databend_common_expression::Scalar;
+    use databend_common_functions::BUILTIN_FUNCTIONS;
+
+    use super::build_inlist_filter;
+
+    #[test]
+    fn test_build_inlist_filter() {
+        let func_ctx = FunctionContext::default();
+
+        // Create test column with values {1, 10}
+        let data_type = DataType::Number(NumberDataType::Int32);
+        let mut builder = ColumnBuilder::with_capacity(&data_type, 2);
+        builder.push(Scalar::Number(1i32.into()).as_ref());
+        builder.push(Scalar::Number(10i32.into()).as_ref());
+        let inlist = builder.build();
+
+        // Create probe key expression: column_a
+        let probe_key = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: "column_a".to_string(),
+            data_type: data_type.clone(),
+            display_name: "column_a".to_string(),
+        });
+
+        // Build the filter expression
+        let filter_expr = build_inlist_filter(inlist, &probe_key).unwrap();
+
+        // Test with ConstantFolder - case where column_a in [2,10] (can be folded to constant)
+        let mut input_domains = HashMap::new();
+        let domain_value_2_10 = Domain::from_min_max(
+            Scalar::Number(2i32.into()),
+            Scalar::Number(10i32.into()),
+            &data_type,
+        );
+        input_domains.insert("column_a".to_string(), domain_value_2_10);
+
+        let (folded_expr, _) = ConstantFolder::fold_with_domain(
+            &filter_expr,
+            &input_domains,
+            &func_ctx,
+            &BUILTIN_FUNCTIONS,
+        );
+
+        // Verify it's not folded to constant
+        assert!(folded_expr.as_constant().is_none());
+
+        // Test with ConstantFolder - case where column_a in [2,9] (should evaluate to false)
+        let mut input_domains_false = HashMap::new();
+        let domain_value_2_9 = Domain::from_min_max(
+            Scalar::Number(2i32.into()),
+            Scalar::Number(9i32.into()),
+            &data_type,
+        );
+        input_domains_false.insert("column_a".to_string(), domain_value_2_9);
+
+        let (folded_expr_false, _) = ConstantFolder::fold_with_domain(
+            &filter_expr,
+            &input_domains_false,
+            &func_ctx,
+            &BUILTIN_FUNCTIONS,
+        );
+
+        // Range [2,9] does not intersect with {1, 10}, so it should fold to constant false
+        match folded_expr_false {
+            Expr::Constant(Constant {
+                scalar: Scalar::Boolean(false),
+                ..
+            }) => {
+                println!("✓ Test passed: column_a in [2,9] correctly evaluated to false");
+            }
+            _ => {
+                panic!("Expected constant false, got: {:?}", folded_expr_false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The expected behavior of inlist runtime filter is to compare each value individually for equality. The contains function compares domains and does not perform individual value comparisons.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
