### PR TITLE
feat: support reset of worksheet session.

### DIFF
--- a/src/query/service/src/servers/http/middleware/session.rs
+++ b/src/query/service/src/servers/http/middleware/session.rs
@@ -68,6 +68,7 @@ use crate::servers::http::error::HttpErrorCode;
 use crate::servers::http::error::JsonErrorOnly;
 use crate::servers::http::error::QueryError;
 use crate::servers::http::middleware::session_header::ClientSession;
+use crate::servers::http::middleware::session_header::ClientSessionType;
 use crate::servers::http::middleware::ClientCapabilities;
 use crate::servers::http::v1::HttpQueryContext;
 use crate::servers::http::v1::SessionClaim;
@@ -453,8 +454,10 @@ impl<E> HTTPSessionEndpoint<E> {
                 //     log every request, which can be distinguished by `session_id = ''`
                 login_history.disable_write = true;
             }
-            s.try_refresh_state(session.get_current_tenant(), &user_name, req.cookie())
-                .await?;
+            if ClientSessionType::IDOnly != s.typ {
+                s.try_refresh_state(session.get_current_tenant(), &user_name, req.cookie())
+                    .await?;
+            }
         }
 
         let session = session_manager.register_session(session)?;

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -398,13 +398,14 @@ async fn query_page_handler(
     Path((query_id, page_no)): Path<(String, usize)>,
 ) -> PoemResult<impl IntoResponse> {
     ctx.check_node_id(&query_id)?;
-    // tracing in middleware
 
     let http_query_manager = HttpQueryManager::instance();
 
     let Some(query) = http_query_manager.get_query(&query_id) else {
         return Err(query_id_not_found(&query_id, &ctx.node_id));
     };
+
+    ctx.try_refresh_worksheet_session().await.ok();
 
     let query_mem_stat = query.query_mem_stat.clone();
 

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -587,6 +587,7 @@ impl HttpQuery {
         http_ctx: &HttpQueryContext,
         req: HttpQueryRequest,
     ) -> Result<HttpQuery> {
+        http_ctx.try_set_worksheet_session(&req.session).await?;
         let (session, ctx) = http_ctx
             .create_session(&req.session, SessionType::HTTPQuery)
             .await?;

--- a/src/query/service/src/servers/http/v1/session/client_session_manager.rs
+++ b/src/query/service/src/servers/http/v1/session/client_session_manager.rs
@@ -168,6 +168,19 @@ impl ClientSessionManager {
             }
         }
     }
+    pub async fn try_refresh_state(
+        &self,
+        tenant: Tenant,
+        sid: &str,
+        user_name: &str,
+    ) -> Result<()> {
+        if self.refresh_in_memory_states(sid, user_name) {
+            self.refresh_session_handle(tenant, user_name.to_string(), sid)
+                .await?;
+            info!("[HTTP-SESSION] refreshing session {}", sid);
+        }
+        Ok(())
+    }
 
     pub async fn refresh_session_handle(
         &self,

--- a/tests/suites/1_stateful/09_http_handler/09_0007_session.py
+++ b/tests/suites/1_stateful/09_http_handler/09_0007_session.py
@@ -167,8 +167,9 @@ HEADER_SESSION_ID = "X-DATABEND-SESSION-ID"
 HEADER_SESSION_ID_V = "101010"
 
 
-def do_query_from_worksheet(client, sql, sid=HEADER_SESSION_ID_V):
-    payload = {"sql": sql, "pagination": {"max_rows_per_page": 2, "wait_time_secs": 10}}
+def do_query_from_worksheet(client, sql, sid=HEADER_SESSION_ID_V, new_session=False):
+    internal = None if new_session else "{}";
+    payload = {"sql": sql, "pagination": {"max_rows_per_page": 2, "wait_time_secs": 10}, "session": {"internal": internal}}
     resp = client.post(
         query_url,
         auth=auth,
@@ -204,6 +205,11 @@ def test_worksheet_session():
     resp = do_query_from_worksheet(client, "select * from t09_0007")
     assert resp["data"] == [["1"]], resp
 
+    resp = do_query_from_worksheet(client, "select * from t09_0007", new_session=True)
+    assert "Unknown table" in resp["error"]["message"], resp
+
+    resp = do_query_from_worksheet(client, "select * from numbers(10) ", new_session=True)
+    assert len(resp["data"]) == 2, resp
 
 def main():
     test_no_session()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. `.session.internal`  can only be null if the session is new/reset. try clear data in mem and s3 when it is null.
2.  this pr has no affect for normal session.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18688)
<!-- Reviewable:end -->
