### PR TITLE
fix(query): fix set_null_schema

### DIFF
--- a/src/query/service/src/interpreters/interpreter_execute_immediate.rs
+++ b/src/query/service/src/interpreters/interpreter_execute_immediate.rs
@@ -62,7 +62,10 @@ impl ProcedureState {
 
     pub async fn set_null_schema(&self) {
         let mut w = self.schema.lock().await;
-        *w = None;
+        *w = Some(DataSchemaRefExt::create(vec![DataField::new(
+            "Result",
+            DataType::String.wrap_nullable(),
+        )]));
     }
 
     pub fn null_result() -> DataBlock {

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -430,12 +430,9 @@ impl ExplainInterpreter {
     }
 
     fn graphical_profiles_to_datablocks(profiles: GraphicalProfiles) -> Vec<DataBlock> {
-        let json_string = serde_json::to_string_pretty(&profiles)
+        let json_string = serde_json::to_string(&profiles)
             .unwrap_or_else(|_| "Failed to format profiles".to_string());
-
-        let line_split_result: Vec<&str> = json_string.lines().collect();
-        let formatted_block = StringType::from_data(line_split_result);
-
+        let formatted_block = StringType::from_data(vec![json_string]);
         vec![DataBlock::new_from_columns(vec![formatted_block])]
     }
 

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -392,6 +392,7 @@ impl ExecuteState {
         } else {
             vec![]
         };
+
         let running_state = ExecuteRunning {
             session,
             ctx: ctx.clone(),
@@ -459,6 +460,10 @@ impl ExecuteState {
             Some(Ok(block)) => {
                 if is_dynamic_schema {
                     if let Some(schema) = interpreter.get_dynamic_schema().await {
+                        info!(
+                            "[HTTP-QUERY] Dynamic schema detected, updating schema to have {} fields",
+                            schema.fields().len()
+                        );
                         Executor::update_schema(&executor, schema);
                     }
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1. fix set_null_schema function
2. `graphical_profiles_to_datablocks` now will have only one row result 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18880)
<!-- Reviewable:end -->
