### PR TITLE
feat: add GC retention guard for undrop operations

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -513,6 +513,8 @@ build_exceptions! {
     UndropDbHasNoHistory(2312),
     /// Undrop table with no drop time
     UndropTableWithNoDropTime(2313),
+    /// Undrop table blocked by vacuum retention guard
+    UndropTableRetentionGuard(2326),
     /// Drop table with drop time
     DropTableWithDropTime(2314),
     /// Drop database with drop time

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -1768,15 +1768,20 @@ where
     ) -> Result<ListDroppedTableResp, KVAppError> {
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
-        let the_limit = req.limit.unwrap_or(usize::MAX);
+        let ListDroppedTableReq {
+            tenant,
+            database_name,
+            drop_time_range,
+            limit,
+        } = req;
 
-        let drop_time_range = req.drop_time_range;
+        let the_limit = limit.unwrap_or(usize::MAX);
 
-        if req.database_name.is_none() {
+        if database_name.is_none() {
             let db_infos = self
                 .get_tenant_history_databases(
                     ListDatabaseReq {
-                        tenant: req.tenant.clone(),
+                        tenant: tenant.clone(),
                     },
                     true,
                 )
@@ -1837,8 +1842,8 @@ where
             });
         }
 
-        let database_name = req.database_name.clone().unwrap();
-        let tenant_dbname = DatabaseNameIdent::new(&req.tenant, database_name);
+        let database_name = database_name.unwrap();
+        let tenant_dbname = DatabaseNameIdent::new(&tenant, database_name.clone());
 
         // Get db by name to ensure presence
         let res = get_db_or_err(

--- a/src/meta/app/src/schema/mod.rs
+++ b/src/meta/app/src/schema/mod.rs
@@ -47,6 +47,8 @@ pub mod sequence_storage;
 mod table;
 pub mod table_lock_ident;
 pub mod table_niv;
+mod vacuum_retention;
+pub mod vacuum_retention_ident;
 
 pub use auto_increment::GetAutoIncrementNextValueReply;
 pub use auto_increment::GetAutoIncrementNextValueReq;
@@ -153,3 +155,4 @@ pub use table::UpsertTableCopiedFileReq;
 pub use table::UpsertTableOptionReply;
 pub use table::UpsertTableOptionReq;
 pub use table_lock_ident::TableLockIdent;
+pub use vacuum_retention::VacuumRetention;

--- a/src/meta/app/src/schema/vacuum_retention.rs
+++ b/src/meta/app/src/schema/vacuum_retention.rs
@@ -1,0 +1,28 @@
+// Copyright 2024 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::DateTime;
+use chrono::Utc;
+
+/// Monotonic timestamp used to guard irreversible vacuum operations.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct VacuumRetention {
+    pub time: DateTime<Utc>,
+}
+
+impl VacuumRetention {
+    pub fn new(time: DateTime<Utc>) -> Self {
+        Self { time }
+    }
+}

--- a/src/meta/app/src/schema/vacuum_retention_ident.rs
+++ b/src/meta/app/src/schema/vacuum_retention_ident.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tenant_key::ident::TIdent;
+
+pub type VacuumRetentionIdent = TIdent<VacuumRetentionRsc, ()>;
+
+pub use kvapi_impl::VacuumRetentionRsc;
+
+impl VacuumRetentionIdent {
+    pub fn new_global(tenant: impl crate::tenant::ToTenant) -> Self {
+        TIdent::new_generic(tenant, ())
+    }
+}
+
+mod kvapi_impl {
+    use databend_common_meta_kvapi::kvapi;
+
+    use crate::schema::vacuum_retention::VacuumRetention;
+    use crate::schema::vacuum_retention_ident::VacuumRetentionIdent;
+    use crate::tenant_key::resource::TenantResource;
+
+    pub struct VacuumRetentionRsc;
+
+    impl TenantResource for VacuumRetentionRsc {
+        const PREFIX: &'static str = "__fd_vacuum_retention_ts";
+        const HAS_TENANT: bool = true;
+        type ValueType = VacuumRetention;
+    }
+
+    impl kvapi::Value for VacuumRetention {
+        type KeyType = VacuumRetentionIdent;
+
+        fn dependency_keys(&self, _key: &Self::KeyType) -> impl IntoIterator<Item = String> {
+            []
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_meta_kvapi::kvapi::Key;
+
+    use super::VacuumRetentionIdent;
+    use crate::tenant::Tenant;
+
+    #[test]
+    fn test_ident() {
+        let tenant = Tenant::new_literal("dummy");
+        let ident = VacuumRetentionIdent::new_global(tenant);
+
+        let key = ident.to_string_key();
+        assert_eq!(key, "__fd_vacuum_retention_ts/dummy");
+
+        assert_eq!(ident, VacuumRetentionIdent::from_str_key(&key).unwrap());
+    }
+}

--- a/src/meta/proto-conv/src/lib.rs
+++ b/src/meta/proto-conv/src/lib.rs
@@ -90,6 +90,7 @@ mod token_from_to_protobuf_impl;
 mod udf_from_to_protobuf_impl;
 mod user_from_to_protobuf_impl;
 mod util;
+mod vacuum_retention_from_to_protobuf_impl;
 
 pub use from_to_protobuf::FromToProto;
 pub use from_to_protobuf::FromToProtoEnum;

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -180,6 +180,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (148, "2025-09-22: Add: virtual_data_type add Decimal, Binary, Date, Timestamp, Interval"),
     (149, "2025-09-24: Add: add AutoIncrement name and display on TableField"),
     (150, "2025-09-26: Add: RoleInfo::comment"),
+    (151, "2025-09-30: Add: VacuumRetention proto"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/src/vacuum_retention_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/vacuum_retention_from_to_protobuf_impl.rs
@@ -1,0 +1,53 @@
+// Copyright 2024 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Conversion between protobuf VacuumRetention and meta struct.
+
+use chrono::DateTime;
+use chrono::Utc;
+use databend_common_meta_app::schema as mt;
+use databend_common_protos::pb;
+
+use crate::reader_check_msg;
+use crate::FromToProto;
+use crate::Incompatible;
+use crate::MIN_READER_VER;
+use crate::VER;
+
+impl FromToProto for mt::VacuumRetention {
+    type PB = pb::VacuumRetention;
+
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.ver
+    }
+
+    fn from_pb(p: Self::PB) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.ver, p.min_reader_ver)?;
+
+        let v = Self {
+            time: DateTime::<Utc>::from_pb(p.time)?,
+        };
+        Ok(v)
+    }
+
+    fn to_pb(&self) -> Result<Self::PB, Incompatible> {
+        let p = pb::VacuumRetention {
+            ver: VER,
+            min_reader_ver: MIN_READER_VER,
+            time: self.time.to_pb()?,
+        };
+        Ok(p)
+    }
+}

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -142,3 +142,4 @@ mod v147_grant_object_procedure;
 mod v148_virtual_schema;
 mod v149_field_auto_increment;
 mod v150_role_comment;
+mod v151_vacuum_retention;

--- a/src/meta/proto-conv/tests/it/v151_vacuum_retention.rs
+++ b/src/meta/proto-conv/tests/it/v151_vacuum_retention.rs
@@ -1,0 +1,32 @@
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::DateTime;
+use chrono::Utc;
+use databend_common_meta_app::schema as mt;
+use fastrace::func_name;
+
+use crate::common;
+
+#[test]
+fn test_decode_v151_vacuum_retention() -> anyhow::Result<()> {
+    let bytes: Vec<u8> = vec![
+        10, 23, 49, 57, 55, 48, 45, 48, 49, 45, 48, 49, 32, 48, 48, 58, 48, 48, 58, 48, 48, 32, 85,
+        84, 67, 160, 6, 150, 1, 168, 6, 24,
+    ];
+
+    let want = || mt::VacuumRetention {
+        time: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+    };
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), bytes.as_slice(), 150, want())?;
+
+    Ok(())
+}

--- a/src/meta/protos/proto/vacuum_retention.proto
+++ b/src/meta/protos/proto/vacuum_retention.proto
@@ -1,0 +1,24 @@
+// Copyright 2024 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package databend_proto;
+
+message VacuumRetention {
+  uint64 ver = 100;
+  uint64 min_reader_ver = 101;
+
+  string time = 1;
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


add GC retention guard for undrop operations

- update gc_drop_tables to persist the tenant retention watermark at vacuum time
- reject UNDROP when drop_on is not newer than the retention guard
- introduce the `VacuumRetention` metadata/proto with v151 compatibility coverage
- extend schema API test suite to validate the guard



## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18808)
<!-- Reviewable:end -->
