### PR TITLE
feat(query): Show Statistics add Virtual Column Stats and Min/Max Fields

### DIFF
--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -244,10 +244,12 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'level'                           | 'system'             | 'settings'               | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'license'                         | 'system'             | 'credits'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'location'                        | 'system'             | 'query_cache'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'max'                             | 'system'             | 'statistics'             | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'memory_usage'                    | 'system'             | 'processes'              | 'Int64'               | 'BIGINT'            | ''       | ''       | 'NO'     | ''       |
 | 'message'                         | 'system'             | 'notification_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'message_source'                  | 'system'             | 'notification_history'   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'metric'                          | 'system'             | 'metrics'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'min'                             | 'system'             | 'statistics'             | 'Nullable(String)'    | 'VARCHAR'           | ''       | ''       | 'YES'    | ''       |
 | 'miss'                            | 'system'             | 'caches'                 | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'mode'                            | 'system'             | 'streams'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'mode'                            | 'system'             | 'streams_terse'          | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -369,6 +369,8 @@ impl Binder {
             .with_column("actual_row_count")
             .with_column("distinct_count")
             .with_column("null_count")
+            .with_column("min")
+            .with_column("max")
             .with_column("avg_size")
             .with_column("histogram");
 

--- a/src/query/storages/fuse/src/io/write/stream/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/io/write/stream/cluster_statistics.rs
@@ -55,7 +55,7 @@ impl ClusterStatisticsBuilder {
         }
 
         let input_schema: Arc<DataSchema> = DataSchema::from(source_schema).into();
-        let input_filed_len = input_schema.fields.len();
+        let input_field_len = input_schema.fields.len();
 
         let cluster_keys = table.linear_cluster_keys(ctx.clone());
         let mut cluster_key_index = Vec::with_capacity(cluster_keys.len());
@@ -70,7 +70,7 @@ impl ClusterStatisticsBuilder {
                 Expr::ColumnRef(ColumnRef { id, .. }) => *id,
                 _ => {
                     exprs.push(expr);
-                    let offset = input_filed_len + extra_key_num;
+                    let offset = input_field_len + extra_key_num;
                     extra_key_num += 1;
                     offset
                 }

--- a/src/query/storages/system/src/statistics_table.rs
+++ b/src/query/storages/system/src/statistics_table.rs
@@ -61,6 +61,8 @@ struct TableColumnStatistics {
     actual_row_count: Option<u64>,
     distinct_count: Option<u64>,
     null_count: Option<u64>,
+    min: Option<String>,
+    max: Option<String>,
     avg_size: Option<u64>,
     histogram: String,
 }
@@ -87,6 +89,8 @@ impl StatisticsTable {
                 "null_count",
                 TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
             ),
+            TableField::new("min", TableDataType::String.wrap_nullable()),
+            TableField::new("max", TableDataType::String.wrap_nullable()),
             TableField::new(
                 "avg_size",
                 TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
@@ -210,9 +214,48 @@ impl StatisticsTable {
                                 actual_row_count,
                                 distinct_count: column_statistics.and_then(|v| v.ndv),
                                 null_count: column_statistics.map(|v| v.null_count),
-                                histogram,
+                                min: column_statistics
+                                    .and_then(|s| s.min.clone())
+                                    .map(|v| v.to_string().unwrap()),
+                                max: column_statistics
+                                    .and_then(|s| s.max.clone())
+                                    .map(|v| v.to_string().unwrap()),
                                 avg_size: columns_statistics.average_size(column_id),
+                                histogram,
                             })
+                        }
+                        // add virtual column statistics
+                        let table_info = table.get_table_info();
+                        if let Some(virtual_schema) = &table_info.meta.virtual_schema {
+                            for virtual_field in virtual_schema.fields() {
+                                if let (Ok(source_field), Some(column_statistics)) = (
+                                    schema.field_of_column_id(virtual_field.source_column_id),
+                                    columns_statistics.column_statistics(virtual_field.column_id),
+                                ) {
+                                    let column_name =
+                                        format!("{}{}", source_field.name, virtual_field.name);
+                                    rows.push(TableColumnStatistics {
+                                        database_name: database.clone(),
+                                        table_name: table.name().into(),
+                                        column_name,
+                                        stats_row_count,
+                                        actual_row_count,
+                                        distinct_count: column_statistics.ndv,
+                                        null_count: Some(column_statistics.null_count),
+                                        min: column_statistics
+                                            .min
+                                            .clone()
+                                            .map(|v| v.to_string().unwrap()),
+                                        max: column_statistics
+                                            .max
+                                            .clone()
+                                            .map(|v| v.to_string().unwrap()),
+                                        avg_size: columns_statistics
+                                            .average_size(virtual_field.column_id),
+                                        histogram: "".to_string(),
+                                    })
+                                }
+                            }
                         }
                     }
                 }
@@ -253,6 +296,8 @@ impl AsyncSystemTable for StatisticsTable {
         let mut actual_row_counts = Vec::with_capacity(rows.len());
         let mut distinct_counts = Vec::with_capacity(rows.len());
         let mut null_counts = Vec::with_capacity(rows.len());
+        let mut mins = Vec::with_capacity(rows.len());
+        let mut maxes = Vec::with_capacity(rows.len());
         let mut avg_sizes = Vec::with_capacity(rows.len());
         let mut histograms = Vec::with_capacity(rows.len());
         for row in rows {
@@ -263,6 +308,8 @@ impl AsyncSystemTable for StatisticsTable {
             actual_row_counts.push(row.actual_row_count);
             distinct_counts.push(row.distinct_count);
             null_counts.push(row.null_count);
+            mins.push(row.min);
+            maxes.push(row.max);
             avg_sizes.push(row.avg_size);
             histograms.push(row.histogram);
         }
@@ -275,6 +322,8 @@ impl AsyncSystemTable for StatisticsTable {
             UInt64Type::from_opt_data(actual_row_counts),
             UInt64Type::from_opt_data(distinct_counts),
             UInt64Type::from_opt_data(null_counts),
+            StringType::from_opt_data(mins),
+            StringType::from_opt_data(maxes),
             UInt64Type::from_opt_data(avg_sizes),
             StringType::from_data(histograms),
         ]))

--- a/tests/sqllogictests/suites/base/06_show/06_0025_show_statistics.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0025_show_statistics.test
@@ -13,7 +13,7 @@ CREATE TABLE showstatistics.t1(c1 int not null) ENGINE = Null;
 query T
 show statistics from table showstatistics.t1;
 ----
-showstatistics t1 c1 NULL NULL NULL NULL NULL (empty)
+showstatistics t1 c1 NULL NULL NULL NULL NULL NULL NULL (empty)
 
 statement ok
 CREATE TABLE IF NOT EXISTS showstatistics.t2(c1 int);
@@ -21,8 +21,8 @@ CREATE TABLE IF NOT EXISTS showstatistics.t2(c1 int);
 query T
 show statistics;
 ----
-showstatistics t1 c1 NULL NULL NULL NULL NULL (empty)
-showstatistics t2 c1 0 0 NULL NULL NULL (empty)
+showstatistics t1 c1 NULL NULL NULL NULL NULL NULL NULL (empty)
+showstatistics t2 c1 0 0 NULL NULL NULL NULL NULL (empty)
 
 statement ok
 insert into showstatistics.t2 values(1),(2);
@@ -30,13 +30,13 @@ insert into showstatistics.t2 values(1),(2);
 query T
 show statistics from table showstatistics.t2;
 ----
-showstatistics t2 c1 2 2 2 0 4 (empty)
+showstatistics t2 c1 2 2 2 0 1 2 4 (empty)
 
 query T
 show statistics from database showstatistics;
 ----
-showstatistics t1 c1 NULL NULL NULL NULL NULL (empty)
-showstatistics t2 c1 2 2 2 0 4 (empty)
+showstatistics t1 c1 NULL NULL NULL NULL NULL NULL NULL (empty)
+showstatistics t2 c1 2 2 2 0 1 2 4 (empty)
 
 statement ok
 set enable_analyze_histogram=1;
@@ -50,7 +50,7 @@ analyze table showstatistics.t2;
 query T
 show statistics from table showstatistics.t2;
 ----
-showstatistics t2 c1 2 2 2 0 4 [bucket id: 0, min: "1", max: "1", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0]
+showstatistics t2 c1 2 2 2 0 1 2 4 [bucket id: 0, min: "1", max: "1", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0]
 
 statement ok
 DROP DATABASE showstatistics

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0020_analyze.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0020_analyze.test
@@ -199,8 +199,8 @@ delete from t2 where a=1;
 query T
 show statistics from table db_09_0020.t2;
 ----
-db_09_0020 t2 a 3 3 2 0 4 (empty)
-db_09_0020 t2 b 3 3 2 0 4 (empty)
+db_09_0020 t2 a 3 3 2 0 2 4 4 (empty)
+db_09_0020 t2 b 3 3 2 0 2 4 4 (empty)
 
 statement ok
 analyze table t2;
@@ -208,8 +208,8 @@ analyze table t2;
 query T
 show statistics from table db_09_0020.t2;
 ----
-db_09_0020 t2 a 3 3 2 0 4 [bucket id: 0, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 2, min: "4", max: "4", ndv: 1.0, count: 1.0]
-db_09_0020 t2 b 3 3 2 0 4 [bucket id: 0, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 2, min: "4", max: "4", ndv: 1.0, count: 1.0]
+db_09_0020 t2 a 3 3 2 0 2 4 4 [bucket id: 0, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 2, min: "4", max: "4", ndv: 1.0, count: 1.0]
+db_09_0020 t2 b 3 3 2 0 2 4 4 [bucket id: 0, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 1, min: "2", max: "2", ndv: 1.0, count: 1.0], [bucket id: 2, min: "4", max: "4", ndv: 1.0, count: 1.0]
 
 query I
 select count() from fuse_snapshot('db_09_0020','t2');
@@ -278,8 +278,8 @@ update t4 set a = 4 where b = 'c';
 query T
 show statistics from table db_09_0020.t4;
 ----
-db_09_0020 t4 a 5 4 4 0 4 (empty)
-db_09_0020 t4 b 5 4 3 0 13 (empty)
+db_09_0020 t4 a 5 4 4 0 1 4 4 (empty)
+db_09_0020 t4 b 5 4 3 0 a c 13 (empty)
 
 statement ok
 alter table t4 set options(enable_auto_analyze = 1);
@@ -287,8 +287,8 @@ alter table t4 set options(enable_auto_analyze = 1);
 query T
 show statistics from table db_09_0020.t4;
 ----
-db_09_0020 t4 a 4 4 4 0 4 (empty)
-db_09_0020 t4 b 4 4 3 0 13 (empty)
+db_09_0020 t4 a 4 4 4 0 1 4 4 (empty)
+db_09_0020 t4 b 4 4 3 0 a c 13 (empty)
 
 statement ok
 delete from t4 where a = 4;
@@ -296,8 +296,8 @@ delete from t4 where a = 4;
 query T
 show statistics from table db_09_0020.t4;
 ----
-db_09_0020 t4 a 3 3 3 0 4 (empty)
-db_09_0020 t4 b 3 3 2 0 13 (empty)
+db_09_0020 t4 a 3 3 3 0 1 3 4 (empty)
+db_09_0020 t4 b 3 3 2 0 a b 13 (empty)
 
 statement ok
 DROP TABLE t4 all;

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
@@ -335,6 +335,21 @@ data['likes'] 2 0 1 (empty)
 data['tags'][0] 2 0 3 (empty)
 data['tags'][1] 2 0 4 (empty)
 
+query TTTIIIITTIT
+SHOW STATISTICS FROM TABLE test_virtual_column.tweets;
+----
+test_virtual_column tweets data 10 10 NULL NULL NULL NULL NULL (empty)
+test_virtual_column tweets data['create'] 10 10 10 0 1/08 6/07 16 (empty)
+test_virtual_column tweets data['id'] 10 10 10 0 1 10 8 (empty)
+test_virtual_column tweets data['likes'] 10 10 2 0 10 25 1 (empty)
+test_virtual_column tweets data['replies'] 10 10 7 3 0 9 8 (empty)
+test_virtual_column tweets data['tags'][0] 10 10 2 0 good new 3 (empty)
+test_virtual_column tweets data['tags'][1] 10 10 2 0 interesting popular 4 (empty)
+test_virtual_column tweets data['text'] 10 10 7 0 a z 13 (empty)
+test_virtual_column tweets data['user']['id'] 10 10 6 0 1 7 8 (empty)
+test_virtual_column tweets id 10 10 10 0 1 10 4 (empty)
+
+
 statement ok
 UPDATE tweets SET data = '{"id":4, "create": "1/08", "text": "aa", "user": {"id": 1}, "replies": 10}' WHERE id = 4;
 
@@ -347,6 +362,17 @@ data['id'] 10 0 8 (empty)
 data['replies'] 7 3 8 (empty)
 data['text'] 8 0 13 (empty)
 data['user']['id'] 4 0 8 (empty)
+
+query TTTIIIITTIT
+SHOW STATISTICS FROM TABLE test_virtual_column.tweets;
+----
+test_virtual_column tweets data 10 10 NULL NULL NULL NULL NULL (empty)
+test_virtual_column tweets data['create'] 10 10 10 0 1/08 6/07 16 (empty)
+test_virtual_column tweets data['id'] 10 10 10 0 1 10 8 (empty)
+test_virtual_column tweets data['replies'] 10 10 7 3 0 10 8 (empty)
+test_virtual_column tweets data['text'] 10 10 8 0 a z 13 (empty)
+test_virtual_column tweets data['user']['id'] 10 10 4 0 1 7 8 (empty)
+test_virtual_column tweets id 10 10 10 0 1 10 4 (empty)
 
 query IITTIITFIT
 select id, data['id'], data['create'], data['text'], data['user']['id'], data['replies'], data['geo'], data['geo']['lat'], data['likes'], data['tags'] from tweets order by id;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces significant enhancements to the `SHOW STATISTICS` statement:

1.  **Virtual Column Statistics Support:** `SHOW STATISTICS` now supports displaying statistics for virtual columns.
2.  **Add Min and Max Fields:** The output of `SHOW STATISTICS` has been extended to include `min` and `max` fields for each columns.

for example
```sql
:) set enable_experimental_virtual_column=1;
:) CREATE OR REPLACE TABLE user_activity_logs AS
SELECT
    number % 100000000 AS id,
    JSON_OBJECT(
        'id', CAST(number % 100000000 AS STRING),
        'email', CONCAT('user', CAST(number % 100000000 AS STRING), '@example.com')
    ) AS data
FROM numbers(10000);

:) SHOW STATISTICS FROM TABLE user_activity_logs;
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ database │        table       │  column_name  │  stats_row_count │ actual_row_count │  distinct_count  │    null_count    │        min       │        max       │     avg_size     │ histogram │
│  String  │       String       │     String    │ Nullable(UInt64) │ Nullable(UInt64) │ Nullable(UInt64) │ Nullable(UInt64) │ Nullable(String) │ Nullable(String) │ Nullable(UInt64) │   String  │
├──────────┼────────────────────┼───────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────┼───────────┤
│ default  │ user_activity_logs │ data          │            10000 │            10000 │             NULL │             NULL │ NULL             │ NULL             │             NULL │           │
│ default  │ user_activity_logs │ data['email'] │            10000 │            10000 │            10000 │                0 │ user0@example.co │ user9@example.c􏿿 │               32 │           │
│ default  │ user_activity_logs │ data['id']    │            10000 │            10000 │             9829 │                0 │ 0                │ 9999             │               16 │           │
│ default  │ user_activity_logs │ id            │            10000 │            10000 │            10000 │                0 │ 0                │ 9999             │                4 │           │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
4 rows read in 0.104 sec. Processed 4 rows, 629 B (38.46 rows/s, 5.91 KiB/s)
```

- fixes: #[Link the issue here]


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18849)
<!-- Reviewable:end -->
