### PR TITLE
fix: error when using materialized CTE in multi-statement transactions

### DIFF
--- a/src/query/storages/common/session/src/transaction.rs
+++ b/src/query/storages/common/session/src/transaction.rs
@@ -136,6 +136,13 @@ impl TxnBuffer {
                 .or_insert(stream_meta.clone());
         }
     }
+
+    fn clear_temp_table_by_id(&mut self, table_id: u64) {
+        if let Some(temp_table) = self.mutated_temp_tables.remove(&table_id) {
+            let desc = format!("'{}'.'{}'", temp_table.db_name, temp_table.table_name);
+            self.temp_table_desc_to_id.remove(&desc);
+        }
+    }
 }
 
 impl TxnManager {
@@ -404,5 +411,9 @@ impl TxnManager {
             .get(&table_id)
             .unwrap()
             .clone()
+    }
+
+    pub fn clear_temp_table_by_id(&mut self, table_id: u64) {
+        self.txn_buffer.clear_temp_table_by_id(table_id);
     }
 }

--- a/tests/sqllogictests/suites/http_handler/temp_table/m_cte_txn.test
+++ b/tests/sqllogictests/suites/http_handler/temp_table/m_cte_txn.test
@@ -1,0 +1,8 @@
+statement ok
+begin;
+
+statement ok
+with cte as materialized (select * from numbers(1)) select * from cte;
+
+statement ok
+commit;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

CTE temp table should be properly cleaned up in txnbuffer.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
