### PR TITLE
refactor: remove databend-common-meta-api dependency from meta-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,7 +5502,6 @@ dependencies = [
  "backon",
  "chrono",
  "databend-base",
- "databend-common-meta-api",
  "databend-common-meta-client",
  "databend-common-meta-kvapi",
  "databend-common-meta-raft-store",

--- a/src/meta/core/service/Cargo.toml
+++ b/src/meta/core/service/Cargo.toml
@@ -15,7 +15,6 @@ async-trait = { workspace = true }
 backon = { workspace = true }
 chrono = { workspace = true }
 databend-base = { workspace = true }
-databend-common-meta-api = { workspace = true }
 databend-common-meta-client = { workspace = true }
 databend-common-meta-kvapi = { workspace = true }
 databend-common-meta-raft-store = { workspace = true }

--- a/src/meta/core/service/src/meta_node/meta_node.rs
+++ b/src/meta/core/service/src/meta_node/meta_node.rs
@@ -23,7 +23,6 @@ use std::sync::atomic::AtomicI32;
 use std::time::Duration;
 
 use anyerror::AnyError;
-use databend_common_meta_api::reply::reply_to_api_result;
 use databend_common_meta_client::RequestFor;
 use databend_common_meta_raft_store::StateMachineFeature;
 use databend_common_meta_raft_store::config::RaftConfig;
@@ -124,6 +123,7 @@ use crate::request_handling::Handler;
 use crate::store::RaftStore;
 use crate::store::meta_raft_log::MetaRaftLog;
 use crate::store::meta_raft_state_machine::MetaRaftStateMachine;
+use crate::util::reply_to_api_result;
 
 pub type LogStore = MetaRaftLog;
 pub type SMStore<SP> = MetaRaftStateMachine<SP>;

--- a/src/meta/core/service/src/meta_service/forwarder.rs
+++ b/src/meta/core/service/src/meta_service/forwarder.rs
@@ -14,7 +14,6 @@
 
 //! Forward request to another node
 
-use databend_common_meta_api::reply::reply_to_api_result;
 use databend_common_meta_client::MetaGrpcReadReq;
 use databend_common_meta_runtime_api::SpawnApi;
 use databend_common_meta_types::ConnectionError;
@@ -37,6 +36,7 @@ use crate::meta_node::meta_node::MetaRaft;
 use crate::meta_service::MetaNode;
 use crate::request_handling::Forwarder;
 use crate::store::RaftStore;
+use crate::util::reply_to_api_result;
 
 /// Handle a request locally if it is leader. Otherwise, forward it to the leader.
 pub struct MetaForwarder<'a, SP> {

--- a/src/meta/core/service/src/util.rs
+++ b/src/meta/core/service/src/util.rs
@@ -12,7 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_meta_types::InvalidReply;
+use databend_common_meta_types::MetaAPIError;
+use databend_common_meta_types::protobuf::RaftReply;
 use log::debug;
+use serde::de::DeserializeOwned;
+
+/// Deserialize a `RaftReply` into a result type.
+///
+/// If `msg.data` is non-empty, deserialize it as `T`.
+/// Otherwise, deserialize `msg.error` as `MetaAPIError`.
+pub fn reply_to_api_result<T>(msg: RaftReply) -> Result<T, MetaAPIError>
+where T: DeserializeOwned {
+    if !msg.data.is_empty() {
+        let res: T = serde_json::from_str(&msg.data)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.data", &e))?;
+        Ok(res)
+    } else {
+        let err: MetaAPIError = serde_json::from_str(&msg.error)
+            .map_err(|e| InvalidReply::new("can not decode RaftReply.error", &e))?;
+
+        Err(err)
+    }
+}
 
 /// A struct that implements the Drop trait to log a message when it is dropped.
 ///


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: remove databend-common-meta-api dependency from meta-service
The only function used from databend-common-meta-api was reply_to_api_result.
Copy this function locally to eliminate the dependency and reduce the crate's
dependency graph.

Changes:
- Add reply_to_api_result() to util.rs
- Remove databend-common-meta-api from Cargo.toml
- Update imports in meta_node.rs and forwarder.rs to use local function

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19374)
<!-- Reviewable:end -->
