### PR TITLE
feat: enable geo and virtual column settings by default

### DIFF
--- a/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/virtual_columns.rs
@@ -34,10 +34,6 @@ async fn test_fuse_do_refresh_virtual_column() -> Result<()> {
         .default_session()
         .get_settings()
         .set_data_retention_time_in_days(0)?;
-    fixture
-        .default_session()
-        .get_settings()
-        .set_enable_experimental_virtual_column(1)?;
     fixture.create_default_database().await?;
     fixture.create_variant_table().await?;
 

--- a/src/query/ee/tests/it/storages/fuse/operations/virtual_columns_builder.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/virtual_columns_builder.rs
@@ -33,13 +33,8 @@ use jsonb::OwnedJsonb;
 async fn test_virtual_column_builder() -> Result<()> {
     let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
 
-    fixture
-        .default_session()
-        .get_settings()
-        .set_enable_experimental_virtual_column(1)?;
     fixture.create_default_database().await?;
     fixture.create_variant_table().await?;
-
     let ctx = fixture.new_query_ctx().await?;
 
     let table = fixture.latest_default_table().await?;
@@ -402,10 +397,6 @@ async fn test_virtual_column_builder() -> Result<()> {
 async fn test_virtual_column_builder_stream_write() -> Result<()> {
     let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
 
-    fixture
-        .default_session()
-        .get_settings()
-        .set_enable_experimental_virtual_column(1)?;
     fixture.create_default_database().await?;
     fixture.create_variant_table().await?;
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1151,7 +1151,7 @@ impl DefaultSettings {
                 }),
                 // this setting will be removed when geometry type stable.
                 ("enable_geo_create_table", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(1),
                     desc: "Create and alter table with geometry/geography type",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
@@ -1453,7 +1453,7 @@ impl DefaultSettings {
                     range: Some(SettingRange::Numeric(1..=1024)),
                 }),
                 ("enable_experimental_virtual_column", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
+                    value: UserSettingValue::UInt64(1),
                     desc: "Enables experimental virtual column",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
@@ -22,9 +22,6 @@ statement ok
 USE test_virtual_column
 
 statement ok
-set enable_experimental_virtual_column = 1;
-
-statement ok
 drop table if exists t1
 
 statement ok
@@ -786,4 +783,3 @@ set enable_experimental_virtual_column = 0;
 
 statement ok
 DROP DATABASE test_virtual_column
-

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
@@ -25,9 +25,6 @@ statement ok
 USE test_virtual_db
 
 statement ok
-set enable_experimental_virtual_column = 1;
-
-statement ok
 drop table if exists t1
 
 statement ok

--- a/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
+++ b/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
@@ -73,6 +73,9 @@ POINT(5.77922738 7.63098076)
 statement ok
 DROP TABLE IF EXISTS t1
 
+statement ok
+SET enable_geo_create_table=0
+
 statement error 1090
 CREATE TABLE t1 (a int, g geometry)
 

--- a/tests/sqllogictests/suites/query/functions/02_0076_function_geography.test
+++ b/tests/sqllogictests/suites/query/functions/02_0076_function_geography.test
@@ -25,9 +25,6 @@ statement ok
 DROP TABLE IF EXISTS t1
 
 statement ok
-SET enable_geo_create_table=1
-
-statement ok
 CREATE TABLE t1 (a int, g geography)
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Default-enable `enable_geo_create_table` and `enable_experimental_virtual_column` in `src/query/settings/src/settings_default.rs` so new sessions can use geometry and virtual columns without manual session flags.
- Update geometry/geography sqllogictests to remove redundant enables and explicitly disable the feature before negative cases.
- Remove explicit virtual-column enable calls from sqllogictests and EE integration tests now that the default is on.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Not run locally; relying on CI to execute the logic test suites.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): ci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18873)
<!-- Reviewable:end -->
