### PR TITLE
feat(query): apply row access policy in Binder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4169,6 +4169,7 @@ dependencies = [
  "databend-common-storages-basic",
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
+ "databend-enterprise-row-access-policy-feature",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",

--- a/src/query/sql/Cargo.toml
+++ b/src/query/sql/Cargo.toml
@@ -12,6 +12,7 @@ storage-hdfs = ["databend-common-config/storage-hdfs"]
 
 [dependencies]
 databend-common-ast = { workspace = true }
+databend-enterprise-row-access-policy-feature = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-catalog = { workspace = true }
 databend-common-compress = { workspace = true }

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_row_access_policy.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_row_access_policy.test
@@ -16,6 +16,9 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
+set global enable_planner_cache = 0;
+
+statement ok
 drop row access policy if exists rap1;
 
 statement ok
@@ -38,7 +41,7 @@ create row access policy IF NOT EXISTS rap_it as (empl_id varchar) returns boole
 statement ok
 create or replace row access policy rap_it as (empl_id string null) returns boolean ->
   case
-      when 'it_admin' = current_role() then false
+      when 'account_admin' = current_role() then false
       else true
   end;
 
@@ -60,6 +63,14 @@ alter table t ADD ROW ACCESS POLICY rap_it ON (id);
 
 statement ok
 alter table t ADD ROW ACCESS POLICY rap_it ON (empl_id);
+
+statement ok
+insert into t values(1,'x');
+
+query T
+select id from t;
+----
+
 
 statement error 1132
 alter table t ADD ROW ACCESS POLICY rap_it ON (empl_id);
@@ -83,6 +94,11 @@ ALTER TABLE t drop row access policy p1;
 statement ok
 ALTER TABLE t drop row access policy rap_it;
 
+query T
+select id from t;
+----
+1
+
 statement ok
 ALTER TABLE t drop all row access policies;
 
@@ -96,4 +112,10 @@ statement ok
 drop row access policy if exists p1;
 
 statement ok
+drop table if exists t;
+
+statement ok
 unset global enable_experimental_row_access_policy;
+
+statement ok
+unset global enable_planner_cache;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In this pr :

1. Need to disable enable_planner_cache. Because stmt maybe same but table meta is different(add or drop a row access policy).
2. Directly append row access policy expr into where expr.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18609)
<!-- Reviewable:end -->
