### PR TITLE
fix(query): or_filter get incorrectly result

### DIFF
--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1418,7 +1418,7 @@ impl<'a> Evaluator<'a> {
     ) -> Result<Value<AnyType>> {
         assert!(args.len() >= 2);
 
-        let mut result = validity.clone();
+        let mut result = None;
         for arg in args {
             let cond = self.partial_run(arg, validity.clone(), options)?;
             match &cond {

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0050_issue_18964.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0050_issue_18964.test
@@ -1,0 +1,24 @@
+statement ok
+create or replace table t_18964(a int, b int, c bool);
+
+query I
+insert into t_18964 values(1,1,false),(2,2,false),(3,3,false),(4,4,false),(5,5,false);
+----
+5
+
+query I
+update t_18964 set c = true where a < 6 and b in (1, 3, 5);
+----
+3
+
+query IIB
+select * from t_18964 order by a;
+----
+1 1 1
+2 2 0
+3 3 1
+4 4 0
+5 5 1
+
+statement ok
+drop table t_18964 all;

--- a/tests/sqllogictests/suites/query/functions/02_0046_function_logic.test
+++ b/tests/sqllogictests/suites/query/functions/02_0046_function_logic.test
@@ -371,3 +371,14 @@ select number from numbers(6) where number = 1 or number = 5 or number = 3 order
 
 statement ok
 DROP TABLE t_logic
+
+#ISSUE 18964
+statement ok
+set enable_selector_executor = 0;
+
+query I
+select number from numbers(6) where number < 6 and number in (1, 3, 5);
+----
+1
+3
+5


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix a bug in `eval_or_filters` where `result` was incorrectly initialized with `validity`.

- fixes: #18964

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18965)
<!-- Reviewable:end -->
