### PR TITLE
ci: reopen compat tests for py driver.

### DIFF
--- a/tests/nox/java_client/testng.xml
+++ b/tests/nox/java_client/testng.xml
@@ -13,9 +13,7 @@
       <class name="com.databend.jdbc.TestDatabendDriverUri"/>
       <class name="com.databend.jdbc.TestDatabendParameterMetaData"/>
       <class name="com.databend.jdbc.TestFileTransfer"/>
-      <class name="com.databend.jdbc.TestGeometry"/>
       <class name="com.databend.jdbc.TestHeartbeat"/>
-      <class name="com.databend.jdbc.TestMultiHost"/>
       <class name="com.databend.jdbc.TestPrepareStatement"/>
       <class name="com.databend.jdbc.TestPresignContext"/>
       <class name="com.databend.jdbc.TestTempTable"/>

--- a/tests/nox/noxfile.py
+++ b/tests/nox/noxfile.py
@@ -2,7 +2,7 @@ import nox
 import os
 
 
-PYTHON_DRIVER = ["0.33.1"]
+PYTHON_DRIVER = ["0.33.1", "0.33.4"]
 
 
 @nox.session
@@ -17,8 +17,8 @@ def python_client(session, driver_version):
         env = {
             "DRIVER_VERSION": driver_version,
         }
-        # for impl in ['blocking', "asyncio", 'cursor']:
-        #     session.run("behave", f"tests/{impl}", env=env)
+        for impl in ['blocking', "asyncio", 'cursor']:
+            session.run("behave", f"tests/{impl}", env=env)
 
 
 JDBC_DRIVER = ["0.4.0", "main"]

--- a/tests/sqllogictests/suites/query/functions/binary_format.test
+++ b/tests/sqllogictests/suites/query/functions/binary_format.test
@@ -23,6 +23,7 @@ select v from fmt_bin order by id
 statement ok
 set binary_output_format = 'base64'
 
+onlyif http
 query IT
 select v from fmt_bin order by id
 ----
@@ -33,6 +34,7 @@ aGVsbG8gdW5pY29kZQ==
 statement ok
 set binary_output_format = 'utf-8'
 
+onlyif http
 query IT
 select v from fmt_bin order by id
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

1.   reopen compat tests for py driver. 
2.  adjust compat tests for JDBC driver. 
4.  binary_format.test skipif ttc-rust


https://github.com/databendlabs/databend/actions/runs/21202621615/job/60994295942

Test finished, fail fast enabled, 1 out of 8755 records failed to run
0: query failed: Databend sqllogictests error: ParseError: Invalid character 'G' at position 1
[SQL] select v from fmt_bin order by id
at tests/sqllogictests/suites/query/functions/binary_format.test:26

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): ci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19310)
<!-- Reviewable:end -->
