### PR TITLE
feat(ci): add sha input to release workflow for custom commit targeting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,13 @@ on:
           Patch release requires a stable version (v1.0.0).
         required: false
         type: string
+      sha:
+        description: |
+          The commit SHA to release from.
+          If not specified, uses the current HEAD of the branch.
+          Example: cc3d1e657cc8731c976d90764589eb9c748dbca9
+        required: false
+        type: string
       type:
         description: Release type, default to nightly
         required: true
@@ -53,6 +60,7 @@ jobs:
         env:
           TYPE: "${{ inputs.type }}"
           TAG: "${{ inputs.tag }}"
+          SHA: "${{ inputs.sha }}"
         with:
           script: |
             const script = require('./.github/scripts/bump_version.js')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add a `sha` input parameter to the release workflow, allowing manual triggering of releases from a specific commit SHA.

This is useful for:
- Debugging CI failures by testing releases from known-good commits
- Verifying which commit introduced a regression
- Creating releases from specific points in history

Changes:
- Added `sha` input to `.github/workflows/release.yml`
- Updated `.github/scripts/bump_version.js` to use custom SHA when provided
- Works with all release types: nightly, stable, and patch

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - CI workflow change, will be tested by manual workflow dispatch

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19250)
<!-- Reviewable:end -->
