### PR TITLE
chore: fixed time zone on shanghai to fix flasky 02_0079_function_interval.test

### DIFF
--- a/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
+++ b/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
@@ -309,6 +309,9 @@ Charlie 1995-07-22 1995-07-22 00:00:00.000000 29 years 10 months 21 days 29 10 2
 statement ok
 unset timezone;
 
+statement ok
+set timezone='Asia/Shanghai'
+
 query T
 select age(to_timestamp_tz(today()), '2022-02-02 01:00:00 +0800'::timestamp_tz)=age('2022-02-02 01:00:00 +0800'::timestamp_tz);
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
https://github.com/databendlabs/databend/actions/runs/19109849429/job/54610167212?pr=18928

```sql
select age(to_timestamp_tz(today()), '2022-02-02 01:00:00 +0800'::timestamp_tz)=age('2022-02-02 01:00:00 +0800'::timestamp_tz);
```
The `age` method automatically retrieves `today` from `ctx` when a single `timestamptz` is entered, but when two `timestamptz` values ​​are entered, it parses their respective timezones. This issue might be caused by an incorrect `tz` setting in `ctx`.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18930)
<!-- Reviewable:end -->
