### PR TITLE
refactor: add `SpawnApi::prepare_request()` for gRPC metadata injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,6 +4215,7 @@ name = "databend-common-meta-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tokio",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -4308,7 +4309,6 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
- "databend-common-tracing",
  "deepsize",
  "derive_more",
  "display-more 0.2.1",
@@ -5552,7 +5552,9 @@ version = "0.1.0"
 dependencies = [
  "databend-common-base",
  "databend-common-meta-runtime-api",
+ "databend-common-tracing",
  "tokio",
+ "tonic 0.13.1",
 ]
 
 [[package]]

--- a/src/meta/runtime-api/Cargo.toml
+++ b/src/meta/runtime-api/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 
 [dependencies]
 tokio = { workspace = true }
+tonic = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util", "macros"] }

--- a/src/meta/runtime-api/src/lib.rs
+++ b/src/meta/runtime-api/src/lib.rs
@@ -61,6 +61,19 @@ pub trait SpawnApi: Clone + Debug + Send + Sync + 'static {
     where
         Fut: Future<Output = T> + Send + 'a,
         T: Send + 'a;
+
+    /// Prepare a tonic request by injecting implementation-specific metadata.
+    ///
+    /// This is a general-purpose hook for runtime implementations to inject
+    /// any metadata they need into outgoing gRPC requests. For example:
+    /// - Tracing span context (W3C traceparent header)
+    /// - Query ID for request correlation
+    /// - Any other implementation-specific headers
+    ///
+    /// `TokioRuntime` returns the request unchanged.
+    /// `DatabendRuntime` injects tracing context and query ID.
+    fn prepare_request<T>(request: tonic::Request<T>) -> tonic::Request<T>
+    where Self: Sized;
 }
 
 /// Owned runtime instance that can spawn tasks.

--- a/src/meta/runtime-api/src/tokio_impl.rs
+++ b/src/meta/runtime-api/src/tokio_impl.rs
@@ -124,6 +124,11 @@ impl SpawnApi for TokioRuntime {
     {
         Box::pin(fut)
     }
+
+    /// No-op for TokioRuntime - returns request unchanged.
+    fn prepare_request<T>(request: tonic::Request<T>) -> tonic::Request<T> {
+        request
+    }
 }
 
 #[expect(clippy::disallowed_methods)]

--- a/src/meta/runtime/Cargo.toml
+++ b/src/meta/runtime/Cargo.toml
@@ -10,7 +10,9 @@ edition = { workspace = true }
 [dependencies]
 databend-common-base = { workspace = true }
 databend-common-meta-runtime-api = { workspace = true }
+databend-common-tracing = { workspace = true }
 tokio = { workspace = true }
+tonic = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/meta/service/src/network.rs
+++ b/src/meta/service/src/network.rs
@@ -764,7 +764,7 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
             }
 
             // Send the request
-            let req = GrpcHelper::traced_req(raft_req);
+            let req = SP::prepare_request(tonic::Request::new(raft_req));
             raft_metrics::network::incr_sendto_bytes(&self.target, req.get_ref().data.len() as u64);
 
             let mut client = self
@@ -903,7 +903,7 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
 
         // First, try VoteV001 with native protobuf types
         let vote_req_pb = pb::VoteRequest::from(rpc.clone());
-        let req_v001 = GrpcHelper::traced_req(vote_req_pb);
+        let req_v001 = SP::prepare_request(tonic::Request::new(vote_req_pb));
 
         let grpc_res_v001 = client.vote_v001(req_v001).await;
         info!(
@@ -932,7 +932,7 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
 
         // Fallback to old Vote RPC using RaftRequest
         let raft_req = GrpcHelper::encode_raft_request(&rpc).map_err(|e| Unreachable::new(&e))?;
-        let req = GrpcHelper::traced_req(raft_req);
+        let req = SP::prepare_request(tonic::Request::new(raft_req));
 
         let bytes = req.get_ref().data.len() as u64;
         raft_metrics::network::incr_sendto_bytes(&self.target, bytes);
@@ -961,7 +961,7 @@ impl<SP: SpawnApi> RaftNetworkV2<TypeConfig> for Network<SP> {
 
         let r = pb::TransferLeaderRequest::from(req);
 
-        let req = GrpcHelper::traced_req(r);
+        let req = SP::prepare_request(tonic::Request::new(r));
 
         let mut client = self
             .take_client()

--- a/src/meta/types/Cargo.toml
+++ b/src/meta/types/Cargo.toml
@@ -8,7 +8,6 @@ edition = { workspace = true }
 
 [dependencies]
 anyerror = { workspace = true }
-databend-common-tracing = { workspace = true }
 deepsize = { workspace = true }
 derive_more = { workspace = true }
 display-more = { workspace = true }

--- a/src/meta/types/src/grpc_helper.rs
+++ b/src/meta/types/src/grpc_helper.rs
@@ -31,12 +31,6 @@ const HEADER_LEADER: &str = "x-databend-meta-leader-grpc-endpoint";
 pub struct GrpcHelper;
 
 impl GrpcHelper {
-    /// Inject span into a tonic request, so that on the remote peer the tracing context can be restored.
-    pub fn traced_req<T>(t: T) -> tonic::Request<T> {
-        let req = tonic::Request::new(t);
-        databend_common_tracing::inject_span_to_tonic_request(req)
-    }
-
     /// Add leader endpoint to the reply to inform the client to contact the leader directly.
     pub fn add_response_meta_leader<T>(
         reply: &mut tonic::Response<T>,


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### refactor: add `SpawnApi::prepare_request()` for gRPC metadata injection
Add a general-purpose hook to `SpawnApi` trait that allows runtime
implementations to inject any metadata into outgoing gRPC requests.
`DatabendRuntime` injects tracing span and query ID, while `TokioRuntime`
returns requests unchanged.

Changes:
- Add `prepare_request()` method to `SpawnApi` trait
- Remove `GrpcHelper::traced_req()` from `meta-types`
- Remove `traced_req()` helper from `grpc_client.rs`
- Move `databend-common-tracing` dependency from `meta-types` to `meta/runtime`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19329)
<!-- Reviewable:end -->
