### PR TITLE
refactor: Make the ownership key deletion and table/database replace in the same transaction

### DIFF
--- a/src/meta/api/src/schema_api_test_suite.rs
+++ b/src/meta/api/src/schema_api_test_suite.rs
@@ -571,6 +571,7 @@ impl SchemaApiTestSuite {
         {
             let req = CreateDatabaseReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
                     engine: "".to_string(),
@@ -591,6 +592,7 @@ impl SchemaApiTestSuite {
         {
             let req = CreateDatabaseReq {
                 create_option: CreateOption::CreateIfNotExists,
+                catalog_name: None,
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
                     engine: "".to_string(),
@@ -695,6 +697,7 @@ impl SchemaApiTestSuite {
 
             let req = CreateDatabaseReq {
                 create_option: CreateOption::CreateOrReplace,
+                catalog_name: Some("default".to_string()),
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
                     engine: new_engine.to_string(),
@@ -1089,6 +1092,7 @@ impl SchemaApiTestSuite {
             // first create database
             let req = CreateDatabaseReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
                     engine: "github".to_string(),
@@ -1180,6 +1184,7 @@ impl SchemaApiTestSuite {
             // then create database
             let req = CreateDatabaseReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
                     engine: "github".to_string(),
@@ -1209,6 +1214,7 @@ impl SchemaApiTestSuite {
             // first create db2
             let req = CreateDatabaseReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: new_db_name_ident.clone(),
                 meta: DatabaseMeta {
                     engine: "github".to_string(),
@@ -1514,6 +1520,7 @@ impl SchemaApiTestSuite {
 
             let req = CreateTableReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
                     db_name: db_name.to_string(),
@@ -1631,6 +1638,7 @@ impl SchemaApiTestSuite {
         {
             let req = CreateTableReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
                     db_name: db_name.to_string(),
@@ -1881,6 +1889,7 @@ impl SchemaApiTestSuite {
 
             let create_table_req = CreateTableReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
                     db_name: db_name.to_string(),
@@ -3539,6 +3548,7 @@ impl SchemaApiTestSuite {
             // first create database
             let req = CreateDatabaseReq {
                 create_option: CreateOption::Create,
+                catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
                     engine: "github".to_string(),
@@ -3598,6 +3608,7 @@ impl SchemaApiTestSuite {
     ) -> anyhow::Result<()> {
         let req = CreateDatabaseReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: db_name.clone(),
             meta: DatabaseMeta {
                 engine: "github".to_string(),
@@ -3738,6 +3749,7 @@ impl SchemaApiTestSuite {
 
         let req = CreateTableReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident,
             table_meta: create_table_meta.clone(),
             as_dropped: false,
@@ -4554,6 +4566,7 @@ impl SchemaApiTestSuite {
                 let table_name = format!("tb{:?}", i);
                 let req = CreateTableReq {
                     create_option: CreateOption::Create,
+                    catalog_name: None,
                     name_ident: TableNameIdent {
                         tenant: Tenant::new_or_err(tenant, func_name!())?,
                         db_name: db.to_string(),
@@ -4841,7 +4854,6 @@ impl SchemaApiTestSuite {
                 new_table: true,
                 orphan_table_name: None,
                 spec_vec: None,
-                old_table_id: None,
             };
             let cur_db = util.get_database().await?;
             assert!(old_db.meta.seq < cur_db.meta.seq);
@@ -5042,6 +5054,7 @@ impl SchemaApiTestSuite {
 
         let create_table_req = CreateTableReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: util.tenant(),
                 db_name: db_name.to_string(),
@@ -5161,6 +5174,7 @@ impl SchemaApiTestSuite {
             // replace with a new as_dropped = true and table_meta.as_drop is None table
             let create_table_req = CreateTableReq {
                 create_option: CreateOption::CreateOrReplace,
+                catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: util.tenant(),
                     db_name: db_name.to_string(),
@@ -5180,6 +5194,7 @@ impl SchemaApiTestSuite {
 
             let create_table_req = CreateTableReq {
                 create_option: CreateOption::CreateOrReplace,
+                catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: util.tenant(),
                     db_name: db_name.to_string(),
@@ -5215,6 +5230,7 @@ impl SchemaApiTestSuite {
 
             let create_table_req = CreateTableReq {
                 create_option: CreateOption::CreateOrReplace,
+                catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: Tenant::new_or_err(tenant_name, func_name!())?,
                     db_name: db_name.to_string(),
@@ -5308,6 +5324,7 @@ impl SchemaApiTestSuite {
 
         let create_table_req = CreateTableReq {
             create_option: CreateOption::CreateOrReplace,
+            catalog_name: Some("default".to_string()),
             name_ident: TableNameIdent {
                 tenant: Tenant::new_or_err(tenant_name, func_name!())?,
                 db_name: db_name.to_string(),
@@ -7774,6 +7791,7 @@ where MT: SchemaApi + kvapi::KVApi<Error = MetaError>
     async fn create_db(&mut self) -> anyhow::Result<()> {
         let plan = CreateDatabaseReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: DatabaseNameIdent::new(self.tenant(), self.db_name()),
             meta: DatabaseMeta {
                 engine: self.engine(),
@@ -7810,6 +7828,7 @@ where MT: SchemaApi + kvapi::KVApi<Error = MetaError>
 
         let req = CreateTableReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: self.tenant(),
                 db_name: self.db_name(),
@@ -7835,6 +7854,7 @@ where MT: SchemaApi + kvapi::KVApi<Error = MetaError>
         let table_meta = self.table_meta();
         let req = CreateTableReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: self.tenant(),
                 db_name: self.db_name(),

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -272,7 +272,6 @@ where
         }
 
         let mut trials = txn_backoff(None, func_name!());
-        let mut old_table_id = None;
 
         loop {
             trials.next().unwrap()?.await;
@@ -324,7 +323,6 @@ where
                                 spec_vec: None,
                                 prev_table_id: None,
                                 orphan_table_name: None,
-                                old_table_id: None,
                             });
                         }
                         CreateOption::CreateOrReplace => {
@@ -336,11 +334,11 @@ where
 
                                 SeqV::new(id.seq, *id.data)
                             } else {
-                                old_table_id = Some(*id.data);
                                 let (seq, id) = construct_drop_table_txn_operations(
                                     self,
                                     req.name_ident.table_name.clone(),
                                     &req.name_ident.tenant,
+                                    req.catalog_name.clone(),
                                     *id.data,
                                     *seq_db_id.data,
                                     true,
@@ -474,7 +472,6 @@ where
                         spec_vec: None,
                         prev_table_id,
                         orphan_table_name,
-                        old_table_id,
                     });
                 } else {
                     // re-run txn with re-fetched data
@@ -502,6 +499,7 @@ where
                 self,
                 req.table_name.clone(),
                 &req.tenant,
+                None,
                 table_id,
                 req.db_id,
                 req.if_exists,

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -181,6 +181,7 @@ impl Display for DbIdList {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateDatabaseReq {
     pub create_option: CreateOption,
+    pub catalog_name: Option<String>,
     pub name_ident: DatabaseNameIdent,
     pub meta: DatabaseMeta,
 }
@@ -217,7 +218,6 @@ impl Display for CreateDatabaseReq {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseReply {
     pub db_id: DatabaseId,
-    pub old_db_id: Option<DatabaseId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/app/src/schema/table.rs
+++ b/src/meta/app/src/schema/table.rs
@@ -617,6 +617,7 @@ impl Display for TableIdList {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateTableReq {
     pub create_option: CreateOption,
+    pub catalog_name: Option<String>,
     pub name_ident: TableNameIdent,
     pub table_meta: TableMeta,
 
@@ -687,7 +688,6 @@ pub struct CreateTableReply {
     pub spec_vec: Option<(u64, u64)>,
     pub prev_table_id: Option<u64>,
     pub orphan_table_name: Option<String>,
-    pub old_table_id: Option<u64>,
 }
 
 /// Drop table by id.

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -208,6 +208,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .create_database(CreateDatabaseReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: DatabaseNameIdent::new(tenant(), db_name()),
             meta: Default::default(),
         })
@@ -222,6 +223,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .create_table(CreateTableReq {
             create_option: CreateOption::CreateIfNotExists,
+            catalog_name: None,
             name_ident: tb_name_ident(),
             table_meta: Default::default(),
             as_dropped: false,
@@ -268,6 +270,7 @@ async fn benchmark_table(client: &Arc<ClientHandle>, prefix: u64, client_num: u6
     let res = client
         .create_table(CreateTableReq {
             create_option: CreateOption::CreateIfNotExists,
+            catalog_name: None,
             name_ident: tb_name_ident(),
             table_meta: Default::default(),
             as_dropped: false,

--- a/src/query/ee/src/attach_table/handler.rs
+++ b/src/query/ee/src/attach_table/handler.rs
@@ -110,6 +110,11 @@ impl AttachTableHandler for RealAttachTableHandler {
         };
         let req = CreateTableReq {
             create_option: plan.create_option,
+            catalog_name: if plan.create_option.is_overriding() {
+                Some(plan.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: TableNameIdent {
                 tenant: plan.tenant.clone(),
                 db_name: plan.database.to_string(),

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -135,6 +135,11 @@ impl StreamHandler for RealStreamHandler {
 
         let req = CreateTableReq {
             create_option: plan.create_option,
+            catalog_name: if plan.create_option.is_overriding() {
+                Some(plan.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: TableNameIdent {
                 tenant: plan.tenant.clone(),
                 db_name: plan.database.clone(),

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -191,6 +191,7 @@ impl MutableCatalog {
         // Create default database.
         let req = CreateDatabaseReq {
             create_option: CreateOption::CreateIfNotExists,
+            catalog_name: None,
             name_ident: DatabaseNameIdent::new(&tenant, "default"),
             meta: DatabaseMeta {
                 engine: "".to_string(),
@@ -333,10 +334,7 @@ impl Catalog for MutableCatalog {
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(req.name_ident.tenant_name()).await?;
-        Ok(CreateDatabaseReply {
-            db_id: res.db_id,
-            old_db_id: res.old_db_id,
-        })
+        Ok(CreateDatabaseReply { db_id: res.db_id })
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -78,6 +78,7 @@ impl Interpreter for CreateDatabaseInterpreter {
         if let Some(current_role) = self.ctx.get_current_role() {
             // iceberg db do not need to generate ownership.
             if !catalog.is_external() {
+                // revoke ownership handling is now integrated into the create_database transaction
                 let role_api = UserApiProvider::instance().role_api(&tenant);
                 role_api
                     .grant_ownership(
@@ -88,16 +89,6 @@ impl Interpreter for CreateDatabaseInterpreter {
                         &current_role.name,
                     )
                     .await?;
-
-                // if old_db_id is some means create or replace is success, we should delete the old db id's ownership key
-                if let Some(old_db_id) = reply.old_db_id {
-                    role_api
-                        .revoke_ownership(&OwnershipObject::Database {
-                            catalog_name: self.plan.catalog.clone(),
-                            db_id: *old_db_id,
-                        })
-                        .await?;
-                }
                 RoleCacheManager::instance().invalidate_cache(&tenant);
             }
         }

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -323,9 +323,9 @@ impl CreateTableInterpreter {
         Ok(pipeline)
     }
 
+    // revoke ownership handling is now integrated into the create_table transaction
     async fn process_ownership(&self, tenant: &Tenant, reply: CreateTableReply) -> Result<()> {
         // grant the ownership of the table to the current role.
-        let mut invalid_cache = false;
         let current_role = self.ctx.get_current_role();
         let role_api = UserApiProvider::instance().role_api(tenant);
         if let Some(current_role) = current_role {
@@ -339,22 +339,6 @@ impl CreateTableInterpreter {
                     &current_role.name,
                 )
                 .await?;
-            invalid_cache = true;
-        }
-
-        // TODO: can refactor into create_table in one txn
-        // if old_table_id is some means create or replace is success, we should delete the old table id's ownership key
-        if let Some(old_table_id) = reply.old_table_id {
-            role_api
-                .revoke_ownership(&OwnershipObject::Table {
-                    catalog_name: self.plan.catalog.clone(),
-                    db_id: reply.db_id,
-                    table_id: old_table_id,
-                })
-                .await?;
-            invalid_cache = true;
-        }
-        if invalid_cache {
             RoleCacheManager::instance().invalidate_cache(tenant);
         }
         Ok(())
@@ -513,6 +497,11 @@ impl CreateTableInterpreter {
 
         let req = CreateTableReq {
             create_option: self.plan.create_option,
+            catalog_name: if self.plan.create_option.is_overriding() {
+                Some(self.plan.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: TableNameIdent {
                 tenant: self.plan.tenant.clone(),
                 db_name: self.plan.database.to_string(),

--- a/src/query/service/src/interpreters/interpreter_view_create.rs
+++ b/src/query/service/src/interpreters/interpreter_view_create.rs
@@ -108,6 +108,11 @@ impl Interpreter for CreateViewInterpreter {
 
         let plan = CreateTableReq {
             create_option: self.plan.create_option,
+            catalog_name: if self.plan.create_option.is_overriding() {
+                Some(self.plan.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: TableNameIdent {
                 tenant: self.plan.tenant.clone(),
                 db_name: self.plan.database.clone(),

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -73,6 +73,7 @@ async fn test_catalogs_database() -> Result<()> {
     {
         let req = CreateDatabaseReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: DatabaseNameIdent::new(&tenant, "db1"),
             meta: DatabaseMeta {
                 engine: "".to_string(),
@@ -154,6 +155,7 @@ async fn test_catalogs_table() -> Result<()> {
 
         let req = CreateTableReq {
             create_option: CreateOption::Create,
+            catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: tenant.clone(),
                 db_name: "default".to_string(),

--- a/src/query/service/tests/it/catalogs/immutable_catalogs.rs
+++ b/src/query/service/tests/it/catalogs/immutable_catalogs.rs
@@ -48,6 +48,7 @@ async fn test_immutable_catalogs_database() -> Result<()> {
     // create database should failed
     let create_db_req = CreateDatabaseReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "system"),
         meta: Default::default(),
     };

--- a/src/query/service/tests/it/catalogs/test_error_handling.rs
+++ b/src/query/service/tests/it/catalogs/test_error_handling.rs
@@ -66,6 +66,7 @@ async fn test_get_table_error_handling() -> Result<()> {
     // Create a test database and table
     let req = CreateDatabaseReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "test_db"),
         meta: DatabaseMeta::default(),
     };
@@ -78,6 +79,7 @@ async fn test_get_table_error_handling() -> Result<()> {
 
     let table_req = CreateTableReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: TableNameIdent {
             tenant: tenant.clone(),
             db_name: "test_db".to_string(),
@@ -127,6 +129,7 @@ async fn test_get_table_history_error_handling() -> Result<()> {
     // Create a test database
     let req = CreateDatabaseReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "history_test_db"),
         meta: DatabaseMeta::default(),
     };
@@ -197,6 +200,7 @@ async fn test_get_table_by_info_error_handling() -> Result<()> {
     // Create a test database and table
     let req = CreateDatabaseReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "info_test_db"),
         meta: DatabaseMeta::default(),
     };
@@ -209,6 +213,7 @@ async fn test_get_table_by_info_error_handling() -> Result<()> {
 
     let table_req = CreateTableReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: TableNameIdent {
             tenant: tenant.clone(),
             db_name: "info_test_db".to_string(),
@@ -252,6 +257,7 @@ async fn test_delegation_between_catalogs() -> Result<()> {
     // Test that user-created databases are handled by mutable catalog
     let req = CreateDatabaseReq {
         create_option: CreateOption::Create,
+        catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "user_db"),
         meta: DatabaseMeta::default(),
     };

--- a/src/query/sql/src/planner/plans/ddl/database.rs
+++ b/src/query/sql/src/planner/plans/ddl/database.rs
@@ -38,6 +38,11 @@ impl From<CreateDatabasePlan> for CreateDatabaseReq {
     fn from(p: CreateDatabasePlan) -> Self {
         CreateDatabaseReq {
             create_option: p.create_option,
+            catalog_name: if p.create_option.is_overriding() {
+                Some(p.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: DatabaseNameIdent::new(&p.tenant, &p.database),
             meta: p.meta,
         }
@@ -48,6 +53,11 @@ impl From<&CreateDatabasePlan> for CreateDatabaseReq {
     fn from(p: &CreateDatabasePlan) -> Self {
         CreateDatabaseReq {
             create_option: p.create_option,
+            catalog_name: if p.create_option.is_overriding() {
+                Some(p.catalog.to_string())
+            } else {
+                None
+            },
             name_ident: DatabaseNameIdent::new(&p.tenant, &p.database),
             meta: p.meta.clone(),
         }

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -109,7 +109,6 @@ impl TempTblMgr {
         let desc = format!("{}.{}", name_ident.db_name, name_ident.table_name);
         let engine = table_meta.engine.to_string();
         let table_id = self.next_id;
-        let mut old_table_id = None;
         let new_table = match (self.name_to_id.contains_key(&desc), create_option) {
             (true, CreateOption::Create) => {
                 return Err(ErrorCode::TableAlreadyExists(format!(
@@ -123,9 +122,9 @@ impl TempTblMgr {
                     .as_ref()
                     .map(|o| format!("{}.{}", name_ident.db_name, o))
                     .unwrap_or(desc);
-                old_table_id = self.name_to_id.insert(desc.clone(), table_id);
-                if let Some(old_id) = &old_table_id {
-                    self.id_to_table.remove(old_id);
+                let old_id = self.name_to_id.insert(desc.clone(), table_id);
+                if let Some(old_id) = old_id {
+                    self.id_to_table.remove(&old_id);
                 }
                 self.id_to_table.insert(table_id, TempTable {
                     db_name: name_ident.db_name,
@@ -150,7 +149,6 @@ impl TempTblMgr {
             spec_vec: None,
             prev_table_id: None,
             orphan_table_name,
-            old_table_id,
         })
     }
 

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -320,7 +320,6 @@ impl Catalog for IcebergMutableCatalog {
                 {
                     return Ok(CreateDatabaseReply {
                         db_id: DatabaseId::new(0),
-                        old_db_id: None,
                     });
                 }
             }
@@ -347,8 +346,6 @@ impl Catalog for IcebergMutableCatalog {
 
         Ok(CreateDatabaseReply {
             db_id: DatabaseId::new(0),
-            // external catalog directly return None
-            old_db_id: None,
         })
     }
 

--- a/src/query/storages/iceberg/src/database.rs
+++ b/src/query/storages/iceberg/src/database.rs
@@ -202,7 +202,6 @@ impl Database for IcebergDatabase {
                             spec_vec: None,
                             prev_table_id: None,
                             orphan_table_name: None,
-                            old_table_id: None,
                         });
                     }
                 }
@@ -256,7 +255,6 @@ impl Database for IcebergDatabase {
             spec_vec: None,
             prev_table_id: None,
             orphan_table_name: None,
-            old_table_id: None,
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR refactors the code to ensure that the deletion of ownership keys and the replacement of tables/databases are performed within the same database transaction.
The goal is to maintain atomicity and data consistency, preventing partial failures that could lead to inconsistent states.

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - refactor, need all ci pass

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18739)
<!-- Reviewable:end -->
