### PR TITLE
refactor(meta): minor structural cleanups in process, control, admin, semaphore

### DIFF
--- a/src/meta/admin/src/v1/ctrl.rs
+++ b/src/meta/admin/src/v1/ctrl.rs
@@ -44,12 +44,8 @@ impl<SP: SpawnApi> HttpService<SP> {
         meta_handle
             .handle_trigger_snapshot()
             .await
-            .map_err(|e| {
-                poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
-            })?
-            .map_err(|e| {
-                poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
-            })?;
+            .map_err(internal_err)?
+            .map_err(internal_err)?;
         Ok(Json(()).into_response())
     }
 
@@ -60,9 +56,7 @@ impl<SP: SpawnApi> HttpService<SP> {
         let metrics = meta_handle
             .handle_raft_metrics()
             .await
-            .map_err(|e| {
-                poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
-            })?
+            .map_err(internal_err)?
             .borrow_watched()
             .clone();
 
@@ -116,12 +110,8 @@ impl<SP: SpawnApi> HttpService<SP> {
         meta_handle
             .handle_trigger_transfer_leader(to)
             .await
-            .map_err(|e| {
-                poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
-            })?
-            .map_err(|e| {
-                poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
-            })?;
+            .map_err(internal_err)?
+            .map_err(internal_err)?;
 
         Ok(Json(TransferLeaderResponse {
             from: id,
@@ -130,4 +120,8 @@ impl<SP: SpawnApi> HttpService<SP> {
         })
         .into_response())
     }
+}
+
+fn internal_err(e: impl std::fmt::Display) -> poem::Error {
+    poem::Error::from_string(e.to_string(), StatusCode::INTERNAL_SERVER_ERROR)
 }

--- a/src/meta/control/src/export_from_grpc.rs
+++ b/src/meta/control/src/export_from_grpc.rs
@@ -91,7 +91,7 @@ pub async fn export_from_grpc(
 
     let mut stream = exported.into_inner();
 
-    let file: Option<File> = if !save.is_empty() {
+    let mut file: Option<File> = if !save.is_empty() {
         eprintln!("    To:   File: {}", save);
         Some(File::create(&save)?)
     } else {
@@ -114,18 +114,16 @@ pub async fn export_from_grpc(
                 }
             }
 
-            if file.as_ref().is_none() {
-                println!("{}", line);
+            if let Some(ref mut f) = file {
+                f.write_all(format!("{}\n", line).as_bytes())?;
             } else {
-                file.as_ref()
-                    .unwrap()
-                    .write_all(format!("{}\n", line).as_bytes())?;
+                println!("{}", line);
             }
         }
     }
 
-    if file.as_ref().is_some() {
-        file.as_ref().unwrap().sync_all()?;
+    if let Some(ref f) = file {
+        f.sync_all()?;
     }
 
     Ok(())

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -187,9 +187,10 @@ where F: Fn(&str, Vec<u8>) -> Result<Vec<u8>, anyhow::Error>
     }
 
     fn proc_condition(&self, c: TxnCondition) -> TxnCondition {
-        if let Some(Target::Value(_)) = &c.target {
-            unreachable!("we has never used value");
-        }
+        debug_assert!(
+            !matches!(&c.target, Some(Target::Value(_))),
+            "we have never used value"
+        );
         c
     }
 

--- a/src/meta/process/src/process_meta_dir.rs
+++ b/src/meta/process/src/process_meta_dir.rs
@@ -51,8 +51,7 @@ where F: Fn(RaftStoreEntry) -> Result<Option<RaftStoreEntry>, anyhow::Error> {
             converted.len()
         );
 
-        for (v1_ent, v2_ent) in converted {
-            let _ = v1_ent;
+        for (_v1_ent, v2_ent) in converted {
             let (k, v) = RaftStoreEntry::serialize(&v2_ent)?;
             tree.insert(k, v)?;
         }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): minor structural cleanups in process, control, admin, semaphore
Fix 5 code quality items identified in the meta crate review:

- process/kv_processor.rs: replace `unreachable!()` with `debug_assert!()` to
  avoid panics in release builds; `unreachable!` should be used only when the
  compiler cannot prove a code path is impossible.

- process/process_meta_dir.rs: move the unused `v1_ent` suppression into the
  destructuring pattern (`_v1_ent`) instead of a separate `let _ = v1_ent`
  binding.

- control/export_from_grpc.rs: replace `is_some() + unwrap()` with
  `if let Some(ref mut f)`, eliminating redundant borrows.

- plugins/semaphore/semaphore.rs: initialize `seq_policy` directly with
  `GeneratorKey` instead of first setting `TimeBased` then overwriting it.

- admin/v1/ctrl.rs: add a local `internal_err` helper (matching the one in
  `features.rs`) and replace the three verbose
  `map_err(|e| poem::Error::from_string(e.to_string(), INTERNAL_SERVER_ERROR))`
  chains with `.map_err(internal_err)`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19470)
<!-- Reviewable:end -->
