### PR TITLE
fix: /v1/status return  stop time without start time. 

### DIFF
--- a/src/query/service/src/servers/admin/v1/instance_status.rs
+++ b/src/query/service/src/servers/admin/v1/instance_status.rs
@@ -53,14 +53,18 @@ pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
     let (http_query_count, last_query_finished_at_http) = HttpQueryManager::instance().status();
     let status = session_manager.get_current_session_status();
 
-    let last_query_finished_at = [
-        status.last_query_started_at.map(unix_timestamp_secs),
-        last_query_finished_at_http,
-    ]
-    .iter()
-    .flatten()
-    .max()
-    .copied();
+    let last_query_finished_at = if status.last_query_started_at.is_none() {
+        None
+    } else {
+        [
+            status.last_query_finished_at.map(unix_timestamp_secs),
+            last_query_finished_at_http,
+        ]
+        .iter()
+        .flatten()
+        .max()
+        .copied()
+    };
 
     let status = InstanceStatus {
         running_queries_count: status.running_queries_count.max(http_query_count),

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -101,11 +101,13 @@ impl Queries {
         reason: StopReason,
         now: u64,
     ) -> (Option<Arc<HttpQuery>>, bool) {
-        self.num_active_queries = self.num_active_queries.saturating_sub(1);
-        self.last_query_end_at = Some(now);
         let q = self.queries.get(query_id).cloned();
         if let Some(q) = q {
             let stop_first_run = q.mark_stopped(reason);
+            if stop_first_run {
+                self.last_query_end_at = Some(now);
+                self.num_active_queries = self.num_active_queries.saturating_sub(1);
+            }
             return (Some(q), stop_first_run);
         }
         (None, false)

--- a/src/query/service/tests/it/servers/admin/v1/status.rs
+++ b/src/query/service/tests/it/servers/admin/v1/status.rs
@@ -102,7 +102,7 @@ async fn test_status() -> Result<()> {
                 status.last_query_started_at.is_some(),
                 status.last_query_finished_at.is_some(),
             ),
-            (1, true, true),
+            (1, true, false),
             "running"
         );
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix that last_query_started_at is None, but last_query_finished_at is not if receive kill/final on start before any query.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18792)
<!-- Reviewable:end -->
