### PR TITLE
feat: impl `bitmap_construct_agg`

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -989,6 +989,17 @@ pub fn aggregate_bitmap_xor_count_function_desc() -> AggregateFunctionDescriptio
     )
 }
 
+pub fn aggregate_bitmap_xor_function_desc() -> AggregateFunctionDescription {
+    let features = super::AggregateFunctionFeatures {
+        is_decomposable: true,
+        ..Default::default()
+    };
+    AggregateFunctionDescription::creator_with_features(
+        Box::new(try_create_aggregate_bitmap_function::<BITMAP_XOR, BITMAP_AGG_RAW>),
+        features,
+    )
+}
+
 pub fn aggregate_bitmap_union_function_desc() -> AggregateFunctionDescription {
     let features = super::AggregateFunctionFeatures {
         is_decomposable: true,

--- a/src/query/functions/src/aggregates/aggregator.rs
+++ b/src/query/functions/src/aggregates/aggregator.rs
@@ -28,6 +28,7 @@ use super::aggregate_bitmap::aggregate_bitmap_not_count_function_desc;
 use super::aggregate_bitmap::aggregate_bitmap_or_count_function_desc;
 use super::aggregate_bitmap::aggregate_bitmap_union_function_desc;
 use super::aggregate_bitmap::aggregate_bitmap_xor_count_function_desc;
+use super::aggregate_bitmap::aggregate_bitmap_xor_function_desc;
 use super::aggregate_boolean::aggregate_boolean_function_desc;
 use super::aggregate_covariance::aggregate_covariance_population_desc;
 use super::aggregate_covariance::aggregate_covariance_sample_desc;
@@ -154,16 +155,24 @@ impl Aggregators {
             "bitmap_not_count",
             aggregate_bitmap_not_count_function_desc(),
         );
+        factory.register_multi_names(
+            &["bitmap_union", "bitmap_or_agg"],
+            aggregate_bitmap_union_function_desc,
+        );
         factory.register("bitmap_or_count", aggregate_bitmap_or_count_function_desc());
         factory.register(
             "bitmap_xor_count",
             aggregate_bitmap_xor_count_function_desc(),
         );
-        factory.register("bitmap_union", aggregate_bitmap_union_function_desc());
         factory.register(
             "bitmap_intersect",
             aggregate_bitmap_intersect_function_desc(),
         );
+        factory.register_multi_names(
+            &["bitmap_intersect", "bitmap_and_agg"],
+            aggregate_bitmap_intersect_function_desc,
+        );
+        factory.register("bitmap_xor_agg", aggregate_bitmap_xor_function_desc());
         factory.register(
             "intersect_count",
             aggregate_bitmap_intersect_count_function_desc(),

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_bitmap.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_bitmap.test
@@ -85,6 +85,11 @@ SELECT to_string(bitmap_intersect(v)), to_string(bitmap_union(v)) from agg_bitma
 ----
 1 0,1,2,3,4
 
+query III
+SELECT to_string(bitmap_and_agg(v)), to_string(bitmap_or_agg(v)), to_string(bitmap_xor_agg(v)) from agg_bitmap_test
+----
+1 0,1,2,3,4 1,2,3,4
+
 query I
 SELECT bitmap_count(bitmap_construct_agg(id::UNSIGNED)) from agg_bitmap_test
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

add aggregate function: `bitmap_construct_agg`: Bitmap or Aggregate calculations from a unsigned integer column, return Bitmap

- bitmap_construct_agg (UInt) -> Bitmap

rename `bitmap_union` -> `bitmap_or_agg`, `bitmap_intersect` -> `bitmap_and_agg`

add `bitmap_xor_agg`

remove `bitmap_and_count`, `bitmap_or_count`, `bitmap_xor_count`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19053)
<!-- Reviewable:end -->
