### PR TITLE
fix: forbid transform with where clause.

### DIFF
--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -26,12 +26,14 @@ use percent_encoding::percent_decode_str;
 use url::Url;
 
 use crate::ast::quote::QuotedString;
+use crate::ast::write_comma_separated_list;
 use crate::ast::write_comma_separated_map;
 use crate::ast::write_comma_separated_string_list;
 use crate::ast::write_comma_separated_string_map;
 use crate::ast::Hint;
 use crate::ast::Identifier;
 use crate::ast::Query;
+use crate::ast::SelectTarget;
 use crate::ast::TableRef;
 use crate::ast::With;
 use crate::ParseError;
@@ -304,15 +306,19 @@ pub enum CopyIntoTableSource {
     Location(FileLocation),
     /// Load with Transform
     /// limited to `(SELECT ... FROM <location>)`
-    Query(Box<Query>),
+    Query {
+        select_list: Vec<SelectTarget>,
+        from: FileLocation,
+    },
 }
 
 impl Display for CopyIntoTableSource {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CopyIntoTableSource::Location(location) => write!(f, "{location}"),
-            CopyIntoTableSource::Query(query) => {
-                write!(f, "({query})")
+            CopyIntoTableSource::Query { select_list, from } => {
+                write_comma_separated_list(f, select_list)?;
+                write!(f, " FROM {from}")
             }
         }
     }

--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -309,6 +309,8 @@ pub enum CopyIntoTableSource {
     Query {
         select_list: Vec<SelectTarget>,
         from: FileLocation,
+        // no need to support this, for compatible only
+        alias_name: Option<Identifier>,
     },
 }
 
@@ -316,9 +318,19 @@ impl Display for CopyIntoTableSource {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             CopyIntoTableSource::Location(location) => write!(f, "{location}"),
-            CopyIntoTableSource::Query { select_list, from } => {
+            CopyIntoTableSource::Query {
+                select_list,
+                from,
+                alias_name,
+            } => {
+                write!(f, "(SELECT ")?;
                 write_comma_separated_list(f, select_list)?;
-                write!(f, " FROM {from}")
+                write!(f, " FROM {from}")?;
+                if let Some(a) = alias_name {
+                    write!(f, " AS {}", a.name)?;
+                }
+                write!(f, ")")?;
+                Ok(())
             }
         }
     }

--- a/src/query/ast/src/parser/copy.rs
+++ b/src/query/ast/src/parser/copy.rs
@@ -16,6 +16,7 @@ use nom::branch::alt;
 use nom::combinator::map;
 use nom_rule::rule;
 
+use super::query::alias_name;
 use super::query::select_target;
 use super::query::with;
 use crate::ast::CopyIntoLocationOption;
@@ -49,8 +50,12 @@ pub fn copy_into_table(i: Input) -> IResult<Statement> {
     let copy_into_table_source = alt((
         map(file_location, CopyIntoTableSource::Location),
         map(
-            rule! { "(" ~ SELECT ~ #comma_separated_list1(select_target) ~ FROM ~ #file_location ~ ")" },
-            |(_, _, select_list, _, from, _)| CopyIntoTableSource::Query { select_list, from },
+            rule! { "(" ~ SELECT ~ #comma_separated_list1(select_target) ~ FROM ~ #file_location ~  #alias_name? ~ ")" },
+            |(_, _, select_list, _, from, alias_name, _)| CopyIntoTableSource::Query {
+                select_list,
+                from,
+                alias_name,
+            },
         ),
     ));
 

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1134,6 +1134,7 @@ fn test_statement_error() {
                 RETURN sum;
             END;
             $$;"#,
+        r#"copy into t1 from (select a from @data/not_exists where a = 1)"#,
     ];
 
     for case in cases {

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -1263,7 +1263,7 @@ error:
   --> SQL:1:51
   |
 1 | copy into t1 from (select a from @data/not_exists where a = 1)
-  | ----                                              ^^^^^ unexpected `where`, expecting `)`
+  | ----                                              ^^^^^ unexpected `where`, expecting `IDENTIFIER`, <LiteralString>, <Ident>, `)`, or `AS`
   | |                                                  
   | while parsing `COPY
                 INTO { [<database_name>.]<table_name> { ( <columns> ) } }

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -1256,3 +1256,22 @@ error:
   | while parsing `CREATE [ OR REPLACE ] PROCEDURE <procedure_name>() RETURNS { <result_data_type> [ NOT NULL ] | TABLE(<var_name> <data_type>, ...)} LANGUAGE SQL [ COMMENT = '<string_literal>' ] AS <procedure_definition>`
 
 
+---------- Input ----------
+copy into t1 from (select a from @data/not_exists where a = 1)
+---------- Output ---------
+error: 
+  --> SQL:1:51
+  |
+1 | copy into t1 from (select a from @data/not_exists where a = 1)
+  | ----                                              ^^^^^ unexpected `where`, expecting `)`
+  | |                                                  
+  | while parsing `COPY
+                INTO { [<database_name>.]<table_name> { ( <columns> ) } }
+                FROM { internalStage | externalStage | externalLocation | ( <query> ) }
+                [ FILE_FORMAT = ( { TYPE = { CSV | NDJSON | PARQUET | TSV | AVRO } [ formatTypeOptions ] } ) ]
+                [ FILES = ( '<file_name>' [ , '<file_name>' ] [ , ... ] ) ]
+                [ PATTERN = '<regex_pattern>' ]
+                [ VALIDATION_MODE = RETURN_ROWS ]
+                [ copyOptions ]`
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


rewrite parser for transform as
`copy into <table> from (select <columns> from <location>  <alias>) <copy_options>`

instead of `copy into <table> from (query) <copy_options>` and check query for limits.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18681)
<!-- Reviewable:end -->
