### PR TITLE
feat(query): add metrics session_acquired_queries_total

### DIFF
--- a/src/common/metrics/src/metrics/session.rs
+++ b/src/common/metrics/src/metrics/session.rs
@@ -41,6 +41,8 @@ pub static SESSION_QUEUE_ACQUIRE_DURATION_MS: LazyLock<Histogram> =
 
 pub static SESSION_RUNNING_ACQUIRED_QUERIES: LazyLock<Gauge> =
     LazyLock::new(|| register_gauge("session_running_acquired_queries"));
+pub static SESSION_ACQUIRED_QUERIES_TOTAL: LazyLock<Counter> =
+    LazyLock::new(|| register_counter("session_acquired_queries_total"));
 
 pub fn incr_session_connect_numbers() {
     SESSION_CONNECT_NUMBERS.inc();
@@ -80,4 +82,8 @@ pub fn inc_session_running_acquired_queries() {
 
 pub fn dec_session_running_acquired_queries() {
     SESSION_RUNNING_ACQUIRED_QUERIES.dec();
+}
+
+pub fn inc_session_acquired_queries_total() {
+    SESSION_ACQUIRED_QUERIES_TOTAL.inc();
 }

--- a/src/query/service/src/sessions/queue_mgr.rs
+++ b/src/query/service/src/sessions/queue_mgr.rs
@@ -49,6 +49,7 @@ use databend_common_meta_semaphore::errors::AcquireError;
 use databend_common_meta_store::MetaStore;
 use databend_common_meta_store::MetaStoreProvider;
 use databend_common_metrics::session::dec_session_running_acquired_queries;
+use databend_common_metrics::session::inc_session_acquired_queries_total;
 use databend_common_metrics::session::inc_session_running_acquired_queries;
 use databend_common_metrics::session::incr_session_queue_abort_count;
 use databend_common_metrics::session::incr_session_queue_acquire_error_count;
@@ -288,6 +289,7 @@ impl<Data: QueueData> QueueManager<Data> {
         guards.extend(self.acquire_warehouse_queue(data, timeout, instant).await?);
 
         inc_session_running_acquired_queries();
+        inc_session_acquired_queries_total();
         record_session_queue_acquire_duration_ms(start_time.elapsed().unwrap_or_default());
 
         Ok(AcquireQueueGuard::create(guards))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `session_acquired_queries_total` counter so we have a monotonic view of acquired query events alongside the existing gauge. Since `session_running_acquired_queries` is mostly zero on fetch.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19087)
<!-- Reviewable:end -->
