### PR TITLE
feat: clustering_statistics support specify snapshot

### DIFF
--- a/src/query/storages/fuse/src/table_functions/clustering_statistics.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_statistics.rs
@@ -64,6 +64,13 @@ impl TableMetaFunc for ClusteringStatistics {
         snapshot: Arc<TableSnapshot>,
         limit: Option<usize>,
     ) -> Result<DataBlock> {
+        // NOTE (design choice):
+        // Clustering statistics are only meaningful for the current cluster key definition.
+        // Historical cluster information stored in snapshots is intentionally ignored.
+        //
+        // Once the cluster key changes, historical cluster_stats cannot be interpreted
+        // or compared correctly, so snapshots are evaluated against the live table's
+        // cluster key only.
         let Some(cluster_key_id) = tbl.cluster_key_id() else {
             return Err(ErrorCode::UnclusteredTable(format!(
                 "Unclustered table {}",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

clustering_statistics('db','tb'[,'snapshot_id'])
```sql
root@localhost:8000/default/default> create table t(a int)cluster by(a);

create table t(a int) cluster by(a)

root@localhost:8000/default/default> insert into t values(1),(3);

insert into
  t
values
(1),
(3)

╭─────────────────────────╮
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                       2 │
╰─────────────────────────╯
2 rows written in 0.073 sec. Processed 2 rows, 9 B (27.4 rows/s, 123 B/s)

root@localhost:8000/default/default> insert into t values(2),(5);

insert into
  t
values
(2),
(5)

╭─────────────────────────╮
│ number of rows inserted │
│          UInt64         │
├─────────────────────────┤
│                       2 │
╰─────────────────────────╯
2 rows written in 0.102 sec. Processed 2 rows, 9 B (19.61 rows/s, 88 B/s)

root@localhost:8000/default/default> optimize table t compact;

optimize table t compact

4 rows written in 0.275 sec. Processed 4 rows, 17 B (14.55 rows/s, 61 B/s)

root@localhost:8000/default/default> select * from clustering_statistics('default','t');

select
  *
from
  clustering_statistics('default', 't')

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                    segment_name                   │                      block_name                      │        min       │        max       │      level      │       pages      │
│                       String                      │                        String                        │ Nullable(String) │ Nullable(String) │ Nullable(Int32) │ Nullable(String) │
├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────┼──────────────────┼─────────────────┼──────────────────┤
│ 1/19/_sg/h019b53b184bd7cdcbe3e5166b3080f01_v4.mpk │ 1/19/_b/h019b53b184bd72f8a1061f5b10a5aeeb_v2.parquet │ [1]              │ [5]              │               0 │ NULL             │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
1 row read in 0.094 sec. Processed 1 row, 189 B (10.64 rows/s, 1.96 KiB/s)

root@localhost:8000/default/default> select snapshot_id from fuse_snapshot('default','t');

select
  snapshot_id
from
  fuse_snapshot('default', 't')

╭──────────────────────────────────╮
│            snapshot_id           │
│              String              │
├──────────────────────────────────┤
│ 019b4e8b28bd7548bdb3c32eb4823d98 │
│ 019b4e8b179e769f801344f931e1ab6c │
│ 019b4e8b061b739db6859728e6420e39 │
╰──────────────────────────────────╯
3 rows read in 0.034 sec. Processed 3 rows, 770 B (88.24 rows/s, 22.12 KiB/s)

root@localhost:8000/default/default> select * from clustering_statistics('default','t','019b4e8b179e769f801344f931e1ab6c');

select
  *
from
  clustering_statistics('default', 't', '019b4e8b179e769f801344f931e1ab6c')

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                    segment_name                   │                      block_name                      │        min       │        max       │      level      │       pages      │
│                       String                      │                        String                        │ Nullable(String) │ Nullable(String) │ Nullable(Int32) │ Nullable(String) │
├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────┼──────────────────┼─────────────────┼──────────────────┤
│ 1/19/_sg/h019b53b1739e756183d525e9bdad63d8_v4.mpk │ 1/19/_b/h019b53b1739e7ea2be2247b18cdc7d27_v2.parquet │ [2]              │ [5]              │               0 │ NULL             │
│ 1/19/_sg/h019b53b1621b7eb59ac60f52e476b07c_v4.mpk │ 1/19/_b/h019b53b1621b70faba6020e3254ec409_v2.parquet │ [1]              │ [3]              │               0 │ NULL             │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
2 rows read in 0.041 sec. Processed 2 rows, 374 B (48.78 rows/s, 8.91 KiB/s)
```

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - No need test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19148)
<!-- Reviewable:end -->
