### PR TITLE
refactor(exception): enhance ErrorCodeResultExt with comprehensive error codes

### DIFF
--- a/src/common/exception/src/exception.rs
+++ b/src/common/exception/src/exception.rs
@@ -279,7 +279,7 @@ impl ErrorCode {
 ///     x.map_err_to_code(ErrorCode::UnknownException, || 123);
 ///
 /// assert_eq!(
-///     "Code: 1067, Text = 123, cause: an error occurred when formatting an argument.",
+///     "UnknownException. Code: 1067, Text = 123, cause: an error occurred when formatting an argument.",
 ///     y.unwrap_err().to_string()
 /// );
 /// ```
@@ -341,6 +341,20 @@ pub mod error_code_groups {
         ErrorCode::UNKNOWN_VIEW,
         ErrorCode::UNKNOWN_COLUMN,
         ErrorCode::UNKNOWN_SEQUENCE,
+        ErrorCode::UNKNOWN_DICTIONARY,
+        ErrorCode::UNKNOWN_ROLE,
+        ErrorCode::UNKNOWN_NETWORK_POLICY,
+        ErrorCode::UNKNOWN_CONNECTION,
+        ErrorCode::UNKNOWN_FILE_FORMAT,
+        ErrorCode::UNKNOWN_USER,
+        ErrorCode::UNKNOWN_PASSWORD_POLICY,
+        ErrorCode::UNKNOWN_STAGE,
+        ErrorCode::UNKNOWN_WORKLOAD,
+        ErrorCode::UNKNOWN_VARIABLE,
+        ErrorCode::UNKNOWN_SESSION,
+        ErrorCode::UNKNOWN_QUERY,
+        ErrorCode::UNKNOWN_ROW_ACCESS_POLICY,
+        ErrorCode::UNKNOWN_DATAMASK,
     ];
 }
 
@@ -354,6 +368,60 @@ pub trait ErrorCodeResultExt<T> {
 
     /// Converts UNKNOWN_TABLE errors to None, other errors propagate, success becomes Some(T)
     fn or_unknown_table(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_CATALOG errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_catalog(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_VIEW errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_view(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_COLUMN errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_column(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_SEQUENCE errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_sequence(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_DICTIONARY errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_dictionary(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_ROLE errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_role(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_NETWORK_POLICY errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_network_policy(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_CONNECTION errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_connection(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_FILE_FORMAT errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_file_format(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_USER errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_user(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_PASSWORD_POLICY errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_password_policy(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_STAGE errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_stage(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_WORKLOAD errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_workload(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_VARIABLE errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_variable(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_SESSION errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_session(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_QUERY errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_query(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_ROW_ACCESS_POLICY errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_row_access_policy(self) -> Result<Option<T>>;
+
+    /// Converts UNKNOWN_DATAMASK errors to None, other errors propagate, success becomes Some(T)
+    fn or_unknown_datamask(self) -> Result<Option<T>>;
 
     /// Converts common "not found" errors to None (database, table, sequence, etc.)
     fn or_unknown_resource(self) -> Result<Option<T>>;
@@ -374,6 +442,78 @@ impl<T> ErrorCodeResultExt<T> for Result<T> {
 
     fn or_unknown_table(self) -> Result<Option<T>> {
         self.or_error_codes(&[ErrorCode::UNKNOWN_TABLE])
+    }
+
+    fn or_unknown_catalog(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_CATALOG])
+    }
+
+    fn or_unknown_view(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_VIEW])
+    }
+
+    fn or_unknown_column(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_COLUMN])
+    }
+
+    fn or_unknown_sequence(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_SEQUENCE])
+    }
+
+    fn or_unknown_dictionary(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_DICTIONARY])
+    }
+
+    fn or_unknown_role(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_ROLE])
+    }
+
+    fn or_unknown_network_policy(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_NETWORK_POLICY])
+    }
+
+    fn or_unknown_connection(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_CONNECTION])
+    }
+
+    fn or_unknown_file_format(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_FILE_FORMAT])
+    }
+
+    fn or_unknown_user(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_USER])
+    }
+
+    fn or_unknown_password_policy(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_PASSWORD_POLICY])
+    }
+
+    fn or_unknown_stage(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_STAGE])
+    }
+
+    fn or_unknown_workload(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_WORKLOAD])
+    }
+
+    fn or_unknown_variable(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_VARIABLE])
+    }
+
+    fn or_unknown_session(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_SESSION])
+    }
+
+    fn or_unknown_query(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_QUERY])
+    }
+
+    fn or_unknown_row_access_policy(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_ROW_ACCESS_POLICY])
+    }
+
+    fn or_unknown_datamask(self) -> Result<Option<T>> {
+        self.or_error_codes(&[ErrorCode::UNKNOWN_DATAMASK])
     }
 
     fn or_unknown_resource(self) -> Result<Option<T>> {

--- a/src/common/exception/tests/it/error_code_result_ext.rs
+++ b/src/common/exception/tests/it/error_code_result_ext.rs
@@ -144,6 +144,20 @@ fn test_error_code_groups() {
     assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_CATALOG));
     assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_VIEW));
     assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_COLUMN));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_DICTIONARY));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_ROLE));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_NETWORK_POLICY));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_CONNECTION));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_FILE_FORMAT));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_USER));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_PASSWORD_POLICY));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_STAGE));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_WORKLOAD));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_VARIABLE));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_SESSION));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_QUERY));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_ROW_ACCESS_POLICY));
+    assert!(error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::UNKNOWN_DATAMASK));
 
     // Verify that it doesn't contain unrelated error codes
     assert!(!error_code_groups::UNKNOWN_RESOURCE.contains(&ErrorCode::INTERNAL));

--- a/src/query/users/src/network_policy.rs
+++ b/src/query/users/src/network_policy.rs
@@ -14,6 +14,7 @@
 
 use chrono::Utc;
 use databend_common_exception::ErrorCode;
+use databend_common_exception::ErrorCodeResultExt;
 use databend_common_exception::Result;
 use databend_common_meta_api::crud::CrudError;
 use databend_common_meta_app::principal::NetworkPolicy;
@@ -134,16 +135,11 @@ impl UserApiProvider {
     // Check whether a network policy is exist.
     #[async_backtrace::framed]
     pub async fn exists_network_policy(&self, tenant: &Tenant, name: &str) -> Result<bool> {
-        match self.get_network_policy(tenant, name).await {
-            Ok(_) => Ok(true),
-            Err(e) => {
-                if e.code() == ErrorCode::UNKNOWN_NETWORK_POLICY {
-                    Ok(false)
-                } else {
-                    Err(e)
-                }
-            }
-        }
+        Ok(self
+            .get_network_policy(tenant, name)
+            .await
+            .or_unknown_network_policy()?
+            .is_some())
     }
 
     // Get a network_policy by tenant.

--- a/src/query/users/src/role_mgr.rs
+++ b/src/query/users/src/role_mgr.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use databend_common_exception::ErrorCode;
+use databend_common_exception::ErrorCodeResultExt;
 use databend_common_exception::Result;
 use databend_common_management::RoleApi;
 use databend_common_meta_app::principal::GrantObject;
@@ -104,16 +105,11 @@ impl UserApiProvider {
 
     #[async_backtrace::framed]
     pub async fn exists_role(&self, tenant: &Tenant, role: String) -> Result<bool> {
-        match self.get_role(tenant, role).await {
-            Ok(_) => Ok(true),
-            Err(e) => {
-                if e.code() == ErrorCode::UNKNOWN_ROLE {
-                    Ok(false)
-                } else {
-                    Err(e)
-                }
-            }
-        }
+        Ok(self
+            .get_role(tenant, role)
+            .await
+            .or_unknown_role()?
+            .is_some())
     }
 
     // Add a new role info.

--- a/src/query/users/src/user_stage.rs
+++ b/src/query/users/src/user_stage.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_exception::ErrorCode;
+use databend_common_exception::ErrorCodeResultExt;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::CreateOption;
@@ -43,16 +44,11 @@ impl UserApiProvider {
 
     #[async_backtrace::framed]
     pub async fn exists_stage(&self, tenant: &Tenant, stage_name: &str) -> Result<bool> {
-        match self.get_stage(tenant, stage_name).await {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if err.code() == ErrorCode::UNKNOWN_STAGE {
-                    Ok(false)
-                } else {
-                    Err(err)
-                }
-            }
-        }
+        Ok(self
+            .get_stage(tenant, stage_name)
+            .await
+            .or_unknown_stage()?
+            .is_some())
     }
 
     // Get the tenant all stage list.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(exception): enhance ErrorCodeResultExt with comprehensive error codes

Extend ErrorCodeResultExt trait with methods for all UNKNOWN_* error codes
including dictionary, role, network policy, stage, user, and others.
Refactor exists_* functions across catalog and user management to use
the enhanced API, replacing verbose match patterns with concise
.or_unknown_*()?.is_some() calls.


##### refactor(catalog): apply ErrorCodeResultExt to iceberg catalog

Extend error handling consistency by converting 5 methods in
iceberg_catalog.rs to use the ErrorCodeResultExt trait pattern.

- Replace verbose match statements with .or_unknown_database()/.or_unknown_table()
- Convert get_database, get_table_by_info, get_table, list_tables, list_tables_names
- Reduce boilerplate by ~25 lines while maintaining identical behavior
- Achieve consistent error handling across all catalog implementations

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18643)
<!-- Reviewable:end -->
