### PR TITLE
feat: allow retry with the same query id when starting query.

### DIFF
--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -581,7 +581,7 @@ pub struct HttpQuery {
 
     // client states
     client_state: Arc<Mutex<ClientState>>,
-    page_manager: Arc<TokioMutex<PageManager>>,
+    pub(crate) page_manager: Arc<TokioMutex<PageManager>>,
     last_session_conf: Arc<Mutex<Option<HttpSessionConf>>>,
     pub(crate) is_txn_mgr_saved: AtomicBool,
 }

--- a/src/query/service/src/servers/http/v1/query/http_query_context.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_context.rs
@@ -42,6 +42,7 @@ pub struct HttpQueryContext {
     pub session: Arc<Session>,
     pub credential: Credential,
     pub query_id: String,
+    pub is_query_id_from_client: bool,
     pub node_id: String,
     pub expected_node_id: Option<String>,
     pub deduplicate_label: Option<String>,

--- a/src/query/service/src/servers/http/v1/query/http_query_manager.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query_manager.rs
@@ -68,9 +68,18 @@ impl Queries {
         self.active.get(query_id).cloned()
     }
 
-    pub(crate) fn insert(&mut self, query: Arc<HttpQuery>) {
-        self.num_active_queries += 1;
-        self.active.insert(query.id.clone(), query);
+    pub(crate) fn insert(&mut self, query: Arc<HttpQuery>) -> Result<()> {
+        let query_id = query.id.clone();
+        if self.active.contains_key(&query_id) {
+            let err = ErrorCode::BadArguments(format!(
+                "fail to start query: query_id {query_id} already exists"
+            ));
+            return Err(err);
+        } else {
+            self.num_active_queries += 1;
+            self.active.insert(query.id.clone(), query);
+        }
+        return Ok(());
     }
 
     pub(crate) fn remove(&mut self, query_id: &str) -> Option<Arc<HttpQuery>> {
@@ -143,9 +152,8 @@ impl HttpQueryManager {
     }
 
     #[async_backtrace::framed]
-    pub async fn add_query(self: &Arc<Self>, query: HttpQuery) -> Arc<HttpQuery> {
-        let query = Arc::new(query);
-        self.queries.write().insert(query.clone());
+    pub async fn add_query(self: &Arc<Self>, query: Arc<HttpQuery>) -> Result<Arc<HttpQuery>> {
+        self.queries.write().insert(query.clone())?;
 
         let self_clone = self.clone();
         let query_id_clone = query.id.clone();
@@ -182,7 +190,7 @@ impl HttpQueryManager {
                 }
             }
         });
-        query
+        Ok(query)
     }
 
     #[async_backtrace::framed]

--- a/tests/nox/suites/1_stateful/09_http_handler/test_09_0016_retry_start_query.py
+++ b/tests/nox/suites/1_stateful/09_http_handler/test_09_0016_retry_start_query.py
@@ -1,0 +1,33 @@
+import json
+import uuid
+
+import requests
+import pyarrow.ipc as ipc
+
+auth = ("root", "")
+
+
+def do_query(query, pagination, query_id):
+    url = f"http://localhost:8000/v1/query"
+    payload = {
+        "sql": query,
+    }
+    if pagination:
+        payload["pagination"] = pagination
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "x-databend-query-id": query_id,
+    }
+
+    return requests.post(url, headers=headers, json=payload, auth=auth)
+
+
+def test_result_format_settings():
+    sql = 'select 1'
+    query_id = str(uuid.uuid4())
+    do_query('select 1', None, query_id)
+
+    resp = do_query('select 2', None, query_id)
+    print(resp.json())
+    assert resp.json()['data'][0][0] == "1"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

allow retry with the same query id when starting query (POST /v1/query) with same query_id.
the retry return the resp of the first request.
check the user_name (authed) for safety.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19184)
<!-- Reviewable:end -->
