### PR TITLE
refactor: refactor inlist runtime filter with  or_filters and add configurable runtime filter thresholds

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -70,8 +70,6 @@ use crate::pipelines::processors::transforms::hash_join::SingleBinaryHashJoinHas
 use crate::pipelines::processors::HashJoinState;
 use crate::sessions::QueryContext;
 
-pub(crate) const INLIST_RUNTIME_FILTER_THRESHOLD: usize = 1024;
-
 /// Define some shared states for all hash join build threads.
 pub struct HashJoinBuildState {
     pub(crate) ctx: Arc<QueryContext>,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/builder.rs
@@ -37,6 +37,8 @@ struct JoinRuntimeFilterPacketBuilder<'a> {
     build_key_column: Column,
     func_ctx: &'a FunctionContext,
     inlist_threshold: usize,
+    bloom_threshold: usize,
+    min_max_threshold: usize,
 }
 
 impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
@@ -45,12 +47,16 @@ impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
         func_ctx: &'a FunctionContext,
         build_key: &Expr,
         inlist_threshold: usize,
+        bloom_threshold: usize,
+        min_max_threshold: usize,
     ) -> Result<Self> {
         let build_key_column = Self::eval_build_key_column(data_blocks, func_ctx, build_key)?;
         Ok(Self {
             func_ctx,
             build_key_column,
             inlist_threshold,
+            bloom_threshold,
+            min_max_threshold,
         })
     }
     fn build(&self, desc: &RuntimeFilterDesc) -> Result<RuntimeFilterPacket> {
@@ -75,16 +81,15 @@ impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
     }
 
     fn enable_min_max(&self, desc: &RuntimeFilterDesc) -> bool {
-        desc.enable_min_max_runtime_filter
+        desc.enable_min_max_runtime_filter && self.build_key_column.len() < self.min_max_threshold
     }
 
     fn enable_inlist(&self, desc: &RuntimeFilterDesc) -> bool {
-        desc.enable_inlist_runtime_filter
-            && self.build_key_column.len() < self.inlist_threshold
+        desc.enable_inlist_runtime_filter && self.build_key_column.len() < self.inlist_threshold
     }
 
     fn enable_bloom(&self, desc: &RuntimeFilterDesc) -> bool {
-        desc.enable_bloom_runtime_filter
+        desc.enable_bloom_runtime_filter && self.build_key_column.len() < self.bloom_threshold
     }
 
     fn build_min_max(&self) -> Result<SerializableDomain> {
@@ -150,6 +155,8 @@ pub fn build_runtime_filter_packet(
     runtime_filter_desc: &[RuntimeFilterDesc],
     func_ctx: &FunctionContext,
     inlist_threshold: usize,
+    bloom_threshold: usize,
+    min_max_threshold: usize,
 ) -> Result<JoinRuntimeFilterPacket> {
     if build_num_rows == 0 {
         return Ok(JoinRuntimeFilterPacket::default());
@@ -158,8 +165,15 @@ pub fn build_runtime_filter_packet(
     for rf in runtime_filter_desc {
         runtime_filters.insert(
             rf.id,
-            JoinRuntimeFilterPacketBuilder::new(build_chunks, func_ctx, &rf.build_key, inlist_threshold)?
-                .build(rf)?,
+            JoinRuntimeFilterPacketBuilder::new(
+                build_chunks,
+                func_ctx,
+                &rf.build_key,
+                inlist_threshold,
+                bloom_threshold,
+                min_max_threshold,
+            )?
+            .build(rf)?,
         );
     }
     Ok(JoinRuntimeFilterPacket {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/builder.rs
@@ -31,12 +31,12 @@ use super::packet::JoinRuntimeFilterPacket;
 use super::packet::RuntimeFilterPacket;
 use super::packet::SerializableDomain;
 use crate::pipelines::processors::transforms::hash_join::desc::RuntimeFilterDesc;
-use crate::pipelines::processors::transforms::hash_join::hash_join_build_state::INLIST_RUNTIME_FILTER_THRESHOLD;
 use crate::pipelines::processors::transforms::hash_join::util::hash_by_method;
 
 struct JoinRuntimeFilterPacketBuilder<'a> {
     build_key_column: Column,
     func_ctx: &'a FunctionContext,
+    inlist_threshold: usize,
 }
 
 impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
@@ -44,11 +44,13 @@ impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
         data_blocks: &'a [DataBlock],
         func_ctx: &'a FunctionContext,
         build_key: &Expr,
+        inlist_threshold: usize,
     ) -> Result<Self> {
         let build_key_column = Self::eval_build_key_column(data_blocks, func_ctx, build_key)?;
         Ok(Self {
             func_ctx,
             build_key_column,
+            inlist_threshold,
         })
     }
     fn build(&self, desc: &RuntimeFilterDesc) -> Result<RuntimeFilterPacket> {
@@ -78,7 +80,7 @@ impl<'a> JoinRuntimeFilterPacketBuilder<'a> {
 
     fn enable_inlist(&self, desc: &RuntimeFilterDesc) -> bool {
         desc.enable_inlist_runtime_filter
-            && self.build_key_column.len() < INLIST_RUNTIME_FILTER_THRESHOLD
+            && self.build_key_column.len() < self.inlist_threshold
     }
 
     fn enable_bloom(&self, desc: &RuntimeFilterDesc) -> bool {
@@ -147,6 +149,7 @@ pub fn build_runtime_filter_packet(
     build_num_rows: usize,
     runtime_filter_desc: &[RuntimeFilterDesc],
     func_ctx: &FunctionContext,
+    inlist_threshold: usize,
 ) -> Result<JoinRuntimeFilterPacket> {
     if build_num_rows == 0 {
         return Ok(JoinRuntimeFilterPacket::default());
@@ -155,7 +158,7 @@ pub fn build_runtime_filter_packet(
     for rf in runtime_filter_desc {
         runtime_filters.insert(
             rf.id,
-            JoinRuntimeFilterPacketBuilder::new(build_chunks, func_ctx, &rf.build_key)?
+            JoinRuntimeFilterPacketBuilder::new(build_chunks, func_ctx, &rf.build_key, inlist_threshold)?
                 .build(rf)?,
         );
     }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -103,11 +103,15 @@ fn build_inlist_filter(inlist: Column, probe_key: &Expr<String>) -> Result<Expr<
         })
         .collect();
 
-    let or_filters_expr = RawExpr::FunctionCall {
-        span: None,
-        name: "or_filters".to_string(),
-        params: vec![],
-        args: eq_exprs,
+    let or_filters_expr = if eq_exprs.len() == 1 {
+        eq_exprs[0].clone()
+    } else {
+        RawExpr::FunctionCall {
+            span: None,
+            name: "or_filters".to_string(),
+            params: vec![],
+            args: eq_exprs,
+        }
     };
 
     let expr = type_check::check(&or_filters_expr, &BUILTIN_FUNCTIONS)?;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -89,50 +89,29 @@ fn build_inlist_filter(inlist: Column, probe_key: &Expr<String>) -> Result<Expr<
         display_name: probe_key.display_name.clone(),
     };
 
-    let scalars: Vec<_> = inlist
+    let eq_exprs: Vec<RawExpr<String>> = inlist
         .iter()
-        .map(|scalar_ref| scalar_ref.to_owned())
+        .map(|scalar_ref| RawExpr::FunctionCall {
+            span: None,
+            name: "eq".to_string(),
+            params: vec![],
+            args: vec![raw_probe_key.clone(), RawExpr::Constant {
+                span: None,
+                scalar: scalar_ref.to_owned(),
+                data_type: None,
+            }],
+        })
         .collect();
 
-    let balanced_expr = build_balanced_or_tree(&raw_probe_key, &scalars);
+    let or_filters_expr = RawExpr::FunctionCall {
+        span: None,
+        name: "or_filters".to_string(),
+        params: vec![],
+        args: eq_exprs,
+    };
 
-    let expr = type_check::check(&balanced_expr, &BUILTIN_FUNCTIONS)?;
+    let expr = type_check::check(&or_filters_expr, &BUILTIN_FUNCTIONS)?;
     Ok(expr)
-}
-
-fn build_balanced_or_tree(probe_key: &RawExpr<String>, scalars: &[Scalar]) -> RawExpr<String> {
-    match scalars.len() {
-        0 => RawExpr::Constant {
-            span: None,
-            scalar: Scalar::Boolean(false),
-            data_type: None,
-        },
-        1 => {
-            let constant_expr = RawExpr::Constant {
-                span: None,
-                scalar: scalars[0].clone(),
-                data_type: None,
-            };
-            RawExpr::FunctionCall {
-                span: None,
-                name: "eq".to_string(),
-                params: vec![],
-                args: vec![probe_key.clone(), constant_expr],
-            }
-        }
-        _ => {
-            let mid = scalars.len() / 2;
-            let left_subtree = build_balanced_or_tree(probe_key, &scalars[..mid]);
-            let right_subtree = build_balanced_or_tree(probe_key, &scalars[mid..]);
-
-            RawExpr::FunctionCall {
-                span: None,
-                name: "or".to_string(),
-                params: vec![],
-                args: vec![left_subtree, right_subtree],
-            }
-        }
-    }
 }
 
 fn build_min_max_filter(

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/interface.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/interface.rs
@@ -26,13 +26,26 @@ pub async fn build_and_push_down_runtime_filter(
     build_num_rows: usize,
     join: &HashJoinBuildState,
 ) -> Result<()> {
-    let inlist_threshold = join.ctx.get_settings().get_inlist_runtime_filter_threshold()? as usize;
+    let inlist_threshold = join
+        .ctx
+        .get_settings()
+        .get_inlist_runtime_filter_threshold()? as usize;
+    let bloom_threshold = join
+        .ctx
+        .get_settings()
+        .get_bloom_runtime_filter_threshold()? as usize;
+    let min_max_threshold = join
+        .ctx
+        .get_settings()
+        .get_min_max_runtime_filter_threshold()? as usize;
     let mut packet = build_runtime_filter_packet(
         build_chunks,
         build_num_rows,
         join.runtime_filter_desc(),
         &join.func_ctx,
         inlist_threshold,
+        bloom_threshold,
+        min_max_threshold,
     )?;
     log::info!("[RUNTIME-FILTER] build runtime filter packet: {:?}, build_num_rows: {}, runtime_filter_desc: {:?}", packet, build_num_rows, join.runtime_filter_desc());
     if let Some(broadcast_id) = join.broadcast_id {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/interface.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/interface.rs
@@ -26,11 +26,13 @@ pub async fn build_and_push_down_runtime_filter(
     build_num_rows: usize,
     join: &HashJoinBuildState,
 ) -> Result<()> {
+    let inlist_threshold = join.ctx.get_settings().get_inlist_runtime_filter_threshold()? as usize;
     let mut packet = build_runtime_filter_packet(
         build_chunks,
         build_num_rows,
         join.runtime_filter_desc(),
         &join.func_ctx,
+        inlist_threshold,
     )?;
     log::info!("[RUNTIME-FILTER] build runtime filter packet: {:?}, build_num_rows: {}, runtime_filter_desc: {:?}", packet, build_num_rows, join.runtime_filter_desc());
     if let Some(broadcast_id) = join.broadcast_id {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -338,6 +338,20 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
+                ("bloom_runtime_filter_threshold", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(u64::MAX),
+                    desc: "Sets the maximum number of rows for bloom runtime filter generation.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
+                ("min_max_runtime_filter_threshold", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(u64::MAX),
+                    desc: "Sets the maximum number of rows for min-max runtime filter generation.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
                 ("unquoted_ident_case_sensitive", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Set to 1 to make unquoted names (like table or column names) case-sensitive, or 0 for case-insensitive.",

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -331,6 +331,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
+                ("inlist_runtime_filter_threshold", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1024),
+                    desc: "Sets the maximum number of values in an IN list for runtime filter generation.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
                 ("unquoted_ident_case_sensitive", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "Set to 1 to make unquoted names (like table or column names) case-sensitive, or 0 for case-insensitive.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -313,6 +313,9 @@ impl Settings {
     pub fn get_max_inlist_to_or(&self) -> Result<u64> {
         self.try_get_u64("max_inlist_to_or")
     }
+    pub fn get_inlist_runtime_filter_threshold(&self) -> Result<u64> {
+        self.try_get_u64("inlist_runtime_filter_threshold")
+    }
 
     pub fn get_unquoted_ident_case_sensitive(&self) -> Result<bool> {
         Ok(self.try_get_u64("unquoted_ident_case_sensitive")? != 0)

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -316,6 +316,12 @@ impl Settings {
     pub fn get_inlist_runtime_filter_threshold(&self) -> Result<u64> {
         self.try_get_u64("inlist_runtime_filter_threshold")
     }
+    pub fn get_bloom_runtime_filter_threshold(&self) -> Result<u64> {
+        self.try_get_u64("bloom_runtime_filter_threshold")
+    }
+    pub fn get_min_max_runtime_filter_threshold(&self) -> Result<u64> {
+        self.try_get_u64("min_max_runtime_filter_threshold")
+    }
 
     pub fn get_unquoted_ident_case_sensitive(&self) -> Result<bool> {
         Ok(self.try_get_u64("unquoted_ident_case_sensitive")? != 0)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 This PR refactors runtime filter handling to use configurable settings instead of hardcoded constants, and replaces manual nested OR expression construction with the or_filters function for better performance and cleaner code.

1. Replace Manual OR Expression Construction with or_filters

 2. Make Runtime Filter Thresholds Configurable. If the number of rows on the build side exceeds the limit at runtime, runtime filter construction will be stopped

  | Setting                          | Default  | 
  |----------------------------------|----------|
  | inlist_runtime_filter_threshold  | 1,024    |
  | bloom_runtime_filter_threshold   | u64::MAX |
  | min_max_runtime_filter_threshold | u64::MAX |

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18622)
<!-- Reviewable:end -->
