### PR TITLE
chore: catch `to_date`/`to_timestamp` unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4980,6 +4980,7 @@ name = "databend-functions-scalar-datetime"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "databend-common-base",
  "databend-common-column",
  "databend-common-exception",
  "databend-common-expression",

--- a/src/query/functions/src/scalars/timestamp/Cargo.toml
+++ b/src/query/functions/src/scalars/timestamp/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { workspace = true }
+databend-common-base = { workspace = true }
 databend-common-column = { workspace = true }
 databend-common-exception = { workspace = true }
 databend-common-expression = { workspace = true }

--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -17,10 +17,10 @@ use std::borrow::Cow;
 use std::fmt::Display;
 use std::fmt::FormattingOptions;
 use std::io::Write;
-use std::panic::catch_unwind;
 
 use chrono::Datelike;
 use chrono::NaiveDate;
+use databend_common_base::runtime::catch_unwind;
 use databend_common_column::types::months_days_micros;
 use databend_common_exception::ErrorCode;
 use databend_common_expression::error_to_null;
@@ -314,7 +314,7 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
         vectorize_with_builder_1_arg::<StringType, TimestampType>(|val, output, ctx| {
             let mut d = string_to_timestamp(val, &ctx.func_ctx.tz);
             if !ctx.func_ctx.enable_strict_datetime_parser {
-                d = match catch_unwind(std::panic::AssertUnwindSafe(|| {
+                d = match catch_unwind(|| {
                     d.or_else(|_| {
                         parse(val)
                             .map_err(|err| ErrorCode::BadArguments(format!("{err}")))
@@ -322,7 +322,7 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
                                 string_to_timestamp(naive_dt.to_string(), &ctx.func_ctx.tz)
                             })
                     })
-                })) {
+                }) {
                     Ok(result) => result,
                     Err(_) => Err(ErrorCode::BadArguments(format!(
                         "TIMESTAMP '{}' is not recognized.",
@@ -651,7 +651,7 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
         vectorize_with_builder_1_arg::<StringType, DateType>(|val, output, ctx| {
             let mut d = string_to_date(val, &ctx.func_ctx.tz);
             if !ctx.func_ctx.enable_strict_datetime_parser {
-                d = match catch_unwind(std::panic::AssertUnwindSafe(|| {
+                d = match catch_unwind(|| {
                     d.or_else(|_| {
                         parse(val)
                             .map_err(|err| ErrorCode::BadArguments(format!("{err}")))
@@ -659,7 +659,7 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
                                 string_to_date(naive_dt.to_string(), &ctx.func_ctx.tz)
                             })
                     })
-                })) {
+                }) {
                     Ok(result) => result,
                     Err(_) => Err(ErrorCode::BadArguments(format!(
                         "Date '{}' is not recognized.",

--- a/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
+++ b/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
@@ -187,7 +187,7 @@ SELECT to_date('2022-02-03T00:00:00+09:00') = to_date('2022-02-02'), to_date('20
 ----
 1 1
 
-statement error
+statement error 1006
 SELECT to_date('2020.10.')
 
 
@@ -196,7 +196,7 @@ SELECT to_timestamp(1640019661000000) = to_timestamp('2021-12-20 17:01:01.000000
 ----
 1
 
-statement error
+statement error 1006
 SELECT to_timestamp('2020.10.')
 
 query B

--- a/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
+++ b/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
@@ -187,12 +187,17 @@ SELECT to_date('2022-02-03T00:00:00+09:00') = to_date('2022-02-02'), to_date('20
 ----
 1 1
 
+statement error
+SELECT to_date('2020.10.')
+
 
 query B
 SELECT to_timestamp(1640019661000000) = to_timestamp('2021-12-20 17:01:01.000000')
 ----
 1
 
+statement error
+SELECT to_timestamp('2020.10.')
 
 query B
 SELECT to_variant(true)::boolean


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When executing an obviously incorrect expression like to_date('2010.10.'), the third-party parsing library dtparse will panic. This pr is used to handle panic and provide more humane error feedback.

example: 
```shell
set enable_strict_datetime_parser = 0;

# before
SELECT to_date('2020.10.');
error: APIError: QueryFailed: [1104]index out of bounds: the len is 4 but the index is 4

# after
SELECT to_date('2020.10.');
error: APIError: QueryFailed: [1006]cannot parse to type `DATE`. BadArguments. Code: 1006, Text = Date '2020.10.' is not recognized.. while evaluating function `to_date('2020.10.')` in expr `CAST('2020.10.' AS Date)`

```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18677)
<!-- Reviewable:end -->
