### PR TITLE
fix(query): replace regex-based block comment lexer with memchr scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "indent",
  "itertools 0.13.0",
  "logos",
+ "memchr",
  "nom 8.0.0",
  "nom-rule",
  "ordered-float 5.1.0",

--- a/src/query/ast/Cargo.toml
+++ b/src/query/ast/Cargo.toml
@@ -18,6 +18,7 @@ fastrace = { workspace = true }
 indent = { workspace = true }
 itertools = { workspace = true }
 logos = { workspace = true }
+memchr = { workspace = true }
 nom = { workspace = true }
 nom-rule = { workspace = true }
 ordered-float = { workspace = true }

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -862,6 +862,10 @@ SELECT * from s;"#,
         "--各环节转各环节转各环节转各环节转各\n  select 34343",
         "-- 96477300355	31379974136	3.074486292973661\nselect 34343",
         "-- xxxxx\n  select 34343;",
+        r#"/**/ select 1;"#,
+        r#"/***不正常，注释后面多了个星号**/ select 1;"#,
+        r#"/* outer /* inner */ select 1;"#,
+        r#"/* outer /* inner **/ select 1;"#,
         r#"REMOVE @t;"#,
         r#"SELECT sum(d) OVER (w) FROM e;"#,
         r#"SELECT first_value(d) OVER (w) FROM e;"#,
@@ -1194,6 +1198,7 @@ fn test_statement_error() {
             END;
             $$;"#,
         r#"copy into t1 from (select a from @data/not_exists where a = 1)"#,
+        "/*SELECT * FROM t; /* old query */more code here*/ select 1;",
     ];
 
     for case in cases {

--- a/src/query/ast/tests/it/testdata/lexer.txt
+++ b/src/query/ast/tests/it/testdata/lexer.txt
@@ -82,3 +82,15 @@ create table "user" (id int, name varchar /* the user name */);
 [(CREATE, "create", 0..6), (TABLE, "table", 7..12), (LiteralString, "\"user\"", 13..19), (LParen, "(", 20..21), (Ident, "id", 21..23), (INT, "int", 24..27), (Comma, ",", 27..28), (Ident, "name", 29..33), (VARCHAR, "varchar", 34..41), (RParen, ")", 61..62), (SemiColon, ";", 62..63), (EOI, "", 63..63)]
 
 
+---------- Input ----------
+/**/ select 1;
+---------- Output ---------
+[(SELECT, "select", 5..11), (LiteralInteger, "1", 12..13), (SemiColon, ";", 13..14), (EOI, "", 14..14)]
+
+
+---------- Input ----------
+/***不正常，注释后面多了个星号**/ select 1;
+---------- Output ---------
+[(SELECT, "select", 47..53), (LiteralInteger, "1", 54..55), (SemiColon, ";", 55..56), (EOI, "", 56..56)]
+
+

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -1290,3 +1290,13 @@ error:
                 [ copyOptions ]`
 
 
+---------- Input ----------
+/*SELECT * FROM t; /* old query */more code here*/ select 1;
+---------- Output ---------
+error: 
+  --> SQL:1:35
+  |
+1 | /*SELECT * FROM t; /* old query */more code here*/ select 1;
+  |                                   ^^^^ expecting SQL statement
+
+

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -26326,6 +26326,198 @@ Query(
 
 
 ---------- Input ----------
+/**/ select 1;
+---------- Output ---------
+SELECT 1
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            5..13,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    5..13,
+                ),
+                hints: None,
+                distinct: false,
+                top_n: None,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                12..13,
+                            ),
+                            value: UInt64(
+                                1,
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: None,
+                having: None,
+                window_list: None,
+                qualify: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
+/***不正常，注释后面多了个星号**/ select 1;
+---------- Output ---------
+SELECT 1
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            47..55,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    47..55,
+                ),
+                hints: None,
+                distinct: false,
+                top_n: None,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                54..55,
+                            ),
+                            value: UInt64(
+                                1,
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: None,
+                having: None,
+                window_list: None,
+                qualify: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
+/* outer /* inner */ select 1;
+---------- Output ---------
+SELECT 1
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            21..29,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    21..29,
+                ),
+                hints: None,
+                distinct: false,
+                top_n: None,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                28..29,
+                            ),
+                            value: UInt64(
+                                1,
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: None,
+                having: None,
+                window_list: None,
+                qualify: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
+/* outer /* inner **/ select 1;
+---------- Output ---------
+SELECT 1
+---------- AST ------------
+Query(
+    Query {
+        span: Some(
+            22..30,
+        ),
+        with: None,
+        body: Select(
+            SelectStmt {
+                span: Some(
+                    22..30,
+                ),
+                hints: None,
+                distinct: false,
+                top_n: None,
+                select_list: [
+                    AliasedExpr {
+                        expr: Literal {
+                            span: Some(
+                                29..30,
+                            ),
+                            value: UInt64(
+                                1,
+                            ),
+                        },
+                        alias: None,
+                    },
+                ],
+                from: [],
+                selection: None,
+                group_by: None,
+                having: None,
+                window_list: None,
+                qualify: None,
+            },
+        ),
+        order_by: [],
+        limit: [],
+        offset: None,
+        ignore_result: false,
+    },
+)
+
+
+---------- Input ----------
 REMOVE @t;
 ---------- Output ---------
 REMOVE @t

--- a/src/query/ast/tests/it/token.rs
+++ b/src/query/ast/tests/it/token.rs
@@ -70,6 +70,8 @@ fn test_lexer() {
         r#"select /* the user name */ /*+SET_VAR(timezone='Asia/Shanghai') */ 1;"#,
         r#"create view v_t as select /*+ SET_VAR(timezone='Asia/Shanghai') */ 1;"#,
         r#"create table "user" (id int, name varchar /* the user name */);"#,
+        r#"/**/ select 1;"#,
+        r#"/***不正常，注释后面多了个星号**/ select 1;"#,
     ];
 
     for case in cases {


### PR DESCRIPTION


  

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

  ## Summary

  Replace the regex-based block comment lexer with a memchr-based scanner
  that finds the first `*/` after `/*`, matching Snowflake behavior.

  ## Changes

  - Replace `#[regex(...)]` with `#[token("/*", lex_comment_block)]`
    and a memchr-based scanner that finds the first `*/` closing delimiter.
  - `/**/` and `/***…**/` now tokenize correctly (previously failed with regex).
  - Nested `/*` inside block comments are treated as plain text (Snowflake-compatible),
    e.g. `/* outer /* inner */ select 1` parses successfully.
  - Add benchmark suite for comment-heavy SQL tokenization.

## Cover Test

  - Lexer tests: `/**/`, `/***…**/`
  - Parser tests: `/**/`, `/***…**/`, `/* outer /* inner */`, `/* outer /* inner **/`

- fixes: #19486


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19487)
<!-- Reviewable:end -->
