### PR TITLE
fix: meta-semaphore: re-connect when no event recevied

### DIFF
--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -412,14 +412,14 @@ async fn benchmark_semaphore(
 
     let permit_str = format!("({sem_key}, id={id})");
 
-    let mut sem = Semaphore::new(client.clone(), &sem_key, param.capacity).await;
+    let mut sem = Semaphore::new(client.clone(), &sem_key, param.capacity, param.ttl()).await;
     if param.time_based {
         sem.set_time_based_seq(None);
     } else {
         sem.set_storage_based_seq();
     }
 
-    let permit_res = sem.acquire(&id, param.ttl()).await;
+    let permit_res = sem.acquire(&id).await;
 
     print_sem_res(i, format!("sem-acquired: {permit_str}",), &permit_res);
 

--- a/src/meta/semaphore/src/acquirer/permit.rs
+++ b/src/meta/semaphore/src/acquirer/permit.rs
@@ -14,16 +14,16 @@
 
 use std::future::Future;
 
-use futures::future::BoxFuture;
+use databend_common_base::runtime::spawn_named;
 use futures::FutureExt;
 use log::debug;
 use log::info;
+use log::warn;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
 use crate::acquirer::Acquirer;
 use crate::acquirer::SharedAcquirerStat;
-use crate::errors::ConnectionClosed;
 use crate::queue::PermitEvent;
 use crate::storage::PermitEntry;
 use crate::storage::PermitKey;
@@ -43,7 +43,15 @@ use crate::storage::PermitKey;
 pub struct Permit {
     pub acquirer_name: String,
     pub stat: SharedAcquirerStat,
-    pub fu: BoxFuture<'static, Result<(), ConnectionClosed>>,
+
+    // Hold it so that the subscriber keep running.
+    pub(crate) _subscriber_cancel_tx: oneshot::Sender<()>,
+
+    // Hold it so that the lease extending task keep running.
+    pub(crate) _leaser_cancel_tx: oneshot::Sender<()>,
+
+    /// Gets ready if the [`PermitEntry`] is removed from meta-service.
+    pub(crate) is_removed_rx: oneshot::Receiver<()>,
 }
 
 impl std::fmt::Debug for Permit {
@@ -68,13 +76,16 @@ impl Drop for Permit {
 }
 
 impl Future for Permit {
-    type Output = Result<(), ConnectionClosed>;
+    type Output = ();
 
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        self.fu.poll_unpin(cx)
+        match self.is_removed_rx.poll_unpin(cx) {
+            std::task::Poll::Ready(_) => std::task::Poll::Ready(()),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
     }
 }
 
@@ -89,18 +100,26 @@ impl Permit {
         permit_entry: PermitEntry,
         leaser_cancel_tx: oneshot::Sender<()>,
     ) -> Self {
+        let (is_removed_tx, is_removed_rx) = oneshot::channel::<()>();
+
+        // There must be a standalone task that consumes incoming events so that it won't block the permit_event_rx sender
+        let acquirer_name = acquirer.name.clone();
         let fu = Self::watch_for_remove(
             acquirer.permit_event_rx,
+            acquirer_name.clone(),
             permit_key,
             permit_entry,
-            acquirer.subscriber_cancel_tx,
-            leaser_cancel_tx,
+            is_removed_tx,
         );
 
+        spawn_named(fu, format!("{}-WatchRemove", acquirer_name.clone()));
+
         Permit {
-            acquirer_name: acquirer.name,
+            acquirer_name,
             stat: acquirer.stat,
-            fu: Box::pin(fu),
+            _subscriber_cancel_tx: acquirer.subscriber_cancel_tx,
+            _leaser_cancel_tx: leaser_cancel_tx,
+            is_removed_rx,
         }
     }
 
@@ -120,30 +139,26 @@ impl Permit {
     /// in such case, the permit may still be valid.
     pub(crate) async fn watch_for_remove(
         mut permit_event_rx: mpsc::Receiver<PermitEvent>,
+        acquirer_name: String,
         permit_key: PermitKey,
         permit_entry: PermitEntry,
-        _subscriber_cancel_tx: oneshot::Sender<()>,
-        _leaser_cancel_tx: oneshot::Sender<()>,
-    ) -> Result<(), ConnectionClosed> {
-        let ctx = format!("Semaphore-Acquired: {}->{}", permit_key, permit_entry);
+        is_removed_tx: oneshot::Sender<()>,
+    ) {
+        let ctx = format!("{}: {}->{}", acquirer_name, permit_key, permit_entry);
 
         while let Some(sem_event) = permit_event_rx.recv().await {
-            debug!("semaphore event: {} received by: {}", sem_event, ctx);
+            debug!("{}: received semaphore event: {}", ctx, sem_event);
 
             match sem_event {
                 PermitEvent::Acquired((_seq, _entry)) => {}
                 PermitEvent::Removed((seq, _)) => {
                     if seq == permit_key.seq {
-                        debug!(
-                            "semaphore PermitEntry is removed: {}->{}",
-                            permit_key, permit_entry.id
-                        );
-                        return Ok(());
+                        warn!("{}: PermitEntry is removed", ctx);
+                        is_removed_tx.send(()).ok();
+                        return;
                     }
                 }
             }
         }
-
-        Err(ConnectionClosed::new_str("semaphore event stream closed").context(&ctx))
     }
 }

--- a/src/meta/semaphore/src/errors/acquirer_closed.rs
+++ b/src/meta/semaphore/src/errors/acquirer_closed.rs
@@ -1,0 +1,102 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+/// Error indicating that a semaphore acquirer or permit has been closed.
+///
+/// This occurs when the acquirer instance becomes unavailable due to connection loss,
+/// explicit closure, permit expiration, or meta-service unavailability.
+#[derive(thiserror::Error, Debug)]
+pub struct AcquirerClosed {
+    reason: String,
+    when: Vec<String>,
+}
+
+impl AcquirerClosed {
+    /// Creates a new acquirer closed error with the specified reason.
+    pub fn new(reason: impl ToString) -> Self {
+        AcquirerClosed {
+            reason: reason.to_string(),
+            when: vec![],
+        }
+    }
+
+    /// Adds contextual information about when or where the error occurred.
+    ///
+    /// Context is displayed in the order it was added and enables method chaining.
+    pub fn context(mut self, context: impl ToString) -> Self {
+        self.when.push(context.to_string());
+        self
+    }
+}
+
+impl fmt::Display for AcquirerClosed {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "distributed-Semaphore Acquirer or Permit is closed: {}",
+            self.reason
+        )?;
+
+        if self.when.is_empty() {
+            return Ok(());
+        }
+
+        write!(f, "; when: (")?;
+
+        for (i, when) in self.when.iter().enumerate() {
+            if i > 0 {
+                write!(f, "; ")?;
+            }
+            write!(f, "{}", when)?;
+        }
+
+        write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_error_creation() {
+        let err = AcquirerClosed::new("Connection timeout");
+        assert_eq!(
+            err.to_string(),
+            "distributed-Semaphore Acquirer or Permit is closed: Connection timeout"
+        );
+    }
+
+    #[test]
+    fn test_error_with_context_chain() {
+        let err = AcquirerClosed::new("Network unreachable")
+            .context("while acquiring read permit")
+            .context("during database query");
+        assert_eq!(
+            err.to_string(),
+            "distributed-Semaphore Acquirer or Permit is closed: Network unreachable; when: (while acquiring read permit; during database query)"
+        );
+    }
+
+    #[test]
+    fn test_error_without_context() {
+        let err = AcquirerClosed::new("Simple error");
+        assert_eq!(
+            err.to_string(),
+            "distributed-Semaphore Acquirer or Permit is closed: Simple error"
+        );
+    }
+}

--- a/src/meta/semaphore/src/errors/mod.rs
+++ b/src/meta/semaphore/src/errors/mod.rs
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 mod acquire_error;
+mod acquirer_closed;
 mod connection_closed;
 mod early_removed;
 mod either;
+mod processer_error;
 
 pub use acquire_error::AcquireError;
+pub use acquirer_closed::AcquirerClosed;
 pub use connection_closed::ConnectionClosed;
 pub use early_removed::EarlyRemoved;
 pub use either::Either;
+pub use processer_error::ProcessorError;

--- a/src/meta/semaphore/src/errors/processer_error.rs
+++ b/src/meta/semaphore/src/errors/processer_error.rs
@@ -1,0 +1,36 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tonic::Status;
+
+use crate::errors::AcquirerClosed;
+use crate::errors::ConnectionClosed;
+
+/// Errors during semaphore permit processing.
+#[derive(thiserror::Error, Debug)]
+pub enum ProcessorError {
+    /// Connection to meta-service was lost.
+    #[error("ProcessorError: {0}")]
+    ConnectionClosed(#[from] ConnectionClosed),
+
+    /// Acquirer or Permit was dropped and there is no receiving end to receive the event.
+    #[error("ProcessorError: the semaphore Acquirer or Permit is dropped {0}")]
+    AcquirerClosed(#[from] AcquirerClosed),
+}
+
+impl From<Status> for ProcessorError {
+    fn from(status: Status) -> Self {
+        ProcessorError::ConnectionClosed(status.into())
+    }
+}

--- a/src/meta/service/src/api/grpc_server.rs
+++ b/src/meta/service/src/api/grpc_server.rs
@@ -43,7 +43,7 @@ pub struct GrpcServer {
     /// GrpcServer is the main container of the gRPC service.
     /// [`MetaNode`] should never be dropped while [`GrpcServer`] is alive.
     /// Therefore, it is held by a strong reference (Arc) to ensure proper lifetime management.
-    pub(crate) meta_node: Arc<MetaNode>,
+    pub meta_node: Arc<MetaNode>,
     join_handle: Option<JoinHandle<()>>,
     stop_grpc_tx: Option<Sender<()>>,
 }

--- a/src/meta/service/src/meta_service/runtime_config.rs
+++ b/src/meta/service/src/meta_service/runtime_config.rs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod errors;
-mod forwarder;
-mod meta_node_kv_api_impl;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
-pub use meta_node_kv_api_impl::MetaKVApi;
-pub use meta_node_kv_api_impl::MetaKVApiOwned;
+pub struct RuntimeConfig {
+    pub broadcast_state_machine_changes: Arc<AtomicBool>,
+}
 
-pub mod meta_leader;
-pub mod meta_node;
-pub mod meta_node_status;
-pub mod raft_service_impl;
-pub mod runtime_config;
-pub mod watcher;
-
-pub use forwarder::MetaForwarder;
-pub use meta_node::MetaNode;
-pub use raft_service_impl::RaftServiceImpl;
-
-pub use crate::message::ForwardRequest;
-pub use crate::message::ForwardRequestBody;
-pub use crate::message::JoinRequest;
-pub use crate::message::LeaveRequest;
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            broadcast_state_machine_changes: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}

--- a/src/meta/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
+++ b/src/meta/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
@@ -16,10 +16,13 @@
 
 use std::time::Duration;
 
+use databend_common_base::runtime::spawn_named;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_semaphore::Semaphore;
 use databend_common_meta_types::UpsertKV;
+use log::info;
 use test_harness::test;
+use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 use crate::testing::meta_service_test_harness;
@@ -162,6 +165,392 @@ async fn test_semaphore_time_based() -> anyhow::Result<()> {
     drop(s1g2);
 
     let _s1g4 = Semaphore::new_acquired_by_time(client(), s1, 2, "id14", None, secs(3)).await?;
+
+    Ok(())
+}
+
+/// Test error handling when acquirer is dropped while operations are in progress
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_acquirer_closed_error_handling() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Create a semaphore and acquire a permit
+    let sem = Semaphore::new(client(), "test_acquirer_close", 1, secs(10)).await;
+
+    // Test dropping the semaphore while trying to acquire
+    {
+        let permit_future = sem.acquire("test_id");
+        // Immediately drop sem to test error handling
+        drop(permit_future);
+    }
+
+    // Test successful case still works
+    let sem2 = Semaphore::new(client(), "test_acquirer_close_2", 1, secs(10)).await;
+    let _permit = sem2.acquire("test_id_2").await?;
+
+    Ok(())
+}
+
+/// Test permit removal notification system
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_permit_removal_notification() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Acquire a permit
+    let permit =
+        Semaphore::new_acquired(client(), "test_notification", 1, "permit_1", secs(10)).await?;
+
+    // Set up the future to wait for removal notification
+    let mut permit_future = std::pin::pin!(permit);
+
+    // The permit should not be ready initially
+    let quick_check = timeout(Duration::from_millis(100), permit_future.as_mut()).await;
+    assert!(quick_check.is_err(), "Permit should not be ready initially");
+
+    // Manually remove the permit entry from meta-service
+    client()
+        .upsert_kv(UpsertKV::delete(
+            "test_notification/queue/00000000000000000001",
+        ))
+        .await?;
+
+    // Now the permit should be notified of removal
+    let notification_result = timeout(Duration::from_secs(5), permit_future.as_mut()).await;
+    assert!(
+        notification_result.is_ok(),
+        "Permit should be notified of removal"
+    );
+
+    Ok(())
+}
+
+/// Test resource cleanup when permits are dropped
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_permit_resource_cleanup() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Test that resources are properly cleaned up when permit is dropped
+    {
+        let permit =
+            Semaphore::new_acquired(client(), "test_cleanup", 2, "permit_1", secs(10)).await?;
+        // Permit goes out of scope here, should trigger cleanup
+        drop(permit);
+    }
+
+    // Verify that capacity is available again after cleanup
+    let _permit2 =
+        Semaphore::new_acquired(client(), "test_cleanup", 2, "permit_2", secs(10)).await?;
+    let _permit3 =
+        Semaphore::new_acquired(client(), "test_cleanup", 2, "permit_3", secs(10)).await?;
+
+    // This should work because the first permit was properly cleaned up
+    Ok(())
+}
+
+/// Test concurrent acquirer operations and error isolation
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_semaphore_concurrent_error_isolation() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Create multiple permits concurrently
+    let permit1_fut = Semaphore::new_acquired(client(), "concurrent_test", 3, "id1", secs(10));
+    let permit2_fut = Semaphore::new_acquired(client(), "concurrent_test", 3, "id2", secs(10));
+    let permit3_fut = Semaphore::new_acquired(client(), "concurrent_test", 3, "id3", secs(10));
+
+    let (permit1, permit2, permit3) = tokio::try_join!(permit1_fut, permit2_fut, permit3_fut)?;
+
+    // Verify all permits were acquired with exact expected format
+    // Extract and verify the uniq numbers to ensure they're different instances
+    let extract_id = |name: &str, expected_id: &str| -> u64 {
+        let expected_suffix = format!("](concurrent_test)-Acquirer(id={})", expected_id);
+        assert!(
+            name.starts_with("Semaphore[uniq="),
+            "Name should start with Semaphore[uniq=: {}",
+            name
+        );
+        assert!(
+            name.ends_with(&expected_suffix),
+            "Name should end with expected suffix: {}",
+            name
+        );
+
+        let start = "Semaphore[uniq=".len();
+        let end = name
+            .find("](concurrent_test)")
+            .expect("Should find end of uniq");
+        name[start..end].parse().expect("Should parse uniq number")
+    };
+
+    let uniq1 = extract_id(&permit1.acquirer_name, "id1");
+    let uniq2 = extract_id(&permit2.acquirer_name, "id2");
+    let uniq3 = extract_id(&permit3.acquirer_name, "id3");
+
+    // Verify each semaphore instance has a different uniq number
+    assert_ne!(
+        uniq1, uniq2,
+        "Different semaphore instances should have different uniq numbers"
+    );
+    assert_ne!(
+        uniq2, uniq3,
+        "Different semaphore instances should have different uniq numbers"
+    );
+    assert_ne!(
+        uniq1, uniq3,
+        "Different semaphore instances should have different uniq numbers"
+    );
+
+    // Drop one permit and verify others remain unaffected
+    drop(permit2);
+
+    // Should be able to acquire a new permit in the freed slot
+    let _permit4 = Semaphore::new_acquired(client(), "concurrent_test", 3, "id4", secs(10)).await?;
+
+    Ok(())
+}
+
+/// Test timeout behavior and recovery
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_semaphore_timeout_behavior() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Test with very short TTL to test timeout behavior
+    let short_ttl = Duration::from_millis(100);
+    let sem = Semaphore::new(client(), "timeout_test", 1, short_ttl).await;
+
+    // Acquire a permit with short TTL
+    let permit = sem.acquire("timeout_id").await?;
+
+    // Wait longer than TTL to ensure timeout handling
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Permit should still be valid immediately after acquisition
+    // (The test validates that the system handles timeouts gracefully)
+    drop(permit);
+
+    // Should be able to acquire again after the previous permit times out
+    let sem2 = Semaphore::new(client(), "timeout_test_2", 1, secs(10)).await;
+    let _permit2 = sem2.acquire("timeout_id_2").await?;
+
+    Ok(())
+}
+
+/// Test watch stream behavior under connection issues
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_watch_stream_resilience() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Create semaphore that will maintain connection
+    let permit =
+        Semaphore::new_acquired(client(), "resilience_test", 2, "resilient_id", secs(30)).await?;
+
+    // Verify permit is working
+    let mut permit_future = std::pin::pin!(permit);
+
+    // Should not be ready under normal conditions
+    let check = timeout(Duration::from_millis(200), permit_future.as_mut()).await;
+    assert!(
+        check.is_err(),
+        "Permit should be stable under normal conditions"
+    );
+
+    // Test continues to work even with some connection variability
+    // (In a real scenario, this would test reconnection after temporary failures)
+
+    Ok(())
+}
+
+/// Test semaphore behavior with different capacity configurations
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_semaphore_capacity_edge_cases() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Test with capacity = 1
+    let _permit1 = Semaphore::new_acquired(client(), "capacity_1", 1, "single", secs(10)).await?;
+
+    // Should timeout when trying to acquire second permit
+    let timeout_result = timeout(
+        Duration::from_millis(500),
+        Semaphore::new_acquired(client(), "capacity_1", 1, "blocked", secs(10)),
+    )
+    .await;
+    assert!(
+        timeout_result.is_err(),
+        "Should timeout with capacity=1 when already occupied"
+    );
+
+    // Test with larger capacity
+    let permits = futures::future::try_join_all((0..5).map(|i| {
+        Semaphore::new_acquired(client(), "capacity_5", 5, format!("permit_{}", i), secs(10))
+    }))
+    .await?;
+
+    assert_eq!(
+        permits.len(),
+        5,
+        "Should acquire all 5 permits with capacity=5"
+    );
+
+    Ok(())
+}
+
+/// Test time-based sequencing behavior
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_time_based_sequencing_edge_cases() -> anyhow::Result<()> {
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
+
+    let addresses = tcs
+        .iter()
+        .map(|tc| tc.config.grpc_api_address.clone())
+        .collect::<Vec<_>>();
+
+    let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    // Test time-based sequencing with custom timestamps
+    let timestamp1 = Some(Duration::from_millis(1000));
+    let timestamp2 = Some(Duration::from_millis(2000));
+
+    let permit1 =
+        Semaphore::new_acquired_by_time(client(), "time_seq", 2, "early", timestamp1, secs(10))
+            .await?;
+
+    let permit2 =
+        Semaphore::new_acquired_by_time(client(), "time_seq", 2, "later", timestamp2, secs(10))
+            .await?;
+
+    // Both should succeed with capacity=2
+    drop(permit1);
+    drop(permit2);
+
+    // Test with None timestamp (current time)
+    let _permit3 =
+        Semaphore::new_acquired_by_time(client(), "time_seq", 2, "current_time", None, secs(10))
+            .await?;
+
+    Ok(())
+}
+
+/// If the meta-service stops streaming changes, the semaphore should re-connect.
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_time_based_pause_streaming() -> anyhow::Result<()> {
+    let mut tcs = crate::tests::start_metasrv_cluster(&[0]).await?;
+
+    let tc = tcs.remove(0);
+
+    let address = tc.config.grpc_api_address.clone();
+
+    let cli = make_grpc_client(vec![address])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    let timestamp1 = Some(Duration::from_millis(1000));
+    let timestamp2 = Some(Duration::from_millis(2000));
+
+    let permit1 =
+        Semaphore::new_acquired_by_time(client(), "time_seq", 1, "early", timestamp1, secs(1))
+            .await?;
+
+    let fu = Semaphore::new_acquired_by_time(client(), "time_seq", 1, "later", timestamp2, secs(1));
+
+    let (tx, rx) = oneshot::channel();
+    spawn_named(
+        async move {
+            //
+            let res = tokio::time::timeout(secs(5), fu).await;
+            info!("permit2: {:?}", res);
+            tx.send(res).ok();
+        },
+        "foo".to_string(),
+    );
+
+    let meta_node = tc.grpc_srv.as_ref().unwrap().meta_node.clone();
+    let rc = meta_node.runtime_config();
+    rc.broadcast_state_machine_changes
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+
+    tokio::time::sleep(secs(2)).await;
+
+    rc.broadcast_state_machine_changes
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    drop(permit1);
+
+    let res = rx.await;
+    info!("permit2: {:?}", res);
+    assert!(res.unwrap().is_ok(), "permit2 should be acquired");
 
     Ok(())
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: meta-semaphore: re-connect when no event recevied

Refactor permit implementation to properly handle acquirer closure and
connection errors.

The permit now uses oneshot channels to detect when the underlying
permit entry is removed from meta-service, replacing the previous
BoxFuture. Because a future that is not polled will block the channel.

If the meta-service does not send an event for `permit_ttl * 1.5`,  the
connection will be re-established.

Add `AcquirerClosed` error type for client side close error.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change


- [x] Bug Fix (non-breaking change which fixes an issue)





## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18690)
<!-- Reviewable:end -->
