### PR TITLE
fix(query): enable role-based S3 credential chain

### DIFF
--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -416,8 +416,11 @@ fn init_s3_operator(cfg: &StorageS3Config) -> Result<impl Builder> {
         builder = builder.default_storage_class(cfg.storage_class.to_string().as_ref())
     }
 
-    // If allow_credential_chain is not set, default to false for security.
-    let allow_credential_chain = cfg.allow_credential_chain.unwrap_or(false);
+    // When a role is configured we must allow the credential chain so AWS can assume it,
+    // otherwise we should disable the credential chain for security.
+    let allow_credential_chain = cfg
+        .allow_credential_chain
+        .unwrap_or(!cfg.role_arn.is_empty());
 
     // Disallowing the credential chain forces unsigned or fully explicit access.
     if !allow_credential_chain {

--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -88,12 +88,13 @@ impl StageFileInfo {
 pub fn init_stage_operator(stage_info: &StageInfo) -> Result<Operator> {
     if stage_info.stage_type == StageType::External {
         // External S3 stages disallow the ambient credential chain by default.
-        // `role_arn` opts into using the credential chain as the source credential.
+        // The S3 operator builder will re-enable it automatically when a role_arn is present.
+        // This hook only needs to force-enable the chain for cases like system history tables.
         let storage = match stage_info.stage_params.storage.clone() {
             StorageParams::S3(mut cfg) => {
-                let allow_credential_chain =
-                    stage_info.allow_credential_chain || !cfg.role_arn.is_empty();
-                cfg.allow_credential_chain = Some(allow_credential_chain);
+                if stage_info.allow_credential_chain {
+                    cfg.allow_credential_chain = Some(true);
+                }
                 StorageParams::S3(cfg)
             }
             v => v,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Problem

All other S3 entry points (config-driven tables, COPY, stages with `role_arn`) already re-enabled the credential chain automatically, but `CREATE TABLE … CONNECTION_NAME` persisted `allow_credential_chain=None`, so AssumeRole silently broke on read/write.

### Solution

The operator now applies the same role-aware default for every S3 config, and the binder/stage glue only overrides when they truly need to. With this change, the connection-backed CREATE TABLE path finally matches the behavior of the other code paths.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19188)
<!-- Reviewable:end -->
