### PR TITLE
refactor(meta-service0): rotbl: use `spawn_blocking()` instead `blocking_in_place()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13198,9 +13198,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9659467da3a686edc86248421dcebabf2971fbba3ad4679e1da2d63c57f8d5dc"
+checksum = "a2a074786ac3e7b62338fd3c2cdf4ea7bb9b95f6f90011501e25f78ecd7d0312"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -462,7 +462,7 @@ reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
 roaring = { version = "^0.10", features = ["serde"] }
-rotbl = { version = "0.2.8", features = [] }
+rotbl = { version = "0.2.9", features = [] }
 rust_decimal = "1.26"
 rustix = "0.38.37"
 rustls = { version = "0.23.27", features = ["ring", "tls12"], default-features = false }

--- a/src/common/base/src/future.rs
+++ b/src/common/base/src/future.rs
@@ -213,6 +213,7 @@ mod tests {
 
         // blocking_in_place sleep
 
+        #[allow(clippy::disallowed_methods)]
         let f = async move {
             tokio::task::spawn_blocking(|| {
                 std::thread::sleep(Duration::from_millis(100));


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service0): rotbl: use `spawn_blocking()` instead `blocking_in_place()`

`blocking_in_place()` may still exhaust the worker threads.


##### chore: test TimedFuture for blocking_in_place and spawn_blocking

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18717)
<!-- Reviewable:end -->
