### PR TITLE
fix: query dropped table in fuse_time_travel_size() report error

### DIFF
--- a/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_time_travel_size.rs
@@ -144,9 +144,9 @@ impl SimpleArgFunc for FuseTimeTravelSize {
                 Some(table_name) => {
                     let start = std::time::Instant::now();
                     info!("loading table {}", table_name);
-                    let table = db.get_table(table_name.as_str()).await?;
+                    let table = db.get_table_history(table_name.as_str()).await?;
                     info!("get_table cost: {:?}", start.elapsed());
-                    vec![table]
+                    table
                 }
                 None => {
                     let start = std::time::Instant::now();

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.result
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.result
@@ -8,6 +8,9 @@ Size difference is less than 10 bytes
 >>>> select is_dropped from fuse_time_travel_size('test_fuse_time_travel_size')
 true
 <<<<
+>>>> select is_dropped from fuse_time_travel_size('test_fuse_time_travel_size', 't')
+true
+<<<<
 >>>> select data_retention_period_in_hours from fuse_time_travel_size('test_fuse_time_travel_size')
 240
 <<<<

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
@@ -25,12 +25,14 @@ else
     echo "Size difference is too large: result_size=$result_size, expected_size=$expected_size"
     exit 1
 fi
-
+    
 stmt "alter table test_fuse_time_travel_size.t SET OPTIONS (data_retention_period_in_hours = 240);"
 
 stmt "drop table test_fuse_time_travel_size.t"
 
 query "select is_dropped from fuse_time_travel_size('test_fuse_time_travel_size')"
+
+query "select is_dropped from fuse_time_travel_size('test_fuse_time_travel_size', 't')"
 
 query "select data_retention_period_in_hours from fuse_time_travel_size('test_fuse_time_travel_size')"
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

use `get_table_history()` instead of `get_table()` in `fuse_time_travel_size('db','table')` to get dropped table correctly.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18748)
<!-- Reviewable:end -->
