### PR TITLE
fix: vacuum tables that are dropped by `create or replace` statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4829,6 +4829,7 @@ dependencies = [
  "databend-common-management",
  "databend-common-meta-api",
  "databend-common-meta-app",
+ "databend-common-meta-kvapi",
  "databend-common-meta-store",
  "databend-common-meta-types",
  "databend-common-metrics",

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -195,7 +195,7 @@ pub async fn get_history_tables_for_gc(
 
     let mut args = vec![];
 
-    let mut maybe_current_live_table_ids = HashSet::with_capacity(table_history_kvs.len());
+    let mut maybe_live_table_ids = HashSet::with_capacity(table_history_kvs.len());
     for (ident, table_history) in table_history_kvs {
         let id_list = &table_history.id_list;
         if !id_list.is_empty() {
@@ -206,17 +206,13 @@ pub async fn get_history_tables_for_gc(
                 let max_id = id_list.iter().max().unwrap();
                 assert_eq!(max_id, last_id);
             }
-            maybe_current_live_table_ids.insert(*last_id);
+            // last_id might still be visible
+            maybe_live_table_ids.insert(*last_id);
             for table_id in id_list.iter() {
                 args.push((TableId::new(*table_id), ident.table_name.clone()));
             }
         }
     }
-
-    eprintln!(
-        "maybe_current_live_table_ids {:#?}",
-        maybe_current_live_table_ids
-    );
 
     let mut filter_tb_infos = vec![];
     const BATCH_SIZE: usize = 1000;
@@ -247,16 +243,22 @@ pub async fn get_history_tables_for_gc(
             };
 
             // TODO doc this
-            if seq_meta.data.drop_on.is_none()
-                && !maybe_current_live_table_ids.contains(&table_id.table_id)
+            if seq_meta.data.drop_on.is_none() && !maybe_live_table_ids.contains(&table_id.table_id)
             {
                 if !drop_time_range.contains(&Some(seq_meta.data.updated_on)) {
-                    debug!("table {:?} is not in drop_time_range", seq_meta.data);
+                    debug!(
+                        "table {:?} is not in drop_time_range by updated_on",
+                        seq_meta.data
+                    );
                     num_out_of_time_range += 1;
                     continue;
                 }
+                // Otherwise pick this table id as vacuum target
             } else if !drop_time_range.contains(&seq_meta.data.drop_on) {
-                debug!("table {:?} is not in drop_time_range", seq_meta.data);
+                debug!(
+                    "table {:?} is not in drop_time_range by drop_on",
+                    seq_meta.data
+                );
                 num_out_of_time_range += 1;
                 continue;
             }

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -276,7 +276,7 @@ pub async fn get_history_tables_for_gc(
             // - Either marked with drop_on
             //   We use its `drop_on` to do the time range filtering
             // - Or has no drop_on, but is not the last visible one of the table
-            //   It is still available for vacuum, and we use its `updated_on` to do the time range
+            //   It is still available for vacuum, and we use its `updated_on` to do the time range filtering
 
             let time_point = if seq_meta.drop_on.is_none() {
                 &Some(seq_meta.updated_on)

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -1600,6 +1600,7 @@ where
                     table_drop_time_range,
                     db_info.database_id.db_id,
                     capacity,
+                    vacuum_db,
                 )
                 .await?;
 
@@ -1646,9 +1647,14 @@ where
         };
 
         let database_id = seq_db_id.data;
-        let table_nivs =
-            get_history_tables_for_gc(self, drop_time_range.clone(), database_id.db_id, the_limit)
-                .await?;
+        let table_nivs = get_history_tables_for_gc(
+            self,
+            drop_time_range.clone(),
+            database_id.db_id,
+            the_limit,
+            false,
+        )
+        .await?;
 
         let mut drop_ids = vec![];
         let mut vacuum_tables = vec![];

--- a/src/query/ee/Cargo.toml
+++ b/src/query/ee/Cargo.toml
@@ -66,6 +66,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 databend-common-functions = { workspace = true }
+databend-common-meta-kvapi = { workspace = true }
 jsonb = { workspace = true }
 tantivy = { workspace = true }
 walkdir = { workspace = true }

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -717,14 +717,14 @@ async fn test_gc_in_progress_db_not_undroppable() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_vacuum_drop_create_or_replace() -> Result<()> {
     // vacuum dropped tables by specific database names
-    test_vacuum_drop_create_or_replace_impl(&vec![
+    test_vacuum_drop_create_or_replace_impl(&[
         "vacuum drop table from db1",
         "vacuum drop table from db2",
     ])
     .await?;
 
     // vacuum dropped tables all
-    test_vacuum_drop_create_or_replace_impl(&vec!["vacuum drop table"]).await?;
+    test_vacuum_drop_create_or_replace_impl(&["vacuum drop table"]).await?;
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Tables implicitly dropped by the `create or replace` statement are not handled correctly:

The vacuum operation collects candidate tables according to the `drop_on` mark of table meta data, unfortunately, during `create or replace`, the table being replaced is NOT marked with `drop_on`.

In this PR,  table ids that have no `drop_on` marks, will also be selected as the candidates for vacuum, except it is the largest table id (of the same table name), which is the last visible table id that should be kept.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18751)
<!-- Reviewable:end -->
