### PR TITLE
fix(http): skip S3 refresh for attached tables in HTTP catalog endpoints

### DIFF
--- a/src/query/service/src/servers/http/v1/catalog/get_database_table.rs
+++ b/src/query/service/src/servers/http/v1/catalog/get_database_table.rs
@@ -64,7 +64,9 @@ async fn handle(
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
 
     let db = catalog.get_database(&tenant, &database).await?;
     if !visibility_checker.check_database_visibility(

--- a/src/query/service/src/servers/http/v1/catalog/list_database_streams.rs
+++ b/src/query/service/src/servers/http/v1/catalog/list_database_streams.rs
@@ -63,7 +63,9 @@ async fn handle(ctx: &HttpQueryContext, database: String) -> Result<ListDatabase
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
     let db = catalog.get_database(&tenant, &database).await?;
 
     if !visibility_checker.check_database_visibility(

--- a/src/query/service/src/servers/http/v1/catalog/list_database_table_fields.rs
+++ b/src/query/service/src/servers/http/v1/catalog/list_database_table_fields.rs
@@ -53,7 +53,9 @@ async fn handle(
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
     let db = catalog.get_database(&tenant, &database).await?;
     if !visibility_checker.check_database_visibility(
         catalog.name().as_str(),

--- a/src/query/service/src/servers/http/v1/catalog/list_database_tables.rs
+++ b/src/query/service/src/servers/http/v1/catalog/list_database_tables.rs
@@ -45,7 +45,9 @@ async fn handle(ctx: &HttpQueryContext, database: String) -> Result<ListDatabase
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
     let db = catalog.get_database(&tenant, &database).await?;
 
     if !visibility_checker.check_database_visibility(

--- a/src/query/service/src/servers/http/v1/catalog/search_tables.rs
+++ b/src/query/service/src/servers/http/v1/catalog/search_tables.rs
@@ -58,10 +58,12 @@ async fn handle(ctx: &HttpQueryContext, keyword: String) -> Result<SearchTablesR
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
 
     let mut tables = vec![];
-    let warnings = vec![];
+    let mut warnings = vec![];
 
     for db in catalog.list_databases(&tenant).await? {
         if !visibility_checker.check_database_visibility(
@@ -71,7 +73,21 @@ async fn handle(ctx: &HttpQueryContext, keyword: String) -> Result<SearchTablesR
         ) {
             continue;
         }
-        for tbl in db.list_tables().await? {
+        let db_tables = match db.list_tables().await {
+            Ok(tables) => tables,
+            Err(err) => {
+                let msg = format!(
+                    "Failed to list tables in database {}.{}: {}",
+                    catalog.name(),
+                    db.name(),
+                    err
+                );
+                log::warn!("{}", msg);
+                warnings.push(msg);
+                continue;
+            }
+        };
+        for tbl in db_tables {
             if !tbl.name().contains(&keyword) {
                 continue;
             }

--- a/src/query/service/src/servers/http/v1/catalog/stats.rs
+++ b/src/query/service/src/servers/http/v1/catalog/stats.rs
@@ -38,7 +38,9 @@ async fn handle(ctx: &HttpQueryContext) -> Result<CatalogStatsResponse> {
         .get_visibility_checker(false, Object::All)
         .await?;
 
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
 
     let mut tables: u64 = 0;
     let mut databases: u64 = 0;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Attached tables whose S3 storage is unreachable from the manage service
cause HTTP catalog endpoints to fail. Add disable_table_info_refresh to
all HTTP catalog endpoints to skip S3 snapshot refresh, using metastore
metadata only. This mirrors the approach already used by system.tables.

Also add per-database error handling in search_tables (which has a
warnings field) so one bad database does not break the whole response.
Other endpoints like stats intentionally remain fail-fast since their
response contracts have no way to signal partial results.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19548)
<!-- Reviewable:end -->
