### PR TITLE
fix(query): Ensure result cache keys include secure filter predicates

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -177,6 +177,8 @@ pub trait TableContext: Send + Sync {
     fn set_partitions(&self, partitions: Partitions) -> Result<()>;
     fn add_partitions_sha(&self, sha: String);
     fn get_partitions_shas(&self) -> Vec<String>;
+    fn add_cache_key_extra(&self, extra: String);
+    fn get_cache_key_extras(&self) -> Vec<String>;
     fn get_cacheable(&self) -> bool;
     fn set_cacheable(&self, cacheable: bool);
     fn get_can_scan_from_agg_index(&self) -> bool;

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -346,7 +346,13 @@ impl ExplainInterpreter {
             && self.ctx.get_cacheable()
             && formatted_ast.is_some()
         {
-            let key = gen_result_cache_key(formatted_ast.as_ref().unwrap());
+            let extras = self.ctx.get_cache_key_extras();
+            let key_source = if extras.is_empty() {
+                formatted_ast.as_ref().unwrap().clone()
+            } else {
+                format!("{}|{}", formatted_ast.as_ref().unwrap(), extras.join("|"))
+            };
+            let key = gen_result_cache_key(&key_source);
             let kv_store = UserApiProvider::instance().get_meta_store_client();
             let cache_reader = ResultCacheReader::create(
                 self.ctx.clone(),

--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -307,7 +307,17 @@ impl Interpreter for SelectInterpreter {
             && self.ctx.get_cacheable()
             && self.formatted_ast.is_some()
         {
-            let key = gen_result_cache_key(self.formatted_ast.as_ref().unwrap());
+            let extras = self.ctx.get_cache_key_extras();
+            let key_source = if extras.is_empty() {
+                self.formatted_ast.as_ref().unwrap().clone()
+            } else {
+                format!(
+                    "{}|{}",
+                    self.formatted_ast.as_ref().unwrap(),
+                    extras.join("|")
+                )
+            };
+            let key = gen_result_cache_key(&key_source);
             // 1. Try to get result from cache.
             let kv_store = UserApiProvider::instance().get_meta_store_client();
 

--- a/src/query/service/src/physical_plans/physical_secure_filter.rs
+++ b/src/query/service/src/physical_plans/physical_secure_filter.rs
@@ -26,6 +26,8 @@ use databend_common_sql::ColumnSet;
 use databend_common_sql::TypeCheck;
 use databend_common_sql::executor::cast_expr_to_non_null_boolean;
 use databend_common_sql::optimizer::ir::SExpr;
+use sha2::Digest;
+use sha2::Sha256;
 
 use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
@@ -165,23 +167,37 @@ impl PhysicalPlanBuilder {
             }
         }
 
+        let predicates = secure_filter
+            .predicates
+            .iter()
+            .map(|scalar| {
+                let expr = scalar
+                    .type_check(input_schema.as_ref())?
+                    .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
+                let expr = cast_expr_to_non_null_boolean(expr)?;
+                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                Ok(expr.as_remote_expr())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        if !predicates.is_empty() {
+            // Use Serde serialization for stable cache key (sql_display may lose structural info)
+            let mut serialized: Vec<String> = predicates
+                .iter()
+                .map(|p| serde_json::to_string(p).unwrap_or_default())
+                .collect();
+            // Sort to ensure order-independent cache key
+            serialized.sort();
+            let combined = serialized.join("|");
+            let hash = format!("{:x}", Sha256::digest(combined.as_bytes()));
+            self.ctx.add_cache_key_extra(format!("secure:{}", hash));
+        }
+
         Ok(PhysicalPlan::new(SecureFilter {
             meta: PhysicalPlanMeta::new("SecureFilter"),
             projections,
             input,
-            predicates: secure_filter
-                .predicates
-                .iter()
-                .map(|scalar| {
-                    let expr = scalar
-                        .type_check(input_schema.as_ref())?
-                        .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                    let expr = cast_expr_to_non_null_boolean(expr)?;
-                    let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
-                    Ok(expr.as_remote_expr())
-                })
-                .collect::<Result<_>>()?,
-
+            predicates,
             stat_info: Some(stat_info),
         }))
     }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -985,6 +985,19 @@ impl TableContext for QueryContext {
         sha
     }
 
+    fn add_cache_key_extra(&self, extra: String) {
+        let mut extras = self.shared.cache_key_extras.write();
+        if !extras.contains(&extra) {
+            extras.push(extra);
+        }
+    }
+
+    fn get_cache_key_extras(&self) -> Vec<String> {
+        let mut extras = self.shared.cache_key_extras.read().clone();
+        extras.sort();
+        extras
+    }
+
     fn get_cacheable(&self) -> bool {
         self.shared.cacheable.load(Ordering::Acquire)
     }

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -141,6 +141,8 @@ pub struct QueryContextShared {
     pub(super) multi_table_insert_status: Arc<Mutex<MultiTableInsertStatus>>,
     /// partitions_sha for each table in the query. Not empty only when enabling query result cache.
     pub(super) partitions_shas: Arc<RwLock<Vec<String>>>,
+    /// Additional factors that should participate in the result cache key.
+    pub(super) cache_key_extras: Arc<RwLock<Vec<String>>>,
     pub(super) cacheable: Arc<AtomicBool>,
     pub(super) can_scan_from_agg_index: Arc<AtomicBool>,
     pub(super) num_fragmented_block_hint: Arc<Mutex<HashMap<String, u64>>>,
@@ -236,6 +238,7 @@ impl QueryContextShared {
             copy_status: Default::default(),
             mutation_status: Default::default(),
             partitions_shas: Arc::new(RwLock::new(vec![])),
+            cache_key_extras: Arc::new(RwLock::new(vec![])),
             cacheable: Arc::new(AtomicBool::new(true)),
             can_scan_from_agg_index: Arc::new(AtomicBool::new(true)),
             num_fragmented_block_hint: Default::default(),

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -627,6 +627,14 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
+    fn add_cache_key_extra(&self, extra: String) {
+        self.ctx.add_cache_key_extra(extra)
+    }
+
+    fn get_cache_key_extras(&self) -> Vec<String> {
+        self.ctx.get_cache_key_extras()
+    }
+
     fn get_cacheable(&self) -> bool {
         todo!()
     }

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -505,6 +505,14 @@ impl TableContext for CtxDelegation {
         todo!()
     }
 
+    fn add_cache_key_extra(&self, extra: String) {
+        self.ctx.add_cache_key_extra(extra)
+    }
+
+    fn get_cache_key_extras(&self) -> Vec<String> {
+        self.ctx.get_cache_key_extras()
+    }
+
     fn get_cacheable(&self) -> bool {
         todo!()
     }

--- a/src/query/storages/basic/src/result_cache/common.rs
+++ b/src/query/storages/basic/src/result_cache/common.rs
@@ -55,4 +55,7 @@ pub struct ResultCacheValue {
     pub partitions_shas: Vec<String>,
     /// The location of the result cache file.
     pub location: String,
+    /// Additional factors that participated in the cache key (e.g., row access policy predicates).
+    #[serde(default)]
+    pub cache_key_extras: Vec<String>,
 }

--- a/src/query/storages/basic/src/result_cache/write/sink.rs
+++ b/src/query/storages/basic/src/result_cache/write/sink.rs
@@ -117,6 +117,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
             result_size: self.cache_writer.current_bytes(),
             num_rows: self.cache_writer.num_rows(),
             location,
+            cache_key_extras: self.ctx.get_cache_key_extras(),
         };
         self.meta_mgr
             .set(self.meta_key.clone(), value, MatchSeq::GE(0), ttl_interval)

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
@@ -1,0 +1,167 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Test: Row Access Policy should not incorrectly hit query result cache
+## when different sessions have different variable values.
+
+statement ok
+set global enable_experimental_row_access_policy = 1;
+
+statement ok
+set enable_planner_cache = 0;
+
+statement ok
+drop table if exists rap_cache_test;
+
+statement ok
+drop row access policy if exists rap_cache_policy;
+
+## Create a row access policy that uses GETVARIABLE
+statement ok
+CREATE ROW ACCESS POLICY rap_cache_policy AS (app_name_col STRING) RETURNS BOOLEAN ->
+  app_name_col = GETVARIABLE('app_name');
+
+statement ok
+create table rap_cache_test(id int, app_name string, data string);
+
+statement ok
+insert into rap_cache_test values
+  (1, 'app_a', 'data for app a - row 1'),
+  (2, 'app_a', 'data for app a - row 2'),
+  (3, 'app_b', 'data for app b - row 1'),
+  (4, 'app_b', 'data for app b - row 2'),
+  (5, 'app_b', 'data for app b - row 3');
+
+statement ok
+alter table rap_cache_test add row access policy rap_cache_policy on (app_name);
+
+## Enable query result cache
+statement ok
+SET enable_query_result_cache = 1;
+
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
+## ========================================
+## Step 1: SET var=a, SELECT, EXPLAIN SELECT (should hit cache)
+## ========================================
+
+statement ok
+SET VARIABLE app_name = 'app_a';
+
+## Execute query - writes to cache
+query ITT
+SELECT * FROM rap_cache_test ORDER BY id;
+----
+1 app_a data for app a - row 1
+2 app_a data for app a - row 2
+
+## EXPLAIN should show cache hit (same variable value)
+query T
+EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
+----
+ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
+├── Number of rows: 2
+└── Result size: 119
+
+## ========================================
+## Step 2: SET var=b, EXPLAIN SELECT (should NOT hit cache)
+## ========================================
+
+statement ok
+SET VARIABLE app_name = 'app_b';
+
+## EXPLAIN should NOT show ReadQueryResultCache because variable changed
+## It should show a normal query plan instead
+query T
+EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
+----
+Sort(Single)
+├── output columns: [rap_cache_test.id (#0), rap_cache_test.app_name (#1), rap_cache_test.data (#2)]
+├── sort keys: [id ASC NULLS LAST]
+├── estimated rows: 2.50
+└── SecureFilter
+    ├── output columns: [rap_cache_test.id (#0), rap_cache_test.app_name (#1), rap_cache_test.data (#2)]
+    ├── secure filters: [SECURE: is_true(rap_cache_test.app_name (#1) = 'app_b')]
+    ├── estimated rows: 2.50
+    └── TableScan
+        ├── table: default.default.rap_cache_test
+        ├── scan id: 0
+        ├── output columns: [id (#0), app_name (#1), data (#2)]
+        ├── read rows: 5
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 5.00
+
+## ========================================
+## Step 3: SELECT, EXPLAIN SELECT (should hit cache now)
+## ========================================
+
+## Execute query with var=b - writes to its own cache
+query ITT
+SELECT * FROM rap_cache_test ORDER BY id;
+----
+3 app_b data for app b - row 1
+4 app_b data for app b - row 2
+5 app_b data for app b - row 3
+
+## EXPLAIN should show cache hit now (cache populated for var=b)
+## Note: Number of rows: 3 (different from app_a's 2 rows)
+query T
+EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
+----
+ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
+├── Number of rows: 3
+└── Result size: 177
+
+## ========================================
+## Step 4: Switch back to var=a, verify it still has its own cache
+## ========================================
+
+statement ok
+SET VARIABLE app_name = 'app_a';
+
+## Should hit cache for var=a (cached earlier)
+query T
+EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
+----
+ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
+├── Number of rows: 2
+└── Result size: 119
+
+## Verify data is correct for app_a
+query ITT
+SELECT * FROM rap_cache_test ORDER BY id;
+----
+1 app_a data for app a - row 1
+2 app_a data for app a - row 2
+
+## ========================================
+## Cleanup
+## ========================================
+
+statement ok
+SET enable_query_result_cache = 0;
+
+statement ok
+drop table rap_cache_test;
+
+statement ok
+drop row access policy rap_cache_policy;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

  ## Summary

  When a table has a Row Access Policy that uses session variables (e.g., `GETVARIABLE('app_name')`), queries with the same SQL text but different variable values should return different results. However, the query result cache was only keyed by the SQL text, causing incorrect cache hits across different sessions.

  **Before this fix:**
  - Session A: `SET VARIABLE app_name='a'; SELECT * FROM t;` → cache key = `hash("SELECT * FROM t")`
  - Session B: `SET VARIABLE app_name='b'; SELECT * FROM t;` → same cache key, **incorrectly returns Session A's data**

  **After this fix:**
  - Session A: cache key = `hash("SELECT * FROM t|secure:<predicate_hash_a>")`
  - Session B: cache key = `hash("SELECT * FROM t|secure:<predicate_hash_b>")` → different cache, correct data

  ## Changes

  - Add `cache_key_extras` mechanism to `TableContext` for extending cache keys with dynamic factors
  - Include SecureFilter predicates (serialized + hashed) in cache key generation
  - Update `interpreter_explain.rs` to use the same cache key logic as `interpreter_select.rs`
  - Add `cache_key_extras` column to `system.query_cache` for debugging/visibility
  - Add `#[serde(default)]` to `ResultCacheValue.cache_key_extras` for backward compatibility

  ## Upgrade Notes

  After upgrading, **existing query result caches for tables with Row Access Policies will be invalidated** because the cache key now includes the policy predicates. This is expected behavior:
  - Queries will be re-executed and new caches will be created with the correct keys
  - No incorrect data will be returned
  - Only affects performance temporarily (cache warm-up)

  Tables without Row Access Policies are not affected.
## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19210)
<!-- Reviewable:end -->
