### PR TITLE
refactor: add `trace_request` to `SpawnApi` for server-side tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5599,6 +5599,7 @@ dependencies = [
  "databend-common-base",
  "databend-common-meta-runtime-api",
  "databend-common-tracing",
+ "fastrace",
  "tokio",
  "tonic 0.13.1",
 ]

--- a/src/meta/core/runtime-api/src/tokio_impl.rs
+++ b/src/meta/core/runtime-api/src/tokio_impl.rs
@@ -129,6 +129,20 @@ impl SpawnApi for TokioRuntime {
     fn prepare_request<T>(request: tonic::Request<T>) -> tonic::Request<T> {
         request
     }
+
+    /// No-op for TokioRuntime - just calls the closure without tracing.
+    fn trace_request<'a, T, F, Fut, R>(
+        _name: &'static str,
+        request: tonic::Request<T>,
+        f: F,
+    ) -> BoxFuture<'a, R>
+    where
+        F: FnOnce(tonic::Request<T>) -> Fut,
+        Fut: Future<Output = R> + Send + 'a,
+        R: Send + 'a,
+    {
+        Box::pin(f(request))
+    }
 }
 
 #[expect(clippy::disallowed_methods)]

--- a/src/meta/core/service/Cargo.toml
+++ b/src/meta/core/service/Cargo.toml
@@ -23,7 +23,6 @@ databend-common-meta-raft-store = { workspace = true }
 databend-common-meta-runtime-api = { workspace = true }
 databend-common-meta-sled-store = { workspace = true }
 databend-common-meta-types = { workspace = true }
-databend-common-tracing = { workspace = true }
 deepsize = { workspace = true }
 derive_more = { workspace = true }
 display-more = { workspace = true }
@@ -59,6 +58,7 @@ databend-common-meta-cache = { workspace = true }
 databend-common-meta-kvapi-test-suite = { workspace = true }
 databend-common-meta-schema-api-test-suite = { workspace = true }
 databend-common-meta-semaphore = { workspace = true }
+databend-common-tracing = { workspace = true }
 databend-common-version = { workspace = true }
 databend-meta-admin = { workspace = true }
 databend-meta-runtime = { workspace = true }

--- a/src/meta/core/service/src/api/grpc/grpc_service.rs
+++ b/src/meta/core/service/src/api/grpc/grpc_service.rs
@@ -52,11 +52,9 @@ use databend_common_meta_types::protobuf::StreamItem;
 use databend_common_meta_types::protobuf::WatchRequest;
 use databend_common_meta_types::protobuf::WatchResponse;
 use databend_common_meta_types::protobuf::meta_service_server::MetaService;
-use databend_common_tracing::start_trace_for_remote_request;
 use display_more::DisplayOptionExt;
 use fastrace::func_name;
 use fastrace::func_path;
-use fastrace::prelude::*;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::TryChunksError;
@@ -399,20 +397,22 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         self.check_token(request.metadata())?;
 
         network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
-        let root = start_trace_for_remote_request(func_path!(), &request);
-        let query_id = get_query_id(&request);
+        let query_id = get_query_id(&request).map(|s| s.to_owned());
 
-        let fu = async move {
-            let _guard = InFlightWrite::guard();
+        SP::trace_request(func_path!(), request, |request| async move {
+            let fu = async move {
+                let _guard = InFlightWrite::guard();
 
-            let reply = self.handle_kv_api(request).await?;
+                let reply = self.handle_kv_api(request).await?;
 
-            network_metrics::incr_sent_bytes(reply.encoded_len() as u64);
+                network_metrics::incr_sent_bytes(reply.encoded_len() as u64);
 
-            Ok(Response::new(reply))
-        };
+                Ok(Response::new(reply))
+            };
 
-        SP::track_future(fu.in_span(root), vec![TrackingData::new_query_id(query_id)]).await
+            SP::track_future(fu, vec![TrackingData::new_query_id(query_id)]).await
+        })
+        .await
     }
 
     type KvReadV1Stream = BoxStream<StreamItem>;
@@ -424,24 +424,25 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         self.check_token(request.metadata())?;
 
         network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
-        let root = start_trace_for_remote_request(func_path!(), &request);
-        let query_id = get_query_id(&request);
-        let req: MetaGrpcReadReq = GrpcHelper::parse_req(request)?;
-        let in_flight = InFlightRequest::new(req.type_name(), format!("ReadRequest: {:?}", req));
+        let query_id = get_query_id(&request).map(|s| s.to_owned());
 
-        let fut = async {
-            let (endpoint, strm) = self.handle_kv_read_v1(req).await?;
+        SP::trace_request(func_path!(), request, |request| async move {
+            let req: MetaGrpcReadReq = GrpcHelper::parse_req(request)?;
+            let in_flight =
+                InFlightRequest::new(req.type_name(), format!("ReadRequest: {:?}", req));
 
-            let strm = in_flight.track(strm);
+            let fut = async {
+                let (endpoint, strm) = self.handle_kv_read_v1(req).await?;
 
-            let mut resp = Response::new(strm.boxed());
-            GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
-            Ok(resp)
-        };
+                let strm = in_flight.track(strm);
 
-        SP::track_future(fut.in_span(root), vec![TrackingData::new_query_id(
-            query_id,
-        )])
+                let mut resp = Response::new(strm.boxed());
+                GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
+                Ok(resp)
+            };
+
+            SP::track_future(fut, vec![TrackingData::new_query_id(query_id)]).await
+        })
         .await
     }
 
@@ -459,28 +460,28 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
         self.check_token(request.metadata())?;
 
         network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
-        let root = start_trace_for_remote_request(func_path!(), &request);
-        let query_id = get_query_id(&request);
-        let in_flight = InFlightRequest::new(
-            "kv_list",
-            format!(
-                "KvList: prefix={}, limit={}",
-                request.get_ref().prefix,
-                request.get_ref().limit.display()
-            ),
-        );
-        let req = request.into_inner();
+        let query_id = get_query_id(&request).map(|s| s.to_owned());
 
-        let fut = async {
-            let strm = self.handle_kv_list(req.prefix, req.limit).await?;
+        SP::trace_request(func_path!(), request, |request| async move {
+            let in_flight = InFlightRequest::new(
+                "kv_list",
+                format!(
+                    "KvList: prefix={}, limit={}",
+                    request.get_ref().prefix,
+                    request.get_ref().limit.display()
+                ),
+            );
+            let req = request.into_inner();
 
-            let strm = in_flight.track(strm);
-            Ok(Response::new(strm.boxed()))
-        };
+            let fut = async {
+                let strm = self.handle_kv_list(req.prefix, req.limit).await?;
 
-        SP::track_future(fut.in_span(root), vec![TrackingData::new_query_id(
-            query_id,
-        )])
+                let strm = in_flight.track(strm);
+                Ok(Response::new(strm.boxed()))
+            };
+
+            SP::track_future(fut, vec![TrackingData::new_query_id(query_id)]).await
+        })
         .await
     }
 
@@ -497,24 +498,23 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
     ) -> Result<Response<Self::KvGetManyStream>, Status> {
         self.check_token(request.metadata())?;
 
-        let root = start_trace_for_remote_request(func_path!(), &request);
-        let query_id = get_query_id(&request);
+        let query_id = get_query_id(&request).map(|s| s.to_owned());
 
-        let in_flight = InFlightRequest::new("kv_get_many", "KvGetMany".to_string());
-        let input = request
-            .into_inner()
-            .inspect_ok(|req| network_metrics::incr_recv_bytes(req.encoded_len() as u64));
+        SP::trace_request(func_path!(), request, |request| async move {
+            let in_flight = InFlightRequest::new("kv_get_many", "KvGetMany".to_string());
+            let input = request
+                .into_inner()
+                .inspect_ok(|req| network_metrics::incr_recv_bytes(req.encoded_len() as u64));
 
-        let fut = async {
-            let strm = self.handle_kv_get_many(input).await?;
+            let fut = async {
+                let strm = self.handle_kv_get_many(input).await?;
 
-            let strm = in_flight.track(strm);
-            Ok(Response::new(strm.boxed()))
-        };
+                let strm = in_flight.track(strm);
+                Ok(Response::new(strm.boxed()))
+            };
 
-        SP::track_future(fut.in_span(root), vec![TrackingData::new_query_id(
-            query_id,
-        )])
+            SP::track_future(fut, vec![TrackingData::new_query_id(query_id)]).await
+        })
         .await
     }
 
@@ -524,26 +524,25 @@ impl<SP: SpawnApi> MetaService for MetaServiceImpl<SP> {
     ) -> Result<Response<TxnReply>, Status> {
         self.check_token(request.metadata())?;
 
-        let root = start_trace_for_remote_request(func_path!(), &request);
-        let query_id = get_query_id(&request);
+        let query_id = get_query_id(&request).map(|s| s.to_owned());
 
-        let fut = async move {
-            network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
-            let _guard = InFlightWrite::guard();
+        SP::trace_request(func_path!(), request, |request| async move {
+            let fut = async move {
+                network_metrics::incr_recv_bytes(request.get_ref().encoded_len() as u64);
+                let _guard = InFlightWrite::guard();
 
-            let (endpoint, reply) = self.handle_txn(request).await?;
+                let (endpoint, reply) = self.handle_txn(request).await?;
 
-            network_metrics::incr_sent_bytes(reply.encoded_len() as u64);
+                network_metrics::incr_sent_bytes(reply.encoded_len() as u64);
 
-            let mut resp = Response::new(reply);
-            GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
+                let mut resp = Response::new(reply);
+                GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
 
-            Ok(resp)
-        };
+                Ok(resp)
+            };
 
-        SP::track_future(fut.in_span(root), vec![TrackingData::new_query_id(
-            query_id,
-        )])
+            SP::track_future(fut, vec![TrackingData::new_query_id(query_id)]).await
+        })
         .await
     }
 

--- a/src/meta/core/service/src/meta_service/raft_service_impl.rs
+++ b/src/meta/core/service/src/meta_service/raft_service_impl.rs
@@ -49,8 +49,8 @@ use databend_common_meta_types::raft_types::Vote;
 use databend_common_meta_types::raft_types::VoteRequest;
 use databend_common_meta_types::snapshot_db::DB;
 use databend_common_meta_types::sys_data::SysData;
+use fastrace::func_name;
 use fastrace::func_path;
-use fastrace::prelude::*;
 use futures::TryStreamExt;
 use log::error;
 use log::info;
@@ -315,9 +315,7 @@ impl<SP: SpawnApi> RaftServiceImpl<SP> {
 #[async_trait::async_trait]
 impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
     async fn forward(&self, request: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-
-        async {
+        SP::trace_request(func_path!(), request, |request| async {
             let forward_req: ForwardRequest<ForwardRequestBody> = GrpcHelper::parse_req(request)?;
 
             let res = self.meta_node.handle_forwardable_request(forward_req).await;
@@ -327,8 +325,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             let raft_reply: RaftReply = res.into();
 
             Ok(Response::new(raft_reply))
-        }
-        .in_span(root)
+        })
         .await
     }
 
@@ -338,9 +335,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<Response<Self::KvReadV1Stream>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-
-        async {
+        SP::trace_request(func_path!(), request, |request| async {
             let forward_req: ForwardRequest<MetaGrpcReadReq> = GrpcHelper::parse_req(request)?;
 
             let (endpoint, strm) = self
@@ -353,8 +348,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             GrpcHelper::add_response_meta_leader(&mut resp, endpoint.as_ref());
 
             Ok(resp)
-        }
-        .in_span(root)
+        })
         .await
     }
 
@@ -362,10 +356,8 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<Response<RaftReply>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        let remote_addr = remote_addr(&request);
-
-        async {
+        SP::trace_request(func_path!(), request, |request| async {
+            let remote_addr = remote_addr(&request);
             self.incr_meta_metrics_recv_bytes_from_peer(&request);
 
             let ae_req: AppendEntriesRequest = GrpcHelper::parse_req(request)?;
@@ -388,8 +380,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             );
 
             GrpcHelper::ok_response(&resp)
-        }
-        .in_span(root)
+        })
         .await
     }
 
@@ -397,23 +388,25 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         &self,
         request: Request<Streaming<SnapshotChunkRequestV003>>,
     ) -> Result<Response<SnapshotResponseV003>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        self.do_install_snapshot_v003(request).in_span(root).await
+        SP::trace_request(func_path!(), request, |request| {
+            self.do_install_snapshot_v003(request)
+        })
+        .await
     }
 
     async fn install_snapshot_v004(
         &self,
         request: Request<Streaming<InstallEntryV004>>,
     ) -> Result<Response<InstallSnapshotResponseV004>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        self.do_install_snapshot_v004(request).in_span(root).await
+        SP::trace_request(func_path!(), request, |request| {
+            self.do_install_snapshot_v004(request)
+        })
+        .await
     }
 
     async fn vote(&self, request: Request<RaftRequest>) -> Result<Response<RaftReply>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        let remote_addr = remote_addr(&request);
-
-        async {
+        SP::trace_request(func_path!(), request, |request| async {
+            let remote_addr = remote_addr(&request);
             self.incr_meta_metrics_recv_bytes_from_peer(&request);
 
             let v_req: VoteRequest = GrpcHelper::parse_req(request)?;
@@ -435,8 +428,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             );
 
             GrpcHelper::ok_response(&resp)
-        }
-        .in_span(root)
+        })
         .await
     }
 
@@ -444,10 +436,8 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         &self,
         request: Request<pb::VoteRequest>,
     ) -> Result<Response<pb::VoteResponse>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        let remote_addr = remote_addr(&request);
-
-        async {
+        SP::trace_request(func_path!(), request, |request| async {
+            let remote_addr = remote_addr(&request);
             let v_req_pb = request.into_inner();
 
             let v_req: VoteRequest = v_req_pb.into();
@@ -470,8 +460,7 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
 
             let resp_pb = pb::VoteResponse::from(resp);
             Ok(Response::new(resp_pb))
-        }
-        .in_span(root)
+        })
         .await
     }
 
@@ -479,10 +468,8 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
         &self,
         request: Request<pb::TransferLeaderRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let root = databend_common_tracing::start_trace_for_remote_request(func_path!(), &request);
-        let remote_addr = remote_addr(&request);
-
-        let fu = async {
+        SP::trace_request(func_path!(), request, |request| async {
+            let remote_addr = remote_addr(&request);
             let req = request.into_inner();
             let req: TransferLeaderRequest = req.try_into()?;
 
@@ -507,8 +494,8 @@ impl<SP: SpawnApi> RaftService for RaftServiceImpl<SP> {
             );
 
             Ok(Response::new(pb::Empty {}))
-        };
-        fu.in_span(root).await
+        })
+        .await
     }
 }
 

--- a/src/meta/runtime/Cargo.toml
+++ b/src/meta/runtime/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-meta-runtime-api = { workspace = true }
 databend-common-tracing = { workspace = true }
+fastrace = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add `trace_request` to `SpawnApi` for server-side tracing
Add a server-side tracing method to `SpawnApi` that extracts trace context
from incoming requests and wraps the handler with the span. This mirrors
the client-side `prepare_request` method while keeping fastrace types
internal to the runtime implementation.

Changes:
- Add `trace_request()` method to `SpawnApi` trait
- Implement no-op version in `TokioRuntime`
- Implement active tracing in `DatabendRuntime` using `start_trace_for_remote_request()`
- Replace direct `start_trace_for_remote_request` + `.in_span()` calls in `raft_service_impl.rs`
- Replace direct calls in `grpc_service.rs`, combining with `track_future()`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19346)
<!-- Reviewable:end -->
