### PR TITLE
feat: Add `RuleFilterFlattenOr`

### DIFF
--- a/src/query/expression/src/expression.rs
+++ b/src/query/expression/src/expression.rs
@@ -771,9 +771,9 @@ impl<Index: ColumnIndex> Expr<Index> {
         }
     }
 
-    pub fn visit_func(&self, func_name: &str, visitor: &mut impl FnMut(&FunctionCall<Index>)) {
+    pub fn visit_func(&self, func_names: &[&str], visitor: &mut impl FnMut(&FunctionCall<Index>)) {
         struct Visitor<'a, Index: ColumnIndex, F: FnMut(&FunctionCall<Index>)> {
-            name: String,
+            names: &'a [&'a str],
             visitor: &'a mut F,
             _marker: std::marker::PhantomData<Index>,
         }
@@ -785,7 +785,7 @@ impl<Index: ColumnIndex> Expr<Index> {
                 &mut self,
                 call: &FunctionCall<Index>,
             ) -> Result<Option<Expr<Index>>, Self::Error> {
-                if call.function.signature.name == self.name {
+                if self.names.contains(&call.function.signature.name.as_str()) {
                     (self.visitor)(call);
                 }
                 Self::visit_function_call(call, self)
@@ -793,7 +793,7 @@ impl<Index: ColumnIndex> Expr<Index> {
         }
 
         visit_expr(self, &mut Visitor {
-            name: func_name.to_string(),
+            names: func_names,
             visitor,
             _marker: std::marker::PhantomData,
         })

--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -113,7 +113,7 @@ impl FilterHelpers {
                     // for the equality columns set,let's call `ecs`
                     // if any side of `or` of the name columns is not in `ecs`, it's valid
                     // otherwise, it's invalid
-                    expr.visit_func("or", &mut |call| {
+                    expr.visit_func(&["or", "or_filters"], &mut |call| {
                         for arg in call.args.iter() {
                             let mut ecs = HashSet::new();
                             arg.find_function_literals("eq", &mut |col_name, _scalar, _| {

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -156,8 +156,8 @@ impl SubqueryDecorrelatorOptimizer {
                     ..
                 } => {
                     if is_equal_op {
-                        left_conditions.push(left.clone());
-                        right_conditions.push(right.clone());
+                        left_conditions.push(left.into_owned());
+                        right_conditions.push(right.into_owned());
                     } else {
                         non_equi_conditions.push(pred.clone());
                     }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
@@ -79,7 +79,9 @@ fn predicate_scalar(scalar: &ScalarExpr) -> PredicateScalar {
             }
             PredicateScalar::And(and_args)
         }
-        ScalarExpr::FunctionCall(func) if func.func_name == "or" => {
+        ScalarExpr::FunctionCall(func)
+            if matches!(func.func_name.as_str(), "or" | "or_filters") =>
+        {
             let mut or_args = vec![];
             for argument in func.arguments.iter() {
                 // Recursively flatten the OR expressions.

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
@@ -24,6 +24,7 @@ use crate::optimizer::optimizers::rule::RuleEliminateEvalScalar;
 use crate::optimizer::optimizers::rule::RuleEliminateFilter;
 use crate::optimizer::optimizers::rule::RuleEliminateSort;
 use crate::optimizer::optimizers::rule::RuleEliminateUnion;
+use crate::optimizer::optimizers::rule::RuleFilterFlattenOr;
 use crate::optimizer::optimizers::rule::RuleFilterNulls;
 use crate::optimizer::optimizers::rule::RuleFoldCountAggregate;
 use crate::optimizer::optimizers::rule::RuleGroupingSetsToUnion;
@@ -71,6 +72,7 @@ impl RuleFactory {
             RuleID::FilterNulls => Ok(Box::new(RuleFilterNulls::new(
                 ctx.get_enable_distributed_optimization(),
             ))),
+            RuleID::FilterFlattenOr => Ok(Box::new(RuleFilterFlattenOr::new())),
             RuleID::PushDownFilterUnion => Ok(Box::new(RulePushDownFilterUnion::new())),
             RuleID::PushDownFilterEvalScalar => Ok(Box::new(RulePushDownFilterEvalScalar::new())),
             RuleID::PushDownFilterJoin => Ok(Box::new(RulePushDownFilterJoin::new(metadata))),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/mod.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod rule_eliminate_filter;
+mod rule_filter_flatten_or;
 mod rule_filter_nulls;
 mod rule_merge_filter;
 mod rule_merge_filter_into_mutation;
@@ -30,6 +31,7 @@ mod rule_push_down_sort_filter_scan;
 mod rule_push_down_sort_scan;
 
 pub use rule_eliminate_filter::RuleEliminateFilter;
+pub use rule_filter_flatten_or::RuleFilterFlattenOr;
 pub use rule_filter_nulls::RuleFilterNulls;
 pub use rule_merge_filter::RuleMergeFilter;
 pub use rule_merge_filter_into_mutation::RuleMergeFilterIntoMutation;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_flatten_or.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_flatten_or.rs
@@ -1,0 +1,105 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+
+use crate::optimizer::ir::Matcher;
+use crate::optimizer::ir::SExpr;
+use crate::optimizer::optimizers::rule::Rule;
+use crate::optimizer::optimizers::rule::RuleID;
+use crate::optimizer::optimizers::rule::TransformResult;
+use crate::plans::Filter;
+use crate::plans::FunctionCall;
+use crate::plans::RelOp;
+use crate::plans::ScalarExpr;
+
+pub struct RuleFilterFlattenOr {
+    id: RuleID,
+    matchers: Vec<Matcher>,
+}
+
+impl RuleFilterFlattenOr {
+    pub fn new() -> Self {
+        Self {
+            id: RuleID::FilterFlattenOr,
+            // Filter
+            //  \
+            //   *
+            matchers: vec![Matcher::MatchOp {
+                op_type: RelOp::Filter,
+                children: vec![Matcher::Leaf],
+            }],
+        }
+    }
+}
+
+impl Default for RuleFilterFlattenOr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for RuleFilterFlattenOr {
+    fn id(&self) -> RuleID {
+        self.id
+    }
+
+    fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
+        let mut filter: Filter = s_expr.plan().clone().try_into()?;
+        let mut has_replace = false;
+
+        for predicate in filter.predicates.iter_mut() {
+            let mut or_exprs = Vec::new();
+            flatten_or_expr(predicate, &mut or_exprs);
+
+            if or_exprs.len() > 2 {
+                *predicate = FunctionCall {
+                    span: None,
+                    func_name: "or_filters".to_string(),
+                    params: vec![],
+                    arguments: or_exprs,
+                }
+                .into();
+                has_replace = true
+            }
+        }
+        if !has_replace {
+            state.add_result(s_expr.clone());
+            return Ok(());
+        }
+        let mut res =
+            SExpr::create_unary(Arc::new(filter.into()), Arc::new(s_expr.child(0)?.clone()));
+        res.set_applied_rule(&self.id());
+        state.add_result(res);
+
+        Ok(())
+    }
+
+    fn matchers(&self) -> &[Matcher] {
+        &self.matchers
+    }
+}
+
+fn flatten_or_expr(expr: &ScalarExpr, or_exprs: &mut Vec<ScalarExpr>) {
+    match expr {
+        ScalarExpr::FunctionCall(func) if func.func_name == "or" => {
+            for argument in func.arguments.iter() {
+                flatten_or_expr(argument, or_exprs);
+            }
+        }
+        _ => or_exprs.push(expr.clone()),
+    }
+}

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
@@ -267,8 +267,8 @@ pub fn try_push_down_filter_join(s_expr: &SExpr, metadata: MetadataRef) -> Resul
             }
             JoinPredicate::Both { left, right, .. } => {
                 join.equi_conditions.push(JoinEquiCondition::new(
-                    left.clone(),
-                    right.clone(),
+                    left.into_owned(),
+                    right.into_owned(),
                     false,
                 ));
             }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/extract_or_predicates.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/extract_or_predicates.rs
@@ -155,10 +155,16 @@ fn make_and_expr(scalars: &[ScalarExpr]) -> ScalarExpr {
 
 // Merge predicates to OR scalar
 fn make_or_expr(scalars: &[ScalarExpr]) -> ScalarExpr {
-    ScalarExpr::FunctionCall(FunctionCall {
-        span: None,
-        func_name: "or_filters".to_string(),
-        params: vec![],
-        arguments: scalars.to_vec(),
-    })
+    scalars
+        .iter()
+        .cloned()
+        .reduce(|lhs, rhs| {
+            ScalarExpr::FunctionCall(FunctionCall {
+                span: None,
+                func_name: "or".to_string(),
+                params: vec![],
+                arguments: vec![lhs, rhs],
+            })
+        })
+        .unwrap()
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/mark_join_to_semi_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/mark_join_to_semi_join.rs
@@ -27,7 +27,7 @@ pub fn convert_mark_to_semi_join(s_expr: &SExpr) -> Result<(SExpr, bool)> {
     let mut join: Join = s_expr.child(0)?.plan().clone().try_into()?;
 
     let has_disjunction = filter.predicates.iter().any(
-        |predicate| matches!(predicate, ScalarExpr::FunctionCall(func) if func.func_name == "or"),
+        |predicate| matches!(predicate, ScalarExpr::FunctionCall(func) if matches!(func.func_name.as_str(), "or" | "or_filters")),
     );
 
     if !join.join_type.is_mark_join() || has_disjunction {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
@@ -152,8 +152,8 @@ impl Rule for RuleLeftExchangeJoin {
                 } => {
                     if is_equal_op {
                         join_3.equi_conditions.push(JoinEquiCondition::new(
-                            left.clone(),
-                            right.clone(),
+                            left.into_owned(),
+                            right.into_owned(),
                             false,
                         ));
                     } else {
@@ -188,8 +188,8 @@ impl Rule for RuleLeftExchangeJoin {
                 } => {
                     if is_equal_op {
                         join_4.equi_conditions.push(JoinEquiCondition::new(
-                            left.clone(),
-                            right.clone(),
+                            left.into_owned(),
+                            right.into_owned(),
                             false,
                         ));
                     } else {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/rule.rs
@@ -32,6 +32,7 @@ pub static DEFAULT_REWRITE_RULES: LazyLock<Vec<RuleID>> = LazyLock::new(|| {
         RuleID::MergeEvalScalar,
         // Filter
         RuleID::FilterNulls,
+        RuleID::FilterFlattenOr,
         RuleID::EliminateFilter,
         RuleID::MergeFilter,
         RuleID::NormalizeScalarFilter,
@@ -92,6 +93,7 @@ pub enum RuleID {
     PushDownFilterAggregate,
     PushDownFilterEvalScalar,
     FilterNulls,
+    FilterFlattenOr,
     PushDownFilterUnion,
     PushDownFilterJoin,
     PushDownFilterScan,
@@ -137,6 +139,7 @@ impl Display for RuleID {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             RuleID::FilterNulls => write!(f, "FilterNulls"),
+            RuleID::FilterFlattenOr => write!(f, "FilterFlattenOr"),
             RuleID::PushDownFilterUnion => write!(f, "PushDownFilterUnion"),
             RuleID::PushDownFilterEvalScalar => write!(f, "PushDownFilterEvalScalar"),
             RuleID::PushDownFilterJoin => write!(f, "PushDownFilterJoin"),

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -59,7 +59,7 @@ Filter
     ├── estimated rows: 0.00
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
-    │   ├── filters: [or_filters(t1.a (#0) > 3, t1.a (#0) > 1)]
+    │   ├── filters: [(t1.a (#0) > 3 OR t1.a (#0) > 1)]
     │   ├── estimated rows: 0.00
     │   └── TableScan
     │       ├── table: default.default.t1
@@ -69,11 +69,11 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 0
     │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
-    │       ├── push downs: [filters: [or_filters(t1.a (#0) > 3, t1.a (#0) > 1)], limit: NONE]
+    │       ├── push downs: [filters: [(t1.a (#0) > 3 OR t1.a (#0) > 1)], limit: NONE]
     │       └── estimated rows: 1.00
     └── Filter(Probe)
         ├── output columns: [t2.a (#2), t2.b (#3)]
-        ├── filters: [or_filters(t2.a (#2) > 3, t2.a (#2) > 1)]
+        ├── filters: [(t2.a (#2) > 3 OR t2.a (#2) > 1)]
         ├── estimated rows: 3.40
         └── TableScan
             ├── table: default.default.t2
@@ -83,7 +83,7 @@ Filter
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            ├── push downs: [filters: [or_filters(t2.a (#2) > 3, t2.a (#2) > 1)], limit: NONE]
+            ├── push downs: [filters: [(t2.a (#2) > 3 OR t2.a (#2) > 1)], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 5.00
 
@@ -338,7 +338,7 @@ Filter
     ├── estimated rows: 4.40
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
-    │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)]
+    │   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)]
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
@@ -348,11 +348,11 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)], limit: NONE]
+    │       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)], limit: NONE]
     │       └── estimated rows: 1.00
     └── Filter(Probe)
         ├── output columns: [t2.a (#2), t2.b (#3)]
-        ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
+        ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
         ├── estimated rows: 4.40
         └── TableScan
             ├── table: default.default.t2
@@ -362,7 +362,7 @@ Filter
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
+            ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
             └── estimated rows: 5.00
 
 query T
@@ -474,7 +474,7 @@ HashJoin
 ├── estimated rows: 28.16
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
-│   ├── filters: [((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)), or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4))]
+│   ├── filters: [((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4))]
 │   ├── estimated rows: 3.52
 │   └── HashJoin
 │       ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -486,7 +486,7 @@ HashJoin
 │       ├── estimated rows: 4.40
 │       ├── Filter(Build)
 │       │   ├── output columns: [t1.a (#0), t1.b (#1)]
-│       │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)]
+│       │   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)]
 │       │   ├── estimated rows: 1.00
 │       │   └── TableScan
 │       │       ├── table: default.default.t1
@@ -496,11 +496,11 @@ HashJoin
 │       │       ├── partitions total: 1
 │       │       ├── partitions scanned: 1
 │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│       │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)], limit: NONE]
+│       │       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)], limit: NONE]
 │       │       └── estimated rows: 1.00
 │       └── Filter(Probe)
 │           ├── output columns: [t2.a (#2), t2.b (#3)]
-│           ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
+│           ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
 │           ├── estimated rows: 4.40
 │           └── TableScan
 │               ├── table: default.default.t2
@@ -510,7 +510,7 @@ HashJoin
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│               ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
+│               ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
 │               └── estimated rows: 5.00
 └── Filter(Probe)
     ├── output columns: [t3.a (#4), t3.b (#5)]
@@ -567,7 +567,7 @@ Limit
             │       └── estimated rows: 1.00
             └── Filter(Probe)
                 ├── output columns: [t2.a (#2), t2.b (#3)]
-                ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
+                ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
                 ├── estimated rows: 4.40
                 └── TableScan
                     ├── table: default.default.t2
@@ -577,7 +577,7 @@ Limit
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-                    ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
+                    ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
                     └── estimated rows: 5.00
 
 query 
@@ -593,7 +593,7 @@ HashJoin
 ├── estimated rows: 5.00
 ├── Filter(Build)
 │   ├── output columns: [t1.a (#0), t1.b (#1)]
-│   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2), or_filters(t1.a (#0) > 1, t1.b (#1) < 2)]
+│   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2)]
 │   ├── estimated rows: 1.00
 │   └── TableScan
 │       ├── table: default.default.t1
@@ -603,7 +603,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│       ├── push downs: [filters: [and_filters((t1.a (#0) > 1 OR t1.b (#1) < 2), or_filters(t1.a (#0) > 1, t1.b (#1) < 2))], limit: NONE]
+│       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2)], limit: NONE]
 │       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.default.t2

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -59,7 +59,7 @@ Filter
     ├── estimated rows: 0.00
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
-    │   ├── filters: [(t1.a (#0) > 3 OR t1.a (#0) > 1)]
+    │   ├── filters: [or_filters(t1.a (#0) > 3, t1.a (#0) > 1)]
     │   ├── estimated rows: 0.00
     │   └── TableScan
     │       ├── table: default.default.t1
@@ -69,11 +69,11 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 0
     │       ├── pruning stats: [segments: <range pruning: 1 to 0>]
-    │       ├── push downs: [filters: [(t1.a (#0) > 3 OR t1.a (#0) > 1)], limit: NONE]
+    │       ├── push downs: [filters: [or_filters(t1.a (#0) > 3, t1.a (#0) > 1)], limit: NONE]
     │       └── estimated rows: 1.00
     └── Filter(Probe)
         ├── output columns: [t2.a (#2), t2.b (#3)]
-        ├── filters: [(t2.a (#2) > 3 OR t2.a (#2) > 1)]
+        ├── filters: [or_filters(t2.a (#2) > 3, t2.a (#2) > 1)]
         ├── estimated rows: 3.40
         └── TableScan
             ├── table: default.default.t2
@@ -83,7 +83,7 @@ Filter
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            ├── push downs: [filters: [(t2.a (#2) > 3 OR t2.a (#2) > 1)], limit: NONE]
+            ├── push downs: [filters: [or_filters(t2.a (#2) > 3, t2.a (#2) > 1)], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 5.00
 
@@ -338,7 +338,7 @@ Filter
     ├── estimated rows: 4.40
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
-    │   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)]
+    │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)]
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
@@ -348,11 +348,11 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-    │       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)], limit: NONE]
+    │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)], limit: NONE]
     │       └── estimated rows: 1.00
     └── Filter(Probe)
         ├── output columns: [t2.a (#2), t2.b (#3)]
-        ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
+        ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
         ├── estimated rows: 4.40
         └── TableScan
             ├── table: default.default.t2
@@ -362,7 +362,7 @@ Filter
             ├── partitions total: 1
             ├── partitions scanned: 1
             ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
+            ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
             └── estimated rows: 5.00
 
 query T
@@ -370,7 +370,7 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 ----
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
-├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t1.a (#0) = 2)]
+├── filters: [or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4), t1.a (#0) = 2)]
 ├── estimated rows: 4.00
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -382,7 +382,7 @@ Filter
     ├── estimated rows: 5.00
     ├── Filter(Build)
     │   ├── output columns: [t1.a (#0), t1.b (#1)]
-    │   ├── filters: [((t1.a (#0) > 1 OR t1.b (#1) < 3) OR t1.a (#0) = 2)]
+    │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3, t1.a (#0) = 2)]
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t1
@@ -392,7 +392,7 @@ Filter
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
     │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
-    │       ├── push downs: [filters: [((t1.a (#0) > 1 OR t1.b (#1) < 3) OR t1.a (#0) = 2)], limit: NONE]
+    │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3, t1.a (#0) = 2)], limit: NONE]
     │       └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.default.t2
@@ -420,7 +420,7 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── keys is null equal: []
-├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
+├── filters: [or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4), t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -474,7 +474,7 @@ HashJoin
 ├── estimated rows: 28.16
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
-│   ├── filters: [((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4))]
+│   ├── filters: [((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)), or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4))]
 │   ├── estimated rows: 3.52
 │   └── HashJoin
 │       ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -486,7 +486,7 @@ HashJoin
 │       ├── estimated rows: 4.40
 │       ├── Filter(Build)
 │       │   ├── output columns: [t1.a (#0), t1.b (#1)]
-│       │   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)]
+│       │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)]
 │       │   ├── estimated rows: 1.00
 │       │   └── TableScan
 │       │       ├── table: default.default.t1
@@ -496,11 +496,11 @@ HashJoin
 │       │       ├── partitions total: 1
 │       │       ├── partitions scanned: 1
 │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│       │       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 3)], limit: NONE]
+│       │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3)], limit: NONE]
 │       │       └── estimated rows: 1.00
 │       └── Filter(Probe)
 │           ├── output columns: [t2.a (#2), t2.b (#3)]
-│           ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
+│           ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
 │           ├── estimated rows: 4.40
 │           └── TableScan
 │               ├── table: default.default.t2
@@ -510,7 +510,7 @@ HashJoin
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
 │               ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│               ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
+│               ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
 │               └── estimated rows: 5.00
 └── Filter(Probe)
     ├── output columns: [t3.a (#4), t3.b (#5)]
@@ -553,7 +553,7 @@ Limit
             ├── estimated rows: 4.40
             ├── Filter(Build)
             │   ├── output columns: [t1.a (#0), t1.b (#1)]
-            │   ├── filters: [((t1.a (#0) > 1 OR t1.b (#1) < 2) OR t1.b (#1) < 3)]
+            │   ├── filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 2, t1.b (#1) < 3)]
             │   ├── estimated rows: 1.00
             │   └── TableScan
             │       ├── table: default.default.t1
@@ -563,11 +563,11 @@ Limit
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
             │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            │       ├── push downs: [filters: [((t1.a (#0) > 1 OR t1.b (#1) < 2) OR t1.b (#1) < 3)], limit: NONE]
+            │       ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 2, t1.b (#1) < 3)], limit: NONE]
             │       └── estimated rows: 1.00
             └── Filter(Probe)
                 ├── output columns: [t2.a (#2), t2.b (#3)]
-                ├── filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)]
+                ├── filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)]
                 ├── estimated rows: 4.40
                 └── TableScan
                     ├── table: default.default.t2
@@ -577,7 +577,7 @@ Limit
                     ├── partitions total: 1
                     ├── partitions scanned: 1
                     ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-                    ├── push downs: [filters: [(t2.a (#2) > 2 OR t2.b (#3) < 4)], limit: NONE]
+                    ├── push downs: [filters: [or_filters(t2.a (#2) > 2, t2.b (#3) < 4)], limit: NONE]
                     └── estimated rows: 5.00
 
 query 
@@ -593,7 +593,7 @@ HashJoin
 ├── estimated rows: 5.00
 ├── Filter(Build)
 │   ├── output columns: [t1.a (#0), t1.b (#1)]
-│   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2)]
+│   ├── filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2), or_filters(t1.a (#0) > 1, t1.b (#1) < 2)]
 │   ├── estimated rows: 1.00
 │   └── TableScan
 │       ├── table: default.default.t1
@@ -603,7 +603,7 @@ HashJoin
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-│       ├── push downs: [filters: [(t1.a (#0) > 1 OR t1.b (#1) < 2)], limit: NONE]
+│       ├── push downs: [filters: [and_filters((t1.a (#0) > 1 OR t1.b (#1) < 2), or_filters(t1.a (#0) > 1, t1.b (#1) < 2))], limit: NONE]
 │       └── estimated rows: 1.00
 └── TableScan(Probe)
     ├── table: default.default.t2

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -102,3 +102,20 @@ Filter
     ├── pruning stats: [segments: <range pruning: 2 to 0>]
     ├── push downs: [filters: [t2.d (#0) < CAST(t2.a (#1) AS Timestamp)], limit: NONE]
     └── estimated rows: 200.00
+
+query T
+explain select number from numbers(6) where number = 1 or number = 5 or number = 3;
+----
+Filter
+├── output columns: [numbers.number (#0)]
+├── filters: [or_filters(numbers.number (#0) = 1, numbers.number (#0) = 5, numbers.number (#0) = 3)]
+├── estimated rows: 1.20
+└── TableScan
+    ├── table: default.system.numbers
+    ├── output columns: [number (#0)]
+    ├── read rows: 6
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── push downs: [filters: [or_filters(numbers.number (#0) = 1, numbers.number (#0) = 5, numbers.number (#0) = 3)], limit: NONE]
+    └── estimated rows: 6.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -109,7 +109,7 @@ explain select number from numbers(6) where number = 1 or number = 5 or number =
 Filter
 ├── output columns: [numbers.number (#0)]
 ├── filters: [or_filters(numbers.number (#0) = 1, numbers.number (#0) = 5, numbers.number (#0) = 3)]
-├── estimated rows: 1.20
+├── estimated rows: 0.01
 └── TableScan
     ├── table: default.system.numbers
     ├── output columns: [number (#0)]

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/explain.test
@@ -338,7 +338,7 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 ----
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
-├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t1.a (#0) = 2)]
+├── filters: [or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4), t1.a (#0) = 2)]
 ├── estimated rows: 4.00
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -356,7 +356,7 @@ Filter
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
     │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
-    │   ├── push downs: [filters: [((t1.a (#0) > 1 OR t1.b (#1) < 3) OR t1.a (#0) = 2)], limit: NONE]
+    │   ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 3, t1.a (#0) = 2)], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
         ├── table: default.default.t2
@@ -384,7 +384,7 @@ HashJoin
 ├── build keys: []
 ├── probe keys: []
 ├── keys is null equal: []
-├── filters: [(((t1.a (#0) > 1 AND t2.a (#2) > 2) OR (t1.b (#1) < 3 AND t2.b (#3) < 4)) OR t3.a (#4) = 2)]
+├── filters: [or_filters((t1.a (#0) > 1 AND t2.a (#2) > 2), (t1.b (#1) < 3 AND t2.b (#3) < 4), t3.a (#4) = 2)]
 ├── estimated rows: 50.00
 ├── HashJoin(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
@@ -511,7 +511,7 @@ Limit
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
             │   ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1>]
-            │   ├── push downs: [filters: [((t1.a (#0) > 1 OR t1.b (#1) < 2) OR t1.b (#1) < 3)], limit: NONE]
+            │   ├── push downs: [filters: [or_filters(t1.a (#0) > 1, t1.b (#1) < 2, t1.b (#1) < 3)], limit: NONE]
             │   └── estimated rows: 1.00
             └── TableScan(Probe)
                 ├── table: default.default.t2

--- a/tests/sqllogictests/suites/query/functions/02_0046_function_logic.test
+++ b/tests/sqllogictests/suites/query/functions/02_0046_function_logic.test
@@ -362,5 +362,12 @@ select number, or_filters(number = 1, number = 5 , number = 3) from numbers(6) o
 4 0
 5 1
 
+query I
+select number from numbers(6) where number = 1 or number = 5 or number = 3 order by number;
+----
+1
+3
+5
+
 statement ok
 DROP TABLE t_logic


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add `RuleFilterFlattenOr` is used to fold the outer `or` of the predicate in Filter into `or_filters`

Tips: 
example:
```sql
explain select number from numbers(6) where number = 1 or number = 5 or number = 3;

👇

explain select number from numbers(6) where or_filters(number = 1, number = 5, number = 3);
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18621)
<!-- Reviewable:end -->
