### PR TITLE
refactor: reduce max page size of http handler to 4MB.

### DIFF
--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -37,6 +37,7 @@ use headers::HeaderMapExt;
 use http::HeaderMap;
 use http::HeaderValue;
 use http::StatusCode;
+use itertools::Itertools;
 use log::error;
 use log::info;
 use log::warn;
@@ -714,6 +715,11 @@ pub async fn heartbeat_handler(
     Json(body): Json<HeartBeatRequest>,
 ) -> poem::error::Result<impl IntoResponse> {
     let local_id = GlobalConfig::instance().query.node_id.clone();
+    let queries = &body.node_to_queries.values().flatten().join(",");
+    info!(
+        "Received heartbeat, session={:?}, queries={}",
+        ctx.client_session_id, queries
+    );
     let mut queries_to_remove = vec![];
     let mut nodes_to_forwards = vec![];
     for (node_id, queries) in body.node_to_queries {

--- a/src/query/service/src/servers/http/v1/query/sized_spsc.rs
+++ b/src/query/service/src/servers/http/v1/query/sized_spsc.rs
@@ -179,7 +179,7 @@ impl PageBuilder {
     fn new(max_rows: usize) -> Self {
         Self {
             blocks: Vec::new(),
-            remain_size: 10 * 1024 * 1024,
+            remain_size: 4 * 1024 * 1024,
             remain_rows: max_rows,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 reduce max page size of http handler from 10MB to 4MB to avoid client timeout due to serialization.

by the way, also add logging for slow serialization and heartbeat request.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19136)
<!-- Reviewable:end -->
