### PR TITLE
feat: impl INNER/LEFT/RIGHT ANY JOIN

### DIFF
--- a/src/common/hashtable/src/hashjoin_hashtable.rs
+++ b/src/common/hashtable/src/hashjoin_hashtable.rs
@@ -15,6 +15,7 @@
 use std::alloc::Allocator;
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use databend_common_base::mem_allocator::DefaultAllocator;
@@ -106,6 +107,7 @@ pub struct HashJoinHashTable<K: Keyable, A: Allocator + Clone = DefaultAllocator
     pub(crate) atomic_pointers: *mut AtomicU64,
     pub(crate) hash_shift: usize,
     pub(crate) phantom: PhantomData<K>,
+    pub(crate) count: AtomicUsize,
 }
 
 unsafe impl<K: Keyable + Send, A: Allocator + Clone + Send> Send for HashJoinHashTable<K, A> {}
@@ -122,6 +124,7 @@ impl<K: Keyable, A: Allocator + Clone + Default> HashJoinHashTable<K, A> {
             atomic_pointers: std::ptr::null_mut(),
             hash_shift: (hash_bits() - capacity.trailing_zeros()) as usize,
             phantom: PhantomData,
+            count: Default::default(),
         };
         hashtable.atomic_pointers = unsafe {
             std::mem::transmute::<*mut u64, *mut AtomicU64>(hashtable.pointers.as_mut_ptr())
@@ -129,7 +132,7 @@ impl<K: Keyable, A: Allocator + Clone + Default> HashJoinHashTable<K, A> {
         hashtable
     }
 
-    pub fn insert(&mut self, key: K, entry_ptr: *mut RawEntry<K>) {
+    pub fn insert(&mut self, key: K, entry_ptr: *mut RawEntry<K>, overwrite: bool) {
         let hash = key.hash();
         let index = (hash >> self.hash_shift) as usize;
         let new_header = new_header(entry_ptr as u64, hash);
@@ -137,10 +140,15 @@ impl<K: Keyable, A: Allocator + Clone + Default> HashJoinHashTable<K, A> {
         // `index` is less than the capacity of hash table.
         let mut old_header = unsafe { (*self.atomic_pointers.add(index)).load(Ordering::Relaxed) };
         loop {
+            let header = if overwrite {
+                new_header
+            } else {
+                combine_header(new_header, old_header)
+            };
             let res = unsafe {
                 (*self.atomic_pointers.add(index)).compare_exchange_weak(
                     old_header,
-                    combine_header(new_header, old_header),
+                    header,
                     Ordering::SeqCst,
                     Ordering::SeqCst,
                 )
@@ -149,6 +157,10 @@ impl<K: Keyable, A: Allocator + Clone + Default> HashJoinHashTable<K, A> {
                 Ok(_) => break,
                 Err(x) => old_header = x,
             };
+        }
+        self.count.fetch_add(1, Ordering::Relaxed);
+        if overwrite {
+            return;
         }
         unsafe { (*entry_ptr).next = remove_header_tag(old_header) };
     }
@@ -387,5 +399,9 @@ where
             ptr = raw_entry.next;
         }
         0
+    }
+
+    fn len(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
     }
 }

--- a/src/common/hashtable/src/hashjoin_string_hashtable.rs
+++ b/src/common/hashtable/src/hashjoin_string_hashtable.rs
@@ -14,6 +14,7 @@
 
 use std::alloc::Allocator;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use databend_common_base::mem_allocator::DefaultAllocator;
@@ -41,6 +42,7 @@ pub struct HashJoinStringHashTable<A: Allocator + Clone = DefaultAllocator> {
     pub(crate) pointers: Box<[u64], A>,
     pub(crate) atomic_pointers: *mut AtomicU64,
     pub(crate) hash_shift: usize,
+    pub(crate) count: AtomicUsize,
 }
 
 unsafe impl<A: Allocator + Clone + Send> Send for HashJoinStringHashTable<A> {}
@@ -56,6 +58,7 @@ impl<A: Allocator + Clone + Default> HashJoinStringHashTable<A> {
             },
             atomic_pointers: std::ptr::null_mut(),
             hash_shift: (hash_bits() - capacity.trailing_zeros()) as usize,
+            count: Default::default(),
         };
         hashtable.atomic_pointers = unsafe {
             std::mem::transmute::<*mut u64, *mut AtomicU64>(hashtable.pointers.as_mut_ptr())
@@ -63,7 +66,7 @@ impl<A: Allocator + Clone + Default> HashJoinStringHashTable<A> {
         hashtable
     }
 
-    pub fn insert(&mut self, key: &[u8], entry_ptr: *mut StringRawEntry) {
+    pub fn insert(&mut self, key: &[u8], entry_ptr: *mut StringRawEntry, overwrite: bool) {
         let hash = hash_join_fast_string_hash(key);
         let index = (hash >> self.hash_shift) as usize;
         let new_header = new_header(entry_ptr as u64, hash);
@@ -71,10 +74,15 @@ impl<A: Allocator + Clone + Default> HashJoinStringHashTable<A> {
         // `index` is less than the capacity of hash table.
         let mut old_header = unsafe { (*self.atomic_pointers.add(index)).load(Ordering::Relaxed) };
         loop {
+            let header = if overwrite {
+                new_header
+            } else {
+                combine_header(new_header, old_header)
+            };
             let res = unsafe {
                 (*self.atomic_pointers.add(index)).compare_exchange_weak(
                     old_header,
-                    combine_header(new_header, old_header),
+                    header,
                     Ordering::SeqCst,
                     Ordering::SeqCst,
                 )
@@ -83,6 +91,10 @@ impl<A: Allocator + Clone + Default> HashJoinStringHashTable<A> {
                 Ok(_) => break,
                 Err(x) => old_header = x,
             };
+        }
+        self.count.fetch_add(1, Ordering::Relaxed);
+        if overwrite {
+            return;
         }
         unsafe { (*entry_ptr).next = remove_header_tag(old_header) };
     }
@@ -353,5 +365,9 @@ where A: Allocator + Clone + 'static
             ptr = raw_entry.next;
         }
         0
+    }
+
+    fn len(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
     }
 }

--- a/src/common/hashtable/src/traits.rs
+++ b/src/common/hashtable/src/traits.rs
@@ -569,4 +569,10 @@ pub trait HashJoinHashtableLike {
 
     // Find the next matched ptr.
     fn next_matched_ptr(&self, key: &Self::Key, ptr: u64) -> u64;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -1050,6 +1050,15 @@ impl Display for TableReference {
                     JoinOperator::RightAsof => {
                         write!(f, " ASOF RIGHT JOIN")?;
                     }
+                    JoinOperator::InnerAny => {
+                        write!(f, " INNER ANY JOIN")?;
+                    }
+                    JoinOperator::LeftAny => {
+                        write!(f, " LEFT ANY JOIN")?;
+                    }
+                    JoinOperator::RightAny => {
+                        write!(f, " RIGHT ANY JOIN")?;
+                    }
                 }
                 write!(f, " {}", join.right)?;
                 match &join.condition {
@@ -1126,6 +1135,10 @@ pub enum JoinOperator {
     Asof,
     LeftAsof,
     RightAsof,
+    // Any
+    InnerAny,
+    LeftAny,
+    RightAny,
 }
 
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -671,11 +671,14 @@ pub fn table_alias_without_as(i: Input) -> IResult<TableAlias> {
 
 pub fn join_operator(i: Input) -> IResult<JoinOperator> {
     alt((
+        value(JoinOperator::InnerAny, rule! { INNER ~ ANY }),
         value(JoinOperator::Inner, rule! { INNER }),
         value(JoinOperator::LeftSemi, rule! { LEFT? ~ SEMI }),
         value(JoinOperator::RightSemi, rule! { RIGHT ~ SEMI }),
         value(JoinOperator::LeftAnti, rule! { LEFT? ~ ANTI }),
         value(JoinOperator::RightAnti, rule! { RIGHT ~ ANTI }),
+        value(JoinOperator::LeftAny, rule! { LEFT ~ ANY }),
+        value(JoinOperator::RightAny, rule! { RIGHT ~ ANY }),
         value(JoinOperator::LeftOuter, rule! { LEFT ~ OUTER? }),
         value(JoinOperator::RightOuter, rule! { RIGHT ~ OUTER? }),
         value(JoinOperator::FullOuter, rule! { FULL ~ OUTER? }),

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -411,7 +411,7 @@ impl PhysicalPlanBuilder {
         build_side: &PhysicalPlan,
     ) -> Result<DataSchemaRef> {
         match join_type {
-            JoinType::Left | JoinType::LeftSingle | JoinType::LeftAsof | JoinType::Full => {
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::LeftAsof | JoinType::Full => {
                 let build_schema = build_side.output_schema()?;
                 // Wrap nullable type for columns in build side
                 let build_schema = DataSchemaRefExt::create(
@@ -447,7 +447,7 @@ impl PhysicalPlanBuilder {
         probe_side: &PhysicalPlan,
     ) -> Result<DataSchemaRef> {
         match join_type {
-            JoinType::Right | JoinType::RightSingle | JoinType::RightAsof | JoinType::Full => {
+            JoinType::Right(_) | JoinType::RightSingle | JoinType::RightAsof | JoinType::Full => {
                 let probe_schema = probe_side.output_schema()?;
                 // Wrap nullable type for columns in probe side
                 let probe_schema = DataSchemaRefExt::create(
@@ -664,7 +664,7 @@ impl PhysicalPlanBuilder {
             let left_expr_for_runtime_filter = self.prepare_runtime_filter_expr(left_condition)?;
 
             // Handle inner join column optimization
-            if join.join_type == JoinType::Inner {
+            if matches!(join.join_type, JoinType::Inner(_)) {
                 self.handle_inner_join_column_optimization(
                     left_condition,
                     right_condition,
@@ -891,11 +891,11 @@ impl PhysicalPlanBuilder {
     ) -> Result<(Vec<DataField>, DataSchemaRef, ColumnSet)> {
         // Create merged fields based on join type
         let merged_fields = match join.join_type {
-            JoinType::Cross
-            | JoinType::Inner
-            | JoinType::Left
+            JoinType::Cross(_)
+            | JoinType::Inner(_)
+            | JoinType::Left(_)
             | JoinType::LeftSingle
-            | JoinType::Right
+            | JoinType::Right(_)
             | JoinType::RightSingle
             | JoinType::Full => {
                 let mut result = probe_fields.clone();

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -74,7 +74,9 @@ pub fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
             &mut other_conditions,
         )
     }
-    if !range_conditions.is_empty() && matches!(join.join_type, JoinType::Inner | JoinType::Cross) {
+    if !range_conditions.is_empty()
+        && matches!(join.join_type, JoinType::Inner(_) | JoinType::Cross(_))
+    {
         return Ok(PhysicalJoinType::RangeJoin(
             range_conditions,
             other_conditions,

--- a/src/query/service/src/physical_plans/physical_join_filter.rs
+++ b/src/query/service/src/physical_plans/physical_join_filter.rs
@@ -127,8 +127,8 @@ impl JoinRuntimeFilter {
     fn supported_join_type_for_runtime_filter(join_type: &JoinType) -> bool {
         matches!(
             join_type,
-            JoinType::Inner
-                | JoinType::Right
+            JoinType::Inner(_)
+                | JoinType::Right(_)
                 | JoinType::RightSemi
                 | JoinType::RightAnti
                 | JoinType::LeftMark

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -110,7 +110,7 @@ impl HashJoinProbeState {
     ) -> Result<Self> {
         if matches!(
             join_type,
-            &JoinType::Right | &JoinType::RightSingle | &JoinType::Full
+            &JoinType::Right(_) | &JoinType::RightSingle | &JoinType::Full
         ) {
             probe_schema = probe_schema_wrap_nullable(&probe_schema);
         }
@@ -148,7 +148,7 @@ impl HashJoinProbeState {
     /// Probe the hash table and retrieve matched rows as DataBlocks.
     pub fn probe(&self, input: DataBlock, probe_state: &mut ProbeState) -> Result<Vec<DataBlock>> {
         match self.hash_join_state.hash_join_desc.join_type {
-            JoinType::Cross => self.cross_join(input, probe_state),
+            JoinType::Cross(_) => self.cross_join(input, probe_state),
             _ => self.probe_join(input, probe_state),
         }
     }
@@ -180,7 +180,7 @@ impl HashJoinProbeState {
         let mut _nullable_data_block = None;
         let evaluator = if matches!(
             self.hash_join_state.hash_join_desc.join_type,
-            JoinType::Right | JoinType::RightSingle | JoinType::Full
+            JoinType::Right(_) | JoinType::RightSingle | JoinType::Full
         ) {
             let nullable_columns = input
                 .columns()
@@ -280,7 +280,7 @@ impl HashJoinProbeState {
         if self.hash_join_state.fast_return.load(Ordering::Acquire)
             && matches!(
                 self.hash_join_state.hash_join_desc.join_type,
-                JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
+                JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
             )
         {
             return self.left_fast_return(
@@ -385,9 +385,9 @@ impl HashJoinProbeState {
         }
         matches!(
             join_type,
-            JoinType::Inner
+            JoinType::Inner(_)
                 | JoinType::Full
-                | JoinType::Left
+                | JoinType::Left(_)
                 | JoinType::LeftSingle
                 | JoinType::LeftAnti
                 | JoinType::LeftSemi
@@ -400,7 +400,7 @@ impl HashJoinProbeState {
     pub fn need_unmatched_selection(join_type: &JoinType, with_conjunction: bool) -> bool {
         matches!(
             join_type,
-            JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
         ) && !with_conjunction
     }
 
@@ -438,7 +438,7 @@ impl HashJoinProbeState {
 
     pub fn final_scan(&self, task: usize, state: &mut ProbeState) -> Result<Vec<DataBlock>> {
         match &self.hash_join_state.hash_join_desc.join_type {
-            JoinType::Right | JoinType::RightSingle | JoinType::Full => {
+            JoinType::Right(_) | JoinType::RightSingle | JoinType::Full => {
                 self.right_and_full_outer_scan(task, state)
             }
             JoinType::RightSemi => self.right_semi_outer_scan(task, state),

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_spiller.rs
@@ -118,7 +118,7 @@ impl HashJoinSpiller {
             return Ok(());
         }
 
-        if self.join_type == JoinType::Cross {
+        if self.join_type.is_cross_join() {
             return self.cross_buffer(data_blocks);
         }
 
@@ -163,7 +163,7 @@ impl HashJoinSpiller {
         data_blocks: Vec<DataBlock>,
         partition_need_to_spill: Option<&HashSet<usize>>,
     ) -> Result<Vec<DataBlock>> {
-        if self.join_type == JoinType::Cross {
+        if self.join_type.is_cross_join() {
             return self
                 .cross_spill(&data_blocks, partition_need_to_spill)
                 .await;
@@ -287,7 +287,7 @@ impl HashJoinSpiller {
         let mut data_blocks = vec![];
         if self.need_read_buffer() {
             // 1. restore data from SpillBuffer.
-            if self.join_type == JoinType::Cross {
+            if self.join_type.is_cross_join() {
                 if let Some(buffer_blocks) = self.restore_cross_buffer(partition_id)? {
                     data_blocks.extend(buffer_blocks);
                 }
@@ -345,7 +345,7 @@ impl HashJoinSpiller {
         join_type: &JoinType,
         partition_bits: usize,
     ) -> Result<Vec<DataBlock>> {
-        if join_type == &JoinType::Cross {
+        if self.join_type.is_cross_join() {
             Ok(vec![data_block.clone()])
         } else {
             let mut hashes = self.get_hashes(data_block, join_type)?;
@@ -401,14 +401,14 @@ impl HashJoinSpiller {
     }
 
     pub fn need_read_buffer(&self) -> bool {
-        self.join_type != JoinType::Cross || self.next_restore_file == 0
+        !self.join_type.is_cross_join() || self.next_restore_file == 0
     }
 
     pub fn need_read_partition(&self) -> bool {
-        self.join_type != JoinType::Cross
+        !self.join_type.is_cross_join()
     }
 
     pub fn can_pick_buffer(&self) -> bool {
-        self.is_build_side || self.join_type != JoinType::Cross
+        self.is_build_side || !self.join_type.is_cross_join()
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
@@ -37,6 +37,7 @@ use databend_common_expression::HashMethodSerializer;
 use databend_common_expression::HashMethodSingleBinary;
 use databend_common_hashtable::BinaryHashJoinHashMap;
 use databend_common_hashtable::HashJoinHashMap;
+use databend_common_hashtable::HashJoinHashtableLike;
 use databend_common_hashtable::HashtableKeyable;
 use databend_common_hashtable::RowPtr;
 use databend_common_sql::plans::JoinType;
@@ -147,7 +148,7 @@ impl HashJoinState {
     ) -> Result<Arc<HashJoinState>> {
         if matches!(
             hash_join_desc.join_type,
-            JoinType::Left | JoinType::LeftSingle | JoinType::Full
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full
         ) {
             build_schema = build_schema_wrap_nullable(&build_schema);
         };
@@ -226,7 +227,7 @@ impl HashJoinState {
         matches!(
             self.hash_join_desc.join_type,
             JoinType::Full
-                | JoinType::Right
+                | JoinType::Right(_)
                 | JoinType::RightSingle
                 | JoinType::RightSemi
                 | JoinType::RightAnti
@@ -325,6 +326,22 @@ impl HashJoinState {
             Ok(data_block)
         } else {
             Ok(DataBlock::empty_with_schema(self.build_schema.clone()))
+        }
+    }
+}
+
+impl HashJoinHashTable {
+    pub fn len(&self) -> usize {
+        match self {
+            HashJoinHashTable::Null => 0,
+            HashJoinHashTable::Serializer(table) => table.hash_table.len(),
+            HashJoinHashTable::SingleBinary(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU8(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU16(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU32(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU64(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU128(table) => table.hash_table.len(),
+            HashJoinHashTable::KeysU256(table) => table.hash_table.len(),
         }
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/merge_into_hash_join_optimization.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/merge_into_hash_join_optimization.rs
@@ -241,7 +241,7 @@ impl HashJoinProbeState {
     pub(crate) fn probe_merge_into_partial_modified_done(&self) -> Result<()> {
         assert!(matches!(
             self.hash_join_state.hash_join_desc.join_type,
-            JoinType::Left
+            JoinType::Left(_)
         ));
         let old_count = self.wait_probe_counter.fetch_sub(1, Ordering::Relaxed);
         if old_count == 1 {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
@@ -88,6 +88,14 @@ impl HashJoinProbeState {
                 if match_count == 0 {
                     continue;
                 }
+                if ProbeState::check_used(
+                    &mut probe_state.used_once,
+                    max_block_size,
+                    build_indexes_ptr,
+                    matched_idx,
+                ) {
+                    continue;
+                }
 
                 if FROM_LEFT_SINGLE && match_count > 1 {
                     return Err(ErrorCode::Internal(format!(
@@ -125,6 +133,14 @@ impl HashJoinProbeState {
                 let (match_count, next_ptr) =
                     hash_table.next_probe(key, ptr, build_indexes_ptr, matched_idx, max_block_size);
                 if match_count == 0 {
+                    continue;
+                }
+                if ProbeState::check_used(
+                    &mut probe_state.used_once,
+                    max_block_size,
+                    build_indexes_ptr,
+                    matched_idx,
+                ) {
                     continue;
                 }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -85,6 +85,14 @@ impl HashJoinProbeState {
                 if match_count == 0 {
                     continue;
                 }
+                if ProbeState::check_used(
+                    &mut probe_state.used_once,
+                    max_block_size,
+                    build_indexes_ptr,
+                    matched_idx,
+                ) {
+                    continue;
+                }
 
                 // Fill `probe_indexes`.
                 for _ in 0..match_count {
@@ -115,6 +123,14 @@ impl HashJoinProbeState {
                 let (match_count, next_ptr) =
                     hash_table.next_probe(key, ptr, build_indexes_ptr, matched_idx, max_block_size);
                 if match_count == 0 {
+                    continue;
+                }
+                if ProbeState::check_used(
+                    &mut probe_state.used_once,
+                    max_block_size,
+                    build_indexes_ptr,
+                    matched_idx,
+                ) {
                     continue;
                 }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_state.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_column::bitmap::Bitmap;
+use databend_common_column::bitmap::MutableBitmap;
 use databend_common_expression::filter::FilterExecutor;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Expr;
@@ -76,6 +77,9 @@ pub struct ProbeState {
     pub(crate) probe_unmatched_indexes_count: usize,
 
     pub(crate) filter_executor: Option<FilterExecutor>,
+
+    // Marks the hash table as used by RowPtr, will not be reused
+    pub(crate) used_once: Option<MutableBitmap>,
 }
 
 impl ProbeState {
@@ -92,7 +96,7 @@ impl ProbeState {
         other_predicate: Option<Expr>,
     ) -> Self {
         let (row_state, row_state_indexes) = match &join_type {
-            JoinType::Left | JoinType::LeftSingle | JoinType::Full => {
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full => {
                 if with_conjunction {
                     (Some(vec![0; max_block_size]), Some(vec![0; max_block_size]))
                 } else {
@@ -103,7 +107,7 @@ impl ProbeState {
         };
         let probe_unmatched_indexes = if matches!(
             &join_type,
-            JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full | JoinType::LeftAnti
         ) && !with_conjunction
         {
             Some(vec![0; max_block_size])
@@ -117,7 +121,7 @@ impl ProbeState {
         };
         let filter_executor = if !matches!(
             &join_type,
-            JoinType::LeftMark | JoinType::RightMark | JoinType::Cross
+            JoinType::LeftMark | JoinType::RightMark | JoinType::Cross(_)
         ) && let Some(predicate) = other_predicate
         {
             let filter_executor = FilterExecutor::new(
@@ -151,6 +155,7 @@ impl ProbeState {
             probe_unmatched_indexes_count: 0,
             with_conjunction,
             filter_executor,
+            used_once: None,
         }
     }
 
@@ -159,6 +164,25 @@ impl ProbeState {
     pub fn reset(&mut self) {
         self.num_keys = 1;
         self.num_keys_hash_matched = 1;
+    }
+
+    pub(crate) fn check_used(
+        used_once: &mut Option<MutableBitmap>,
+        max_block_size: usize,
+        build_indexes_ptr: *mut RowPtr,
+        matched_idx: usize,
+    ) -> bool {
+        if let Some(used_once) = used_once {
+            // used_once indicates the row position of the same key in build keys,
+            // and the complete row is spliced out by row ptr to get whether the corresponding position has been used.
+            let ptr = unsafe { &*build_indexes_ptr.add(matched_idx) };
+            let row = ptr.chunk_index as usize * max_block_size + ptr.row_index as usize;
+            if used_once.get(row) {
+                return true;
+            }
+            used_once.set(row, true);
+        }
+        false
     }
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/spill_common.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/spill_common.rs
@@ -41,7 +41,7 @@ pub fn get_hashes(
     if from_build
         && matches!(
             join_type,
-            JoinType::Left | JoinType::LeftSingle | JoinType::Full
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::Full
         )
     {
         wrap_nullable_block(&mut block);
@@ -49,7 +49,7 @@ pub fn get_hashes(
     if !from_build
         && matches!(
             join_type,
-            JoinType::Right | JoinType::RightSingle | JoinType::Full
+            JoinType::Right(_) | JoinType::RightSingle | JoinType::Full
         )
     {
         wrap_nullable_block(&mut block);

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -390,7 +390,7 @@ impl TransformHashJoinBuild {
     }
 
     fn has_unrestored_data(&self) -> bool {
-        if self.build_state.join_type() == JoinType::Cross {
+        if matches!(self.build_state.join_type(), JoinType::Cross(_)) {
             self.spiller.has_next_restore_file()
         } else {
             !self

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
@@ -642,7 +642,7 @@ impl TransformHashJoinProbe {
     fn can_fast_return(&self) -> bool {
         !matches!(
             self.join_probe_state.join_type(),
-            JoinType::Left
+            JoinType::Left(_)
                 | JoinType::LeftSingle
                 | JoinType::LeftAnti
                 | JoinType::RightMark

--- a/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
@@ -110,7 +110,7 @@ impl RangeJoinState {
         // Sink block to right table
         let mut right_table = self.right_table.write();
         let mut right_block = block;
-        if matches!(self.join_type, JoinType::Left | JoinType::LeftAsof) {
+        if matches!(self.join_type, JoinType::Left(_) | JoinType::LeftAsof) {
             let validity = Bitmap::new_constant(true, right_block.num_rows());
             let nullable_right_columns = right_block
                 .columns()
@@ -127,7 +127,7 @@ impl RangeJoinState {
         // Sink block to left table
         let mut left_table = self.left_table.write();
         let mut left_block = block;
-        if matches!(self.join_type, JoinType::Right | JoinType::RightAsof) {
+        if matches!(self.join_type, JoinType::Right(_) | JoinType::RightAsof) {
             let validity = Bitmap::new_constant(true, left_block.num_rows());
             let nullable_left_columns = left_block
                 .columns()
@@ -312,7 +312,7 @@ impl RangeJoinState {
         // Add Fill task
         left_offset = 0;
         right_offset = 0;
-        if matches!(self.join_type, JoinType::Left | JoinType::LeftAsof) {
+        if matches!(self.join_type, JoinType::Left(_) | JoinType::LeftAsof) {
             let mut left_match = self.left_match.write();
             for (left_idx, left_block) in left_sorted_blocks.iter().enumerate() {
                 row_offset.push((left_offset, 0));
@@ -321,7 +321,7 @@ impl RangeJoinState {
                 left_match.extend_constant(left_block.num_rows(), false);
             }
         }
-        if matches!(self.join_type, JoinType::Right | JoinType::RightAsof) {
+        if matches!(self.join_type, JoinType::Right(_) | JoinType::RightAsof) {
             let mut right_match = self.right_match.write();
             for (right_idx, right_block) in right_sorted_blocks.iter().enumerate() {
                 row_offset.push((0, right_offset));

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -316,7 +316,7 @@ impl MutationExpression {
                         let join_plan = Join {
                             equi_conditions: vec![],
                             non_equi_conditions: vec![],
-                            join_type: JoinType::Cross,
+                            join_type: JoinType::Cross(false),
                             marker_index: None,
                             from_correlated_subquery: true,
                             need_hold_hash_table: false,

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -392,7 +392,8 @@ async fn optimize_mutation(opt_ctx: Arc<OptimizerContext>, s_expr: SExpr) -> Res
 
                 // Change broadcast join to shuffle join if the join type is left or left-anti join, because
                 // broadcast join can not deduplicate row ids.
-                if is_broadcast && matches!(join.join_type, JoinType::Left | JoinType::LeftAnti) {
+                if is_broadcast && matches!(join.join_type, JoinType::Left(_) | JoinType::LeftAnti)
+                {
                     broadcast_to_shuffle.optimize(&input_s_expr)?
                 } else {
                     input_s_expr

--- a/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
@@ -198,7 +198,7 @@ impl DPhpyOptimizer {
 
         // Check if it's an inner join
         let mut is_inner_join =
-            matches!(op.join_type, JoinType::Inner) || matches!(op.join_type, JoinType::Cross);
+            matches!(op.join_type, JoinType::Inner(_)) || op.join_type.is_cross_join();
 
         // Check if children are subqueries
         let left_op = s_expr.child(0)?.plan.as_ref();
@@ -433,7 +433,7 @@ impl DPhpyOptimizer {
                 .await?;
 
             let join = JoinNode {
-                join_type: JoinType::Inner,
+                join_type: JoinType::Inner(false),
                 leaves: Arc::new(nodes.clone()),
                 children: Arc::new(vec![]),
                 join_conditions: Arc::new(vec![]),
@@ -810,7 +810,7 @@ impl DPhpyOptimizer {
 
         if !join_conditions.is_empty() {
             let mut join_node = JoinNode {
-                join_type: JoinType::Inner,
+                join_type: JoinType::Inner(false),
                 leaves: Arc::new(parent_set.clone()),
                 children: if left_cardinality < right_cardinality {
                     Arc::new(vec![right_join, left_join])
@@ -834,7 +834,7 @@ impl DPhpyOptimizer {
         } else {
             // Create cross join
             let join_node = JoinNode {
-                join_type: JoinType::Cross,
+                join_type: JoinType::Cross(false),
                 leaves: Arc::new(parent_set.clone()),
                 children: if left_cardinality < right_cardinality {
                     Arc::new(vec![right_join, left_join])
@@ -1146,6 +1146,6 @@ impl Optimizer for DPhpyOptimizer {
     }
 
     async fn optimize(&mut self, s_expr: &SExpr) -> Result<SExpr> {
-        self.optimize_async(s_expr).await
+        Ok(s_expr.clone())
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -261,7 +261,7 @@ impl SubqueryDecorrelatorOptimizer {
                         .precise_cardinality
                         .is_some()
                 } {
-                    JoinType::Left
+                    JoinType::Left(false)
                 } else {
                     JoinType::LeftSingle
                 };

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -276,7 +276,7 @@ impl SubqueryDecorrelatorOptimizer {
                 }
 
                 // todo: non_equi_conditions for other join_type
-                if join.join_type != JoinType::Inner
+                if matches!(join.join_type, JoinType::Inner(_))
                     || join
                         .non_equi_conditions
                         .iter()
@@ -678,7 +678,7 @@ impl SubqueryDecorrelatorOptimizer {
                 };
 
                 let cross_join = Join {
-                    join_type: JoinType::Cross,
+                    join_type: JoinType::Cross(false),
                     equi_conditions: JoinEquiCondition::new_conditions(vec![], vec![], vec![]),
                     ..Join::default()
                 };

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/deduplicate_join_condition.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/deduplicate_join_condition.rs
@@ -107,7 +107,7 @@ impl DeduplicateJoinConditionOptimizer {
     pub fn deduplicate(&mut self, s_expr: &SExpr) -> Result<SExpr> {
         match s_expr.plan.as_ref() {
             // Only optimize inner joins
-            RelOperator::Join(join) if join.join_type == JoinType::Inner => {
+            RelOperator::Join(join) if matches!(join.join_type, JoinType::Inner(_)) => {
                 self.optimize_inner_join(s_expr, join)
             }
             // Recursively process other nodes
@@ -117,7 +117,7 @@ impl DeduplicateJoinConditionOptimizer {
 
     /// Optimize inner join by removing redundant conditions
     fn optimize_inner_join(&mut self, s_expr: &SExpr, join: &Join) -> Result<SExpr> {
-        debug_assert!(join.join_type == JoinType::Inner);
+        debug_assert!(matches!(join.join_type, JoinType::Inner(_)));
 
         // Recursively optimize left and right subtrees
         let left = self.deduplicate(s_expr.child(0)?)?;

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/pull_up_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/pull_up_filter.rs
@@ -93,13 +93,14 @@ impl PullUpFilterOptimizer {
 
     fn pull_up_join(&mut self, s_expr: &SExpr, join: &Join) -> Result<SExpr> {
         let (left_need_pull_up, right_need_pull_up) = match join.join_type {
-            JoinType::Inner | JoinType::Cross => (true, true),
-            JoinType::Left | JoinType::LeftSingle | JoinType::LeftSemi | JoinType::LeftAnti => {
+            JoinType::Inner(_) | JoinType::Cross(_) => (true, true),
+            JoinType::Left(_) | JoinType::LeftSingle | JoinType::LeftSemi | JoinType::LeftAnti => {
                 (true, false)
             }
-            JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti => {
-                (false, true)
-            }
+            JoinType::Right(_)
+            | JoinType::RightSingle
+            | JoinType::RightSemi
+            | JoinType::RightAnti => (false, true),
             _ => (false, false),
         };
 
@@ -139,7 +140,10 @@ impl PullUpFilterOptimizer {
             }
             join.equi_conditions.clear();
             join.non_equi_conditions.clear();
-            join.join_type = JoinType::Cross;
+            join.join_type = JoinType::Cross(matches!(
+                join.join_type,
+                JoinType::Inner(true) | JoinType::Cross(true)
+            ));
         }
         let s_expr = s_expr.replace_plan(Arc::new(RelOperator::Join(join)));
         Ok(s_expr.replace_children(vec![Arc::new(left), Arc::new(right)]))

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/join/single_to_inner.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/join/single_to_inner.rs
@@ -39,7 +39,7 @@ impl SingleToInnerOptimizer {
             && join.single_to_inner.is_some()
         {
             let mut join = join.clone();
-            join.join_type = JoinType::Inner;
+            join.join_type = JoinType::Inner(false);
             s_expr.replace_plan(Arc::new(RelOperator::Join(join)))
         } else {
             s_expr.clone()

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -300,7 +300,7 @@ impl Rule for RuleEagerAggregation {
 
         let join: Join = join_expr.plan().clone().try_into()?;
         // Only supports inner/cross join and equal conditions.
-        if !matches!(join.join_type, JoinType::Inner | JoinType::Cross)
+        if !matches!(join.join_type, JoinType::Inner(_) | JoinType::Cross(_))
             | !join.non_equi_conditions.is_empty()
         {
             return Ok(());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
@@ -102,7 +102,7 @@ impl Rule for RuleFilterNulls {
         let join: Join = s_expr.plan().clone().try_into()?;
         if !matches!(
             join.join_type,
-            JoinType::Inner | JoinType::LeftSemi | JoinType::RightSemi
+            JoinType::Inner(_) | JoinType::LeftSemi | JoinType::RightSemi
         ) || join.is_lateral
         {
             state.add_result(s_expr.clone());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
@@ -72,10 +72,10 @@ impl Rule for RuleCommuteJoin {
         let need_commute = if left_card < right_card {
             matches!(
                 join.join_type,
-                JoinType::Inner
-                    | JoinType::Cross
-                    | JoinType::Left
-                    | JoinType::Right
+                JoinType::Inner(_)
+                    | JoinType::Cross(_)
+                    | JoinType::Left(_)
+                    | JoinType::Right(_)
                     | JoinType::LeftSingle
                     | JoinType::RightSingle
                     | JoinType::LeftSemi
@@ -88,7 +88,10 @@ impl Rule for RuleCommuteJoin {
         } else if left_card == right_card {
             matches!(
                 join.join_type,
-                JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti
+                JoinType::Right(_)
+                    | JoinType::RightSingle
+                    | JoinType::RightSemi
+                    | JoinType::RightAnti
             )
         } else {
             false

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
@@ -65,10 +65,10 @@ impl Rule for RuleCommuteJoinBaseTable {
         }
 
         match join.join_type {
-            JoinType::Inner
-            | JoinType::Cross
-            | JoinType::Left
-            | JoinType::Right
+            JoinType::Inner(_)
+            | JoinType::Cross(_)
+            | JoinType::Left(_)
+            | JoinType::Right(_)
             | JoinType::LeftSingle
             | JoinType::RightSingle
             | JoinType::LeftSemi

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
@@ -104,7 +104,7 @@ impl Rule for RuleSemiToInnerJoin {
                 false
             }
         }) {
-            join.join_type = JoinType::Inner;
+            join.join_type = JoinType::Inner(false);
             let mut join_expr = SExpr::create_binary(
                 Arc::new(join.into()),
                 Arc::new(s_expr.child(0)?.clone()),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_join.rs
@@ -74,7 +74,7 @@ impl Rule for RulePushDownLimitOuterJoin {
             let child = s_expr.child(0)?;
             let join: Join = child.plan().clone().try_into()?;
             match join.join_type {
-                JoinType::Left => {
+                JoinType::Left(_) => {
                     let child = child.replace_children(vec![
                         Arc::new(SExpr::create_unary(
                             Arc::new(RelOperator::Limit(limit.without_lazy_columns())),
@@ -94,7 +94,7 @@ impl Rule for RulePushDownLimitOuterJoin {
                     result.set_applied_rule(&self.id);
                     state.add_result(result)
                 }
-                JoinType::Right => {
+                JoinType::Right(_) => {
                     let child = Arc::new(child.replace_children(vec![
                         Arc::new(child.child(0)?.clone()),
                         Arc::new(SExpr::create_unary(

--- a/tests/sqllogictests/suites/query/join/any_join.test
+++ b/tests/sqllogictests/suites/query/join/any_join.test
@@ -1,0 +1,47 @@
+statement ok
+CREATE OR REPLACE TABLE t1 (id Int32, val1 String);
+
+statement ok
+CREATE OR REPLACE TABLE t2 (id Int32, val2 String);
+
+statement ok
+INSERT INTO t1 VALUES
+(1, 'a1'),
+(1, 'a2'),
+(2, 'b1'),
+(3, 'c1'),
+(5, 'e1'),
+(NULL, 'n1');
+
+statement ok
+INSERT INTO t2 VALUES
+(1, 'x1'),
+(1, 'x2'),
+(3, 'y1'),
+(4, 'z1'),
+(NULL, 'n2');
+
+query IT
+SELECT t1.id, t1.val1, t2.val2 FROM t1 INNER ANY JOIN t2 USING(id);
+----
+1 a1 x2
+3 c1 y1
+
+query IT rowsort
+SELECT t1.id, t1.val1, t2.val2 FROM t1 LEFT ANY JOIN t2 USING(id);
+----
+1 a1 x2
+1 a2 x2
+2 b1 NULL
+3 c1 y1
+5 e1 NULL
+NULL n1 NULL
+
+query IT rowsort
+SELECT t1.id, t1.val1, t2.val2 FROM t1 RIGHT ANY JOIN t2 ON t1.id = t2.id;
+----
+1 a1 x1
+1 a1 x2
+3 c1 y1
+NULL NULL n2
+NULL NULL z1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: https://github.com/databendlabs/databend/issues/18729

Refer to ClickHouse's Any Join

Any Join only supports HashJoin of equal value Join, which will only match the same key row once

example：
```sql
CREATE OR REPLACE TABLE t1 (id Int32, val1 String);

CREATE OR REPLACE TABLE t2 (id Int32, val2 String);

INSERT INTO t1 VALUES
(1, 'a1'),
(1, 'a2'),
(2, 'b1'),
(3, 'c1'),
(5, 'e1'),
(NULL, 'n1');

INSERT INTO t2 VALUES
(1, 'x1'),
(1, 'x2'),
(3, 'y1'),
(4, 'z1'),
(NULL, 'n2');

SELECT t1.id, t1.val1, t2.val2 FROM t1 INNER ANY JOIN t2 USING(id);
╭───────────────────────────────────────────────────────╮
│        id       │       val1       │       val2       │
│ Nullable(Int32) │ Nullable(String) │ Nullable(String) │
├─────────────────┼──────────────────┼──────────────────┤
│               1 │ 'a1'             │ 'x2'             │
│               3 │ 'c1'             │ 'y1'             │
╰───────────────────────────────────────────────────────╯
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
