### PR TITLE
fix(mysql): set UNSIGNED_FLAG for unsigned integer columns

### DIFF
--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -247,12 +247,31 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
         }
 
         fn make_column_from_field(field: &DataField) -> Result<Column> {
-            convert_field_type(field).map(|column_type| Column {
-                table: "".to_string(),
-                column: field.name().to_string(),
-                collen: column_length(field),
-                coltype: column_type,
-                colflags: ColumnFlags::empty(),
+            convert_field_type(field).map(|column_type| {
+                let mut colflags = ColumnFlags::empty();
+
+                if !field.is_nullable() {
+                    colflags |= ColumnFlags::NOT_NULL_FLAG;
+                }
+
+                if matches!(
+                    field.data_type().remove_nullable(),
+                    DataType::Number(
+                        NumberDataType::UInt8
+                            | NumberDataType::UInt16
+                            | NumberDataType::UInt32
+                            | NumberDataType::UInt64
+                    )
+                ) {
+                    colflags |= ColumnFlags::UNSIGNED_FLAG;
+                }
+                Column {
+                    table: "".to_string(),
+                    column: field.name().to_string(),
+                    collen: column_length(field),
+                    coltype: column_type,
+                    colflags,
+                }
             })
         }
 

--- a/src/query/service/tests/it/servers/mysql/mysql_handler.rs
+++ b/src/query/service/tests/it/servers/mysql/mysql_handler.rs
@@ -28,6 +28,8 @@ use databend_query::test_kits::TestFixture;
 use mysql_async::FromRowError;
 use mysql_async::Row;
 use mysql_async::SslOpts;
+use mysql_async::consts::ColumnFlags;
+use mysql_async::consts::ColumnType;
 use mysql_async::prelude::FromRow;
 use mysql_async::prelude::Queryable;
 use tokio::sync::Barrier;
@@ -211,4 +213,46 @@ impl FromRow for EmptyRow {
     where Self: Sized {
         Ok(EmptyRow)
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_unsigned_integer_column_flags() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let tcp_keepalive_timeout_secs = 120;
+    let mut handler = MySQLHandler::create(tcp_keepalive_timeout_secs, MySQLTlsConfig::default())?;
+
+    let listening = "127.0.0.1:0".parse::<SocketAddr>()?;
+    let runnable_server = handler.start(listening).await?;
+    let mut connection = create_connection(runnable_server.port(), false).await?;
+
+    // Test case: SELECT 32767 + 1
+    // Due to constant folding and shrink_scalar, 32768 fits in UInt16.
+    // The UNSIGNED_FLAG must be set so clients interpret it correctly.
+    let mut result = connection.query_iter("SELECT 32767 + 1").await?;
+    let columns = result.columns_ref();
+
+    assert_eq!(columns.len(), 1);
+    let col = &columns[0];
+    // The type should be SHORT (INT16/UINT16 both map to MYSQL_TYPE_SHORT)
+    assert_eq!(col.column_type(), ColumnType::MYSQL_TYPE_SHORT);
+    // The UNSIGNED_FLAG must be set since shrink_scalar produces UInt16
+    // The NOT_NULL_FLAG must be set since the expression is not nullable
+    assert!(
+        col.flags().contains(ColumnFlags::UNSIGNED_FLAG),
+        "Expected UNSIGNED_FLAG to be set for UInt16 column, got flags: {:?}",
+        col.flags()
+    );
+    assert!(
+        col.flags().contains(ColumnFlags::NOT_NULL_FLAG),
+        "Expected NOT_NULL_FLAG to be set for non-nullable column, got flags: {:?}",
+        col.flags()
+    );
+
+    // Verify the value is correct and doesn't overflow
+    let row: Option<Row> = result.next().await?;
+    let value: (u32,) = mysql_async::from_row(row.unwrap());
+    assert_eq!(value, (32768,));
+
+    Ok(())
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When executing expressions like `SELECT 32767 + 1`, Databend's constant folding shrinks the result (32768) to UInt16 since it fits. However, the MySQL protocol was returning MYSQL_TYPE_SHORT without the UNSIGNED_FLAG, causing MySQL clients (e.g., sqlx) to interpret it as signed INT16.

Since signed INT16 range is -32768~32767, the value 32768 appears to overflow from the client's perspective.

This fix sets UNSIGNED_FLAG for UInt8/UInt16/UInt32/UInt64 columns in the MySQL protocol response, allowing clients to correctly interpret the value range.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19400)
<!-- Reviewable:end -->
