### PR TITLE
fix(query): tolerate unknown TaggableObject variants in tag reference listing

### DIFF
--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -387,7 +387,7 @@ build_exceptions! {
     IndexColumnIdNotFound(2726),
 }
 
-// Tag Errors [2750-2753]
+// Tag Errors [2750-2754]
 build_exceptions! {
     /// Tag already exists
     TagAlreadyExists(2750),
@@ -397,6 +397,8 @@ build_exceptions! {
     NotAllowedTagValue(2752),
     /// Tag still has references
     TagHasReferences(2753),
+    /// Tag has unrecognized references
+    TagHasUnrecognizedReferences(2754),
 }
 
 // Cloud and Integration Errors [1701-1703]

--- a/src/meta/app/src/schema/tag/error.rs
+++ b/src/meta/app/src/schema/tag/error.rs
@@ -33,6 +33,14 @@ pub enum TagError {
         reference_count: usize,
         references_display: String,
     },
+
+    #[error(
+        "TAG `{tag_name}` has {unrecognized_reference_count} unrecognized reference key(s). Remove the references before dropping it."
+    )]
+    TagHasUnrecognizedReferences {
+        tag_name: String,
+        unrecognized_reference_count: usize,
+    },
 }
 
 impl TagError {
@@ -52,6 +60,16 @@ impl TagError {
             tag_name,
             reference_count,
             references_display,
+        }
+    }
+
+    pub fn tag_has_unrecognized_references(
+        tag_name: String,
+        unrecognized_reference_count: usize,
+    ) -> Self {
+        Self::TagHasUnrecognizedReferences {
+            tag_name,
+            unrecognized_reference_count,
         }
     }
 }
@@ -114,6 +132,9 @@ impl From<TagError> for ErrorCode {
         match value {
             TagError::TagNotFound { .. } => ErrorCode::UnknownTag(s),
             TagError::TagHasReferences { .. } => ErrorCode::TagHasReferences(s),
+            TagError::TagHasUnrecognizedReferences { .. } => {
+                ErrorCode::TagHasUnrecognizedReferences(s)
+            }
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Tag DDL was introduced in v1.2.863 (#19109), and User/Role/Stream tagging was added later (#19484). If a newer binary writes tag references for these new object types and the cluster is rolled back to any version between v1.2.863 and v1.2.883, list_pb fails to deserialize the unknown variants, breaking both drop_tag and list_tag_references entirely.

Replace list_pb with raw list_kv + manual key decoding (list_tag_ref_keys_tolerant) so unrecognized keys are collected separately instead of causing hard failures. drop_tag blocks deletion with a dedicated TagHasUnrecognizedReferences error to preserve data for investigation, while list_tag_references silently skips them.

  ## Changes
  - Replace `list_pb` decode path with tolerant `list_kv` + manual key decode in tag reference scanning.
  - Skip unrecognized tag reference keys (with warn logs) instead of failing the whole operation.
  - Keep `drop_tag` safe: return `TagHasUnrecognizedReferences` if unknown references exist.
  - Add new error code: `TagHasUnrecognizedReferences(2754)`.
  - Make scanning streaming (`try_next`) to avoid `try_collect` memory spikes on large prefixes.

  Affected versions: v1.2.863~ v1.2.883 (all versions with tag support but without this fix).

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19497)
<!-- Reviewable:end -->
