### PR TITLE
feat(meta): add member-list subcommand to databend-metactl

### DIFF
--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -34,6 +34,7 @@ use databend_common_meta_control::args::GlobalArgs;
 use databend_common_meta_control::args::ImportArgs;
 use databend_common_meta_control::args::ListFeatures;
 use databend_common_meta_control::args::LuaArgs;
+use databend_common_meta_control::args::MemberListArgs;
 use databend_common_meta_control::args::MetricsArgs;
 use databend_common_meta_control::args::SetFeature;
 use databend_common_meta_control::args::StatusArgs;
@@ -286,6 +287,17 @@ return metrics, nil
         }
     }
 
+    async fn member_list(&self, args: &MemberListArgs) -> anyhow::Result<()> {
+        let addresses = vec![args.grpc_api_address.clone()];
+        let client = self.new_grpc_client(addresses)?;
+
+        let res = client.get_member_list().await?;
+        for member in res.data {
+            println!("{}", member);
+        }
+        Ok(())
+    }
+
     fn new_grpc_client(&self, addresses: Vec<String>) -> Result<Arc<ClientHandle>, CreationError> {
         lua_support::new_grpc_client(addresses, &BUILD_INFO)
     }
@@ -305,6 +317,7 @@ enum CtlCommand {
     Upsert(UpsertArgs),
     Get(GetArgs),
     Lua(LuaArgs),
+    MemberList(MemberListArgs),
     Metrics(MetricsArgs),
 }
 
@@ -379,6 +392,9 @@ async fn main() -> anyhow::Result<()> {
             }
             CtlCommand::Lua(args) => {
                 app.run_lua(args).await?;
+            }
+            CtlCommand::MemberList(args) => {
+                app.member_list(args).await?;
             }
             CtlCommand::Metrics(args) => {
                 app.get_metrics(args).await?;

--- a/src/meta/client/src/client_handle.rs
+++ b/src/meta/client/src/client_handle.rs
@@ -28,6 +28,7 @@ use databend_common_base::runtime::UnlimitedFuture;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
+use databend_common_meta_types::protobuf::MemberListReply;
 use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
@@ -237,6 +238,11 @@ impl ClientHandle {
     #[async_backtrace::framed]
     pub async fn get_cluster_status(&self) -> Result<ClusterStatus, MetaClientError> {
         self.request(message::GetClusterStatus {}).await
+    }
+
+    #[async_backtrace::framed]
+    pub async fn get_member_list(&self) -> Result<MemberListReply, MetaClientError> {
+        self.request(message::GetMemberList {}).await
     }
 
     #[async_backtrace::framed]

--- a/src/meta/client/src/grpc_action.rs
+++ b/src/meta/client/src/grpc_action.rs
@@ -25,6 +25,7 @@ use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
+use databend_common_meta_types::protobuf::MemberListReply;
 use databend_common_meta_types::protobuf::RaftRequest;
 use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::protobuf::WatchRequest;
@@ -43,6 +44,7 @@ use crate::message::ExportReq;
 use crate::message::GetClientInfo;
 use crate::message::GetClusterStatus;
 use crate::message::GetEndpoints;
+use crate::message::GetMemberList;
 use crate::message::MakeEstablishedClient;
 use crate::message::Streamed;
 use crate::InitFlag;
@@ -203,6 +205,10 @@ impl RequestFor for TxnRequest {
 
 impl RequestFor for GetClusterStatus {
     type Reply = ClusterStatus;
+}
+
+impl RequestFor for GetMemberList {
+    type Reply = MemberListReply;
 }
 
 impl RequestFor for GetClientInfo {

--- a/src/meta/client/src/grpc_client.rs
+++ b/src/meta/client/src/grpc_client.rs
@@ -414,6 +414,10 @@ impl MetaGrpcClient {
                 let resp = self.get_cluster_status().await;
                 Response::GetClusterStatus(resp)
             }
+            message::Request::GetMemberList(_) => {
+                let resp = self.get_member_list().await;
+                Response::GetMemberList(resp)
+            }
             message::Request::GetClientInfo(_) => {
                 let resp = self.get_client_info().await;
                 Response::GetClientInfo(resp)
@@ -823,6 +827,19 @@ impl MetaGrpcClient {
         let mut client = self.get_established_client().await?;
         client.ensure_feature("get_cluster_status")?;
         let res = client.get_cluster_status(Empty {}).await?;
+        Ok(res.into_inner())
+    }
+
+    /// Get member list
+    #[fastrace::trace]
+    #[async_backtrace::framed]
+    pub async fn get_member_list(&self) -> Result<MemberListReply, MetaClientError> {
+        debug!("{}::get_member_list", self);
+        let mut client = self.get_established_client().await?;
+        let req = MemberListRequest {
+            data: "".to_string(),
+        };
+        let res = client.member_list(req).await?;
         Ok(res.into_inner())
     }
 

--- a/src/meta/client/src/message.rs
+++ b/src/meta/client/src/message.rs
@@ -23,6 +23,7 @@ use databend_common_meta_kvapi::kvapi::UpsertKVReply;
 use databend_common_meta_types::protobuf::ClientInfo;
 use databend_common_meta_types::protobuf::ClusterStatus;
 use databend_common_meta_types::protobuf::ExportedChunk;
+use databend_common_meta_types::protobuf::MemberListReply;
 use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
@@ -116,6 +117,9 @@ pub enum Request {
     /// Get cluster status, for metactl
     GetClusterStatus(GetClusterStatus),
 
+    /// Get member list, for metactl
+    GetMemberList(GetMemberList),
+
     /// Get info about the client
     GetClientInfo(GetClientInfo),
 }
@@ -133,6 +137,7 @@ impl Request {
             Request::MakeEstablishedClient(_) => "MakeClient",
             Request::GetEndpoints(_) => "GetEndpoints",
             Request::GetClusterStatus(_) => "GetClusterStatus",
+            Request::GetMemberList(_) => "GetMemberList",
             Request::GetClientInfo(_) => "GetClientInfo",
         }
     }
@@ -151,6 +156,7 @@ pub enum Response {
     MakeEstablishedClient(Result<EstablishedClient, MetaClientError>),
     GetEndpoints(Result<Vec<String>, MetaError>),
     GetClusterStatus(Result<ClusterStatus, MetaClientError>),
+    GetMemberList(Result<MemberListReply, MetaClientError>),
     GetClientInfo(Result<ClientInfo, MetaClientError>),
 }
 
@@ -187,6 +193,9 @@ impl fmt::Debug for Response {
             Response::GetClusterStatus(x) => {
                 write!(f, "GetClusterStatus({:?})", x)
             }
+            Response::GetMemberList(x) => {
+                write!(f, "GetMemberList({:?})", x)
+            }
             Response::GetClientInfo(x) => {
                 write!(f, "GetClientInfo({:?})", x)
             }
@@ -215,6 +224,7 @@ impl Response {
             Response::MakeEstablishedClient(res) => to_err(res),
             Response::GetEndpoints(res) => to_err(res),
             Response::GetClusterStatus(res) => to_err(res),
+            Response::GetMemberList(res) => to_err(res),
             Response::GetClientInfo(res) => to_err(res),
         };
 
@@ -244,6 +254,10 @@ pub struct GetEndpoints {}
 /// Get cluster status
 #[derive(Clone, Debug)]
 pub struct GetClusterStatus {}
+
+/// Get member list
+#[derive(Clone, Debug)]
+pub struct GetMemberList {}
 
 /// Get info about client
 #[derive(Clone, Debug)]

--- a/src/meta/control/src/args.rs
+++ b/src/meta/control/src/args.rs
@@ -276,3 +276,9 @@ pub struct MetricsArgs {
     #[clap(long, default_value = "127.0.0.1:28002")]
     pub admin_api_address: String,
 }
+
+#[derive(Debug, Clone, Deserialize, Args)]
+pub struct MemberListArgs {
+    #[clap(long, default_value = "127.0.0.1:9191")]
+    pub grpc_api_address: String,
+}

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_member_list.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_member_list.rs
@@ -1,0 +1,167 @@
+// Copyright 2025 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use databend_common_base::base::tokio::time::sleep;
+use databend_common_base::base::tokio::time::Duration;
+use databend_common_meta_sled_store::openraft::ServerState;
+use databend_common_version::BUILD_INFO;
+use databend_meta::message::ForwardRequest;
+use databend_meta::message::ForwardRequestBody;
+use databend_meta::message::JoinRequest;
+use databend_meta::meta_service::MetaNode;
+use pretty_assertions::assert_eq;
+use test_harness::test;
+
+use crate::testing::meta_service_test_harness;
+use crate::tests::service::MetaSrvTestContext;
+
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_member_list() -> anyhow::Result<()> {
+    // - Start a metasrv server.
+    // - Get member list
+
+    let (tc, _addr) = crate::tests::start_metasrv().await?;
+
+    let client = tc.grpc_client().await?;
+
+    let resp = client.get_member_list().await?;
+    println!("member list: {:?}", resp);
+
+    // The member list should contain at least one member (the current node)
+    assert!(!resp.data.is_empty(), "member list should not be empty");
+
+    // Each member address should be in the expected format (host:port)
+    for member in &resp.data {
+        assert!(
+            member.contains(':'),
+            "member address should contain port: {}",
+            member
+        );
+        // Check that the address has valid format like "127.0.0.1:port" or "host:port"
+        let parts: Vec<&str> = member.split(':').collect();
+        assert_eq!(
+            parts.len(),
+            2,
+            "member address should have host:port format: {}",
+            member
+        );
+
+        // Check that port is a valid number
+        let port = parts[1].parse::<u16>();
+        assert!(
+            port.is_ok(),
+            "member address should have valid port number: {}",
+            member
+        );
+    }
+
+    Ok(())
+}
+
+#[test(harness = meta_service_test_harness)]
+#[fastrace::trace]
+async fn test_member_list_with_learner() -> anyhow::Result<()> {
+    // This test verifies that member_list API returns both voters and learners
+    // Start with 2 voters, then add 1 learner
+
+    // Start initial cluster with 2 voters
+    let tcs = crate::tests::start_metasrv_cluster(&[0, 1]).await?;
+
+    // Create a learner node but don't start it as part of the initial cluster
+    let learner_node_id = 2;
+    let learner_tc = MetaSrvTestContext::new(learner_node_id);
+    let learner_mn = MetaNode::open(&learner_tc.config.raft_config, &BUILD_INFO).await?;
+
+    // Get the leader to send join request
+    let leader_tc = &tcs[0];
+    let leader_mn = leader_tc.grpc_srv.as_ref().unwrap().meta_node.clone();
+
+    // Join the learner to the cluster
+    let endpoint = learner_tc.config.raft_config.raft_api_addr().await?;
+    let grpc_api_advertise_address = learner_tc
+        .config
+        .grpc_api_advertise_address()
+        .unwrap_or_else(|| "127.0.0.1:29191".to_string());
+
+    let admin_req = ForwardRequest {
+        forward_to_leader: 0,
+        body: ForwardRequestBody::Join(
+            JoinRequest::new(
+                learner_node_id,
+                endpoint,
+                Some(grpc_api_advertise_address.clone()),
+            )
+            .with_role_learner(),
+        ),
+    };
+
+    leader_mn.handle_forwardable_request(admin_req).await?;
+
+    // Wait for the learner to be added and reach the correct state
+    sleep(Duration::from_millis(1000)).await;
+
+    // Verify learner state
+    learner_mn
+        .raft
+        .wait(Some(Duration::from_secs(10)))
+        .state(ServerState::Learner, "learner should be in learner state")
+        .await?;
+
+    // Get member list from leader
+    let client = leader_tc.grpc_client().await?;
+    let resp = client.get_member_list().await?;
+
+    println!("member list with 2 voters + 1 learner: {:?}", resp);
+
+    // Should have exactly 3 members (2 voters + 1 learner)
+    assert_eq!(
+        resp.data.len(),
+        3,
+        "member list should contain exactly 3 members (2 voters + 1 learner), got: {}",
+        resp.data.len()
+    );
+
+    // Collect expected addresses
+    let mut expected_addresses = HashSet::new();
+    for tc in &tcs {
+        if let Some(addr) = tc.config.grpc_api_advertise_address() {
+            expected_addresses.insert(addr);
+        }
+    }
+    expected_addresses.insert(grpc_api_advertise_address.clone());
+
+    // Verify all expected addresses are in the member list
+    let member_set: HashSet<String> = resp.data.into_iter().collect();
+
+    assert_eq!(
+        expected_addresses.len(),
+        3,
+        "should have 3 expected addresses, got: {}",
+        expected_addresses.len()
+    );
+
+    for expected_addr in &expected_addresses {
+        assert!(
+            member_set.contains(expected_addr),
+            "member list should contain expected address: {}, got: {:?}",
+            expected_addr,
+            member_set
+        );
+    }
+
+    Ok(())
+}

--- a/src/meta/service/tests/it/grpc/mod.rs
+++ b/src/meta/service/tests/it/grpc/mod.rs
@@ -20,6 +20,7 @@ pub mod metasrv_grpc_handshake;
 pub mod metasrv_grpc_kv_api;
 pub mod metasrv_grpc_kv_api_restart_cluster;
 pub mod metasrv_grpc_kv_read_v1;
+pub mod metasrv_grpc_member_list;
 pub mod metasrv_grpc_schema_api;
 pub mod metasrv_grpc_schema_api_follower_follower;
 pub mod metasrv_grpc_schema_api_leader_follower;

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -32,7 +32,7 @@ use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::storage::StorageParams;
-use databend_common_meta_kvapi::kvapi::KVApi;
+use databend_common_meta_kvapi::kvapi::KvApiExt;
 use databend_common_meta_store::MetaStore;
 use databend_common_meta_store::MetaStoreProvider;
 use databend_common_meta_types::TxnRequest;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta): add member-list subcommand to databend-metactl

Add a new `member-list` subcommand to databend-metactl that calls the
meta grpc member_list API to display cluster member addresses, including
voters and non-voters(learners)

Changes:
- Add MemberListArgs struct and CLI handling in metactl
- Implement get_member_list() method in MetaGrpcClient

Usage: databend-metactl member-list [--grpc-api-address <addr>]

Example:
```
$ databend-metactl member-list
127.0.0.1:9191

$ databend-metactl member-list --grpc-api-address meta1.example.com:9191
meta1.example.com:9191
meta2.example.com:9191
meta3.example.com:9191
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18760)
<!-- Reviewable:end -->
