### PR TITLE
feat(metrics): add databend_session_running_queries

### DIFF
--- a/src/common/metrics/src/metrics/session.rs
+++ b/src/common/metrics/src/metrics/session.rs
@@ -44,6 +44,9 @@ pub static SESSION_RUNNING_ACQUIRED_QUERIES: LazyLock<Gauge> =
 pub static SESSION_ACQUIRED_QUERIES_TOTAL: LazyLock<Counter> =
     LazyLock::new(|| register_counter("session_acquired_queries_total"));
 
+pub static SESSION_RUNNING_QUERIES: LazyLock<Gauge> =
+    LazyLock::new(|| register_gauge("session_running_queries"));
+
 pub fn incr_session_connect_numbers() {
     SESSION_CONNECT_NUMBERS.inc();
 }
@@ -86,4 +89,8 @@ pub fn dec_session_running_acquired_queries() {
 
 pub fn inc_session_acquired_queries_total() {
     SESSION_ACQUIRED_QUERIES_TOTAL.inc();
+}
+
+pub fn set_session_running_queries(count: u64) {
+    SESSION_RUNNING_QUERIES.set(count as i64);
 }

--- a/src/query/service/src/sessions/session_mgr_status.rs
+++ b/src/query/service/src/sessions/session_mgr_status.rs
@@ -14,6 +14,8 @@
 
 use std::time::SystemTime;
 
+use databend_common_metrics::session::set_session_running_queries;
+
 #[derive(Clone)]
 pub struct SessionManagerStatus {
     pub running_queries_count: u64,
@@ -27,12 +29,14 @@ pub struct SessionManagerStatus {
 impl SessionManagerStatus {
     pub(crate) fn query_start(&mut self, now: SystemTime) {
         self.running_queries_count += 1;
-        self.last_query_started_at = Some(now)
+        self.last_query_started_at = Some(now);
+        set_session_running_queries(self.running_queries_count);
     }
 
     pub(crate) fn query_finish(&mut self, now: SystemTime) {
         self.running_queries_count = self.running_queries_count.saturating_sub(1);
-        self.last_query_finished_at = Some(now)
+        self.last_query_finished_at = Some(now);
+        set_session_running_queries(self.running_queries_count);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Expose running_queries_count as a Prometheus metric 
- fixes: #17634 

## Tests

- [x] No Test - improve metrics

## Type of change

- [x] Other (please describe): metrics enhancement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19381)
<!-- Reviewable:end -->
