### PR TITLE
fix: prevent panic in multi-table insert commit by handling missing t…

### DIFF
--- a/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
@@ -208,7 +208,7 @@ impl AsyncSink for CommitMultiTableInsert {
                                     self.ctx.txn_mgr(),
                                     *self.table_meta_timestampss.get(&tid).unwrap(),
                                     hlls.get(&tid).unwrap(),
-                                    *insert_rows.get(&tid).unwrap(),
+                                    *insert_rows.get(&tid).unwrap_or_default(),
                                 )
                                 .await?;
                                 break;

--- a/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
@@ -208,7 +208,7 @@ impl AsyncSink for CommitMultiTableInsert {
                                     self.ctx.txn_mgr(),
                                     *self.table_meta_timestampss.get(&tid).unwrap(),
                                     hlls.get(&tid).unwrap(),
-                                    *insert_rows.get(&tid).unwrap_or_default(),
+                                    insert_rows.get(&tid).cloned().unwrap_or_default(),
                                 )
                                 .await?;
                                 break;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The insert_rows map tracks row counts for each table in the multi-table insert operation. 

If a table ID is missing from this map, it means: No rows were actually inserted for that table.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18793)
<!-- Reviewable:end -->
