### PR TITLE
feat: enable Decimal64 handling in fuse table deserialization

### DIFF
--- a/src/common/native/src/read/batch_read.rs
+++ b/src/common/native/src/read/batch_read.rs
@@ -73,6 +73,16 @@ fn read_nested_column<R: NativeReadBuf>(
         }
         ),
         Decimal(decimal) => match decimal {
+            DecimalDataType::Decimal64(decimal_size) => {
+                init.push(InitNested::Primitive(is_nullable));
+                read_nested_decimal::<i64, i64, _>(
+                    &mut readers.pop().unwrap(),
+                    data_type.clone(),
+                    decimal_size,
+                    init,
+                    page_metas.pop().unwrap(),
+                )?
+            }
             DecimalDataType::Decimal128(decimal_size) => {
                 init.push(InitNested::Primitive(is_nullable));
                 let mut results = read_nested_decimal::<i128, i128, _>(
@@ -115,7 +125,6 @@ fn read_nested_column<R: NativeReadBuf>(
                     page_metas.pop().unwrap(),
                 )?
             }
-            _ => unreachable!(),
         },
         Interval => {
             init.push(InitNested::Primitive(is_nullable));

--- a/src/common/native/src/read/deserialize.rs
+++ b/src/common/native/src/read/deserialize.rs
@@ -168,6 +168,15 @@ where
             ))
         }
         TableDataType::Decimal(decimal) => match decimal {
+            DecimalDataType::Decimal64(size) => {
+                init.push(InitNested::Primitive(is_nullable));
+                DynIter::new(DecimalNestedIter::<_, i64, i64>::new(
+                    readers.pop().unwrap(),
+                    data_type.clone(),
+                    size,
+                    init,
+                ))
+            }
             DecimalDataType::Decimal128(size) => {
                 init.push(InitNested::Primitive(is_nullable));
                 DynIter::new(DecimalNestedIter::<_, i128, i128>::new(
@@ -187,7 +196,6 @@ where
                     readers.pop().unwrap(), data_type.clone(), size, init
                 ))
             }
-            _ => unreachable!(),
         },
         t if t.is_physical_binary() => {
             init.push(InitNested::Primitive(is_nullable));

--- a/src/common/native/src/write/serialize.rs
+++ b/src/common/native/src/write/serialize.rs
@@ -17,11 +17,9 @@ use std::io::Write;
 use databend_common_column::bitmap::Bitmap;
 use databend_common_column::buffer::Buffer;
 use databend_common_column::types::i256;
-use databend_common_expression::types::AccessType;
 use databend_common_expression::types::AnyType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::DecimalColumn;
-use databend_common_expression::types::DecimalView;
 use databend_common_expression::types::GeographyColumn;
 use databend_common_expression::types::NullableColumn;
 use databend_common_expression::types::NumberColumn;
@@ -100,16 +98,13 @@ impl<'a, W: Write> ValueVisitor for WriteVisitor<'a, W> {
 
     fn visit_any_decimal(&mut self, column: DecimalColumn) -> Result<()> {
         match column {
-            DecimalColumn::Decimal64(buffer, _) => {
-                let buffer: Vec<_> = DecimalView::<i64, i128>::iter_column(&buffer).collect();
-                write_primitive::<_, W>(
-                    self.w,
-                    &buffer.into(),
-                    self.validity.clone(),
-                    &self.write_options,
-                    self.scratch,
-                )
-            }
+            DecimalColumn::Decimal64(buffer, _) => write_primitive::<_, W>(
+                self.w,
+                &buffer,
+                self.validity.clone(),
+                &self.write_options,
+                self.scratch,
+            ),
             DecimalColumn::Decimal128(column, _) => write_primitive::<_, W>(
                 self.w,
                 &column,

--- a/src/query/expression/src/converts/arrow/from.rs
+++ b/src/query/expression/src/converts/arrow/from.rs
@@ -45,7 +45,6 @@ use crate::types::AnyType;
 use crate::types::ArrayColumn;
 use crate::types::DataType;
 use crate::types::DecimalColumn;
-use crate::types::DecimalDataKind;
 use crate::types::DecimalDataType;
 use crate::types::DecimalSize;
 use crate::types::GeographyColumn;
@@ -135,14 +134,17 @@ impl TryFrom<&Field> for TableField {
                 ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 | ArrowDataType::Utf8View => {
                     TableDataType::String
                 }
+                ArrowDataType::Decimal64(precision, scale) if *scale >= 0 => {
+                    TableDataType::Decimal(DecimalDataType::Decimal64(DecimalSize::new(
+                        *precision,
+                        *scale as _,
+                    )?))
+                }
                 ArrowDataType::Decimal128(precision, scale) if *scale >= 0 => {
-                    let size = DecimalSize::new(*precision, *scale as _)?;
-                    match size.data_kind() {
-                        DecimalDataKind::Decimal64 | DecimalDataKind::Decimal128 => {
-                            TableDataType::Decimal(DecimalDataType::Decimal128(size))
-                        }
-                        _ => unreachable!(),
-                    }
+                    TableDataType::Decimal(DecimalDataType::Decimal128(DecimalSize::new(
+                        *precision,
+                        *scale as _,
+                    )?))
                 }
                 ArrowDataType::Decimal256(precision, scale) if *scale >= 0 => {
                     TableDataType::Decimal(DecimalDataType::Decimal256(DecimalSize::new(

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -1678,7 +1678,10 @@ pub fn infer_schema_type(data_type: &DataType) -> Result<TableDataType> {
         DataType::Number(number_type) => Ok(TableDataType::Number(*number_type)),
         DataType::Timestamp => Ok(TableDataType::Timestamp),
         DataType::Decimal(size) => match size.data_kind() {
-            DecimalDataKind::Decimal64 | DecimalDataKind::Decimal128 => {
+            DecimalDataKind::Decimal64 => {
+                Ok(TableDataType::Decimal(DecimalDataType::Decimal64(*size)))
+            }
+            DecimalDataKind::Decimal128 => {
                 Ok(TableDataType::Decimal(DecimalDataType::Decimal128(*size)))
             }
             DecimalDataKind::Decimal256 => {

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -17,6 +17,6 @@
 2	{"k":"v"}
 --- large parquet file should be worked on parallel by rowgroups
 5000000
-├── partitions total: 6
-├── partitions scanned: 6
+├── partitions total: 3
+├── partitions scanned: 3
 5000000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fuse-table **parquet** deserialization now loads decimal columns with precision ≤18 as Decimal64 instead of Decimal128.  

    Parquet already picks the physical type based on precision during serialization, so only the read path needed to change. This remains fully backward compatible and **safe for rolling upgrades**.

- Fuse-table **native** serialization and deserialization now store Decimal64 columns as true 64-bit values per row instead of widening them to 128 bits. 

    This change is **not backward compatible**:  tables produced before this PR cannot be read by a build that includes this PR and will fail during Decimal64 decoding. 
    
    But given the clear performance gain and the native format still being in the research phase, accepting this compatibility trade-off seems reasonable.


- To keep rolling upgrades viable, we leave the table-column metadata protobuf in meta untouched even though it still lacks Decimal64; changing it would break older nodes in mixed-version deployments.

    Technically we could push part of the Decimal conversion logic into `schema_from_to_protobuf_impl.rs`, but that would force edits to existing `proto_conv` unit tests which would break that module’s append-only testing style and feels like a poor trade-off.
  
 ### Performance

  - Environment: r7i.8xlarge (single node), disk cache on, TPC-H SF1000 lineitem fully cached on disk.
  - Builds: This PR vs v1.2.848-nightly.
  - Queries
      - q1: `select l_quantity from lineitem ignore_result`
      - q2: `select l_extendedprice from lineitem ignore_result`
  
  
  Three hot runs per query/version (all values in seconds).

  | Query | Version | Run 1 | Run 2 | Run 3 | Avg |
  | --- | --- | --- | --- | --- | --- |
  | q1 | This PR | 1.04 | 1.02 | 1.00 | 1.02 |
  |  | v1.2.848-nightly | 3.28 | 3.47 | 3.32 | 3.36 |
  | q2 | This PR | 4.43 | 4.37 | 4.38 | 4.39 |
  |  | v1.2.848-nightly | 6.29 | 6.23 | 6.29 | 6.27 |
  
  
  -----------

- fixes: #18993

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19008)
<!-- Reviewable:end -->
