### PR TITLE
chore: ensuring all imperfect blocks are compacted

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -100,7 +100,7 @@ async fn do_hook_compact(
                         return Ok(());
                     }
                     CompactionLimits {
-                        segment_limit: Some(compaction_num_block_hint as usize),
+                        segment_limit: None,
                         block_limit: Some(compaction_num_block_hint as usize),
                     }
                 }

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -947,8 +947,8 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
                 ("compact_max_block_selection", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(10000),
-                    desc: "Limits the maximum number of blocks that can be selected during a compact operation.",
+                    value: UserSettingValue::UInt64(1000),
+                    desc: "Limits the maximum number of imperfect blocks that can be selected during a compact operation.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(2..=u64::MAX)),

--- a/src/query/storages/fuse/src/operations/common/generators/append_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/append_generator.rs
@@ -207,14 +207,10 @@ impl SnapshotGenerator for AppendGenerator {
             // If imperfect_count is larger, SLIGHTLY increase the number of blocks
             // eligible for auto-compaction, this adjustment is intended to help reduce
             // fragmentation over time.
-            //
-            // To prevent the off-by-one mistake, we need to add 1 to it;
-            // this way, the potentially previously left non-compacted segment will
-            // also be included.
             let compact_num_block_hint = std::cmp::min(
                 imperfect_count,
                 (auto_compaction_imperfect_blocks_threshold as f64 * 1.5).ceil() as u64,
-            ) + 1;
+            );
             info!("set compact_num_block_hint to {compact_num_block_hint }");
             self.ctx
                 .set_compaction_num_block_hint(table_info.name.as_str(), compact_num_block_hint);

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -118,6 +118,7 @@ impl BlockCompactMutator {
 
         let mut segment_idx = 0;
         let mut is_end = false;
+        let mut stop_after_next = false;
         let mut parts = Vec::new();
         let chunk_size = max_threads * 4;
         for chunk in segment_locations.chunks(chunk_size) {
@@ -154,9 +155,24 @@ impl BlockCompactMutator {
                     checker.generate_part(segments, &mut parts);
                 }
 
-                if checker.is_limit_reached(num_segment_limit, num_block_limit) {
+                if stop_after_next {
                     is_end = true;
                     break;
+                }
+
+                match checker.is_limit_reached(num_segment_limit, num_block_limit) {
+                    CompactLimitState::Continue => {}
+                    CompactLimitState::ReachedBlockLimit => {
+                        // When the block limit is reached, we allow one more iteration
+                        // to include the next segment in compaction.
+                        // This "+1" behavior ensures that previously un-compacted segments
+                        // near the boundary are not skipped due to strict block counting.
+                        stop_after_next = true;
+                    }
+                    CompactLimitState::ReachedSegmentLimit => {
+                        is_end = true;
+                        break;
+                    }
                 }
             }
 
@@ -303,6 +319,16 @@ impl BlockCompactMutator {
     }
 }
 
+// CompactLimitState indicates the current compaction progress state.
+pub enum CompactLimitState {
+    /// Continue collecting more segments and blocks.
+    Continue,
+    /// Hit the block threshold — take one more segment before stopping.
+    ReachedBlockLimit,
+    /// Hit the segment threshold — stop immediately.
+    ReachedSegmentLimit,
+}
+
 pub struct SegmentCompactChecker {
     thresholds: BlockThresholds,
     segments: Vec<(SegmentIndex, Arc<CompactSegmentInfo>)>,
@@ -310,8 +336,7 @@ pub struct SegmentCompactChecker {
     cluster_key_id: Option<u32>,
 
     compacted_segment_cnt: usize,
-    compacted_block_cnt: u64,
-    compacted_perfect_block_cnt: u64,
+    compacted_imperfect_block_cnt: u64,
 }
 
 impl SegmentCompactChecker {
@@ -322,8 +347,7 @@ impl SegmentCompactChecker {
             thresholds,
             cluster_key_id,
             compacted_segment_cnt: 0,
-            compacted_block_cnt: 0,
-            compacted_perfect_block_cnt: 0,
+            compacted_imperfect_block_cnt: 0,
         }
     }
 
@@ -362,13 +386,10 @@ impl SegmentCompactChecker {
         }
 
         self.compacted_segment_cnt += segments.len();
-        (self.compacted_block_cnt, self.compacted_perfect_block_cnt) = segments
+        self.compacted_imperfect_block_cnt += segments
             .iter()
-            .map(|(_, info)| (info.summary.block_count, info.summary.perfect_block_count))
-            .fold(
-                (self.compacted_block_cnt, self.compacted_perfect_block_cnt),
-                |(b_sum, p_sum), (b, p)| (b_sum + b, p_sum + p),
-            );
+            .map(|(_, info)| info.summary.block_count - info.summary.perfect_block_count)
+            .sum::<u64>();
         true
     }
 
@@ -421,28 +442,30 @@ impl SegmentCompactChecker {
     }
 
     /// Check if compaction limit is reached.
-    pub fn is_limit_reached(&self, num_segment_limit: usize, num_block_limit: usize) -> bool {
-        let (compacted_block_cnt, compacted_perfect_block_cnt) = self
-            .segments
-            .iter()
-            .map(|(_, info)| (info.summary.block_count, info.summary.perfect_block_count))
-            .fold(
-                (self.compacted_block_cnt, self.compacted_perfect_block_cnt),
-                |(b_sum, p_sum), (b, p)| (b_sum + b, p_sum + p),
-            );
-        let compacted_imperfect_block_cnt = compacted_block_cnt - compacted_perfect_block_cnt;
-        // When the total number of *imperfect blocks* reaches (num_block_limit - 1)
-        // and total selected blocks reach num_block_limit, we trigger compaction.
-        //
-        // Because `compact_num_block_hint` was intentionally increased by +1 during its calculation,
-        // to slightly expand the compaction range and include previously un-compacted segments.
-        if compacted_imperfect_block_cnt >= num_block_limit.saturating_sub(1) as u64
-            && compacted_block_cnt >= num_block_limit as u64
-        {
-            return true;
+    pub fn is_limit_reached(
+        &self,
+        num_segment_limit: usize,
+        num_block_limit: usize,
+    ) -> CompactLimitState {
+        // Stop immediately if the number of compacted segments reaches limit
+        if self.compacted_segment_cnt + self.segments.len() >= num_segment_limit {
+            return CompactLimitState::ReachedSegmentLimit;
         }
 
-        self.compacted_segment_cnt + self.segments.len() >= num_segment_limit
+        // Count the total number of imperfect blocks (those that still need compaction).
+        let compacted_imperfect_block_cnt =
+            self.segments
+                .iter()
+                .fold(self.compacted_imperfect_block_cnt, |mut acc, (_, info)| {
+                    acc += info.summary.block_count - info.summary.perfect_block_count;
+                    acc
+                });
+        // If the imperfect block count exceeds the limit, signal "take one more".
+        if compacted_imperfect_block_cnt >= num_block_limit as u64 {
+            CompactLimitState::ReachedBlockLimit
+        } else {
+            CompactLimitState::Continue
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When checking the compaction block limit, we now verify the number of *imperfect blocks* among the selected blocks.
Once reached for imperfect blocks, triggers one final segment acquisition before stopping. This “+1” segment behaviour ensures boundary blocks are not missed and avoids off-by-one omissions.

Refactors the `is_limit_reached` method to return an explicit state enum (`CompactLimitState`) with values: `Continue`, `ReachedBlockLimit`, `ReachedSegmentLimit`. This clarifies the intent of each stop condition and aligns the control flow with the outer loop logic.

Improves readability of the compaction loop by handling the “take one more” state outside the immediate stop condition, thus making the workflow more predictable and maintainable.

This change ensures that auto-compaction covers all eligible segments/blocks without accidentally skipping near-limit items, and also tightly bounds resource usage by segments.

Fixes: #18859

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18860)
<!-- Reviewable:end -->
