### PR TITLE
refactor(query): use snapshot_location for DummyTableScan cache invalidation

### DIFF
--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -175,7 +175,11 @@ pub trait TableContext: Send + Sync {
         unimplemented!()
     }
     fn set_partitions(&self, partitions: Partitions) -> Result<()>;
-    fn add_partitions_sha(&self, sha: String);
+    /// Add a cache invalidation key for query result cache.
+    ///
+    /// Historically named `partitions_sha` because most callers use a partition SHA256,
+    /// but some callers may use other stable version identifiers (e.g. Fuse snapshot_location).
+    fn add_partitions_sha(&self, key: String);
     fn get_partitions_shas(&self) -> Vec<String>;
     fn get_cacheable(&self) -> bool;
     fn set_cacheable(&self, cacheable: bool);

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -966,13 +966,13 @@ impl TableContext for QueryContext {
 
     fn add_partitions_sha(&self, s: String) {
         let mut shas = self.shared.partitions_shas.write();
-        // Avoid duplicate SHAs when the same table is scanned multiple times.
+        // Avoid duplicate invalidation keys when the same table is scanned multiple times.
         // Example: `SELECT * FROM t WHERE a > (SELECT MIN(a) FROM t)`
         // In this query, table `t` appears twice:
         // 1. The main TableScan adds SHA via table_read_plan.rs
         // 2. The scalar subquery is optimized to DummyTableScan, which also
-        //    adds SHA for its source table `t` via build_dummy_table_scan
-        // Without deduplication, the same SHA would appear twice in the list.
+        //    adds an invalidation key for its source table `t` via build_dummy_table_scan
+        // Without deduplication, the same key would appear twice in the list.
         if !shas.contains(&s) {
             shas.push(s);
         }
@@ -980,7 +980,7 @@ impl TableContext for QueryContext {
 
     fn get_partitions_shas(&self) -> Vec<String> {
         let mut sha = self.shared.partitions_shas.read().clone();
-        // Sort to make sure the SHAs are stable for the same query.
+        // Sort to make sure the keys are stable for the same query.
         sha.sort();
         sha
     }

--- a/src/query/sql/src/executor/table_read_plan.rs
+++ b/src/query/sql/src/executor/table_read_plan.rs
@@ -94,7 +94,8 @@ impl ToReadDataSourcePlan for dyn Table {
             bytes: statistics.read_bytes,
         });
 
-        // We need the partition sha256 to specify the result cache.
+        // Add a cache invalidation key for query result cache.
+        // For normal table scans we use the partition SHA256.
         let settings = ctx.get_settings();
         if settings.get_enable_query_result_cache()? {
             let sha = parts.compute_sha256()?;

--- a/src/query/sql/src/planner/plans/dummy_table_scan.rs
+++ b/src/query/sql/src/planner/plans/dummy_table_scan.rs
@@ -53,11 +53,16 @@ use crate::plans::RelOperator;
 ///
 /// The `source_table_indexes` field solves this by tracking which tables' data was used
 /// to compute the constant values. During physical plan building, we use these indexes
-/// to compute partition SHAs for the source tables, ensuring proper cache invalidation.
+/// to add cache invalidation keys for the source tables, ensuring proper cache invalidation.
+///
+/// Note: The query result cache stores these keys under the historical name
+/// `partitions_shas`. For normal table scans we use a partition SHA256; for Fuse tables
+/// (e.g. when folded into DummyTableScan) we may use snapshot_location (or a stable
+/// sentinel for empty tables) as the invalidation key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct DummyTableScan {
     /// Table indexes that this DummyTableScan depends on.
-    /// When building the physical plan, we compute partition SHAs for these tables
+    /// When building the physical plan, we add cache invalidation keys for these tables
     /// to ensure query result cache is invalidated when source data changes.
     pub source_table_indexes: Vec<IndexType>,
 }

--- a/src/query/storages/basic/src/result_cache/write/sink.rs
+++ b/src/query/storages/basic/src/result_cache/write/sink.rs
@@ -87,12 +87,12 @@ impl AsyncMpscSink for WriteResultCacheSink {
             return Ok(());
         }
 
-        // Skip cache writing if there are no partition SHAs.
-        // Without partition SHAs, we cannot detect data changes and the cache
+        // Skip cache writing if there are no cache invalidation keys.
+        // Without invalidation keys, we cannot detect data changes and the cache
         // may return stale results. This can happen when queries are pure constants
         // (like SELECT 1) that don't depend on any table data.
         // Note: Queries with DummyTableScan that depend on table statistics should
-        // have partition SHAs added via DummyTableScan.source_table_indexes.
+        // have invalidation keys added via DummyTableScan.source_table_indexes.
         if self.partitions_shas.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  Replace partition SHA256 computation with snapshot_location lookup for
  Fuse tables. This simplifies the cache key derivation and avoids the
  async read_partitions call during physical plan building.

  For non-Fuse tables, conservatively disable caching.

Fixe: https://github.com/databendlabs/databend/pull/19202 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - refactor keep ci happy

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19214)
<!-- Reviewable:end -->
