### PR TITLE
fix(query): support unquoted Unicode aliases and identifiers

### DIFF
--- a/src/query/ast/src/ast/quote.rs
+++ b/src/query/ast/src/ast/quote.rs
@@ -18,9 +18,12 @@ use std::iter::Peekable;
 use std::str::FromStr;
 
 use crate::parser::Dialect;
+use crate::parser::token::is_ident_continue;
+use crate::parser::token::is_ident_start;
 
-// In ANSI SQL, it does not need to quote an identifier if the identifier matches
-// the following regular expression: [A-Za-z_][A-Za-z0-9_$]*.
+// An identifier does not need quoting if it matches the rules defined by
+// is_ident_start / is_ident_continue (ASCII letters, underscore, digits, `$`,
+// plus any Unicode Alphabetic character — CJK, Cyrillic, etc.).
 //
 // There are also two known special cases in Databend which do not require quoting:
 // - "~" is a valid stage name
@@ -37,12 +40,12 @@ pub fn ident_needs_quote(ident: &str) -> bool {
 
     let mut chars = ident.chars();
     let first = chars.next().unwrap();
-    if !first.is_ascii_alphabetic() && first != '_' {
+    if !is_ident_start(first) {
         return true;
     }
 
     for c in chars {
-        if !c.is_ascii_alphanumeric() && c != '_' && c != '$' {
+        if !is_ident_continue(c) {
             return true;
         }
     }
@@ -57,7 +60,11 @@ pub fn display_ident(
     dialect: Dialect,
 ) -> String {
     // Db-s -> "Db-s" ; dbs -> dbs
-    if name.chars().any(|c| c.is_ascii_uppercase()) && quoted_ident_case_sensitive
+    // Quote the identifier if it would change under to_lowercase(), so that
+    // round-tripping through normalize_identifier (which lowercases unquoted
+    // idents) preserves the original name.  This covers both uppercase (Lu)
+    // and titlecase (Lt) Unicode characters — e.g. ǅ (U+01C5).
+    if name != name.to_lowercase() && quoted_ident_case_sensitive
         || ident_needs_quote(name)
         || force_quoted_ident
     {
@@ -73,7 +80,7 @@ pub fn ident_opt_quote(
     quoted_ident_case_sensitive: bool,
     dialect: Dialect,
 ) -> Option<char> {
-    if name.chars().any(|c| c.is_ascii_uppercase()) && quoted_ident_case_sensitive
+    if name != name.to_lowercase() && quoted_ident_case_sensitive
         || ident_needs_quote(name)
         || force_quoted_ident
     {

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -137,6 +137,45 @@ impl<'a> Iterator for Tokenizer<'a> {
     }
 }
 
+/// Returns true if `c` can start an unquoted identifier.
+///
+/// ASCII letters and underscore are accepted, plus any Unicode character with
+/// the Alphabetic derived property (`char::is_alphabetic()` — covers CJK,
+/// Cyrillic, Arabic, etc. while excluding separators, punctuation, and symbols).
+pub fn is_ident_start(c: char) -> bool {
+    c == '_' || c.is_alphabetic()
+}
+
+/// Returns true if `c` can continue an unquoted identifier.
+///
+/// Same as `is_ident_start`, plus ASCII digits and `$`.
+/// Non-ASCII digits are also accepted via `char::is_alphanumeric()`.
+pub fn is_ident_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_alphanumeric()
+}
+
+fn bump_ident_continue(lex: &mut Lexer<TokenKind>) {
+    loop {
+        match lex.remainder().chars().next() {
+            Some(c) if is_ident_continue(c) => lex.bump(c.len_utf8()),
+            _ => break,
+        }
+    }
+}
+
+fn lex_ascii_ident(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    bump_ident_continue(lex);
+    logos::FilterResult::Emit(())
+}
+
+fn lex_unicode_ident(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    if !is_ident_start(lex.slice().chars().next().unwrap()) {
+        return logos::FilterResult::Error;
+    }
+    bump_ident_continue(lex);
+    logos::FilterResult::Emit(())
+}
+
 fn lex_comment_block(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
     let remainder = lex.remainder().as_bytes();
 
@@ -167,7 +206,8 @@ pub enum TokenKind {
     #[token("/*", lex_comment_block)]
     CommentBlock,
 
-    #[regex(r#"[_a-zA-Z][_$a-zA-Z0-9]*"#)]
+    #[regex(r#"[_a-zA-Z][_$a-zA-Z0-9]*"#, lex_ascii_ident)]
+    #[regex(r"[^\x00-\x7f]", lex_unicode_ident)]
     Ident,
 
     #[regex(r#"\$[_a-zA-Z][_$a-zA-Z0-9]*"#)]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1728,7 +1728,7 @@ fn test_quote() {
         ("a\\\"b", "\"a\\\"\"b\""),
         ("12", "\"12\""),
         ("🍣", "\"🍣\""),
-        ("価格", "\"価格\""),
+        ("価格", "価格"),
         ("\t", "\"\t\""),
         ("complex \"string\"", "\"complex \"\"string\"\"\""),
         ("\"\"\"", "\"\"\"\"\"\"\"\""),
@@ -1747,5 +1747,45 @@ fn test_quote() {
         } else {
             assert_eq!(input, expected);
         };
+    }
+}
+
+#[test]
+fn test_unicode_ident_tokenize() {
+    let cases = &[
+        ("中文", vec![(TokenKind::Ident, "中文")]),
+        ("価格", vec![(TokenKind::Ident, "価格")]),
+        ("SELECT 'a' AS 中文", vec![
+            (TokenKind::SELECT, "SELECT"),
+            (TokenKind::LiteralString, "'a'"),
+            (TokenKind::AS, "AS"),
+            (TokenKind::Ident, "中文"),
+        ]),
+        // Mixed ASCII and Unicode
+        ("abc中文", vec![(TokenKind::Ident, "abc中文")]),
+        ("abc中文123", vec![(TokenKind::Ident, "abc中文123")]),
+        ("_中文", vec![(TokenKind::Ident, "_中文")]),
+        ("_列名_1", vec![(TokenKind::Ident, "_列名_1")]),
+        // Non-BMP but Alphabetic (CJK Extension B U+20000) — still valid
+        ("𠀀", vec![(TokenKind::Ident, "𠀀")]),
+        ("abc𠀀123", vec![(TokenKind::Ident, "abc𠀀123")]),
+        ("_𠀀$1", vec![(TokenKind::Ident, "_𠀀$1")]),
+    ];
+
+    for (input, expected) in cases {
+        let tokens: Vec<_> = Tokenizer::new(input)
+            .map(|t| t.unwrap())
+            .filter(|t| t.kind != TokenKind::EOI)
+            .map(|t| (t.kind, t.text().to_string()))
+            .collect();
+        let tokens: Vec<_> = tokens.iter().map(|(k, s)| (*k, s.as_str())).collect();
+        assert_eq!(tokens, *expected, "input: {input}");
+    }
+
+    // Emoji is not Alphabetic, tokenizer must return an error
+    let err_cases = &["🍣"];
+    for input in err_cases {
+        let result: std::result::Result<Vec<_>, _> = Tokenizer::new(input).collect();
+        assert!(result.is_err(), "expected error for input: {input}");
     }
 }

--- a/src/query/sql/src/planner/semantic/name_resolution.rs
+++ b/src/query/sql/src/planner/semantic/name_resolution.rs
@@ -41,7 +41,7 @@ pub enum NameResolutionSuggest {
 
 impl NameResolutionContext {
     pub fn not_found_suggest(&self, ident: &Identifier) -> Option<NameResolutionSuggest> {
-        if !ident.name.chars().any(|c| c.is_ascii_uppercase()) {
+        if !ident.name.chars().any(|c| c.is_uppercase()) {
             return None;
         }
         match (

--- a/src/query/sql/src/planner/semantic/tests/identifier_quote_test.rs
+++ b/src/query/sql/src/planner/semantic/tests/identifier_quote_test.rs
@@ -15,6 +15,7 @@
 mod tests {
 
     use databend_common_ast::ast::Identifier;
+    use databend_common_ast::ast::quote::display_ident;
     use databend_common_ast::parser::Dialect;
     use databend_common_ast::parser::parse_sql;
     use databend_common_ast::parser::tokenize_sql;
@@ -182,6 +183,40 @@ mod tests {
 
         // The name should be lowercase due to the case insensitive context
         assert_eq!(third_norm.name, "mixedcaseidentifier");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_display_ident_quotes_unicode_uppercase_when_case_sensitive() -> anyhow::Result<()> {
+        let context = NameResolutionContext {
+            unquoted_ident_case_sensitive: false,
+            quoted_ident_case_sensitive: true,
+            deny_column_reference: false,
+        };
+
+        let rendered = display_ident(
+            "Ж",
+            false,
+            context.quoted_ident_case_sensitive,
+            Dialect::PostgreSQL,
+        );
+        assert_eq!(
+            rendered, r#""Ж""#,
+            "Unicode uppercase identifiers must stay quoted in output"
+        );
+
+        let reparsed_unquoted = Identifier {
+            span: Default::default(),
+            name: "Ж".to_string(),
+            quote: None,
+            ident_type: Default::default(),
+        };
+        let normalized = normalize_identifier(&reparsed_unquoted, &context);
+        assert_eq!(
+            normalized.name, "ж",
+            "Unquoted reparsing lowercases the identifier, so output must preserve quotes"
+        );
 
         Ok(())
     }

--- a/tests/sqllogictests/suites/query/alias/unicode_ident.test
+++ b/tests/sqllogictests/suites/query/alias/unicode_ident.test
@@ -1,0 +1,33 @@
+query T
+SELECT 'a' AS 中文
+----
+a
+
+query T
+SELECT 'hello' AS 価格
+----
+hello
+
+query TI
+SELECT 'x' AS 名前, 1 AS 数値
+----
+x 1
+
+statement ok
+CREATE OR REPLACE TABLE 测试表 (列名 STRING, 数量 INT)
+
+statement ok
+INSERT INTO 测试表 VALUES ('foo', 42)
+
+query TI
+SELECT 列名, 数量 FROM 测试表
+----
+foo 42
+
+query TI
+SELECT 列名 AS 名前, 数量 AS 値 FROM 测试表
+----
+foo 42
+
+statement ok
+DROP TABLE IF EXISTS 测试表


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 Accept Unicode alphabetic characters in unquoted identifiers so
  aliases like `AS 中文` work without quotes.

  Keep lexer and quote/display rules consistent by sharing the same
  identifier character checks. Symbols, separators, and emoji remain
  rejected.

Fix: #19522

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19526)
<!-- Reviewable:end -->
