### PR TITLE
refactor: group gRPC and admin config fields into nested structs

### DIFF
--- a/src/meta/core/service/src/api/grpc_server.rs
+++ b/src/meta/core/service/src/api/grpc_server.rs
@@ -114,7 +114,7 @@ impl<SP: SpawnApi> GrpcServer<SP> {
             builder
         };
 
-        let addr = conf.grpc_api_address.parse::<std::net::SocketAddr>()?;
+        let addr = conf.grpc.api_address.parse::<std::net::SocketAddr>()?;
 
         info!("start gRPC listening: {}", addr);
 
@@ -211,9 +211,9 @@ impl<SP: SpawnApi> GrpcServer<SP> {
     }
 
     async fn tls_config(conf: &Config) -> Result<Option<ServerTlsConfig>, std::io::Error> {
-        if conf.tls_rpc_server_enabled() {
-            let cert = tokio::fs::read(conf.grpc_tls_server_cert.as_str()).await?;
-            let key = tokio::fs::read(conf.grpc_tls_server_key.as_str()).await?;
+        if conf.grpc.tls_enabled() {
+            let cert = tokio::fs::read(conf.grpc.tls_server_cert.as_str()).await?;
+            let key = tokio::fs::read(conf.grpc.tls_server_key.as_str()).await?;
             let server_identity = Identity::from_pem(cert, key);
 
             let tls = ServerTlsConfig::new().identity(server_identity);

--- a/src/meta/core/service/src/configs/inner.rs
+++ b/src/meta/core/service/src/configs/inner.rs
@@ -21,6 +21,67 @@ use databend_common_tracing::Config as LogConfig;
 
 use super::outer_v0::Config as OuterV0Config;
 
+/// Configuration for the gRPC API server.
+///
+/// This struct holds settings for the gRPC endpoint that serves client requests,
+/// including the listening address, optional advertise host for cluster communication,
+/// and TLS certificates for secure connections.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Serialize)]
+pub struct GrpcConfig {
+    /// The address the gRPC server listens on, e.g., "0.0.0.0:9191".
+    pub api_address: String,
+
+    /// Optional hostname to advertise to other nodes in the cluster.
+    /// If set, this host combined with the port from `api_address` forms the
+    /// address other nodes use to connect to this server.
+    pub advertise_host: Option<String>,
+
+    /// Path to the TLS certificate file for the gRPC server.
+    /// Leave empty to disable TLS.
+    pub tls_server_cert: String,
+
+    /// Path to the TLS private key file for the gRPC server.
+    /// Leave empty to disable TLS.
+    pub tls_server_key: String,
+}
+
+impl GrpcConfig {
+    /// Returns `true` if TLS is enabled (both cert and key are provided).
+    pub fn tls_enabled(&self) -> bool {
+        !self.tls_server_key.is_empty() && !self.tls_server_cert.is_empty()
+    }
+
+    /// Returns the advertise address if `advertise_host` is set.
+    /// The address is formed by combining `advertise_host` with the port from `api_address`.
+    pub fn advertise_address(&self) -> Option<String> {
+        if let Some(h) = &self.advertise_host {
+            // Safe unwrap(): Config::validate() ensures api_address is valid.
+            let a: SocketAddr = self.api_address.parse().unwrap();
+            Some(format!("{}:{}", h, a.port()))
+        } else {
+            None
+        }
+    }
+}
+
+/// Configuration for the Admin HTTP API server.
+///
+/// This struct holds settings for the HTTP endpoint that serves administrative
+/// requests such as health checks, metrics, and cluster management operations.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Serialize)]
+pub struct AdminConfig {
+    /// The address the admin HTTP server listens on, e.g., "0.0.0.0:28002".
+    pub api_address: String,
+
+    /// Path to the TLS certificate file for the admin server.
+    /// Leave empty to disable TLS.
+    pub tls_server_cert: String,
+
+    /// Path to the TLS private key file for the admin server.
+    /// Leave empty to disable TLS.
+    pub tls_server_key: String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct Config {
     pub cmd: String,
@@ -32,14 +93,8 @@ pub struct Config {
     pub password: String,
     pub config_file: String,
     pub log: LogConfig,
-    pub admin_api_address: String,
-    pub admin_tls_server_cert: String,
-    pub admin_tls_server_key: String,
-    pub grpc_api_address: String,
-    pub grpc_api_advertise_host: Option<String>,
-    /// Certificate for server to identify itself
-    pub grpc_tls_server_cert: String,
-    pub grpc_tls_server_key: String,
+    pub admin: AdminConfig,
+    pub grpc: GrpcConfig,
     pub raft_config: RaftConfig,
 }
 
@@ -55,13 +110,17 @@ impl Default for Config {
             password: "".to_string(),
             config_file: "".to_string(),
             log: LogConfig::default(),
-            admin_api_address: "127.0.0.1:28002".to_string(),
-            admin_tls_server_cert: "".to_string(),
-            admin_tls_server_key: "".to_string(),
-            grpc_api_address: "127.0.0.1:9191".to_string(),
-            grpc_api_advertise_host: None,
-            grpc_tls_server_cert: "".to_string(),
-            grpc_tls_server_key: "".to_string(),
+            admin: AdminConfig {
+                api_address: "127.0.0.1:28002".to_string(),
+                tls_server_cert: "".to_string(),
+                tls_server_key: "".to_string(),
+            },
+            grpc: GrpcConfig {
+                api_address: "127.0.0.1:9191".to_string(),
+                advertise_host: None,
+                tls_server_cert: "".to_string(),
+                tls_server_key: "".to_string(),
+            },
             raft_config: Default::default(),
         }
     }
@@ -80,10 +139,10 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<(), MetaStartupError> {
-        let _a: SocketAddr = self.grpc_api_address.parse().map_err(|e| {
+        let _a: SocketAddr = self.grpc.api_address.parse().map_err(|e| {
             MetaStartupError::InvalidConfig(format!(
                 "{} while parsing {}",
-                e, self.grpc_api_address
+                e, self.grpc.api_address
             ))
         })?;
         Ok(())
@@ -118,22 +177,6 @@ impl Config {
             self.raft_config.id,
             self.raft_config.raft_api_advertise_host_endpoint(),
         )
-        .with_grpc_advertise_address(self.grpc_api_advertise_address())
-    }
-
-    pub fn grpc_api_advertise_address(&self) -> Option<String> {
-        if let Some(h) = &self.grpc_api_advertise_host {
-            // Safe unwrap(): Self::validate() ensures it is valid.
-            let a: SocketAddr = self.grpc_api_address.parse().unwrap();
-
-            let addr = format!("{}:{}", h, a.port());
-            Some(addr)
-        } else {
-            None
-        }
-    }
-
-    pub fn tls_rpc_server_enabled(&self) -> bool {
-        !self.grpc_tls_server_key.is_empty() && !self.grpc_tls_server_cert.is_empty()
+        .with_grpc_advertise_address(self.grpc.advertise_address())
     }
 }

--- a/src/meta/core/service/src/configs/mod.rs
+++ b/src/meta/core/service/src/configs/mod.rs
@@ -15,4 +15,6 @@
 mod inner;
 pub mod outer_v0;
 
+pub use inner::AdminConfig;
 pub use inner::Config;
+pub use inner::GrpcConfig;

--- a/src/meta/core/service/src/configs/outer_v0.rs
+++ b/src/meta/core/service/src/configs/outer_v0.rs
@@ -45,7 +45,9 @@ use serfig::collectors::from_file;
 use serfig::collectors::from_self;
 use serfig::parsers::Toml;
 
+use super::inner::AdminConfig;
 use super::inner::Config as InnerConfig;
+use super::inner::GrpcConfig;
 use crate::version::MIN_METACLI_SEMVER;
 
 /// Full version string for databend-meta including build info, min client version, and data version
@@ -188,13 +190,17 @@ impl TryFrom<Config> for InnerConfig {
             password: outer.password,
             config_file: outer.config_file,
             log,
-            admin_api_address: outer.admin_api_address,
-            admin_tls_server_cert: outer.admin_tls_server_cert,
-            admin_tls_server_key: outer.admin_tls_server_key,
-            grpc_api_address: outer.grpc_api_address,
-            grpc_api_advertise_host: outer.grpc_api_advertise_host,
-            grpc_tls_server_cert: outer.grpc_tls_server_cert,
-            grpc_tls_server_key: outer.grpc_tls_server_key,
+            admin: AdminConfig {
+                api_address: outer.admin_api_address,
+                tls_server_cert: outer.admin_tls_server_cert,
+                tls_server_key: outer.admin_tls_server_key,
+            },
+            grpc: GrpcConfig {
+                api_address: outer.grpc_api_address,
+                advertise_host: outer.grpc_api_advertise_host,
+                tls_server_cert: outer.grpc_tls_server_cert,
+                tls_server_key: outer.grpc_tls_server_key,
+            },
             raft_config: outer.raft_config.into(),
         })
     }
@@ -214,13 +220,13 @@ impl From<InnerConfig> for Config {
             log_level: inner.log.file.level.clone(),
             log_dir: inner.log.file.dir.clone(),
             log: inner.log.into(),
-            admin_api_address: inner.admin_api_address,
-            admin_tls_server_cert: inner.admin_tls_server_cert,
-            admin_tls_server_key: inner.admin_tls_server_key,
-            grpc_api_address: inner.grpc_api_address,
-            grpc_api_advertise_host: inner.grpc_api_advertise_host,
-            grpc_tls_server_cert: inner.grpc_tls_server_cert,
-            grpc_tls_server_key: inner.grpc_tls_server_key,
+            admin_api_address: inner.admin.api_address,
+            admin_tls_server_cert: inner.admin.tls_server_cert,
+            admin_tls_server_key: inner.admin.tls_server_key,
+            grpc_api_address: inner.grpc.api_address,
+            grpc_api_advertise_host: inner.grpc.advertise_host,
+            grpc_tls_server_cert: inner.grpc.tls_server_cert,
+            grpc_tls_server_key: inner.grpc.tls_server_key,
             raft_config: inner.raft_config.into(),
         }
     }

--- a/src/meta/core/service/tests/it/api/http/cluster_state_test.rs
+++ b/src/meta/core/service/tests/it/api/http/cluster_state_test.rs
@@ -69,7 +69,7 @@ async fn test_cluster_nodes() -> anyhow::Result<()> {
     let res = meta_handle_1
         .request(move |mn| {
             let fu = async move {
-                mn.join_cluster(&c.raft_config, c.grpc_api_advertise_address())
+                mn.join_cluster(&c.raft_config, c.grpc.advertise_address())
                     .await
             };
             Box::pin(fu)
@@ -115,10 +115,7 @@ async fn test_cluster_state() -> anyhow::Result<()> {
 
     let mn1 = MetaNode::<TokioRuntime>::start(&tc1.config, BUILD_INFO.semver()).await?;
     let _ = mn1
-        .join_cluster(
-            &tc1.config.raft_config,
-            tc1.config.grpc_api_advertise_address(),
-        )
+        .join_cluster(&tc1.config.raft_config, tc1.config.grpc.advertise_address())
         .await?;
 
     info!("--- write sample data to the cluster ---");
@@ -264,9 +261,9 @@ async fn test_http_service_cluster_state() -> anyhow::Result<()> {
 
     tc1.config.raft_config.single = false;
     tc1.config.raft_config.join = vec![tc0.config.raft_config.raft_api_addr().await?.to_string()];
-    tc1.config.admin_api_address = addr_str.to_owned();
-    tc1.config.admin_tls_server_key = TEST_SERVER_KEY.to_owned();
-    tc1.config.admin_tls_server_cert = TEST_SERVER_CERT.to_owned();
+    tc1.config.admin.api_address = addr_str.to_owned();
+    tc1.config.admin.tls_server_key = TEST_SERVER_KEY.to_owned();
+    tc1.config.admin.tls_server_cert = TEST_SERVER_CERT.to_owned();
 
     let _meta_node0 = MetaNode::<TokioRuntime>::start(&tc0.config, BUILD_INFO.semver()).await?;
 
@@ -279,7 +276,7 @@ async fn test_http_service_cluster_state() -> anyhow::Result<()> {
     let _ = meta_handle_1
         .request(move |mn| {
             let fu = async move {
-                mn.join_cluster(&c.raft_config, c.grpc_api_advertise_address())
+                mn.join_cluster(&c.raft_config, c.grpc.advertise_address())
                     .await
             };
             Box::pin(fu)
@@ -287,9 +284,9 @@ async fn test_http_service_cluster_state() -> anyhow::Result<()> {
         .await??;
 
     let http_cfg = HttpServiceConfig {
-        admin_api_address: tc1.config.admin_api_address.clone(),
-        admin_tls_server_cert: tc1.config.admin_tls_server_cert.clone(),
-        admin_tls_server_key: tc1.config.admin_tls_server_key.clone(),
+        admin_api_address: tc1.config.admin.api_address.clone(),
+        admin_tls_server_cert: tc1.config.admin.tls_server_cert.clone(),
+        admin_tls_server_key: tc1.config.admin.tls_server_key.clone(),
         config_display: format!("{:?}", tc1.config),
     };
     let mut srv = HttpService::create(http_cfg, meta_handle_1);

--- a/src/meta/core/service/tests/it/api/http/features.rs
+++ b/src/meta/core/service/tests/it/api/http/features.rs
@@ -37,9 +37,9 @@ async fn test_features() -> anyhow::Result<()> {
 
     let meta0 = tcs[0].grpc_srv.as_ref().unwrap().get_meta_handle();
     let http_cfg0 = HttpServiceConfig {
-        admin_api_address: tcs[0].config.admin_api_address.clone(),
-        admin_tls_server_cert: tcs[0].config.admin_tls_server_cert.clone(),
-        admin_tls_server_key: tcs[0].config.admin_tls_server_key.clone(),
+        admin_api_address: tcs[0].config.admin.api_address.clone(),
+        admin_tls_server_cert: tcs[0].config.admin.tls_server_cert.clone(),
+        admin_tls_server_key: tcs[0].config.admin.tls_server_key.clone(),
         config_display: format!("{:?}", tcs[0].config),
     };
     let mut srv0 = HttpService::create(http_cfg0, meta0.clone());
@@ -47,9 +47,9 @@ async fn test_features() -> anyhow::Result<()> {
 
     let meta1 = tcs[1].grpc_srv.as_ref().unwrap().get_meta_handle();
     let http_cfg1 = HttpServiceConfig {
-        admin_api_address: tcs[1].config.admin_api_address.clone(),
-        admin_tls_server_cert: tcs[1].config.admin_tls_server_cert.clone(),
-        admin_tls_server_key: tcs[1].config.admin_tls_server_key.clone(),
+        admin_api_address: tcs[1].config.admin.api_address.clone(),
+        admin_tls_server_cert: tcs[1].config.admin.tls_server_cert.clone(),
+        admin_tls_server_key: tcs[1].config.admin.tls_server_key.clone(),
         config_display: format!("{:?}", tcs[1].config),
     };
     let mut srv1 = HttpService::create(http_cfg1, meta1.clone());
@@ -61,14 +61,14 @@ async fn test_features() -> anyhow::Result<()> {
     let list_features_url = |i: usize| {
         format!(
             "http://{}/v1/features/list",
-            &tcs[i].config.admin_api_address
+            &tcs[i].config.admin.api_address
         )
     };
 
     let set_feature_url = |i: usize, feature: &str, enable: bool| {
         format!(
             "http://{}/v1/features/set?feature={}&enable={}",
-            &tcs[i].config.admin_api_address, feature, enable
+            &tcs[i].config.admin.api_address, feature, enable
         )
     };
 

--- a/src/meta/core/service/tests/it/api/http/transfer_leader.rs
+++ b/src/meta/core/service/tests/it/api/http/transfer_leader.rs
@@ -38,9 +38,9 @@ async fn test_transfer_leader() -> anyhow::Result<()> {
     assert_eq!(metrics.current_leader, Some(0));
 
     let http_cfg = HttpServiceConfig {
-        admin_api_address: tcs[0].config.admin_api_address.clone(),
-        admin_tls_server_cert: tcs[0].config.admin_tls_server_cert.clone(),
-        admin_tls_server_key: tcs[0].config.admin_tls_server_key.clone(),
+        admin_api_address: tcs[0].config.admin.api_address.clone(),
+        admin_tls_server_cert: tcs[0].config.admin.tls_server_cert.clone(),
+        admin_tls_server_key: tcs[0].config.admin.tls_server_key.clone(),
         config_display: format!("{:?}", tcs[0].config),
     };
     let mut srv = HttpService::create(http_cfg, meta0.clone());
@@ -49,7 +49,7 @@ async fn test_transfer_leader() -> anyhow::Result<()> {
     let transfer_url = || {
         format!(
             "http://{}/v1/ctrl/trigger_transfer_leader?to=2",
-            &tcs[0].config.admin_api_address
+            &tcs[0].config.admin.api_address
         )
     };
 

--- a/src/meta/core/service/tests/it/configs.rs
+++ b/src/meta/core/service/tests/it/configs.rs
@@ -21,11 +21,11 @@ use tempfile::tempdir;
 #[test]
 fn test_tls_rpc_enabled() -> anyhow::Result<()> {
     let mut conf = Config::default();
-    assert!(!conf.tls_rpc_server_enabled());
-    conf.grpc_tls_server_key = "test".to_owned();
-    assert!(!conf.tls_rpc_server_enabled());
-    conf.grpc_tls_server_cert = "test".to_owned();
-    assert!(conf.tls_rpc_server_enabled());
+    assert!(!conf.grpc.tls_enabled());
+    conf.grpc.tls_server_key = "test".to_owned();
+    assert!(!conf.grpc.tls_enabled());
+    conf.grpc.tls_server_cert = "test".to_owned();
+    assert!(conf.grpc.tls_enabled());
     Ok(())
 }
 
@@ -72,12 +72,12 @@ cluster_name = "foo_cluster"
         let cfg = Config::load_for_test().expect("load must success");
         assert_eq!(cfg.log.file.level, "ERROR");
         assert_eq!(cfg.log.file.dir, "foo/logs");
-        assert_eq!(cfg.admin_api_address, "127.0.0.1:9000");
-        assert_eq!(cfg.admin_tls_server_cert, "admin tls cert");
-        assert_eq!(cfg.admin_tls_server_key, "admin tls key");
-        assert_eq!(cfg.grpc_api_address, "127.0.0.1:10000");
-        assert_eq!(cfg.grpc_tls_server_cert, "grpc server cert");
-        assert_eq!(cfg.grpc_tls_server_key, "grpc server key");
+        assert_eq!(cfg.admin.api_address, "127.0.0.1:9000");
+        assert_eq!(cfg.admin.tls_server_cert, "admin tls cert");
+        assert_eq!(cfg.admin.tls_server_key, "admin tls key");
+        assert_eq!(cfg.grpc.api_address, "127.0.0.1:10000");
+        assert_eq!(cfg.grpc.tls_server_cert, "grpc server cert");
+        assert_eq!(cfg.grpc.tls_server_key, "grpc server key");
         assert_eq!(cfg.raft_config.raft_listen_host, "127.0.0.1");
         assert_eq!(cfg.raft_config.raft_api_port, 11000);
         assert_eq!(cfg.raft_config.raft_dir, "raft dir");

--- a/src/meta/core/service/tests/it/grpc/metasrv_connection_error.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_connection_error.rs
@@ -45,7 +45,7 @@ async fn test_metasrv_connection_error() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();
@@ -92,7 +92,7 @@ async fn test_metasrv_one_client_follower_down() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a1 = || addresses[1].clone();
@@ -125,7 +125,7 @@ async fn test_metasrv_one_client_leader_down() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a1 = || addresses[1].clone();

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_api.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_api.rs
@@ -237,9 +237,9 @@ async fn test_auto_sync_addr() -> anyhow::Result<()> {
     start_metasrv_with_context(&mut tc1).await?;
     start_metasrv_with_context(&mut tc2).await?;
 
-    let addr0 = tc0.config.grpc_api_address.clone();
-    let addr1 = tc1.config.grpc_api_address.clone();
-    let addr2 = tc2.config.grpc_api_address.clone();
+    let addr0 = tc0.config.grpc.api_address.clone();
+    let addr1 = tc1.config.grpc.api_address.clone();
+    let addr2 = tc2.config.grpc.api_address.clone();
 
     let client = tc1.grpc_client().await?;
 
@@ -339,7 +339,7 @@ async fn test_auto_sync_addr() -> anyhow::Result<()> {
 
         debug!("got leader, metrics: {metrics:?}");
 
-        let addr3 = tc3.config.grpc_api_address.clone();
+        let addr3 = tc3.config.grpc.api_address.clone();
 
         let mut i = 0;
         let mut res = vec![];

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_api_restart_cluster.rs
@@ -163,7 +163,7 @@ async fn test_kv_api_restart_cluster_token_expired() -> anyhow::Result<()> {
 
     let tcs = start_metasrv_cluster(&[0, 1, 2]).await?;
     let client = MetaGrpcClient::<DatabendRuntime>::try_create(
-        vec![tcs[0].config.grpc_api_address.clone()],
+        vec![tcs[0].config.grpc.api_address.clone()],
         BUILD_INFO.semver(),
         "root",
         "xxx",

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_get_many.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_get_many.rs
@@ -106,8 +106,8 @@ async fn test_kv_get_many_on_leader() -> anyhow::Result<()> {
 async fn test_kv_get_many_on_follower_returns_leader() -> anyhow::Result<()> {
     let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
 
-    let leader_addr = &tcs[0].config.grpc_api_address;
-    let follower_addr = &tcs[1].config.grpc_api_address;
+    let leader_addr = &tcs[0].config.grpc.api_address;
+    let follower_addr = &tcs[1].config.grpc.api_address;
 
     let client = make_grpc_client(vec![follower_addr.clone()])?;
     let mut ec = client.make_established_client().await?;
@@ -134,7 +134,7 @@ async fn test_kv_get_many_on_follower_returns_leader() -> anyhow::Result<()> {
 async fn test_kv_get_many_no_quorum_no_leader() -> anyhow::Result<()> {
     let mut tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
 
-    let remaining_addr = tcs[2].config.grpc_api_address.clone();
+    let remaining_addr = tcs[2].config.grpc.api_address.clone();
 
     tcs[0].grpc_srv.take().unwrap().do_stop(None).await;
     tcs[1].grpc_srv.take().unwrap().do_stop(None).await;

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_list.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_list.rs
@@ -73,8 +73,8 @@ async fn test_kv_list_on_leader() -> anyhow::Result<()> {
 async fn test_kv_list_on_follower_returns_leader() -> anyhow::Result<()> {
     let tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
 
-    let leader_addr = &tcs[0].config.grpc_api_address;
-    let follower_addr = &tcs[1].config.grpc_api_address;
+    let leader_addr = &tcs[0].config.grpc.api_address;
+    let follower_addr = &tcs[1].config.grpc.api_address;
 
     let client = make_grpc_client(vec![follower_addr.clone()])?;
     let mut ec = client.make_established_client().await?;
@@ -98,7 +98,7 @@ async fn test_kv_list_on_follower_returns_leader() -> anyhow::Result<()> {
 async fn test_kv_list_no_quorum_no_leader() -> anyhow::Result<()> {
     let mut tcs = crate::tests::start_metasrv_cluster(&[0, 1, 2]).await?;
 
-    let remaining_addr = tcs[2].config.grpc_api_address.clone();
+    let remaining_addr = tcs[2].config.grpc.api_address.clone();
 
     tcs[0].grpc_srv.take().unwrap().do_stop(None).await;
     tcs[1].grpc_srv.take().unwrap().do_stop(None).await;

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_kv_read_v1.rs
@@ -81,7 +81,7 @@ async fn test_kv_read_v1_follower_responds_leader_endpoint() -> anyhow::Result<(
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_member_list.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_member_list.rs
@@ -102,7 +102,8 @@ async fn test_member_list_with_learner() -> anyhow::Result<()> {
     let endpoint = learner_tc.config.raft_config.raft_api_addr().await?;
     let grpc_api_advertise_address = learner_tc
         .config
-        .grpc_api_advertise_address()
+        .grpc
+        .advertise_address()
         .unwrap_or_else(|| "127.0.0.1:29191".to_string());
 
     let admin_req = ForwardRequest {
@@ -151,7 +152,7 @@ async fn test_member_list_with_learner() -> anyhow::Result<()> {
     // Collect expected addresses
     let mut expected_addresses = HashSet::new();
     for tc in &tcs {
-        if let Some(addr) = tc.config.grpc_api_advertise_address() {
+        if let Some(addr) = tc.config.grpc.advertise_address() {
             expected_addresses.insert(addr);
         }
     }

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_tls.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_tls.rs
@@ -38,13 +38,13 @@ use crate::tests::tls_constants::TEST_SERVER_KEY;
 async fn test_tls_server() -> anyhow::Result<()> {
     let mut tc = MetaSrvTestContext::new(0);
 
-    tc.config.grpc_tls_server_key = TEST_SERVER_KEY.to_owned();
-    tc.config.grpc_tls_server_cert = TEST_SERVER_CERT.to_owned();
+    tc.config.grpc.tls_server_key = TEST_SERVER_KEY.to_owned();
+    tc.config.grpc.tls_server_cert = TEST_SERVER_CERT.to_owned();
 
     let r = start_metasrv_with_context(&mut tc).await;
     assert!(r.is_ok());
 
-    let addr = tc.config.grpc_api_address.clone();
+    let addr = tc.config.grpc.api_address.clone();
 
     let tls_conf = RpcClientTlsConfig {
         rpc_tls_server_root_ca_cert: TEST_CA_CERT.to_string(),
@@ -74,8 +74,8 @@ async fn test_tls_server() -> anyhow::Result<()> {
 async fn test_tls_server_config_failure() -> anyhow::Result<()> {
     let mut tc = MetaSrvTestContext::new(0);
 
-    tc.config.grpc_tls_server_key = "../tests/data/certs/not_exist.key".to_owned();
-    tc.config.grpc_tls_server_cert = "../tests/data/certs/not_exist.pem".to_owned();
+    tc.config.grpc.tls_server_key = "../tests/data/certs/not_exist.key".to_owned();
+    tc.config.grpc.tls_server_cert = "../tests/data/certs/not_exist.pem".to_owned();
 
     let r = start_metasrv_with_context(&mut tc).await;
     assert!(r.is_err());

--- a/src/meta/core/service/tests/it/grpc/metasrv_grpc_transaction.rs
+++ b/src/meta/core/service/tests/it/grpc/metasrv_grpc_transaction.rs
@@ -28,7 +28,7 @@ async fn test_transaction_follower_responds_leader_endpoint() -> anyhow::Result<
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();

--- a/src/meta/core/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
+++ b/src/meta/core/service/tests/it/grpc/t51_metasrv_grpc_semaphore.rs
@@ -36,7 +36,7 @@ async fn test_semaphore_simple() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();
@@ -87,7 +87,7 @@ async fn test_semaphore_guard_future() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();
@@ -127,7 +127,7 @@ async fn test_semaphore_time_based() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();
@@ -178,7 +178,7 @@ async fn test_acquirer_closed_error_handling() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -210,7 +210,7 @@ async fn test_permit_removal_notification() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -253,7 +253,7 @@ async fn test_permit_resource_cleanup() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -286,7 +286,7 @@ async fn test_semaphore_concurrent_error_isolation() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -357,7 +357,7 @@ async fn test_semaphore_timeout_behavior() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -393,7 +393,7 @@ async fn test_watch_stream_resilience() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -428,7 +428,7 @@ async fn test_semaphore_capacity_edge_cases() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -472,7 +472,7 @@ async fn test_time_based_sequencing_edge_cases() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let cli = make_grpc_client(vec![addresses[0].clone(), addresses[1].clone()])?;
@@ -511,7 +511,7 @@ async fn test_time_based_pause_streaming() -> anyhow::Result<()> {
 
     let tc = tcs.remove(0);
 
-    let address = tc.config.grpc_api_address.clone();
+    let address = tc.config.grpc.api_address.clone();
 
     let cli = make_grpc_client(vec![address])?;
     let client = || cli.clone();
@@ -580,7 +580,7 @@ async fn test_time_based_connection_closed_error() -> anyhow::Result<()> {
 
     let mut tc = tcs.remove(0);
 
-    let address = tc.config.grpc_api_address.clone();
+    let address = tc.config.grpc.api_address.clone();
 
     let cli = make_grpc_client(vec![address])?;
     let client = || cli.clone();

--- a/src/meta/core/service/tests/it/grpc/t52_metasrv_grpc_cache.rs
+++ b/src/meta/core/service/tests/it/grpc/t52_metasrv_grpc_cache.rs
@@ -35,7 +35,7 @@ async fn test_cache_basic() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();
@@ -99,7 +99,7 @@ async fn test_cache_when_leader_down() -> anyhow::Result<()> {
 
     let addresses = tcs
         .iter()
-        .map(|tc| tc.config.grpc_api_address.clone())
+        .map(|tc| tc.config.grpc.api_address.clone())
         .collect::<Vec<_>>();
 
     let a0 = || addresses[0].clone();

--- a/src/meta/core/service/tests/it/meta_node/meta_node_lifecycle.rs
+++ b/src/meta/core/service/tests/it/meta_node/meta_node_lifecycle.rs
@@ -124,7 +124,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
         let admin_req = join_req(
             node_id,
             tc2.config.raft_config.raft_api_addr().await?,
-            tc2.config.grpc_api_advertise_address(),
+            tc2.config.grpc.advertise_address(),
             0,
         );
         leader.handle_forwardable_request(admin_req).await?;
@@ -161,7 +161,7 @@ async fn test_meta_node_join() -> anyhow::Result<()> {
         let admin_req = join_req(
             node_id,
             tc3.config.raft_config.raft_api_addr().await?,
-            tc3.config.grpc_api_advertise_address(),
+            tc3.config.grpc.advertise_address(),
             1,
         );
         client.forward(admin_req).await?;
@@ -242,7 +242,7 @@ async fn test_meta_node_join_as_learner() -> anyhow::Result<()> {
         let leader = all[leader_id as usize].clone();
 
         let endpoint = tc2.config.raft_config.raft_api_addr().await?;
-        let grpc_api_advertise_address = tc2.config.grpc_api_advertise_address();
+        let grpc_api_advertise_address = tc2.config.grpc.advertise_address();
 
         let admin_req = ForwardRequest {
             forward_to_leader: 0,
@@ -343,7 +343,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
     let req = join_req(
         node_id,
         tc1.config.raft_config.raft_api_addr().await?,
-        tc1.config.grpc_api_advertise_address(),
+        tc1.config.grpc.advertise_address(),
         1,
     );
     leader.handle_forwardable_request(req).await?;
@@ -375,7 +375,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
         let req = join_req(
             node_id,
             tc2.config.raft_config.raft_api_addr().await?,
-            tc2.config.grpc_api_advertise_address(),
+            tc2.config.grpc.advertise_address(),
             1,
         );
         leader.handle_forwardable_request(req).await?;
@@ -385,7 +385,7 @@ async fn test_meta_node_join_rejoin() -> anyhow::Result<()> {
         let req = join_req(
             node_id,
             tc2.config.raft_config.raft_api_addr().await?,
-            tc2.config.grpc_api_advertise_address(),
+            tc2.config.grpc.advertise_address(),
             1,
         );
         mn1.handle_forwardable_request(req).await?;
@@ -431,19 +431,13 @@ async fn test_meta_node_join_with_state() -> anyhow::Result<()> {
     let mut log_index = 3;
 
     let res = n1
-        .join_cluster(
-            &tc0.config.raft_config,
-            tc0.config.grpc_api_advertise_address(),
-        )
+        .join_cluster(&tc0.config.raft_config, tc0.config.grpc.advertise_address())
         .await?;
     assert_eq!(Err("Did not join: --join is empty".to_string()), res);
 
     let n1 = MetaNode::<TokioRuntime>::start(&tc1.config, BUILD_INFO.semver()).await?;
     let res = n1
-        .join_cluster(
-            &tc1.config.raft_config,
-            tc1.config.grpc_api_advertise_address(),
-        )
+        .join_cluster(&tc1.config.raft_config, tc1.config.grpc.advertise_address())
         .await?;
     assert_eq!(Ok(()), res);
 
@@ -467,10 +461,7 @@ async fn test_meta_node_join_with_state() -> anyhow::Result<()> {
     {
         let n2 = MetaNode::<TokioRuntime>::start(&tc2.config, BUILD_INFO.semver()).await?;
         let res = n2
-            .join_cluster(
-                &tc2.config.raft_config,
-                tc2.config.grpc_api_advertise_address(),
-            )
+            .join_cluster(&tc2.config.raft_config, tc2.config.grpc.advertise_address())
             .await?;
         assert_eq!(Ok(()), res);
 
@@ -495,10 +486,7 @@ async fn test_meta_node_join_with_state() -> anyhow::Result<()> {
     {
         let n2 = MetaNode::<TokioRuntime>::start(&tc2.config, BUILD_INFO.semver()).await?;
         let res = n2
-            .join_cluster(
-                &tc2.config.raft_config,
-                tc2.config.grpc_api_advertise_address(),
-            )
+            .join_cluster(&tc2.config.raft_config, tc2.config.grpc.advertise_address())
             .await?;
         assert_eq!(
             Err("Did not join: node 2 already in cluster".to_string()),

--- a/src/meta/core/service/tests/it/tests/meta_node.rs
+++ b/src/meta/core/service/tests/it/tests/meta_node.rs
@@ -208,7 +208,7 @@ pub(crate) async fn start_meta_node_non_voter(
             .add_node(
                 id,
                 Node::new(id, addr.clone())
-                    .with_grpc_advertise_address(tc.config.grpc_api_advertise_address()),
+                    .with_grpc_advertise_address(tc.config.grpc.advertise_address()),
             )
             .await?;
         match resp {

--- a/src/meta/core/service/tests/it/tests/service.rs
+++ b/src/meta/core/service/tests/it/tests/service.rs
@@ -47,7 +47,7 @@ pub async fn start_metasrv() -> Result<(MetaSrvTestContext, String)> {
 
     start_metasrv_with_context(&mut tc).await?;
 
-    let addr = tc.config.grpc_api_address.clone();
+    let addr = tc.config.grpc.api_address.clone();
 
     Ok((tc, addr))
 }
@@ -61,7 +61,7 @@ pub async fn start_metasrv_with_context(tc: &mut MetaSrvTestContext) -> Result<(
     let _ = mh
         .request(move |mn| {
             let fu = async move {
-                mn.join_cluster(&c.raft_config, c.grpc_api_advertise_address())
+                mn.join_cluster(&c.raft_config, c.grpc.advertise_address())
                     .await
             };
             Box::pin(fu)
@@ -169,13 +169,13 @@ impl MetaSrvTestContext {
 
         {
             let grpc_port = next_port();
-            config.grpc_api_address = format!("{}:{}", host, grpc_port);
-            config.grpc_api_advertise_host = Some(host.to_string());
+            config.grpc.api_address = format!("{}:{}", host, grpc_port);
+            config.grpc.advertise_host = Some(host.to_string());
         }
 
         {
             let http_port = next_port();
-            config.admin_api_address = format!("{}:{}", host, http_port);
+            config.admin.api_address = format!("{}:{}", host, http_port);
         }
 
         info!("new test context config: {:?}", config);
@@ -210,7 +210,7 @@ impl MetaSrvTestContext {
     }
 
     pub async fn grpc_client(&self) -> anyhow::Result<Arc<ClientHandle<DatabendRuntime>>> {
-        let addr = self.config.grpc_api_address.clone();
+        let addr = self.config.grpc.api_address.clone();
 
         let client = MetaGrpcClient::<DatabendRuntime>::try_create(
             vec![addr],

--- a/src/meta/core/store/src/local.rs
+++ b/src/meta/core/store/src/local.rs
@@ -60,7 +60,7 @@ impl fmt::Display for LocalMetaService {
         write!(
             f,
             "LocalMetaService({}: raft={} grpc={})",
-            self.name, self.config.raft_config.raft_api_port, self.config.grpc_api_address
+            self.name, self.config.raft_config.raft_api_port, self.config.grpc.api_address
         )
     }
 }
@@ -133,13 +133,13 @@ impl LocalMetaService {
 
         {
             let grpc_port = next_port();
-            config.grpc_api_address = format!("{}:{}", host, grpc_port);
-            config.grpc_api_advertise_host = Some(host.to_string());
+            config.grpc.api_address = format!("{}:{}", host, grpc_port);
+            config.grpc.advertise_host = Some(host.to_string());
         }
 
         {
             let http_port = next_port();
-            config.admin_api_address = format!("{}:{}", host, http_port);
+            config.admin.api_address = format!("{}:{}", host, http_port);
         }
 
         info!("new LocalMetaService({}) with config: {:?}", name, config);
@@ -188,7 +188,7 @@ impl LocalMetaService {
         config: &configs::Config,
         version: Version,
     ) -> Result<Arc<ClientHandle<DatabendRuntime>>, CreationError> {
-        let addr = config.grpc_api_address.clone();
+        let addr = config.grpc.api_address.clone();
         let client = MetaGrpcClient::<DatabendRuntime>::try_create(
             vec![addr],
             version,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: group gRPC and admin config fields into nested structs
Restructure Config to use nested `GrpcConfig` and `AdminConfig` structs
instead of flat prefixed fields. This improves code organization and
encapsulates related methods with their data.

Changes:
- Add `GrpcConfig` struct with `tls_enabled()` and `advertise_address()` methods
- Add `AdminConfig` struct for admin HTTP server settings
- Update `Config` to use `grpc` and `admin` nested fields
- Update all usages from `conf.grpc_api_address` to `conf.grpc.api_address`
- Export `GrpcConfig` and `AdminConfig` from configs module

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19336)
<!-- Reviewable:end -->
