### PR TITLE
chore: remove fixeme on TimestampTz

### DIFF
--- a/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0016_insert_into_values.test
@@ -68,9 +68,8 @@ create table if not exists ts1(a timestamp, b timestamp with time zone)
 statement ok
 insert into ts1 values (1676620596564, '2024-10-22 12:00:00+0900')
 
-# FIXME: After Parser update then remove ::STRING
 query T
-select a, b::STRING from ts1
+select a, b from ts1
 ----
 2023-02-17 07:56:36.564000 2024-10-22 21:00:00.000000 +0900
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0001_remote_insert.test
@@ -50,9 +50,8 @@ CREATE TABLE IF NOT EXISTS t3(a Boolean, b Timestamp, c Date, d Array(Int), e Tu
 statement ok
 INSERT INTO t3 (a,b,c,d,e,f) values(true, '2021-09-07 21:38:35.000000', '2021-09-07', [1, 2, 3], (10, 'abc'), '2024-10-22 12:00:00+0900'), (false, 1631050715000000, 18877, [4, 5, 6], (20, 'xyz'), '2024-10-22 12:00:00');
 
-# FIXME: After Parser update then remove ::STRING
 query BTTTTT
-SELECT a, b, c, d, e, f::string FROM t3 order by a desc;
+SELECT a, b, c, d, e, f FROM t3 order by a desc;
 ----
 1 2021-09-07 21:38:35.000000 2021-09-07 [1,2,3] (10,'abc') 2024-10-22 21:00:00.000000 +0900
 0 2021-09-07 21:38:35.000000 2021-09-07 [4,5,6] (20,'xyz') 2024-10-22 12:00:00.000000 +0000
@@ -148,9 +147,8 @@ CREATE TABLE IF NOT EXISTS t_compression_zstd(a Boolean, b Timestamp, c Date, e 
 statement ok
 INSERT INTO t_compression_zstd (a,b,c,e) values(true, '2021-09-07 21:38:35.000000', '2021-09-07', '2024-10-22 12:00:00+0900'), (false, 1631050715000000, 18877, '2024-10-22 12:00:00');
 
-# FIXME: After Parser update then remove ::STRING
 query BTTT
-SELECT a, b, c, e::string FROM t_compression_zstd order by a desc;
+SELECT a, b, c, e FROM t_compression_zstd order by a desc;
 ----
 1 2021-09-07 21:38:35.000000 2021-09-07 2024-10-22 21:00:00.000000 +0900
 0 2021-09-07 21:38:35.000000 2021-09-07 2024-10-22 12:00:00.000000 +0000

--- a/tests/sqllogictests/suites/base/11_data_type/11_0001_data_type_date_time.test
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0001_data_type_date_time.test
@@ -81,9 +81,8 @@ select '2021-01-01T00:00:00+00:00'::timestamp = '2021-01-01T01:00:00+01:00'::tim
 ----
 1
 
-# FIXME: After Parser update then remove ::STRING
 query T
-select '2044-05-06 03:25:02.868894'::TIMESTAMP_TZ::STRING
+select '2044-05-06 03:25:02.868894'::TIMESTAMP_TZ
 ----
 2044-05-06 03:25:02.868894 +0000
 

--- a/tests/sqllogictests/suites/base/11_data_type/11_0005_data_type_date.test
+++ b/tests/sqllogictests/suites/base/11_data_type/11_0005_data_type_date.test
@@ -16,9 +16,8 @@ select '0099-05-16'::DATE
 ----
 0099-05-16
 
-# FIXME: After Parser update then remove ::STRING
 query T
-select '1022-05-16'::DATE, date '1022-05-16', timestamp '1022-05-16', (timestamp_tz '1022-05-16')::string
+select '1022-05-16'::DATE, date '1022-05-16', timestamp '1022-05-16', timestamp_tz '1022-05-16'
 ----
 1022-05-16 1022-05-16 1022-05-16 00:00:00.000000 1022-05-16 00:00:00.000000 +0000
 

--- a/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
+++ b/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
@@ -204,9 +204,8 @@ SELECT to_timestamp(1640019661000000) = to_timestamp('2021-12-20 17:01:01.000000
 statement error 1006
 SELECT to_timestamp('2020.10.')
 
-# FIXME: After Parser update then remove ::STRING
 query T
-select to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000'))::STRING
+select to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000'))
 ----
 2021-12-20 17:01:01.000000 +0000
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

after: https://github.com/databendlabs/bendsql/pull/696

BendSQL now supports TimstampTz, so it no longer needs to be converted to a String.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): fmt test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18924)
<!-- Reviewable:end -->
