### PR TITLE
fix: auto commit of ddl not work when calling procedure in transaction

### DIFF
--- a/tests/compat_fuse/compat-logictest/rbac/fuse_compat_write
+++ b/tests/compat_fuse/compat-logictest/rbac/fuse_compat_write
@@ -59,5 +59,4 @@ GRANT create sequence on *.* to role 'role1';
 statement ok
 GRANT create procedure on *.* to role 'role1';
 
-statement ok
-unset global enable_experimental_procedure;
+

--- a/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
@@ -192,5 +192,3 @@ call procedure p2('x');
 statement ok
 drop procedure p2(string);
 
-statement ok
-unset global enable_experimental_procedure;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
@@ -91,15 +91,3 @@ query I
 select count(*) from test_table;
 ----
 1
-
-statement ok
-drop procedure proc_create_table();
-
-statement ok
-drop procedure proc_drop_table();
-
-statement ok
-drop procedure proc_only_dml();
-
-statement ok
-drop database test_auto_commit;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
@@ -1,0 +1,105 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace database test_auto_commit;
+
+statement ok
+use test_auto_commit;
+
+statement ok
+create table test_table (id int, data string);
+
+statement ok
+drop procedure if exists proc_create_table();
+
+statement ok
+CREATE PROCEDURE proc_create_table() RETURNS int LANGUAGE SQL AS $$
+BEGIN
+    CREATE TABLE new_table (x int);
+    INSERT INTO new_table VALUES (42);
+    RETURN 1;
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_drop_table();
+
+statement ok
+CREATE PROCEDURE proc_drop_table() RETURNS int LANGUAGE SQL AS $$
+BEGIN
+    DROP TABLE IF EXISTS new_table;
+    RETURN 1;
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_only_dml();
+
+statement ok
+CREATE PROCEDURE proc_only_dml() RETURNS int LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO test_table VALUES (2, 'from_proc');
+    UPDATE test_table SET data = 'updated' WHERE id = 1;
+    RETURN 1;
+END;
+$$;
+
+statement ok
+begin;
+
+statement ok
+insert into test_table values (10, 'txn_data');
+
+statement ok
+call procedure proc_create_table();
+
+query I
+select count(*) from test_table;
+----
+1
+
+statement ok
+rollback;
+
+query I
+select count(*) from test_table;
+----
+1
+
+statement ok
+call procedure proc_drop_table();
+
+statement ok
+begin;
+
+statement ok
+insert into test_table values (11, 'txn_data2');
+
+statement ok
+call procedure proc_only_dml();
+
+query I
+select count(*) from test_table;
+----
+3
+
+statement ok
+rollback;
+
+query I
+select count(*) from test_table;
+----
+1
+
+statement ok
+drop procedure proc_create_table();
+
+statement ok
+drop procedure proc_drop_table();
+
+statement ok
+drop procedure proc_only_dml();
+
+statement ok
+drop database test_auto_commit;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0004_procedure_rollback.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0004_procedure_rollback.test
@@ -1,0 +1,95 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace table t_rollback_1 (str varchar);
+
+statement ok
+drop procedure if exists test_rollback_on_error();
+
+# Test procedure with automatic rollback on division by zero error
+statement ok
+CREATE PROCEDURE test_rollback_on_error() RETURNS int not null LANGUAGE SQL AS $$
+BEGIN
+    insert into t_rollback_1 (str) values ('a'), ('b');
+    select 1/0;
+    RETURN 1;
+END;
+$$;
+
+# Test error causes rollback - data should not be inserted
+statement error
+begin;
+call procedure test_rollback_on_error();
+commit;
+
+query I
+select * from t_rollback_1;
+----
+
+
+statement ok
+create or replace table t_rollback_1 (str varchar);
+
+statement ok
+drop procedure if exists test_rollback_on_syntax_error();
+
+# Test procedure with automatic rollback on syntax error
+statement ok
+CREATE PROCEDURE test_rollback_on_syntax_error() RETURNS int not null LANGUAGE SQL AS $$
+BEGIN
+    insert into t_rollback_1 (str) values ('a'), ('b');
+    1;
+    RETURN 1;
+END;
+$$;
+
+# Test syntax error causes rollback - data should not be inserted
+statement error
+begin;
+call procedure test_rollback_on_syntax_error();
+commit;
+
+query I
+select * from t_rollback_1;
+----
+
+
+statement ok
+create or replace table t_rollback_1 (str varchar);
+
+statement ok
+drop procedure if exists test_rollback_on_column_error();
+
+# Test procedure with automatic rollback on non-existent column error
+statement ok
+CREATE PROCEDURE test_rollback_on_column_error() RETURNS int not null LANGUAGE SQL AS $$
+BEGIN
+    insert into t_rollback_1 (str) values ('a'), ('b');
+    select nonexistent from t_rollback_1;
+    RETURN 1;
+END;
+$$;
+
+# Test column error causes rollback - data should not be inserted
+statement error
+begin;
+call procedure test_rollback_on_column_error();
+commit;
+
+query I
+select * from t_rollback_1;
+----
+
+
+statement ok
+drop procedure if exists test_rollback_on_error();
+
+statement ok
+drop procedure if exists test_rollback_on_syntax_error();
+
+statement ok
+drop procedure if exists test_rollback_on_column_error();
+
+statement ok
+drop table t_rollback_1;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0005_procedure_snapshots.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0005_procedure_snapshots.test
@@ -1,0 +1,83 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace database test_procedure_snapshots;
+
+statement ok
+use test_procedure_snapshots;
+
+statement ok
+create or replace table t(c int);
+
+###################################
+# no snapshots left if tx aborted #
+###################################
+
+statement ok
+drop procedure if exists test_rollback_no_snapshots();
+
+# Test procedure that will be rolled back - should leave no snapshots
+statement ok
+CREATE PROCEDURE test_rollback_no_snapshots() RETURNS int not null LANGUAGE SQL AS $$
+BEGIN
+    insert into t values(1);
+    insert into t values(1);
+    select 1/0;
+    RETURN 1;
+END;
+$$;
+
+statement error
+begin;
+call procedure test_rollback_no_snapshots();
+rollback;
+
+query I
+select count() from fuse_snapshot('test_procedure_snapshots', 't');
+----
+0
+
+#####################################################
+# one snapshot left if table mutated multiple times #
+#####################################################
+
+statement ok
+drop procedure if exists test_commit_one_snapshot();
+
+# Test procedure that commits successfully - should create one snapshot
+statement ok
+CREATE PROCEDURE test_commit_one_snapshot() RETURNS int not null LANGUAGE SQL AS $$
+BEGIN
+    insert into t values(1);
+    insert into t values(1);
+    insert into t values(1);
+    RETURN 1;
+END;
+$$;
+
+statement ok
+begin;
+
+statement ok
+call procedure test_commit_one_snapshot();
+
+statement ok
+commit;
+
+query I
+select count() from fuse_snapshot('test_procedure_snapshots', 't');
+----
+1
+
+statement ok
+create or replace table transaction(c int);
+
+statement ok
+drop procedure if exists test_rollback_no_snapshots();
+
+statement ok
+drop procedure if exists test_commit_one_snapshot();
+
+statement ok
+drop database test_procedure_snapshots;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0006_procedure_merge_into.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0006_procedure_merge_into.test
@@ -1,0 +1,191 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace database test_procedure_merge_into;
+
+statement ok
+use test_procedure_merge_into;
+
+statement ok
+CREATE TABLE employees (
+    employee_id INT,
+    employee_name VARCHAR(255),
+    department VARCHAR(255)
+);
+
+statement ok
+CREATE TABLE salaries (
+    employee_id INT,
+    salary DECIMAL(10, 2)
+);
+
+statement ok
+drop procedure if exists test_merge_operations();
+
+# Test procedure performing complex merge operations within transaction
+statement ok
+CREATE PROCEDURE test_merge_operations() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO employees VALUES
+        (1, 'Alice', 'HR'),
+        (2, 'Bob', 'IT'),
+        (3, 'Charlie', 'Finance'),
+        (4, 'David', 'HR');
+    
+    INSERT INTO salaries VALUES
+        (1, 50000.00),
+        (2, 60000.00);
+    
+    MERGE INTO salaries
+        USING (SELECT * FROM employees) AS employees
+        ON salaries.employee_id = employees.employee_id
+        WHEN MATCHED AND employees.department = 'HR' THEN
+            UPDATE SET
+                salaries.salary = salaries.salary + 1000.00
+        WHEN MATCHED THEN
+            UPDATE SET
+                salaries.salary = salaries.salary + 500.00
+        WHEN NOT MATCHED THEN
+            INSERT (employee_id, salary)
+                VALUES (employees.employee_id, 55000.00);
+                
+    RETURN 'merge completed';
+END;
+$$;
+
+statement ok
+BEGIN;
+
+statement ok
+call procedure test_merge_operations();
+
+query I
+select count(*) from fuse_snapshot('test_procedure_merge_into','employees');
+----
+1
+
+query I
+select count(*) from fuse_snapshot('test_procedure_merge_into','salaries');
+----
+1
+
+query IF
+SELECT employee_id, salary FROM salaries order by employee_id;
+----
+1   51000.00
+2   60500.00
+3   55000.00
+4   55000.00
+
+statement ok
+COMMIT;
+
+query I
+select count(*) from fuse_snapshot('test_procedure_merge_into','salaries');
+----
+1
+
+query I
+select count(*) from fuse_snapshot('test_procedure_merge_into','employees');
+----
+1
+
+query IF
+SELECT employee_id, salary FROM salaries order by employee_id;
+----
+1   51000.00
+2   60500.00
+3   55000.00
+4   55000.00
+
+statement ok
+drop database test_procedure_merge_into;
+
+# Test second scenario with BEGIN TRANSACTION
+statement ok
+create or replace database test_procedure_merge_into;
+
+statement ok
+use test_procedure_merge_into;
+
+statement ok
+CREATE TABLE employees (
+    employee_id INT,
+    employee_name VARCHAR(255),
+    department VARCHAR(255)
+);
+
+statement ok
+CREATE TABLE salaries (
+    employee_id INT,
+    salary DECIMAL(10, 2)
+);
+
+statement ok
+drop procedure if exists test_merge_operations_v2();
+
+# Test procedure performing merge operations with BEGIN TRANSACTION syntax
+statement ok
+CREATE PROCEDURE test_merge_operations_v2() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO employees VALUES
+        (1, 'Alice', 'HR'),
+        (2, 'Bob', 'IT'),
+        (3, 'Charlie', 'Finance'),
+        (4, 'David', 'HR');
+    
+    INSERT INTO salaries VALUES
+        (1, 50000.00),
+        (2, 60000.00);
+    
+    MERGE INTO salaries
+        USING (SELECT * FROM employees) AS employees
+        ON salaries.employee_id = employees.employee_id
+        WHEN MATCHED AND employees.department = 'HR' THEN
+            UPDATE SET
+                salaries.salary = salaries.salary + 1000.00
+        WHEN MATCHED THEN
+            UPDATE SET
+                salaries.salary = salaries.salary + 500.00
+        WHEN NOT MATCHED THEN
+            INSERT (employee_id, salary)
+                VALUES (employees.employee_id, 55000.00);
+                
+    RETURN 'merge completed v2';
+END;
+$$;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+call procedure test_merge_operations_v2();
+
+query IF
+SELECT employee_id, salary FROM salaries order by employee_id;
+----
+1   51000.00
+2   60500.00
+3   55000.00
+4   55000.00
+
+statement ok
+COMMIT;
+
+query IF
+SELECT employee_id, salary FROM salaries order by employee_id;
+----
+1   51000.00
+2   60500.00
+3   55000.00
+4   55000.00
+
+statement ok
+drop procedure if exists test_merge_operations();
+
+statement ok
+drop procedure if exists test_merge_operations_v2();
+
+statement ok
+drop database test_procedure_merge_into;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0007_procedure_dedup_label.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0007_procedure_dedup_label.test
@@ -1,0 +1,58 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace database test_procedure_dedup_label;
+
+statement ok
+use test_procedure_dedup_label;
+
+statement ok
+CREATE TABLE t1(a Int, b bool);
+
+statement ok
+drop procedure if exists test_dedup_operations();
+
+# Test procedure with deduplication labels within transaction
+statement ok
+CREATE PROCEDURE test_dedup_operations() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT /*+ SET_VAR(deduplicate_label='databend') */ INTO t1 (a, b) VALUES(1, false);
+    UPDATE /*+ SET_VAR(deduplicate_label='databend') */ t1 SET a = 20 WHERE b = false;
+    RETURN 'dedup operations completed';
+END;
+$$;
+
+statement ok
+begin;
+
+statement ok
+call procedure test_dedup_operations();
+
+query II
+SELECT * FROM t1;
+----
+1 0
+
+statement ok
+commit;
+
+query II
+SELECT * FROM t1;
+----
+1 0
+
+# Test REPLACE with deduplication label outside procedure
+statement ok
+REPLACE /*+ SET_VAR(deduplicate_label='databend') */ INTO t1 on(a,b) VALUES(40, false);
+
+query II
+SELECT * FROM t1;
+----
+1 0
+
+statement ok
+drop procedure if exists test_dedup_operations();
+
+statement ok
+drop database test_procedure_dedup_label;

--- a/tests/sqllogictests/suites/base/15_procedure/15_0008_procedure_multi_transaction.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0008_procedure_multi_transaction.test
@@ -1,0 +1,256 @@
+statement ok
+set global enable_experimental_procedure=1;
+
+statement ok
+create or replace database test_procedure_multi;
+
+statement ok
+use test_procedure_multi;
+
+statement ok
+CREATE TABLE t1(id int, name varchar(50));
+
+statement ok
+CREATE TABLE t2(id int, amount decimal(10,2));
+
+statement ok
+CREATE TABLE t3(id int, status varchar(20));
+
+# Test multiple procedures in single transaction - all succeed
+statement ok
+drop procedure if exists proc_insert_user();
+
+statement ok
+CREATE PROCEDURE proc_insert_user() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t1 VALUES (1, 'Alice'), (2, 'Bob');
+    RETURN 'users inserted';
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_insert_amounts();
+
+statement ok
+CREATE PROCEDURE proc_insert_amounts() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t2 VALUES (1, 1000.50), (2, 2000.75);
+    RETURN 'amounts inserted';
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_update_status();
+
+statement ok
+CREATE PROCEDURE proc_update_status() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t3 VALUES (1, 'active'), (2, 'pending');
+    UPDATE t3 SET status = 'confirmed' WHERE id = 1;
+    RETURN 'status updated';
+END;
+$$;
+
+# Test all procedures succeed in transaction
+statement ok
+BEGIN;
+
+statement ok
+call procedure proc_insert_user();
+
+statement ok
+call procedure proc_insert_amounts();
+
+statement ok
+call procedure proc_update_status();
+
+statement ok
+COMMIT;
+
+query IS
+SELECT * FROM t1 ORDER BY id;
+----
+1 Alice
+2 Bob
+
+query IF
+SELECT * FROM t2 ORDER BY id;
+----
+1 1000.50
+2 2000.75
+
+query IS
+SELECT * FROM t3 ORDER BY id;
+----
+1 confirmed
+2 pending
+
+# Test multiple procedures with one failure - all should rollback
+statement ok
+create or replace table t1(id int, name varchar(50));
+
+statement ok
+create or replace table t2(id int, amount decimal(10,2));
+
+statement ok
+create or replace table t3(id int, status varchar(20));
+
+statement ok
+drop procedure if exists proc_insert_user_v2();
+
+statement ok
+CREATE PROCEDURE proc_insert_user_v2() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t1 VALUES (3, 'Charlie'), (4, 'David');
+    RETURN 'users inserted v2';
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_failing_operation();
+
+statement ok
+CREATE PROCEDURE proc_failing_operation() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t2 VALUES (3, 3000.25);
+    SELECT 1/0; 
+    RETURN 'this should not return';
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_more_updates();
+
+statement ok
+CREATE PROCEDURE proc_more_updates() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t3 VALUES (3, 'new');
+    RETURN 'more updates done';
+END;
+$$;
+
+# Test transaction with failure - all should be rolled back
+statement error
+BEGIN;
+call procedure proc_insert_user_v2();
+call procedure proc_failing_operation();
+call procedure proc_more_updates();
+COMMIT;
+
+# Verify all tables are empty due to rollback
+query IS
+SELECT * FROM t1;
+----
+
+query IF
+SELECT * FROM t2;
+----
+
+query IS
+SELECT * FROM t3;
+----
+
+# Test procedures with complex operations across multiple tables
+statement ok
+drop procedure if exists proc_complex_operations();
+
+statement ok
+CREATE PROCEDURE proc_complex_operations() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    INSERT INTO t1 VALUES (5, 'Eve'), (6, 'Frank');
+    INSERT INTO t2 VALUES (5, 5000.00), (6, 6000.00);
+    
+    UPDATE t2 SET amount = amount * 1.1 WHERE id = 5;
+    
+    INSERT INTO t3 SELECT id, 'calculated' FROM t1 WHERE id >= 5;
+    
+    RETURN 'complex operations completed';
+END;
+$$;
+
+statement ok
+drop procedure if exists proc_final_adjustments();
+
+statement ok
+CREATE PROCEDURE proc_final_adjustments() RETURNS string not null LANGUAGE SQL AS $$
+BEGIN
+    UPDATE t3 SET status = 'finalized' WHERE status = 'calculated';
+    DELETE FROM t2 WHERE amount < 5500.00;
+    RETURN 'final adjustments completed';
+END;
+$$;
+
+# Test complex multi-procedure transaction
+statement ok
+BEGIN;
+
+statement ok
+call procedure proc_complex_operations();
+
+statement ok
+call procedure proc_final_adjustments();
+
+statement ok
+COMMIT;
+
+query IS
+SELECT * FROM t1 ORDER BY id;
+----
+5 Eve
+6 Frank
+
+query IF
+SELECT * FROM t2 ORDER BY id;
+----
+5 5500.00
+6 6000.00
+
+query IS
+SELECT * FROM t3 ORDER BY id;
+----
+5 finalized
+6 finalized
+
+# Test snapshot consistency across multiple procedures
+query I
+select count(*) from fuse_snapshot('test_procedure_multi','t1');
+----
+1
+
+query I
+select count(*) from fuse_snapshot('test_procedure_multi','t2');
+----
+1
+
+query I
+select count(*) from fuse_snapshot('test_procedure_multi','t3');
+----
+1
+
+# Cleanup
+statement ok
+drop procedure if exists proc_insert_user();
+
+statement ok
+drop procedure if exists proc_insert_amounts();
+
+statement ok
+drop procedure if exists proc_update_status();
+
+statement ok
+drop procedure if exists proc_insert_user_v2();
+
+statement ok
+drop procedure if exists proc_failing_operation();
+
+statement ok
+drop procedure if exists proc_more_updates();
+
+statement ok
+drop procedure if exists proc_complex_operations();
+
+statement ok
+drop procedure if exists proc_final_adjustments();
+
+statement ok
+drop database test_procedure_multi;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. By design, if a DDL statement is executed while a transaction is active, the DDL statement will implicitly commits the active transaction. This pr supports this behavior when ddl is in a procedure.
2.  Add stored procedure tests covering transaction scenarios including rollback behavior, snapshot management, merge operations, deduplication labels, and multi-procedure transactions.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18753)
<!-- Reviewable:end -->
