### PR TITLE
fix(query): flush blocks on grace switch

### DIFF
--- a/.github/workflows/reuse.sqllogic.yml
+++ b/.github/workflows/reuse.sqllogic.yml
@@ -263,14 +263,17 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - { dirs: "query", runner: "4c" }
-          - { dirs: "duckdb", runner: "4c" }
-          - { dirs: "crdb", runner: "2c", parallel: "2" }
-          - { dirs: "base", runner: "2c", parallel: "2" }
-          - { dirs: "ydb", runner: "2c" }
           - { dirs: "tpcds", runner: "4c" }
-          - { dirs: "tpch", runner: "2c" }
-          - { dirs: "cluster", runner: "2c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
+          - { dirs: "tpcds", runner: "4c" }
         handler:
           - "hybrid"
           - "http"

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/hybrid/hybrid_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/hybrid/hybrid_join.rs
@@ -119,9 +119,7 @@ impl HybridHashJoin {
     /// Switch from Memory mode to Grace mode
     fn switch_to_grace_mode(&mut self, finished: bool) -> Result<()> {
         if let HybridJoinMode::Memory(memory_join) = &mut self.mode {
-            if !finished {
-                memory_join.add_block(None)?;
-            }
+            memory_join.add_block(None)?;
 
             self.state.set_spilled();
             self.add_transition_work()?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Always flush memory blocks when switching hybrid join to grace mode to avoid missing spill
- Repeat TPC-DS runs in reuse sqllogic workflow for stability regression

## Changes

- Remove the finished guard so `add_block(None)` always runs before switching to grace mode
- Update the cluster matrix in `reuse.sqllogic.yml` to run `tpcds` repeatedly

## Implementation

1. Call `add_block(None)` unconditionally in `switch_to_grace_mode`
2. Reduce the cluster test matrix to repeated `tpcds` entries for quick reruns

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - use the reuse sqllogic workflow to rerun TPC-DS repeatedly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19428)
<!-- Reviewable:end -->
