### PR TITLE
refactor(meta): upgrade openraft to v0.10.0-alpha.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11346,7 +11346,7 @@ dependencies = [
 [[package]]
 name = "openraft"
 version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.11#6847fd3e341da8b8cf1a2bbacd593554081ad363"
+source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.13#8d3592cc2e44e12dbdeeb74ae367d042e98af606"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -11356,10 +11356,11 @@ dependencies = [
  "futures",
  "maplit",
  "openraft-macros",
+ "openraft-rt",
+ "openraft-rt-tokio",
  "rand 0.9.2",
  "serde",
  "thiserror 1.0.69",
- "tokio",
  "tracing",
  "tracing-futures",
  "validit",
@@ -11368,13 +11369,34 @@ dependencies = [
 [[package]]
 name = "openraft-macros"
 version = "0.10.0"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.11#6847fd3e341da8b8cf1a2bbacd593554081ad363"
+source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.13#8d3592cc2e44e12dbdeeb74ae367d042e98af606"
 dependencies = [
  "chrono",
  "proc-macro2",
  "quote",
  "semver",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "openraft-rt"
+version = "0.10.0"
+source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.13#8d3592cc2e44e12dbdeeb74ae367d042e98af606"
+dependencies = [
+ "futures",
+ "openraft-macros",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "openraft-rt-tokio"
+version = "0.10.0"
+source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.13#8d3592cc2e44e12dbdeeb74ae367d042e98af606"
+dependencies = [
+ "futures",
+ "openraft-rt",
+ "rand 0.9.2",
+ "tokio",
 ]
 
 [[package]]
@@ -16682,9 +16704,9 @@ dependencies = [
 
 [[package]]
 name = "validit"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fad49f3eae9c160c06b4d49700a99e75817f127cf856e494b56d5e23170020"
+checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
 dependencies = [
  "anyerror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -571,7 +571,7 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
-openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.11" }
+openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.13" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc812ad7010" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }

--- a/src/meta/raft-store/src/sm_v003/snapshot_store_error.rs
+++ b/src/meta/raft-store/src/sm_v003/snapshot_store_error.rs
@@ -87,3 +87,9 @@ impl From<SnapshotStoreError> for MetaStorageError {
         })
     }
 }
+
+impl From<SnapshotStoreError> for io::Error {
+    fn from(e: SnapshotStoreError) -> Self {
+        io::Error::other(e)
+    }
+}

--- a/src/meta/service/src/meta_node/meta_handle.rs
+++ b/src/meta/service/src/meta_node/meta_handle.rs
@@ -45,12 +45,12 @@ use databend_common_meta_types::raft_types::Fatal;
 use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::raft_types::RaftMetrics;
 use databend_common_meta_types::raft_types::Wait;
+use databend_common_meta_types::raft_types::WatchReceiver;
 use databend_common_meta_types::sys_data::SysData;
 use futures::Stream;
 use futures::stream::BoxStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::sync::watch;
 use tonic::Status;
 
 use crate::analysis::count_prefix::count_prefix;
@@ -330,9 +330,7 @@ impl MetaHandle {
         .await
     }
 
-    pub async fn handle_raft_metrics(
-        &self,
-    ) -> Result<watch::Receiver<RaftMetrics>, MetaNodeStopped> {
+    pub async fn handle_raft_metrics(&self) -> Result<WatchReceiver<RaftMetrics>, MetaNodeStopped> {
         self.request(move |meta_node| {
             let fu = async move { meta_node.raft.metrics() };
 

--- a/src/meta/service/src/meta_node/meta_node.rs
+++ b/src/meta/service/src/meta_node/meta_node.rs
@@ -26,7 +26,6 @@ use databend_common_base::base::BuildInfoRef;
 use databend_common_base::base::tokio;
 use databend_common_base::base::tokio::sync::Mutex;
 use databend_common_base::base::tokio::sync::watch;
-use databend_common_base::base::tokio::sync::watch::error::RecvError;
 use databend_common_base::base::tokio::task::JoinHandle;
 use databend_common_base::base::tokio::time::Instant;
 use databend_common_base::base::tokio::time::sleep;
@@ -41,6 +40,8 @@ use databend_common_meta_raft_store::raft_log_v004::RaftLogStat;
 use databend_common_meta_raft_store::utils::seq_marked_to_seqv;
 use databend_common_meta_sled_store::openraft;
 use databend_common_meta_sled_store::openraft::ChangeMembers;
+use databend_common_meta_sled_store::openraft::async_runtime::RecvError;
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver as WatchReceiverTrait;
 use databend_common_meta_sled_store::openraft::error::RaftError;
 use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::AppliedState;
@@ -67,6 +68,7 @@ use databend_common_meta_types::raft_types::MembershipNode;
 use databend_common_meta_types::raft_types::NodeId;
 use databend_common_meta_types::raft_types::RaftMetrics;
 use databend_common_meta_types::raft_types::TypeConfig;
+use databend_common_meta_types::raft_types::WatchReceiver;
 use databend_common_meta_types::raft_types::new_log_id;
 use databend_common_meta_types::snapshot_db::DBStat;
 use fastrace::func_name;
@@ -327,7 +329,10 @@ impl MetaNode {
             if r.is_err() {
                 break;
             }
-            info!("waiting for raft to shutdown, metrics: {:?}", rx.borrow());
+            info!(
+                "waiting for raft to shutdown, metrics: {:?}",
+                rx.borrow_watched()
+            );
         }
         info!("shutdown raft");
 
@@ -351,7 +356,7 @@ impl MetaNode {
     }
 
     /// Spawn a monitor to watch raft state changes and report metrics changes.
-    pub async fn subscribe_metrics(mn: Arc<Self>, metrics_rx: watch::Receiver<RaftMetrics>) {
+    pub async fn subscribe_metrics(mn: Arc<Self>, metrics_rx: WatchReceiver<RaftMetrics>) {
         info!("Start a task subscribing raft metrics and forward to metrics API");
 
         let fut = Self::report_metrics_loop(mn.clone(), metrics_rx);
@@ -369,7 +374,7 @@ impl MetaNode {
     /// Report metrics changes periodically.
     async fn report_metrics_loop(
         meta_node: Arc<Self>,
-        mut metrics_rx: watch::Receiver<RaftMetrics>,
+        mut metrics_rx: WatchReceiver<RaftMetrics>,
     ) -> Result<(), AnyError> {
         const RATE_LIMIT_INTERVAL: Duration = Duration::from_millis(200);
         let mut last_leader: Option<u64> = None;
@@ -388,7 +393,7 @@ impl MetaNode {
                 break;
             }
 
-            let mm = metrics_rx.borrow().clone();
+            let mm = metrics_rx.borrow_watched().clone();
 
             // Report metrics about server state and role.
             server_metrics::set_node_is_health(
@@ -403,7 +408,7 @@ impl MetaNode {
             // metrics about raft log and state machine.
             server_metrics::set_current_term(mm.current_term);
             server_metrics::set_last_log_index(mm.last_log_index.unwrap_or_default());
-            server_metrics::set_proposals_applied(mm.last_applied.unwrap_or_default().index);
+            server_metrics::set_proposals_applied(mm.last_applied.map(|id| id.index).unwrap_or(0));
             server_metrics::set_last_seq(meta_node.get_last_seq().await);
 
             {
@@ -1193,7 +1198,7 @@ impl MetaNode {
         let snapshot_key_count = self.get_snapshot_key_count().await;
         let snapshot_key_space_stat = self.get_snapshot_key_space_stat().await;
 
-        let metrics = self.raft.metrics().borrow().clone();
+        let metrics = self.raft.metrics().borrow_watched().clone();
 
         let leader = if let Some(leader_id) = metrics.current_leader {
             self.get_node(&leader_id).await
@@ -1455,7 +1460,7 @@ impl MetaNode {
         let mut expire_at: Option<Instant> = None;
 
         loop {
-            if let Some(l) = rx.borrow().current_leader {
+            if let Some(l) = rx.borrow_watched().current_leader {
                 return Ok(Some(l));
             }
 

--- a/src/meta/service/src/meta_service/meta_leader.rs
+++ b/src/meta/service/src/meta_service/meta_leader.rs
@@ -21,6 +21,7 @@ use databend_common_meta_client::MetaGrpcReadReq;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::KvApiExt;
 use databend_common_meta_sled_store::openraft::ChangeMembers;
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver;
 use databend_common_meta_stoerr::MetaStorageError;
 use databend_common_meta_types::AppliedState;
 use databend_common_meta_types::Cmd;
@@ -178,7 +179,7 @@ impl<'a> MetaLeader<'a> {
         let role = req.role();
         let node_id = req.node_id;
         let endpoint = req.endpoint;
-        let metrics = self.raft.metrics().borrow().clone();
+        let metrics = self.raft.metrics().borrow_watched().clone();
         let membership = metrics.membership_config.membership();
 
         let voters = membership.voter_ids().collect::<BTreeSet<_>>();

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -23,7 +23,6 @@ use backon::BackoffBuilder;
 use backon::ExponentialBuilder;
 use databend_common_base::base::tokio;
 use databend_common_base::base::tokio::sync::mpsc;
-use databend_common_base::base::tokio::time::Instant;
 use databend_common_base::future::TimedFutureExt;
 use databend_common_base::runtime;
 use databend_common_base::runtime::spawn_named;
@@ -31,9 +30,7 @@ use databend_common_meta_raft_store::leveled_store::persisted_codec::PersistedCo
 use databend_common_meta_sled_store::openraft;
 use databend_common_meta_sled_store::openraft::MessageSummary;
 use databend_common_meta_sled_store::openraft::RaftNetworkFactory;
-use databend_common_meta_sled_store::openraft::error::PayloadTooLarge;
 use databend_common_meta_sled_store::openraft::error::ReplicationClosed;
-use databend_common_meta_sled_store::openraft::error::Unreachable;
 use databend_common_meta_sled_store::openraft::network::RPCOption;
 use databend_common_meta_sled_store::openraft::network::v2::RaftNetworkV2;
 use databend_common_meta_types::Endpoint;
@@ -43,7 +40,6 @@ use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::protobuf as pb;
 use databend_common_meta_types::protobuf::InstallEntryV004;
 use databend_common_meta_types::protobuf::RaftReply;
-use databend_common_meta_types::protobuf::RaftRequest;
 use databend_common_meta_types::protobuf::SnapshotChunkRequestV003;
 use databend_common_meta_types::raft_types::AppendEntriesRequest;
 use databend_common_meta_types::raft_types::AppendEntriesResponse;
@@ -58,6 +54,7 @@ use databend_common_meta_types::raft_types::StorageError;
 use databend_common_meta_types::raft_types::StreamingError;
 use databend_common_meta_types::raft_types::TransferLeaderRequest;
 use databend_common_meta_types::raft_types::TypeConfig;
+use databend_common_meta_types::raft_types::Unreachable;
 use databend_common_meta_types::raft_types::Vote;
 use databend_common_meta_types::raft_types::VoteRequest;
 use databend_common_meta_types::raft_types::VoteResponse;
@@ -278,54 +275,31 @@ impl Network {
         RPCError::Unreachable(Unreachable::new(&e))
     }
 
-    /// Create a new RaftRequest for AppendEntriesRequest,
-    /// if it is too large, return `PayloadTooLarge` error
-    /// to tell Openraft to split it in to smaller chunks.
-    fn new_append_entries_raft_req<E>(
-        &self,
-        rpc: &AppendEntriesRequest,
-    ) -> Result<RaftRequest, RPCError<E>>
-    where
-        E: std::error::Error,
-    {
-        let start = Instant::now();
-        let raft_req = GrpcHelper::encode_raft_request(rpc).map_err(|e| Unreachable::new(&e))?;
-        debug!(
-            "Raft NetworkConnection: new_append_entries_raft_req() encode_raft_request: target={}, elapsed={:?}",
-            self.target,
-            start.elapsed()
+    /// Build a partial AppendEntriesRequest with only the first `n` entries.
+    fn build_partial_append_request(
+        original: &AppendEntriesRequest,
+        n: usize,
+    ) -> AppendEntriesRequest {
+        AppendEntriesRequest {
+            vote: original.vote,
+            prev_log_id: original.prev_log_id,
+            leader_commit: original.leader_commit,
+            entries: original.entries[..n].to_vec(),
+        }
+    }
+
+    /// Reduce entry count by half. Returns `None` if already at minimum.
+    fn try_reduce_entries(&self, current: usize, reason: &str) -> Option<usize> {
+        if current <= 1 {
+            return None;
+        }
+
+        let new_count = current / 2;
+        warn!(
+            "append_entries: target={}, {}, reducing entries {} -> {}",
+            self.target, reason, current, new_count
         );
-
-        if raft_req.data.len() <= GrpcConfig::advisory_encoding_size() {
-            return Ok(raft_req);
-        }
-
-        // data.len() is too large
-
-        let l = rpc.entries.len();
-        if l == 0 {
-            // impossible.
-            Ok(raft_req)
-        } else if l == 1 {
-            warn!(
-                "append_entries req too large: target={}, len={}, can not split",
-                self.target,
-                raft_req.data.len()
-            );
-            // can not split, just try to send this big request
-            Ok(raft_req)
-        } else {
-            // l > 1
-            let n = std::cmp::max(1, l / 2);
-            warn!(
-                "append_entries req too large: target={}, len={}, reduce NO entries from {} to {}",
-                self.target,
-                raft_req.data.len(),
-                l,
-                n
-            );
-            Err(PayloadTooLarge::new_entries_hint(n as u64).into())
-        }
+        Some(new_count)
     }
 
     pub(crate) fn back_off(&self) -> impl Iterator<Item = Duration> + use<> {
@@ -400,9 +374,9 @@ impl Network {
             chunk_size
         );
 
-        let mut bf = db
-            .open_file()
-            .map_err(|e| StorageError::read_snapshot(Some(snapshot_meta.signature()), &e))?;
+        let mut bf = db.open_file().map_err(|e| {
+            StorageError::read_snapshot(Some(snapshot_meta.signature()), (&e).into())
+        })?;
 
         let mut c = std::pin::pin!(cancel);
 
@@ -424,7 +398,7 @@ impl Network {
             let mut offset = 0;
             while offset < buf.len() {
                 let n_read = bf.read(&mut buf[offset..]).map_err(|e| {
-                    StorageError::read_snapshot(Some(snapshot_meta.signature()), &e)
+                    StorageError::read_snapshot(Some(snapshot_meta.signature()), (&e).into())
                 })?;
 
                 debug!("offset: {}, n_read: {}", offset, n_read);
@@ -514,11 +488,9 @@ impl Network {
 
         let mut kv_count = 0u64;
 
-        while let Some(chunk) = strm
-            .try_next()
-            .await
-            .map_err(|err| StorageError::read_snapshot(Some(snapshot_meta.signature()), &err.1))?
-        {
+        while let Some(chunk) = strm.try_next().await.map_err(|err| {
+            StorageError::read_snapshot(Some(snapshot_meta.signature()), (&err.1).into())
+        })? {
             // Check for cancellation
             if let Some(err) = c.as_mut().now_or_never() {
                 return Err(err.into());
@@ -555,8 +527,9 @@ impl Network {
         info!("V004 snapshot streaming: completed {} KV entries", kv_count);
 
         // Send commit entry
-        let sys_data_json = serde_json::to_string(db.sys_data())
-            .map_err(|e| StorageError::read_snapshot(Some(snapshot_meta.signature()), &e))?;
+        let sys_data_json = serde_json::to_string(db.sys_data()).map_err(|e| {
+            StorageError::read_snapshot(Some(snapshot_meta.signature()), (&e).into())
+        })?;
 
         // Convert Vote to protobuf Vote using existing conversion
         let pb_vote = pb::Vote::from(vote);
@@ -744,6 +717,10 @@ impl Network {
 }
 
 impl RaftNetworkV2<TypeConfig> for Network {
+    /// Send AppendEntries RPC with automatic payload size management.
+    ///
+    /// If the payload exceeds gRPC size limit, reduces entry count and retries.
+    /// Returns error if a single entry exceeds the limit.
     #[logcall::logcall(err = "debug")]
     #[fastrace::trace]
     async fn append_entries(
@@ -758,36 +735,79 @@ impl RaftNetworkV2<TypeConfig> for Network {
             "send_append_entries",
         );
 
-        let raft_req = self.new_append_entries_raft_req(&rpc)?;
-        let req = GrpcHelper::traced_req(raft_req);
+        let total = rpc.entries.len();
+        let mut entries_to_send = rpc.entries.len();
 
-        let bytes = req.get_ref().data.len() as u64;
-        raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
+        loop {
+            let partial_rpc = Self::build_partial_append_request(&rpc, entries_to_send);
+            let raft_req =
+                GrpcHelper::encode_raft_request(&partial_rpc).map_err(|e| Unreachable::new(&e))?;
+            let payload_size = raft_req.data.len();
 
-        let mut client = self
-            .take_client()
-            .log_elapsed_debug("Raft NetworkConnection append_entries take_client()")
-            .await?;
-
-        let grpc_res = client
-            .append_entries(req)
-            .with_timing(observe_append_send_spent(self.target))
-            .await;
-        debug!(
-            "append_entries resp from: target={}: {:?}",
-            self.target, grpc_res
-        );
-
-        match &grpc_res {
-            Ok(_) => {
-                self.client.lock().await.replace(client);
+            // Check size before sending
+            if payload_size > GrpcConfig::advisory_encoding_size() {
+                let reason = format!("payload too large: {} bytes", payload_size);
+                match self.try_reduce_entries(entries_to_send, &reason) {
+                    Some(n) => {
+                        entries_to_send = n;
+                        continue;
+                    }
+                    None => {
+                        let err = AnyError::error(reason);
+                        return Err(RPCError::Unreachable(Unreachable::new(&err)));
+                    }
+                }
             }
-            Err(e) => {
-                warn!(target = self.target, rpc = rpc.summary(); "append_entries failed: {}", e);
+
+            // Send the request
+            let req = GrpcHelper::traced_req(raft_req);
+            raft_metrics::network::incr_sendto_bytes(&self.target, req.get_ref().data.len() as u64);
+
+            let mut client = self
+                .take_client()
+                .log_elapsed_debug("Raft NetworkConnection append_entries take_client()")
+                .await?;
+
+            let grpc_res = client
+                .append_entries(req)
+                .with_timing(observe_append_send_spent(self.target))
+                .await;
+
+            debug!(
+                "append_entries resp from: target={}: {:?}",
+                self.target, grpc_res
+            );
+
+            match &grpc_res {
+                Ok(_) => {
+                    self.client.lock().await.replace(client);
+
+                    // If we sent partial entries, return PartialSuccess
+                    if entries_to_send < total {
+                        let last_log_id = partial_rpc.entries.last().map(|e| e.log_id);
+                        return Ok(AppendEntriesResponse::PartialSuccess(last_log_id));
+                    }
+
+                    return self.parse_grpc_resp::<_, openraft::error::Infallible>(grpc_res);
+                }
+                Err(status) if status.code() == tonic::Code::ResourceExhausted => {
+                    match self.try_reduce_entries(entries_to_send, "ResourceExhausted") {
+                        Some(n) => {
+                            entries_to_send = n;
+                            continue;
+                        }
+                        None => {
+                            let err = AnyError::error("ResourceExhausted: single entry too large");
+                            return Err(RPCError::Unreachable(Unreachable::new(&err)));
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(target = self.target, rpc = partial_rpc.summary(); "append_entries failed: {}", e);
+                    return self.parse_grpc_resp::<_, openraft::error::Infallible>(grpc_res);
+                }
             }
         }
-
-        self.parse_grpc_resp::<_, openraft::error::Infallible>(grpc_res)
     }
 
     /// Send snapshot to target node. Currently uses V004 streaming protocol.

--- a/src/meta/service/src/store/meta_raft_state_machine/raft_state_machine_impl.rs
+++ b/src/meta/service/src/store/meta_raft_state_machine/raft_state_machine_impl.rs
@@ -12,20 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
 use databend_common_meta_raft_store::sm_v003::SnapshotStoreV004;
 use databend_common_meta_raft_store::sm_v003::open_snapshot::OpenSnapshot;
 use databend_common_meta_sled_store::openraft::OptionalSend;
 use databend_common_meta_sled_store::openraft::RaftSnapshotBuilder;
+use databend_common_meta_sled_store::openraft::storage::EntryResponder;
 use databend_common_meta_sled_store::openraft::storage::RaftStateMachine;
-use databend_common_meta_types::AppliedState;
-use databend_common_meta_types::raft_types::Entry;
 use databend_common_meta_types::raft_types::LogId;
 use databend_common_meta_types::raft_types::Snapshot;
 use databend_common_meta_types::raft_types::SnapshotMeta;
-use databend_common_meta_types::raft_types::StorageError;
 use databend_common_meta_types::raft_types::StoredMembership;
 use databend_common_meta_types::raft_types::TypeConfig;
 use databend_common_meta_types::snapshot_db::DB;
+use futures::Stream;
 use log::debug;
 use log::error;
 use log::info;
@@ -35,7 +36,7 @@ use crate::store::meta_raft_state_machine::MetaRaftStateMachine;
 
 impl RaftSnapshotBuilder<TypeConfig> for MetaRaftStateMachine {
     #[fastrace::trace]
-    async fn build_snapshot(&mut self) -> Result<Snapshot, StorageError> {
+    async fn build_snapshot(&mut self) -> Result<Snapshot, io::Error> {
         self.do_build_snapshot().await
     }
 }
@@ -43,7 +44,7 @@ impl RaftSnapshotBuilder<TypeConfig> for MetaRaftStateMachine {
 impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
     type SnapshotBuilder = MetaRaftStateMachine;
 
-    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), StorageError> {
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), io::Error> {
         let sm = self.get_inner();
         let last_applied = *sm.sys_data().last_applied_ref();
         let last_membership = sm.sys_data().last_membership_ref().clone();
@@ -57,15 +58,10 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
     }
 
     #[fastrace::trace]
-    async fn apply<I>(&mut self, entries: I) -> Result<Vec<AppliedState>, StorageError>
-    where
-        I: IntoIterator<Item = Entry> + OptionalSend,
-        I::IntoIter: OptionalSend,
+    async fn apply<Strm>(&mut self, entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend
     {
-        let sm = self.get_inner();
-        let res = sm.apply_entries(entries).await?;
-
-        Ok(res)
+        self.get_inner().apply_entries(entries).await
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
@@ -74,7 +70,7 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
 
     // This method is not used
     #[fastrace::trace]
-    async fn begin_receiving_snapshot(&mut self) -> Result<DB, StorageError> {
+    async fn begin_receiving_snapshot(&mut self) -> Result<DB, io::Error> {
         unreachable!(
             "begin_receiving_snapshot is only required when using OpenRaft Chunked snapshot transmit"
         );
@@ -85,7 +81,7 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
         &mut self,
         meta: &SnapshotMeta,
         snapshot: DB,
-    ) -> Result<(), StorageError> {
+    ) -> Result<(), io::Error> {
         let data_size = snapshot.file_size();
 
         info!(
@@ -94,21 +90,17 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
             "decoding snapshot for installation"
         );
 
-        let sig = meta.signature();
-
         let ss_store = SnapshotStoreV004::new(self.config.as_ref().clone());
         let (storage_path, rel_path) = ss_store
             .snapshot_config()
-            .move_to_final_path(&snapshot.path(), meta.snapshot_id.clone())
-            .map_err(|e| StorageError::write_snapshot(Some(sig.clone()), &e))?;
+            .move_to_final_path(&snapshot.path(), meta.snapshot_id.clone())?;
 
         let db = DB::open_snapshot(
             storage_path,
             rel_path,
             meta.snapshot_id.clone(),
             self.config.to_rotbl_config(),
-        )
-        .map_err(|e| StorageError::read_snapshot(Some(sig.clone()), &e))?;
+        )?;
 
         info!("snapshot meta: {:?}", meta);
 
@@ -126,7 +118,7 @@ impl RaftStateMachine<TypeConfig> for MetaRaftStateMachine {
     }
 
     #[fastrace::trace]
-    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, StorageError> {
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, io::Error> {
         info!(id = self.id; "get snapshot start");
 
         let r = self.get_inner();

--- a/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -20,6 +20,7 @@ use databend_common_base::base::tokio;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::KvApiExt;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver;
 use databend_common_meta_types::SeqV;
 use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::normalize_meta::NormalizeMeta;
@@ -290,7 +291,7 @@ async fn test_auto_sync_addr() -> anyhow::Result<()> {
         let old_term = meta_handle
             .handle_raft_metrics()
             .await?
-            .borrow()
+            .borrow_watched()
             .current_term;
 
         let mut srv = tc0.grpc_srv.take().unwrap();

--- a/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -20,6 +20,7 @@ use databend_common_meta_kvapi::kvapi::KvApiExt;
 use databend_common_meta_sled_store::openraft::LogIdOptionExt;
 use databend_common_meta_sled_store::openraft::RaftLogReader;
 use databend_common_meta_sled_store::openraft::ServerState;
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::Endpoint;
 use databend_common_meta_types::LogEntry;
@@ -85,7 +86,7 @@ async fn test_meta_node_graceful_shutdown() -> anyhow::Result<()> {
             break;
         }
 
-        info!("st: {:?}", rx0.borrow());
+        info!("st: {:?}", rx0.borrow_watched());
     }
     assert!(rx0.changed().await.is_err());
     Ok(())
@@ -916,7 +917,7 @@ async fn assert_upsert_kv_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> a
     let leader_id = meta_nodes[0].get_leader().await?.unwrap();
     let leader = meta_nodes[leader_id as usize].clone();
 
-    let last_applied = leader.raft.metrics().borrow().last_applied;
+    let last_applied = leader.raft.metrics().borrow_watched().last_applied;
     info!("leader: last_applied={:?}", last_applied);
     {
         leader

--- a/src/meta/service/tests/it/meta_node/meta_node_replication.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_replication.rs
@@ -23,6 +23,7 @@ use databend_common_meta_raft_store::sm_v003::SnapshotStoreV004;
 use databend_common_meta_raft_store::state_machine::MetaSnapshotId;
 use databend_common_meta_sled_store::openraft::LogIdOptionExt;
 use databend_common_meta_sled_store::openraft::ServerState;
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver;
 use databend_common_meta_sled_store::openraft::testing::log_id;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::LogEntry;
@@ -223,7 +224,7 @@ async fn test_raft_service_install_snapshot_v003() -> anyhow::Result<()> {
     assert_eq!(resp.vote, Vote::new_committed(10, 2));
 
     let meta_node = tc0.meta_node.as_ref().unwrap();
-    let m = meta_node.raft.metrics().borrow().clone();
+    let m = meta_node.raft.metrics().borrow_watched().clone();
 
     assert_eq!(Some(last_log_id), m.snapshot);
 
@@ -312,7 +313,7 @@ async fn test_raft_service_install_snapshot_v004() -> anyhow::Result<()> {
     assert_eq!(vote, Vote::new_committed(10, 2));
 
     let meta_node = tc0.meta_node.as_ref().unwrap();
-    let m = meta_node.raft.metrics().borrow().clone();
+    let m = meta_node.raft.metrics().borrow_watched().clone();
 
     assert_eq!(Some(last_log_id), m.snapshot);
 

--- a/src/meta/service/tests/it/meta_node/meta_node_request_forwarding.rs
+++ b/src/meta/service/tests/it/meta_node/meta_node_request_forwarding.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use databend_common_meta_sled_store::openraft::async_runtime::WatchReceiver;
 use databend_common_meta_sled_store::openraft::error::RaftError;
 use databend_common_meta_types::Cmd;
 use databend_common_meta_types::LogEntry;
@@ -39,7 +40,12 @@ async fn test_meta_node_forward_to_leader() -> anyhow::Result<()> {
     let (mut _nlog, tcs) = start_meta_node_cluster(btreeset![0, 1, 2], btreeset![3]).await?;
     let all = test_context_nodes(&tcs);
 
-    let leader_id = all[0].raft.metrics().borrow().current_leader.unwrap();
+    let leader_id = all[0]
+        .raft
+        .metrics()
+        .borrow_watched()
+        .current_leader
+        .unwrap();
 
     // test writing to leader and non-leader
     let key = "t-non-leader-write";

--- a/src/meta/types/src/cmd/cmd_context.rs
+++ b/src/meta/types/src/cmd/cmd_context.rs
@@ -23,6 +23,7 @@ use crate::Time;
 use crate::cmd::io_timing::IoTimer;
 use crate::cmd::io_timing::IoTiming;
 use crate::raft_types::LogId;
+use crate::raft_types::new_log_id;
 
 /// A context used when executing a [`Cmd`], to provide additional environment information.
 ///
@@ -65,7 +66,7 @@ impl CmdContext {
     pub fn new(time: Time) -> Self {
         CmdContext {
             time,
-            log_id: LogId::default(),
+            log_id: new_log_id(0, 0, 0),
             io_timing: Arc::new(Mutex::new(IoTiming::new())),
         }
     }

--- a/src/meta/types/src/raft_types.rs
+++ b/src/meta/types/src/raft_types.rs
@@ -42,7 +42,10 @@ impl RaftTypeConfig for TypeConfig {
     type Entry = openraft::entry::Entry<TypeConfig>;
     type SnapshotData = DB;
     type AsyncRuntime = TokioRuntime;
-    type ResponderBuilder = OneshotResponder<TypeConfig>;
+    type Responder<T>
+        = OneshotResponder<Self, T>
+    where T: openraft::OptionalSend + 'static;
+    type ErrorSource = anyerror::AnyError;
 }
 
 pub type IOFlushed = openraft::storage::IOFlushed<TypeConfig>;
@@ -60,6 +63,7 @@ pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
 pub type Snapshot = openraft::Snapshot<TypeConfig>;
 
 pub type RaftMetrics = openraft::RaftMetrics<TypeConfig>;
+pub type WatchReceiver<T> = openraft::type_config::alias::WatchReceiverOf<TypeConfig, T>;
 pub type Wait = openraft::metrics::Wait<TypeConfig>;
 
 pub type ErrorSubject = openraft::ErrorSubject<TypeConfig>;
@@ -68,7 +72,7 @@ pub type ErrorVerb = openraft::ErrorVerb;
 pub type RPCError<E = Infallible> = openraft::error::RPCError<TypeConfig, E>;
 pub type RemoteError<E> = openraft::error::RemoteError<TypeConfig, E>;
 pub type RaftError<E = Infallible> = openraft::error::RaftError<TypeConfig, E>;
-pub type NetworkError = openraft::error::NetworkError;
+pub type NetworkError = openraft::error::NetworkError<TypeConfig>;
 
 pub type StorageError = openraft::StorageError<TypeConfig>;
 pub type ForwardToLeader = openraft::error::ForwardToLeader<TypeConfig>;
@@ -77,6 +81,7 @@ pub type ChangeMembershipError = openraft::error::ChangeMembershipError<TypeConf
 pub type ClientWriteError = openraft::error::ClientWriteError<TypeConfig>;
 pub type InitializeError = openraft::error::InitializeError<TypeConfig>;
 pub type StreamingError = openraft::error::StreamingError<TypeConfig>;
+pub type Unreachable = openraft::error::Unreachable<TypeConfig>;
 
 pub type AppendEntriesRequest = openraft::raft::AppendEntriesRequest<TypeConfig>;
 pub type AppendEntriesResponse = openraft::raft::AppendEntriesResponse<TypeConfig>;
@@ -88,6 +93,7 @@ pub type SnapshotMismatch = openraft::error::SnapshotMismatch;
 pub type VoteRequest = openraft::raft::VoteRequest<TypeConfig>;
 pub type VoteResponse = openraft::raft::VoteResponse<TypeConfig>;
 pub type TransferLeaderRequest = openraft::raft::TransferLeaderRequest<TypeConfig>;
+pub type EntryResponder = openraft::storage::EntryResponder<TypeConfig>;
 
 pub fn new_log_id(term: u64, node_id: NodeId, index: u64) -> LogId {
     LogId::new(CommittedLeaderId::new(term, node_id), index)

--- a/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
+++ b/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
@@ -51,12 +51,34 @@ def test_dump_raft_log_wal():
 ChunkId(00_000_000_000_000_000_000)
   R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
   R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
-  R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N0.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
+  R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
   R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)
   R-00005: [000_000_225, 000_000_277) Size(52): Append(log_id: T1-N1.1, payload: blank)
   R-00006: [000_000_277, 000_000_472) Size(195): Append(log_id: T1-N1.2, payload: normal:time: <TIME> cmd: add_node(no-override):1=id=1 raft=localhost:28103 grpc=127.0.0.1:9191)
   R-00007: [000_000_472, 000_000_518) Size(46): Commit(T1-N1.1)
+  R-00008: [000_000_518, 000_000_564) Size(46): Commit(T1-N1.2)
+  R-00009: [000_000_564, 000_000_643) Size(79): Append(log_id: T1-N1.3, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
+  R-00010: [000_000_643, 000_000_689) Size(46): Commit(T1-N1.3)
+  R-00011: [000_000_689, 000_000_884) Size(195): Append(log_id: T1-N1.4, payload: normal:time: <TIME> cmd: add_node(override):1=id=1 raft=localhost:28103 grpc=127.0.0.1:9191)
+  R-00012: [000_000_884, 000_000_930) Size(46): Commit(T1-N1.4)
+  R-00013: [000_000_930, 000_001_192) Size(262): Append(log_id: T1-N1.5, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/db/host >= seq(0)] then:[Put(Put key=app/db/host)] else:[Get(Get key=app/db/host)]})
+  R-00014: [000_001_192, 000_001_238) Size(46): Commit(T1-N1.5)
+  R-00015: [000_001_238, 000_001_495) Size(257): Append(log_id: T1-N1.6, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/db/port >= seq(0)] then:[Put(Put key=app/db/port)] else:[Get(Get key=app/db/port)]})
+  R-00016: [000_001_495, 000_001_541) Size(46): Commit(T1-N1.6)
+  R-00017: [000_001_541, 000_001_817) Size(276): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})
+  R-00018: [000_001_817, 000_001_863) Size(46): Commit(T1-N1.7)"""
+
+    expected2 = """RaftLog:
+ChunkId(00_000_000_000_000_000_000)
+  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
+  R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
+  R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
+  R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
+  R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)
+  R-00005: [000_000_225, 000_000_277) Size(52): Append(log_id: T1-N1.1, payload: blank)
+  R-00006: [000_000_277, 000_000_323) Size(46): Commit(T1-N1.1)
+  R-00007: [000_000_323, 000_000_518) Size(195): Append(log_id: T1-N1.2, payload: normal:time: <TIME> cmd: add_node(no-override):1=id=1 raft=localhost:28103 grpc=127.0.0.1:9191)
   R-00008: [000_000_518, 000_000_564) Size(46): Commit(T1-N1.2)
   R-00009: [000_000_564, 000_000_643) Size(79): Append(log_id: T1-N1.3, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00010: [000_000_643, 000_000_689) Size(46): Commit(T1-N1.3)
@@ -77,31 +99,31 @@ ChunkId(00_000_000_000_000_000_000)
         )
         return text
 
-    # Normalize both actual and expected output
-    actual_lines = result.strip().split("\n")
-    expected_lines = expected.strip().split("\n")
+    def compare_output(actual_lines, expected_str):
+        """Compare actual output against expected. Returns (success, error_msg)."""
+        expected_lines = expected_str.strip().split("\n")
+        if len(actual_lines) != len(expected_lines):
+            return False, f"Line count mismatch: got {len(actual_lines)}, expected {len(expected_lines)}"
+        for i, (actual_line, expected_line) in enumerate(zip(actual_lines, expected_lines)):
+            if actual_line != expected_line:
+                return False, f"Line {i} mismatch:\n  Actual  : {actual_line}\n  Expected: {expected_line}"
+        return True, None
 
     # Mask time in actual output
+    actual_lines = result.strip().split("\n")
     actual_masked = [mask_time(line) for line in actual_lines]
 
-    # Verify line count matches
-    assert len(actual_masked) == len(expected_lines), (
-        f"Line count mismatch: got {len(actual_masked)} lines, expected {len(expected_lines)} lines"
-    )
-
-    # Compare line by line
-    for i, (actual_line, expected_line) in enumerate(
-        zip(actual_masked, expected_lines)
-    ):
-        assert actual_line == expected_line, (
-            f"Line {i} mismatch:\n"
-            f"  Actual  : {actual_line}\n"
-            f"  Expected: {expected_line}"
-        )
-
-    print(
-        f"✓ All {len(actual_masked)} lines match expected output (time fields masked)"
-    )
+    # Check against all expected outputs (order may vary by platform)
+    expected_outputs = [expected, expected2]
+    for i, exp in enumerate(expected_outputs):
+        success, error_msg = compare_output(actual_masked, exp)
+        if success:
+            print(f"✓ All {len(actual_masked)} lines match expected output #{i+1} (time fields masked)")
+            break
+    else:
+        # None matched, show error from first expected
+        _, error_msg = compare_output(actual_masked, expected_outputs[0])
+        assert False, error_msg
 
     # Clean up only on success
     shutil.rmtree(".databend", ignore_errors=True)

--- a/tests/metactl/subcommands/cmd_export_from_grpc.py
+++ b/tests/metactl/subcommands/cmd_export_from_grpc.py
@@ -47,7 +47,7 @@ def test_export_from_grpc():
 ["raft_log",{"Vote":{"leader_id":{"term":1,"node_id":1},"committed":true}}]
 ["raft_log",{"Committed":{"leader_id":{"term":1,"node_id":1},"index":7}}]
 ["raft_log",{"Purged":null}]
-["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":0},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
+["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":1},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":1},"payload":"Blank"}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":2},"payload":{"Normal":{"time_ms":1753508277701,"cmd":{"AddNode":{"node_id":1,"node":{"name":"1","endpoint":{"addr":"localhost","port":28103},"grpc_api_advertise_address":"127.0.0.1:9191"},"overriding":false}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":3},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]

--- a/tests/metactl/subcommands/cmd_export_from_raft_dir.py
+++ b/tests/metactl/subcommands/cmd_export_from_raft_dir.py
@@ -52,7 +52,7 @@ def test_export_from_raft_dir():
 ["raft_log",{"Vote":{"leader_id":{"term":1,"node_id":1},"committed":true}}]
 ["raft_log",{"Committed":{"leader_id":{"term":1,"node_id":1},"index":7}}]
 ["raft_log",{"Purged":null}]
-["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":0},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
+["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":1},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":1},"payload":"Blank"}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":2},"payload":{"Normal":{"time_ms":1753508277701,"cmd":{"AddNode":{"node_id":1,"node":{"name":"1","endpoint":{"addr":"localhost","port":28103},"grpc_api_advertise_address":"127.0.0.1:9191"},"overriding":false}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":3},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]

--- a/tests/metactl/subcommands/cmd_import.py
+++ b/tests/metactl/subcommands/cmd_import.py
@@ -24,7 +24,7 @@ def test_import_subcommand():
 ["raft_log",{"Vote":{"leader_id":{"term":1,"node_id":1},"committed":true}}]
 ["raft_log",{"Committed":{"leader_id":{"term":1,"node_id":1},"index":7}}]
 ["raft_log",{"Purged":null}]
-["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":0},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
+["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":1},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":1},"payload":"Blank"}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":2},"payload":{"Normal":{"time_ms":1753508277701,"cmd":{"AddNode":{"node_id":1,"node":{"name":"1","endpoint":{"addr":"localhost","port":28103},"grpc_api_advertise_address":"127.0.0.1:9191"},"overriding":false}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":3},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): upgrade openraft to v0.10.0-alpha.13
Upgrade openraft dependency and adapt to API changes in the new version.
The main changes include a new streaming apply API and updated watch
receiver trait methods.

Changes:
- Upgrade openraft from `v0.10.0-alpha.11` to `v0.10.0-alpha.13`
- Update `TypeConfig` to use new `Responder<T>` and `ErrorSource` types
- Add type aliases: `WatchReceiver<T>`, `Unreachable`, `EntryResponder`
- Change `SMV003::apply_entries()` to accept stream instead of iterator
- Replace `.borrow()` with `.borrow_watched()` for watch receivers
- Add `From<SnapshotStoreError> for io::Error` implementation
- Update tests to use stream-based apply API

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19193)
<!-- Reviewable:end -->
