### PR TITLE
fix: remove incorrect assertion in collecting dropped table ids

### DIFF
--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -229,12 +229,7 @@ pub async fn get_history_tables_for_gc(
     for (ident, table_history) in table_history_kvs {
         let id_list = &table_history.id_list;
         if !id_list.is_empty() {
-            // Make sure that the last table id is also the max one (of each table name).
             let last_id = id_list.last().unwrap();
-            {
-                let max_id = id_list.iter().max().unwrap();
-                assert_eq!(max_id, last_id);
-            }
             latest_table_ids.insert(*last_id);
 
             for table_id in id_list.iter() {

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -209,29 +209,26 @@ pub async fn get_history_tables_for_gc(
 
     let mut args = vec![];
 
-    // For table ids of each table with the same name, we keep the largest one, e.g.
+    // For table ids of each table with the same name, we keep the last one, e.g.
     // ```
-    //  create or replace table t ... ; -- table_id 1
-    //  create or replace table t ... ; -- table_id 2
+    //  create or replace table t ... ; -- table_id a
+    //  create or replace table t ... ; -- table_id b
     // ```
-    // table_id 2 will be kept for table t (we do not care about the table name though),
+    // table_id `b` will be kept for table t,
     //
-    // Please note that the largest table id might be "invisible", e.g.
+    // Please note that the largest table id might be dropped, e.g.
     // ```
     //  create or replace table t ... ; -- table_id 1
-    //  create or replace table t ... ; -- table_id 2
+    //  ...
     //  drop table t ... ;
     // ```
-    // In this case, table_id 2 is marked as dropped.
 
     let mut latest_table_ids = HashSet::with_capacity(table_history_kvs.len());
 
     for (ident, table_history) in table_history_kvs {
         let id_list = &table_history.id_list;
-        if !id_list.is_empty() {
-            let last_id = id_list.last().unwrap();
+        if let Some(last_id) = id_list.last() {
             latest_table_ids.insert(*last_id);
-
             for table_id in id_list.iter() {
                 args.push((TableId::new(*table_id), ident.table_name.clone()));
             }

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_issue_18794.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_issue_18794.test
@@ -1,0 +1,35 @@
+statement ok
+create or replace database issue_18794;
+
+statement ok
+use issue_18794;
+
+statement ok
+create or replace table t (c int);
+
+statement ok
+create or replace table t (c int);
+
+statement ok
+create or replace table t (c int);
+
+statement ok
+alter table t rename to t1;
+
+statement ok
+create or replace table t (c int);
+
+statement ok
+drop table t;
+
+statement ok
+alter table t1 rename to t;
+
+statement ok
+drop table t;
+
+statement ok
+set data_retention_time_in_days = 0;
+
+statement ok
+vacuum drop table;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The last table id in the TableIdHistoryIdent  KV pair, is NOT necessarily to be the largest one.


fixes: #18794 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18780)
<!-- Reviewable:end -->
