### PR TITLE
fix(ci): increase pool_max_idle_per_host

### DIFF
--- a/tests/sqllogictests/src/client/http_client.rs
+++ b/tests/sqllogictests/src/client/http_client.rs
@@ -124,7 +124,7 @@ impl HttpClient {
             .default_headers(header)
             // https://github.com/hyperium/hyper/issues/2136#issuecomment-589488526
             .http2_keep_alive_timeout(Duration::from_secs(15))
-            .pool_max_idle_per_host(0)
+            .pool_max_idle_per_host(16)
             .build()?;
 
         let url = format!("http://127.0.0.1:{}/v1/session/login", port);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Increase `pool_max_idle_per_host` from 0 to 16 for HTTP client in sqllogictests
- This improves connection reuse and reduces connection establishment overhead

## Changes

This PR fixes the HTTP client configuration in sqllogictests to allow connection pooling by increasing `pool_max_idle_per_host` from 0 to 16.

## Implementation

1. Modified `tests/sqllogictests/src/client/http_client.rs` line 127
2. Changed `pool_max_idle_per_host(0)` to `pool_max_idle_per_host(16)`
3. This allows up to 16 idle connections per host to be kept alive for reuse

## Tests

- [x] No Test - Pair with the reviewer to explain why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19241)
<!-- Reviewable:end -->
