### PR TITLE
feat: add configurable connection TTL for meta client

### DIFF
--- a/src/meta/client/src/channel_manager.rs
+++ b/src/meta/client/src/channel_manager.rs
@@ -27,6 +27,7 @@ use databend_common_meta_types::MetaClientError;
 use databend_common_meta_types::MetaNetworkError;
 use databend_common_meta_types::protobuf::meta_service_client::MetaServiceClient;
 use log::info;
+use log::warn;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tonic::async_trait;
@@ -39,14 +40,44 @@ use crate::established_client::EstablishedClient;
 use crate::grpc_client::AuthInterceptor;
 use crate::grpc_client::RealClient;
 
-/// Default connection TTL: 20 seconds.
+/// Default connection TTL: 5 seconds.
 ///
 /// This prevents h2 stream reset accumulation that can lead to
 /// `too_many_internal_resets` errors (ENHANCE_YOUR_CALM).
 /// The h2 library has a default limit of 1024 locally-reset streams
 /// per connection. By refreshing connections periodically, we prevent
 /// hitting this limit.
-pub const DEFAULT_CONNECTION_TTL: Duration = Duration::from_secs(20);
+pub const DEFAULT_CONNECTION_TTL: Duration = Duration::from_secs(5);
+
+/// Override meta-client connection TTL in seconds.
+///
+/// This is intended for CI/release builds that run high-concurrency SQL tests for a long time,
+/// where stream reset accumulation may trip h2's `too_many_internal_resets` flood protection.
+pub const META_CLIENT_CONNECTION_TTL_SECS_ENV: &str = "DATABEND_META_CLIENT_CONNECTION_TTL_SECS";
+
+fn default_connection_ttl() -> Duration {
+    static TTL: OnceCell<Duration> = OnceCell::new();
+    *TTL.get_or_init(|| {
+        let Ok(v) = std::env::var(META_CLIENT_CONNECTION_TTL_SECS_ENV) else {
+            return DEFAULT_CONNECTION_TTL;
+        };
+
+        if v.trim().is_empty() {
+            return DEFAULT_CONNECTION_TTL;
+        }
+
+        match v.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(e) => {
+                warn!(
+                    "Invalid {META_CLIENT_CONNECTION_TTL_SECS_ENV}={v:?}: {e}; using default {:?}",
+                    DEFAULT_CONNECTION_TTL
+                );
+                DEFAULT_CONNECTION_TTL
+            }
+        }
+    })
+}
 
 #[derive(Debug)]
 pub struct MetaChannelManager {
@@ -90,7 +121,7 @@ impl MetaChannelManager {
             tls_config,
             required_features,
             endpoints,
-            connection_ttl: connection_ttl.unwrap_or(DEFAULT_CONNECTION_TTL),
+            connection_ttl: connection_ttl.unwrap_or_else(default_connection_ttl),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add configurable connection TTL for meta client to prevent h2 stream reset accumulation in high-concurrency scenarios.

**Changes:**
- Reduce default connection TTL from 20s to 5s
- Add DATABEND_META_CLIENT_CONNECTION_TTL_SECS environment variable for runtime configuration
- This prevents h2 too_many_internal_resets errors during long-running high-concurrency SQL tests

**Background:**
The h2 library has a default limit of 1024 locally-reset streams per connection. In ARM release builds with sustained high concurrency, stream resets can accumulate and trigger the flood protection mechanism. By refreshing connections more frequently (5s vs 20s), we prevent hitting this limit.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19259)
<!-- Reviewable:end -->
