### PR TITLE
chore: set correct engine name for StageTable and StageSinkTable

### DIFF
--- a/src/query/storages/stage/src/append/stage_sink_table.rs
+++ b/src/query/storages/stage/src/append/stage_sink_table.rs
@@ -22,6 +22,7 @@ use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::TableMeta;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_storages_common_stage::CopyIntoLocationInfo;
@@ -50,6 +51,10 @@ impl StageSinkTable {
     ) -> Result<Arc<dyn Table>> {
         let table_info_placeholder = TableInfo {
             name: "stage_sink".to_string(),
+            meta: TableMeta {
+                engine: "STAGE_SINK".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         }
         .set_schema(schema.clone());

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -34,6 +34,7 @@ use databend_common_expression::FILENAME_COLUMN_ID;
 use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::TableMeta;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_storage::StageFileInfo;
 use databend_common_storage::init_stage_operator;
@@ -60,6 +61,10 @@ impl StageTable {
         let table_info_placeholder = TableInfo {
             // `system.stage` is used to forbid the user to select * from text files.
             name: "stage".to_string(),
+            meta: TableMeta {
+                engine: "STAGE".to_string(),
+                ..Default::default()
+            },
             ..Default::default()
         }
         .set_schema(table_info.schema());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

StageTable and StageSinkTable use the default table engine, which may cause them to be mistaken for Fuse tables.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19347)
<!-- Reviewable:end -->
