### PR TITLE
feat: check snapshot timestamp when update table meta

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -497,7 +497,7 @@ build_exceptions! {
     IllegalUser(2218),
 }
 
-// Database and Catalog Management Errors [2301-2317, 2321-2323]
+// Database and Catalog Management Errors [2301-2317, 2321-2327]
 build_exceptions! {
     /// Database already exists
     DatabaseAlreadyExists(2301),
@@ -537,6 +537,8 @@ build_exceptions! {
     RowAccessPolicyAlreadyExists(2324),
     /// General failures met while garbage collecting database meta
     GeneralDbGcFailure(2325),
+    /// Table snapshot is expired
+    TableSnapshotExpired(2327),
 }
 
 // Stage and Connection Errors [2501-2505, 2510-2512]

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -31,6 +31,7 @@ use databend_common_meta_app::app_error::MultiStmtTxnCommitFailed;
 use databend_common_meta_app::app_error::StreamAlreadyExists;
 use databend_common_meta_app::app_error::StreamVersionMismatched;
 use databend_common_meta_app::app_error::TableAlreadyExists;
+use databend_common_meta_app::app_error::TableSnapshotExpired;
 use databend_common_meta_app::app_error::TableVersionMismatched;
 use databend_common_meta_app::app_error::UndropTableHasNoHistory;
 use databend_common_meta_app::app_error::UndropTableWithNoDropTime;
@@ -1178,6 +1179,7 @@ where
         txn_sender: &IdempotentKVTxnSender,
     ) -> Result<UpdateMultiTableMetaResult, KVAppError> {
         let UpdateMultiTableMetaReq {
+            tenant,
             mut update_table_metas,
             copied_files,
             update_stream_metas,
@@ -1188,29 +1190,50 @@ where
         let mut tbl_seqs = HashMap::new();
         let mut txn = TxnRequest::default();
         let mut mismatched_tbs = vec![];
-        let tid_vec = update_table_metas
+        let (tid_vec, lvt_vec): (Vec<_>, Vec<_>) = update_table_metas
             .iter()
-            .map(|req| {
-                TableId {
-                    table_id: req.0.table_id,
-                }
-                .to_string_key()
+            .map(|(req, _)| {
+                (
+                    TableId {
+                        table_id: req.table_id,
+                    }
+                    .to_string_key(),
+                    LeastVisibleTimeIdent::new(&tenant, req.table_id),
+                )
             })
-            .collect::<Vec<_>>();
+            .unzip();
         let mut tb_meta_vec: Vec<(u64, Option<TableMeta>)> = mget_pb_values(self, &tid_vec).await?;
-        for (req, (tb_meta_seq, table_meta)) in
-            update_table_metas.iter().zip(tb_meta_vec.iter_mut())
+        let tb_lvt_vec = self.get_pb_values_vec(lvt_vec).await?;
+
+        for (((req, _), (tb_meta_seq, table_meta)), lvt) in update_table_metas
+            .iter()
+            .zip(tb_meta_vec.iter_mut())
+            .zip(tb_lvt_vec.iter())
         {
-            let req_seq = req.0.seq;
+            let req_seq = req.seq;
 
             if *tb_meta_seq == 0 || table_meta.is_none() {
                 return Err(KVAppError::AppError(AppError::UnknownTableId(
-                    UnknownTableId::new(req.0.table_id, "update_multi_table_meta"),
+                    UnknownTableId::new(req.table_id, "update_multi_table_meta"),
                 )));
+            }
+            if let Some(lvt) = lvt {
+                if let Some(ts) = req.snapshot_ts {
+                    // req.snapshot_ts records the timestamp of the snapshot that will become
+                    // visible after commit. Vacuum may be purging snapshots at the same time,
+                    // so rejecting snapshots older than LVT prevents them from being cleaned
+                    // up immediately after commit.
+                    let lvt = lvt.data.time;
+                    if lvt > ts {
+                        return Err(KVAppError::AppError(AppError::TableSnapshotExpired(
+                            TableSnapshotExpired::new(req.table_id, ts, lvt),
+                        )));
+                    }
+                }
             }
             if req_seq.match_seq(tb_meta_seq).is_err() {
                 mismatched_tbs.push((
-                    req.0.table_id,
+                    req.table_id,
                     *tb_meta_seq,
                     std::mem::take(table_meta).unwrap(),
                 ));

--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -740,6 +740,7 @@ pub struct UpdateTableMetaReq {
     pub seq: MatchSeq,
     pub new_table_meta: TableMeta,
     pub base_snapshot_location: Option<String>,
+    pub snapshot_ts: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -750,8 +751,9 @@ pub struct UpdateTempTableReq {
     pub copied_files: BTreeMap<String, TableCopiedFileInfo>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UpdateMultiTableMetaReq {
+    pub tenant: Tenant,
     pub update_table_metas: Vec<(UpdateTableMetaReq, TableInfo)>,
     pub copied_files: Vec<(u64, UpsertTableCopiedFileReq)>,
     pub update_stream_metas: Vec<UpdateStreamMetaReq>,
@@ -760,6 +762,17 @@ pub struct UpdateMultiTableMetaReq {
 }
 
 impl UpdateMultiTableMetaReq {
+    pub fn empty(tenant: Tenant) -> Self {
+        Self {
+            tenant,
+            update_table_metas: vec![],
+            copied_files: vec![],
+            update_stream_metas: vec![],
+            deduplicated_labels: vec![],
+            update_temp_tables: vec![],
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.update_table_metas.is_empty()
             && self.copied_files.is_empty()

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -432,11 +432,12 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     // update stream metas, currently used by "copy into location form stream"
     async fn update_stream_metas(
         &self,
+        tenant: &Tenant,
         update_stream_metas: Vec<UpdateStreamMetaReq>,
     ) -> Result<()> {
         self.update_multi_table_meta(UpdateMultiTableMetaReq {
             update_stream_metas,
-            ..Default::default()
+            ..UpdateMultiTableMetaReq::empty(tenant.clone())
         })
         .await
         .map(|_| ())
@@ -444,6 +445,7 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
 
     async fn update_single_table_meta(
         &self,
+        tenant: &Tenant,
         req: UpdateTableMetaReq,
         table_info: &TableInfo,
     ) -> Result<UpdateTableMetaReply> {
@@ -463,7 +465,7 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
         self.update_multi_table_meta(UpdateMultiTableMetaReq {
             update_table_metas,
             update_temp_tables,
-            ..Default::default()
+            ..UpdateMultiTableMetaReq::empty(tenant.clone())
         })
         .await
     }

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -116,7 +116,7 @@ pub async fn do_vacuum2(
     // By default, do not vacuum all the historical snapshots.
     let mut is_vacuum_all = false;
     let mut respect_flash_back_with_lvt = None;
-
+    let mut need_update_lvt = false;
     let snapshots_before_lvt = match retention_policy {
         RetentionPolicy::ByTimePeriod(delta_duration) => {
             info!("Using ByTimePeriod policy {:?}", delta_duration);
@@ -180,6 +180,7 @@ pub async fn do_vacuum2(
                 // as gc root, this flag will be propagated to the select_gc_root func later.
                 is_vacuum_all = true;
             }
+            need_update_lvt = true;
 
             // When selecting the GC root later, the last snapshot in `snapshots` (after truncation)
             // is the candidate, but its commit status is uncertain, so its previous snapshot is used
@@ -226,6 +227,18 @@ pub async fn do_vacuum2(
 
     let start = std::time::Instant::now();
     let gc_root_timestamp = gc_root.timestamp.unwrap();
+    // NOTE: when using the time-based retention policy we already persisted an LVT above to
+    // constrain snapshot listing, and that value can legitimately be newer than the gc_root.
+    // The meta side only ever moves LVT forward, so only retention policies that have not
+    // written an LVT in this run (e.g. keep-N-snapshots) need to persist it here.
+    if need_update_lvt {
+        let cat = ctx.get_default_catalog()?;
+        cat.set_table_lvt(
+            &LeastVisibleTimeIdent::new(ctx.get_tenant(), fuse_table.get_id()),
+            &LeastVisibleTime::new(gc_root_timestamp),
+        )
+        .await?;
+    }
     let gc_root_segments = gc_root
         .segments
         .iter()

--- a/src/query/service/src/interpreters/common/stream.rs
+++ b/src/query/service/src/interpreters/common/stream.rs
@@ -131,6 +131,7 @@ pub async fn query_build_update_stream_req(
                 seq: MatchSeq::Exact(stream_info.ident.seq),
                 new_table_meta,
                 base_snapshot_location: None,
+                snapshot_ts: None,
             },
             stream_info.clone(),
         ));

--- a/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
@@ -87,8 +87,11 @@ impl Interpreter for AlterTableClusterKeyInterpreter {
             seq: MatchSeq::Exact(table_info.ident.seq),
             new_table_meta,
             base_snapshot_location: fuse_table.snapshot_loc(),
+            snapshot_ts: None,
         };
-        catalog.update_single_table_meta(req, table_info).await?;
+        catalog
+            .update_single_table_meta(&tenant, req, table_info)
+            .await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/src/interpreters/interpreter_cluster_key_drop.rs
+++ b/src/query/service/src/interpreters/interpreter_cluster_key_drop.rs
@@ -75,8 +75,11 @@ impl Interpreter for DropTableClusterKeyInterpreter {
             seq: MatchSeq::Exact(table_info.ident.seq),
             new_table_meta,
             base_snapshot_location: fuse_table.snapshot_loc(),
+            snapshot_ts: None,
         };
-        catalog.update_single_table_meta(req, table_info).await?;
+        catalog
+            .update_single_table_meta(&tenant, req, table_info)
+            .await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -14,6 +14,8 @@
 
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableExt;
@@ -232,7 +234,7 @@ pub(crate) async fn commit_table_meta(
         let table_id = table_info.ident.table_id;
         let table_version = table_info.ident.seq;
 
-        let new_snapshot_location =
+        let (new_snapshot_location, snapshot_ts) =
             generate_new_snapshot(ctx, fuse_tbl, &new_table_meta.schema).await?;
 
         if let Some(new_snapshot_location) = &new_snapshot_location {
@@ -242,14 +244,18 @@ pub(crate) async fn commit_table_meta(
             );
         };
 
+        let tenant = ctx.get_tenant();
         let req = UpdateTableMetaReq {
             table_id,
             seq: MatchSeq::Exact(table_version),
             new_table_meta: new_table_meta.clone(),
             base_snapshot_location: fuse_tbl.snapshot_loc(),
+            snapshot_ts,
         };
 
-        catalog.update_single_table_meta(req, table_info).await?;
+        catalog
+            .update_single_table_meta(&tenant, req, table_info)
+            .await?;
 
         if let Some(new_snapshot_location) = new_snapshot_location {
             FuseTable::write_last_snapshot_hint(
@@ -265,11 +271,11 @@ pub(crate) async fn commit_table_meta(
     Ok(())
 }
 
-pub(crate) async fn generate_new_snapshot(
+async fn generate_new_snapshot(
     ctx: &dyn TableContext,
     fuse_table: &FuseTable,
     new_table_schema: &TableSchema,
-) -> Result<Option<String>> {
+) -> Result<(Option<String>, Option<DateTime<Utc>>)> {
     if let Some(snapshot) = fuse_table.read_table_snapshot().await? {
         let mut new_snapshot = TableSnapshot::try_from_previous(
             snapshot.clone(),
@@ -291,9 +297,9 @@ pub(crate) async fn generate_new_snapshot(
             .write(&new_snapshot_location, data)
             .await?;
 
-        Ok(Some(new_snapshot_location))
+        Ok((Some(new_snapshot_location), new_snapshot.timestamp))
     } else {
         info!("Snapshot not found, no need to generate new snapshot");
-        Ok(None)
+        Ok((None, None))
     }
 }

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -674,14 +674,18 @@ impl ModifyTableColumnInterpreter {
         let table_id = table_info.ident.table_id;
         let table_version = table_info.ident.seq;
 
+        let tenant = self.ctx.get_tenant();
         let req = UpdateTableMetaReq {
             table_id,
             seq: MatchSeq::Exact(table_version),
             new_table_meta,
             base_snapshot_location: fuse_table.snapshot_loc(),
+            snapshot_ts: None,
         };
 
-        let _resp = catalog.update_single_table_meta(req, table_info).await?;
+        let _resp = catalog
+            .update_single_table_meta(&tenant, req, table_info)
+            .await?;
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
@@ -133,6 +133,7 @@ impl AsyncSink for CommitMultiTableInsert {
 
         loop {
             let update_multi_table_meta_req = UpdateMultiTableMetaReq {
+                tenant: self.ctx.get_tenant(),
                 update_table_metas: update_table_metas.clone(),
                 copied_files: vec![],
                 update_stream_metas: self.update_stream_meta.clone(),
@@ -307,6 +308,9 @@ async fn build_update_table_meta_req(
         seq: MatchSeq::Exact(table_version),
         new_table_meta,
         base_snapshot_location: fuse_table.snapshot_loc(),
+        // Same reasoning as single-table commits: meta must reject any new snapshot
+        // whose timestamp would fall behind the table's LVT to avoid vacuum races.
+        snapshot_ts: snapshot.timestamp,
     };
     Ok(req)
 }

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -330,6 +330,9 @@ async fn try_rebuild_req(
             seq: MatchSeq::Exact(table_version),
             new_table_meta,
             base_snapshot_location: latest_table.snapshot_loc(),
+            // Vacuum can advance LVT mid-commit; sending the new snapshot timestamp lets
+            // meta prevent committing something that vacuum could delete instantly.
+            snapshot_ts: merged_snapshot.timestamp,
         };
         *update_table_meta_req = req;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Ensure snapshot timestamp is not behind the table’s least visible time when updating table metadata

This PR adds a safety check during table metadata updates to verify that the snapshot timestamp is greater than or equal to the table’s least visible time (LVT).
This prevents newly referenced or committed snapshots from falling behind the vacuum boundary and being incorrectly reclaimed while vacuum is running.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19106)
<!-- Reviewable:end -->
