### PR TITLE
chore: add test about create sequence to keep old version

### DIFF
--- a/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0036_sequence.test
@@ -14,7 +14,7 @@ statement error 2004
 CREATE SEQUENCE seq start = 1 increment = 0
 
 statement ok
-CREATE SEQUENCE seq start = 1 increment = 1
+CREATE SEQUENCE seq
 
 statement ok
 DROP TABLE IF EXISTS tmp;

--- a/tests/suites/0_stateless/18_rbac/18_0016_seq_rbac.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0016_seq_rbac.sh
@@ -30,9 +30,9 @@ echo "drop table if exists tmp_b1;" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists tmp_b2;" | $BENDSQL_CLIENT_CONNECT
 echo "drop table if exists tmp_b3;" | $BENDSQL_CLIENT_CONNECT
 
-echo "CREATE sequence seq1 start = 1 increment =1" | $USER_A_CONNECT
-echo "create sequence seq2 start = 1 increment =1" | $USER_A_CONNECT
-echo "create sequence seq3 start = 1 increment =1" | $USER_A_CONNECT
+echo "CREATE sequence seq1" | $USER_A_CONNECT
+echo "create sequence seq2" | $USER_A_CONNECT
+echo "create sequence seq3" | $USER_A_CONNECT
 echo "DESC sequence seq1;" | $USER_A_CONNECT | grep seq1 | wc -l
 echo "DESC sequence seq2;" | $USER_A_CONNECT | grep seq2 | wc -l
 echo "DESC sequence seq3;" | $USER_A_CONNECT | grep seq3 | wc -l
@@ -46,9 +46,9 @@ echo "=== NEW LOGIC: user has super privileges can operator all sequences with e
 echo "=== TEST USER A WITH SUPER PRIVILEGES ==="
 echo "set global enable_experimental_sequence_privilege_check=1;" | $USER_A_CONNECT
 echo "--- CREATE 3 sequences WILL SUCCESS ---"
-echo "CREATE sequence seq1 start = 1 increment =1" | $USER_A_CONNECT
-echo "create sequence seq2 start = 1 increment =1" | $USER_A_CONNECT
-echo "create sequence seq3 start = 1 increment =1" | $USER_A_CONNECT
+echo "CREATE sequence seq1" | $USER_A_CONNECT
+echo "create sequence seq2" | $USER_A_CONNECT
+echo "create sequence seq3" | $USER_A_CONNECT
 echo "DESC sequence seq1;" | $USER_A_CONNECT | grep seq1 | wc -l
 echo "DESC sequence seq2;" | $USER_A_CONNECT | grep seq2 | wc -l
 echo "DESC sequence seq3;" | $USER_A_CONNECT | grep seq3 | wc -l
@@ -68,14 +68,14 @@ echo "create role role3;" | $BENDSQL_CLIENT_CONNECT
 echo "grant create sequence on *.* to role role1;" | $BENDSQL_CLIENT_CONNECT
 echo "grant role role1 to b;" | $BENDSQL_CLIENT_CONNECT
 echo "--- USER b failed to create conn seq1 because current role is public, can not create ---"
-echo "CREATE sequence seq1 start = 1 increment =1" | $USER_B_CONNECT
+echo "CREATE sequence seq1" | $USER_B_CONNECT
 
 echo "alter user b with default_role='role1';" | $BENDSQL_CLIENT_CONNECT
 
 echo "--- success, seq1,2,3 owner role is role1 ---";
-echo "CREATE sequence seq1 start = 1 increment =1" | $USER_B_CONNECT
-echo "create sequence seq2 start = 1 increment =1" | $USER_B_CONNECT
-echo "create sequence seq3 start = 1 increment =1" | $USER_B_CONNECT
+echo "CREATE sequence seq1" | $USER_B_CONNECT
+echo "create sequence seq2" | $USER_B_CONNECT
+echo "create sequence seq3" | $USER_B_CONNECT
 echo "DESC sequence seq1;" | $USER_B_CONNECT | grep seq1 | wc -l
 echo "DESC sequence seq2;" | $USER_B_CONNECT | grep seq2 | wc -l
 echo "DESC sequence seq3;" | $USER_B_CONNECT | grep seq3 | wc -l


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Update the sqllogictest test cases

File: tests/sqllogictests/suites/base / 05 _ddl / 05 _0036_sequence test
Change

Test "CREATE SEQUENCE seq start = 1 increment = 1" and "CREATE SEQUENCE seq" side by side to ensure that both syntaxes can be executed correctly.
Ensure that the old version of the syntax (without the start and increment parameters) remains valid.



2. Update the RBAC test script

File: tests/suites/0_stateless/18_rbac/18_0016_seq_rbac.sh
Change

In the RBAC (Role-Based Access Control) scenario, test both the old and new versions of the CREATE SEQUENCE syntax simultaneously.
Ensure that different roles can correctly create sequences when enable_experimental_sequence_privilege_check is enabled or disabled.
<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18673)
<!-- Reviewable:end -->
