### PR TITLE
fix: trim duplicated metrics suffix

### DIFF
--- a/src/common/storage/src/operator_cache.rs
+++ b/src/common/storage/src/operator_cache.rs
@@ -32,9 +32,9 @@ use crate::operator::init_operator_uncached;
 
 // Internal metrics for monitoring cache effectiveness
 static CACHE_HIT_COUNT: LazyLock<Counter> =
-    LazyLock::new(|| register_counter("storage_operator_cache_hit_total"));
+    LazyLock::new(|| register_counter("storage_operator_cache_hit"));
 static CACHE_MISS_COUNT: LazyLock<Counter> =
-    LazyLock::new(|| register_counter("storage_operator_cache_miss_total"));
+    LazyLock::new(|| register_counter("storage_operator_cache_miss"));
 static CACHE_SIZE: LazyLock<Gauge> =
     LazyLock::new(|| register_gauge("storage_operator_cache_size"));
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Counter already has a `_total` suffix, this would result in a metric named
`databend_storage_operator_cache_miss_total_total`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18908)
<!-- Reviewable:end -->
