### PR TITLE
refactor: use `DatabendRuntime::spawn` in meta binaries

### DIFF
--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -29,7 +29,6 @@ use std::time::Instant;
 
 use chrono::Utc;
 use clap::Parser;
-use databend_common_base::runtime;
 use databend_common_meta_api::DatabaseApi;
 use databend_common_meta_api::TableApi;
 use databend_common_meta_api::serialize_struct;
@@ -49,6 +48,7 @@ use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_client::required;
 use databend_common_meta_kvapi::kvapi::KVApi;
+use databend_common_meta_runtime_api::SpawnApi;
 use databend_common_meta_semaphore::Semaphore;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::Operation;
@@ -60,6 +60,7 @@ use databend_common_tracing::StderrConfig;
 use databend_common_tracing::init_logging;
 use databend_common_version::BUILD_INFO;
 use databend_common_version::METASRV_COMMIT_VERSION;
+use databend_meta_runtime::DatabendRuntime;
 use futures::TryStreamExt;
 use serde::Deserialize;
 use serde::Serialize;
@@ -155,25 +156,28 @@ async fn main() {
 
         let client = client.clone();
 
-        let handle = runtime::spawn(async move {
-            for i in 0..config.number {
-                if cmd == "upsert_kv" {
-                    benchmark_upsert(&client, prefix, client_num, i).await;
-                } else if cmd == "table" {
-                    benchmark_table(&client, prefix, client_num, i).await;
-                } else if cmd == "get_table" {
-                    benchmark_get_table(&client, prefix, client_num, i).await;
-                } else if cmd == "table_copy_file" {
-                    benchmark_table_copy_file(&client, prefix, client_num, i, &param).await;
-                } else if cmd == "semaphore" {
-                    benchmark_semaphore(&client, prefix, client_num, i, &param).await;
-                } else if cmd == "list" {
-                    benchmark_list(&client, prefix, client_num, i, &param).await;
-                } else {
-                    unreachable!("Invalid config.rpc: {}", rpc);
+        let handle = DatabendRuntime::spawn(
+            async move {
+                for i in 0..config.number {
+                    if cmd == "upsert_kv" {
+                        benchmark_upsert(&client, prefix, client_num, i).await;
+                    } else if cmd == "table" {
+                        benchmark_table(&client, prefix, client_num, i).await;
+                    } else if cmd == "get_table" {
+                        benchmark_get_table(&client, prefix, client_num, i).await;
+                    } else if cmd == "table_copy_file" {
+                        benchmark_table_copy_file(&client, prefix, client_num, i, &param).await;
+                    } else if cmd == "semaphore" {
+                        benchmark_semaphore(&client, prefix, client_num, i, &param).await;
+                    } else if cmd == "list" {
+                        benchmark_list(&client, prefix, client_num, i, &param).await;
+                    } else {
+                        unreachable!("Invalid config.rpc: {}", rpc);
+                    }
                 }
-            }
-        });
+            },
+            None,
+        );
         handles.push(handle)
     }
 

--- a/src/meta/binaries/metaverifier/main.rs
+++ b/src/meta/binaries/metaverifier/main.rs
@@ -26,11 +26,11 @@ use std::time::Instant;
 use anyhow::Result;
 use anyhow::bail;
 use clap::Parser;
-use databend_common_base::runtime;
 use databend_common_meta_client::ClientHandle;
 use databend_common_meta_client::MetaGrpcClient;
 use databend_common_meta_kvapi::kvapi::KVApi;
 use databend_common_meta_kvapi::kvapi::KvApiExt;
+use databend_common_meta_runtime_api::SpawnApi;
 use databend_common_meta_types::MatchSeq;
 use databend_common_meta_types::Operation;
 use databend_common_meta_types::UpsertKV;
@@ -40,6 +40,7 @@ use databend_common_tracing::StderrConfig;
 use databend_common_tracing::init_logging;
 use databend_common_version::BUILD_INFO;
 use databend_common_version::METASRV_COMMIT_VERSION;
+use databend_meta_runtime::DatabendRuntime;
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -127,70 +128,79 @@ async fn main() -> Result<()> {
             .map(|addr| addr.to_string())
             .collect();
 
-        let handle = runtime::spawn(async move {
-            let client = MetaGrpcClient::try_create(
-                addrs.clone(),
-                BUILD_INFO.semver(),
-                "root",
-                "xxx",
-                None,
-                None,
-                None,
-            );
+        let handle = DatabendRuntime::spawn(
+            async move {
+                let client = MetaGrpcClient::try_create(
+                    addrs.clone(),
+                    BUILD_INFO.semver(),
+                    "root",
+                    "xxx",
+                    None,
+                    None,
+                    None,
+                );
 
-            let client = match client {
-                Ok(client) => client,
-                Err(e) => {
-                    fs::write(VERIFIER_RESULT_FILE, "ERROR")?;
-                    eprintln!("Failed to create client: {}", e);
-                    bail!("Failed to create client: {}", e);
-                }
-            };
+                let client = match client {
+                    Ok(client) => client,
+                    Err(e) => {
+                        fs::write(VERIFIER_RESULT_FILE, "ERROR")?;
+                        eprintln!("Failed to create client: {}", e);
+                        bail!("Failed to create client: {}", e);
+                    }
+                };
 
-            verifier(
-                &client,
-                prefix,
-                config.number,
-                client_num,
-                config.remove_percent,
-            )
-            .await
-        });
+                verifier(
+                    &client,
+                    prefix,
+                    config.number,
+                    client_num,
+                    config.remove_percent,
+                )
+                .await
+            },
+            None,
+        );
         println!("verifier worker {} started..", client_num);
         handles.push(handle)
     }
 
-    let waiter_handle = runtime::spawn(async move {
-        let result = rx.recv_timeout(Duration::from_secs(config.time));
+    let waiter_handle = DatabendRuntime::spawn(
+        async move {
+            let result = rx.recv_timeout(Duration::from_secs(config.time));
 
-        match result {
-            Ok(_) => {
-                println!("verifier completed within the timeout.");
+            match result {
+                Ok(_) => {
+                    println!("verifier completed within the timeout.");
+                }
+                Err(e) => {
+                    println!(
+                        "verifier did not complete within the timeout: {:?}s, error: {:?}",
+                        config.time, e
+                    );
+                    let _ = fs::write(VERIFIER_RESULT_FILE, "ERROR");
+                    panic!("verifier did not complete within the timeout.")
+                }
             }
-            Err(e) => {
-                println!(
-                    "verifier did not complete within the timeout: {:?}s, error: {:?}",
-                    config.time, e
-                );
-                let _ = fs::write(VERIFIER_RESULT_FILE, "ERROR");
-                panic!("verifier did not complete within the timeout.")
-            }
-        }
-    });
+        },
+        None,
+    );
 
-    let wait_verifier_handle = runtime::spawn(async move {
-        for handle in handles {
-            let ret = handle.await.unwrap();
-            if let Err(e) = ret {
-                fs::write(VERIFIER_RESULT_FILE, "ERROR")?;
-                println!("verifier return error: {:?}", e);
-                return Err(e);
+    let wait_verifier_handle = DatabendRuntime::spawn(
+        async move {
+            for handle in handles {
+                let ret = handle.await.unwrap();
+                if let Err(e) = ret {
+                    fs::write(VERIFIER_RESULT_FILE, "ERROR")?;
+                    println!("verifier return error: {:?}", e);
+                    return Err(e);
+                }
             }
-        }
-        tx.send(()).unwrap();
+            tx.send(()).unwrap();
 
-        Ok(())
-    });
+            Ok(())
+        },
+        None,
+    );
 
     let _ret = wait_verifier_handle.await.unwrap();
     if let Err(e) = waiter_handle.await {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: use `DatabendRuntime::spawn` in meta binaries
Replace `databend_common_base::runtime::spawn` with `DatabendRuntime::spawn`
from the `SpawnApi` trait to decouple meta binaries from `databend-common-base`
runtime implementation.

Changes:
- Replace `runtime::spawn()` with `DatabendRuntime::spawn()` in `metaverifier`
- Replace `runtime::spawn()` with `DatabendRuntime::spawn()` in `metabench`
- Remove `databend_common_base::runtime` imports

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19324)
<!-- Reviewable:end -->
