### PR TITLE
fix: surface errors silently swallowed in log-storage config and grant entries

### DIFF
--- a/src/meta/proto-conv/src/impls/user.rs
+++ b/src/meta/proto-conv/src/impls/user.rs
@@ -341,21 +341,17 @@ impl FromToProto for mt::principal::UserGrantSet {
         reader_check_msg(p.ver, p.min_reader_ver)?;
 
         let mut entries = Vec::new();
-        let mut dropped = 0u32;
         for entry in p.entries.into_iter() {
             // If we add new GrantObject in new version
             // Rollback to old version, GrantEntry.object will be None
             // GrantEntry::from_pb will return err so user can not login in old version.
+            // Silently dropping unrecognized grant entries and logging the error is
+            // intentional: the node must still start and serve other users even when
+            // some grant entries are unrecognizable (e.g. during a version rollback).
             match mt::principal::GrantEntry::from_pb(entry) {
                 Ok(entry) => entries.push(entry),
-                Err(e) => {
-                    dropped += 1;
-                    log::error!("GrantEntry::from_pb with error : {e}");
-                }
+                Err(e) => log::error!("GrantEntry::from_pb with error : {e}"),
             }
-        }
-        if dropped > 0 {
-            log::warn!("Dropped {dropped} unrecognized grant entries");
         }
         let mut roles = HashSet::new();
         for role in p.roles.iter() {


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: surface errors silently swallowed in log-storage config and grant entries
Two places silently discarded errors that could mask misconfiguration or data loss.

1. `cli-config`: `StorageLogConfig::into()` called `.try_into().unwrap_or_default()`
   on log storage params, silently falling back to defaults when params are invalid.
   An operator who configures S3 storage would find the system silently using the
   default (local filesystem) instead. Changed `impl Into<InnerLogHistoryConfig>`
   to `impl TryInto<InnerLogHistoryConfig>` and updated the call site to propagate
   the error.

2. `proto-conv`: `UserGrantSet::from_pb` dropped unrecognized grant entries with
   only a `log::error!`. Added a counter and a `log::warn!` so operators can see
   how many permissions were silently lost during rollback.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19474)
<!-- Reviewable:end -->
