### PR TITLE
fix(test): force HTTP/1.1 for sqllogictests client

### DIFF
--- a/tests/sqllogictests/src/client/http_client.rs
+++ b/tests/sqllogictests/src/client/http_client.rs
@@ -124,6 +124,7 @@ impl HttpClient {
             .default_headers(header)
             .http1_only()
             .pool_max_idle_per_host(16)
+            .tcp_keepalive(Duration::from_secs(60))
             .build()?;
 
         let url = format!("http://127.0.0.1:{}/v1/session/login", port);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add `.http1_only()` to HTTP client configuration in sqllogictests
- This forces the client to use HTTP/1.1 protocol instead of HTTP/2

## Changes

This PR modifies the HTTP client configuration in sqllogictests to force HTTP/1.1 protocol usage by adding `.http1_only()` method call.

## Implementation

1. Modified `tests/sqllogictests/src/client/http_client.rs` line 125
2. Added `.http1_only()` method call to `ClientBuilder`
3. This ensures the client uses HTTP/1.1 protocol for all connections

## Tests

- [x] No Test - Pair with the reviewer to explain why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19243)
<!-- Reviewable:end -->
