### PR TITLE
fix: fuse_vacuum2 panic while vauuming empty table with data_retentio…

### DIFF
--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -84,7 +84,7 @@ join_spilling_memory_ratio = 60
 [log]
 
 [log.file]
-level = "DEBUG"
+level = "INFO"
 format = "text"
 dir = "./.databend/logs_1"
 limit = 12 # 12 files, 1 file per hour

--- a/scripts/ci/deploy/config/databend-query-node-1.toml
+++ b/scripts/ci/deploy/config/databend-query-node-1.toml
@@ -84,7 +84,7 @@ join_spilling_memory_ratio = 60
 [log]
 
 [log.file]
-level = "INFO"
+level = "DEBUG"
 format = "text"
 dir = "./.databend/logs_1"
 limit = 12 # 12 files, 1 file per hour

--- a/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_drop_tables.rs
@@ -189,9 +189,13 @@ pub async fn vacuum_drop_tables_by_table_info(
         }
     };
 
+    let (_, failed_tables) = &result;
+    let (success_count, failed_count) = (num_tables - failed_tables.len(), failed_tables.len());
     info!(
-        "vacuum {} dropped tables, cost:{:?}",
+        "vacuum {} dropped tables completed - success: {}, failed: {}, total_cost: {:?}",
         num_tables,
+        success_count,
+        failed_count,
         start.elapsed()
     );
 

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -58,7 +58,7 @@ impl VacuumDropTablesInterpreter {
         drop_ids: Vec<DroppedId>,
     ) -> Result<()> {
         info!(
-            "vacuum drop table from db {:?}, gc_drop_tables",
+            "vacuum metadata of dropped table from db {:?}",
             self.plan.database,
         );
 
@@ -74,6 +74,12 @@ impl VacuumDropTablesInterpreter {
                 }
             }
         }
+
+        info!(
+            "found {} database meta data and {} table metadata need to be cleaned",
+            drop_db_ids.len(),
+            drop_db_table_ids.len()
+        );
 
         let chunk_size = 50;
 

--- a/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
+++ b/src/query/service/src/interpreters/interpreter_vacuum_drop_tables.rs
@@ -124,8 +124,10 @@ impl Interpreter for VacuumDropTablesInterpreter {
         let retention_time = chrono::Utc::now() - duration;
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str()).await?;
         info!(
-            "vacuum drop table from db {:?}, duration: {:?}, retention_time: {:?}",
-            self.plan.database, duration, retention_time
+            "=== VACUUM DROP TABLE STARTED === db: {:?}, retention_days: {}, retention_time: {:?}",
+            self.plan.database,
+            ctx.get_settings().get_data_retention_time_in_days()?,
+            retention_time
         );
         // if database if empty, vacuum all tables
         let database_name = if self.plan.database.is_empty() {
@@ -153,13 +155,18 @@ impl Interpreter for VacuumDropTablesInterpreter {
         }
 
         info!(
-            "vacuum drop table from db {:?}, get_drop_table_infos return tables: {:?},tables.len: {:?}, drop_ids: {:?}",
+            "vacuum drop table from db {:?}, found {} tables: [{}], drop_ids: {:?}",
             self.plan.database,
+            tables.len(),
             tables
                 .iter()
-                .map(|t| t.get_table_info())
-                .collect::<Vec<_>>(),
-            tables.len(),
+                .map(|t| format!(
+                    "{}(id:{})",
+                    t.get_table_info().name,
+                    t.get_table_info().ident.table_id
+                ))
+                .collect::<Vec<_>>()
+                .join(", "),
             drop_ids
         );
 
@@ -176,12 +183,17 @@ impl Interpreter for VacuumDropTablesInterpreter {
         }
 
         info!(
-            "after filter read-only tables: {:?}, tables.len: {:?}",
+            "after filter read-only tables: {} tables remain: [{}]",
+            tables.len(),
             tables
                 .iter()
-                .map(|t| t.get_table_info())
-                .collect::<Vec<_>>(),
-            tables.len()
+                .map(|t| format!(
+                    "{}(id:{})",
+                    t.get_table_info().name,
+                    t.get_table_info().ident.table_id
+                ))
+                .collect::<Vec<_>>()
+                .join(", ")
         );
 
         let tables_count = tables.len();
@@ -226,17 +238,30 @@ impl Interpreter for VacuumDropTablesInterpreter {
                 }
             }
             info!(
-                "failed dbs:{:?}, failed_tables:{:?}, success_drop_ids:{:?}",
-                failed_db_ids, failed_tables, success_dropped_ids
+                "vacuum drop table summary - failed dbs: {}, failed tables: {}, successfully cleaned: {} items",
+                failed_db_ids.len(),
+                failed_tables.len(),
+                success_dropped_ids.len()
             );
+            if !failed_tables.is_empty() {
+                info!("failed table ids: {:?}", failed_tables);
+            }
 
             self.gc_drop_tables(catalog, success_dropped_ids).await?;
         }
 
+        let success_count = tables_count as u64 - failed_tables.len() as u64;
+        let failed_count = failed_tables.len() as u64;
+
+        info!(
+            "=== VACUUM DROP TABLE COMPLETED === success: {}, failed: {}, total: {}",
+            success_count, failed_count, tables_count
+        );
+
         match files_opt {
             None => PipelineBuildResult::from_blocks(vec![DataBlock::new_from_columns(vec![
-                UInt64Type::from_data(vec![tables_count as u64 - failed_tables.len() as u64]),
-                UInt64Type::from_data(vec![failed_tables.len() as u64]),
+                UInt64Type::from_data(vec![success_count]),
+                UInt64Type::from_data(vec![failed_count]),
             ])]),
             Some(purge_files) => {
                 let mut len = min(purge_files.len(), DRY_RUN_LIMIT);

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0019_issue_18743.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0019_issue_18743.test
@@ -1,0 +1,14 @@
+statement ok
+create or replace database issue_18743;
+
+statement ok
+use issue_18743;
+
+statement ok
+CREATE OR REPLACE TABLE t(c int);
+
+statement ok
+call system$fuse_vacuum2('issue_18743', 't');
+
+statement ok
+call system$fuse_vacuum2();


### PR DESCRIPTION
Return early if found table has no snapshot

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Return early during execution of `fuse_vacuum2` if found that target table has no snapshot

- fixes: #18743

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18744)
<!-- Reviewable:end -->
