### PR TITLE
chore: fix misleading comment about CTAS and `allow_append_only_skip`

### DIFF
--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -386,10 +386,9 @@ where F: SnapshotGenerator + Send + Sync + 'static
             .is_some()
     }
 
-    /// Append-only inserts (e.g. `INSERT INTO t SELECT ...`) may skip committing if
-    /// nothing was written. Overwrite/CTAS (`CREATE OR REPLACE TABLE t AS SELECT ...`
-    /// or `INSERT OVERWRITE ...`) still need a snapshot even when nothing was written,
-    /// so we disable skipping when `AppendGenerator` is in overwrite mode.
+    /// Append-only inserts (e.g. `INSERT INTO t SELECT ...`) may skip committing if nothing was
+    /// written. `INSERT OVERWRITE ...` still need a snapshot even when nothing was written, so we
+    /// disable skipping when `AppendGenerator` is in overwrite mode.
     fn allow_append_only_skip(&self) -> bool {
         self.snapshot_gen
             .as_any()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Previous comments about the behavior of `CommitSink::allow_append_only_skip` were incorrect. In fact,
CTAS operations are allowed to skip the `update_table_meta` operation inside CommitSink if no data 
is inserted to the target table.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - fix comments only

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): fix code comments

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19189)
<!-- Reviewable:end -->
