### PR TITLE
fix(query): prevent stack overflow in CTE processing with recursive annotations

### DIFF
--- a/src/query/sql/src/planner/binder/bind_query/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind.rs
@@ -67,6 +67,7 @@ impl CTERefCounter {
 }
 
 impl Binder {
+    #[recursive::recursive]
     pub(crate) fn bind_query(
         &mut self,
         bind_context: &mut BindContext,
@@ -119,6 +120,7 @@ impl Binder {
         Ok(())
     }
 
+    #[recursive::recursive]
     pub fn compute_cte_ref_count(
         &self,
         with: &With,
@@ -209,6 +211,7 @@ impl Binder {
         ))
     }
 
+    #[recursive::recursive]
     pub fn m_cte_to_temp_table(
         &mut self,
         cte: &CTE,
@@ -345,6 +348,7 @@ impl TableNameReplacer {
         }
     }
 
+    #[recursive::recursive]
     fn enter_table_reference(&mut self, table_reference: &mut TableReference) {
         if let TableReference::Table {
             database, table, ..
@@ -356,6 +360,7 @@ impl TableNameReplacer {
         }
     }
 
+    #[recursive::recursive]
     fn enter_expr(&mut self, expr: &mut Expr) {
         if let Expr::ColumnRef { column, .. } = expr {
             if column.database.is_none() || column.database.as_ref().unwrap().name == self.database

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_cte.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_cte.rs
@@ -165,6 +165,7 @@ impl Binder {
         Ok((s_expr, new_bind_context))
     }
 
+    #[recursive::recursive]
     pub fn bind_cte_definition(
         &mut self,
         cte_name: &str,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix stack overflow in CTE processing that caused segmentation faults when processing complex queries with many UNION operations.

- Close #18577 related issue

## 🐛 Problem Description

PR #18577 introduced a regression causing segmentation faults when processing complex CTE (Common Table Expression) queries with many UNION operations. The issue manifests as stack overflow due to deep recursive calls during query binding and AST traversal.

### Root Cause
The `m_cte_to_temp_table()` function performs double recursion:
1. **TableNameReplacer** recursively traverses AST nodes via `drive_mut()`  
2. **Query binding** recursively processes the modified query via `bind_query()`

For queries with 150+ UNION operations, this creates ~300 levels of recursive calls, exceeding stack limits.

## 🔧 Solution

Following the pattern established in PR #18268, this fix adds `#[recursive::recursive]` annotations to key CTE processing functions. The `recursive` library automatically grows stack size when needed, preventing overflow.

### Modified Functions
- `bind_query()` - Main query binding entry point
- `m_cte_to_temp_table()` - CTE temporary table creation  
- `compute_cte_ref_count()` - CTE reference counting
- `bind_cte_definition()` - CTE definition binding
- `TableNameReplacer` visitor methods - AST traversal for name replacement

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18588)
<!-- Reviewable:end -->
