### PR TITLE
refactor(query): stream style block writer for hash join spill

### DIFF
--- a/src/common/native/src/compression/binary/mod.rs
+++ b/src/common/native/src/compression/binary/mod.rs
@@ -60,9 +60,9 @@ pub fn compress_binary(
                 offsets.clone()
             } else {
                 let first = offsets.first().unwrap();
-                let mut zero_offsets = Vec::with_capacity(offsets.len());
-                for offset in offsets.iter() {
-                    zero_offsets.push(*offset - *first);
+                let mut zero_offsets = vec![0_u64; offsets.len()];
+                for (idx, offset) in offsets.iter().enumerate() {
+                    zero_offsets[idx] = *offset - *first;
                 }
                 zero_offsets.into()
             };

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
@@ -90,7 +90,12 @@ impl HashJoinSpiller {
         // if the partition memory size exceeds the threshold.
         let partition_threshold = partition_buffer_threshold * 1024 * 1024 / num_partitions;
 
-        let block_bytes = ctx.get_settings().get_max_block_bytes()? as usize;
+        let mut block_bytes = ctx.get_settings().get_max_block_bytes()? as usize;
+
+        if ctx.get_settings().get_force_join_data_spill()? {
+            block_bytes = 1;
+        }
+
         // Create a PartitionBuffer to buffer data before spilling.
         let partition_buffer = PartitionBuffer::create(num_partitions);
 
@@ -195,6 +200,10 @@ impl HashJoinSpiller {
             for (partition_id, data_block) in ready_partitions {
                 if !need_spill(partition_id) {
                     unspilled_data_blocks.push(data_block);
+                    continue;
+                }
+
+                if data_block.is_empty() {
                     continue;
                 }
 

--- a/src/query/service/src/spillers/adapter.rs
+++ b/src/query/service/src/spillers/adapter.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::DerefMut;
@@ -35,14 +36,15 @@ use super::inner::*;
 use super::serialize::*;
 use super::Location;
 use crate::sessions::QueryContext;
-use crate::spillers::stream_writer::BlockWriter;
+use crate::spillers::block_reader::BlocksReader;
+use crate::spillers::block_writer::BlocksWriter;
 
 pub struct PartitionAdapter {
     ctx: Arc<QueryContext>,
     // Stores the spilled files that controlled by current spiller
     private_spilled_files: Arc<RwLock<HashMap<Location, Layout>>>,
     /// 1 partition -> N partition files
-    partition_location: HashMap<usize, Vec<Location>>,
+    partition_location: HashMap<usize, Vec<(Location, usize, usize)>>,
 }
 
 impl SpillAdapter for PartitionAdapter {
@@ -82,12 +84,21 @@ impl Spiller {
         self.adapter.partition_location.keys().copied().collect()
     }
 
+    pub fn partition_blocks_reader(&mut self, id: &usize) -> BlocksReader<'_> {
+        let locations: &[_] = match self.adapter.partition_location.get(id) {
+            None => &[],
+            Some(locations) => locations,
+        };
+
+        BlocksReader::new(locations, self.operator.clone())
+    }
+
     #[async_backtrace::framed]
     /// Read spilled data with partition id
     pub async fn read_spilled_partition(&mut self, procedure_id: &usize) -> Result<Vec<DataBlock>> {
         if let Some(locs) = self.adapter.partition_location.get(procedure_id) {
             let mut spilled_data = Vec::with_capacity(locs.len());
-            for loc in locs.iter() {
+            for (loc, _data_size, _blocks_num) in locs.iter() {
                 let block = self.read_spilled_file(loc).await?;
 
                 if block.num_rows() != 0 {
@@ -100,14 +111,15 @@ impl Spiller {
         }
     }
 
-    pub fn get_partition_locations(&self, partition_id: &usize) -> Option<&Vec<Location>> {
-        self.adapter.partition_location.get(partition_id)
+    pub fn get_partition_locations(&self, partition_id: &usize) -> Option<Vec<Location>> {
+        let locations = self.adapter.partition_location.get(partition_id)?;
+        Some(locations.iter().map(|(loc, _, _)| loc.clone()).collect())
     }
 
-    pub async fn block_stream_writer(&mut self) -> Result<BlockWriter> {
+    pub async fn block_stream_writer(&mut self) -> Result<BlocksWriter> {
         let location = self.create_unique_location();
         let writer = self.operator.writer_with(&location).await?;
-        Ok(BlockWriter::create(writer, Location::Remote(location)))
+        Ok(BlocksWriter::create(writer, Location::Remote(location)))
     }
 
     pub fn inc_progress(&self, progress_val: ProgressValues) {
@@ -117,24 +129,24 @@ impl Spiller {
             .incr(&progress_val);
     }
 
-    pub fn add_partition_location(
+    pub fn add_hash_join_location(
         &mut self,
         partition: usize,
         location: Location,
-        layout: Layout,
+        block_num: usize,
         data_size: usize,
     ) {
         self.adapter
-            .add_spill_file(location.clone(), layout, data_size);
+            .add_spill_file(location.clone(), Layout::Parquet, data_size);
 
         if let Some(v) = self.adapter.partition_location.get_mut(&partition) {
-            v.push(location);
+            v.push((location, data_size, block_num));
             return;
         }
 
         self.adapter
             .partition_location
-            .insert(partition, vec![location]);
+            .insert(partition, vec![(location, data_size, block_num)]);
     }
 
     #[async_backtrace::framed]
@@ -156,13 +168,15 @@ impl Spiller {
         };
 
         let location = self.spill(data).await?;
-        self.adapter
-            .partition_location
-            .entry(partition_id)
-            .and_modify(|locs| {
-                locs.push(location.clone());
-            })
-            .or_insert(vec![location.clone()]);
+
+        match self.adapter.partition_location.entry(partition_id) {
+            Entry::Vacant(v) => {
+                v.insert(vec![(location, 0, 0)]);
+            }
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().push((location, 0, 0));
+            }
+        };
 
         self.adapter
             .ctx

--- a/src/query/service/src/spillers/block_reader.rs
+++ b/src/query/service/src/spillers/block_reader.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
+use std::mem::size_of;
 
 use byteorder::BigEndian;
 use byteorder::ReadBytesExt;

--- a/src/query/service/src/spillers/block_reader.rs
+++ b/src/query/service/src/spillers/block_reader.rs
@@ -1,0 +1,103 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+use byteorder::BigEndian;
+use byteorder::ReadBytesExt;
+use bytes::Buf;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_pipeline_transforms::traits::Location;
+use opendal::Operator;
+
+use crate::spillers::serialize::deserialize_block;
+use crate::spillers::Layout;
+
+pub struct BlocksReader<'a> {
+    read_bytes: u64,
+    current: usize,
+    location_offset: usize,
+    offsets: VecDeque<u64>,
+    locations: &'a [(Location, usize, usize)],
+    operator: Operator,
+}
+
+impl<'a> BlocksReader<'a> {
+    pub fn new(locations: &'a [(Location, usize, usize)], operator: Operator) -> Self {
+        BlocksReader {
+            operator,
+            locations,
+            current: 0,
+            read_bytes: 0,
+            location_offset: 0,
+            offsets: VecDeque::new(),
+        }
+    }
+
+    pub async fn read(&mut self) -> Result<Option<DataBlock>> {
+        if self.offsets.is_empty() {
+            self.advance_location().await?;
+        }
+
+        if let Some(offset) = self.offsets.pop_front() {
+            let (Location::Remote(location), _, _) = &self.locations[self.current] else {
+                unreachable!();
+            };
+
+            let data = self
+                .operator
+                .read_with(location)
+                .range(self.read_bytes..offset)
+                .await?;
+
+            let data_block = deserialize_block(&Layout::Parquet, data)?;
+
+            self.read_bytes = offset;
+            return Ok(Some(data_block));
+        }
+
+        Ok(None)
+    }
+
+    async fn advance_location(&mut self) -> Result<()> {
+        if self.location_offset >= self.locations.len() {
+            return Ok(());
+        }
+
+        let (location, data_size, block_size) = &self.locations[self.location_offset];
+
+        let Location::Remote(location) = location else {
+            unreachable!()
+        };
+
+        let offset = (*data_size - (*block_size * size_of::<u64>())) as u64;
+        let bytes = self
+            .operator
+            .read_with(location)
+            .range(offset..(*data_size as u64))
+            .await?;
+
+        let mut offset_reader = bytes.reader();
+        for _index in 0..*block_size {
+            let offset = offset_reader.read_u64::<BigEndian>()?;
+            self.offsets.push_back(offset);
+        }
+
+        self.read_bytes = 0;
+        self.current = self.location_offset;
+        self.location_offset += 1;
+        Ok(())
+    }
+}

--- a/src/query/service/src/spillers/block_writer.rs
+++ b/src/query/service/src/spillers/block_writer.rs
@@ -43,6 +43,8 @@ impl BlocksWriter {
         }
     }
     pub async fn write(&mut self, block: DataBlock) -> Result<()> {
+        assert!(!block.is_empty());
+
         let mut block_encoder = BlocksEncoder::new(true, Alignment::MIN, 8 * 1024 * 1024);
         block_encoder.add_blocks(vec![block]);
 
@@ -60,6 +62,8 @@ impl BlocksWriter {
     }
 
     pub async fn close(mut self) -> Result<(Location, usize, usize)> {
+        assert!(self.written > 0);
+
         let bytes = BytesMut::new();
 
         let mut offset_writer = bytes.writer();

--- a/src/query/service/src/spillers/mod.rs
+++ b/src/query/service/src/spillers/mod.rs
@@ -16,6 +16,7 @@ mod adapter;
 mod inner;
 mod partition_buffer;
 mod serialize;
+mod stream_writer;
 #[cfg(test)]
 mod test_memory;
 
@@ -25,3 +26,4 @@ pub use inner::*;
 pub use partition_buffer::PartitionBuffer;
 pub use partition_buffer::PartitionBufferFetchOption;
 pub use serialize::Layout;
+pub use stream_writer::*;

--- a/src/query/service/src/spillers/mod.rs
+++ b/src/query/service/src/spillers/mod.rs
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 mod adapter;
+mod block_reader;
+mod block_writer;
 mod inner;
 mod partition_buffer;
 mod serialize;
-mod stream_writer;
 #[cfg(test)]
 mod test_memory;
 
 pub use adapter::*;
+pub use block_writer::*;
 pub use databend_common_pipeline_transforms::traits::Location;
 pub use inner::*;
 pub use partition_buffer::PartitionBuffer;
 pub use partition_buffer::PartitionBufferFetchOption;
 pub use serialize::Layout;
-pub use stream_writer::*;

--- a/src/query/service/src/spillers/stream_writer.rs
+++ b/src/query/service/src/spillers/stream_writer.rs
@@ -1,0 +1,60 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_base::base::dma_buffer_to_bytes;
+use databend_common_base::base::Alignment;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_pipeline_transforms::traits::Location;
+use opendal::Buffer;
+use opendal::Writer;
+
+use crate::spillers::serialize::BlocksEncoder;
+use crate::spillers::Layout;
+
+pub struct BlockWriter {
+    writer: Writer,
+    location: Location,
+    written: usize,
+}
+
+impl BlockWriter {
+    pub fn create(writer: Writer, location: Location) -> BlockWriter {
+        BlockWriter {
+            writer,
+            location,
+            written: 0,
+        }
+    }
+    pub async fn write(&mut self, block: DataBlock) -> Result<()> {
+        let mut block_encoder = BlocksEncoder::new(true, Alignment::MIN, 8 * 1024 * 1024);
+        block_encoder.add_blocks(vec![block]);
+
+        let buf = block_encoder
+            .buf
+            .into_data()
+            .into_iter()
+            .map(dma_buffer_to_bytes)
+            .collect::<Buffer>();
+
+        self.written += buf.len();
+        self.writer.write(buf).await?;
+        Ok(())
+    }
+
+    pub async fn close(mut self) -> Result<(Location, Layout, usize)> {
+        self.writer.close().await?;
+        Ok((self.location, Layout::Parquet, self.written))
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

refactor(query): stream style block writer for hash join spill

- preallocate shifted offsets in binary compression to avoid per-push bounds checks
- keep block reader imports aligned after streaming writer refactor

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
