### PR TITLE
feat: add ANY_VALUE as alias for ANY aggregate function

### DIFF
--- a/src/query/functions/src/aggregates/aggregator.rs
+++ b/src/query/functions/src/aggregates/aggregator.rs
@@ -76,7 +76,7 @@ impl Aggregators {
 
         factory.register("min", aggregate_min_function_desc());
         factory.register("max", aggregate_max_function_desc());
-        factory.register("any", aggregate_any_function_desc());
+        factory.register_multi_names(&["any", "any_value"], aggregate_any_function_desc);
         factory.register("arg_min", aggregate_arg_min_function_desc());
         factory.register("arg_max", aggregate_arg_max_function_desc());
 

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_min_max_any.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_min_max_any.test
@@ -59,3 +59,36 @@ select c, min(h), max(h) from t_min_max_any group by c order by c
 
 statement ok
 drop table t_min_max_any
+
+# Test ANY_VALUE alias functionality
+statement ok
+create table t_any_value_test(region varchar(10), salesperson varchar(10), sales decimal(10,2))
+
+statement ok
+insert into t_any_value_test values 
+('North', 'Alice', 15000.00), 
+('North', 'Bob', 12000.00), 
+('South', 'Carol', 20000.00), 
+('South', 'Dave', 16000.00)
+
+# Test ANY_VALUE as alias for ANY
+query TTR
+select region, any_value(salesperson), sum(sales) from t_any_value_test group by region order by region
+----
+North Alice 27000.00
+South Carol 36000.00
+
+# Test that ANY and ANY_VALUE produce same results
+query TT
+select any(salesperson), any_value(salesperson) from t_any_value_test where region = 'North'
+----
+Alice Alice
+
+# Test ANY_VALUE with different data types
+query TIR
+select any_value(region), any_value(sales), any_value(15) from t_any_value_test
+----
+North 15000.00 15
+
+statement ok
+drop table t_any_value_test


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add ANY_VALUE as an alias for the ANY aggregate function to improve SQL compatibility.


## Tests

- [ ] Unit Test
- [x] Logic Test - Added comprehensive tests in 02_0000_function_aggregate_min_max_any.test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18728)
<!-- Reviewable:end -->
