### PR TITLE
docs(meta): fix broken README links for relocated directories

### DIFF
--- a/src/meta/README.md
+++ b/src/meta/README.md
@@ -18,10 +18,10 @@ Databend Meta is a transactional metadata service.
 
 **Higher-level features**:
 - [`admin`](./admin/): Admin HTTP API service for databend-meta.
-- [`cache`](./cache/): Distributed cache that synchronizes with meta-service via watch API.
+- [`cache`](./plugins/cache/): Distributed cache that synchronizes with meta-service via watch API.
 - [`control`](./control/): Meta control utilities.
 - [`process`](./process/): Tools for processing meta-service data.
-- [`semaphore`](./semaphore/): Distributed semaphore implementation based on meta-service.
+- [`semaphore`](./plugins/semaphore/): Distributed semaphore implementation based on meta-service.
 
 **Configuration and runtime**:
 - [`cli-config`](./cli-config/): CLI config parsing for databend-meta.
@@ -34,7 +34,7 @@ Databend Meta is a transactional metadata service.
 - `databend-metaverifier`: Data verification tool.
 
 **Test suites**:
-- [`kvapi-tests`](./kvapi-tests/): Test suite for KV API implementations.
+- [`kv-tests`](./kv-tests/): Test suite for KV API implementations.
 - [`schema-api-test-suite`](./schema-api-test-suite/): Test suite for schema API.
 
 **Enterprise**:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix three broken links in `src/meta/README.md` reported by the link checker:

- `cache` and `semaphore` were moved under `plugins/`; update links from `./cache/` and `./semaphore/` to `./plugins/cache/` and `./plugins/semaphore/`
- `kvapi-tests` was renamed to `kv-tests`; update link accordingly

Fixes #19468

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - doc-only fix

## Type of change

- [x] Documentation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19469)
<!-- Reviewable:end -->
