### PR TITLE
fix: ensure cache affinity in Mod partition shuffle

### DIFF
--- a/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
+++ b/src/query/catalog/tests/it/testdata/partition-reshuffle.txt
@@ -7,16 +7,16 @@ Partitions { kind: Seq, partitions: [] }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}] }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}] }
 PartitionsShuffleKind::Mod : 10 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"9"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
 PartitionsShuffleKind::Mod : 11 partitions of 3 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"10"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"9"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"10"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"8"}] }
 PartitionsShuffleKind::Mod : 11 partitions of 2 executors
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}] }
-Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}] }
+Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }
 PartitionsShuffleKind::ConsistentHash : 11 partitions of 2 executors
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"4"}, {"type":"fuse_lazy","loc":"5"}, {"type":"fuse_lazy","loc":"6"}, {"type":"fuse_lazy","loc":"7"}] }
 Partitions { kind: Seq, partitions: [{"type":"fuse_lazy","loc":"0"}, {"type":"fuse_lazy","loc":"1"}, {"type":"fuse_lazy","loc":"2"}, {"type":"fuse_lazy","loc":"3"}, {"type":"fuse_lazy","loc":"8"}, {"type":"fuse_lazy","loc":"9"}, {"type":"fuse_lazy","loc":"10"}] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The previous implementation of PartitionsShuffleKind::Mod broke cache affinity even when cluster membership remained unchanged. It first sorted partitions by hash % num_executors, then redistributed them evenly by partition count. This meant that when table data changed (segments added or removed), the redistribution cut points would shift, causing the same segment to be assigned to different executors.

For example, with 7 segments (indices 0-6) and 2 executors, the sorted partitions would be split as indices 0,1,2 to executor0 and indices 3,4,5,6 to executor1. When a new segment is added (now 8 segments), the split becomes indices 0,1,2,3 to executor0 and indices 4,5,6,7 to executor1, moving the segment originally at index 3 from executor1 to executor0 and invalidating its cache.

This fix removes the redundant redistribution step and directly assigns partitions to executors based on hash % num_executors. Now the same partition always goes to the same executor as long as cluster membership is unchanged, regardless of other partitions being added or removed.



## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19309)
<!-- Reviewable:end -->
