### PR TITLE
refactor: add `IdempotentKVTxnSender`

### DIFF
--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -105,6 +105,7 @@ use databend_common_proto_conv::FromToProto;
 use crate::errors::TableError;
 use crate::kv_app_error::KVAppError;
 use crate::meta_txn_error::MetaTxnError;
+use crate::util::IdempotentKVTxnSender;
 
 /// SchemaApi defines APIs that provides schema storage, such as database, table.
 #[async_trait::async_trait]
@@ -276,10 +277,10 @@ pub trait SchemaApi: Send + Sync {
         req: UpdateMultiTableMetaReq,
     ) -> Result<UpdateMultiTableMetaResult, KVAppError>;
 
-    async fn update_multi_table_meta_with_txn_id(
+    async fn update_multi_table_meta_with_sender(
         &self,
         req: UpdateMultiTableMetaReq,
-        txn_id: String,
+        kv_txn_sender: &IdempotentKVTxnSender,
     ) -> Result<UpdateMultiTableMetaResult, KVAppError>;
 
     async fn set_table_column_mask_policy(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `IdempotentKVTxnSender`
- make kv txn of `commit_table_meta` idempotent
- refactor `update_multi_table_meta` and `create_lock_revision` by using `IdempotentKVTxnSender`


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - using exist tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
