### PR TITLE
fix(query): handle database ID properly in columns table permission check

### DIFF
--- a/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.result
+++ b/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.result
@@ -30,4 +30,6 @@ Error: APIError: QueryFailed: [1063]Permission denied: User 'a'@'%' does not hav
 0
 === FIX ISSUE 18056 ===
 db1	t	id1
+=== FIX: ISSUE 18797 ===
+sysdb	sysdb_tt
 ======

--- a/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
@@ -57,9 +57,24 @@ echo "create or replace table db1.t(id1 int);" | $BENDSQL_CLIENT_CONNECT
 echo "create or replace database db2;" | $BENDSQL_CLIENT_CONNECT
 echo "create or replace table db2.t(id2 int);" | $BENDSQL_CLIENT_CONNECT
 echo "drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
-echo "create user a identified by 'password';" | $BENDSQL_CLIENT_CONNECT
+echo "create user a identified by '$TEST_USER_PASSWORD';" | $BENDSQL_CLIENT_CONNECT
 echo "grant select on db1.t to a;" | $BENDSQL_CLIENT_CONNECT
 
 echo "select database, table, name from system.columns where database in ('db1', 'db2') and table='t';" | $USER_A_CONNECT
 echo "drop database if exists db1; drop database if exists db2; drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
+
+echo "=== FIX: ISSUE 18797 ==="
+echo "drop user if exists a;" | $BENDSQL_CLIENT_CONNECT
+echo "drop role if exists role1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists sysdb;" | $BENDSQL_CLIENT_CONNECT
+echo "create user a identified by '$TEST_USER_PASSWORD' with default_role='role1';" | $BENDSQL_CLIENT_CONNECT
+echo "create role role1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant role role1 to a;" | $BENDSQL_CLIENT_CONNECT
+echo "create database sysdb;" | $BENDSQL_CLIENT_CONNECT
+echo "create table sysdb.sysdb_tt(id int);" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on sysdb.* to role role1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on sysdb.sysdb_tt to role role1;" | $BENDSQL_CLIENT_CONNECT
+
+echo "select database, table from system.columns where table='sysdb_tt';" | $USER_A_CONNECT
+echo "drop table sysdb.sysdb_tt; drop database if exists sysdb; drop user if exists a; drop role if exists role1;" | $BENDSQL_CLIENT_CONNECT
 echo "======"


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


In main the code didn't properly handle db_id_opt from dbs_in_default_catalog, causing incorrect permission filtering for system.columns table queries.

This fix:
- Collects both database names and IDs from visibility checker
- Uses mget_database_names_by_ids to resolve missing names
- Properly filters databases with both name and ID information
- Fixes with column privilege checking

Fixes #18797

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18798)
<!-- Reviewable:end -->
