### PR TITLE
chore: Date/Time elements are used in AggregateDistinct in numerical form, reducing the memory usage of the Set.

### DIFF
--- a/src/query/functions/src/aggregates/adaptors/aggregate_combinator_distinct.rs
+++ b/src/query/functions/src/aggregates/adaptors/aggregate_combinator_distinct.rs
@@ -42,9 +42,11 @@ use super::AggregateFunctionFeatures;
 use super::AggregateFunctionSortDesc;
 use super::CombinatorDescription;
 use super::StateAddr;
+use super::aggregate_distinct_state::AggregateDistinctDateState;
 use super::aggregate_distinct_state::AggregateDistinctNumberState;
 use super::aggregate_distinct_state::AggregateDistinctState;
 use super::aggregate_distinct_state::AggregateDistinctStringState;
+use super::aggregate_distinct_state::AggregateDistinctTimestampState;
 use super::aggregate_distinct_state::AggregateUniqStringState;
 use super::aggregate_distinct_state::DistinctStateFunc;
 use super::aggregate_null_result::AggregateNullResultFunction;
@@ -298,6 +300,26 @@ fn try_create(
                 }))
             }
         }),
+        [DataType::Timestamp] => Ok(Arc::new(AggregateDistinctCombinator::<
+            AggregateDistinctTimestampState,
+        > {
+            nested_name: nested_name.to_owned(),
+            arguments,
+            skip_null: false,
+            nested,
+            name,
+            _s: PhantomData,
+        })),
+        [DataType::Date] => Ok(Arc::new(AggregateDistinctCombinator::<
+            AggregateDistinctDateState,
+        > {
+            nested_name: nested_name.to_owned(),
+            arguments,
+            skip_null: false,
+            nested,
+            name,
+            _s: PhantomData,
+        })),
         [DataType::String] if matches!(nested_name, "count" | "uniq") => {
             Ok(Arc::new(AggregateDistinctCombinator::<
                 AggregateUniqStringState,

--- a/src/query/functions/src/aggregates/aggregate_distinct_state.rs
+++ b/src/query/functions/src/aggregates/aggregate_distinct_state.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashSet;
 use std::hash::Hasher;
+use std::marker::PhantomData;
 use std::marker::Send;
 use std::sync::Arc;
 
@@ -25,9 +26,12 @@ use databend_common_expression::AggrStateLoc;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
+use databend_common_expression::ColumnView;
 use databend_common_expression::ProjectedBlock;
 use databend_common_expression::Scalar;
 use databend_common_expression::StateSerdeItem;
+use databend_common_expression::types::simple_type::SimpleType;
+use databend_common_expression::types::simple_type::SimpleValueType;
 use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_expression::types::*;
 use databend_common_hashtable::HashSet as CommonHashSet;
@@ -61,6 +65,190 @@ pub(super) trait DistinctStateFunc: Sized + Send + StateSerde + 'static {
     fn merge(&mut self, rhs: &Self) -> Result<()>;
     fn build_entries(&mut self, types: &[DataType]) -> Result<Vec<BlockEntry>>;
 }
+
+pub trait SimpleAccessType: AccessType {
+    type Simple: SimpleType<Scalar = <Self as AccessType>::Scalar>;
+}
+
+impl<T: SimpleType> SimpleAccessType for SimpleValueType<T> {
+    type Simple = T;
+}
+
+pub trait DistinctAdapter: Send + 'static
+where <Self::Access as AccessType>::Scalar: Copy + Send + HashtableKeyable
+{
+    type Access: SimpleAccessType + ArgType;
+
+    fn downcast_column(columns: &ProjectedBlock) -> ColumnView<Self::Access>;
+    fn upcast_column(values: Buffer<<Self::Access as AccessType>::Scalar>) -> BlockEntry;
+}
+
+pub struct NumberAdapter<T>(PhantomData<T>);
+
+impl<T> DistinctAdapter for NumberAdapter<T>
+where T: Number + HashtableKeyable + Copy + Send
+{
+    type Access = NumberType<T>;
+
+    fn downcast_column(columns: &ProjectedBlock) -> ColumnView<Self::Access> {
+        columns[0].downcast::<Self::Access>().unwrap()
+    }
+
+    fn upcast_column(values: Buffer<<Self::Access as AccessType>::Scalar>) -> BlockEntry {
+        NumberType::<T>::upcast_column(values).into()
+    }
+}
+
+pub struct TimestampAdapter;
+
+impl DistinctAdapter for TimestampAdapter {
+    type Access = TimestampType;
+
+    fn downcast_column(columns: &ProjectedBlock) -> ColumnView<Self::Access> {
+        columns[0].downcast::<Self::Access>().unwrap()
+    }
+
+    fn upcast_column(values: Buffer<<Self::Access as AccessType>::Scalar>) -> BlockEntry {
+        TimestampType::upcast_column(values).into()
+    }
+}
+
+pub struct DateAdapter;
+
+impl DistinctAdapter for DateAdapter {
+    type Access = DateType;
+
+    fn downcast_column(columns: &ProjectedBlock) -> ColumnView<Self::Access> {
+        columns[0].downcast::<Self::Access>().unwrap()
+    }
+
+    fn upcast_column(values: Buffer<<Self::Access as AccessType>::Scalar>) -> BlockEntry {
+        DateType::upcast_column(values).into()
+    }
+}
+
+pub struct AggregateDistinctAdapterState<A: DistinctAdapter>
+where <A::Access as AccessType>::Scalar: Copy + Send + HashtableKeyable
+{
+    set: CommonHashSet<<A::Access as AccessType>::Scalar>,
+    _adapter: PhantomData<A>,
+}
+
+impl<A> DistinctStateFunc for AggregateDistinctAdapterState<A>
+where
+    A: DistinctAdapter,
+    <A::Access as AccessType>::Scalar: Copy + Send + HashtableKeyable,
+{
+    fn new() -> Self {
+        AggregateDistinctAdapterState {
+            set: CommonHashSet::with_capacity(4),
+            _adapter: PhantomData,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    fn add(&mut self, columns: ProjectedBlock, row: usize, _skip_null: bool) -> Result<()> {
+        let view = A::downcast_column(&columns);
+        let v = unsafe { view.index_unchecked(row) };
+        let key: <A::Access as AccessType>::Scalar = A::Access::to_owned_scalar(v);
+        let _ = self.set.set_insert(key).is_ok();
+        Ok(())
+    }
+
+    fn batch_add(
+        &mut self,
+        columns: ProjectedBlock,
+        validity: Option<&Bitmap>,
+        input_rows: usize,
+        _skip_null: bool,
+    ) -> Result<()> {
+        let view = A::downcast_column(&columns);
+        match validity {
+            Some(bitmap) => {
+                for (t, v) in view.iter().zip(bitmap.iter()) {
+                    if v {
+                        let key: <A::Access as AccessType>::Scalar = A::Access::to_owned_scalar(t);
+                        let _ = self.set.set_insert(key).is_ok();
+                    }
+                }
+            }
+            None => {
+                for row in 0..input_rows {
+                    let v = unsafe { view.index_unchecked(row) };
+                    let key: <A::Access as AccessType>::Scalar = A::Access::to_owned_scalar(v);
+                    let _ = self.set.set_insert(key).is_ok();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn merge(&mut self, rhs: &Self) -> Result<()> {
+        self.set.set_merge(&rhs.set);
+        Ok(())
+    }
+
+    fn build_entries(&mut self, _types: &[DataType]) -> Result<Vec<BlockEntry>> {
+        let values: Buffer<<A::Access as AccessType>::Scalar> =
+            self.set.iter().map(|e| *e.key()).collect();
+        Ok(vec![A::upcast_column(values)])
+    }
+}
+
+impl<A> StateSerde for AggregateDistinctAdapterState<A>
+where
+    A: DistinctAdapter,
+    <A::Access as AccessType>::Scalar: Copy + Send + HashtableKeyable,
+{
+    fn serialize_type(_: Option<&dyn SerializeInfo>) -> Vec<StateSerdeItem> {
+        vec![DataType::Array(Box::new(A::Access::data_type())).into()]
+    }
+
+    fn batch_serialize(
+        places: &[StateAddr],
+        loc: &[AggrStateLoc],
+        builders: &mut [ColumnBuilder],
+    ) -> Result<()> {
+        batch_serialize1::<ArrayType<A::Access>, Self, _>(
+            places,
+            loc,
+            builders,
+            |state, builder| {
+                for v in state.set.iter() {
+                    builder.put_item(A::Access::to_scalar_ref(v.key()));
+                }
+                builder.commit_row();
+                Ok(())
+            },
+        )
+    }
+
+    fn batch_merge(
+        places: &[StateAddr],
+        loc: &[AggrStateLoc],
+        state: &BlockEntry,
+        filter: Option<&Bitmap>,
+    ) -> Result<()> {
+        batch_merge1::<ArrayType<A::Access>, Self, _>(places, loc, state, filter, |state, data| {
+            for v in A::Access::iter_column(&data) {
+                let key: <A::Access as AccessType>::Scalar = A::Access::to_owned_scalar(v);
+                let _ = state.set.set_insert(key).is_ok();
+            }
+            Ok(())
+        })
+    }
+}
+
+pub type AggregateDistinctNumberState<T> = AggregateDistinctAdapterState<NumberAdapter<T>>;
+pub type AggregateDistinctTimestampState = AggregateDistinctAdapterState<TimestampAdapter>;
+pub type AggregateDistinctDateState = AggregateDistinctAdapterState<DateAdapter>;
 
 pub struct AggregateDistinctState {
     set: HashSet<Vec<u8>>,
@@ -288,118 +476,6 @@ impl StateSerde for AggregateDistinctStringState {
             }
             Ok(())
         })
-    }
-}
-
-pub struct AggregateDistinctNumberState<T: Number + HashtableKeyable> {
-    set: CommonHashSet<T>,
-}
-
-impl<T> DistinctStateFunc for AggregateDistinctNumberState<T>
-where T: Number + HashtableKeyable
-{
-    fn new() -> Self {
-        AggregateDistinctNumberState {
-            set: CommonHashSet::with_capacity(4),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.set.is_empty()
-    }
-
-    fn len(&self) -> usize {
-        self.set.len()
-    }
-
-    fn add(&mut self, columns: ProjectedBlock, row: usize, _skip_null: bool) -> Result<()> {
-        let view = columns[0].downcast::<NumberType<T>>().unwrap();
-        let v = unsafe { view.index_unchecked(row) };
-        let _ = self.set.set_insert(v).is_ok();
-        Ok(())
-    }
-
-    fn batch_add(
-        &mut self,
-        columns: ProjectedBlock,
-        validity: Option<&Bitmap>,
-        input_rows: usize,
-        _skip_null: bool,
-    ) -> Result<()> {
-        let view = columns[0].downcast::<NumberType<T>>().unwrap();
-        match validity {
-            Some(bitmap) => {
-                for (t, v) in view.iter().zip(bitmap.iter()) {
-                    if v {
-                        let _ = self.set.set_insert(t).is_ok();
-                    }
-                }
-            }
-            None => {
-                for row in 0..input_rows {
-                    let v = unsafe { view.index_unchecked(row) };
-                    let _ = self.set.set_insert(v).is_ok();
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn merge(&mut self, rhs: &Self) -> Result<()> {
-        self.set.set_merge(&rhs.set);
-        Ok(())
-    }
-
-    fn build_entries(&mut self, _types: &[DataType]) -> Result<Vec<BlockEntry>> {
-        let values: Buffer<T> = self.set.iter().map(|e| *e.key()).collect();
-        Ok(vec![NumberType::<T>::upcast_column(values).into()])
-    }
-}
-
-impl<T> StateSerde for AggregateDistinctNumberState<T>
-where T: Number + HashtableKeyable
-{
-    fn serialize_type(_: Option<&dyn SerializeInfo>) -> Vec<StateSerdeItem> {
-        vec![DataType::Array(Box::new(NumberType::<T>::data_type())).into()]
-    }
-
-    fn batch_serialize(
-        places: &[StateAddr],
-        loc: &[AggrStateLoc],
-        builders: &mut [ColumnBuilder],
-    ) -> Result<()> {
-        batch_serialize1::<ArrayType<NumberType<T>>, Self, _>(
-            places,
-            loc,
-            builders,
-            |state, builder| {
-                for v in state.set.iter() {
-                    builder.put_item(*v.key());
-                }
-                builder.commit_row();
-                Ok(())
-            },
-        )
-    }
-
-    fn batch_merge(
-        places: &[StateAddr],
-        loc: &[AggrStateLoc],
-        state: &BlockEntry,
-        filter: Option<&Bitmap>,
-    ) -> Result<()> {
-        batch_merge1::<ArrayType<NumberType<T>>, Self, _>(
-            places,
-            loc,
-            state,
-            filter,
-            |state, data| {
-                for v in data.iter() {
-                    let _ = state.set.set_insert(*v);
-                }
-                Ok(())
-            },
-        )
     }
 }
 

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_distinct.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_distinct.test
@@ -31,3 +31,19 @@ query TI
 select 'a',count(distinct null,null) from numbers(5);
 ----
 a 0
+
+query TI
+select 'a', count(distinct ts)
+from (values('2024-01-01 00:00:00'::timestamp),
+           ('2024-01-02 00:00:00'::timestamp),
+           ('2024-01-01 00:00:00'::timestamp)) t(ts);
+----
+a 2
+
+query TI
+select 'a', count(distinct d)
+from (values('2024-01-01'::date),
+           ('2024-01-02'::date),
+           ('2024-01-02'::date)) t(d);
+----
+a 2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In the original code, Time and Date types would enter AggregateDistinctState during distinct operations, using Vec<u8> for deduplication. However, both Time and Date are actually stored in i64/i32. Therefore, AggregateDistinctNumberState is improved to support both Time and Date, using numbers for deduplication.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19157)
<!-- Reviewable:end -->
