### PR TITLE
fix(query): fix row access policy parameter order and case sensitivity

### DIFF
--- a/src/meta/proto-conv/src/row_access_policy_from_to_protobuf_impl.rs
+++ b/src/meta/proto-conv/src/row_access_policy_from_to_protobuf_impl.rs
@@ -36,12 +36,20 @@ impl FromToProto for mt::RowAccessPolicyMeta {
     fn from_pb(p: pb::RowAccessPolicyMeta) -> Result<Self, Incompatible> {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
+        // Prioritize args_v2 (preserves order), fallback to args (backward compatibility)
+        let args: Vec<(String, String)> = if !p.args_v2.is_empty() {
+            p.args_v2
+                .into_iter()
+                .map(|arg| (arg.name, arg.r#type))
+                .collect()
+        } else {
+            // Backward compatibility: read from old args map
+            // Note: BTreeMap sorts keys alphabetically, so order may be lost for old data
+            p.args.into_iter().collect()
+        };
+
         let v = Self {
-            args: p
-                .args
-                .iter()
-                .map(|(arg_name, arg_type)| (arg_name.clone(), arg_type.clone()))
-                .collect::<Vec<_>>(),
+            args,
             body: p.body,
             comment: p.comment.clone(),
             create_on: DateTime::<Utc>::from_pb(p.create_on)?,
@@ -54,14 +62,21 @@ impl FromToProto for mt::RowAccessPolicyMeta {
     }
 
     fn to_pb(&self) -> Result<pb::RowAccessPolicyMeta, Incompatible> {
-        let mut args = BTreeMap::new();
-        for (arg_name, arg_type) in &self.args {
-            args.insert(arg_name.to_string(), arg_type.to_string());
-        }
+        // Write to args_v2 (new format that preserves order)
+        let args_v2: Vec<pb::RowAccessPolicyArg> = self
+            .args
+            .iter()
+            .map(|(arg_name, arg_type)| pb::RowAccessPolicyArg {
+                name: arg_name.clone(),
+                r#type: arg_type.clone(),
+            })
+            .collect();
+
         let p = pb::RowAccessPolicyMeta {
             ver: VER,
             min_reader_ver: MIN_READER_VER,
-            args,
+            args: BTreeMap::new(), // Keep empty for backward compatibility
+            args_v2,
             body: self.body.clone(),
             comment: self.comment.clone(),
             create_on: self.create_on.to_pb()?,

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -184,6 +184,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (152, "2025-10-14: Add: TableDataType::StageLocation and UDFServer add arg_names"),
     (153, "2025-10-16: Add: RowAccessPolicyColumnMap rename to SecurityColumnMap store mask/row_access policy name and column id"),
     (154, "2025-10-16: Add: VacuumWatermark"),
+    (155, "2025-10-24: Add: RowAccessPolicyMeta::RowAccessPolicyArg"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -146,3 +146,4 @@ mod v151_row_access_column_map;
 mod v152_external_udf;
 mod v153_security_column_map;
 mod v154_vacuum_watermark;
+mod v155_row_access_policy_args;

--- a/src/meta/proto-conv/tests/it/v155_row_access_policy_args.rs
+++ b/src/meta/proto-conv/tests/it/v155_row_access_policy_args.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::TimeZone;
+use chrono::Utc;
+use fastrace::func_name;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+// The message bytes are built from the output of `test_pb_from_to()`
+#[test]
+fn test_decode_v155_row_access() -> anyhow::Result<()> {
+    let bytes = vec![
+        10, 11, 10, 1, 97, 18, 6, 83, 116, 114, 105, 110, 103, 18, 76, 99, 97, 115, 101, 10, 32,
+        32, 32, 32, 32, 32, 119, 104, 101, 110, 32, 39, 105, 116, 95, 97, 100, 109, 105, 110, 39,
+        32, 61, 32, 99, 117, 114, 114, 101, 110, 116, 95, 114, 111, 108, 101, 40, 41, 32, 116, 104,
+        101, 110, 32, 116, 114, 117, 101, 10, 32, 32, 32, 32, 32, 32, 101, 108, 115, 101, 32, 102,
+        97, 108, 115, 101, 10, 32, 32, 101, 110, 100, 26, 12, 115, 111, 109, 101, 32, 99, 111, 109,
+        109, 101, 110, 116, 34, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 56, 32, 49, 50, 58, 48, 48,
+        58, 48, 57, 32, 85, 84, 67, 42, 23, 50, 48, 49, 52, 45, 49, 49, 45, 50, 56, 32, 49, 50, 58,
+        48, 48, 58, 48, 57, 32, 85, 84, 67, 160, 6, 155, 1, 168, 6, 24,
+    ];
+
+    let want = || databend_common_meta_app::row_access_policy::RowAccessPolicyMeta {
+        args: vec![("a".to_string(), "String".to_string())],
+        body: "case
+      when 'it_admin' = current_role() then true
+      else false
+  end"
+        .to_string(),
+        comment: Some("some comment".to_string()),
+        create_on: Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),
+        update_on: Some(Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap()),
+    };
+
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), bytes.as_slice(), 155, want())
+}

--- a/src/meta/protos/proto/row_access_policy.proto
+++ b/src/meta/protos/proto/row_access_policy.proto
@@ -16,13 +16,22 @@ syntax = "proto3";
 
 package databend_proto;
 
+message RowAccessPolicyArg {
+  string name = 1;
+  string type = 2;
+}
+
 message RowAccessPolicyMeta {
   uint64 ver = 100;
   uint64 min_reader_ver = 101;
 
+  // Deprecated: preserved for backward compatibility, use args_v2 instead
   map<string, string> args = 1;
   string body = 2;
   optional string comment = 3;
   string create_on = 4;
   optional string update_on = 5;
+
+  // New field that preserves argument order
+  repeated RowAccessPolicyArg args_v2 = 6;
 }

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -542,7 +542,9 @@ impl Binder {
 
         let expr = TypeChecker::clone_expr_with_replacement(&expr, |nest_expr| {
             if let Expr::ColumnRef { column, .. } = nest_expr {
-                if let Some(arg) = args_map.get(column.column.name()) {
+                // Parameter names are normalized to lowercase in row_access_policy.rs
+                // So we need to normalize the lookup key to match
+                if let Some(arg) = args_map.get(column.column.name().to_lowercase().as_str()) {
                     return Ok(Some(arg.clone()));
                 }
             }

--- a/src/query/sql/src/planner/plans/row_access_policy.rs
+++ b/src/query/sql/src/planner/plans/row_access_policy.rs
@@ -52,11 +52,20 @@ impl From<CreateRowAccessPolicyPlan> for CreateRowAccessPolicyReq {
             },
             name: RowAccessPolicyNameIdent::new(p.tenant.clone(), &p.name),
             row_access_policy_meta: RowAccessPolicyMeta {
+                // CRITICAL: Normalize parameter names to lowercase at creation time
+                // This ensures consistent matching when applying row access policies.
+                // SQL identifiers are case-insensitive, so we use lowercase as canonical form.
+                // This mirrors the fix for masking policies (see data_mask.rs).
                 args: p
                     .row_access
                     .parameters
                     .iter()
-                    .map(|arg| (arg.name.to_string(), arg.data_type.to_string()))
+                    .map(|arg| {
+                        (
+                            arg.name.to_lowercase(), // Normalize to lowercase
+                            arg.data_type.to_string(),
+                        )
+                    })
                     .collect(),
                 body: p.row_access.definition.to_string(),
                 comment: p.description,

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
@@ -19,6 +19,42 @@ statement ok
 set global enable_planner_cache = 0;
 
 statement ok
+drop row access policy if exists rap_multi_case;
+
+statement ok
+drop table if exists rap_multi_test;
+
+statement ok
+CREATE ROW ACCESS POLICY rap_multi_case AS (UserId string, Department string) RETURNS boolean ->
+  CASE
+    WHEN current_role() = 'admin' THEN true
+    WHEN Department = 'Engineering' THEN true
+    ELSE false
+  END;
+
+statement ok
+create table rap_multi_test(id int, user_id string, department string);
+
+statement ok
+insert into rap_multi_test values (1, 'alice', 'Engineering'),  (2, 'bob', 'Sales'),  (3, 'charlie', 'Engineering');
+
+statement ok
+alter table rap_multi_test add row access policy rap_multi_case on (user_id, department);
+
+## Should only see Engineering department rows
+query ITT
+select * from rap_multi_test order by id;
+----
+1 alice Engineering
+3 charlie Engineering
+
+statement ok
+drop table if exists rap_case_test;
+
+statement ok
+drop row access policy if exists rap_multi_case;
+
+statement ok
 drop row access policy if exists rap1;
 
 statement ok


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  This commit fixes three critical bugs in row access policy that caused
  incorrect filtering behavior with multi-parameter policies.

  **Issue 1: Parameter case sensitivity (storage)**
  Parameter names were stored with original case but looked up with
  lowercase, causing HashMap mismatches.

  Fix: Normalize parameter names to lowercase at creation time to ensure
  case-insensitive matching (mirrors masking policy fix).

  **Issue 2: Parameter case sensitivity (lookup)**
  When replacing parameters in policy body expressions, the lookup key
  used original case while args_map keys were lowercase.

  Fix: Normalize lookup keys to lowercase when replacing parameters.

  **Issue 3: Parameter order not preserved**
  Using BTreeMap in protobuf serialization sorted parameters alphabetically,
  breaking multi-parameter policies where order matters.

  Example bug:
    CREATE ROW ACCESS POLICY rap AS (UserId, Department) ...
    ALTER TABLE t ADD ROW ACCESS POLICY rap ON (c1, c2);

    Expected mapping: c1 -> UserId, c2 -> Department
    Actual mapping:   c1 -> Department, c2 -> UserId (sorted!)

  Fix: Add args_v2 field using repeated message to preserve order, with
  backward compatibility for old args map field.

  **Changes:**
  - Add RowAccessPolicyArg message and args_v2 field to protobuf
  - Update FromToProto to prioritize args_v2 with fallback to args
  - Normalize parameter names at creation (row_access_policy.rs)
  - Normalize parameter names at lookup (table.rs)
  - Add regression test for multi-parameter mixed-case scenario

  Fixes parameter substitution in row access policies.


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18889)
<!-- Reviewable:end -->
