### PR TITLE
refactor(meta): complete SchemaApi trait decomposition

### DIFF
--- a/src/meta/api/src/index_api.rs
+++ b/src/meta/api/src/index_api.rs
@@ -67,6 +67,7 @@ use crate::serialize_struct;
 use crate::txn_backoff::txn_backoff;
 use crate::txn_cond_eq_seq;
 use crate::txn_cond_seq;
+use crate::txn_op_del;
 use crate::txn_op_put;
 use crate::util::txn_delete_exact;
 use crate::util::txn_op_put_pb;
@@ -493,6 +494,70 @@ where
                 .push((index_name, index_version, index_meta));
         }
         Ok(GetMarkedDeletedTableIndexesReply { table_indexes })
+    }
+
+    #[logcall::logcall]
+    #[fastrace::trace]
+    async fn remove_marked_deleted_index_ids(
+        &self,
+        tenant: &Tenant,
+        table_id: u64,
+        index_ids: &[u64],
+    ) -> Result<(), MetaTxnError> {
+        let mut trials = txn_backoff(None, func_name!());
+
+        loop {
+            trials.next().unwrap()?.await;
+            let mut txn = TxnRequest::default();
+
+            for index_id in index_ids {
+                txn.if_then
+                    .push(txn_op_del(&MarkedDeletedIndexIdIdent::new_generic(
+                        tenant,
+                        MarkedDeletedIndexId::new(table_id, *index_id),
+                    )));
+            }
+
+            let (succ, _responses) = send_txn(self, txn).await?;
+
+            if succ {
+                return Ok(());
+            }
+        }
+    }
+
+    #[logcall::logcall]
+    #[fastrace::trace]
+    async fn remove_marked_deleted_table_indexes(
+        &self,
+        tenant: &Tenant,
+        table_id: u64,
+        indexes: &[(String, String)],
+    ) -> Result<(), MetaTxnError> {
+        let mut trials = txn_backoff(None, func_name!());
+
+        loop {
+            trials.next().unwrap()?.await;
+            let mut txn = TxnRequest::default();
+
+            for (index_name, index_version) in indexes {
+                txn.if_then
+                    .push(txn_op_del(&MarkedDeletedTableIndexIdIdent::new_generic(
+                        tenant,
+                        MarkedDeletedTableIndexId::new(
+                            table_id,
+                            index_name.to_string(),
+                            index_version.to_string(),
+                        ),
+                    )));
+            }
+
+            let (succ, _responses) = send_txn(self, txn).await?;
+
+            if succ {
+                return Ok(());
+            }
+        }
     }
 }
 

--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -1452,25 +1452,25 @@ impl SchemaApiTestSuite {
 
             let lvt_name_ident = LeastVisibleTimeIdent::new(&tenant, table_id);
 
-            let res = mt.get(&lvt_name_ident).await?;
+            let res = mt.get_pb(&lvt_name_ident).await?;
             assert!(res.is_none());
 
             let res = mt.set_table_lvt(&lvt_name_ident, &lvt_big).await?;
             assert_eq!(res.time, time_big);
-            let res = mt.get(&lvt_name_ident).await?;
-            assert_eq!(res.unwrap().time, time_big);
+            let res = mt.get_pb(&lvt_name_ident).await?;
+            assert_eq!(res.unwrap().data.time, time_big);
 
             // test lvt never fall back
 
             let res = mt.set_table_lvt(&lvt_name_ident, &lvt_small).await?;
             assert_eq!(res.time, time_big);
-            let res = mt.get(&lvt_name_ident).await?;
-            assert_eq!(res.unwrap().time, time_big);
+            let res = mt.get_pb(&lvt_name_ident).await?;
+            assert_eq!(res.unwrap().data.time, time_big);
 
             let res = mt.set_table_lvt(&lvt_name_ident, &lvt_bigger).await?;
             assert_eq!(res.time, time_bigger);
-            let res = mt.get(&lvt_name_ident).await?;
-            assert_eq!(res.unwrap().time, time_bigger);
+            let res = mt.get_pb(&lvt_name_ident).await?;
+            assert_eq!(res.unwrap().data.time, time_bigger);
         }
 
         Ok(())

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -21,7 +21,7 @@ use databend_common_catalog::table_context::CheckAbort;
 use databend_common_config::MetaConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_meta_api::SchemaApi;
+use databend_common_meta_api::kv_pb_api::KVPbApi;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
 use databend_common_meta_app::schema::TableInfo;
@@ -605,7 +605,7 @@ async fn test_vacuum_dropped_table_clean_ownership() -> Result<()> {
         table_id: table.get_id(),
     };
     let table_ownership_key = TenantOwnershipObjectIdent::new(tenant.clone(), table_ownership);
-    let v = meta.get(&table_ownership_key).await?;
+    let v = meta.get_pb(&table_ownership_key).await?;
     assert!(v.is_some());
 
     // 5. Drop test database
@@ -624,7 +624,7 @@ async fn test_vacuum_dropped_table_clean_ownership() -> Result<()> {
     };
 
     let table_ownership_key = TenantOwnershipObjectIdent::new(tenant, table_ownership);
-    let v = meta.get(&table_ownership_key).await?;
+    let v = meta.get_pb(&table_ownership_key).await?;
     assert!(v.is_none());
 
     Ok(())

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -30,7 +30,6 @@ use databend_common_meta_api::DictionaryApi;
 use databend_common_meta_api::GarbageCollectionApi;
 use databend_common_meta_api::IndexApi;
 use databend_common_meta_api::LockApi;
-use databend_common_meta_api::SchemaApi;
 use databend_common_meta_api::SecurityApi;
 use databend_common_meta_api::SequenceApi;
 use databend_common_meta_api::TableApi;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): complete SchemaApi trait decomposition

Complete the final phase of SchemaApi refactoring by moving the
last remaining methods to their appropriate domain-specific traits.
This achieves the goal of pure trait composition where SchemaApi
contains only trait bounds with no method implementations.

Changes:
- Move `set_table_lvt()` to TableApi for table time utilities
- Move `remove_marked_deleted_index_ids()` and
  `remove_marked_deleted_table_indexes()` to IndexApi for cleanup
- Transform SchemaApi to pure trait composition pattern
- Replace generic `get()` calls with direct `get_pb()` usage
- Remove unused imports and eliminate wrapper methods

The refactoring successfully extracts all 58 methods from the
monolithic SchemaApi while maintaining backward compatibility
through trait bounds. Each domain-specific trait now handles
its own methods, improving maintainability and enabling focused
testing and development.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18669)
<!-- Reviewable:end -->
