### PR TITLE
fix: meta-service: watch stream should be atomically added

### DIFF
--- a/src/meta/raft-store/src/applier/mod.rs
+++ b/src/meta/raft-store/src/applier/mod.rs
@@ -151,7 +151,7 @@ where SM: StateMachineApi<SysData> + 'static
 
         // Send queued change events to subscriber
         for event in self.changes.drain(..) {
-            debug!("send to EventSender: {:?}", event);
+            info!("send to EventSender: {:?}", event);
             self.sm.on_change_applied(event);
         }
 

--- a/src/meta/raft-store/src/sm_v003/writer_acquirer.rs
+++ b/src/meta/raft-store/src/sm_v003/writer_acquirer.rs
@@ -52,7 +52,15 @@ impl WriterAcquirer {
     }
 }
 
-/// ApplierPermit is used to acquire a permit for applying changes to the state machine.
+/// Exclusive writer permit for state machine operations.
+///
+/// This permit is backed by a semaphore with capacity 1, ensuring exclusive access.
+/// When held, no other writers can modify the state machine, guaranteeing:
+/// - Serialization of Raft log application
+/// - Atomicity of multi-step operations (e.g., watch registration + snapshot read)
+/// - Prevention of MVCC isolation issues from concurrent writes
+///
+/// The permit is automatically released when dropped.
 pub struct WriterPermit {
     _permit: OwnedSemaphorePermit,
     _drop: DropCallback,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: meta-service: watch stream should be atomically added
It requires a `WriterPermit` to ensure atomic watch stream
initialization. The permit prevents race conditions where state machine
writes could occur between snapshot reads and watcher registration,
causing event loss.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18888)
<!-- Reviewable:end -->
