### PR TITLE
refactor(meta-service): avoid useless read when cleaning expired keys

### DIFF
--- a/src/meta/raft-store/src/applier/mod.rs
+++ b/src/meta/raft-store/src/applier/mod.rs
@@ -697,9 +697,8 @@ where SM: StateMachineApi<SysData> + 'static
         }
 
         for (expire_key, key) in to_clean {
-            let upsert = UpsertKV::delete(key);
-            self.upsert_kv(&upsert).await?;
-            info!("clean expired: {} {expire_key}", upsert.key);
+            self.sm.clean_expired(expire_key, key.clone());
+            info!("clean expired: {key} {expire_key}");
         }
 
         Ok(())

--- a/src/meta/raft-store/src/state_machine_api_ext.rs
+++ b/src/meta/raft-store/src/state_machine_api_ext.rs
@@ -53,6 +53,11 @@ use crate::utils::seq_marked_to_seqv;
 
 #[async_trait::async_trait]
 pub trait StateMachineApiExt: StateMachineApi<SysData> {
+    fn clean_expired(&mut self, expire_key: ExpireKey, user_key: String) {
+        self.user_map_mut().set(UserKey::new(user_key), None);
+        self.expire_map_mut().set(expire_key, None);
+    }
+
     /// It returns 2 entries: the previous one and the new one after upsert.
     async fn upsert_kv_primary_index(
         &mut self,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service): avoid useless read when cleaning expired keys

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18733)
<!-- Reviewable:end -->
