### PR TITLE
refactor(query): Optimize set returning function result block max bytes

### DIFF
--- a/src/query/service/src/physical_plans/physical_project_set.rs
+++ b/src/query/service/src/physical_plans/physical_project_set.rs
@@ -127,6 +127,7 @@ impl IPhysicalPlan for ProjectSet {
             .map(|(expr, _)| expr.as_expr(&BUILTIN_FUNCTIONS))
             .collect::<Vec<_>>();
         let max_block_size = builder.settings.get_max_block_size()? as usize;
+        let max_block_bytes = builder.settings.get_max_block_bytes()? as usize;
 
         builder.main_pipeline.add_transform(|input, output| {
             Ok(ProcessorPtr::create(TransformSRF::try_create(
@@ -136,6 +137,7 @@ impl IPhysicalPlan for ProjectSet {
                 self.projections.clone(),
                 srf_exprs.clone(),
                 max_block_size,
+                max_block_bytes,
             )))
         })
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Set returning functions could accumulate a large amount of data into a single block, it may cause an Out-of-Memory (OOM) Error. This PR introduces a check within the set returning functions (SRFs) Transform. If the memory size of the current block exceeds `max_block_bytes`, the function immediately returns the block and starts accumulating data into a new block. This ensures that no single block exceeds the setting `max_block_bytes` limit.

- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
