### PR TITLE
fix(mysql): avoid NOT_NULL for NULL columns

### DIFF
--- a/src/query/service/src/servers/mysql/writers/query_result_writer.rs
+++ b/src/query/service/src/servers/mysql/writers/query_result_writer.rs
@@ -86,6 +86,119 @@ fn write_field<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+fn convert_field_type(field: &DataField) -> Result<ColumnType> {
+    match field.data_type().remove_nullable() {
+        DataType::Null => Ok(ColumnType::MYSQL_TYPE_NULL),
+        DataType::EmptyArray => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::EmptyMap => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Boolean => Ok(ColumnType::MYSQL_TYPE_SHORT),
+        DataType::Binary => Ok(ColumnType::MYSQL_TYPE_BLOB),
+        DataType::String => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Number(num_ty) => match num_ty {
+            NumberDataType::Int8 => Ok(ColumnType::MYSQL_TYPE_TINY),
+            NumberDataType::Int16 => Ok(ColumnType::MYSQL_TYPE_SHORT),
+            NumberDataType::Int32 => Ok(ColumnType::MYSQL_TYPE_LONG),
+            NumberDataType::Int64 => Ok(ColumnType::MYSQL_TYPE_LONGLONG),
+            NumberDataType::UInt8 => Ok(ColumnType::MYSQL_TYPE_TINY),
+            NumberDataType::UInt16 => Ok(ColumnType::MYSQL_TYPE_SHORT),
+            NumberDataType::UInt32 => Ok(ColumnType::MYSQL_TYPE_LONG),
+            NumberDataType::UInt64 => Ok(ColumnType::MYSQL_TYPE_LONGLONG),
+            NumberDataType::Float32 => Ok(ColumnType::MYSQL_TYPE_FLOAT),
+            NumberDataType::Float64 => Ok(ColumnType::MYSQL_TYPE_DOUBLE),
+        },
+        DataType::Date => Ok(ColumnType::MYSQL_TYPE_DATE),
+        DataType::Timestamp => Ok(ColumnType::MYSQL_TYPE_DATETIME),
+        DataType::TimestampTz => Ok(ColumnType::MYSQL_TYPE_DATETIME),
+        DataType::Array(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Map(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Bitmap => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Tuple(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Variant => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Geometry => Ok(ColumnType::MYSQL_TYPE_GEOMETRY),
+        DataType::Geography => Ok(ColumnType::MYSQL_TYPE_GEOMETRY),
+        DataType::Decimal(_) => Ok(ColumnType::MYSQL_TYPE_DECIMAL),
+        DataType::Interval => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        DataType::Vector(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
+        _ => Err(ErrorCode::Unimplemented(format!(
+            "Unsupported column type:{:?}",
+            field.data_type()
+        ))),
+    }
+}
+
+fn compute_length(data_type: &DataType) -> u32 {
+    match data_type {
+        DataType::Null | DataType::EmptyArray | DataType::EmptyMap => 0,
+        DataType::Boolean => 1,
+        DataType::Binary => 16382,
+        DataType::String => 16382 * 4,
+        DataType::Number(num_ty) => match num_ty {
+            NumberDataType::Int8 | NumberDataType::UInt8 => 3,
+            NumberDataType::Int16 | NumberDataType::UInt16 => 5,
+            NumberDataType::Int32 | NumberDataType::UInt32 => 10,
+            NumberDataType::Int64 => 19,
+            NumberDataType::UInt64 => 20,
+            NumberDataType::Float32 => 12,
+            NumberDataType::Float64 => 22,
+        },
+        DataType::Decimal(size) => size.precision() as u32,
+        DataType::Date => 10,
+        DataType::Timestamp => 26,
+        DataType::Interval => 64,
+        DataType::Geometry | DataType::Geography => 1024,
+        DataType::Vector(_) => 1024,
+        DataType::Bitmap | DataType::Variant | DataType::StageLocation => 1024,
+        DataType::Array(inner) | DataType::Map(inner) => {
+            let inner_len = compute_length(inner);
+            (inner_len.saturating_mul(4)).min(16382)
+        }
+        DataType::Tuple(fields) => fields
+            .iter()
+            .map(compute_length)
+            .max()
+            .unwrap_or(1024)
+            .min(1024),
+        DataType::Opaque(_) => 1024,
+        DataType::Nullable(inner) => compute_length(inner),
+        DataType::Generic(_) => 1024,
+        DataType::TimestampTz => 1024,
+    }
+}
+
+fn column_length(field: &DataField) -> u32 {
+    let length = compute_length(field.data_type());
+    length.clamp(1, 16382)
+}
+
+fn make_column_from_field(field: &DataField) -> Result<Column> {
+    convert_field_type(field).map(|column_type| {
+        let mut colflags = ColumnFlags::empty();
+
+        if !field.is_nullable_or_null() {
+            colflags |= ColumnFlags::NOT_NULL_FLAG;
+        }
+
+        if matches!(
+            field.data_type().remove_nullable(),
+            DataType::Number(
+                NumberDataType::UInt8
+                    | NumberDataType::UInt16
+                    | NumberDataType::UInt32
+                    | NumberDataType::UInt64
+            )
+        ) {
+            colflags |= ColumnFlags::UNSIGNED_FLAG;
+        }
+        Column {
+            table: "".to_string(),
+            column: field.name().to_string(),
+            collen: column_length(field),
+            coltype: column_type,
+            colflags,
+        }
+    })
+}
+
 impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
     pub fn create(
         inner: QueryResultWriter<'a, W>,
@@ -160,119 +273,6 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
                 })
                 .await?;
             return Ok(());
-        }
-
-        fn convert_field_type(field: &DataField) -> Result<ColumnType> {
-            match field.data_type().remove_nullable() {
-                DataType::Null => Ok(ColumnType::MYSQL_TYPE_NULL),
-                DataType::EmptyArray => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::EmptyMap => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Boolean => Ok(ColumnType::MYSQL_TYPE_SHORT),
-                DataType::Binary => Ok(ColumnType::MYSQL_TYPE_BLOB),
-                DataType::String => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Number(num_ty) => match num_ty {
-                    NumberDataType::Int8 => Ok(ColumnType::MYSQL_TYPE_TINY),
-                    NumberDataType::Int16 => Ok(ColumnType::MYSQL_TYPE_SHORT),
-                    NumberDataType::Int32 => Ok(ColumnType::MYSQL_TYPE_LONG),
-                    NumberDataType::Int64 => Ok(ColumnType::MYSQL_TYPE_LONGLONG),
-                    NumberDataType::UInt8 => Ok(ColumnType::MYSQL_TYPE_TINY),
-                    NumberDataType::UInt16 => Ok(ColumnType::MYSQL_TYPE_SHORT),
-                    NumberDataType::UInt32 => Ok(ColumnType::MYSQL_TYPE_LONG),
-                    NumberDataType::UInt64 => Ok(ColumnType::MYSQL_TYPE_LONGLONG),
-                    NumberDataType::Float32 => Ok(ColumnType::MYSQL_TYPE_FLOAT),
-                    NumberDataType::Float64 => Ok(ColumnType::MYSQL_TYPE_DOUBLE),
-                },
-                DataType::Date => Ok(ColumnType::MYSQL_TYPE_DATE),
-                DataType::Timestamp => Ok(ColumnType::MYSQL_TYPE_DATETIME),
-                DataType::TimestampTz => Ok(ColumnType::MYSQL_TYPE_DATETIME),
-                DataType::Array(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Map(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Bitmap => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Tuple(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Variant => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Geometry => Ok(ColumnType::MYSQL_TYPE_GEOMETRY),
-                DataType::Geography => Ok(ColumnType::MYSQL_TYPE_GEOMETRY),
-                DataType::Decimal(_) => Ok(ColumnType::MYSQL_TYPE_DECIMAL),
-                DataType::Interval => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                DataType::Vector(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
-                _ => Err(ErrorCode::Unimplemented(format!(
-                    "Unsupported column type:{:?}",
-                    field.data_type()
-                ))),
-            }
-        }
-
-        fn compute_length(data_type: &DataType) -> u32 {
-            match data_type {
-                DataType::Null | DataType::EmptyArray | DataType::EmptyMap => 0,
-                DataType::Boolean => 1,
-                DataType::Binary => 16382,
-                DataType::String => 16382 * 4,
-                DataType::Number(num_ty) => match num_ty {
-                    NumberDataType::Int8 | NumberDataType::UInt8 => 3,
-                    NumberDataType::Int16 | NumberDataType::UInt16 => 5,
-                    NumberDataType::Int32 | NumberDataType::UInt32 => 10,
-                    NumberDataType::Int64 => 19,
-                    NumberDataType::UInt64 => 20,
-                    NumberDataType::Float32 => 12,
-                    NumberDataType::Float64 => 22,
-                },
-                DataType::Decimal(size) => size.precision() as u32,
-                DataType::Date => 10,
-                DataType::Timestamp => 26,
-                DataType::Interval => 64,
-                DataType::Geometry | DataType::Geography => 1024,
-                DataType::Vector(_) => 1024,
-                DataType::Bitmap | DataType::Variant | DataType::StageLocation => 1024,
-                DataType::Array(inner) | DataType::Map(inner) => {
-                    let inner_len = compute_length(inner);
-                    (inner_len.saturating_mul(4)).min(16382)
-                }
-                DataType::Tuple(fields) => fields
-                    .iter()
-                    .map(compute_length)
-                    .max()
-                    .unwrap_or(1024)
-                    .min(1024),
-                DataType::Opaque(_) => 1024,
-                DataType::Nullable(inner) => compute_length(inner),
-                DataType::Generic(_) => 1024,
-                DataType::TimestampTz => 1024,
-            }
-        }
-
-        fn column_length(field: &DataField) -> u32 {
-            let length = compute_length(field.data_type());
-            length.clamp(1, 16382)
-        }
-
-        fn make_column_from_field(field: &DataField) -> Result<Column> {
-            convert_field_type(field).map(|column_type| {
-                let mut colflags = ColumnFlags::empty();
-
-                if !field.is_nullable() {
-                    colflags |= ColumnFlags::NOT_NULL_FLAG;
-                }
-
-                if matches!(
-                    field.data_type().remove_nullable(),
-                    DataType::Number(
-                        NumberDataType::UInt8
-                            | NumberDataType::UInt16
-                            | NumberDataType::UInt32
-                            | NumberDataType::UInt64
-                    )
-                ) {
-                    colflags |= ColumnFlags::UNSIGNED_FLAG;
-                }
-                Column {
-                    table: "".to_string(),
-                    column: field.name().to_string(),
-                    collen: column_length(field),
-                    coltype: column_type,
-                    colflags,
-                }
-            })
         }
 
         fn convert_schema(schema: &DataSchemaRef) -> Result<Vec<Column>> {
@@ -403,5 +403,37 @@ impl<'a, W: AsyncWrite + Send + Unpin> DFQueryResultWriter<'a, W> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_column_flags_for_null() {
+        let field = DataField::new("c", DataType::Null);
+        let column = make_column_from_field(&field).unwrap();
+
+        assert_eq!(column.coltype, ColumnType::MYSQL_TYPE_NULL);
+        assert!(!column.colflags.contains(ColumnFlags::NOT_NULL_FLAG));
+    }
+
+    #[test]
+    fn test_make_column_flags_for_unsigned() {
+        let field = DataField::new("u", DataType::Number(NumberDataType::UInt32));
+        let column = make_column_from_field(&field).unwrap();
+
+        assert!(column.colflags.contains(ColumnFlags::NOT_NULL_FLAG));
+        assert!(column.colflags.contains(ColumnFlags::UNSIGNED_FLAG));
+    }
+
+    #[test]
+    fn test_make_column_flags_for_nullable() {
+        let field = DataField::new_nullable("n", DataType::Number(NumberDataType::Int32));
+        let column = make_column_from_field(&field).unwrap();
+
+        assert!(!column.colflags.contains(ColumnFlags::NOT_NULL_FLAG));
+        assert!(!column.colflags.contains(ColumnFlags::UNSIGNED_FLAG));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fixes: #19417

- Avoid setting NOT_NULL_FLAG for MYSQL_TYPE_NULL columns (e.g. SELECT NULL).
- Add unit tests for NULL/nullable/unsigned column flags and an integration test in MySQL handler.
- Extract column-metadata helpers out of the query path so they can be unit tested.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19416)
<!-- Reviewable:end -->
