### PR TITLE
feat(query): add procedure admin APIs

### DIFF
--- a/src/query/service/src/servers/admin/admin_service.rs
+++ b/src/query/service/src/servers/admin/admin_service.rs
@@ -112,6 +112,18 @@ impl AdminService {
                     get(super::v1::user_functions::user_functions),
                 )
                 .at(
+                    "/v1/tenants/:tenant/procedures",
+                    get(super::v1::procedures::list_procedures),
+                )
+                .at(
+                    "/v1/tenants/:tenant/procedures/:procedure_id",
+                    get(super::v1::procedures::get_procedure_by_id),
+                )
+                .at(
+                    "/v1/tenants/:tenant/procedures/:name",
+                    get(super::v1::procedures::get_procedure_by_name),
+                )
+                .at(
                     "/v1/tenants/:tenant/databases/:database/tables/:table/stats",
                     get(super::v1::table_statistics::get_table_stats_handler),
                 );

--- a/src/query/service/src/servers/admin/v1/mod.rs
+++ b/src/query/service/src/servers/admin/v1/mod.rs
@@ -15,6 +15,7 @@
 pub mod cluster;
 pub mod config;
 pub mod instance_status;
+pub mod procedures;
 pub mod processes;
 pub mod query_dump;
 pub mod settings;

--- a/src/query/service/src/servers/admin/v1/procedures.rs
+++ b/src/query/service/src/servers/admin/v1/procedures.rs
@@ -1,0 +1,71 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_app::tenant::Tenant;
+use databend_common_storages_system::ProceduresTable;
+use http::StatusCode;
+use poem::IntoResponse;
+use poem::web::Json;
+use poem::web::Path;
+use poem::web::Query;
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn list_procedures(Path(tenant): Path<String>) -> poem::Result<impl IntoResponse> {
+    match ProceduresTable::get_procedures(&Tenant::new_literal(&tenant)).await {
+        Ok(procedures) => Ok(Json(procedures)),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to list procedures. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn get_procedure_by_id(
+    Path((tenant, procedure_id)): Path<(String, u64)>,
+) -> poem::Result<impl IntoResponse> {
+    match ProceduresTable::get_procedure_by_id(&Tenant::new_literal(&tenant), procedure_id).await {
+        Ok(Some(procedure)) => Ok(Json(procedure)),
+        Ok(None) => Err(poem::Error::from_string(
+            format!("procedure not found with id: {}", procedure_id),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to get procedure. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn get_procedure_by_name(
+    Path((tenant, name)): Path<(String, String)>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> poem::Result<impl IntoResponse> {
+    let args = params.get("args").map(|s| s.as_str()).unwrap_or("");
+    match ProceduresTable::get_procedure(&Tenant::new_literal(&tenant), &name, args).await {
+        Ok(Some(procedure)) => Ok(Json(procedure)),
+        Ok(None) => Err(poem::Error::from_string(
+            format!("procedure not found: {}({})", name, args),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to get procedure. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}

--- a/src/query/storages/system/src/procedures_table.rs
+++ b/src/query/storages/system/src/procedures_table.rs
@@ -14,6 +14,8 @@
 
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
@@ -27,16 +29,39 @@ use databend_common_expression::types::StringType;
 use databend_common_expression::types::TimestampType;
 use databend_common_expression::types::UInt64Type;
 use databend_common_expression::utils::FromData;
+use databend_common_meta_app::principal::GetProcedureReq;
 use databend_common_meta_app::principal::ListProcedureReq;
+use databend_common_meta_app::principal::ProcedureIdentity;
 use databend_common_meta_app::schema::TableIdent;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
+use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::UserApiProvider;
 use itertools::Itertools;
 
 use crate::meta_service_error;
 use crate::table::AsyncOneBlockSystemTable;
 use crate::table::AsyncSystemTable;
+
+// Response for list procedures API (aligned with SHOW PROCEDURES)
+#[derive(serde::Serialize)]
+pub struct ProcedureListItem {
+    name: String,
+    procedure_id: u64,
+    arguments: String,
+    comment: String,
+    description: String,
+    created_on: DateTime<Utc>,
+}
+
+// Response for get procedure details API (aligned with DESC PROCEDURE)
+#[derive(serde::Serialize)]
+pub struct ProcedureDetail {
+    signature: String,
+    returns: String,
+    language: String,
+    body: String,
+}
 
 pub struct ProceduresTable {
     table_info: TableInfo,
@@ -134,5 +159,127 @@ impl ProceduresTable {
         };
 
         AsyncOneBlockSystemTable::create(ProceduresTable { table_info })
+    }
+
+    #[async_backtrace::framed]
+    pub async fn get_procedures(tenant: &Tenant) -> Result<Vec<ProcedureListItem>> {
+        let user_api = UserApiProvider::instance();
+        let mgr = user_api.procedure_api(tenant);
+        let procedures = mgr
+            .list_procedures(ListProcedureReq {
+                tenant: tenant.clone(),
+                filter: None,
+            })
+            .await
+            .map_err(meta_service_error)?;
+
+        Ok(procedures
+            .into_iter()
+            .map(|proc_info| ProcedureListItem {
+                name: proc_info.name_ident.procedure_name().name.clone(),
+                procedure_id: *proc_info.ident.procedure_id(),
+                arguments: format!(
+                    "{} RETURN ({})",
+                    proc_info.name_ident.procedure_name(),
+                    proc_info.meta.return_types.iter().join(",")
+                ),
+                comment: proc_info.meta.comment.clone(),
+                description: "user-defined procedure".to_string(),
+                created_on: proc_info.meta.created_on,
+            })
+            .collect())
+    }
+
+    #[async_backtrace::framed]
+    pub async fn get_procedure(
+        tenant: &Tenant,
+        name: &str,
+        args: &str,
+    ) -> Result<Option<ProcedureDetail>> {
+        let user_api = UserApiProvider::instance();
+        let mgr = user_api.procedure_api(tenant);
+        let req = GetProcedureReq::new(tenant, ProcedureIdentity::new(name, args));
+
+        match mgr.get_procedure(&req).await.map_err(meta_service_error)? {
+            Some(reply) => {
+                // Format signature as (arg1,arg2,...)
+                let signature = if reply.procedure_meta.arg_names.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!("({})", reply.procedure_meta.arg_names.join(","))
+                };
+
+                // Format returns as (Type1,Type2,...)
+                let returns = if reply.procedure_meta.return_types.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!(
+                        "({})",
+                        reply
+                            .procedure_meta
+                            .return_types
+                            .iter()
+                            .map(|t| t.to_string())
+                            .join(",")
+                    )
+                };
+
+                Ok(Some(ProcedureDetail {
+                    signature,
+                    returns,
+                    language: reply.procedure_meta.procedure_language.clone(),
+                    body: reply.procedure_meta.script.clone(),
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    #[async_backtrace::framed]
+    pub async fn get_procedure_by_id(
+        tenant: &Tenant,
+        procedure_id: u64,
+    ) -> Result<Option<ProcedureDetail>> {
+        let user_api = UserApiProvider::instance();
+        let mgr = user_api.procedure_api(tenant);
+
+        match mgr
+            .get_procedure_by_id(procedure_id)
+            .await
+            .map_err(meta_service_error)?
+        {
+            Some(seq_meta) => {
+                let procedure_meta = seq_meta.data;
+
+                // Format signature as (arg1,arg2,...)
+                let signature = if procedure_meta.arg_names.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!("({})", procedure_meta.arg_names.join(","))
+                };
+
+                // Format returns as (Type1,Type2,...)
+                let returns = if procedure_meta.return_types.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!(
+                        "({})",
+                        procedure_meta
+                            .return_types
+                            .iter()
+                            .map(|t| t.to_string())
+                            .join(",")
+                    )
+                };
+
+                Ok(Some(ProcedureDetail {
+                    signature,
+                    returns,
+                    language: procedure_meta.procedure_language.clone(),
+                    body: procedure_meta.script.clone(),
+                }))
+            }
+            None => Ok(None),
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add three HTTP endpoints for procedure management in the query admin API:
- `GET /v1/tenants/:tenant/procedures` - list all procedures (aligned with SHOW PROCEDURES)
- `GET /v1/tenants/:tenant/procedures/:procedure_id` - get procedure by ID
- `GET /v1/tenants/:tenant/procedures/:name?args=<args>` - get procedure by name with optional args query parameter

The `args` query parameter is a comma-separated type string (e.g., "INT32,STRING"). For procedures without arguments, omit the args parameter (e.g., `/procedures/my_proc`).

Response formats align with SHOW PROCEDURES and DESC PROCEDURE SQL command outputs.

## Tests

- [x] No Test - Admin API requires management_mode and HTTP testing infrastructure

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19396)
<!-- Reviewable:end -->
