### PR TITLE
refactor(proto-conv): extract convert_field helper to deduplicate TryFrom boilerplate

### DIFF
--- a/src/meta/proto-conv/src/impls/stage.rs
+++ b/src/meta/proto-conv/src/impls/stage.rs
@@ -15,8 +15,6 @@
 //! This mod is the key point about compatibility.
 //! Everytime update anything in this file, update the `VER` and let the tests pass.
 
-use std::convert::TryFrom;
-
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_meta_app as mt;
@@ -31,6 +29,7 @@ use crate::Incompatible;
 use crate::MIN_READER_VER;
 use crate::ToProtoOptionExt;
 use crate::VER;
+use crate::convert_field;
 use crate::reader_check_msg;
 
 impl FromToProto for mt::principal::StageParams {
@@ -109,31 +108,10 @@ impl FromToProto for mt::principal::CopyOptions {
         let on_error = mt::principal::OnErrorMode::from_pb(p.on_error.ok_or_else(|| {
             Incompatible::new("CopyOptions.on_error cannot be None".to_string())
         })?)?;
-        let size_limit = usize::try_from(p.size_limit).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.size_limit cannot be convert to usize: {}",
-                err
-            ))
-        })?;
-        let max_files = usize::try_from(p.max_files).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.max_files cannot be convert to usize: {}",
-                err
-            ))
-        })?;
-        let split_size = usize::try_from(p.split_size).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.split_size cannot be convert to usize: {}",
-                err
-            ))
-        })?;
-
-        let max_file_size = usize::try_from(p.max_file_size).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.max_file_size cannot be convert to usize: {}",
-                err
-            ))
-        })?;
+        let size_limit: usize = convert_field(p.size_limit, "CopyOptions.size_limit")?;
+        let max_files: usize = convert_field(p.max_files, "CopyOptions.max_files")?;
+        let split_size: usize = convert_field(p.split_size, "CopyOptions.split_size")?;
+        let max_file_size: usize = convert_field(p.max_file_size, "CopyOptions.max_file_size")?;
         Ok(mt::principal::CopyOptions {
             on_error,
             size_limit,
@@ -150,30 +128,10 @@ impl FromToProto for mt::principal::CopyOptions {
 
     fn to_pb(&self) -> Result<pb::stage_info::CopyOptions, Incompatible> {
         let on_error = mt::principal::OnErrorMode::to_pb(&self.on_error)?;
-        let size_limit = u64::try_from(self.size_limit).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.size_limit cannot be convert to u64: {}",
-                err
-            ))
-        })?;
-        let max_files = u64::try_from(self.max_files).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.max_files cannot be convert to u64: {}",
-                err
-            ))
-        })?;
-        let split_size = u64::try_from(self.split_size).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.split_size cannot be convert to u64: {}",
-                err
-            ))
-        })?;
-        let max_file_size = u64::try_from(self.max_file_size).map_err(|err| {
-            Incompatible::new(format!(
-                "CopyOptions.max_file_size cannot be convert to u64: {}",
-                err
-            ))
-        })?;
+        let size_limit: u64 = convert_field(self.size_limit, "CopyOptions.size_limit")?;
+        let max_files: u64 = convert_field(self.max_files, "CopyOptions.max_files")?;
+        let split_size: u64 = convert_field(self.split_size, "CopyOptions.split_size")?;
+        let max_file_size: u64 = convert_field(self.max_file_size, "CopyOptions.max_file_size")?;
         Ok(pb::stage_info::CopyOptions {
             on_error: Some(on_error),
             size_limit,

--- a/src/meta/proto-conv/src/lib.rs
+++ b/src/meta/proto-conv/src/lib.rs
@@ -72,5 +72,6 @@ pub use traits::ToProtoOptionExt;
 pub use util::MIN_MSG_VER;
 pub use util::MIN_READER_VER;
 pub use util::VER;
+pub use util::convert_field;
 pub use util::missing;
 pub use util::reader_check_msg;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(proto-conv): extract convert_field helper to deduplicate TryFrom boilerplate
8 identical 3-line blocks in `stage.rs` each called `TryFrom::try_from(value)` and
manually formatted an error message naming the field. Extract a generic
`convert_field<T, U>(value: T, field_name: &str) -> Result<U, Incompatible>` helper
that handles the conversion and error formatting in one place.

Changes:
- Add `convert_field` to `util.rs` and re-export from crate root
- Apply to all 8 conversion blocks in `CopyOptions::from_pb` / `to_pb` in `stage.rs`
- Remove the now-unused `std::convert::TryFrom` import from `stage.rs`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19476)
<!-- Reviewable:end -->
