### PR TITLE
fix: udf args recursion crash and binding not found on table

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -5757,13 +5757,13 @@ impl<'a> TypeChecker<'a> {
         let mut visitor = UDFArgVisitor::new(&arg_types, arguments);
         udf_expr.drive_mut(&mut visitor);
 
-        // independent context
+        // Use current binding context so column references inside arguments can be resolved.
         let box (expr, _) = TypeChecker::try_create(
-            &mut BindContext::new(),
+            self.bind_context,
             self.ctx.clone(),
-            &NameResolutionContext::default(),
-            MetadataRef::default(),
-            &[],
+            self.name_resolution_ctx,
+            self.metadata.clone(),
+            self.aliases,
             self.forbid_udf,
         )?
         .resolve(&udf_expr)?;

--- a/src/query/sql/src/planner/semantic/udf_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/udf_rewriter.rs
@@ -243,7 +243,7 @@ impl<'a> VisitorMut<'a> for UdfRewriter {
 }
 
 #[derive(StatementVisitorMut)]
-#[visitor(Expr(enter))]
+#[visitor(Expr(exit))]
 pub struct UDFArgVisitor<'a> {
     arg_types: &'a [(String, DataType)],
     args: &'a [Expr],
@@ -254,7 +254,7 @@ impl<'a> UDFArgVisitor<'a> {
         Self { arg_types, args }
     }
 
-    fn enter_expr(&mut self, expr: &mut Expr) {
+    fn exit_expr(&mut self, expr: &mut Expr) {
         if let Expr::ColumnRef { span, column } = expr {
             if column.database.is_some() || column.table.is_some() {
                 return;

--- a/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0013_select_udf.test
@@ -317,4 +317,18 @@ SELECT bool_not(1 = 0);
 ----
 1
 
+statement ok
+CREATE OR REPLACE FUNCTION substring_index(str STRING, delim STRING, count INT) RETURNS STRING AS $$ ARRAY_TO_STRING(ARRAY_SLICE(SPLIT(str, delim), 1, count), delim) $$;
+
+statement ok
+CREATE OR REPLACE TABLE str_test ( str VARCHAR NULL ) ENGINE=FUSE;
+
+statement ok
+INSERT INTO str_test VALUES('a-b-c-d');
+
+query T
+SELECT substring_index(str, '-', 2) FROM str_test;
+----
+a-b
+
 # TODO: UDF Timestamp Timezone


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- UdfArgVisitor may cause a query crash due to infinite recursion when building casts for parameters.
- Fixed bind_context, used for binding columns.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19091)
<!-- Reviewable:end -->
