### PR TITLE
feat: implement separate RPC delay metrics for read and write operations

### DIFF
--- a/src/meta/service/src/metrics/meta_metrics.rs
+++ b/src/meta/service/src/metrics/meta_metrics.rs
@@ -808,6 +808,8 @@ pub mod network_metrics {
     #[derive(Debug)]
     struct NetworkMetrics {
         rpc_delay_ms: Histogram,
+        rpc_delay_read_ms: Histogram,
+        rpc_delay_write_ms: Histogram,
         sent_bytes: Counter,
         recv_bytes: Counter,
         req_inflights: Gauge,
@@ -832,17 +834,18 @@ pub mod network_metrics {
 
     impl NetworkMetrics {
         pub fn init() -> Self {
+            let rpc_delay_buckets = vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 7.0, //
+                10.0, 20.0, 30.0, 40.0, 50.0, 70.0, //
+                100.0, 200.0, 300.0, 400.0, 500.0, 700.0, //
+                1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0, //
+                10000.0, 20000.0, 30000.0, 40000.0, 50000.0, 70000.0,
+            ];
+
             let metrics = Self {
-                rpc_delay_ms: Histogram::new(
-                    vec![
-                        1.0, 2.0, 3.0, 4.0, 5.0, 7.0, //
-                        10.0, 20.0, 30.0, 40.0, 50.0, 70.0, //
-                        100.0, 200.0, 300.0, 400.0, 500.0, 700.0, //
-                        1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0, //
-                        10000.0, 20000.0, 30000.0, 40000.0, 50000.0, 70000.0,
-                    ]
-                    .into_iter(),
-                ),
+                rpc_delay_ms: Histogram::new(rpc_delay_buckets.clone().into_iter()),
+                rpc_delay_read_ms: Histogram::new(rpc_delay_buckets.clone().into_iter()),
+                rpc_delay_write_ms: Histogram::new(rpc_delay_buckets.into_iter()),
                 sent_bytes: Counter::default(),
                 recv_bytes: Counter::default(),
                 req_inflights: Gauge::default(),
@@ -862,6 +865,16 @@ pub mod network_metrics {
                 key!("rpc_delay_ms"),
                 "rpc delay milliseconds",
                 metrics.rpc_delay_ms.clone(),
+            );
+            registry.register(
+                key!("rpc_delay_read_ms"),
+                "rpc delay milliseconds for read operations",
+                metrics.rpc_delay_read_ms.clone(),
+            );
+            registry.register(
+                key!("rpc_delay_write_ms"),
+                "rpc delay milliseconds for write operations",
+                metrics.rpc_delay_write_ms.clone(),
             );
             registry.register(key!("sent_bytes"), "sent bytes", metrics.sent_bytes.clone());
             registry.register(key!("recv_bytes"), "recv bytes", metrics.recv_bytes.clone());
@@ -910,8 +923,25 @@ pub mod network_metrics {
 
     static NETWORK_METRICS: LazyLock<NetworkMetrics> = LazyLock::new(NetworkMetrics::init);
 
+    /// Sample RPC delay for operations where read/write type is unknown.
+    /// Prefer using `sample_rpc_read_delay` or `sample_rpc_write_delay` when the operation type is known.
+    #[deprecated(
+        note = "Use sample_rpc_read_delay or sample_rpc_write_delay for better metrics granularity"
+    )]
     pub fn sample_rpc_delay(d: Duration) {
         NETWORK_METRICS.rpc_delay_ms.observe(d.as_millis() as f64);
+    }
+
+    pub fn sample_rpc_read_delay(d: Duration) {
+        let delay_ms = d.as_millis() as f64;
+        NETWORK_METRICS.rpc_delay_ms.observe(delay_ms);
+        NETWORK_METRICS.rpc_delay_read_ms.observe(delay_ms);
+    }
+
+    pub fn sample_rpc_write_delay(d: Duration) {
+        let delay_ms = d.as_millis() as f64;
+        NETWORK_METRICS.rpc_delay_ms.observe(delay_ms);
+        NETWORK_METRICS.rpc_delay_write_ms.observe(delay_ms);
     }
 
     pub fn incr_sent_bytes(bytes: u64) {
@@ -971,13 +1001,13 @@ pub mod network_metrics {
     }
 }
 
-/// RAII metrics counter of in-flight requests count and delay.
+/// RAII metrics counter for in-flight requests with const generic to distinguish read/write operations
 #[derive(Default)]
-pub(crate) struct RequestInFlight {
+pub(crate) struct InFlightMetrics<const IS_READ: bool> {
     start: Option<Instant>,
 }
 
-impl count::Count for RequestInFlight {
+impl<const IS_READ: bool> count::Count for InFlightMetrics<IS_READ> {
     fn incr_count(&mut self, n: i64) {
         network_metrics::incr_request_inflights(n);
 
@@ -986,11 +1016,22 @@ impl count::Count for RequestInFlight {
             self.start = Some(Instant::now());
         } else if n < 0 {
             if let Some(s) = self.start {
-                network_metrics::sample_rpc_delay(s.elapsed())
+                let elapsed = s.elapsed();
+                if IS_READ {
+                    network_metrics::sample_rpc_read_delay(elapsed);
+                } else {
+                    network_metrics::sample_rpc_write_delay(elapsed);
+                }
             }
         }
     }
 }
+
+/// Type alias for read request metrics
+pub(crate) type InFlightRead = InFlightMetrics<true>;
+
+/// Type alias for write request metrics
+pub(crate) type InFlightWrite = InFlightMetrics<false>;
 
 /// RAII metrics counter of pending raft proposals
 #[derive(Default)]

--- a/src/meta/service/src/metrics/mod.rs
+++ b/src/meta/service/src/metrics/mod.rs
@@ -19,6 +19,7 @@ pub use meta_metrics::meta_metrics_to_prometheus_string;
 pub use meta_metrics::network_metrics;
 pub use meta_metrics::raft_metrics;
 pub use meta_metrics::server_metrics;
+pub(crate) use meta_metrics::InFlightRead;
+pub(crate) use meta_metrics::InFlightWrite;
 pub(crate) use meta_metrics::ProposalPending;
-pub(crate) use meta_metrics::RequestInFlight;
 pub(crate) use meta_metrics::SnapshotBuilding;

--- a/src/meta/service/tests/it/api/http/metrics.rs
+++ b/src/meta/service/tests/it/api/http/metrics.rs
@@ -42,6 +42,8 @@ async fn test_metrics() -> anyhow::Result<()> {
     // record some metrics to make the registry get initialized
     server_metrics::incr_leader_change();
     network_metrics::incr_recv_bytes(1);
+    network_metrics::sample_rpc_read_delay(std::time::Duration::from_millis(10));
+    network_metrics::sample_rpc_write_delay(std::time::Duration::from_millis(20));
     raft_metrics::network::incr_recvfrom_bytes("addr".to_string(), 1);
     raft_metrics::storage::incr_raft_storage_fail("fun", true);
 
@@ -271,6 +273,16 @@ async fn test_metrics() -> anyhow::Result<()> {
     assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_ms_bucket"));
     assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_ms_count"));
     assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_ms_sum"));
+
+    // Meta network RPC read delay metrics (milliseconds)
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_read_ms_bucket"));
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_read_ms_count"));
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_read_ms_sum"));
+
+    // Meta network RPC write delay metrics (milliseconds)
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_write_ms_bucket"));
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_write_ms_count"));
+    assert!(metric_keys.contains("metasrv_meta_network_rpc_delay_write_ms_sum"));
 
     // Raft network metrics
     assert!(metric_keys.contains("metasrv_raft_network_active_peers"));


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: implement separate RPC delay metrics for read and write operations

- Remove deprecated rpc_delay_seconds metric completely
- Add rpc_delay_read_ms and rpc_delay_write_ms histograms for granular tracking
- Maintain backward compatibility with existing rpc_delay_ms histogram
- Categorize gRPC operations: transactions as Write, exports/status/info as Read
- Both new delay functions update the general rpc_delay_ms for backward compatibility

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)






## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18648)
<!-- Reviewable:end -->
