### PR TITLE
feat: add default_warehouse option to user settings

### DIFF
--- a/src/meta/app/src/principal/user_info.rs
+++ b/src/meta/app/src/principal/user_info.rs
@@ -192,6 +192,7 @@ impl TryFrom<Vec<u8>> for UserInfo {
 pub struct UserOption {
     flags: BitFlags<UserOptionFlag>,
     default_role: Option<String>,
+    default_warehouse: Option<String>,
     network_policy: Option<String>,
     password_policy: Option<String>,
     workload_group: Option<String>,
@@ -204,6 +205,7 @@ impl UserOption {
         Self {
             flags,
             default_role: None,
+            default_warehouse: None,
             network_policy: None,
             password_policy: None,
             workload_group: None,
@@ -223,6 +225,11 @@ impl UserOption {
 
     pub fn with_default_role(mut self, default_role: Option<String>) -> Self {
         self.default_role = default_role;
+        self
+    }
+
+    pub fn with_default_warehouse(mut self, default_warehouse: Option<String>) -> Self {
+        self.default_warehouse = default_warehouse;
         self
     }
 
@@ -264,6 +271,10 @@ impl UserOption {
         self.default_role.as_ref()
     }
 
+    pub fn default_warehouse(&self) -> Option<&String> {
+        self.default_warehouse.as_ref()
+    }
+
     pub fn network_policy(&self) -> Option<&String> {
         self.network_policy.as_ref()
     }
@@ -287,6 +298,10 @@ impl UserOption {
 
     pub fn set_default_role(&mut self, default_role: Option<String>) {
         self.default_role = default_role;
+    }
+
+    pub fn set_default_warehouse(&mut self, default_warehouse: Option<String>) {
+        self.default_warehouse = default_warehouse;
     }
 
     pub fn set_network_policy(&mut self, network_policy: Option<String>) {
@@ -339,6 +354,7 @@ impl UserOption {
                 }
             }
             UserOptionItem::DefaultRole(v) => self.default_role = Some(v.clone()),
+            UserOptionItem::DefaultWarehouse(v) => self.default_warehouse = Some(v.clone()),
             UserOptionItem::SetNetworkPolicy(v) => self.network_policy = Some(v.clone()),
             UserOptionItem::UnsetNetworkPolicy => self.network_policy = None,
             UserOptionItem::SetPasswordPolicy(v) => self.password_policy = Some(v.clone()),
@@ -391,6 +407,33 @@ mod tests {
             assert_eq!(AuthInfo::JWT, u.auth_info);
             assert_eq!(BitFlags::all(), u.option.flags);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_user_option_default_warehouse() -> anyhow::Result<()> {
+        use databend_common_ast::ast::UserOptionItem;
+
+        // default is None
+        let opt = UserOption::empty();
+        assert_eq!(opt.default_warehouse(), None);
+
+        // with_default_warehouse builder
+        let opt = UserOption::empty().with_default_warehouse(Some("wh1".to_string()));
+        assert_eq!(opt.default_warehouse(), Some(&"wh1".to_string()));
+
+        // set_default_warehouse
+        let mut opt = UserOption::empty();
+        opt.set_default_warehouse(Some("wh2".to_string()));
+        assert_eq!(opt.default_warehouse(), Some(&"wh2".to_string()));
+        opt.set_default_warehouse(None);
+        assert_eq!(opt.default_warehouse(), None);
+
+        // apply DefaultWarehouse
+        let mut opt = UserOption::empty();
+        opt.apply(&UserOptionItem::DefaultWarehouse("wh3".to_string()));
+        assert_eq!(opt.default_warehouse(), Some(&"wh3".to_string()));
 
         Ok(())
     }

--- a/src/meta/proto-conv/src/impls/user.rs
+++ b/src/meta/proto-conv/src/impls/user.rs
@@ -103,6 +103,7 @@ impl FromToProto for mt::principal::UserOption {
         Ok(mt::principal::UserOption::default()
             .with_flags(flags)
             .with_default_role(p.default_role)
+            .with_default_warehouse(p.default_warehouse)
             .with_network_policy(p.network_policy)
             .with_password_policy(p.password_policy)
             .with_workload_group(p.workload_group)
@@ -116,6 +117,7 @@ impl FromToProto for mt::principal::UserOption {
             min_reader_ver: MIN_READER_VER,
             flags: self.flags().bits(),
             default_role: self.default_role().cloned(),
+            default_warehouse: self.default_warehouse().cloned(),
             network_policy: self.network_policy().cloned(),
             password_policy: self.password_policy().cloned(),
             workload_group: self.workload_group().cloned(),

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -195,6 +195,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (163, "2025-12-31: Add: SnapshotRef"),
     (164, "2026-01-22: Update: user.proto/CsvFileFormatParams add allow_quoted_nulls and quoted_empty_field_as, change null_display to optional", ),
     (165, "2026-01-24: Add: add cluster_key_v2 on TableMeta"),
+    (166, "2026-02-13: Add: UserOption::default_warehouse"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -157,3 +157,4 @@ mod v162_tag;
 mod v163_snapshot_ref;
 mod v164_csv_format_params;
 mod v165_table_meta;
+mod v166_user_option_default_warehouse;

--- a/src/meta/proto-conv/tests/it/v166_user_option_default_warehouse.rs
+++ b/src/meta/proto-conv/tests/it/v166_user_option_default_warehouse.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use fastrace::func_name;
+
+use crate::common;
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+// The message bytes are built from the output of `test_pb_from_to()`
+#[test]
+fn test_decode_v166_user_option_default_warehouse() -> anyhow::Result<()> {
+    let user_option_v166 = vec![
+        8, 1, 18, 5, 114, 111, 108, 101, 49, 26, 8, 109, 121, 112, 111, 108, 105, 99, 121, 58, 4,
+        109, 121, 119, 103, 66, 4, 109, 121, 119, 104, 160, 6, 166, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        databend_common_meta_app::principal::UserOption::default()
+            .with_set_flag(databend_common_meta_app::principal::UserOptionFlag::TenantSetting)
+            .with_default_role(Some("role1".into()))
+            .with_network_policy(Some("mypolicy".to_string()))
+            .with_workload_group(Some("mywg".to_string()))
+            .with_default_warehouse(Some("mywh".to_string()))
+    };
+
+    common::test_pb_from_to(func_name!(), want())?;
+    common::test_load_old(func_name!(), user_option_v166.as_slice(), 166, want())
+}

--- a/src/meta/protos/proto/user.proto
+++ b/src/meta/protos/proto/user.proto
@@ -154,6 +154,7 @@ message UserOption {
   optional bool disabled = 5;
   optional bool must_change_password = 6;
   optional string workload_group = 7;
+  optional string default_warehouse = 8;
 }
 
 message UserInfo {

--- a/src/query/ast/src/ast/statements/user.rs
+++ b/src/query/ast/src/ast/statements/user.rs
@@ -317,6 +317,7 @@ pub enum SecondaryRolesOption {
 pub enum UserOptionItem {
     TenantSetting(bool),
     DefaultRole(String),
+    DefaultWarehouse(String),
     Disabled(bool),
     SetNetworkPolicy(String),
     UnsetNetworkPolicy,
@@ -333,6 +334,7 @@ impl Display for UserOptionItem {
             UserOptionItem::TenantSetting(true) => write!(f, "TENANTSETTING"),
             UserOptionItem::TenantSetting(false) => write!(f, "NOTENANTSETTING"),
             UserOptionItem::DefaultRole(v) => write!(f, "DEFAULT_ROLE = '{}'", v),
+            UserOptionItem::DefaultWarehouse(v) => write!(f, "DEFAULT_WAREHOUSE = '{}'", v),
             UserOptionItem::SetNetworkPolicy(v) => write!(f, "SET NETWORK POLICY = '{}'", v),
             UserOptionItem::UnsetNetworkPolicy => write!(f, "UNSET NETWORK POLICY"),
             UserOptionItem::SetPasswordPolicy(v) => write!(f, "SET PASSWORD POLICY = '{}'", v),

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -5561,6 +5561,12 @@ pub fn user_option(i: Input) -> IResult<UserOptionItem> {
         },
         |(_, _, role)| UserOptionItem::DefaultRole(role),
     );
+    let default_warehouse_option = map(
+        rule! {
+            DEFAULT_WAREHOUSE ~ ^"=" ~ ^#literal_string
+        },
+        |(_, _, warehouse)| UserOptionItem::DefaultWarehouse(warehouse),
+    );
     let set_network_policy = map(
         rule! {
             SET ~ NETWORK ~ POLICY ~ ^"=" ~ ^#literal_string
@@ -5614,6 +5620,7 @@ pub fn user_option(i: Input) -> IResult<UserOptionItem> {
         #tenant_setting
         | #no_tenant_setting
         | #default_role_option
+        | #default_warehouse_option
         | #set_network_policy
         | #unset_network_policy
         | #set_password_policy

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -919,6 +919,8 @@ pub enum TokenKind {
     NOTENANTSETTING,
     #[token("DEFAULT_ROLE", ignore(ascii_case))]
     DEFAULT_ROLE,
+    #[token("DEFAULT_WAREHOUSE", ignore(ascii_case))]
+    DEFAULT_WAREHOUSE,
     #[token("NULL", ignore(ascii_case))]
     NULL,
     #[token("NULLABLE", ignore(ascii_case))]

--- a/src/query/service/src/interpreters/interpreter_user_desc.rs
+++ b/src/query/service/src/interpreters/interpreter_user_desc.rs
@@ -64,6 +64,7 @@ impl Interpreter for DescUserInterpreter {
         let hostnames = vec![user.hostname.clone()];
         let auth_types = vec![user.auth_info.get_type().to_str().to_string()];
         let default_roles = vec![user.option.default_role().cloned().unwrap_or_default()];
+        let default_warehouses = vec![user.option.default_warehouse().cloned().unwrap_or_default()];
         let roles = vec![user.grants.roles().iter().sorted().join(", ").to_string()];
         let disableds = vec![user.option.disabled().cloned().unwrap_or_default()];
         let network_policies = vec![user.option.network_policy().cloned()];
@@ -86,6 +87,7 @@ impl Interpreter for DescUserInterpreter {
             StringType::from_data(hostnames),
             StringType::from_data(auth_types),
             StringType::from_data(default_roles),
+            StringType::from_data(default_warehouses),
             StringType::from_data(roles),
             BooleanType::from_data(disableds),
             StringType::from_opt_data(network_policies),

--- a/src/query/service/src/servers/http/v1/users.rs
+++ b/src/query/service/src/servers/http/v1/users.rs
@@ -38,6 +38,7 @@ pub struct CreateUserRequest {
     pub auth_type: Option<String>,
     pub auth_string: Option<String>,
     pub default_role: Option<String>,
+    pub default_warehouse: Option<String>,
     pub roles: Option<Vec<String>>,
     pub grant_all: Option<bool>,
 }
@@ -53,6 +54,7 @@ pub struct UserItem {
     pub hostname: String,
     pub auth_type: String,
     pub default_role: String,
+    pub default_warehouse: String,
     pub grant_roles: Vec<String>,
     pub disabled: bool,
     pub network_policy: Option<String>,
@@ -71,6 +73,7 @@ async fn handle(ctx: &HttpQueryContext) -> Result<ListUsersResponse> {
             hostname: user.hostname.clone(),
             auth_type: user.auth_info.get_type().to_str().to_string(),
             default_role: user.option.default_role().cloned().unwrap_or_default(),
+            default_warehouse: user.option.default_warehouse().cloned().unwrap_or_default(),
             grant_roles: user.grants.roles_vec(),
             disabled: user.option.disabled().cloned().unwrap_or_default(),
             network_policy: user.option.network_policy().cloned(),
@@ -108,7 +111,10 @@ async fn create_user(ctx: &HttpQueryContext, req: CreateUserRequest) -> Result<(
         &req.hostname.unwrap_or("%".to_string()),
         auth_info,
     );
-    user_info.option = user_info.option.with_default_role(req.default_role);
+    user_info.option = user_info
+        .option
+        .with_default_role(req.default_role)
+        .with_default_warehouse(req.default_warehouse);
     if let Some(roles) = req.roles {
         for role in roles {
             user_info.grants.grant_role(role);

--- a/src/query/service/src/servers/http/v1/verify.rs
+++ b/src/query/service/src/servers/http/v1/verify.rs
@@ -28,6 +28,7 @@ pub struct VerifyResponse {
     auth_type: String,
     is_configured: bool,
     default_role: String,
+    default_warehouse: String,
     roles: Vec<String>,
 }
 
@@ -44,6 +45,7 @@ pub async fn verify_handler(ctx: &HttpQueryContext) -> PoemResult<impl IntoRespo
         .is_some();
     let auth_type = user.auth_info.get_type().to_str().to_string();
     let default_role = user.option.default_role().cloned().unwrap_or_default();
+    let default_warehouse = user.option.default_warehouse().cloned().unwrap_or_default();
     let roles = ctx
         .session
         .get_all_effective_roles()
@@ -58,6 +60,7 @@ pub async fn verify_handler(ctx: &HttpQueryContext) -> PoemResult<impl IntoRespo
         is_configured,
         auth_type,
         default_role,
+        default_warehouse,
         roles,
     }))
 }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -847,6 +847,7 @@ async fn test_user_apis() -> anyhow::Result<()> {
         auth_type: Some("double_sha1_password".to_string()),
         auth_string: Some("test_password".to_string()),
         default_role: None,
+        default_warehouse: None,
         roles: None,
         grant_all: Some(true),
     };

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -481,7 +481,7 @@ async fn test_users_table() -> anyhow::Result<()> {
     let stream = table.read_data_block_stream(ctx, &source_plan).await?;
     let result = stream.try_collect::<Vec<_>>().await?;
     let block = &result[0];
-    assert_eq!(block.num_columns(), 13);
+    assert_eq!(block.num_columns(), 14);
     assert!(block.num_rows() >= 2);
 
     let output = box_render(

--- a/src/query/service/tests/it/storages/testdata/columns_table.txt
+++ b/src/query/service/tests/it/storages/testdata/columns_table.txt
@@ -152,6 +152,7 @@ DB.Table: 'system'.'columns', Table: columns-table_id:1, ver:0, Engine: SystemCo
 | 'default_expression'              | 'system'             | 'columns'                 | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'default_kind'                    | 'system'             | 'columns'                 | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'default_role'                    | 'system'             | 'users'                   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
+| 'default_warehouse'               | 'system'             | 'users'                   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'definition'                      | 'system'             | 'indexes'                 | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'definition'                      | 'system'             | 'task_history'            | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |
 | 'definition'                      | 'system'             | 'tasks'                   | 'String'              | 'VARCHAR'           | ''       | ''       | 'NO'     | ''       |

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -375,7 +375,7 @@ impl Binder {
             Statement::ShowUsers { show_options } => {
                 let (show_limit, limit_str) = get_show_options(show_options, None);
                 let query = format!(
-                    "SELECT name, hostname, auth_type, is_configured, default_role, roles, disabled, network_policy, password_policy, must_change_password FROM default.system.users {} ORDER BY name {}",
+                    "SELECT name, hostname, auth_type, is_configured, default_role, default_warehouse, roles, disabled, network_policy, password_policy, must_change_password FROM default.system.users {} ORDER BY name {}",
                     show_limit, limit_str
                 );
                 self.bind_rewrite_to_query(bind_context, &query, RewriteKind::ShowUsers)

--- a/src/query/sql/src/planner/plans/ddl/account.rs
+++ b/src/query/sql/src/planner/plans/ddl/account.rs
@@ -65,6 +65,7 @@ impl DescUserPlan {
             DataField::new("hostname", DataType::String),
             DataField::new("auth_type", DataType::String),
             DataField::new("default_role", DataType::String),
+            DataField::new("default_warehouse", DataType::String),
             DataField::new("roles", DataType::String),
             DataField::new("disabled", DataType::Boolean),
             DataField::new(

--- a/src/query/storages/system/src/users_table.rs
+++ b/src/query/storages/system/src/users_table.rs
@@ -72,6 +72,10 @@ impl AsyncSystemTable for UsersTable {
             .iter()
             .map(|x| x.option.default_role().cloned().unwrap_or_default())
             .collect();
+        let mut default_warehouses: Vec<String> = users
+            .iter()
+            .map(|x| x.option.default_warehouse().cloned().unwrap_or_default())
+            .collect();
         let mut is_configureds: Vec<String> = vec!["NO".to_string(); users.len()];
         let mut disableds: Vec<bool> = users
             .iter()
@@ -121,6 +125,7 @@ impl AsyncSystemTable for UsersTable {
             hostnames.push("%".to_string());
             auth_types.push(auth_info.get_type().to_str().to_string());
             default_roles.push(BUILTIN_ROLE_ACCOUNT_ADMIN.to_string());
+            default_warehouses.push(String::new());
             is_configureds.push("YES".to_string());
             disableds.push(false);
             roles.push(BUILTIN_ROLE_ACCOUNT_ADMIN.to_string());
@@ -139,6 +144,7 @@ impl AsyncSystemTable for UsersTable {
             StringType::from_data(hostnames),
             StringType::from_data(auth_types),
             StringType::from_data(default_roles),
+            StringType::from_data(default_warehouses),
             StringType::from_data(is_configureds),
             BooleanType::from_data(disableds),
             StringType::from_data(roles),
@@ -161,6 +167,7 @@ impl UsersTable {
             TableField::new("hostname", TableDataType::String),
             TableField::new("auth_type", TableDataType::String),
             TableField::new("default_role", TableDataType::String),
+            TableField::new("default_warehouse", TableDataType::String),
             TableField::new("is_configured", TableDataType::String),
             TableField::new("disabled", TableDataType::Boolean),
             TableField::new("roles", TableDataType::String),

--- a/tests/sqllogictests/suites/base/05_ddl/05_0004_ddl_create_user.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0004_ddl_create_user.test
@@ -37,6 +37,15 @@ CREATE USER IF NOT EXISTS 'test-d' IDENTIFIED WITH sha256_password BY 'password'
 statement ok
 CREATE USER IF NOT EXISTS 'test-e' IDENTIFIED BY '123' WITH DEFAULT_ROLE = role1
 
+statement ok
+DROP USER IF EXISTS 'test-wh'
+
+statement ok
+CREATE USER 'test-wh' IDENTIFIED BY '123' WITH DEFAULT_WAREHOUSE = 'my_warehouse'
+
+statement ok
+DROP USER IF EXISTS 'test-wh'
+
 statement error 1005
 CREATE USER 'test-f'@'127.0.0.1' IDENTIFIED BY 'password'
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0005_ddl_alter_user.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0005_ddl_alter_user.test
@@ -60,6 +60,9 @@ statement ok
 ALTER USER 'test-h' WITH DEFAULT_ROLE = role1
 
 statement ok
+ALTER USER 'test-h' WITH DEFAULT_WAREHOUSE = 'my_warehouse'
+
+statement ok
 DROP USER IF EXISTS 'test-e'
 
 statement ok

--- a/tests/sqllogictests/suites/base/05_ddl/05_0032_ddl_network_policy.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0032_ddl_network_policy.test
@@ -52,10 +52,10 @@ CREATE USER user1 IDENTIFIED BY '123456' WITH SET NETWORK POLICY='test_policy2'
 statement ok
 CREATE USER user1 IDENTIFIED BY '123456' WITH SET NETWORK POLICY='test_policy'
 
-query TTTTTBTTBT
+query TTTTTTBTTBT
 DESC USER user1
 ----
-user1 % double_sha1_password (empty) (empty) 0 test_policy NULL NULL NULL
+user1 % double_sha1_password (empty) (empty) (empty) 0 test_policy NULL NULL NULL
 
 statement error 2210
 DROP NETWORK POLICY test_policy

--- a/tests/sqllogictests/suites/base/05_ddl/05_0035_ddl_password_policy.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0035_ddl_password_policy.test
@@ -110,10 +110,10 @@ CREATE USER user1 IDENTIFIED BY '123456abc' WITH SET PASSWORD POLICY='default_po
 statement ok
 CREATE USER user1 IDENTIFIED BY '123456abcD' WITH SET PASSWORD POLICY='default_policy'
 
-query TTTTTBTTBT
+query TTTTTTBTTBT
 DESC USER user1
 ----
-user1 % double_sha1_password (empty) (empty) 0 NULL default_policy NULL NULL
+user1 % double_sha1_password (empty) (empty) (empty) 0 NULL default_policy NULL NULL
 
 statement error 2215
 ALTER USER user1 IDENTIFIED BY '123456abcd'

--- a/tests/sqllogictests/suites/base/06_show/06_0016_show_users.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0016_show_users.test
@@ -25,23 +25,23 @@ grant role role2 to showuser1;
 statement ok
 alter user showuser1 with default_role=role2;
 
-query TTTTTTBTTB
+query TTTTTTTBTTB
 SHOW USERS
 ----
-default % no_password YES account_admin account_admin 0 NULL NULL NULL
-root % no_password YES account_admin account_admin 0 NULL NULL NULL
-showuser1 % double_sha1_password NO role2 role1, role2 0 NULL NULL NULL
-showuser2 % double_sha1_password NO (empty) (empty) 1 NULL NULL NULL
+default % no_password YES account_admin (empty) account_admin 0 NULL NULL NULL
+root % no_password YES account_admin (empty) account_admin 0 NULL NULL NULL
+showuser1 % double_sha1_password NO role2 (empty) role1, role2 0 NULL NULL NULL
+showuser2 % double_sha1_password NO (empty) (empty) (empty) 1 NULL NULL NULL
 
-query TTTTTTBTTB
+query TTTTTTTBTTB
 SHOW USERS where name ='default'
 ----
-default % no_password YES account_admin account_admin 0 NULL NULL NULL
+default % no_password YES account_admin (empty) account_admin 0 NULL NULL NULL
 
-query TTTTTBTTBT
+query TTTTTTBTTBT
 DESC USER 'showuser2'
 ----
-showuser2 % double_sha1_password (empty) (empty) 1 NULL NULL NULL NULL
+showuser2 % double_sha1_password (empty) (empty) (empty) 1 NULL NULL NULL NULL
 
 statement ok
 DROP USER IF EXISTS 'showuser1'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `default_warehouse` as a new user option, similar to the existing `default_role`. The field is an optional string that defaults to empty.

Supported syntax:
- `CREATE USER u1 IDENTIFIED BY 'pwd' WITH DEFAULT_WAREHOUSE = 'my_wh'`
- `ALTER USER u1 WITH DEFAULT_WAREHOUSE = 'my_wh'`

The new field is visible in `DESC USER`, `system.users` table, and the HTTP user API.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19456)
<!-- Reviewable:end -->
