### PR TITLE
refactor: meta: unify FetchAddU64 into FetchIncreaseU64

### DIFF
--- a/src/meta/api/src/auto_increment_nextval_impl.rs
+++ b/src/meta/api/src/auto_increment_nextval_impl.rs
@@ -19,7 +19,7 @@ use databend_common_meta_app::tenant::ToTenant;
 use databend_common_meta_kvapi::kvapi;
 use databend_common_meta_kvapi::kvapi::Key;
 use databend_common_meta_types::anyerror::func_name;
-use databend_common_meta_types::protobuf::FetchAddU64Response;
+use databend_common_meta_types::protobuf::FetchIncreaseU64Response;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnOp;
 use databend_common_meta_types::TxnRequest;
@@ -46,7 +46,7 @@ where KV: kvapi::KVApi<Error = MetaError> + ?Sized
         self,
         tenant: impl ToTenant,
         count: u64,
-    ) -> Result<Result<FetchAddU64Response, AutoIncrementError>, MetaTxnError> {
+    ) -> Result<Result<FetchIncreaseU64Response, AutoIncrementError>, MetaTxnError> {
         debug!("{}", func_name!());
 
         // Key for the sequence number value.
@@ -69,7 +69,7 @@ where KV: kvapi::KVApi<Error = MetaError> + ?Sized
         );
         debug_assert!(succ);
 
-        let resp = responses[0].try_as_fetch_add_u64().unwrap();
+        let resp = responses[0].try_as_fetch_increase_u64().unwrap();
         let got_delta = resp.delta();
 
         if got_delta < delta {

--- a/src/meta/api/src/sequence_nextval_impl.rs
+++ b/src/meta/api/src/sequence_nextval_impl.rs
@@ -127,7 +127,7 @@ where KV: kvapi::KVApi<Error = MetaError> + ?Sized
         );
 
         if succ {
-            let resp = responses[0].try_as_fetch_add_u64().unwrap();
+            let resp = responses[0].try_as_fetch_increase_u64().unwrap();
 
             let got_delta = resp.delta();
 

--- a/src/meta/client/src/lib.rs
+++ b/src/meta/client/src/lib.rs
@@ -158,8 +158,11 @@ use semver::Version;
 /// - 2025-09-30: since 1.2.823
 ///   🖥 server: store raft-log proposing time `proposed_at_ms` in `KVMeta`.
 ///
-/// - 2025-09-27: since TODO: update when merged
+/// - 2025-09-27: since 1.2.823
 ///   👥 client: require 1.2.770, remove calling RPC kv_api
+///
+/// - 2025-10-16: since TODO
+///   🖥 server: rename `FetchAddU64` to `FetchIncreaseU64`, add `max_value`.
 ///
 /// Server feature set:
 /// ```yaml

--- a/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
+++ b/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
@@ -20,7 +20,7 @@ use databend_common_meta_kvapi::kvapi::KvApiExt;
 use databend_common_meta_types::normalize_meta::NormalizeMeta;
 use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::BooleanExpression;
-use databend_common_meta_types::protobuf::FetchAddU64Response;
+use databend_common_meta_types::protobuf::FetchIncreaseU64Response;
 use databend_common_meta_types::protobuf::KvMeta;
 use databend_common_meta_types::txn_condition;
 use databend_common_meta_types::txn_op;
@@ -1259,8 +1259,8 @@ impl TestSuite {
             let resp = kv.transaction(txn).await?;
 
             assert_eq!(
-                resp.responses[0].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[0].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 0,
                     before: 0,
@@ -1269,8 +1269,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[1].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[1].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k2".to_string(),
                     before_seq: 0,
                     before: 0,
@@ -1290,8 +1290,8 @@ impl TestSuite {
             let resp = kv.transaction(txn).await?;
 
             assert_eq!(
-                resp.responses[0].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[0].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 1,
                     before: 2,
@@ -1300,8 +1300,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[1].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[1].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k2".to_string(),
                     before_seq: 2,
                     before: 3,
@@ -1322,8 +1322,8 @@ impl TestSuite {
             let resp = kv.transaction(txn).await?;
 
             assert_eq!(
-                resp.responses[0].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[0].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 3,
                     before: 4,
@@ -1332,8 +1332,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[1].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[1].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k2".to_string(),
                     before_seq: 4,
                     before: 6,
@@ -1342,8 +1342,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[2].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k2".to_string(),
                     before_seq: 6,
                     before: u64::MAX / 2 + 6,
@@ -1378,8 +1378,8 @@ impl TestSuite {
             let resp = kv.transaction(txn).await?;
 
             assert_eq!(
-                resp.responses[0].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[0].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 0,
                     before: 0,
@@ -1388,8 +1388,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[1].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[1].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 1,
                     before: 2,
@@ -1398,8 +1398,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[2].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 1,
                     before: 2,
@@ -1408,8 +1408,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[3].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[3].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k2".to_string(),
                     before_seq: 0,
                     before: 0,
@@ -1430,8 +1430,8 @@ impl TestSuite {
             let resp = kv.transaction(txn).await?;
 
             assert_eq!(
-                resp.responses[0].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[0].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 2,
                     before: 6,
@@ -1440,8 +1440,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[1].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[1].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 4,
                     before: 8,
@@ -1450,8 +1450,8 @@ impl TestSuite {
                 }
             );
             assert_eq!(
-                resp.responses[2].try_as_fetch_add_u64().unwrap(),
-                &FetchAddU64Response {
+                resp.responses[2].try_as_fetch_increase_u64().unwrap(),
+                &FetchIncreaseU64Response {
                     key: "k1".to_string(),
                     before_seq: 4,
                     before: 8,

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -210,7 +210,7 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
             }
             Request::Delete(_) => {}
             Request::DeleteByPrefix(_) => {}
-            Request::FetchAddU64(_) => {}
+            Request::FetchIncreaseU64(_) => {}
             Request::PutSequential(_) => {}
         }
 

--- a/src/meta/types/build.rs
+++ b/src/meta/types/build.rs
@@ -155,11 +155,11 @@ fn build_proto() {
             r#"#[serde(skip_serializing_if = "Vec::is_empty")] #[serde(default)]"#,
         )
         .type_attribute(
-            "FetchAddU64",
+            "FetchIncreaseU64",
             "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(
-            "FetchAddU64Response",
+            "FetchIncreaseU64Response",
             "#[derive(Eq, serde::Serialize, serde::Deserialize, deepsize::DeepSizeOf)]",
         )
         .type_attribute(

--- a/src/meta/types/proto/meta.proto
+++ b/src/meta/types/proto/meta.proto
@@ -183,7 +183,7 @@ message TxnOp {
     TxnDeleteRequest delete = 3;
     TxnDeleteByPrefixRequest delete_by_prefix = 4;
 
-    FetchAddU64 fetch_add_u64 = 5;
+    FetchIncreaseU64 fetch_increase_u64 = 5;
     PutSequential put_sequential = 6;
   }
 }
@@ -195,7 +195,7 @@ message TxnOpResponse {
     TxnDeleteResponse delete = 3;
     TxnDeleteByPrefixResponse delete_by_prefix = 4;
 
-    FetchAddU64Response fetch_add_u64 = 5;
+    FetchIncreaseU64Response fetch_increase_u64 = 5;
   }
 }
 

--- a/src/meta/types/proto/request.proto
+++ b/src/meta/types/proto/request.proto
@@ -45,14 +45,19 @@ message TxnGetResponse {
   optional SeqV value = 2;
 }
 
-// Return the value by key, then add the delta to the key.
+// Fetch and increase the value: after = max(current, max_value) + delta
 //
-// This operation assume the value bytes is a json encoded `uint64`,
+// This operation assumes the value bytes is a json encoded `uint64`,
 // e.g. `1025` in bytes is `b"1025"`.
 // If the result is negative, it will be set to zero.
-message FetchAddU64 {
+//
+// Use cases:
+// - Pure ADD: max_value=0, delta=N -> adds N to current value
+// - Pure MAX: max_value=N, delta=0 -> ensures value is at least N
+// - Combined: max_value=N, delta=M -> ensures at least N, then adds M
+message FetchIncreaseU64 {
 
-  // The key to fetch and add the delta.
+  // The key to fetch and increase.
   string key = 1;
 
   // Assert the seq number of the record before update.
@@ -60,12 +65,15 @@ message FetchAddU64 {
   // - If it is None, the update will always be made.
   optional uint64 match_seq = 3;
 
-  // The delta to add to the value.
+  // The delta to add to the value after taking max.
   int64 delta = 2;
+
+  // The minimum value to ensure before adding delta. Defaults to 0 for backward compatibility.
+  uint64 max_value = 4;
 }
 
-// Response for FetchAddU64, contains the value before and after `add`
-message FetchAddU64Response {
+// Response for FetchIncreaseU64, contains the value before and after increase
+message FetchIncreaseU64Response {
 
   string key = 1;
 

--- a/src/meta/types/src/proto_ext/conditional_operation_ext.rs
+++ b/src/meta/types/src/proto_ext/conditional_operation_ext.rs
@@ -115,7 +115,7 @@ mod tests {
         ));
         assert!(matches!(
             cond_op.operations[3].request,
-            Some(pb::txn_op::Request::FetchAddU64(_))
+            Some(pb::txn_op::Request::FetchIncreaseU64(_))
         ));
     }
 

--- a/src/meta/types/src/proto_ext/fetch_increase_u64.rs
+++ b/src/meta/types/src/proto_ext/fetch_increase_u64.rs
@@ -16,9 +16,13 @@ use std::fmt;
 
 use crate::protobuf as pb;
 
-impl fmt::Display for pb::FetchAddU64 {
+impl fmt::Display for pb::FetchIncreaseU64 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FetchAddU64 key={} delta={}", self.key, self.delta)?;
+        write!(
+            f,
+            "FetchIncreaseU64 key={} max_value={} delta={}",
+            self.key, self.max_value, self.delta
+        )?;
         if let Some(match_seq) = self.match_seq {
             write!(f, " match_seq: {}", match_seq)?;
         }
@@ -31,22 +35,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_display_fetch_add_u64() {
-        let req = pb::FetchAddU64 {
+    fn test_display_fetch_increase_u64() {
+        let req = pb::FetchIncreaseU64 {
             key: "k1".to_string(),
             match_seq: None,
             delta: 1,
+            max_value: 0,
         };
-        assert_eq!(req.to_string(), "FetchAddU64 key=k1 delta=1");
+        assert_eq!(
+            req.to_string(),
+            "FetchIncreaseU64 key=k1 max_value=0 delta=1"
+        );
 
-        let req_with_seq = pb::FetchAddU64 {
+        let req_with_seq = pb::FetchIncreaseU64 {
             key: "k1".to_string(),
             match_seq: Some(10),
             delta: 1,
+            max_value: 100,
         };
         assert_eq!(
             req_with_seq.to_string(),
-            "FetchAddU64 key=k1 delta=1 match_seq: 10"
+            "FetchIncreaseU64 key=k1 max_value=100 delta=1 match_seq: 10"
         );
     }
 }

--- a/src/meta/types/src/proto_ext/fetch_increase_u64_response_ext.rs
+++ b/src/meta/types/src/proto_ext/fetch_increase_u64_response_ext.rs
@@ -18,7 +18,7 @@ use std::fmt::Formatter;
 use crate::protobuf as pb;
 use crate::SeqV;
 
-impl pb::FetchAddU64Response {
+impl pb::FetchIncreaseU64Response {
     pub fn new(key: impl ToString, before: SeqV<u64>, after: SeqV<u64>) -> Self {
         Self {
             key: key.to_string(),
@@ -44,11 +44,11 @@ impl pb::FetchAddU64Response {
     }
 }
 
-impl Display for pb::FetchAddU64Response {
+impl Display for pb::FetchIncreaseU64Response {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "FetchAddU64Response{{ key={} before=(seq={} {}), after=(seq={} {}), delta={} }}",
+            "FetchIncreaseU64Response{{ key={} before=(seq={} {}), after=(seq={} {}), delta={} }}",
             self.key,
             self.before_seq,
             self.before,
@@ -64,25 +64,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_fetch_add_u64_response() {
-        let resp = pb::FetchAddU64Response::new("foo", SeqV::new(10, 100), SeqV::new(20, 200));
+    fn test_fetch_increase_u64_response() {
+        let resp = pb::FetchIncreaseU64Response::new("foo", SeqV::new(10, 100), SeqV::new(20, 200));
 
         assert_eq!(resp.delta(), 100);
     }
 
     #[test]
-    fn test_display_fetch_add_u64_response() {
-        let resp = pb::FetchAddU64Response::new("k1", SeqV::new(1, 3), SeqV::new(2, 4));
+    fn test_display_fetch_increase_u64_response() {
+        let resp = pb::FetchIncreaseU64Response::new("k1", SeqV::new(1, 3), SeqV::new(2, 4));
         assert_eq!(
             resp.to_string(),
-            "FetchAddU64Response{ key=k1 before=(seq=1 3), after=(seq=2 4), delta=1 }"
+            "FetchIncreaseU64Response{ key=k1 before=(seq=1 3), after=(seq=2 4), delta=1 }"
         );
     }
 
     #[test]
-    fn test_fetch_add_u64_response_new() {
-        let resp = pb::FetchAddU64Response::new("k1", SeqV::new(1, 3), SeqV::new(2, 4));
-        assert_eq!(resp, pb::FetchAddU64Response {
+    fn test_fetch_increase_u64_response_new() {
+        let resp = pb::FetchIncreaseU64Response::new("k1", SeqV::new(1, 3), SeqV::new(2, 4));
+        assert_eq!(resp, pb::FetchIncreaseU64Response {
             key: "k1".to_string(),
             before_seq: 1,
             before: 3,
@@ -92,9 +92,9 @@ mod tests {
     }
 
     #[test]
-    fn test_fetch_add_u64_response_new_unchanged() {
-        let resp = pb::FetchAddU64Response::new_unchanged("k1", SeqV::new(1, 3));
-        assert_eq!(resp, pb::FetchAddU64Response {
+    fn test_fetch_increase_u64_response_new_unchanged() {
+        let resp = pb::FetchIncreaseU64Response::new_unchanged("k1", SeqV::new(1, 3));
+        assert_eq!(resp, pb::FetchIncreaseU64Response {
             key: "k1".to_string(),
             before_seq: 1,
             before: 3,

--- a/src/meta/types/src/proto_ext/mod.rs
+++ b/src/meta/types/src/proto_ext/mod.rs
@@ -16,8 +16,8 @@
 
 mod boolean_expression_ext;
 mod conditional_operation_ext;
-mod fetch_add_u64;
-mod fetch_add_u64_response_ext;
+mod fetch_increase_u64;
+mod fetch_increase_u64_response_ext;
 mod keys_count_ext;
 mod put_sequential_ext;
 mod raft_types_ext;

--- a/src/meta/types/src/proto_ext/txn_op_ext/request_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_op_ext/request_ext.rs
@@ -33,8 +33,8 @@ impl fmt::Display for Request {
             Request::DeleteByPrefix(r) => {
                 write!(f, "DeleteByPrefix({})", r)
             }
-            Request::FetchAddU64(r) => {
-                write!(f, "FetchAddU64({})", r)
+            Request::FetchIncreaseU64(r) => {
+                write!(f, "FetchIncreaseU64({})", r)
             }
             Request::PutSequential(r) => {
                 write!(f, "PutSequential({})", r)
@@ -69,8 +69,11 @@ mod tests {
             "DeleteByPrefix(TxnDeleteByPrefixRequest prefix=)"
         );
         assert_eq!(
-            format!("{}", Request::FetchAddU64(pb::FetchAddU64::default())),
-            "FetchAddU64(FetchAddU64 key= delta=0)"
+            format!(
+                "{}",
+                Request::FetchIncreaseU64(pb::FetchIncreaseU64::default())
+            ),
+            "FetchIncreaseU64(FetchIncreaseU64 key= max_value=0 delta=0)"
         );
     }
 }

--- a/src/meta/types/src/proto_ext/txn_op_response_ext/response_ext.rs
+++ b/src/meta/types/src/proto_ext/txn_op_response_ext/response_ext.rs
@@ -34,8 +34,8 @@ impl Display for Response {
             Response::DeleteByPrefix(r) => {
                 write!(f, "DeleteByPrefix: {}", r)
             }
-            Response::FetchAddU64(r) => {
-                write!(f, "FetchAddU64: {}", r)
+            Response::FetchIncreaseU64(r) => {
+                write!(f, "FetchIncreaseU64: {}", r)
             }
         }
     }
@@ -47,14 +47,14 @@ mod tests {
     use crate::SeqV;
     #[test]
     fn test_from() {
-        let resp = Response::from(pb::FetchAddU64Response::new_unchanged(
+        let resp = Response::from(pb::FetchIncreaseU64Response::new_unchanged(
             "key",
             SeqV::new(1, 2),
         ));
 
         assert_eq!(
             resp,
-            Response::FetchAddU64(pb::FetchAddU64Response {
+            Response::FetchIncreaseU64(pb::FetchIncreaseU64Response {
                 key: "key".to_string(),
                 before_seq: 1,
                 before: 2,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: unify FetchAddU64 into FetchIncreaseU64
Rename FetchAddU64 to FetchIncreaseU64 and add `max_value` field
to support unified atomic operation semantics. The new operation
computes: `after = max(current_value, max_value) + delta`.

This unified approach supports three use cases through a single
operation:
- Pure ADD: max_value=0, delta=N (backward compatible)
- Pure MAX: max_value=N, delta=0 (new capability)
- Combined: max_value=N, delta=M (ensures minimum then adds)

The refactoring maintains backward compatibility through the
existing `fetch_add_u64()` helper method which automatically sets
max_value=0. Two new helper methods are added:
- `fetch_increase_u64(key, max_value, delta)` for combined ops
- `fetch_max_u64(key, max_value)` for pure max operations


##### fix: use compile-time cfg for platform-specific DMA flags

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18847)
<!-- Reviewable:end -->
