### PR TITLE
chore: make query service start after meta

### DIFF
--- a/scripts/distribution/systemd/databend-query.service
+++ b/scripts/distribution/systemd/databend-query.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Databend Query
 Documentation=https://docs.databend.com
-After=network-online.target
+After=network-online.target databend-meta.service
 Requires=network-online.target
 
 [Service]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR updates the `databend-query.service` systemd unit file to ensure proper startup ordering when `databend-meta` and `databend-query` are deployed on the same machine, while maintaining flexibility for separate deployments.

**Background:**
- `databend-meta` and `databend-query` can be deployed either on the same machine or on different machines
- When deployed together, `databend-query` needs to start after `databend-meta` to ensure the meta service is ready
- However, we cannot use a hard dependency (like `Requires=`) because the services may be deployed separately

**Solution:**
Added `databend-meta.service` to the `After=` directive in `databend-query.service`. This ensures:
- On the same machine: `databend-query` will start after `databend-meta` if both services exist
- On different machines: If `databend-meta.service` doesn't exist, systemd will simply ignore the directive and `databend-query` can start normally
- No hard dependency: Using only `After=` without `Requires=` or `Wants=` means the services are not tightly coupled

**Related.**
- fix: https://github.com/databendlabs/databend/issues/19000

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _This is a systemd configuration change that doesn't require automated testing. Manual verification of service startup order is sufficient._

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Infrastructure/Deployment configuration improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19002)
<!-- Reviewable:end -->
