### PR TITLE
refactor: meta-service: compact immutable levels periodically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
  "reqwest",
  "rustls 0.23.27",
  "semver",
+ "seq-marked",
  "serde",
  "serde_json",
  "serfig",

--- a/src/meta/control/src/import.rs
+++ b/src/meta/control/src/import.rs
@@ -201,7 +201,7 @@ async fn init_new_cluster(
     let sto = RaftStore::open(&raft_config).await?;
 
     let last_applied = {
-        let sm2 = sto.state_machine().get_inner();
+        let sm2 = sto.get_sm_v003();
         *sm2.sys_data().last_applied_ref()
     };
 
@@ -213,7 +213,7 @@ async fn init_new_cluster(
 
     // Update snapshot: Replace nodes set and membership config.
     {
-        let sm2 = sto.state_machine().get_inner();
+        let sm2 = sto.get_sm_v003();
 
         // It must set membership to state machine because
         // the snapshot may contain more logs than the last_log_id.

--- a/src/meta/raft-store/src/applier/mod.rs
+++ b/src/meta/raft-store/src/applier/mod.rs
@@ -169,7 +169,25 @@ where SM: StateMachineApi<SysData> + 'static
                 node_id,
                 node,
                 overriding,
-            } => self.apply_add_node(node_id, node, *overriding),
+            } => {
+                info!(
+                    "applying AddNode: {}={:?}, overriding: {}, sys_data: {:?}",
+                    node_id,
+                    node,
+                    overriding,
+                    self.sm.with_sys_data(|s| s.clone())
+                );
+
+                let res = self.apply_add_node(node_id, node, *overriding);
+
+                info!(
+                    "applied AddNode: {}={:?}, sys_data: {:?}",
+                    node_id,
+                    node,
+                    self.sm.with_sys_data(|s| s.clone())
+                );
+                res
+            }
 
             Cmd::RemoveNode { ref node_id } => self.apply_remove_node(node_id),
 

--- a/src/meta/raft-store/src/config.rs
+++ b/src/meta/raft-store/src/config.rs
@@ -127,6 +127,9 @@ pub struct RaftConfig {
     /// Default: 1GB (1,073,741,824 bytes).
     pub snapshot_db_block_cache_size: u64,
 
+    /// Interval in milliseconds to compact the in memory immutable levels.
+    pub compact_immutables_ms: Option<u64>,
+
     /// Single node metasrv. It creates a single node cluster if meta data is not initialized.
     /// Otherwise it opens the previous one.
     /// This is mainly for testing purpose.
@@ -200,6 +203,7 @@ impl Default for RaftConfig {
             snapshot_db_block_cache_item: 1024,
             snapshot_db_block_cache_size: 1073741824,
 
+            compact_immutables_ms: None,
             single: false,
             join: vec![],
             learner: false,

--- a/src/meta/raft-store/src/immutable_compactor/mod.rs
+++ b/src/meta/raft-store/src/immutable_compactor/mod.rs
@@ -1,0 +1,170 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use display_more::DisplaySliceExt;
+use log::info;
+use seq_marked::InternalSeq;
+
+use crate::leveled_store::leveled_map::LeveledMap;
+use crate::sm_v003::compactor_acquirer::CompactorPermit;
+use crate::sm_v003::writer_acquirer::WriterPermit;
+use crate::sm_v003::SMV003;
+
+/// Compact `ImmutableLevels` to reduce the number of levels.
+pub struct InMemoryCompactor {
+    writer_permit: WriterPermit,
+    immutable_compactor: ImmutableCompactor,
+}
+
+impl fmt::Display for InMemoryCompactor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InMemoryCompactor({})", self.name())
+    }
+}
+
+impl InMemoryCompactor {
+    pub async fn new(sm: Arc<SMV003>, name: impl ToString) -> Self {
+        let name = name.to_string();
+
+        // Always acquire the compactor permit first to avoid deadlock.
+        let compactor_permit = sm.new_compactor_acquirer(name.clone()).acquire().await;
+        let writer_permit = sm.new_writer_acquirer().acquire().await;
+
+        Self {
+            writer_permit,
+            immutable_compactor: ImmutableCompactor::new(
+                sm.leveled_map().clone(),
+                compactor_permit,
+                name,
+            ),
+        }
+    }
+
+    /// Move the writable level to immutable levels,
+    /// and return the `ImmutableCompactor` to do the further compaction of immutable levels.
+    pub fn freeze(mut self) -> ImmutableCompactor {
+        let leveled_map = self.leveled_map().clone();
+
+        let writable_stat = leveled_map.writable_stat();
+
+        leveled_map.freeze_writable(
+            &mut self.writer_permit,
+            &mut self.immutable_compactor.compactor_permit,
+        );
+
+        let immutable_stat = leveled_map.immutable_levels().stat();
+
+        info!(
+            "{} DONE freeze writable: {}; immutables: {}",
+            self,
+            writable_stat,
+            immutable_stat.display_n(64)
+        );
+
+        self.immutable_compactor
+    }
+
+    pub fn leveled_map(&self) -> &LeveledMap {
+        &self.immutable_compactor.leveled_map
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.immutable_compactor.name
+    }
+}
+
+pub struct ImmutableCompactor {
+    name: String,
+    compactor_permit: CompactorPermit,
+    leveled_map: LeveledMap,
+}
+
+impl fmt::Display for ImmutableCompactor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ImmutableCompactor({})", self.name())
+    }
+}
+
+impl ImmutableCompactor {
+    pub fn new(
+        leveled_map: LeveledMap,
+        compactor_permit: CompactorPermit,
+        name: impl ToString,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            leveled_map,
+            compactor_permit,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn compact(self, min_snapshot_seq: InternalSeq) {
+        //
+        let immutable_levels = self.leveled_map.immutable_levels();
+
+        let old_stat = immutable_levels.stat();
+
+        info!(
+            "{} Start compact immutables: {}",
+            self,
+            old_stat.display_n(64)
+        );
+
+        if let Err(e) = immutable_levels.need_compact() {
+            info!("{} Skip compact immutables because: {}", self, e);
+            return;
+        }
+
+        let new_immutable_levels = immutable_levels.compact_min_adjacent(min_snapshot_seq);
+
+        let old_stat = immutable_levels.stat();
+        let new_stat = new_immutable_levels.stat();
+
+        if old_stat == new_stat {
+            info!(
+                "{} Done compact immutables: No compaction: {}",
+                self,
+                old_stat.display_n(64),
+            );
+            return;
+        } else {
+            for i in 0..new_stat.len() {
+                let old = &old_stat[i];
+                let new = &new_stat[i];
+
+                if old.level_index != new.level_index {
+                    info!(
+                        "{} Done compact {} = {} + {}, final: {}",
+                        self,
+                        &new_stat[i - 1],
+                        &old_stat[i - 1],
+                        &old_stat[i],
+                        new_stat.display_n(64)
+                    );
+                    break;
+                }
+            }
+        }
+
+        self.leveled_map
+            .replace_immutable_levels(new_immutable_levels);
+    }
+}

--- a/src/meta/raft-store/src/leveled_store/immutable_levels/compact_conductor.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable_levels/compact_conductor.rs
@@ -12,17 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use display_more::DisplaySliceExt;
+
 use crate::leveled_store::immutable_levels::ImmutableLevels;
 
 impl ImmutableLevels {
     /// Determine if the layout needs compaction based on the total size of all levels.
     #[allow(dead_code)]
-    pub(crate) fn need_compact(&self) -> bool {
+    pub(crate) fn need_compact(&self) -> Result<(), String> {
         let min_size = self.newest_to_oldest().map(|l| l.size()).min().unwrap_or(0);
         let max_size = self.newest_to_oldest().map(|l| l.size()).max().unwrap_or(0);
 
         let n_levels = self.immutables.len() as u64;
 
-        n_levels >= 6 && max_size > min_size * 4
+        if n_levels < 6 {
+            return Err("not enough levels(<6) to compact".to_string());
+        }
+
+        if n_levels > 20 {
+            return Ok(());
+        }
+
+        if max_size <= min_size * 4 {
+            return Err(format!(
+                "size difference between levels(min: {}, max: {}) is not large enough, stat: {}",
+                min_size,
+                max_size,
+                self.stat().display()
+            ));
+        }
+
+        Ok(())
     }
 }

--- a/src/meta/raft-store/src/leveled_store/immutable_levels/compact_min_adjacent.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable_levels/compact_min_adjacent.rs
@@ -25,7 +25,7 @@ impl ImmutableLevels {
     /// # Returns
     /// A new `ImmutableLevels` with the two smallest adjacent levels compacted into one.
     /// If there are 0 or 1 levels, returns a clone of self.
-    pub async fn compact_min_adjacent(&self, min_snapshot_seq: InternalSeq) -> Self {
+    pub fn compact_min_adjacent(&self, min_snapshot_seq: InternalSeq) -> Self {
         let n = self.immutables.len();
         if n <= 1 {
             return self.clone();
@@ -83,7 +83,7 @@ mod tests {
     #[tokio::test]
     async fn test_compact_min_adjacent_empty() {
         let empty_levels = ImmutableLevels::default();
-        let result = empty_levels.compact_min_adjacent(InternalSeq::new(0)).await;
+        let result = empty_levels.compact_min_adjacent(InternalSeq::new(0));
         assert_eq!(result.immutables.len(), 0);
         assert!(result.immutables.is_empty());
     }
@@ -98,7 +98,7 @@ mod tests {
         let original_index = *immutable.level_index();
         let levels = ImmutableLevels::new_form_iter([immutable]);
 
-        let result = levels.compact_min_adjacent(InternalSeq::new(0)).await;
+        let result = levels.compact_min_adjacent(InternalSeq::new(0));
         assert_eq!(result.immutables.len(), 1);
 
         let result_indexes: Vec<_> = result.immutables.keys().cloned().collect();
@@ -131,7 +131,7 @@ mod tests {
 
         let levels = ImmutableLevels::new_form_iter([immutable1, immutable2, immutable3]);
 
-        let result = levels.compact_min_adjacent(InternalSeq::new(0)).await;
+        let result = levels.compact_min_adjacent(InternalSeq::new(0));
 
         assert_eq!(result.immutables.len(), 2);
 
@@ -169,7 +169,7 @@ mod tests {
         let level2_index = *immutable2.level_index();
         let levels = ImmutableLevels::new_form_iter([immutable1, immutable2]);
 
-        let result = levels.compact_min_adjacent(InternalSeq::new(0)).await;
+        let result = levels.compact_min_adjacent(InternalSeq::new(0));
         assert_eq!(result.immutables.len(), 1);
 
         let result_indexes: Vec<_> = result.immutables.keys().cloned().collect();
@@ -203,7 +203,7 @@ mod tests {
         let immutable2 = Immutable::new_from_level(level2);
         let levels = ImmutableLevels::new_form_iter([immutable1, immutable2]);
 
-        let result = levels.compact_min_adjacent(InternalSeq::new(18)).await;
+        let result = levels.compact_min_adjacent(InternalSeq::new(18));
         assert_eq!(result.immutables.len(), 1);
 
         assert_eq!(

--- a/src/meta/raft-store/src/leveled_store/immutable_levels/mod.rs
+++ b/src/meta/raft-store/src/leveled_store/immutable_levels/mod.rs
@@ -28,6 +28,7 @@ use stream_more::KMerge;
 use stream_more::StreamMore;
 
 use crate::leveled_store::immutable::Immutable;
+use crate::leveled_store::level::LevelStat;
 use crate::leveled_store::level_index::LevelIndex;
 use crate::leveled_store::map_api::MapKey;
 
@@ -50,6 +51,13 @@ impl ImmutableLevels {
                 .map(|immu| (*immu.level_index(), immu))
                 .collect(),
         }
+    }
+
+    /// Get statistics of all levels from newest to oldest.
+    pub fn stat(&self) -> Vec<LevelStat> {
+        self.newest_to_oldest()
+            .map(|imm| imm.inner().stat().with_index(*imm.level_index()))
+            .collect()
     }
 
     pub(crate) fn indexes(&self) -> Vec<LevelIndex> {

--- a/src/meta/raft-store/src/leveled_store/level/mod.rs
+++ b/src/meta/raft-store/src/leveled_store/level/mod.rs
@@ -35,6 +35,9 @@ use state_machine_api::UserKey;
 
 use crate::leveled_store::get_sub_table::GetSubTable;
 
+mod stat;
+pub use stat::LevelStat;
+
 /// A single level of state machine data.
 ///
 /// State machine data is composed of multiple levels.
@@ -115,6 +118,14 @@ impl Level {
         level.with_sys_data(|s| s.incr_data_seq());
 
         level
+    }
+
+    pub fn stat(&self) -> LevelStat {
+        LevelStat {
+            level_index: None,
+            user_count: self.kv.inner.len() as u64,
+            expire_count: self.expire.inner.len() as u64,
+        }
     }
 
     pub(crate) fn with_sys_data<T>(&mut self, f: impl FnOnce(&mut SysData) -> T) -> T {

--- a/src/meta/raft-store/src/leveled_store/level/stat.rs
+++ b/src/meta/raft-store/src/leveled_store/level/stat.rs
@@ -1,0 +1,47 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::leveled_store::level_index::LevelIndex;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LevelStat {
+    pub(crate) level_index: Option<LevelIndex>,
+    pub(crate) user_count: u64,
+    pub(crate) expire_count: u64,
+}
+
+impl LevelStat {
+    pub fn with_index(mut self, index: LevelIndex) -> Self {
+        self.level_index = Some(index);
+        self
+    }
+}
+
+impl fmt::Display for LevelStat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(idx) = &self.level_index {
+            write!(f, "[{}]", idx)?;
+        } else {
+            write!(f, "[writable]")?;
+        }
+
+        write!(
+            f,
+            "(user={}, expire={})",
+            self.user_count, self.expire_count
+        )
+    }
+}

--- a/src/meta/raft-store/src/leveled_store/level_index.rs
+++ b/src/meta/raft-store/src/leveled_store/level_index.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 /// Represents a unique identifier for a level.
 ///
 /// The magnitude of the index indicates the relative freshness of the level.
@@ -22,6 +24,12 @@ pub struct LevelIndex {
 
     /// A unique number within the process.
     uniq: u64,
+}
+
+impl fmt::Display for LevelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LVL-{}-{}", self.internal_seq, self.uniq)
+    }
 }
 
 impl LevelIndex {

--- a/src/meta/raft-store/src/leveled_store/leveled_map/impl_commit.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/impl_commit.rs
@@ -33,8 +33,8 @@ impl mvcc::Commit<Namespace, Key, Value> for LeveledMap {
         mut changes: BTreeMap<Namespace, Table<Key, Value>>,
     ) -> Result<(), Error> {
         info!(
-            "Committing changes to leveled map data: last_seq={}, changes = {:?}",
-            last_seq, changes
+            "Committing changes to leveled map data: last_seq={}",
+            last_seq
         );
         let mut inner = self.data.lock().unwrap();
 

--- a/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
+++ b/src/meta/raft-store/src/leveled_store/leveled_map/leveled_map_test.rs
@@ -68,7 +68,7 @@ async fn test_freeze() -> anyhow::Result<()> {
 
     let last_seq = immutables.newest().unwrap().sys_data().curr_seq();
 
-    let mut tmp = LeveledMap::default();
+    let tmp = LeveledMap::default();
     tmp.with_sys_data(|s| s.update_seq(last_seq));
     tmp.replace_immutable_levels(immutables);
     let view = tmp.to_view();
@@ -239,7 +239,7 @@ async fn test_two_levels() -> anyhow::Result<()> {
 
     let immutables = l.immutable_levels();
 
-    let mut tmp = LeveledMap::default();
+    let tmp = LeveledMap::default();
     tmp.replace_immutable_levels(immutables);
 
     let strm = tmp.range(user_key("").., u64::MAX).await?;

--- a/src/meta/raft-store/src/lib.rs
+++ b/src/meta/raft-store/src/lib.rs
@@ -41,6 +41,7 @@
 
 pub mod applier;
 pub mod config;
+pub mod immutable_compactor;
 pub mod key_spaces;
 pub mod leveled_store;
 pub mod ondisk;

--- a/src/meta/raft-store/src/sm_v003/sm_v003.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003.rs
@@ -26,6 +26,7 @@ use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::sys_data::SysData;
 use databend_common_meta_types::AppliedState;
 use log::debug;
+use log::info;
 use map_api::mvcc::ScopedGet;
 use openraft::entry::RaftEntry;
 use state_machine_api::SeqV;
@@ -281,9 +282,16 @@ impl SMV003 {
     }
 
     pub fn new_compactor(&self, permit: CompactorPermit) -> Compactor {
+        let immutable_data = self.leveled_map.immutable_data();
+
+        info!(
+            "new_compactor: with immutable data: {}",
+            immutable_data.stat()
+        );
+
         Compactor {
             _permit: permit,
-            immutable_data: self.leveled_map.immutable_data(),
+            immutable_data,
         }
     }
 

--- a/src/meta/service/Cargo.toml
+++ b/src/meta/service/Cargo.toml
@@ -56,6 +56,7 @@ prost = { workspace = true }
 raft-log = { workspace = true }
 rustls = { workspace = true }
 semver = { workspace = true }
+seq-marked = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serfig = { workspace = true }

--- a/src/meta/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/service/src/api/grpc/grpc_service.rs
@@ -498,7 +498,7 @@ impl MetaService for MetaServiceImpl {
         // This approach prevents race conditions and guarantees that no events will be
         // delivered out of order to the watcher.
         let stream = {
-            let sm = mn.raft_store.state_machine().get_inner();
+            let sm = mn.raft_store.get_sm_v003();
 
             let sender = mn.new_watch_sender(watch, tx.clone())?;
             let sender_str = sender.to_string();

--- a/src/meta/service/src/api/http/v1/features.rs
+++ b/src/meta/service/src/api/http/v1/features.rs
@@ -114,7 +114,7 @@ pub async fn set(
 
 pub fn features_state(meta_node: &Arc<MetaNode>) -> FeatureResponse {
     let enabled = {
-        let sm = meta_node.raft_store.state_machine().get_inner();
+        let sm = meta_node.raft_store.get_sm_v003();
         let x = sm.sys_data().features().clone();
         x.into_iter().collect()
     };

--- a/src/meta/service/src/store/meta_raft_log/mod.rs
+++ b/src/meta/service/src/store/meta_raft_log/mod.rs
@@ -27,7 +27,7 @@ mod impl_raft_log_storage;
 pub struct MetaRaftLog {
     pub(crate) id: NodeId,
     #[allow(dead_code)]
-    pub(crate) config: RaftConfig,
+    pub(crate) config: Arc<RaftConfig>,
     inner: Arc<RwLock<RaftLogV004>>,
 }
 
@@ -40,7 +40,7 @@ impl Deref for MetaRaftLog {
 }
 
 impl MetaRaftLog {
-    pub fn new(id: NodeId, config: RaftConfig, inner: RaftLogV004) -> Self {
+    pub fn new(id: NodeId, config: Arc<RaftConfig>, inner: RaftLogV004) -> Self {
         Self {
             id,
             config,

--- a/src/meta/service/src/store/meta_raft_state_machine/mod.rs
+++ b/src/meta/service/src/store/meta_raft_state_machine/mod.rs
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
+use databend_common_base::runtime::spawn_named;
 use databend_common_meta_raft_store::config::RaftConfig;
+use databend_common_meta_raft_store::immutable_compactor::InMemoryCompactor;
 use databend_common_meta_raft_store::sm_v003::SnapshotStoreV004;
 use databend_common_meta_raft_store::sm_v003::WriteEntry;
 use databend_common_meta_raft_store::sm_v003::SMV003;
@@ -28,9 +32,12 @@ use databend_common_meta_types::raft_types::SnapshotMeta;
 use databend_common_meta_types::raft_types::StorageError;
 use databend_common_meta_types::snapshot_db::DB;
 use databend_common_metrics::count::Count;
+use futures::FutureExt;
 use futures::TryStreamExt;
 use log::error;
 use log::info;
+use seq_marked::InternalSeq;
+use tokio::sync::oneshot;
 
 use crate::metrics::raft_metrics;
 use crate::metrics::SnapshotBuilding;
@@ -42,27 +49,76 @@ mod raft_state_machine_impl;
 pub struct MetaRaftStateMachine {
     pub(crate) id: NodeId,
 
-    pub(crate) config: RaftConfig,
+    pub(crate) config: Arc<RaftConfig>,
+
+    pub(crate) in_memory_compactor_cancel: Option<Arc<oneshot::Sender<()>>>,
 
     inner: Arc<Mutex<Arc<SMV003>>>,
 }
 
 impl MetaRaftStateMachine {
-    pub fn new(id: NodeId, config: RaftConfig, inner: Arc<SMV003>) -> Self {
+    pub fn new(id: NodeId, config: Arc<RaftConfig>, inner: Arc<SMV003>) -> Self {
         Self {
             id,
             config,
+            in_memory_compactor_cancel: None,
             inner: Arc::new(Mutex::new(inner)),
         }
     }
 
-    pub fn get_inner(&self) -> Arc<SMV003> {
-        self.inner.lock().unwrap().clone()
+    pub(crate) fn spawn_in_memory_compactor(&mut self, interval: Duration) {
+        let (tx, rx) = oneshot::channel();
+
+        self.in_memory_compactor_cancel = Some(Arc::new(tx));
+
+        let fu = Self::compact_loop(self.clone(), interval, rx);
+
+        let _j = spawn_named(fu, "in_memory_compactor".to_string());
     }
 
-    pub fn set_inner(&self, inner: Arc<SMV003>) {
+    async fn compact_loop(self, interval: Duration, cancel: oneshot::Receiver<()>) {
+        let mut c = std::pin::pin!(cancel);
+
+        loop {
+            let timeout_fu = tokio::time::sleep(interval);
+            futures::select! {
+                _ = c.as_mut().fuse() => {
+                    info!("in_memory_compact canceled by user");
+                    return;
+                }
+
+                _ = timeout_fu.fuse() => {
+                    info!("in_memory_compact is woken up, try to compact");
+                }
+
+            }
+
+            Self::in_memory_compact_once(self.get_inner()).await
+        }
+    }
+
+    async fn in_memory_compact_once(sm: Arc<SMV003>) {
+        let compactor = InMemoryCompactor::new(sm, "in_memory_compactor").await;
+
+        // 1. freeze the writable
+        let immutable_compactor = compactor.freeze();
+
+        // 2. compact two adjacent levels if needed.
+        // TODO: add snapshot seq when a mvcc is created.
+        //       currently, use the max value to eliminate all older records.
+        let min_snapshot_seq = InternalSeq::new(u64::MAX);
+        immutable_compactor.compact(min_snapshot_seq);
+
+        info!("in_memory_compact completed");
+    }
+
+    pub fn get_inner(&self) -> Arc<SMV003> {
+        self.inner.lock().unwrap().deref().clone()
+    }
+
+    pub fn set_inner(&self, sm: Arc<SMV003>) {
         let mut guard = self.inner.lock().unwrap();
-        *guard = inner;
+        *guard = sm;
     }
 
     #[fastrace::trace]
@@ -73,19 +129,19 @@ impl MetaRaftStateMachine {
 
         let _guard = SnapshotBuilding::guard();
 
-        let mut compactor_permit = self
-            .get_inner()
+        let sm_v003 = self.get_inner();
+        let mut compactor_permit = sm_v003
             .new_compactor_acquirer("build_snapshot")
             .acquire()
             .await;
         {
-            let mut writer_permit = self.get_inner().acquire_writer_permit().await;
-            self.get_inner()
+            let mut writer_permit = sm_v003.acquire_writer_permit().await;
+            sm_v003
                 .leveled_map()
                 .freeze_writable(&mut writer_permit, &mut compactor_permit);
         }
 
-        let mut compactor = self.get_inner().new_compactor(compactor_permit);
+        let mut compactor = sm_v003.new_compactor(compactor_permit);
 
         info!("do_build_snapshot compactor created");
 
@@ -168,7 +224,7 @@ impl MetaRaftStateMachine {
             snapshot_stat :% = db.stat(); "do_build_snapshot complete");
 
         {
-            self.get_inner()
+            sm_v003
                 .leveled_map()
                 .replace_with_compacted(&mut compactor, db.clone());
             info!("do_build_snapshot-replace_with_compacted returned");
@@ -198,7 +254,7 @@ impl MetaRaftStateMachine {
 
     /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.
     #[fastrace::trace]
-    pub async fn do_install_snapshot(&self, db: DB) -> Result<(), MetaStorageError> {
+    pub async fn do_install_snapshot(&mut self, db: DB) -> Result<(), MetaStorageError> {
         let data_size = db.inner().file_size();
         let sys_data = db.sys_data().clone();
 
@@ -231,16 +287,13 @@ impl MetaRaftStateMachine {
 
         let new_sm = sm.install_snapshot_v003(db);
 
-        {
-            let mut g = self.inner.lock().unwrap();
-            *g = Arc::new(new_sm);
-        }
+        self.set_inner(Arc::new(new_sm));
 
         Ok(())
     }
 
     /// Return a snapshot store of this instance.
     pub fn snapshot_store(&self) -> SnapshotStoreV004 {
-        SnapshotStoreV004::new(self.config.clone())
+        SnapshotStoreV004::new(self.config.as_ref().clone())
     }
 }

--- a/src/meta/service/src/store/meta_raft_state_machine/raft_state_machine_impl.rs
+++ b/src/meta/service/src/store/meta_raft_state_machine/raft_state_machine_impl.rs
@@ -94,7 +94,7 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
 
         let sig = meta.signature();
 
-        let ss_store = SnapshotStoreV004::new(self.config.clone());
+        let ss_store = SnapshotStoreV004::new(self.config.as_ref().clone());
         let (storage_path, rel_path) = ss_store
             .snapshot_config()
             .move_to_final_path(&snapshot.path(), meta.snapshot_id.clone())

--- a/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_kv_api_expire.rs
@@ -114,7 +114,7 @@ async fn test_meta_node_replicate_kv_with_expire() -> anyhow::Result<()> {
     // This way on every node applying a log always get the same result.
     info!("--- get updated kv with new expire, assert the updated value");
     {
-        let sm = learner.raft_store.state_machine().get_inner();
+        let sm = learner.raft_store.get_sm_v003();
         let resp = sm.kv_api().get_kv(key).await.unwrap();
         let seq_v = resp.unwrap();
         assert_eq!(

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -138,7 +138,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
 
     for i in 0..n_req {
         let key = format!("test_meta_node_snapshot_replication-key-{}", i);
-        let sm = mn1.raft_store.state_machine().get_inner();
+        let sm = mn1.raft_store.get_sm_v003();
         let got = sm.get_maybe_expired_kv(&key).await?;
         match got {
             None => {

--- a/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
+++ b/src/meta/service/tests/it/meta_node/t90_time_revert_cross_snapshot_boundary.rs
@@ -127,8 +127,7 @@ async fn write_two_logs(
     // Check final state
     let result = meta_node
         .raft_store
-        .state_machine()
-        .get_inner()
+        .get_sm_v003()
         .kv_api()
         .get_kv("k1")
         .await?;

--- a/src/meta/service/tests/it/store.rs
+++ b/src/meta/service/tests/it/store.rs
@@ -208,7 +208,7 @@ async fn test_meta_store_build_snapshot() -> anyhow::Result<()> {
     let (logs, want) = snapshot_logs();
 
     sto.log().clone().blocking_append(logs.clone()).await?;
-    sto.state_machine().get_inner().apply_entries(logs).await?;
+    sto.get_sm_v003().apply_entries(logs).await?;
 
     let curr_snap = sto.state_machine().clone().build_snapshot().await?;
     assert_eq!(Some(new_log_id(1, 0, 9)), curr_snap.meta.last_log_id);
@@ -257,8 +257,8 @@ async fn test_meta_store_current_snapshot() -> anyhow::Result<()> {
 
     sto.log().clone().blocking_append(logs.clone()).await?;
     {
-        let sm = sto.state_machine();
-        sm.get_inner().apply_entries(logs).await?;
+        let sm = sto.get_sm_v003();
+        sm.apply_entries(logs).await?;
     }
 
     sto.state_machine().clone().build_snapshot().await?;
@@ -306,7 +306,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
         info!("--- feed logs and state machine");
 
         sto.log().clone().blocking_append(logs.clone()).await?;
-        sto.state_machine().get_inner().apply_entries(logs).await?;
+        sto.get_sm_v003().apply_entries(logs).await?;
 
         snap = sto.state_machine().clone().build_snapshot().await?;
     }
@@ -329,12 +329,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
 
         info!("--- check installed meta");
         {
-            let mem = sto
-                .state_machine()
-                .get_inner()
-                .sys_data()
-                .last_membership_ref()
-                .clone();
+            let mem = sto.get_sm_v003().sys_data().last_membership_ref().clone();
 
             assert_eq!(
                 StoredMembership::new(
@@ -344,11 +339,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
                 mem
             );
 
-            let last_applied = *sto
-                .state_machine()
-                .get_inner()
-                .sys_data()
-                .last_applied_ref();
+            let last_applied = *sto.get_sm_v003().sys_data().last_applied_ref();
             assert_eq!(Some(log_id(1, 0, 9)), last_applied);
         }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

#### refactor: meta-service: compact immutable levels periodically

Add a background task to compact immutable levels into bigger one.
Thus the size of the top writable level won't  grow too big before
building a snapshot.

with config `compact_immutables_ms = 2000`(default enabled: 1000ms), the
`snapshot_logs_since_last` is allowed to set a larger value, in order to
reduce the rate of building a snapshot.

To reduce cache invalidation, a recommended config is:
```
compact_immutables_ms = 1000
snapshot_logs_since_last = 55000
```

I.e., build a snapshot for each 55,000 applied raft-log entries.

`compact_immutables_ms` is enabled by default with interval `1000 ms`,
set to `0` to disable it for testing.

#### Testing

Add a learner node with `databend-meta --join ... --learner`
to replciate the data with `compact_immutables_ms` enabeld, and with a
larger `snapshot_logs_since_last` value,  ensure the `last_seq` matches
the leaders.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change




- [x] Refactoring



## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18757)
<!-- Reviewable:end -->
