### PR TITLE
fix: Pruning multithreading without accumulating time

### DIFF
--- a/src/query/storages/fuse/src/pruning/pruning_statistics.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_statistics.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::array;
 use std::future::Future;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -226,29 +228,36 @@ fn duration_to_micros(duration: Duration) -> u64 {
     duration.as_micros().min(u64::MAX as u128) as u64
 }
 
+fn duration_to_nanos(duration: Duration) -> u64 {
+    duration.as_nanos().min(u64::MAX as u128) as u64
+}
+
 #[derive(Clone)]
 pub struct PruningCostController {
     stats: Arc<FusePruningStatistics>,
     enabled: bool,
+    timers: Arc<PruningCostTimers>,
 }
 
 impl PruningCostController {
     pub fn new(stats: Arc<FusePruningStatistics>, enabled: bool) -> Self {
-        Self { stats, enabled }
+        Self {
+            stats,
+            enabled,
+            timers: Arc::new(PruningCostTimers::new()),
+        }
     }
 
     pub fn timer(&self, kind: PruningCostKind) -> PruningCostGuard {
         if self.enabled {
             PruningCostGuard {
-                start: Some(Instant::now()),
                 stats: self.stats.clone(),
-                kind,
+                token: Some(self.timers.acquire(kind)),
             }
         } else {
             PruningCostGuard {
-                start: None,
                 stats: self.stats.clone(),
-                kind,
+                token: None,
             }
         }
     }
@@ -269,7 +278,7 @@ impl PruningCostController {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PruningCostKind {
     SegmentsRange,
     BlocksRange,
@@ -279,37 +288,164 @@ pub enum PruningCostKind {
     BlocksTopN,
 }
 
+const PRUNING_COST_KIND_COUNT: usize = 6;
+
+impl PruningCostKind {
+    const fn as_index(self) -> usize {
+        match self {
+            PruningCostKind::SegmentsRange => 0,
+            PruningCostKind::BlocksRange => 1,
+            PruningCostKind::BlocksBloom => 2,
+            PruningCostKind::BlocksInverted => 3,
+            PruningCostKind::BlocksVector => 4,
+            PruningCostKind::BlocksTopN => 5,
+        }
+    }
+}
+
 pub struct PruningCostGuard {
-    start: Option<Instant>,
     stats: Arc<FusePruningStatistics>,
+    token: Option<PruningCostGuardToken>,
+}
+
+struct PruningCostGuardToken {
     kind: PruningCostKind,
+    timers: Arc<PruningCostTimers>,
 }
 
 impl Drop for PruningCostGuard {
     fn drop(&mut self) {
-        let Some(start) = self.start.take() else {
+        if let Some(token) = self.token.take() {
+            token.finish(&self.stats);
+        }
+    }
+}
+
+impl PruningCostGuardToken {
+    fn finish(self, stats: &Arc<FusePruningStatistics>) {
+        let Some(elapsed) = self.timers.release(self.kind) else {
             return;
         };
-        let elapsed = start.elapsed();
+
         match self.kind {
             PruningCostKind::SegmentsRange => {
-                self.stats.add_segments_range_pruning_cost(elapsed);
+                stats.add_segments_range_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksRange => {
-                self.stats.add_blocks_range_pruning_cost(elapsed);
+                stats.add_blocks_range_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksBloom => {
-                self.stats.add_blocks_bloom_pruning_cost(elapsed);
+                stats.add_blocks_bloom_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksInverted => {
-                self.stats.add_blocks_inverted_index_pruning_cost(elapsed);
+                stats.add_blocks_inverted_index_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksVector => {
-                self.stats.add_blocks_vector_index_pruning_cost(elapsed);
+                stats.add_blocks_vector_index_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksTopN => {
-                self.stats.add_blocks_topn_pruning_cost(elapsed);
+                stats.add_blocks_topn_pruning_cost(elapsed);
             }
         }
+    }
+}
+
+struct PruningCostTimers {
+    epoch: Instant,
+    states: [PruningCostState; PRUNING_COST_KIND_COUNT],
+}
+
+impl PruningCostTimers {
+    fn new() -> Self {
+        Self {
+            epoch: Instant::now(),
+            states: array::from_fn(|_| PruningCostState::new()),
+        }
+    }
+
+    fn acquire(self: &Arc<Self>, kind: PruningCostKind) -> PruningCostGuardToken {
+        let state = &self.states[kind.as_index()];
+        if state.active.fetch_add(1, Ordering::AcqRel) == 0 {
+            state.start.store(self.elapsed_nanos(), Ordering::Release);
+        }
+
+        PruningCostGuardToken {
+            kind,
+            timers: self.clone(),
+        }
+    }
+
+    fn release(&self, kind: PruningCostKind) -> Option<Duration> {
+        let state = &self.states[kind.as_index()];
+        if state.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            let start = state.start.load(Ordering::Acquire);
+            let now = self.elapsed_nanos();
+            let elapsed_nanos = now.saturating_sub(start);
+            Some(Duration::from_nanos(elapsed_nanos))
+        } else {
+            None
+        }
+    }
+
+    fn elapsed_nanos(&self) -> u64 {
+        duration_to_nanos(self.epoch.elapsed())
+    }
+}
+
+struct PruningCostState {
+    active: AtomicUsize,
+    start: AtomicU64,
+}
+
+impl PruningCostState {
+    const fn new() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            start: AtomicU64::new(0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Barrier;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn pruning_cost_controller_records_parallel_time_once() {
+        let stats = Arc::new(FusePruningStatistics::default());
+        let controller = PruningCostController::new(stats.clone(), true);
+        let threads = 6;
+        let barrier = Arc::new(Barrier::new(threads));
+        let sleep_time = Duration::from_millis(100);
+
+        let mut handles = Vec::with_capacity(threads);
+        for _ in 0..threads {
+            let barrier = barrier.clone();
+            let controller = controller.clone();
+            handles.push(databend_common_base::runtime::Thread::spawn(move || {
+                barrier.wait();
+                controller.measure(PruningCostKind::BlocksTopN, || {
+                    thread::sleep(sleep_time);
+                });
+            }));
+        }
+        handles.into_iter().for_each(|h| h.join().unwrap());
+
+        let recorded = stats.get_blocks_topn_pruning_cost();
+        let lower = Duration::from_millis(80).as_micros() as u64;
+        let upper = Duration::from_millis(220).as_micros() as u64;
+        assert!(
+            recorded >= lower,
+            "recorded pruning cost {recorded}us is too small"
+        );
+        assert!(
+            recorded <= upper,
+            "recorded pruning cost {recorded}us exceeded expected bound"
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

During the Explain process, Pruning might be calculated using multiple threads. Therefore, the previous Cost logic would accumulate the times from these multiple threads. This pr ensures that the same timer is used across multiple threads and records the time after the last thread finishes executing.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19044)
<!-- Reviewable:end -->
