### PR TITLE
chore: remove redundant experimental procedure toggles

### DIFF
--- a/tests/compat_fuse/compat-logictest/rbac/fuse_compat_write
+++ b/tests/compat_fuse/compat-logictest/rbac/fuse_compat_write
@@ -11,9 +11,6 @@ statement ok
 create function a as (a) -> (a+1);
 
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 drop procedure if exists p1(int);
 
 statement ok
@@ -58,5 +55,4 @@ GRANT create sequence on *.* to role 'role1';
 
 statement ok
 GRANT create procedure on *.* to role 'role1';
-
 

--- a/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 drop procedure if exists p1(int);
 
 statement ok
@@ -206,5 +203,4 @@ call procedure p3('x');
 
 statement ok
 drop procedure p3(string);
-
 

--- a/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0003_procedure_auto_commit.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace database test_auto_commit;
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0004_procedure_rollback.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0004_procedure_rollback.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace table t_rollback_1 (str varchar);
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0005_procedure_snapshots.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0005_procedure_snapshots.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace database test_procedure_snapshots;
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0006_procedure_merge_into.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0006_procedure_merge_into.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace database test_procedure_merge_into;
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0007_procedure_dedup_label.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0007_procedure_dedup_label.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace database test_procedure_dedup_label;
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0008_procedure_multi_transaction.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0008_procedure_multi_transaction.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 create or replace database test_procedure_multi;
 
 statement ok

--- a/tests/sqllogictests/suites/base/15_procedure/15_0009_procedure_call.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0009_procedure_call.test
@@ -1,7 +1,4 @@
 statement ok
-set global enable_experimental_procedure=1;
-
-statement ok
 CREATE OR REPLACE PROCEDURE p1() RETURNS int not null LANGUAGE SQL AS $$
 BEGIN
     RETURN 1;

--- a/tests/suites/0_stateless/18_rbac/18_0017_procedure_rbac.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0017_procedure_rbac.sh
@@ -10,8 +10,6 @@ export USER_ADMIN_USER_CONNECT="bendsql --user=admin_user --password=123 --host=
 export USER_DEV_USER_CONNECT="bendsql --user=dev_user --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 export USER_TEST_USER_CONNECT="bendsql --user=test_user --password=123 --host=${QUERY_MYSQL_HANDLER_HOST} --port ${QUERY_HTTP_HANDLER_PORT}"
 
-echo "set global enable_experimental_procedure=1;" | $BENDSQL_CLIENT_CONNECT
-
 # Create roles
 echo "=== Creating roles ==="
 echo "DROP ROLE IF EXISTS admin_role;" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Remove redundant `set global enable_experimental_procedure=1;` statements in procedure-related tests now that the flag defaults to enabled.

Fixes: N/A

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_ (non-functional cleanup; relies on existing default setting)

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Test cleanup to align with default setting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18875)
<!-- Reviewable:end -->
