### PR TITLE
fix(python-binding): resolve virtual environment permission conflicts in CI

### DIFF
--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -80,6 +80,8 @@ runs:
           # Install cargo-zigbuild manually to avoid musl target issues
           cargo install cargo-zigbuild --target ${{ inputs.target }}
           ../../scripts/setup/dev_setup.sh -yb
+          # Clean up any existing virtual environment
+          rm -rf .venv || true
           uv venv --python=python3.12
           uv sync --all-groups --all-extras
 
@@ -96,6 +98,9 @@ runs:
       working-directory: src/bendpy
       run: |
         echo "Building development wheel for testing..."
+
+        # Clean up any existing virtual environment
+        rm -rf .venv || true
 
         # Create and activate virtual environment
         uv venv --python python3.12
@@ -123,6 +128,9 @@ runs:
       working-directory: src/bendpy
       run: |
         echo "Testing built wheels..."
+
+        # Clean up any existing virtual environment
+        rm -rf .venv || true
 
         # Install from built wheel for release testing
         uv venv --python python3.12

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -1,20 +1,21 @@
 name: Bindings Python
 
 on:
-  ## uncomment it when bendpy is enabled
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (optional for testing)
+        description: Version to build (optional, leave empty for development build)
         required: false
         type: string
-        default: "test-build"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "src/**"
-      - ".github/workflows/bindings.python.yml"
+        default: ""
+      build_type:
+        description: Build type
+        required: false
+        type: choice
+        default: "development"
+        options:
+          - "development"
+          - "release"
   workflow_call:
     inputs:
       version:
@@ -33,9 +34,45 @@ permissions:
   packages: write
 
 jobs:
+  # Get version info
+  get-version:
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            # Use provided version
+            VERSION="${{ inputs.version }}"
+            echo "Using provided version: $VERSION"
+          elif [[ "${{ inputs.build_type }}" == "release" ]]; then
+            # Get latest tag for release build
+            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0")
+            echo "Using latest tag: $VERSION"
+          else
+            # Development build
+            VERSION=""
+            echo "Development build - no version"
+          fi
+          
+          IS_RELEASE=$([[ "${{ inputs.build_type }}" == "release" || -n "${{ inputs.version }}" ]] && echo "true" || echo "false")
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_release=$IS_RELEASE" >> $GITHUB_OUTPUT
+          echo "Final version: $VERSION, is_release: $IS_RELEASE"
+
   test:
-    # Run tests on all PRs and workflow dispatches
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # Run tests on workflow dispatches
+    if: github.event_name == 'workflow_dispatch'
+    needs: [get-version]
     runs-on:
       - self-hosted
       - X64
@@ -49,11 +86,12 @@ jobs:
       - uses: ./.github/actions/build_bindings_python
         with:
           target: x86_64-unknown-linux-gnu
-          # No version means development build with tests
+          version: ${{ needs.get-version.outputs.is_release == 'true' && needs.get-version.outputs.version || '' }}
 
   linux:
-    # Only run for version builds (releases)
-    if: inputs.version
+    # Run for release builds (workflow_call with version OR workflow_dispatch with release type)
+    if: (github.event_name == 'workflow_call' && inputs.version) || (github.event_name == 'workflow_dispatch' && needs.get-version.outputs.is_release == 'true')
+    needs: [get-version]
     runs-on:
       - self-hosted
       - "${{ matrix.runner }}"
@@ -72,16 +110,16 @@ jobs:
       - uses: ./.github/actions/build_bindings_python
         with:
           target: ${{ matrix.arch }}-unknown-linux-gnu
-          version: ${{ inputs.version }}
+          version: ${{ github.event_name == 'workflow_call' && inputs.version || needs.get-version.outputs.version }}
       - name: upload
-        if: inputs.version
         uses: actions/upload-artifact@v4
         with:
           name: python-linux-${{ matrix.arch }}
           path: src/bendpy/dist/*.whl
 
   # macos:
-  #   if: inputs.version
+  #   if: (github.event_name == 'workflow_call' && inputs.version) || (github.event_name == 'workflow_dispatch' && needs.get-version.outputs.is_release == 'true')
+  #   needs: [get-version]
   #   runs-on: macos-latest
   #   strategy:
   #     matrix:
@@ -94,18 +132,17 @@ jobs:
   #     - uses: ./.github/actions/build_bindings_python
   #       with:
   #         target: ${{ matrix.arch }}-apple-darwin
-  #         version: ${{ inputs.version }}
+  #         version: ${{ github.event_name == 'workflow_call' && inputs.version || needs.get-version.outputs.version }}
   #     - name: upload
-  #       if: inputs.version
   #       uses: actions/upload-artifact@v4
   #       with:
   #         name: python-macos-${{ matrix.arch }}
   #         path: src/bendpy/dist/*.whl
 
   publish:
-    if: inputs.version
+    if: (github.event_name == 'workflow_call' && inputs.version) || (github.event_name == 'workflow_dispatch' && needs.get-version.outputs.is_release == 'true')
     name: Publish
-    needs: [linux]
+    needs: [get-version, linux]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
- Fixed Python binding CI failures caused by virtual environment permission conflicts
- Added cleanup of existing `.venv` directories before creating new virtual environments
- Resolved Docker container vs GitHub runner permission mismatches

## Background
The Python binding CI was failing with "Permission denied" errors when trying to create virtual environments:
```
error: Failed to create virtual environment
  Caused by: failed to create file `/runner/_work/databend/databend/src/bendpy/.venv/.gitignore`: Permission denied (os error 13)
```

This occurred because the maturin action runs in a Docker container with different user permissions than the GitHub runner, causing permission conflicts when subsequent steps try to reuse the `.venv` directory.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18708)
<!-- Reviewable:end -->
