### PR TITLE
feat: add `limit` parameter to `KVApi::list_kv()` and related methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,6 +4187,7 @@ dependencies = [
  "databend-common-meta-types",
  "display-more 0.2.1",
  "fastrace",
+ "futures-util",
  "log",
  "state-machine-api",
  "tokio",

--- a/src/meta/api/src/crud/mod.rs
+++ b/src/meta/api/src/crud/mod.rs
@@ -259,10 +259,10 @@ where
 
     #[async_backtrace::framed]
     #[fastrace::trace]
-    pub async fn list(&self) -> Result<Vec<ValueOf<R>>, MetaError> {
+    pub async fn list(&self, limit: Option<u64>) -> Result<Vec<ValueOf<R>>, MetaError> {
         let dir_name = DirName::new(self.ident("dummy"));
 
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, limit).await?;
         let values = values.try_collect().await?;
 
         Ok(values)

--- a/src/meta/api/src/data_mask_api_impl.rs
+++ b/src/meta/api/src/data_mask_api_impl.rs
@@ -156,7 +156,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> DatamaskApi for KV {
             ));
 
             // List all table-policy references
-            let table_policy_refs = self.list_pb_vec(&table_policy_ref_prefix).await?;
+            let table_policy_refs = self.list_pb_vec(&table_policy_ref_prefix, None).await?;
 
             // Policy is in use - cannot drop
             if !table_policy_refs.is_empty() {

--- a/src/meta/api/src/database_api.rs
+++ b/src/meta/api/src/database_api.rs
@@ -583,7 +583,7 @@ where
         let name_ident = DatabaseIdHistoryIdent::new(&req.tenant, "dummy");
         let dir_name = DirName::new(name_ident);
 
-        let name_idlists = self.list_pb_vec(&dir_name).await?;
+        let name_idlists = self.list_pb_vec(&dir_name, None).await?;
 
         let mut dbs = BTreeMap::new();
 
@@ -647,7 +647,7 @@ where
         let name_key = DatabaseNameIdent::new(req.tenant(), "dummy");
         let dir = DirName::new(name_key);
 
-        let name_seq_ids = self.list_pb_vec(&dir).await?;
+        let name_seq_ids = self.list_pb_vec(&dir, None).await?;
 
         let id_idents = name_seq_ids
             .iter()

--- a/src/meta/api/src/database_util.rs
+++ b/src/meta/api/src/database_util.rs
@@ -153,7 +153,11 @@ pub(crate) async fn drop_database_meta(
         ObjectTagIdRef::new(taggable_object.clone(), 0),
     );
     let obj_tag_dir = DirName::new(obj_tag_prefix);
-    let tag_entries: Vec<_> = kv_api.list_pb(&obj_tag_dir).await?.try_collect().await?;
+    let tag_entries: Vec<_> = kv_api
+        .list_pb(&obj_tag_dir, None)
+        .await?
+        .try_collect()
+        .await?;
     for entry in tag_entries {
         let tag_id = entry.key.name().tag_id;
         // Delete object -> tag reference

--- a/src/meta/api/src/garbage_collection_api.rs
+++ b/src/meta/api/src/garbage_collection_api.rs
@@ -206,7 +206,7 @@ async fn remove_copied_files_for_dropped_table(
 
         let dir_name = DirName::new(copied_file_ident);
 
-        let key_stream = kv_api.list_pb_keys(&dir_name).await?;
+        let key_stream = kv_api.list_pb_keys(&dir_name, None).await?;
         let copied_files = key_stream.take(batch_size).try_collect::<Vec<_>>().await?;
 
         if copied_files.is_empty() {
@@ -259,7 +259,7 @@ pub async fn get_history_tables_for_gc(
         table_name: "dummy".to_string(),
     };
     let dir_name = DirName::new(ident);
-    let table_history_kvs = kv_api.list_pb_vec(&dir_name).await?;
+    let table_history_kvs = kv_api.list_pb_vec(&dir_name, None).await?;
 
     let mut args = vec![];
 
@@ -466,7 +466,7 @@ async fn gc_dropped_db_by_id(
 
         let mut num_db_id_table_name_keys_removed = 0;
         let batch_size = 1024;
-        let key_stream = kv_api.list_pb_keys(&dir_name).await?;
+        let key_stream = kv_api.list_pb_keys(&dir_name, None).await?;
         let mut chunks = key_stream.chunks(batch_size);
         while let Some(targets) = chunks.next().await {
             let mut txn = TxnRequest::default();
@@ -511,7 +511,7 @@ async fn gc_dropped_db_by_id(
     };
     let dir_name = DirName::new(table_history_ident);
 
-    let table_history_items = kv_api.list_pb_vec(&dir_name).await?;
+    let table_history_items = kv_api.list_pb_vec(&dir_name, None).await?;
 
     let mut txn = TxnRequest::default();
 
@@ -566,7 +566,7 @@ async fn gc_dropped_db_by_id(
             ObjectTagIdRef::new(taggable_object.clone(), 0),
         );
         let obj_tag_dir = DirName::new(obj_tag_prefix);
-        let mut tag_stream = kv_api.list_pb(&obj_tag_dir).await?;
+        let mut tag_stream = kv_api.list_pb(&obj_tag_dir, None).await?;
         while let Some(entry) = tag_stream.try_next().await? {
             let tag_id = entry.key.name().tag_id;
             // Delete object -> tag reference
@@ -762,7 +762,7 @@ async fn remove_data_for_dropped_table(
             tenant,
             auto_increment_key,
         ));
-        let mut auto_increments = kv_api.list_pb_keys(&dir_name).await?;
+        let mut auto_increments = kv_api.list_pb_keys(&dir_name, None).await?;
 
         while let Some(auto_increment_ident) = auto_increments.try_next().await? {
             txn.if_then.push(txn_op_del(&auto_increment_ident));
@@ -805,7 +805,7 @@ async fn remove_data_for_dropped_table(
             ObjectTagIdRef::new(taggable_object.clone(), 0),
         );
         let obj_tag_dir = DirName::new(obj_tag_prefix);
-        let mut tag_stream = kv_api.list_pb(&obj_tag_dir).await?;
+        let mut tag_stream = kv_api.list_pb(&obj_tag_dir, None).await?;
         while let Some(entry) = tag_stream.try_next().await? {
             let tag_id = entry.key.name().tag_id;
             // Delete object -> tag reference

--- a/src/meta/api/src/index_api.rs
+++ b/src/meta/api/src/index_api.rs
@@ -247,7 +247,7 @@ where
                 DirName::new_with_level(ident, 2)
             }
         };
-        let list_res = self.list_pb_vec(&dir).await?;
+        let list_res = self.list_pb_vec(&dir, None).await?;
         let mut table_indexes = HashMap::new();
         for (k, v) in list_res {
             let table_id = k.name().table_id;
@@ -482,7 +482,7 @@ where
                 DirName::new_with_level(ident, 3)
             }
         };
-        let list_res = self.list_pb_vec(&dir).await?;
+        let list_res = self.list_pb_vec(&dir, None).await?;
         let mut table_indexes = HashMap::new();
         for (k, v) in list_res {
             let table_id = k.name().table_id;

--- a/src/meta/api/src/kv_fetch_util.rs
+++ b/src/meta/api/src/kv_fetch_util.rs
@@ -130,7 +130,7 @@ pub async fn list_u64_value<K: kvapi::Key>(
     kv_api: &(impl kvapi::KVApi<Error = MetaError> + ?Sized),
     key: &K,
 ) -> Result<(Vec<K>, Vec<u64>), MetaError> {
-    let res = kv_api.list_kv_collect(&key.to_string_key()).await?;
+    let res = kv_api.list_kv_collect(&key.to_string_key(), None).await?;
 
     let n = res.len();
 

--- a/src/meta/api/src/lock_api.rs
+++ b/src/meta/api/src/lock_api.rs
@@ -60,7 +60,7 @@ where
         req: ListLockRevReq,
     ) -> Result<Vec<(u64, LockMeta)>, KVAppError> {
         let dir = req.lock_key.gen_prefix();
-        let strm = self.list_pb(&dir).await?;
+        let strm = self.list_pb(&dir, None).await?;
 
         let list = strm
             .map_ok(|itm| (itm.key.revision(), itm.seqv.data))
@@ -182,7 +182,7 @@ where
     async fn list_locks(&self, req: ListLocksReq) -> Result<Vec<LockInfo>, KVAppError> {
         let mut reply = vec![];
         for dir in &req.prefixes {
-            let strm = self.list_pb(dir).await?;
+            let strm = self.list_pb(dir, None).await?;
             let locks = strm
                 .map_ok(|itm| LockInfo {
                     table_id: itm.key.table_id(),

--- a/src/meta/api/src/name_id_value_api.rs
+++ b/src/meta/api/src/name_id_value_api.rs
@@ -292,7 +292,7 @@ where
     > + Send {
         async move {
             let tenant = prefix.key().tenant();
-            let strm = self.list_pb(prefix).await?;
+            let strm = self.list_pb(prefix, None).await?;
             let name_ids = strm.try_collect::<Vec<_>>().await?;
 
             let id_idents = name_ids
@@ -448,7 +448,11 @@ mod tests {
             Ok(strm.boxed())
         }
 
-        async fn list_kv(&self, _prefix: &str) -> Result<KVStream<Self::Error>, Self::Error> {
+        async fn list_kv(
+            &self,
+            _prefix: &str,
+            _limit: Option<u64>,
+        ) -> Result<KVStream<Self::Error>, Self::Error> {
             unimplemented!()
         }
 

--- a/src/meta/api/src/row_access_policy_api_impl.rs
+++ b/src/meta/api/src/row_access_policy_api_impl.rs
@@ -148,7 +148,7 @@ impl<KV: kvapi::KVApi<Error = MetaError>> RowAccessPolicyApi for KV {
             ));
 
             // List all table-policy references
-            let table_policy_refs = self.list_pb_vec(&table_policy_ref_prefix).await?;
+            let table_policy_refs = self.list_pb_vec(&table_policy_ref_prefix, None).await?;
 
             // Policy is in use - cannot drop
             if !table_policy_refs.is_empty() {

--- a/src/meta/api/src/schema_api.rs
+++ b/src/meta/api/src/schema_api.rs
@@ -347,7 +347,11 @@ pub async fn construct_drop_table_txn_operations(
         ObjectTagIdRef::new(taggable_object.clone(), 0),
     );
     let obj_tag_dir = DirName::new(obj_tag_prefix);
-    let tag_entries: Vec<_> = kv_api.list_pb(&obj_tag_dir).await?.try_collect().await?;
+    let tag_entries: Vec<_> = kv_api
+        .list_pb(&obj_tag_dir, None)
+        .await?
+        .try_collect()
+        .await?;
     for entry in tag_entries {
         let tag_id = entry.key.name().tag_id;
         // Delete object -> tag reference

--- a/src/meta/api/src/sequence_api_impl.rs
+++ b/src/meta/api/src/sequence_api_impl.rs
@@ -134,7 +134,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
         let dir_name = DirName::new(SequenceIdent::new(tenant, "dummy"));
 
         let ident_metas = self
-            .list_pb(&dir_name)
+            .list_pb(&dir_name, None)
             .await?
             .map_ok(|itm| (itm.key, itm.seqv.data))
             .try_collect::<Vec<_>>()

--- a/src/meta/api/src/table_api.rs
+++ b/src/meta/api/src/table_api.rs
@@ -952,7 +952,7 @@ where
                 file: "dummy".to_string(),
             };
             let dir_name = DirName::new(copied_file_ident);
-            let copied_files = self.list_pb_vec(&dir_name).await?;
+            let copied_files = self.list_pb_vec(&dir_name, None).await?;
 
             let seq_2 = self.get_seq(&table_id).await?;
 
@@ -1627,7 +1627,7 @@ where
 
         let dir_name = DirName::new(table_id_history_ident);
 
-        let ident_histories = self.list_pb_vec(&dir_name).await?;
+        let ident_histories = self.list_pb_vec(&dir_name, None).await?;
 
         let mut res = vec![];
         let now = Utc::now();
@@ -1762,7 +1762,7 @@ where
             file: "".to_string(),
         };
 
-        let res = self.list_pb_vec(&DirName::new(key)).await?;
+        let res = self.list_pb_vec(&DirName::new(key), None).await?;
         let mut file_info = BTreeMap::new();
         for (name_key, seqv) in res {
             file_info.insert(name_key.file, seqv.data);

--- a/src/meta/api/src/tag_api.rs
+++ b/src/meta/api/src/tag_api.rs
@@ -188,7 +188,7 @@ where
 
             // Transaction failed. Check if it's due to references or concurrent modification.
             let refs: Vec<String> = self
-                .list_pb(&refs_dir)
+                .list_pb(&refs_dir, None)
                 .await?
                 .map_ok(|entry| entry.key.name().object.to_string())
                 .try_collect()
@@ -456,7 +456,7 @@ where
         let obj_ref_key =
             ObjectTagIdRefIdent::new_generic(tenant, ObjectTagIdRef::new(object.clone(), 0));
         let refs_dir = DirName::new(obj_ref_key);
-        let stream = self.list_pb(&refs_dir).await?;
+        let stream = self.list_pb(&refs_dir, None).await?;
         Ok(stream
             .map_ok(|entry| ObjectTagValue {
                 tag_id: entry.key.name().tag_id,
@@ -482,7 +482,7 @@ where
             2,
         );
         let refs = self
-            .list_pb(&refs_dir)
+            .list_pb(&refs_dir, None)
             .await?
             .map_ok(|entry| {
                 let object = entry.key.name().object.clone();

--- a/src/meta/binaries/meta/kvapi.rs
+++ b/src/meta/binaries/meta/kvapi.rs
@@ -88,7 +88,7 @@ impl KvApiCommand {
                 serde_json::to_string_pretty(&res)?
             }
             KvApiCommand::List(prefix) => {
-                let res = client.list_kv_collect(prefix.as_str()).await?;
+                let res = client.list_kv_collect(prefix.as_str(), None).await?;
                 serde_json::to_string_pretty(&res)?
             }
         };

--- a/src/meta/client/src/kv_api_impl.rs
+++ b/src/meta/client/src/kv_api_impl.rs
@@ -17,6 +17,7 @@ use databend_common_meta_kvapi::kvapi::KVStream;
 use databend_common_meta_kvapi::kvapi::ListKVReq;
 use databend_common_meta_kvapi::kvapi::MGetKVReq;
 use databend_common_meta_kvapi::kvapi::UpsertKVReply;
+use databend_common_meta_kvapi::kvapi::limit_stream;
 use databend_common_meta_types::MetaError;
 use databend_common_meta_types::TxnReply;
 use databend_common_meta_types::TxnRequest;
@@ -46,7 +47,11 @@ impl kvapi::KVApi for ClientHandle {
     }
 
     #[fastrace::trace]
-    async fn list_kv(&self, prefix: &str) -> Result<KVStream<Self::Error>, Self::Error> {
+    async fn list_kv(
+        &self,
+        prefix: &str,
+        limit: Option<u64>,
+    ) -> Result<KVStream<Self::Error>, Self::Error> {
         let strm = self
             .request(Streamed(ListKVReq {
                 prefix: prefix.to_string(),
@@ -54,7 +59,7 @@ impl kvapi::KVApi for ClientHandle {
             .await?;
 
         let strm = strm.map_err(MetaError::from);
-        Ok(strm.boxed())
+        Ok(limit_stream(strm, limit))
     }
 
     #[fastrace::trace]

--- a/src/meta/kvapi-test-suite/Cargo.toml
+++ b/src/meta/kvapi-test-suite/Cargo.toml
@@ -14,6 +14,7 @@ databend-common-meta-kvapi = { workspace = true }
 databend-common-meta-types = { workspace = true }
 display-more = { workspace = true }
 fastrace = { workspace = true }
+futures-util = { workspace = true }
 log = { workspace = true }
 state-machine-api = { workspace = true }
 tokio = { workspace = true }

--- a/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
+++ b/src/meta/kvapi-test-suite/src/kvapi_test_suite.rs
@@ -49,6 +49,7 @@ use display_more::DisplayOptionExt;
 use display_more::DisplaySliceExt;
 use fastrace::func_name;
 use fastrace::func_path;
+use futures_util::TryStreamExt;
 use log::debug;
 use log::info;
 use state_machine_api::KVMeta;
@@ -98,6 +99,9 @@ impl TestSuite {
 
         self.kv_meta(&builder.build().await).await?;
         self.kv_list(&builder.build().await).await?;
+        self.kv_list_with_limit(&builder.build().await).await?;
+        self.kv_list_collect_with_limit(&builder.build().await)
+            .await?;
         self.kv_mget(&builder.build().await).await?;
 
         self.kv_txn_absent_seq_0(&builder.build().await).await?;
@@ -379,7 +383,7 @@ impl TestSuite {
 
         info!("--- list should not return expired");
         {
-            let res = kv.list_kv_collect("k").await?;
+            let res = kv.list_kv_collect("k", None).await?;
             let res_vec = res.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
 
             assert_eq!(res_vec, vec!["k2".to_string(),]);
@@ -584,7 +588,7 @@ impl TestSuite {
             kv.upsert_kv(UpsertKV::update("v", b"")).await?;
         }
 
-        let res = kv.list_kv_collect("__users/").await?;
+        let res = kv.list_kv_collect("__users/", None).await?;
         assert_eq!(
             res.iter()
                 .map(|(_key, val)| val.data.clone())
@@ -594,6 +598,113 @@ impl TestSuite {
                 .map(|v| v.as_bytes().to_vec())
                 .collect::<Vec<_>>()
         );
+        Ok(())
+    }
+
+    /// Test `list_kv` with limit parameter
+    pub async fn kv_list_with_limit<KV: kvapi::KVApi>(&self, kv: &KV) -> anyhow::Result<()> {
+        info!("--- kvapi::KVApiTestSuite::kv_list_with_limit() start");
+
+        // Insert 5 keys
+        for i in 0..5 {
+            let key = format!("__limit_test/{}", i);
+            let val = format!("val_{}", i);
+            kv.upsert_kv(UpsertKV::update(&key, val.as_bytes())).await?;
+        }
+
+        // List all with no limit
+        let res: Vec<_> = kv
+            .list_kv("__limit_test/", None)
+            .await?
+            .map_ok(|item| item.key)
+            .try_collect()
+            .await?;
+        assert_eq!(res, vec![
+            "__limit_test/0",
+            "__limit_test/1",
+            "__limit_test/2",
+            "__limit_test/3",
+            "__limit_test/4",
+        ]);
+
+        // List with limit 3
+        let res: Vec<_> = kv
+            .list_kv("__limit_test/", Some(3))
+            .await?
+            .map_ok(|item| item.key)
+            .try_collect()
+            .await?;
+        assert_eq!(res, vec![
+            "__limit_test/0",
+            "__limit_test/1",
+            "__limit_test/2",
+        ]);
+
+        // List with limit 0
+        let res: Vec<_> = kv
+            .list_kv("__limit_test/", Some(0))
+            .await?
+            .map_ok(|item| item.key)
+            .try_collect()
+            .await?;
+        assert_eq!(res, Vec::<String>::new());
+
+        // List with limit larger than result set
+        let res: Vec<_> = kv
+            .list_kv("__limit_test/", Some(100))
+            .await?
+            .map_ok(|item| item.key)
+            .try_collect()
+            .await?;
+        assert_eq!(res, vec![
+            "__limit_test/0",
+            "__limit_test/1",
+            "__limit_test/2",
+            "__limit_test/3",
+            "__limit_test/4",
+        ]);
+
+        Ok(())
+    }
+
+    /// Test `list_kv_collect` with limit parameter
+    pub async fn kv_list_collect_with_limit<KV: kvapi::KVApi>(
+        &self,
+        kv: &KV,
+    ) -> anyhow::Result<()> {
+        info!("--- kvapi::KVApiTestSuite::kv_list_collect_with_limit() start");
+
+        // Insert 5 keys
+        for i in 0..5 {
+            let key = format!("__collect_limit/{}", i);
+            let val = format!("val_{}", i);
+            kv.upsert_kv(UpsertKV::update(&key, val.as_bytes())).await?;
+        }
+
+        // List all with no limit
+        let res = kv.list_kv_collect("__collect_limit/", None).await?;
+        let keys: Vec<_> = res.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec![
+            "__collect_limit/0",
+            "__collect_limit/1",
+            "__collect_limit/2",
+            "__collect_limit/3",
+            "__collect_limit/4",
+        ]);
+
+        // List with limit 3
+        let res = kv.list_kv_collect("__collect_limit/", Some(3)).await?;
+        let keys: Vec<_> = res.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec![
+            "__collect_limit/0",
+            "__collect_limit/1",
+            "__collect_limit/2",
+        ]);
+
+        // List with limit 0
+        let res = kv.list_kv_collect("__collect_limit/", Some(0)).await?;
+        assert_eq!(res, vec![]);
+
         Ok(())
     }
 
@@ -1929,7 +2040,7 @@ impl TestSuite {
 
         info!("--- test list on other node");
         {
-            let res = kv2.list_kv_collect("__users/").await?;
+            let res = kv2.list_kv_collect("__users/", None).await?;
             assert_eq!(
                 res.iter()
                     .map(|(_key, val)| val.data.clone())

--- a/src/meta/kvapi/src/kvapi/api.rs
+++ b/src/meta/kvapi/src/kvapi/api.rs
@@ -21,6 +21,8 @@ use databend_common_meta_types::TxnRequest;
 use databend_common_meta_types::UpsertKV;
 use databend_common_meta_types::errors;
 use databend_common_meta_types::protobuf::StreamItem;
+use futures_util::Stream;
+use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
 
 use crate::kvapi;
@@ -37,6 +39,15 @@ pub trait ApiBuilder<T>: Clone {
 
 /// A stream of key-value records that are returned by stream based API such as mget and list.
 pub type KVStream<E> = BoxStream<'static, Result<StreamItem, E>>;
+
+/// Apply an optional limit to a stream, returning a boxed stream.
+pub fn limit_stream<S, E>(strm: S, limit: Option<u64>) -> KVStream<E>
+where S: Stream<Item = Result<StreamItem, E>> + Send + 'static {
+    match limit {
+        Some(n) => strm.take(n as usize).boxed(),
+        None => strm.boxed(),
+    }
+}
 
 /// API of a key-value store.
 #[async_trait]
@@ -59,7 +70,12 @@ pub trait KVApi: Send + Sync {
     /// List key-value records that are starts with the specified prefix.
     ///
     /// Same as `prefix_list_kv()`, except it returns a stream.
-    async fn list_kv(&self, prefix: &str) -> Result<KVStream<Self::Error>, Self::Error>;
+    /// If `limit` is `Some(n)`, at most `n` records will be returned.
+    async fn list_kv(
+        &self,
+        prefix: &str,
+        limit: Option<u64>,
+    ) -> Result<KVStream<Self::Error>, Self::Error>;
 
     /// Run transaction: update one or more records if specified conditions are met.
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, Self::Error>;
@@ -77,8 +93,12 @@ impl<U: kvapi::KVApi, T: Deref<Target = U> + Send + Sync> kvapi::KVApi for T {
         self.deref().get_kv_stream(keys).await
     }
 
-    async fn list_kv(&self, prefix: &str) -> Result<KVStream<Self::Error>, Self::Error> {
-        self.deref().list_kv(prefix).await
+    async fn list_kv(
+        &self,
+        prefix: &str,
+        limit: Option<u64>,
+    ) -> Result<KVStream<Self::Error>, Self::Error> {
+        self.deref().list_kv(prefix, limit).await
     }
 
     async fn transaction(&self, txn: TxnRequest) -> Result<TxnReply, Self::Error> {

--- a/src/meta/kvapi/src/kvapi/kv_api_ext.rs
+++ b/src/meta/kvapi/src/kvapi/kv_api_ext.rs
@@ -64,10 +64,14 @@ pub trait KvApiExt: KVApi {
     /// List key-value starting with the specified prefix and return a [`Vec`]
     ///
     /// Same as [`Self::list_kv`] but return a [`Vec`] instead of a stream.
-    async fn list_kv_collect(&self, prefix: &str) -> Result<Vec<(String, SeqV)>, Self::Error> {
+    async fn list_kv_collect(
+        &self,
+        prefix: &str,
+        limit: Option<u64>,
+    ) -> Result<Vec<(String, SeqV)>, Self::Error> {
         let now = std::time::Instant::now();
 
-        let strm = self.list_kv(prefix).await?;
+        let strm = self.list_kv(prefix, limit).await?;
 
         debug!("list_kv() took {:?}", now.elapsed());
 

--- a/src/meta/kvapi/src/kvapi/mod.rs
+++ b/src/meta/kvapi/src/kvapi/mod.rs
@@ -33,6 +33,7 @@ pub use api::ApiBuilder;
 pub use api::AsKVApi;
 pub use api::KVApi;
 pub use api::KVStream;
+pub use api::limit_stream;
 pub use dir_name::DirName;
 pub use item::Item;
 pub use item::NonEmptyItem;

--- a/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
+++ b/src/meta/raft-store/src/sm_v003/sm_v003_test.rs
@@ -75,7 +75,7 @@ async fn test_one_level_upsert_get_range() -> anyhow::Result<()> {
 
     let got = sm
         .kv_api()
-        .list_kv("")
+        .list_kv("", None)
         .await?
         .map_ok(|strm_item| strm_item.into_pair())
         .try_collect::<Vec<_>>()
@@ -151,7 +151,7 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
 
     let got = sm
         .kv_api()
-        .list_kv("")
+        .list_kv("", None)
         .await?
         .map_ok(|strm_item| strm_item.into_pair())
         .try_collect::<Vec<_>>()
@@ -165,13 +165,69 @@ async fn test_two_level_upsert_get_range() -> anyhow::Result<()> {
 
     let got = sm
         .kv_api()
-        .list_kv("a")
+        .list_kv("a", None)
         .await?
         .map_ok(|strm_item| strm_item.into_pair())
         .try_collect::<Vec<_>>()
         .await?
         .without_proposed_at();
     assert_eq!(got, vec![(s("a"), SeqV::new(1, b("a0"))),]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_kv_with_limit() -> anyhow::Result<()> {
+    let sm = SMV003::default();
+
+    // Insert 5 keys
+    let mut a = sm.new_applier().await;
+    a.upsert_kv(&UpsertKV::update("key/a", b"a")).await?;
+    a.upsert_kv(&UpsertKV::update("key/b", b"b")).await?;
+    a.upsert_kv(&UpsertKV::update("key/c", b"c")).await?;
+    a.upsert_kv(&UpsertKV::update("key/d", b"d")).await?;
+    a.upsert_kv(&UpsertKV::update("key/e", b"e")).await?;
+    a.commit().await?;
+
+    // List all with no limit
+    let got = sm
+        .kv_api()
+        .list_kv("key/", None)
+        .await?
+        .map_ok(|item| item.key)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(got, vec!["key/a", "key/b", "key/c", "key/d", "key/e"]);
+
+    // List with limit 3
+    let got = sm
+        .kv_api()
+        .list_kv("key/", Some(3))
+        .await?
+        .map_ok(|item| item.key)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(got, vec!["key/a", "key/b", "key/c"]);
+
+    // List with limit 0
+    let got = sm
+        .kv_api()
+        .list_kv("key/", Some(0))
+        .await?
+        .map_ok(|item| item.key)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(got, Vec::<String>::new());
+
+    // List with limit larger than result set
+    let got = sm
+        .kv_api()
+        .list_kv("key/", Some(100))
+        .await?
+        .map_ok(|item| item.key)
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(got, vec!["key/a", "key/b", "key/c", "key/d", "key/e"]);
+
     Ok(())
 }
 

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum.rs
@@ -860,12 +860,12 @@ async fn test_vacuum_drop_create_or_replace_impl(vacuum_stmts: &[&str]) -> Resul
 
     // there should be 6 table ids : create or replace table 6 times
     let prefix = "__fd_table_by_id";
-    let items = meta.list_kv_collect(prefix).await?;
+    let items = meta.list_kv_collect(prefix, None).await?;
     assert_eq!(items.len(), 6);
 
     // there should be ownerships for 2 db ids and 5 table ids, one of the ownership is revoked by drop table
     let prefix = "__fd_object_owners";
-    let items = meta.list_kv_collect(prefix).await?;
+    let items = meta.list_kv_collect(prefix, None).await?;
     assert_eq!(items.len(), 7);
 
     for sql in vacuum_stmts {
@@ -874,16 +874,16 @@ async fn test_vacuum_drop_create_or_replace_impl(vacuum_stmts: &[&str]) -> Resul
 
     // After vacuum, 1 table ids left
     let prefix = "__fd_table_by_id";
-    let items = meta.list_kv_collect(prefix).await?;
+    let items = meta.list_kv_collect(prefix, None).await?;
     assert_eq!(items.len(), 1);
 
     let prefix = "__fd_table_id_to_name";
-    let items = meta.list_kv_collect(prefix).await?;
+    let items = meta.list_kv_collect(prefix, None).await?;
     assert_eq!(items.len(), 1);
 
     // There are ownership objs of  2 dbs and 1 tables
     let prefix = "__fd_object_owners";
-    let items = meta.list_kv_collect(prefix).await?;
+    let items = meta.list_kv_collect(prefix, None).await?;
     assert_eq!(items.len(), 3);
 
     // db1.t1 should still be accessible

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -249,7 +249,10 @@ impl RoleApi for RoleMgr {
     #[fastrace::trace]
     async fn get_raw_meta_roles(&self) -> Result<ListKVReply, ErrorCode> {
         let role_prefix = self.role_prefix();
-        Ok(self.kv_api.list_kv_collect(role_prefix.as_str()).await?)
+        Ok(self
+            .kv_api
+            .list_kv_collect(role_prefix.as_str(), None)
+            .await?)
     }
 
     #[async_backtrace::framed]
@@ -289,7 +292,7 @@ impl RoleApi for RoleMgr {
             kvs
         } else {
             self.kv_api
-                .list_kv_collect(object_owner_prefix.as_str())
+                .list_kv_collect(object_owner_prefix.as_str(), None)
                 .await?
         };
 
@@ -322,7 +325,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let udfs = values.try_collect().await?;
         Ok(udfs)
     }
@@ -336,7 +339,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let stages = values.try_collect().await?;
         Ok(stages)
     }
@@ -350,7 +353,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let seqs = values.try_collect().await?;
         Ok(seqs)
     }
@@ -364,7 +367,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let seqs = values.try_collect().await?;
         Ok(seqs)
     }
@@ -380,7 +383,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let conns = values.try_collect().await?;
         Ok(conns)
     }
@@ -396,7 +399,7 @@ impl RoleApi for RoleMgr {
 
         let ident = TenantOwnershipObjectIdent::new(self.tenant.clone(), obj);
         let dir_name = DirName::new(ident);
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let ws = values.try_collect().await?;
         Ok(ws)
     }

--- a/src/query/management/src/setting/setting_mgr.rs
+++ b/src/query/management/src/setting/setting_mgr.rs
@@ -72,7 +72,7 @@ impl SettingMgr {
     #[fastrace::trace]
     pub async fn get_settings(&self) -> Result<Vec<UserSetting>> {
         let prefix = self.setting_prefix();
-        let mut strm = self.kv_api.list_kv(&prefix).await?;
+        let mut strm = self.kv_api.list_kv(&prefix, None).await?;
 
         let mut settings = Vec::new();
         while let Some(item) = strm.try_next().await? {

--- a/src/query/management/src/stage/stage_mgr.rs
+++ b/src/query/management/src/stage/stage_mgr.rs
@@ -116,7 +116,7 @@ impl StageApi for StageMgr {
     async fn get_stages(&self) -> Result<Vec<StageInfo>> {
         let dir_name = DirName::new(self.stage_ident("dummy"));
 
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let stages = values.try_collect().await?;
 
         Ok(stages)
@@ -138,7 +138,7 @@ impl StageApi for StageMgr {
             };
 
             // list all stage file keys, and delete them
-            let file_keys = self.kv_api.list_kv_collect(&file_key_prefix).await?;
+            let file_keys = self.kv_api.list_kv_collect(&file_key_prefix, None).await?;
             let mut dels: Vec<TxnOp> = file_keys
                 .iter()
                 .map(|(key, _)| TxnOp::delete(key))
@@ -232,7 +232,7 @@ impl StageApi for StageMgr {
     async fn list_files(&self, name: &str) -> Result<Vec<StageFile>> {
         let dir_name = DirName::new(self.stage_file_ident(name, "dummy"));
 
-        let values = self.kv_api.list_pb_values(&dir_name).await?;
+        let values = self.kv_api.list_pb_values(&dir_name, None).await?;
         let files = values.try_collect().await?;
 
         Ok(files)

--- a/src/query/management/src/task/task_mgr.rs
+++ b/src/query/management/src/task/task_mgr.rs
@@ -224,7 +224,7 @@ impl TaskMgr {
     #[fastrace::trace]
     pub async fn list_task(&self) -> Result<Vec<Task>, MetaError> {
         let key = DirName::new(TaskIdent::new(&self.tenant, ""));
-        let strm = self.kv_api.list_pb_values(&key).await?;
+        let strm = self.kv_api.list_pb_values(&key, None).await?;
 
         strm.try_collect().await
     }

--- a/src/query/management/src/udf/udf_mgr.rs
+++ b/src/query/management/src/udf/udf_mgr.rs
@@ -123,7 +123,7 @@ impl UdfMgr {
     #[fastrace::trace]
     pub async fn list_udf(&self) -> Result<Vec<UserDefinedFunction>, ErrorCode> {
         let key = DirName::new(UdfIdent::new(&self.tenant, ""));
-        let strm = self.kv_api.list_pb_values(&key).await?;
+        let strm = self.kv_api.list_pb_values(&key, None).await?;
 
         match strm.try_collect().await {
             Ok(udfs) => Ok(udfs),
@@ -138,7 +138,7 @@ impl UdfMgr {
         let dir = DirName::new(key);
         let udfs = self
             .kv_api
-            .list_pb_values(&dir)
+            .list_pb_values(&dir, None)
             .await?
             .try_collect::<Vec<_>>()
             .await?;

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -132,7 +132,10 @@ impl UserApi for UserMgr {
     #[fastrace::trace]
     async fn get_raw_users(&self) -> Result<ListKVReply> {
         let user_prefix = self.user_prefix();
-        Ok(self.kv_api.list_kv_collect(user_prefix.as_str()).await?)
+        Ok(self
+            .kv_api
+            .list_kv_collect(user_prefix.as_str(), None)
+            .await?)
     }
 
     #[async_backtrace::framed]

--- a/src/query/management/src/warehouse/warehouse_mgr.rs
+++ b/src/query/management/src/warehouse/warehouse_mgr.rs
@@ -369,7 +369,7 @@ impl WarehouseMgr {
 
         let list_reply = self
             .metastore
-            .list_kv_collect(&self.warehouse_info_key_prefix)
+            .list_kv_collect(&self.warehouse_info_key_prefix, None)
             .await?;
 
         let mut unhealthy_warehouses = HashMap::with_capacity(list_reply.len());
@@ -708,7 +708,7 @@ impl WarehouseMgr {
                 )));
             };
 
-            let values = self.metastore.list_kv_collect(&nodes_prefix).await?;
+            let values = self.metastore.list_kv_collect(&nodes_prefix, None).await?;
 
             let mut after_txn = TxnRequest::default();
             let mut cluster_node_seq = Vec::with_capacity(values.len());
@@ -824,7 +824,7 @@ impl WarehouseMgr {
     async fn unassigned_nodes(&self) -> Result<HashMap<Option<String>, Vec<(u64, NodeInfo)>>> {
         let online_nodes = self
             .metastore
-            .list_kv_collect(&self.node_key_prefix)
+            .list_kv_collect(&self.node_key_prefix, None)
             .await?;
         let mut unassigned_nodes = HashMap::with_capacity(online_nodes.len());
 
@@ -1226,7 +1226,7 @@ impl WarehouseApi for WarehouseMgr {
             // get online nodes
             let online_nodes = self
                 .metastore
-                .list_kv_collect(&self.node_key_prefix)
+                .list_kv_collect(&self.node_key_prefix, None)
                 .await?;
 
             let mut unassign_online_nodes = Vec::with_capacity(online_nodes.len());
@@ -1385,7 +1385,7 @@ impl WarehouseApi for WarehouseMgr {
     async fn list_warehouses(&self) -> Result<Vec<WarehouseInfo>> {
         let values = self
             .metastore
-            .list_kv_collect(&self.warehouse_info_key_prefix)
+            .list_kv_collect(&self.warehouse_info_key_prefix, None)
             .await?;
 
         let mut warehouses = Vec::with_capacity(values.len());
@@ -1512,7 +1512,7 @@ impl WarehouseApi for WarehouseMgr {
             escape_for_key(&warehouse)?
         );
 
-        let values = self.metastore.list_kv_collect(&nodes_prefix).await?;
+        let values = self.metastore.list_kv_collect(&nodes_prefix, None).await?;
 
         let mut nodes_info = Vec::with_capacity(values.len());
         for (node_key, value) in values {
@@ -2138,7 +2138,7 @@ impl WarehouseApi for WarehouseMgr {
 
         let values = self
             .metastore
-            .list_kv_collect(&cluster_nodes_prefix)
+            .list_kv_collect(&cluster_nodes_prefix, None)
             .await?;
 
         let mut nodes_info = Vec::with_capacity(values.len());
@@ -2163,7 +2163,7 @@ impl WarehouseApi for WarehouseMgr {
     async fn list_online_nodes(&self) -> Result<Vec<NodeInfo>> {
         let reply = self
             .metastore
-            .list_kv_collect(&self.node_key_prefix)
+            .list_kv_collect(&self.node_key_prefix, None)
             .await?;
         let mut online_nodes = Vec::with_capacity(reply.len());
 

--- a/src/query/management/src/workload/workload_mgr.rs
+++ b/src/query/management/src/workload/workload_mgr.rs
@@ -267,7 +267,7 @@ impl WorkloadApi for WorkloadMgr {
     async fn get_all(&self) -> Result<Vec<WorkloadGroup>> {
         let list_reply = self
             .metastore
-            .list_kv_collect(&format!("{}/", self.workload_key_prefix))
+            .list_kv_collect(&format!("{}/", self.workload_key_prefix), None)
             .await?;
 
         let mut workload_groups = Vec::with_capacity(list_reply.len());

--- a/src/query/service/src/table_functions/policy_references/policy_references_table.rs
+++ b/src/query/service/src/table_functions/policy_references/policy_references_table.rs
@@ -327,7 +327,7 @@ async fn collect_policy_reference_rows(
                             policy_id,
                             table_id: 0,
                         });
-                    meta.list_pb_vec(&DirName::new(ident))
+                    meta.list_pb_vec(&DirName::new(ident), None)
                         .await?
                         .into_iter()
                         .map(|(key, _)| key.name().table_id)
@@ -341,7 +341,7 @@ async fn collect_policy_reference_rows(
                             table_id: 0,
                         },
                     );
-                    meta.list_pb_vec(&DirName::new(ident))
+                    meta.list_pb_vec(&DirName::new(ident), None)
                         .await?
                         .into_iter()
                         .map(|(key, _)| key.name().table_id)

--- a/src/query/storages/basic/src/result_cache/meta_manager.rs
+++ b/src/query/storages/basic/src/result_cache/meta_manager.rs
@@ -72,7 +72,7 @@ impl ResultCacheMetaManager {
 
     #[async_backtrace::framed]
     pub async fn list(&self, prefix: &str) -> Result<Vec<ResultCacheValue>> {
-        let result = self.inner.list_kv_collect(prefix).await?;
+        let result = self.inner.list_kv_collect(prefix, None).await?;
 
         let mut r = vec![];
         for (_key, val) in result {

--- a/src/query/users/src/connection.rs
+++ b/src/query/users/src/connection.rs
@@ -54,7 +54,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_connections(&self, tenant: &Tenant) -> Result<Vec<UserDefinedConnection>> {
         let connection_api_provider = self.connection_api(tenant);
-        let get_connections = connection_api_provider.list();
+        let get_connections = connection_api_provider.list(None);
 
         match get_connections.await {
             Err(e) => Err(ErrorCode::from(e).add_message_back(" (while get connection)")),

--- a/src/query/users/src/file_format.rs
+++ b/src/query/users/src/file_format.rs
@@ -54,7 +54,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_file_formats(&self, tenant: &Tenant) -> Result<Vec<UserDefinedFileFormat>> {
         let file_format_api_provider = self.file_format_api(tenant);
-        let get_file_formats = file_format_api_provider.list();
+        let get_file_formats = file_format_api_provider.list(None);
 
         match get_file_formats.await {
             Err(e) => Err(ErrorCode::from(e).add_message_back(" (while get file_format)")),

--- a/src/query/users/src/network_policy.rs
+++ b/src/query/users/src/network_policy.rs
@@ -154,7 +154,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_network_policies(&self, tenant: &Tenant) -> Result<Vec<NetworkPolicy>> {
         let client = self.network_policy_api(tenant);
-        let network_policies = client.list().await.map_err(|e| {
+        let network_policies = client.list(None).await.map_err(|e| {
             let e = ErrorCode::from(e);
             e.add_message_back(" (while get network policies).")
         })?;

--- a/src/query/users/src/password_policy.rs
+++ b/src/query/users/src/password_policy.rs
@@ -228,7 +228,7 @@ impl UserApiProvider {
     #[async_backtrace::framed]
     pub async fn get_password_policies(&self, tenant: &Tenant) -> Result<Vec<PasswordPolicy>> {
         let client = self.password_policy_api(tenant);
-        let password_policies = client.list().await.map_err(|e| {
+        let password_policies = client.list(None).await.map_err(|e| {
             let e = ErrorCode::from(e);
             e.add_message_back(" (while get password policies).")
         })?;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### change: add `limit` parameter to `KVApi::list_kv()` and related methods
Add optional `limit: Option<u64>` parameter to limit the number of items
returned from key-value listing operations. The limit is applied via
`StreamExt::take(n)` after receiving the stream.

Changes:
- Add `limit` parameter to `KVApi::list_kv()` trait method
- Add `limit` parameter to `KvApiExt::list_kv_collect()` extension method
- Add `limit` parameter to `KVPbApi::list_pb*()` methods
- Add `limit` parameter to `CrudMgr::list()` method
- Update all callers to pass `None` for unlimited results
- Add tests for limit functionality

Upgrade tip:

Update `list_kv()` calls to include the limit parameter:
- `kv.list_kv("prefix/")` → `kv.list_kv("prefix/", None)`
- `kv.list_kv("prefix/")` → `kv.list_kv("prefix/", Some(100))` for limited results

Similarly for `list_kv_collect()`, `list_pb*()`, and `CrudMgr::list()`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19240)
<!-- Reviewable:end -->
