### PR TITLE
fix: Invalid character on mysql output

### DIFF
--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -256,7 +256,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for InteractiveWorke
                     .await
                     .map_err(|err| err.display_with_sql(query));
 
-                let format = self.base.session.get_format_settings();
+                let format = self.base.session.get_format_settings()?;
 
                 let mut write_result = writer.write(query_result, &format).await;
 

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -225,8 +225,10 @@ impl Session {
         self.format_settings = other
     }
 
-    pub fn get_format_settings(&self) -> FormatSettings {
-        self.format_settings.clone()
+    pub fn get_format_settings(&self) -> Result<FormatSettings> {
+        let mut format_settings = self.format_settings.clone();
+        format_settings.binary_format = self.get_settings().get_binary_output_format()?;
+        Ok(format_settings)
     }
 
     pub fn get_current_query_id(&self) -> Option<String> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

https://github.com/databendlabs/databend/actions/runs/21202621615/job/60994295942

Test finished, fail fast enabled, 1 out of 8755 records failed to run
0: query failed: Databend sqllogictests error: ParseError: Invalid character 'G' at position 1
[SQL] select v from fmt_bin order by id
at tests/sqllogictests/suites/query/functions/binary_format.test:26

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19312)
<!-- Reviewable:end -->
