### PR TITLE
feat: new setting controls extra tbl stats generation

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -995,9 +995,9 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
-                ("enable_table_hll_statistics", DefaultSettingValue {
+                ("enable_additional_table_stats", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
-                    desc: "Enable HLL-based NDV statistics generation for table snapshots",
+                    desc: "Enable additional statistics generation for table snapshots",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -995,6 +995,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_table_hll_statistics", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Enable HLL-based NDV statistics generation for table snapshots",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("enable_experimental_row_access_policy", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "experiment setting enable row access policy(disable by default).",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -1064,4 +1064,8 @@ impl Settings {
     pub fn get_enable_binary_to_utf8_lossy(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_binary_to_utf8_lossy")? == 1)
     }
+
+    pub fn get_enable_table_hll_statistics(&self) -> Result<u64> {
+        self.try_get_u64("enable_table_hll_statistics")
+    }
 }

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -1065,7 +1065,7 @@ impl Settings {
         Ok(self.try_get_u64("enable_binary_to_utf8_lossy")? == 1)
     }
 
-    pub fn get_enable_table_hll_statistics(&self) -> Result<u64> {
-        self.try_get_u64("enable_table_hll_statistics")
+    pub fn get_enable_additional_table_stats(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_additional_table_stats")? != 0)
     }
 }

--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -219,7 +219,7 @@ impl SinkAnalyzeState {
         )?;
 
         // 3. Generate new table statistics
-        if self.ctx.get_settings().get_enable_table_hll_statistics()? != 0 {
+        if self.ctx.get_settings().get_enable_additional_table_stats()? {
             new_snapshot.summary.additional_stats_meta = Some(AdditionalStatsMeta {
                 hll: Some(encode_column_hll(&self.ndv_states)?),
                 row_count: snapshot.summary.row_count,
@@ -751,7 +751,7 @@ impl Processor for AnalyzeCollectNDVSource {
                     ..Default::default()
                 };
                 self.dal.write(&segment_stats_location, data).await?;
-                if self.ctx.get_settings().get_enable_table_hll_statistics()? != 0 {
+                if self.ctx.get_settings().get_enable_additional_table_stats()? {
                     origin_summary.additional_stats_meta = Some(additional_stats_meta);
                 } else {
                     origin_summary.additional_stats_meta = None;

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -359,7 +359,7 @@ impl TableMutationAggregator {
             let location_gen = self.location_gen.clone();
             let op = self.dal.clone();
             let table_meta_timestamps = self.table_meta_timestamps;
-            let enable_hll_statistics = self.ctx.get_settings().get_enable_table_hll_statistics()? != 0;
+            let enable_hll_statistics = self.ctx.get_settings().get_enable_additional_table_stats()?;
             tasks.push(async move {
                 write_segment(
                     op,
@@ -485,7 +485,7 @@ impl TableMutationAggregator {
     ) -> Result<Vec<SegmentLite>> {
         let thresholds = self.thresholds;
         let default_cluster_key_id = self.default_cluster_key_id;
-        let enable_hll_statistics = self.ctx.get_settings().get_enable_table_hll_statistics()? != 0;
+        let enable_hll_statistics = self.ctx.get_settings().get_enable_additional_table_stats()?;
         let kind = self.kind;
         let set_hilbert_level = self.set_hilbert_level;
         let mut tasks = Vec::with_capacity(segment_indices.len());

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -76,6 +76,7 @@ pub struct TransformSerializeSegment<B: SegmentBuilder> {
     hll_accumulator: ColumnHLLAccumulator,
     state: State<B>,
 
+    ctx: Arc<dyn TableContext>,
     input: Arc<InputPort>,
     output: Arc<OutputPort>,
     output_data: Option<DataBlock>,
@@ -98,7 +99,7 @@ impl<B: SegmentBuilder> TransformSerializeSegment<B> {
     ) -> Self {
         let table_meta = &table.table_info.meta;
         let virtual_column_accumulator = VirtualColumnAccumulator::try_create(
-            ctx,
+            ctx.clone(),
             &table_meta.schema,
             &table_meta.virtual_schema,
         );
@@ -106,6 +107,7 @@ impl<B: SegmentBuilder> TransformSerializeSegment<B> {
         let default_cluster_key_id = table.cluster_key_id();
 
         TransformSerializeSegment {
+            ctx,
             input,
             output,
             output_data: None,

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -276,7 +276,7 @@ impl<B: SegmentBuilder> Processor for TransformSerializeSegment<B> {
 
                 let mut additional_stats_meta = None;
                 let mut stats = None;
-                if !self.hll_accumulator.is_empty() {
+                if !self.hll_accumulator.is_empty() && self.ctx.get_settings().get_enable_table_hll_statistics()? != 0 {
                     let segment_stats_location = TableMetaLocationGenerator::gen_segment_stats_location_from_segment_location(location.as_str());
                     let stats_data = self.hll_accumulator.build().to_bytes()?;
                     let stats_summary = self.hll_accumulator.take_summary();

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -278,7 +278,7 @@ impl<B: SegmentBuilder> Processor for TransformSerializeSegment<B> {
 
                 let mut additional_stats_meta = None;
                 let mut stats = None;
-                if !self.hll_accumulator.is_empty() && self.ctx.get_settings().get_enable_table_hll_statistics()? != 0 {
+                if !self.hll_accumulator.is_empty() && self.ctx.get_settings().get_enable_additional_table_stats()? {
                     let segment_stats_location = TableMetaLocationGenerator::gen_segment_stats_location_from_segment_location(location.as_str());
                     let stats_data = self.hll_accumulator.build().to_bytes()?;
                     let stats_summary = self.hll_accumulator.take_summary();

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -109,7 +109,7 @@ impl SegmentCompactMutator {
         let fuse_segment_io =
             SegmentsIO::create(self.ctx.clone(), self.data_accessor.clone(), schema);
         let chunk_size = self.ctx.get_settings().get_max_threads()? as usize * 4;
-        let enable_hll_statistics = self.ctx.get_settings().get_enable_table_hll_statistics()? != 0;
+        let enable_hll_statistics = self.ctx.get_settings().get_enable_additional_table_stats()?;
         let compactor = SegmentCompactor::new(
             self.compact_params.block_per_seg as u64,
             self.default_cluster_key_id,

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -398,7 +398,11 @@ impl<'a> SegmentCompactor<'a> {
             self.operator
                 .write(&segment_stats_location, stats_data)
                 .await?;
-            new_statistics.additional_stats_meta = Some(additional_stats_meta);
+            if self.ctx.get_settings().get_enable_table_hll_statistics()? != 0 {
+                new_statistics.additional_stats_meta = Some(additional_stats_meta);
+            } else {
+                new_statistics.additional_stats_meta = None;
+            }
         }
 
         // 2.3 write down new segment


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add setting `enable_additional_table_stats` to control additional table stats generation.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18641)
<!-- Reviewable:end -->
