### PR TITLE
fix(query): prevent modification of columns with security policies

### DIFF
--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -363,21 +363,6 @@ impl Default for TableMeta {
     }
 }
 
-impl TableMeta {
-    /// Check if a column has masking policy.
-    pub fn has_masking_policy(&self, column_id: &ColumnId) -> bool {
-        self.column_mask_policy_columns_ids.contains_key(column_id)
-    }
-
-    /// Check if a column has row access policy.
-    pub fn has_row_access_policy(&self, column_id: &ColumnId) -> bool {
-        self.row_access_policy_columns_ids
-            .as_ref()
-            .map(|policy| policy.columns_ids.contains(column_id))
-            .unwrap_or(false)
-    }
-}
-
 impl Display for TableMeta {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(

--- a/src/meta/app/src/schema/table/ops.rs
+++ b/src/meta/app/src/schema/table/ops.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ColumnId;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::TableField;
 
@@ -82,6 +83,16 @@ impl TableMeta {
             )));
         };
         Ok(())
+    }
+
+    /// Check if a column reference a security policy.
+    pub fn is_column_reference_policy(&self, column_id: &ColumnId) -> bool {
+        self.column_mask_policy_columns_ids.contains_key(column_id)
+            || self
+                .row_access_policy_columns_ids
+                .as_ref()
+                .map(|policy| policy.columns_ids.contains(column_id))
+                .unwrap_or(false)
     }
 }
 

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -60,7 +60,6 @@ use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 
 use crate::interpreters::common::check_referenced_computed_columns;
 use crate::interpreters::interpreter_table_add_column::commit_table_meta;
-use crate::interpreters::util::check_column_has_policy;
 use crate::interpreters::Interpreter;
 use crate::physical_plans::DistributedInsertSelect;
 use crate::physical_plans::PhysicalPlan;
@@ -147,11 +146,15 @@ impl ModifyTableColumnInterpreter {
                 ErrorCode::UnknownColumn(format!("Cannot find column {}", column))
             })?;
 
-            check_column_has_policy(&table_info.meta, &data_field.column_id)
-                .map_err(|_| ErrorCode::AlterTableError(format!(
+            if table_info
+                .meta
+                .is_column_reference_policy(&data_field.column_id)
+            {
+                return Err(ErrorCode::AlterTableError(format!(
                     "Column '{}' is already attached to a security policy. A column cannot be attached to multiple security policies",
                     data_field.name
-                )))?;
+                )));
+            }
 
             let column_type = data_field.data_type();
             if policy_data_type != column_type.remove_nullable() {
@@ -248,12 +251,15 @@ impl ModifyTableColumnInterpreter {
         let mut modify_comment = false;
         for (field, comment) in field_and_comments {
             if let Some((i, old_field)) = schema.column_with_name(&field.name) {
-                check_column_has_policy(&table_info.meta, &old_field.column_id).map_err(|_| {
-                    ErrorCode::AlterTableError(format!(
+                if table_info
+                    .meta
+                    .is_column_reference_policy(&old_field.column_id)
+                {
+                    return Err(ErrorCode::AlterTableError(format!(
                         "Cannot modify column '{}' which is associated with a security policy",
                         old_field.name
-                    ))
-                })?;
+                    )));
+                }
 
                 if old_field.data_type != field.data_type {
                     // If the column is defined in bloom index columns,

--- a/src/query/service/src/interpreters/util.rs
+++ b/src/query/service/src/interpreters/util.rs
@@ -234,18 +234,3 @@ impl<'a, T: serde::Serialize> AuditElement<'a, T> {
         }
     }
 }
-
-/// Check if a column has security policies that would prevent the operation.
-/// Returns an error if the column has masking policy or row access policy.
-pub fn check_column_has_policy(
-    table_meta: &databend_common_meta_app::schema::TableMeta,
-    column_id: &databend_common_expression::ColumnId,
-) -> databend_common_exception::Result<()> {
-    if table_meta.has_masking_policy(column_id) {
-        return Err(ErrorCode::AlterTableError(""));
-    }
-    if table_meta.has_row_access_policy(column_id) {
-        return Err(ErrorCode::AlterTableError(""));
-    }
-    Ok(())
-}


### PR DESCRIPTION
This ensures policy integrity and prevents accidental security configuration corruption during table schema alterations.

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Fix:

Bug-1: Prevent dropping or modifying columns with attached policies
  Columns that have masking policies or serve as row access policy
  parameters must not be dropped or modified, as this would break
  security policy enforcement. Added validation in:
  - interpreter_table_drop_column: Blocks DROP COLUMN operations
  - interpreter_table_modify_column: Blocks data type changes

Bug-2: Prevent duplicate policy assignment on columns
  A column cannot have multiple security policies attached
  simultaneously. Added checks in:
  - interpreter_table_modify_column: Validates before SET MASKING POLICY
  - interpreter_table_row_access_add: Validates before SET ROW ACCESS POLICY

### Implementation:
  - Created check_column_has_policy() utility in interpreters/util.rs
  - Validates against both masking and row access policies
  - Returns descriptive error messages to prevent security violations

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18896)
<!-- Reviewable:end -->
