### PR TITLE
feat: http handler return geometry_output_format with data.

### DIFF
--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -142,6 +141,14 @@ impl QueryResponseField {
     }
 }
 
+// settings also used by driver, may be set in query/session/global level
+// only available after binding
+#[derive(Serialize, Debug, Clone)]
+pub struct ResultFormatSettings {
+    pub timezone: String,
+    pub geometry_output_format: String,
+}
+
 #[derive(Serialize, Debug, Clone)]
 pub struct QueryResponse {
     pub id: String,
@@ -161,11 +168,9 @@ pub struct QueryResponse {
     pub data: Arc<BlocksSerializer>,
     pub affect: Option<QueryAffect>,
     pub result_timeout_secs: Option<u64>,
-    // settings also used by driver, may be set in query/session/global level
-    // only include timezone for now
-    // only available after binding
+
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<BTreeMap<String, String>>,
+    pub settings: Option<ResultFormatSettings>,
 
     pub stats: QueryStats,
 
@@ -195,7 +200,7 @@ impl QueryResponse {
                     affect,
                     error,
                     warnings,
-                    driver_settings,
+                    result_format_settings: driver_settings,
                 },
         }: HttpQueryResponseInternal,
         is_final: bool,

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -67,6 +67,7 @@ use super::PageManager;
 use super::ResponseData;
 use super::Wait;
 use crate::servers::http::error::QueryError;
+use crate::servers::http::v1::http_query_handlers::ResultFormatSettings;
 use crate::servers::http::v1::ClientSessionManager;
 use crate::servers::http::v1::HttpQueryManager;
 use crate::servers::http::v1::QueryResponse;
@@ -491,7 +492,7 @@ pub struct StageAttachmentConf {
 pub struct ResponseState {
     pub has_result_set: Option<bool>,
     pub schema: DataSchemaRef,
-    pub driver_settings: Option<BTreeMap<String, String>>,
+    pub result_format_settings: Option<ResultFormatSettings>,
     pub running_time_ms: i64,
     pub progresses: Progresses,
     pub state: ExecuteStateKind,
@@ -848,7 +849,7 @@ impl HttpQuery {
                     let state = ExecuteStopped {
                         stats: Progresses::default(),
                         schema: Default::default(),
-                        driver_settings: None,
+                        result_format_settings: None,
                         has_result_set: None,
                         reason: Err(e.clone()),
                         session_state: ExecutorSessionState::new(

--- a/tests/nox/suites/1_stateful/09_http_handler/test_09_0001_json_response.py
+++ b/tests/nox/suites/1_stateful/09_http_handler/test_09_0001_json_response.py
@@ -44,22 +44,3 @@ def test_json_response_errors():
     assert response3.json() == json.loads(
         '{"error": {"code": 404, "message": "not found"}}'
     )
-
-def query_page_0(sql):
-    data = {
-        'sql': sql,
-        "pagination": { "wait_time_secs": 5}
-    }
-    data = json.dumps(data)
-    response = requests.post(
-        query_url,
-        auth=auth,
-        headers={"Content-Type": "application/json"},
-        data=data,
-    )
-    return response.json()
-
-def test_timezone():
-    timezone = 'Asia/Shanghai'
-    r = query_page_0(f"settings (timezone='{timezone}') select 1")
-    assert r.get('settings', {}).get('timezone') == timezone

--- a/tests/nox/suites/1_stateful/09_http_handler/test_09_0014_query_lifecycle.py
+++ b/tests/nox/suites/1_stateful/09_http_handler/test_09_0014_query_lifecycle.py
@@ -8,6 +8,7 @@ auth = ("root", "")
 STICKY_HEADER = "X-DATABEND-STICKY-NODE"
 
 timezone = 'Asia/Shanghai'
+geometry_output_format = 'EWKB'
 
 scan_progress = "scan_progress"
 
@@ -25,7 +26,8 @@ def do_query(query, timeout=10, pagination=None, port=8000, patch=True):
     session = {
         "settings": {
             "http_handler_result_timeout_secs": f"{timeout}",
-            "timezone": f"{timezone}"
+            "timezone": f"{timezone}",
+            "geometry_output_format": f"{geometry_output_format}"
         }
     }
 
@@ -154,7 +156,8 @@ def test_query_lifecycle_finalized(rows):
            "final_uri": f"/v1/query/{query_id}/final",
            "next_uri": f"/v1/query/{query_id}/page/1",
            "kill_uri": f"/v1/query/{query_id}/kill",
-           'settings': {'timezone': 'Asia/Shanghai'},
+           'settings': {'timezone': 'Asia/Shanghai',
+                        "geometry_output_format": f"{geometry_output_format}" },
            'session': {'catalog': 'default',
                        'database': 'default',
                        'internal': sessions_internal,
@@ -162,7 +165,8 @@ def test_query_lifecycle_finalized(rows):
                        'need_sticky': False,
                        'role': 'account_admin',
                        'settings': {'http_handler_result_timeout_secs': f'{timeout}',
-                                    'timezone': f"{timezone}"},
+                                    'timezone': f"{timezone}",
+                                    "geometry_output_format": f"{geometry_output_format}" },
                        'txn_state': 'AutoCommit'}
            }
 

--- a/tests/nox/suites/1_stateful/09_http_handler/test_09_0015_arrow_ipc.py
+++ b/tests/nox/suites/1_stateful/09_http_handler/test_09_0015_arrow_ipc.py
@@ -69,3 +69,28 @@ def test_arrow_ipc():
 
     rows.sort()
     assert rows == [x for x in range(97)]
+
+def query_page_0(sql):
+    query_url = "http://localhost:8000/v1/query"
+
+    data = {
+        'sql': sql,
+        "pagination": { "wait_time_secs": 5}
+    }
+    data = json.dumps(data)
+    response = requests.post(
+        query_url,
+        auth=auth,
+        headers={"Content-Type": "application/json"},
+        data=data,
+    )
+    return response.json()
+
+def test_result_format_settings():
+    timezone = 'Asia/Shanghai'
+    r = query_page_0(f"settings (timezone='{timezone}') select 1")
+    assert r.get('settings', {}).get('timezone') == timezone
+
+    geometry_output_format = 'EWKB'
+    r = query_page_0(f"settings (geometry_output_format='{geometry_output_format}') select 1")
+    assert r.get('settings', {}).get('geometry_output_format') == geometry_output_format


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1.  change QueryResponse.settings from map to struct. no breaking since the same json output.
2. add geometry_output_format. 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18963)
<!-- Reviewable:end -->
