### PR TITLE
refactor(meta-service): decouple IO depending stream

### DIFF
--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -131,7 +131,7 @@ async fn main() {
         &BUILD_INFO,
         "root",
         "xxx",
-        None,
+        Some(Duration::from_secs(5)),
         None,
         None,
         required::read_write(),


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta-service): decouple IO depending stream

Do not send a Stream that contains IO operations to outer service
runtime, by decoupling such as stream with a channel.
So that the IO operations will all be done inside the io runtime.


##### chore: set timeout to 5 sec for benchmark

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change






- [x] Other

## Related Issues