### PR TITLE
ci: Temporarily disable warehouse testing of private tasks

### DIFF
--- a/.github/actions/test_private_tasks/action.yml
+++ b/.github/actions/test_private_tasks/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         bash ./tests/task/test-private-task.sh
-        bash ./tests/task/test-private-task-warehouse.sh
+#        bash ./tests/task/test-private-task-warehouse.sh
 
     - name: Upload failure
       if: failure()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

ci test-private-task recently encountered a warehouse test exception, which cannot be reproduced locally. Temporarily shut down the warehouse test.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18709)
<!-- Reviewable:end -->
