### PR TITLE
fix: Block::to_record_batch fail when a column is array of NULLs.

### DIFF
--- a/tests/sqllogictests/suites/stage/unload.test
+++ b/tests/sqllogictests/suites/stage/unload.test
@@ -34,18 +34,18 @@ create file format if not exists csv_zip type=csv compression=zip;
 
 
 # test csv
-query
+query 
 copy into @unload from ii file_format=(type=csv);
 -----
 ----
 3 12 12
 
-query
+query 
 select right(name, 4), size from list_stage(location=>'@unload');
 ----
 .csv 12
 
-query
+query 
 select $1, $2 from @unload(file_format=>'csv');
 ----
 1 2
@@ -56,7 +56,7 @@ select $1, $2 from @unload(file_format=>'csv');
 statement ok
 remove @unload;
 
-query
+query 
 copy into @unload from ii file_format=(format_name='csv_gzip');
 ----
 3 12 32
@@ -64,38 +64,38 @@ copy into @unload from ii file_format=(format_name='csv_gzip');
 statement error
 copy into @unload from ii file_format=(format_name='csv_snappy');
 
-query
+query 
 copy into @unload from ii file_format=(format_name='csv_none');
 ----
 3 12 12
 
-query
+query 
 copy into @unload from ii file_format=(format_name='csv_zip');
 ----
 3 12 136
 
-query
+query 
 select right(name, 7), size from list_stage(location=>'@unload');
 ----
 .csv.gz 32
 000.csv 12
 csv.zip 136
 
-query
+query 
 select $1, $2 from @unload(file_format => 'csv_gzip' pattern => '.*.gz');
 ----
 1 2
 3 4
 5 6
 
-query
+query 
 select $1, $2 from @unload(file_format => 'csv_none' pattern => '.*.csv');
 ----
 1 2
 3 4
 5 6
 
-query
+query 
 select $1, $2 from @unload(file_format => 'csv_zip' pattern => '.*.zip');
 ----
 1 2
@@ -106,37 +106,48 @@ select $1, $2 from @unload(file_format => 'csv_zip' pattern => '.*.zip');
 statement ok
 remove @unload;
 
-query
+query 
 copy into @unload from ii file_format=(format_name='tsv');
 ----
 3 12 12
 
-query
+query 
 select right(name, 4), size from list_stage(location=>'@unload');
 ----
 .tsv 12
 
-query
+query 
 select $1, $2 from @unload(file_format => 'tsv');
 ----
 1 2
 3 4
 5 6
 
-query
+query 
 copy into @unload/a_raw_path.csv from (select 1,2) file_format=(type=csv) single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
 ----
 a_raw_path.csv 4 1
 
-query
+query 
 copy into @unload/a_raw_path.csv from (select 3,4) file_format=(type=csv) single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
 ----
 a_raw_path.csv 4 1
 
-query
+query 
 select $1, $2 from @unload/a_raw_path.csv (file_format => 'csv');
 ----
 3 4
 
 statement error 1006.*file already exists
 copy into @unload/a_raw_path.csv from (select 3,4) file_format=(type=csv) single=true include_query_id=false use_raw_path=true detailed_output=false overwrite=false;
+
+
+query 
+copy into @unload/array_of_nulls from (select [NULL, NULL]);
+----
+1 8 548
+
+query 
+select * from @unload/array_of_nulls;
+----
+[NULL,NULL]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix:  

```
root@localhost:8000/default/default> copy into @s1 from (select [NULL, NULL]);

copy into @s1
from
  (
    select
      [NULL, NULL]
  )

error: error happens after fetched 0 rows: APIError: QueryFailed: [1104]called `Result::unwrap()` on an `Err` value: InvalidArgumentError("Non-nullable field of LargeListArray \"_array\" cannot contain nulls")

```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/18989)
<!-- Reviewable:end -->
