### PR TITLE
fix(rbac): create or replace ownership_object should delete the old ownership key

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -4841,6 +4841,7 @@ impl SchemaApiTestSuite {
                 new_table: true,
                 orphan_table_name: None,
                 spec_vec: None,
+                old_table_id: None,
             };
             let cur_db = util.get_database().await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -269,6 +269,8 @@ where
         }
 
         let mut trials = txn_backoff(None, func_name!());
+        let mut old_table_id = None;
+
         loop {
             trials.next().unwrap()?.await;
 
@@ -319,6 +321,7 @@ where
                                 spec_vec: None,
                                 prev_table_id: None,
                                 orphan_table_name: None,
+                                old_table_id: None,
                             });
                         }
                         CreateOption::CreateOrReplace => {
@@ -330,6 +333,7 @@ where
 
                                 SeqV::new(id.seq, *id.data)
                             } else {
+                                old_table_id = Some(*id.data);
                                 let (seq, id) = construct_drop_table_txn_operations(
                                     self,
                                     req.name_ident.table_name.clone(),
@@ -467,6 +471,7 @@ where
                         spec_vec: None,
                         prev_table_id,
                         orphan_table_name,
+                        old_table_id,
                     });
                 } else {
                     // re-run txn with re-fetched data

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -217,6 +217,7 @@ impl Display for CreateDatabaseReq {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseReply {
     pub db_id: DatabaseId,
+    pub old_db_id: Option<DatabaseId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -659,6 +659,7 @@ pub struct CreateTableReply {
     pub spec_vec: Option<(u64, u64)>,
     pub prev_table_id: Option<u64>,
     pub orphan_table_name: Option<String>,
+    pub old_table_id: Option<u64>,
 }
 
 /// Drop table by id.

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -330,7 +330,10 @@ impl Catalog for MutableCatalog {
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(req.name_ident.tenant_name()).await?;
-        Ok(CreateDatabaseReply { db_id: res.db_id })
+        Ok(CreateDatabaseReply {
+            db_id: res.db_id,
+            old_db_id: res.old_db_id,
+        })
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -88,6 +88,16 @@ impl Interpreter for CreateDatabaseInterpreter {
                         &current_role.name,
                     )
                     .await?;
+
+                // if old_db_id is some means create or replace is success, we should delete the old db id's ownership key
+                if let Some(old_db_id) = reply.old_db_id {
+                    role_api
+                        .revoke_ownership(&OwnershipObject::Database {
+                            catalog_name: self.plan.catalog.clone(),
+                            db_id: *old_db_id,
+                        })
+                        .await?;
+                }
                 RoleCacheManager::instance().invalidate_cache(&tenant);
             }
         }

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -33,6 +33,7 @@ use databend_common_management::RoleApi;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::schema::CommitTableMetaReq;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableIndexType;
@@ -41,6 +42,7 @@ use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_app::schema::TablePartition;
 use databend_common_meta_app::schema::TableStatistics;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_types::MatchSeq;
 use databend_common_pipeline_core::always_callback;
 use databend_common_pipeline_core::ExecutionInfo;
@@ -228,22 +230,7 @@ impl CreateTableInterpreter {
         let db_id = reply.db_id;
 
         if !req.table_meta.options.contains_key(OPT_KEY_TEMP_PREFIX) {
-            // grant the ownership of the table to the current role.
-            let current_role = self.ctx.get_current_role();
-            if let Some(current_role) = current_role {
-                let role_api = UserApiProvider::instance().role_api(&tenant);
-                role_api
-                    .grant_ownership(
-                        &OwnershipObject::Table {
-                            catalog_name: self.plan.catalog.clone(),
-                            db_id,
-                            table_id,
-                        },
-                        &current_role.name,
-                    )
-                    .await?;
-                RoleCacheManager::instance().invalidate_cache(&tenant);
-            }
+            self.process_ownership(&tenant, reply).await?;
         }
 
         // If the table creation query contains column definitions, like 'CREATE TABLE t1(a int) AS SELECT * from t2',
@@ -336,6 +323,42 @@ impl CreateTableInterpreter {
         Ok(pipeline)
     }
 
+    async fn process_ownership(&self, tenant: &Tenant, reply: CreateTableReply) -> Result<()> {
+        // grant the ownership of the table to the current role.
+        let mut invalid_cache = false;
+        let current_role = self.ctx.get_current_role();
+        let role_api = UserApiProvider::instance().role_api(tenant);
+        if let Some(current_role) = current_role {
+            role_api
+                .grant_ownership(
+                    &OwnershipObject::Table {
+                        catalog_name: self.plan.catalog.clone(),
+                        db_id: reply.db_id,
+                        table_id: reply.table_id,
+                    },
+                    &current_role.name,
+                )
+                .await?;
+            invalid_cache = true;
+        }
+
+        // if old_table_id is some means create or replace is success, we should delete the old table id's ownership key
+        if let Some(old_table_id) = reply.old_table_id {
+            role_api
+                .revoke_ownership(&OwnershipObject::Table {
+                    catalog_name: self.plan.catalog.clone(),
+                    db_id: reply.db_id,
+                    table_id: old_table_id,
+                })
+                .await?;
+            invalid_cache = true;
+        }
+        if invalid_cache {
+            RoleCacheManager::instance().invalidate_cache(tenant);
+        }
+        Ok(())
+    }
+
     #[async_backtrace::framed]
     async fn create_table(&self) -> Result<PipelineBuildResult> {
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str()).await?;
@@ -390,27 +413,10 @@ impl CreateTableInterpreter {
             self.register_temp_table(prefix).await?;
         }
 
+        // iceberg table do not need to generate ownership.
         if !req.table_meta.options.contains_key(OPT_KEY_TEMP_PREFIX) && !catalog.is_external() {
-            // iceberg table do not need to generate ownership.
-            // grant the ownership of the table to the current role, the above req.table_meta.owner could be removed in the future.
-            if let Some(current_role) = self.ctx.get_current_role() {
-                let tenant = self.ctx.get_tenant();
-                let db = catalog.get_database(&tenant, &self.plan.database).await?;
-                let db_id = db.get_db_info().database_id.db_id;
-
-                let role_api = UserApiProvider::instance().role_api(&tenant);
-                role_api
-                    .grant_ownership(
-                        &OwnershipObject::Table {
-                            catalog_name: self.plan.catalog.clone(),
-                            db_id,
-                            table_id: reply.table_id,
-                        },
-                        &current_role.name,
-                    )
-                    .await?;
-                RoleCacheManager::instance().invalidate_cache(&tenant);
-            }
+            let tenant = self.ctx.get_tenant();
+            self.process_ownership(&tenant, reply).await?;
         }
 
         Ok(PipelineBuildResult::create())

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -128,8 +128,8 @@ pub trait Setup {
     async fn setup(&self) -> Result<InnerConfig>;
 }
 
-struct OSSSetup {
-    config: InnerConfig,
+pub struct OSSSetup {
+    pub config: InnerConfig,
 }
 
 #[async_trait::async_trait]

--- a/src/query/service/tests/it/storages/fuse/operations/create_or_replace_ownership_object.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/create_or_replace_ownership_object.rs
@@ -1,0 +1,189 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_base::base::tokio;
+use databend_common_config::MetaConfig;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_meta_api::SchemaApi;
+use databend_common_meta_app::principal::OwnershipObject;
+use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
+use databend_common_meta_store::MetaStore;
+use databend_common_meta_store::MetaStoreProvider;
+use databend_common_storages_fuse::TableContext;
+use databend_common_version::BUILD_INFO;
+use databend_query::test_kits::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fuse_db_table_create_replace_clean_ownership_key() -> Result<()> {
+    let version = &BUILD_INFO;
+    let meta_config = MetaConfig::default();
+    let meta = {
+        let config = meta_config.to_meta_grpc_client_conf(version);
+        let provider = Arc::new(MetaStoreProvider::new(config));
+        provider.create_meta_store().await.map_err(|e| {
+            ErrorCode::MetaServiceError(format!("Failed to create meta store: {}", e))
+        })?
+    };
+
+    // Extracts endpoints to comunicate with meta service
+    let MetaStore::L(local) = &meta else {
+        panic!("MetaStore should not be local");
+    };
+
+    let endpoints = local.endpoints.clone();
+
+    // Modify config to use local meta store
+    let mut config = ConfigBuilder::create().config();
+    config.meta.endpoints = endpoints.clone();
+    // 2. Setup test fixture by using local meta store
+    let fixture = TestFixture::setup_with_custom(OSSSetup { config }).await?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    let tenant = ctx.get_tenant();
+
+    // test create or replace table
+    {
+        fixture.create_default_database().await?;
+
+        let db_name = fixture.default_db_name();
+        let tbl_name = fixture.default_table_name();
+        let catalog_name = fixture.default_catalog_name();
+
+        fixture
+            .execute_command(&format!(
+                "create table {}.{}.{} (id int)",
+                catalog_name, db_name, tbl_name
+            ))
+            .await?;
+
+        let db = ctx
+            .get_default_catalog()?
+            .get_database(&tenant, &db_name)
+            .await?;
+
+        let old_tbl_id = db
+            .get_table(&tbl_name)
+            .await?
+            .get_table_info()
+            .ident
+            .table_id;
+        let table_ownership = OwnershipObject::Table {
+            catalog_name: catalog_name.clone(),
+            db_id: db.get_db_info().database_id.db_id,
+            table_id: old_tbl_id,
+        };
+        let table_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership);
+        let v = meta.get(&table_ownership_key).await?;
+        assert!(v.is_some());
+
+        fixture
+            .execute_command(&format!(
+                "create or replace table {}.{}.{} (id int)",
+                catalog_name, db_name, tbl_name
+            ))
+            .await?;
+        let v = meta.get(&table_ownership_key).await?;
+        assert!(v.is_none());
+
+        let tbl_name = "ownership_table_test";
+        fixture
+            .execute_command(&format!(
+                "create or replace table {}.{}.{} (id int)",
+                catalog_name, db_name, tbl_name
+            ))
+            .await?;
+        let tbl = db.get_table(tbl_name).await?;
+        let first_create_id = tbl.get_table_info().ident.table_id;
+        let table_ownership = OwnershipObject::Table {
+            catalog_name: catalog_name.clone(),
+            db_id: db.get_db_info().database_id.db_id,
+            table_id: first_create_id,
+        };
+        let table_ownership_key =
+            TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership.clone());
+        let v = meta.get(&table_ownership_key).await?;
+        assert!(v.is_some());
+
+        fixture
+            .execute_command(&format!(
+                "create or replace table {}.{}.{} (id int)",
+                catalog_name, db_name, tbl_name
+            ))
+            .await?;
+        let tbl = db.get_table(tbl_name).await?;
+        let second_create_id = tbl.get_table_info().ident.table_id;
+        assert_ne!(second_create_id, first_create_id);
+        let db_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership);
+        let v = meta.get(&db_ownership_key).await?;
+        assert!(v.is_none());
+
+        let table_ownership = OwnershipObject::Table {
+            catalog_name: catalog_name.clone(),
+            db_id: db.get_db_info().database_id.db_id,
+            table_id: second_create_id,
+        };
+        let db_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership);
+        let v = meta.get(&db_ownership_key).await?;
+        assert!(v.is_some());
+    }
+
+    // test create or replace database
+    {
+        let db_name = "db1";
+        fixture
+            .execute_command(&format!("create or replace database {}", db_name))
+            .await?;
+        let db = ctx
+            .get_default_catalog()?
+            .get_database(&tenant, db_name)
+            .await?;
+        let first_create_db_id = db.get_db_info().database_id;
+        let catalog_name = fixture.default_catalog_name();
+        let db_ownership = OwnershipObject::Database {
+            catalog_name: catalog_name.clone(),
+            db_id: *first_create_db_id,
+        };
+        let db_ownership_key =
+            TenantOwnershipObjectIdent::new(tenant.clone(), db_ownership.clone());
+        let v = meta.get(&db_ownership_key).await?;
+        assert!(v.is_some());
+
+        fixture
+            .execute_command(&format!("create or replace database {}", db_name))
+            .await?;
+        let db = ctx
+            .get_default_catalog()?
+            .get_database(&tenant, db_name)
+            .await?;
+        let second_create_db_id = db.get_db_info().database_id;
+        assert_ne!(second_create_db_id, first_create_db_id);
+
+        let db_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), db_ownership);
+        let v = meta.get(&db_ownership_key).await?;
+        assert!(v.is_none());
+
+        let db_ownership = OwnershipObject::Database {
+            catalog_name: catalog_name.clone(),
+            db_id: *second_create_db_id,
+        };
+        let db_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), db_ownership);
+        let v = meta.get(&db_ownership_key).await?;
+        assert!(v.is_some());
+    }
+
+    Ok(())
+}

--- a/src/query/service/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mod.rs
@@ -17,6 +17,7 @@ mod alter_table;
 mod analyze;
 mod clustering;
 mod commit;
+mod create_or_replace_ownership_object;
 mod gc;
 mod internal_column;
 mod mutation;

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -109,6 +109,7 @@ impl TempTblMgr {
         let desc = format!("{}.{}", name_ident.db_name, name_ident.table_name);
         let engine = table_meta.engine.to_string();
         let table_id = self.next_id;
+        let mut old_table_id = None;
         let new_table = match (self.name_to_id.contains_key(&desc), create_option) {
             (true, CreateOption::Create) => {
                 return Err(ErrorCode::TableAlreadyExists(format!(
@@ -122,9 +123,9 @@ impl TempTblMgr {
                     .as_ref()
                     .map(|o| format!("{}.{}", name_ident.db_name, o))
                     .unwrap_or(desc);
-                let old_id = self.name_to_id.insert(desc.clone(), table_id);
-                if let Some(old_id) = old_id {
-                    self.id_to_table.remove(&old_id);
+                old_table_id = self.name_to_id.insert(desc.clone(), table_id);
+                if let Some(old_id) = &old_table_id {
+                    self.id_to_table.remove(old_id);
                 }
                 self.id_to_table.insert(table_id, TempTable {
                     db_name: name_ident.db_name,
@@ -149,6 +150,7 @@ impl TempTblMgr {
             spec_vec: None,
             prev_table_id: None,
             orphan_table_name,
+            old_table_id,
         })
     }
 

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -320,6 +320,7 @@ impl Catalog for IcebergMutableCatalog {
                 {
                     return Ok(CreateDatabaseReply {
                         db_id: DatabaseId::new(0),
+                        old_db_id: None,
                     });
                 }
             }
@@ -346,6 +347,8 @@ impl Catalog for IcebergMutableCatalog {
 
         Ok(CreateDatabaseReply {
             db_id: DatabaseId::new(0),
+            // external catalog directly return None
+            old_db_id: None,
         })
     }
 

--- a/src/query/storages/iceberg/src/database.rs
+++ b/src/query/storages/iceberg/src/database.rs
@@ -202,6 +202,7 @@ impl Database for IcebergDatabase {
                             spec_vec: None,
                             prev_table_id: None,
                             orphan_table_name: None,
+                            old_table_id: None,
                         });
                     }
                 }
@@ -255,6 +256,7 @@ impl Database for IcebergDatabase {
             spec_vec: None,
             prev_table_id: None,
             orphan_table_name: None,
+            old_table_id: None,
         })
     }
 

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -34,7 +34,7 @@ echo "set default role 'r_0002'" | $TEST_USER_CONNECT
 ## database/table
 echo "=== test db/table ==="
 echo "create database d_0002" | $TEST_USER_CONNECT
-echo "create table d_0002.t(id int)" | $TEST_USER_CONNECT
+echo "create or replace table d_0002.t(id int)" | $TEST_USER_CONNECT
 echo "insert into d_0002.t values(200)" | $TEST_USER_CONNECT
 echo "select * from d_0002.t" | $TEST_USER_CONNECT
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When using the CREATE OR REPLACE operation (such as replacing a database or table), the ownership key of the old object is not correctly deleted, resulting in confusion in permission management. This PR fixes this issue, ensuring that the ownership key of the old object is correctly removed when replacing the object.

More detailed info see: #18666

- CreateTable/DatabaseReplay add new item old_table/db_id.

- Only CreateOrReplace will make this item as Some(old_id) other case will directly return None.


<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.


-->

- fixes: #18666

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18667)
<!-- Reviewable:end -->
