### PR TITLE
chore: remove common-password feature to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,7 @@ ordq = "0.2.0"
 p256 = "0.13"
 parking_lot = "0.12.1"
 parquet = { version = "55", features = ["async"] }
-passwords = { version = "3.1.16", features = ["common-password"] }
+passwords = { version = "3.1.16" }
 paste = "1.0.15"
 percent-encoding = "2.3.1"
 petgraph = { version = "0.6.2", features = ["serde-1"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

  Remove "common-password" feature from passwords dependency which generates
  a 6.4MB array, significantly reducing binary size and memory footprint.

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18868)
<!-- Reviewable:end -->
