### PR TITLE
feat:  add has_data in system.streams

### DIFF
--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -200,6 +200,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'file_name'                       | 'system'             | 'temp_files'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'file_type'                       | 'system'             | 'temp_files'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'group'                           | 'system'             | 'configs'                 | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'has_data'                        | 'system'             | 'streams'                 | 'Boolean'             | 'BOOLEAN'           | ''       | ''       | 'NO'     | ''       |
 | 'histogram'                       | 'system'             | 'statistics'              | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'hit'                             | 'system'             | 'caches'                  | 'UInt64'              | 'BIGINT UNSIGNED'   | ''       | ''       | 'NO'     | ''       |
 | 'host'                            | 'system'             | 'clusters'                | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/sql/src/planner/binder/ddl/stream.rs
+++ b/src/query/sql/src/planner/binder/ddl/stream.rs
@@ -142,7 +142,8 @@ impl Binder {
                 .with_column("owner")
                 .with_column("comment")
                 .with_column("mode")
-                .with_column("invalid_reason");
+                .with_column("invalid_reason")
+                .with_column("has_data");
         } else {
             select_builder
                 .with_column(format!("name AS `Streams_in_{database}`"))
@@ -210,7 +211,8 @@ impl Binder {
             .with_column("owner")
             .with_column("comment")
             .with_column("mode")
-            .with_column("invalid_reason");
+            .with_column("invalid_reason")
+            .with_column("has_data");
         select_builder.with_filter(format!("catalog = '{catalog}'"));
         select_builder.with_filter(format!("database = '{database}'"));
         select_builder.with_filter(format!("name = '{stream}'"));

--- a/tests/suites/5_ee/05_stream/05_0000_ee_stream.result
+++ b/tests/suites/5_ee/05_stream/05_0000_ee_stream.result
@@ -2,6 +2,6 @@ true
 2	INSERT	false	true
 test_s	db_stream.t	append_only
 test_s1	db_stream.t	standard
-test_s default default db_stream.t NULL test append_only
-test_s1 default default db_stream.t NULL standard standard
-test_s default default db_stream.t NULL test append_only
+test_s default default db_stream.t NULL test append_only true
+test_s1 default default db_stream.t NULL standard standard true
+test_s default default db_stream.t NULL test append_only true

--- a/tests/suites/5_ee/05_stream/05_0000_ee_stream.sh
+++ b/tests/suites/5_ee/05_stream/05_0000_ee_stream.sh
@@ -18,8 +18,8 @@ echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID'
 
 echo "create stream test_s1 on table db_stream.t at(stream => default.test_s) append_only=false comment = 'standard'" | $BENDSQL_CLIENT_CONNECT
 echo "show streams like 'test_s%'" | $BENDSQL_CLIENT_CONNECT
-echo "show full streams like 'test_s%'" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
-echo "desc stream default.test_s" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
+echo "show full streams like 'test_s%'" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
+echo "desc stream default.test_s" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
 
 echo "drop stream if exists default.test_s" | $BENDSQL_CLIENT_CONNECT
 echo "drop stream if exists default.test_s1" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

show full streams support show whether the stream may has data.
```sql
root@localhost:8000/default/default> create table t(a int);

root@localhost:8000/default/default> create stream s on table t;

root@localhost:8000/default/default> insert into t values(1);
╭─────────────────────────╮
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                       1 │
╰─────────────────────────╯
1 row written in 0.095 sec. Processed 1 row, 5 B (10.53 rows/s, 52 B/s)

root@localhost:8000/default/default> create stream s1 on table t;

root@localhost:8000/default/default> show full streams;
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│         created_on         │  name  │  database │  catalog  │     table_on     │       owner      │ comment │      mode     │ invalid_reason │ has_data │
│          Timestamp         │ String │   String  │   String  │ Nullable(String) │ Nullable(String) │  String │     String    │     String     │  Boolean │
├────────────────────────────┼────────┼───────────┼───────────┼──────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼──────────┤
│ 2025-11-03 14:18:06.282666 │ 's'    │ 'default' │ 'default' │ 'default.t'      │ NULL             │ ''      │ 'append_only' │ ''             │ true     │
│ 2025-11-03 14:18:24.519781 │ 's1'   │ 'default' │ 'default' │ 'default.t'      │ NULL             │ ''      │ 'append_only' │ ''             │ false    │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
2 rows read in 0.139 sec. Processed 2 rows, 425 B (14.39 rows/s, 2.99 KiB/s)

root@localhost:8000/default/default> desc stream s;
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│         created_on         │  name  │  database │  catalog  │     table_on     │       owner      │ comment │      mode     │ invalid_reason │ has_data │
│          Timestamp         │ String │   String  │   String  │ Nullable(String) │ Nullable(String) │  String │     String    │     String     │  Boolean │
├────────────────────────────┼────────┼───────────┼───────────┼──────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼──────────┤
│ 2025-11-03 14:18:06.282666 │ 's'    │ 'default' │ 'default' │ 'default.t'      │ NULL             │ ''      │ 'append_only' │ ''             │ true     │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
1 row read in 0.145 sec. Processed 2 row, 425 B (13.79 rows/s, 2.86 KiB/s)

root@localhost:8000/default/default> desc stream s1;

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│         created_on         │  name  │  database │  catalog  │     table_on     │       owner      │ comment │      mode     │ invalid_reason │ has_data │
│          Timestamp         │ String │   String  │   String  │ Nullable(String) │ Nullable(String) │  String │     String    │     String     │  Boolean │
├────────────────────────────┼────────┼───────────┼───────────┼──────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼──────────┤
│ 2025-11-03 14:18:24.519781 │ 's1'   │ 'default' │ 'default' │ 'default.t'      │ NULL             │ ''      │ 'append_only' │ ''             │ false    │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
1 row read in 0.131 sec. Processed 2 row, 425 B (15.27 rows/s, 3.17 KiB/s)
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18920)
<!-- Reviewable:end -->
