### PR TITLE
fix(query): build mysql tls config

### DIFF
--- a/src/query/service/src/servers/mysql/tls.rs
+++ b/src/query/service/src/servers/mysql/tls.rs
@@ -47,6 +47,10 @@ impl MySQLTlsConfig {
             return Ok(None);
         }
 
+        // Set default crypto provider to use
+        // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let cert = certs(&mut BufReader::new(File::open(&self.cert_path)?))
             .try_collect()
             .map_err(|err| ErrorCode::TLSConfigurationFailure(err.to_string()))?;

--- a/src/query/service/tests/it/servers/mysql/mysql_handler.rs
+++ b/src/query/service/tests/it/servers/mysql/mysql_handler.rs
@@ -55,10 +55,6 @@ async fn test_generic_code_with_on_query() -> Result<()> {
 
 #[tokio::test(flavor = "current_thread")]
 async fn test_connect_with_tls() -> Result<()> {
-    // Set default crypto provider to use
-    // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
     let _fixture = TestFixture::setup().await?;
 
     let tcp_keepalive_timeout_secs = 120;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix MySQL TLS startup panic by installing rustls’s default CryptoProvider before building the server config, allowing the query service to boot when custom certificates are enabled.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18953)
<!-- Reviewable:end -->
