### PR TITLE
feat: support field_delimiter=none for reading entire CSV lines as single field

### DIFF
--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -241,6 +241,12 @@ impl FileFormatParams {
                 let headers = reader.take_u64(OPT_SKIP_HEADER, default.headers)?;
                 let field_delimiter =
                     reader.take_string(OPT_FIELD_DELIMITER, default.field_delimiter);
+                // Normalize "NONE" keyword to empty string for no-delimiter mode
+                let field_delimiter = if field_delimiter.eq_ignore_ascii_case("NONE") {
+                    "".to_string()
+                } else {
+                    field_delimiter
+                };
                 let record_delimiter =
                     reader.take_string(OPT_RECORDE_DELIMITER, default.record_delimiter);
                 let nan_display = reader.take_string(OPT_NAN_DISPLAY, default.nan_display);
@@ -977,12 +983,13 @@ pub fn check_field_delimiter(option: &str) -> std::result::Result<(), String> {
 }
 
 pub fn check_field_delimiter_csv(option: &str) -> std::result::Result<(), String> {
-    if option.len() == 1 && option.as_bytes()[0].is_ascii_alphanumeric() {
+    if option.is_empty() {
+        // field_delimiter = NONE: read entire line as single field
+        Ok(())
+    } else if option.len() == 1 && option.as_bytes()[0].is_ascii_alphanumeric() {
         Err("Expecting a non-alphanumeric character.".into())
     } else if option.len() > 20 {
         Err("Expecting at most 20 bytes.".into())
-    } else if option.is_empty() {
-        Err("Should not be empty.".into())
     } else {
         Ok(())
     }

--- a/src/query/formats/src/output_format/csv.rs
+++ b/src/query/formats/src/output_format/csv.rs
@@ -25,7 +25,7 @@ use crate::output_format::OutputFormat;
 pub struct CSVOutputFormat {
     schema: TableSchemaRef,
     field_encoder: FieldEncoderCSV,
-    field_delimiter: u8,
+    field_delimiter: Option<u8>,
     record_delimiter: Vec<u8>,
     quote: u8,
 
@@ -42,7 +42,7 @@ impl CSVOutputFormat {
         Self {
             schema,
             field_encoder,
-            field_delimiter: params.field_delimiter.as_bytes()[0],
+            field_delimiter: params.field_delimiter.as_bytes().first().copied(),
             record_delimiter: params.record_delimiter.as_bytes().to_vec(),
             quote: params.quote.as_bytes()[0],
             headers,
@@ -51,11 +51,12 @@ impl CSVOutputFormat {
 
     fn serialize_strings(&self, values: Vec<String>) -> Vec<u8> {
         let mut buf = vec![];
-        let fd = self.field_delimiter;
 
         for (col_index, v) in values.iter().enumerate() {
             if col_index != 0 {
-                buf.push(fd);
+                if let Some(fd) = self.field_delimiter {
+                    buf.push(fd);
+                }
             }
             write_csv_string(v.as_bytes(), &mut buf, self.quote);
         }
@@ -83,7 +84,9 @@ impl OutputFormat for CSVOutputFormat {
         for row_index in 0..rows_size {
             for (col_index, column) in columns.iter().enumerate() {
                 if col_index != 0 {
-                    buf.push(fd);
+                    if let Some(fd) = fd {
+                        buf.push(fd);
+                    }
                 }
                 self.field_encoder
                     .write_field(column, row_index, &mut buf)?;

--- a/src/query/storages/stage/src/read/row_based/formats/csv/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/csv/separator.rs
@@ -89,8 +89,16 @@ impl CsvReader {
         } else {
             Some(format.params.escape.as_bytes()[0])
         };
-        let reader = csv_core::ReaderBuilder::new()
-            .delimiter_bytes(format.params.field_delimiter.as_bytes())
+        let no_field_delimiter = format.params.field_delimiter.is_empty();
+        let mut builder = csv_core::ReaderBuilder::new();
+        if no_field_delimiter {
+            // No-delimiter mode: use a byte that won't appear in normal text
+            // and disable quoting so the entire line is a single field.
+            builder.delimiter(b'\x01').quoting(false);
+        } else {
+            builder.delimiter_bytes(format.params.field_delimiter.as_bytes());
+        }
+        let reader = builder
             .quote(format.params.quote.as_bytes()[0])
             .escape(escape)
             .terminator(match format.params.record_delimiter.as_str().try_into()? {

--- a/tests/data/csv/no_field_delimiter.csv
+++ b/tests/data/csv/no_field_delimiter.csv
@@ -1,0 +1,3 @@
+This is line 1 with commas, and more commas
+This is line 2 with tabs	and spaces
+This is line 3 with "quotes" and 'more'

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_delimiter.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_delimiter.test
@@ -130,3 +130,17 @@ select * from tt2 order by b
 a马 2
 马c 3
 NULL 马4
+
+# field_delimiter = NONE: read entire line as single field
+statement ok
+create or replace table tt2(line string)
+
+statement ok
+copy into tt2 from @data/csv/no_field_delimiter.csv file_format = (type = CSV, field_delimiter = NONE)
+
+query T
+select * from tt2 order by line
+----
+This is line 1 with commas, and more commas
+This is line 2 with tabs	and spaces
+This is line 3 with "quotes" and 'more'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Support `field_delimiter = NONE` option in CSV file format to allow reading entire lines as single fields without field delimitation. This is useful for reading raw line data, log files, or files where the entire line should be treated as a single value.

Closes #19384

## Changes

```sql
-- Read entire lines as single field
CREATE TABLE raw_lines (line STRING);

COPY INTO raw_lines
FROM '@stage/file.txt'
FILE_FORMAT = (TYPE = CSV, field_delimiter = NONE);
```

## Implementation

1. Modified `check_field_delimiter_csv` in `file_format.rs` to accept empty string (no-delimiter mode)
2. Normalized `NONE` keyword to empty string during CSV format params construction
3. Updated CSV separator reader to use a sentinel delimiter byte (`\x01`) with quoting disabled when field_delimiter is empty, so the entire line is read as a single field
4. Updated `CSVOutputFormat` to handle `Option<u8>` field_delimiter to avoid panics on empty delimiter
5. Existing guards in `copy_into_location` and `infer_schema` already reject `len() != 1`, correctly preventing no-delimiter mode for output/infer (only input is supported)

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Added test in `csv_delimiter.test` for `field_delimiter = NONE` with a file containing commas, tabs, and quotes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19489)
<!-- Reviewable:end -->
