### PR TITLE
fix(query): Set Parquet default encoding to `PLAIN` to ensure data compatibility

### DIFF
--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -34,6 +34,7 @@ use databend_storages_common_stage::CopyIntoLocationInfo;
 use opendal::Operator;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
+use parquet::basic::Encoding;
 use parquet::basic::ZstdLevel;
 use parquet::file::properties::EnabledStatistics;
 use parquet::file::properties::WriterProperties;
@@ -89,6 +90,7 @@ fn create_writer(
         .set_compression(compression)
         .set_created_by(create_by)
         .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
+        .set_encoding(Encoding::PLAIN)
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_dictionary_enabled(true)
         .set_bloom_filter_enabled(false)

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -90,6 +90,9 @@ fn create_writer(
         .set_compression(compression)
         .set_created_by(create_by)
         .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
+        // The default encoding must be set to `Plain`,
+        // otherwise, `Decimal` may be encoded as `Delta_Byte_Array`,
+        // read with other databases may report invalid error.
         .set_encoding(Encoding::PLAIN)
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_dictionary_enabled(true)

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -17,6 +17,6 @@
 2	{"k":"v"}
 --- large parquet file should be worked on parallel by rowgroups
 5000000	173888890
-├── partitions total: 10
-├── partitions scanned: 10
+├── partitions total: 6
+├── partitions scanned: 6
 5000000	173888890

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -17,6 +17,6 @@
 2	{"k":"v"}
 --- large parquet file should be worked on parallel by rowgroups
 5000000	173888890
-├── partitions total: 3
-├── partitions scanned: 3
+├── partitions total: 10
+├── partitions scanned: 10
 5000000	173888890

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -47,7 +47,7 @@ echo 'remove @s4;' | $BENDSQL_CLIENT_CONNECT
 echo 'remove @s1;' | $BENDSQL_CLIENT_CONNECT
 echo "copy into @s4 from (select number a, number::string b, number::decimal(15,2) c from numbers(5000000)) file_format=(type=parquet) single=true;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
 
-## 5MB divide by 2MB = 2.5, so we will read 3 partitions
+## 18.8MB divide by 2MB = 9.4, so we will read 10 partitions
 echo """
 set parquet_rowgroup_hint_bytes = 2 * 1024 * 1024;
 explain select * from @s4;

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -47,7 +47,7 @@ echo 'remove @s4;' | $BENDSQL_CLIENT_CONNECT
 echo 'remove @s1;' | $BENDSQL_CLIENT_CONNECT
 echo "copy into @s4 from (select number a, number::string b, number::decimal(15,2) c from numbers(5000000)) file_format=(type=parquet) single=true;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
 
-## 18.8MB divide by 2MB = 9.4, so we will read 10 partitions
+## 12MB divide by 2MB = 6, so we will read 6 partitions
 echo """
 set parquet_rowgroup_hint_bytes = 2 * 1024 * 1024;
 explain select * from @s4;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes a compatibility issue when copying data to Parquet files. Without setting a default encoding, Decimal data might be encoded as `Delta_Byte_Array`, which could cause errors when opening this parquet file in other databases. Setting the encoding to `Plain` resolves this issue and ensures file compatibility. However, it also results in larger exported Parquet files.

- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18724)
<!-- Reviewable:end -->
