### PR TITLE
refactor: release table lock earlier during DML execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,6 +4334,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
+ "parking_lot 0.12.3",
  "petgraph 0.6.5",
  "serde",
  "tokio",

--- a/src/query/pipeline/Cargo.toml
+++ b/src/query/pipeline/Cargo.toml
@@ -16,6 +16,7 @@ databend-common-tracing = { workspace = true }
 fastrace = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
+parking_lot = { workspace = true }
 petgraph = { workspace = true }
 serde = { workspace = true }
 

--- a/src/query/pipeline/src/core/mod.rs
+++ b/src/query/pipeline/src/core/mod.rs
@@ -31,6 +31,7 @@ pub use finished_chain::always_callback;
 pub use finished_chain::basic_callback;
 pub use input_error::InputError;
 pub use lock_guard::LockGuard;
+pub use lock_guard::SharedLockGuard;
 pub use lock_guard::UnlockApi;
 pub use pipe::Pipe;
 pub use pipe::PipeItem;

--- a/src/query/service/src/interpreters/interpreter_mutation.rs
+++ b/src/query/service/src/interpreters/interpreter_mutation.rs
@@ -119,7 +119,11 @@ impl Interpreter for MutationInterpreter {
         // Execute hook.
         self.execute_hook(&mutation, &mut build_res).await;
 
-        build_res.main_pipeline.add_lock_guard(mutation.lock_guard);
+        let lock_guard = mutation
+            .lock_guard
+            .as_ref()
+            .and_then(|holder| holder.try_take());
+        build_res.main_pipeline.add_lock_guard(lock_guard);
 
         Ok(build_res)
     }

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -753,9 +753,12 @@ impl Interpreter for ModifyTableColumnInterpreter {
             }
         };
 
-        build_res
-            .main_pipeline
-            .add_lock_guard(self.plan.lock_guard.clone());
+        let lock_guard = self
+            .plan
+            .lock_guard
+            .as_ref()
+            .and_then(|holder| holder.try_take());
+        build_res.main_pipeline.add_lock_guard(lock_guard);
         Ok(build_res)
     }
 }

--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -28,6 +28,7 @@ use databend_common_exception::Result;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::DataType;
+use databend_common_pipeline::core::SharedLockGuard;
 
 use crate::BindContext;
 use crate::ColumnEntry;
@@ -154,6 +155,7 @@ impl Binder {
                 )
                 .await
                 .map_err(|err| target_table_identifier.not_found_suggest_error(err))?
+                .map(SharedLockGuard::new)
         } else {
             None
         };

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -90,6 +90,7 @@ use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::TableIndex;
 use databend_common_meta_app::schema::TableIndexType;
 use databend_common_meta_app::storage::StorageParams;
+use databend_common_pipeline::core::SharedLockGuard;
 use databend_common_storage::check_operator;
 use databend_common_storage::init_operator;
 use databend_common_storages_basic::view_table::QUERY;
@@ -1225,7 +1226,8 @@ impl Binder {
                                 &table,
                                 &LockTableOption::LockWithRetry,
                             )
-                            .await?;
+                            .await?
+                            .map(SharedLockGuard::new);
                         let schema = self
                             .ctx
                             .get_table(&catalog, &database, &table)

--- a/src/query/sql/src/planner/binder/replace.rs
+++ b/src/query/sql/src/planner/binder/replace.rs
@@ -20,6 +20,7 @@ use databend_common_ast::ast::Statement;
 use databend_common_catalog::lock::LockTableOption;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_pipeline::core::SharedLockGuard;
 
 use crate::BindContext;
 use crate::binder::Binder;
@@ -61,7 +62,8 @@ impl Binder {
                 &table_name,
                 &LockTableOption::LockWithRetry,
             )
-            .await?;
+            .await?
+            .map(SharedLockGuard::new);
 
         let table = self
             .ctx

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -34,7 +34,7 @@ use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_app::schema::UndropTableReq;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_meta_app::tenant::Tenant;
-use databend_common_pipeline::core::LockGuard;
+use databend_common_pipeline::core::SharedLockGuard;
 
 use crate::plans::Plan;
 
@@ -406,7 +406,7 @@ pub struct ModifyTableColumnPlan {
     pub database: String,
     pub table: String,
     pub action: ModifyColumnAction,
-    pub lock_guard: Option<Arc<LockGuard>>,
+    pub lock_guard: Option<SharedLockGuard>,
 }
 
 impl ModifyTableColumnPlan {

--- a/src/query/sql/src/planner/plans/mutation.rs
+++ b/src/query/sql/src/planner/plans/mutation.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -23,7 +22,7 @@ use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
-use databend_common_pipeline::core::LockGuard;
+use databend_common_pipeline::core::SharedLockGuard;
 
 use crate::BindContext;
 use crate::ColumnSet;
@@ -77,7 +76,7 @@ pub struct Mutation {
     // `update *`` or `update set t1.a = t2.a ...`, the right expr on the `=` must be only a column,
     // we don't support complex expressions.
     pub can_try_update_column_only: bool,
-    pub lock_guard: Option<Arc<LockGuard>>,
+    pub lock_guard: Option<SharedLockGuard>,
     // When the filter is always false, do nothing.
     pub no_effect: bool,
 

--- a/src/query/sql/src/planner/plans/replace.rs
+++ b/src/query/sql/src/planner/plans/replace.rs
@@ -23,7 +23,7 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::StringType;
 use databend_common_meta_types::MetaId;
-use databend_common_pipeline::core::LockGuard;
+use databend_common_pipeline::core::SharedLockGuard;
 
 use super::insert::format_insert_source;
 use crate::FormatOptions;
@@ -39,7 +39,7 @@ pub struct Replace {
     pub schema: TableSchemaRef,
     pub source: InsertInputSource,
     pub delete_when: Option<Expr>,
-    pub lock_guard: Option<Arc<LockGuard>>,
+    pub lock_guard: Option<SharedLockGuard>,
 }
 
 impl PartialEq for Replace {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Table lock scope now limited to pipeline execution, it was tied to interpreters lifetime before this PR.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - use existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19113)
<!-- Reviewable:end -->
