### PR TITLE
feat: new vaccum table option `ALL`

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -84,7 +84,7 @@ join_spilling_memory_ratio = 60
 [log]
 
 [log.file]
-level = "DEBUG"
+level = "INFO"
 format = "text"
 dir = "./.databend/logs_1"
 limit = 12 # 12 files, 1 file per hour

--- a/src/admin_procedures/vacuu_all.sql
+++ b/src/admin_procedures/vacuu_all.sql
@@ -1,0 +1,19 @@
+-- Vacuum objects in one go
+CREATE OR REPLACE PROCEDURE sys_vacuum_all()
+RETURNS STRING
+LANGUAGE SQL
+as
+$$
+begin
+
+-- Vacuum all temporary tables that have not been cleaned by accident (session panic, force cluster restart etc.)
+SELECT * FROM FUSE_VACUUM_TEMPORARY_TABLE();
+
+--  Vacuum dropped database / tables
+VACUUM DROP TABLE;
+
+-- Vacuum all table historical data (using vacuum2)
+CALL SYSTEM$FUSE_VACUUM2();
+
+end;
+$$

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -188,6 +188,7 @@ pub enum Statement {
     OptimizeTable(OptimizeTableStmt),
     VacuumTable(VacuumTableStmt),
     VacuumDropTable(VacuumDropTableStmt),
+    VacuumAll(VacuumAllStmt),
     VacuumTemporaryFiles(VacuumTemporaryFiles),
     AnalyzeTable(AnalyzeTableStmt),
     ExistsTable(ExistsTableStmt),
@@ -477,6 +478,7 @@ impl Statement {
             | Statement::VacuumTable(..)
             | Statement::VacuumDropTable(..)
             | Statement::VacuumTemporaryFiles(..)
+            | Statement::VacuumAll(..)
             | Statement::AnalyzeTable(..)
             | Statement::ExistsTable(..)
             | Statement::ShowCreateDictionary(..)
@@ -1081,6 +1083,9 @@ impl Display for Statement {
             Statement::RenameWorkloadGroup(stmt) => write!(f, "{stmt}")?,
             Statement::SetWorkloadQuotasGroup(stmt) => write!(f, "{stmt}")?,
             Statement::UnsetWorkloadQuotasGroup(stmt) => write!(f, "{stmt}")?,
+            Statement::VacuumAll(_) => {
+                todo!()
+            }
         }
         Ok(())
     }

--- a/src/query/service/src/table_functions/fuse_vacuum2/fuse_vacuum2_table.rs
+++ b/src/query/service/src/table_functions/fuse_vacuum2/fuse_vacuum2_table.rs
@@ -182,6 +182,14 @@ impl FuseVacuum2Table {
         ctx: &Arc<dyn TableContext>,
         catalog: &dyn Catalog,
     ) -> Result<Vec<String>> {
+        databend_common_storages_fuse::operations::vacuum_all_tables(ctx, self.handler.as_ref(), catalog).await
+    }
+
+    async fn apply_all_tables_internal(
+        ctx: &Arc<dyn TableContext>,
+        handler: & VacuumHandlerWrapper,
+        catalog: &dyn Catalog,
+    ) -> Result<Vec<String>> {
         let tenant_id = ctx.get_tenant();
         let dbs = catalog.list_databases(&tenant_id).await?;
         let num_db = dbs.len();
@@ -229,7 +237,7 @@ impl FuseVacuum2Table {
                     continue;
                 }
 
-                let res = self.handler.do_vacuum2(tbl, ctx.clone(), false).await;
+                let res = handler.do_vacuum2(tbl, ctx.clone(), false).await;
 
                 if let Err(e) = res {
                     warn!(
@@ -244,4 +252,5 @@ impl FuseVacuum2Table {
 
         Ok(vec![])
     }
+
 }

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -329,6 +329,10 @@ impl Binder {
             Statement::VacuumTemporaryFiles(stmt) => {
                 self.bind_vacuum_temporary_files(bind_context, stmt).await?
             }
+
+            Statement::VacuumAll(stmt) => {
+                todo!()
+            }
             Statement::AnalyzeTable(stmt) => self.bind_analyze_table(stmt).await?,
             Statement::ExistsTable(stmt) => self.bind_exists_table(stmt).await?,
             // Dictionaries

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -105,12 +105,24 @@ impl DropTablePlan {
     }
 }
 
-/// Vacuum
+
 #[derive(Clone, Debug)]
-pub struct VacuumTablePlan {
+pub struct VacuumTargetTable {
     pub catalog: String,
     pub database: String,
     pub table: String,
+}
+
+#[derive(Clone, Debug)]
+pub enum VacuumTarget {
+   Table(VacuumTargetTable),
+    All,
+}
+
+/// Vacuum
+#[derive(Clone, Debug)]
+pub struct VacuumTablePlan {
+    pub target: VacuumTarget,
     pub option: VacuumTableOption,
 }
 

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -57,3 +57,5 @@ pub use util::column_parquet_metas;
 pub use util::read_block;
 pub use util::set_backoff;
 pub use vacuum::vacuum_tables_from_info;
+pub use vacuum::vacuum_all_tables;
+pub use vacuum::vacuum_table;

--- a/src/query/storages/fuse/src/operations/vacuum.rs
+++ b/src/query/storages/fuse/src/operations/vacuum.rs
@@ -16,14 +16,14 @@
 
 use std::sync::Arc;
 
-use databend_common_catalog::table::TableExt;
+use databend_common_catalog::table::{Table, TableExt};
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::TableInfo;
 use databend_enterprise_vacuum_handler::VacuumHandlerWrapper;
 use log::info;
 use log::warn;
-
+use databend_common_catalog::catalog::Catalog;
 use crate::FuseTable;
 
 pub async fn vacuum_table(
@@ -55,6 +55,7 @@ pub async fn vacuum_tables_from_info(
     table_infos: Vec<TableInfo>,
     ctx: Arc<dyn TableContext>,
     vacuum_handler: Arc<VacuumHandlerWrapper>,
+
 ) -> Result<()> {
     for table_info in table_infos {
         let table = FuseTable::do_create(table_info)?
@@ -65,4 +66,72 @@ pub async fn vacuum_tables_from_info(
     }
 
     Ok(())
+}
+
+pub async fn vacuum_all_tables(
+    ctx: &Arc<dyn TableContext>,
+    handler: & VacuumHandlerWrapper,
+    catalog: &dyn Catalog,
+) -> Result<Vec<String>> {
+    let tenant_id = ctx.get_tenant();
+    let dbs = catalog.list_databases(&tenant_id).await?;
+    let num_db = dbs.len();
+
+    for (idx_db, db) in dbs.iter().enumerate() {
+        if db.engine().to_uppercase() == "SYSTEM" {
+            info!("Bypass system database [{}]", db.name());
+            continue;
+        }
+
+        info!(
+                "Processing db {}, progress: {}/{}",
+                db.name(),
+                idx_db + 1,
+                num_db
+            );
+        let tables = catalog.list_tables(&tenant_id, db.name()).await?;
+        info!("Found {} tables in db {}", tables.len(), db.name());
+
+        let num_tbl = tables.len();
+        for (idx_tbl, table) in tables.iter().enumerate() {
+            info!(
+                    "Processing table {}.{}, db level progress: {}/{}",
+                    db.name(),
+                    table.get_table_info().name,
+                    idx_tbl + 1,
+                    num_tbl
+                );
+
+            let Ok(tbl) = FuseTable::try_from_table(table.as_ref()) else {
+                info!(
+                        "Bypass non-fuse table {}.{}",
+                        db.name(),
+                        table.get_table_info().name
+                    );
+                continue;
+            };
+
+            if tbl.is_read_only() {
+                info!(
+                        "Bypass read only table {}.{}",
+                        db.name(),
+                        table.get_table_info().name
+                    );
+                continue;
+            }
+
+            let res = handler.do_vacuum2(tbl, ctx.clone(), false).await;
+
+            if let Err(e) = res {
+                warn!(
+                        "vacuum2 table {}.{} failed: {}",
+                        db.name(),
+                        table.get_table_info().name,
+                        e
+                    );
+            };
+        }
+    }
+
+    Ok(vec![])
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

new vaccum table option `ALL`

-  `Vacuum table ALL` will vacuum all applicable tables 
    - According to global and table's vacuum settings 
    - Using the vauum2 implementation
-  `Vacuum table xxx` will switch to the `vacuum2` impl by default
    - Legacy vacuum impl is deprecated , but will be kept for a while, and could be switch back to by settings `fallback_to_legacy_vaccum`
  
- Add dry run behavior to vacuum2 impl



## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
