### PR TITLE
refactor(native): preallocate zero offsets before compression

### DIFF
--- a/src/common/native/src/compression/binary/mod.rs
+++ b/src/common/native/src/compression/binary/mod.rs
@@ -60,9 +60,9 @@ pub fn compress_binary(
                 offsets.clone()
             } else {
                 let first = offsets.first().unwrap();
-                let mut zero_offsets = Vec::with_capacity(offsets.len());
-                for offset in offsets.iter() {
-                    zero_offsets.push(*offset - *first);
+                let mut zero_offsets = vec![0_u64; offsets.len()];
+                for (idx, offset) in offsets.iter().enumerate() {
+                    zero_offsets[idx] = *offset - *first;
                 }
                 zero_offsets.into()
             };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

perf(native): preallocate zero offsets before compression

- preallocate shifted offsets in binary compression to avoid per-push bounds checks

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18756)
<!-- Reviewable:end -->
