### PR TITLE
fix: clean `db_id_table_name` during vacuuming dropped tables

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -525,6 +525,8 @@ build_exceptions! {
     CreateAsDropTableWithoutDropTime(2323),
     /// Row Policy already exists
     RowAccessPolicyAlreadyExists(2324),
+    /// General failures met while garbage collecting database meta
+    UndropDbGeneralFailure(2325),
 }
 
 // Stage and Connection Errors [2501-2505, 2510-2512]

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -526,7 +526,7 @@ build_exceptions! {
     /// Row Policy already exists
     RowAccessPolicyAlreadyExists(2324),
     /// General failures met while garbage collecting database meta
-    UndropDbGeneralFailure(2325),
+    GeneralDbGcFailure(2325),
 }
 
 // Stage and Connection Errors [2501-2505, 2510-2512]

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -385,7 +385,7 @@ async fn gc_dropped_db_by_id(
             .push(txn_put_pb(&db_id_history_ident, &db_id_list)?);
     }
 
-    // Verify data_meta hasn't changed since the mark database meta as gc_in_progress phase
+    // Verify database_meta hasn't changed since the mark database meta as gc_in_progress phase.
     // This establishes a condition for the transaction that will prevent it from committing
     // if the database metadata was modified by another concurrent operation (like un-dropping).
     txn.condition.push(txn_cond_eq_seq(&dbid, db_meta_seq));

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -17,6 +17,9 @@ use std::ops::Range;
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_base::vec_ext::VecExt;
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::CleanDbIdTableNamesFailed;
+use databend_common_meta_app::app_error::MarkDatabaseMetaAsGCInProgressFailed;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
 use databend_common_meta_app::schema::index_id_ident::IndexIdIdent;
@@ -57,6 +60,7 @@ use crate::txn_op_del;
 use crate::util::txn_delete_exact;
 use crate::util::txn_op_put_pb;
 use crate::util::txn_put_pb;
+use crate::util::txn_replace_exact;
 
 /// GarbageCollectionApi defines APIs for garbage collection operations.
 ///
@@ -154,6 +158,8 @@ async fn remove_copied_files_for_dropped_table(
             copied_files.display()
         );
 
+        // Txn failures are ignored for simplicity, since copied files kv pairs are put with ttl,
+        // they will not be leaked permanently, will be cleaned eventually.
         send_txn(kv_api, txn).await?;
     }
     unreachable!()
@@ -226,8 +232,6 @@ pub async fn get_history_tables_for_gc(
 }
 
 /// Permanently remove a dropped database from the meta-service.
-///
-/// Upon calling this method, the dropped database must be already marked as `gc_in_progress`,
 /// then remove all **dropped and non-dropped** tables in the database.
 async fn gc_dropped_db_by_id(
     kv_api: &(impl GarbageCollectionApi + IndexApi + ?Sized),
@@ -237,7 +241,7 @@ async fn gc_dropped_db_by_id(
     db_name: String,
 ) -> Result<(), KVAppError> {
     // List tables by tenant, db_id, table_name.
-    let db_id_history_ident = DatabaseIdHistoryIdent::new(tenant, db_name);
+    let db_id_history_ident = DatabaseIdHistoryIdent::new(tenant, db_name.clone());
     let Some(seq_dbid_list) = kv_api.get_pb(&db_id_history_ident).await? else {
         return Ok(());
     };
@@ -262,17 +266,59 @@ async fn gc_dropped_db_by_id(
         return Ok(());
     }
 
-    // TODO: enable this when gc_in_progress is set.
-    // if !seq_db_meta.gc_in_progress {
-    //     let err = UnknownDatabaseId::new(
-    //         db_id,
-    //         "database is not in gc_in_progress state, \
-    //         can not gc. \
-    //         First mark the database as gc_in_progress, \
-    //         then gc is allowed.",
-    //     );
-    //     return Err(AppError::from(err).into());
-    // }
+    if !seq_db_meta.gc_in_progress {
+        // Mark db_meta as gc_in_process, in which state that db can no longer be undropped.
+        let mut new_db_meta = seq_db_meta.clone();
+        new_db_meta.gc_in_progress = true;
+        let mut txn = TxnRequest::default();
+        txn_replace_exact(&mut txn, &dbid, seq_db_meta.seq, &seq_db_meta.data)?;
+        let (success, _) = send_txn(kv_api, txn).await?;
+        if !success {
+            return Err(KVAppError::AppError(AppError::from(
+                MarkDatabaseMetaAsGCInProgressFailed::new(format!(
+                    "Failed to mark database {}[{}] as gc_in_progress",
+                    db_name, db_id
+                )),
+            )));
+        }
+    }
+
+    // Cleaning up DbIdTableName keys
+    {
+        let db_id_table_name = DBIdTableName {
+            db_id,
+            // Going to use 1 level DirName as list prefix, thus the table_name field does not matter
+            table_name: "".to_string(),
+        };
+        let dir_name = DirName::new_with_level(db_id_table_name, 1);
+
+        let batch_size = 1024;
+        let key_stream = kv_api.list_pb_keys(&dir_name).await?;
+        let mut chunks = key_stream.chunks(batch_size);
+        while let Some(targets) = chunks.next().await {
+            let mut txn = TxnRequest::default();
+            use itertools::Itertools;
+            let targets: Vec<DBIdTableName> = targets.into_iter().try_collect()?;
+            for target in &targets {
+                txn.if_then.push(txn_op_del(target));
+            }
+            let (succ, _resp) = send_txn(kv_api, txn).await?;
+            if !succ {
+                return Err(KVAppError::AppError(AppError::from(
+                    CleanDbIdTableNamesFailed::new(format!(
+                        "Failed to clean dbIdTableNames of database {}[{}]",
+                        db_name, db_id
+                    )),
+                )));
+            } else {
+                // Audit log, output all the items in the batch intentionally
+                info!(
+                    "DbIdTableNames cleaned (database {}[{}]): {:?}",
+                    db_name, db_id, targets
+                );
+            }
+        }
+    }
 
     let id_to_name = DatabaseIdToName { db_id };
     let Some(seq_name) = kv_api.get_pb(&id_to_name).await? else {
@@ -292,8 +338,6 @@ async fn gc_dropped_db_by_id(
     for (ident, table_history) in table_history_items {
         for tb_id in table_history.id_list.iter() {
             let table_id_ident = TableId { table_id: *tb_id };
-
-            // TODO: mark table as gc_in_progress
 
             remove_copied_files_for_dropped_table(kv_api, &table_id_ident).await?;
             let _ = remove_data_for_dropped_table(

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -353,7 +353,35 @@ pub struct UpdateStreamMetasFailed {
     message: String,
 }
 
-impl crate::app_error::UpdateStreamMetasFailed {
+impl UpdateStreamMetasFailed {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[error("MarkDatabaseMetaAsGCInProgressFailed : {message}")]
+pub struct MarkDatabaseMetaAsGCInProgressFailed {
+    message: String,
+}
+
+impl MarkDatabaseMetaAsGCInProgressFailed {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[error("CleanDbIdTableNamesFailed : {message}")]
+pub struct CleanDbIdTableNamesFailed {
+    message: String,
+}
+
+impl CleanDbIdTableNamesFailed {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -1123,6 +1151,12 @@ pub enum AppError {
     #[error(transparent)]
     UpdateStreamMetasFailed(#[from] UpdateStreamMetasFailed),
 
+    #[error(transparent)]
+    MarkDatabaseMetaAsGCInProgressFailed(#[from] MarkDatabaseMetaAsGCInProgressFailed),
+
+    #[error(transparent)]
+    CleanDbIdTableNamesFailed(#[from] CleanDbIdTableNamesFailed),
+
     // dictionary
     #[error(transparent)]
     DictionaryAlreadyExists(
@@ -1188,11 +1222,7 @@ impl AppErrorMessage for TenantIsEmpty {
     }
 }
 
-impl AppErrorMessage for UnknownDatabase {
-    fn message(&self) -> String {
-        format!("Unknown database '{}'", self.db_name)
-    }
-}
+impl AppErrorMessage for UnknownDatabase {}
 
 impl AppErrorMessage for DatabaseAlreadyExists {
     fn message(&self) -> String {
@@ -1237,6 +1267,10 @@ impl AppErrorMessage for UnknownStreamId {}
 impl AppErrorMessage for MultiStmtTxnCommitFailed {}
 
 impl AppErrorMessage for UpdateStreamMetasFailed {}
+
+impl AppErrorMessage for MarkDatabaseMetaAsGCInProgressFailed {}
+
+impl AppErrorMessage for CleanDbIdTableNamesFailed {}
 
 impl AppErrorMessage for DuplicatedUpsertFiles {}
 
@@ -1651,6 +1685,12 @@ impl From<AppError> for ErrorCode {
                 ErrorCode::VirtualColumnIdOutBound(err.message())
             }
             AppError::VirtualColumnTooMany(err) => ErrorCode::VirtualColumnTooMany(err.message()),
+            AppError::MarkDatabaseMetaAsGCInProgressFailed(err) => {
+                ErrorCode::UndropDbGeneralFailure(err.message())
+            }
+            AppError::CleanDbIdTableNamesFailed(err) => {
+                ErrorCode::UndropDbGeneralFailure(err.message())
+            }
         }
     }
 }

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -1222,7 +1222,11 @@ impl AppErrorMessage for TenantIsEmpty {
     }
 }
 
-impl AppErrorMessage for UnknownDatabase {}
+impl AppErrorMessage for UnknownDatabase {
+    fn message(&self) -> String {
+        format!("Unknown database '{}'", self.db_name)
+    }
+}
 
 impl AppErrorMessage for DatabaseAlreadyExists {
     fn message(&self) -> String {

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -1690,10 +1690,10 @@ impl From<AppError> for ErrorCode {
             }
             AppError::VirtualColumnTooMany(err) => ErrorCode::VirtualColumnTooMany(err.message()),
             AppError::MarkDatabaseMetaAsGCInProgressFailed(err) => {
-                ErrorCode::UndropDbGeneralFailure(err.message())
+                ErrorCode::GeneralDbGcFailure(err.message())
             }
             AppError::CleanDbIdTableNamesFailed(err) => {
-                ErrorCode::UndropDbGeneralFailure(err.message())
+                ErrorCode::GeneralDbGcFailure(err.message())
             }
         }
     }

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -21,14 +21,20 @@ use databend_common_catalog::table_context::CheckAbort;
 use databend_common_config::MetaConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_api::get_u64_value;
 use databend_common_meta_api::kv_pb_api::KVPbApi;
+use databend_common_meta_api::send_txn;
+use databend_common_meta_api::util::txn_replace_exact;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
+use databend_common_meta_app::schema::DBIdTableName;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_store::MetaStore;
 use databend_common_meta_store::MetaStoreProvider;
+use databend_common_meta_types::TxnRequest;
 use databend_common_storage::DataOperator;
 use databend_common_storages_fuse::TableContext;
 use databend_common_version::BUILD_INFO;
@@ -547,21 +553,8 @@ async fn test_remove_files_in_batch_do_not_swallow_errors() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_vacuum_dropped_table_clean_ownership() -> Result<()> {
     // 1. Prepare local meta service
-    let version = &BUILD_INFO;
-    let meta_config = MetaConfig::default();
-    let meta = {
-        let config = meta_config.to_meta_grpc_client_conf(version);
-        let provider = Arc::new(MetaStoreProvider::new(config));
-        provider.create_meta_store().await.map_err(|e| {
-            ErrorCode::MetaServiceError(format!("Failed to create meta store: {}", e))
-        })?
-    };
-
-    // Extracts endpoints to comunicate with meta service
-    let MetaStore::L(local) = &meta else {
-        panic!("MetaStore should not be local");
-    };
-    let endpoints = local.endpoints.clone();
+    let meta = new_local_meta().await;
+    let endpoints = meta.endpoints.clone();
 
     // Modify config to use local meta store
     let mut ee_setup = EESetup::new();
@@ -598,15 +591,25 @@ async fn test_vacuum_dropped_table_clean_ownership() -> Result<()> {
         .get_database(&tenant, db_name)
         .await?;
 
+    let db_id = db.get_db_info().database_id.db_id;
     let catalog_name = fixture.default_catalog_name();
     let table_ownership = OwnershipObject::Table {
         catalog_name: catalog_name.clone(),
-        db_id: db.get_db_info().database_id.db_id,
+        db_id,
         table_id: table.get_id(),
     };
     let table_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership);
     let v = meta.get_pb(&table_ownership_key).await?;
     assert!(v.is_some());
+
+    // 4. Check that DbIdTableName mapping exists
+    let db_id_table_name = DBIdTableName {
+        db_id,
+        table_name: tbl_name.to_owned(),
+    };
+
+    let (seq, _) = get_u64_value(&meta, &db_id_table_name).await?;
+    assert!(seq > 0);
 
     // 5. Drop test database
     fixture
@@ -627,5 +630,91 @@ async fn test_vacuum_dropped_table_clean_ownership() -> Result<()> {
     let v = meta.get_pb(&table_ownership_key).await?;
     assert!(v.is_none());
 
+    // 8. Chek that DbIdTableName mapping is cleaned up
+    let (seq, _) = get_u64_value(&meta, &db_id_table_name).await?;
+    assert_eq!(seq, 0);
+
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gc_in_progress_db_not_undroppable() -> Result<()> {
+    // 1. Prepare local meta service
+    let meta = new_local_meta().await;
+    let endpoints = meta.endpoints.clone();
+
+    // Modify config to use local meta store
+    let mut ee_setup = EESetup::new();
+    let config = ee_setup.config_mut();
+    config.meta.endpoints = endpoints.clone();
+
+    // 2. Setup test fixture by using local meta store
+    let fixture = TestFixture::setup_with_custom(ee_setup).await?;
+
+    // Adjust retention period to 0, so that dropped tables will be vacuumed immediately
+    let session = fixture.default_session();
+    session.get_settings().set_data_retention_time_in_days(0)?;
+
+    // 3. Prepare test db and table
+    let ctx = fixture.new_query_ctx().await?;
+    let db_name = "test_vacuum_clean_ownership";
+    let tbl_name = "t";
+    fixture
+        .execute_command(format!("create database {db_name}").as_str())
+        .await?;
+    fixture
+        .execute_command(format!("create table {db_name}.{tbl_name} (a int)").as_str())
+        .await?;
+
+    let tenant = ctx.get_tenant();
+    let db = ctx
+        .get_default_catalog()?
+        .get_database(&tenant, db_name)
+        .await?;
+
+    let db_id = db.get_db_info().database_id.db_id;
+
+    // Drop the database
+    fixture
+        .execute_command(format!("drop database {db_name}").as_str())
+        .await?;
+
+    // 4. Simulate gc_in_progress
+
+    let db_id_key = DatabaseId { db_id };
+    let mut seq_db_meta = meta.get_pb(&db_id_key).await?.unwrap();
+
+    seq_db_meta.gc_in_progress = true;
+
+    let mut txn = TxnRequest::default();
+    txn_replace_exact(&mut txn, &db_id_key, seq_db_meta.seq, &seq_db_meta.data).unwrap();
+    let (success, _) = send_txn(&meta, txn).await?;
+
+    assert!(success, "update gc_in_progress to true should work");
+
+    // 5. undrop database should fail
+    let res = fixture
+        .execute_command(format!("undrop database {db_name}").as_str())
+        .await;
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert_eq!(err.code(), ErrorCode::UNKNOWN_DATABASE);
+    eprintln!("{}", err.message());
+
+    Ok(())
+}
+
+async fn new_local_meta() -> MetaStore {
+    let version = &BUILD_INFO;
+    let meta_config = MetaConfig::default();
+    let meta = {
+        let config = meta_config.to_meta_grpc_client_conf(version);
+        let provider = Arc::new(MetaStoreProvider::new(config));
+        provider
+            .create_meta_store()
+            .await
+            .map_err(|e| ErrorCode::MetaServiceError(format!("Failed to create meta store: {}", e)))
+            .unwrap()
+    };
+    meta
 }

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -651,7 +651,7 @@ async fn test_gc_in_progress_db_not_undroppable() -> Result<()> {
     // 2. Setup test fixture by using local meta store
     let fixture = TestFixture::setup_with_custom(ee_setup).await?;
 
-    // Adjust retention period to 0, so that dropped tables will be vacuumed immediately
+    // Adjust retention period to 0, so that dropped tables will be available for vacuum immediately
     let session = fixture.default_session();
     session.get_settings().set_data_retention_time_in_days(0)?;
 

--- a/src/query/service/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mod.rs
@@ -18,8 +18,7 @@ mod analyze;
 mod clustering;
 mod commit;
 
-// TODO comment out temporarily
-// mod create_or_replace_ownership_object;
+mod create_or_replace_ownership_object;
 mod gc;
 mod internal_column;
 mod mutation;

--- a/src/query/service/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mod.rs
@@ -17,7 +17,9 @@ mod alter_table;
 mod analyze;
 mod clustering;
 mod commit;
-mod create_or_replace_ownership_object;
+
+// TODO comment out temporarily
+// mod create_or_replace_ownership_object;
 mod gc;
 mod internal_column;
 mod mutation;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- During vacuum dropped table, remove db_id_table_name kv pairs

- Utilize `DatabaseMeta::gc_in_progress` as a irreversible flag, once set to true, never flip back.

  - during vacuuming dropped databases, `database_meta.gc_in_progress` will be set to true firstly, before removing any other database meta keys
  
  - The db_id_table_name kv pairs are deleted in batch before other database meta keys are cleaned; thus if process crashed in the middle, the vacuum drop operation could be "roll forward" by retry.

  - during `undrop database`, if `database_meta.gc_in_progress` is true, the operation will abort, and UnknowDatabse exception will be propagated to the frontend user

  The kv txns used by `vacuum drop` and `undrop database` ensure that once gc_in_progress is true, it can no longer be set to false.




## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18665)
<!-- Reviewable:end -->
