### PR TITLE
feat: optimize small bloom index reads

### DIFF
--- a/src/query/service/tests/it/indexes/ngram_index/index_refresh.rs
+++ b/src/query/service/tests/it/indexes/ngram_index/index_refresh.rs
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use databend_common_exception::Result;
 use databend_common_storage::DataOperator;
+use databend_common_storages_fuse::TableContext;
 use databend_common_storages_fuse::io::read::bloom::block_filter_reader::load_bloom_filter_by_columns;
 use databend_query::storages::index::filters::BlockFilter;
 use databend_query::test_kits::TestFixture;
+use databend_storages_common_io::ReadSettings;
 use futures_util::StreamExt;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -117,8 +121,11 @@ async fn get_block_filter(fixture: &TestFixture, columns: &[String]) -> Result<B
     let path = *path.as_string().unwrap();
     let length = block.get_by_offset(1).index(0).unwrap();
 
+    let ctx = fixture.new_query_ctx().await?;
+    let table_ctx: Arc<dyn TableContext> = ctx.clone();
     load_bloom_filter_by_columns(
         DataOperator::instance().operator(),
+        &ReadSettings::from_ctx(&table_ctx)?,
         columns,
         path,
         *length.as_number().unwrap().as_u_int64().unwrap(),

--- a/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use arrow::datatypes::Field;
 use arrow::datatypes::Fields;
 use arrow::datatypes::Schema;
+use bytes::Bytes;
 use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_base::runtime::Runtime;
 use databend_common_exception::ErrorCode;
@@ -28,25 +29,33 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
+use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CachedObject;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_index::BloomIndexMeta;
 use databend_storages_common_index::filters::FilterImpl;
+use databend_storages_common_io::ReadSettings;
 use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::SingleColumnMeta;
 use futures_util::future::try_join_all;
 use opendal::Operator;
 use parquet::arrow::ArrowSchemaConverter;
+use parquet::format::FileMetaData;
 use parquet::schema::types::SchemaDescPtr;
+use parquet::thrift::TSerializable;
+use thrift::protocol::TCompactInputProtocol;
 
 use crate::index::filters::BlockBloomFilterIndexVersion;
 use crate::index::filters::BlockFilter;
 use crate::io::MetaReaders;
 use crate::io::read::bloom::column_filter_reader::BloomColumnFilterReader;
+
 #[async_trait::async_trait]
 pub trait BloomBlockFilterReader {
     async fn read_block_filter(
         &self,
         dal: Operator,
+        settings: &ReadSettings,
         columns: &[String],
         index_length: u64,
     ) -> Result<BlockFilter>;
@@ -60,6 +69,7 @@ impl BloomBlockFilterReader for Location {
     async fn read_block_filter(
         &self,
         dal: Operator,
+        settings: &ReadSettings,
         columns: &[String],
         index_length: u64,
     ) -> Result<BlockFilter> {
@@ -72,7 +82,8 @@ impl BloomBlockFilterReader for Location {
             BlockBloomFilterIndexVersion::V2(_)
             | BlockBloomFilterIndexVersion::V3(_)
             | BlockBloomFilterIndexVersion::V4(_) => {
-                let res = load_bloom_filter_by_columns(dal, columns, path, index_length).await?;
+                let res = load_bloom_filter_by_columns(dal, settings, columns, path, index_length)
+                    .await?;
                 Ok(res)
             }
         }
@@ -83,12 +94,17 @@ impl BloomBlockFilterReader for Location {
 #[fastrace::trace]
 pub async fn load_bloom_filter_by_columns<'a>(
     dal: Operator,
+    settings: &ReadSettings,
     column_needed: &'a [String],
     index_path: &'a str,
     index_length: u64,
 ) -> Result<BlockFilter> {
+    let whole_file =
+        prepare_bloom_index_read_source(&dal, settings, index_path, index_length).await?;
+
     // 1. load index meta
-    let bloom_index_meta = load_index_meta(dal.clone(), index_path, index_length).await?;
+    let bloom_index_meta =
+        load_index_meta(dal.clone(), index_path, index_length, whole_file.as_ref()).await?;
 
     // 2. filter out columns that needed and exist in the index
     // 2.1 dedup the columns
@@ -125,6 +141,7 @@ pub async fn load_bloom_filter_by_columns<'a>(
                 index_path,
                 &dal,
                 bloom_index_schema_desc.clone(),
+                whole_file.as_ref(),
             )
         })
         .collect::<Vec<_>>();
@@ -155,6 +172,7 @@ async fn load_column_bloom_filter<'a>(
     index_path: &'a str,
     dal: &'a Operator,
     bloom_index_schema_desc: SchemaDescPtr,
+    whole_file: Option<&Arc<Bytes>>,
 ) -> Result<Arc<FilterImpl>> {
     let storage_runtime = GlobalIORuntime::instance();
     let bytes = {
@@ -166,7 +184,8 @@ async fn load_column_bloom_filter<'a>(
             dal.clone(),
             bloom_index_schema_desc,
         );
-        async move { column_data_reader.read().await }
+        let whole_file = whole_file.cloned();
+        async move { column_data_reader.read(whole_file.as_ref()).await }
     }
     .execute_in_runtime(&storage_runtime)
     .await??;
@@ -180,7 +199,16 @@ pub async fn load_index_meta(
     dal: Operator,
     path: &str,
     length: u64,
+    whole_file: Option<&Arc<Bytes>>,
 ) -> Result<Arc<BloomIndexMeta>> {
+    if let Some(whole_file) = whole_file {
+        let meta = load_index_meta_from_bytes(whole_file)?;
+        if let Some(cache) = BloomIndexMeta::cache() {
+            return Ok(cache.insert(path.to_owned(), meta));
+        }
+        return Ok(Arc::new(meta));
+    }
+
     let path_owned = path.to_owned();
     async move {
         let reader = MetaReaders::bloom_index_meta_reader(dal);
@@ -199,6 +227,63 @@ pub async fn load_index_meta(
     }
     .execute_in_runtime(&GlobalIORuntime::instance())
     .await?
+}
+
+async fn prepare_bloom_index_read_source(
+    dal: &Operator,
+    settings: &ReadSettings,
+    path: &str,
+    index_length: u64,
+) -> Result<Option<Arc<Bytes>>> {
+    if should_read_whole_bloom_index(path, settings, index_length) {
+        let data = dal.read(path).await?;
+        return Ok(Some(Arc::new(data.to_bytes())));
+    }
+
+    Ok(None)
+}
+
+fn should_read_whole_bloom_index(path: &str, settings: &ReadSettings, index_length: u64) -> bool {
+    if index_length > settings.parquet_fast_read_bytes {
+        return false;
+    }
+
+    !BloomIndexMeta::cache().is_some_and(|cache| cache.contains_key(path))
+}
+
+fn load_index_meta_from_bytes(data: &Bytes) -> Result<BloomIndexMeta> {
+    const HEADER_SIZE: usize = 4;
+    const FOOTER_SIZE: usize = 8;
+    const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
+
+    if data.len() < HEADER_SIZE + FOOTER_SIZE {
+        return Err(ErrorCode::StorageOther(
+            "read bloom index meta failed, A parquet file must contain a header and footer with at least 12 bytes"
+                .to_string(),
+        ));
+    }
+
+    if data[data.len() - PARQUET_MAGIC.len()..] != PARQUET_MAGIC {
+        return Err(ErrorCode::StorageOther(
+            "read bloom index meta failed, Invalid Parquet file. Corrupt footer".to_string(),
+        ));
+    }
+
+    let metadata_len = i32::from_le_bytes(data[data.len() - 8..data.len() - 4].try_into().unwrap());
+    let metadata_len: u64 = metadata_len.try_into()?;
+    let footer_len = FOOTER_SIZE as u64 + metadata_len;
+    if footer_len > data.len() as u64 {
+        return Err(ErrorCode::StorageOther(
+            "read bloom index meta failed, The footer size must be smaller or equal to the file's size"
+                .to_string(),
+        ));
+    }
+
+    let remaining = data.len() - footer_len as usize;
+    let mut prot = TCompactInputProtocol::new(&data[remaining..]);
+    let thrift_meta = FileMetaData::read_from_in_protocol(&mut prot)
+        .map_err(|err| ErrorCode::StorageOther(format!("read bloom index meta failed, {err}")))?;
+    BloomIndexMeta::try_from(thrift_meta)
 }
 
 #[async_trait::async_trait]
@@ -220,5 +305,135 @@ where
             .spawn(self)
             .await
             .map_err(|e| ErrorCode::TokioError(format!("runtime join error. {}", e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::OnceLock;
+
+    use databend_common_base::base::GlobalInstance;
+    use databend_common_base::runtime::GlobalIORuntime;
+    use databend_common_config::CacheConfig;
+    use databend_common_exception::Result;
+    use databend_common_expression::DataBlock;
+    use databend_common_expression::FromData;
+    use databend_common_expression::FunctionContext;
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::types::Int32Type;
+    use databend_storages_common_blocks::blocks_to_parquet;
+    use databend_storages_common_cache::CacheAccessor;
+    use databend_storages_common_cache::CacheManager;
+    use databend_storages_common_cache::CachedObject;
+    use databend_storages_common_index::BloomIndex;
+    use databend_storages_common_index::BloomIndexBuilder;
+    use databend_storages_common_index::filters::BlockFilter;
+    use databend_storages_common_table_meta::meta::Versioned;
+    use databend_storages_common_table_meta::table::TableCompression;
+
+    use super::*;
+
+    fn init_test_globals() -> Result<()> {
+        static INIT: OnceLock<Result<()>> = OnceLock::new();
+        INIT.get_or_init(|| {
+            GlobalInstance::init_production();
+            GlobalIORuntime::init(1)?;
+            CacheManager::init(&CacheConfig::default(), &(1024 * 1024), "test", false)
+        })
+        .clone()
+    }
+
+    fn write_bloom_index_bytes() -> Result<(Vec<u8>, String)> {
+        let schema = TableSchema::new(vec![TableField::new(
+            "y",
+            TableDataType::Number(databend_common_expression::types::NumberDataType::Int32),
+        )]);
+        let field = schema.field_with_name("y")?;
+        let bloom_columns_map = BTreeMap::from([(0usize, field.clone())]);
+        let mut builder =
+            BloomIndexBuilder::create(FunctionContext::default(), bloom_columns_map, &[])?;
+        let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![1, 2, 3, 4])]);
+        builder.add_block(&block)?;
+        let bloom_index = builder.finalize()?.unwrap();
+
+        let index_block = bloom_index.serialize_to_data_block()?;
+        let mut data = Vec::new();
+        let _ = blocks_to_parquet(
+            &bloom_index.filter_schema,
+            vec![index_block],
+            &mut data,
+            TableCompression::None,
+            false,
+            None,
+        )?;
+
+        let filter_name = BloomIndex::build_filter_bloom_name(
+            BlockFilter::VERSION,
+            schema.field_with_name("y")?,
+        )?;
+        Ok((data, filter_name))
+    }
+
+    #[test]
+    fn test_should_read_whole_bloom_index_by_threshold_and_cache() -> Result<()> {
+        init_test_globals()?;
+        let path = "bloom_index";
+        let settings = ReadSettings {
+            max_gap_size: 0,
+            max_range_size: 0,
+            parquet_fast_read_bytes: 1024,
+        };
+
+        if let Some(cache) = BloomIndexMeta::cache() {
+            cache.evict(path);
+        }
+        assert!(should_read_whole_bloom_index(path, &settings, 512));
+        assert!(!should_read_whole_bloom_index(path, &settings, 2048));
+
+        if let Some(cache) = BloomIndexMeta::cache() {
+            cache.insert(path.to_string(), BloomIndexMeta { columns: vec![] });
+        }
+        assert!(!should_read_whole_bloom_index(path, &settings, 512));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_load_bloom_filter_by_columns_from_small_whole_file() -> Result<()> {
+        init_test_globals()?;
+
+        let (data, filter_name) = write_bloom_index_bytes()?;
+        let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
+        let path = "bloom_index";
+        operator.write(path, data.clone()).await?;
+
+        if let Some(cache) = BloomIndexMeta::cache() {
+            cache.evict(path);
+        }
+        if let Some(cache) = FilterImpl::cache() {
+            cache.evict(&format!("{path}-{filter_name}"));
+        }
+
+        let settings = ReadSettings {
+            max_gap_size: 0,
+            max_range_size: 0,
+            parquet_fast_read_bytes: data.len() as u64,
+        };
+
+        let block_filter = load_bloom_filter_by_columns(
+            operator,
+            &settings,
+            &[filter_name.clone()],
+            path,
+            data.len() as u64,
+        )
+        .await?;
+
+        assert_eq!(block_filter.filter_schema.num_fields(), 1);
+        assert_eq!(block_filter.filter_schema.fields()[0].name(), &filter_name);
+        assert_eq!(block_filter.filters.len(), 1);
+        Ok(())
     }
 }

--- a/src/query/storages/fuse/src/io/read/bloom/column_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/column_filter_reader.rs
@@ -14,13 +14,15 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
 use databend_common_exception::Result;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnId;
 use databend_common_metrics::storage::metrics_inc_block_index_read_bytes;
+use databend_storages_common_cache::BloomIndexFilterCache;
+use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheKey;
 use databend_storages_common_cache::CachedObject;
-use databend_storages_common_cache::HybridCacheReader;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_cache::Loader;
 use databend_storages_common_index::filters::Filter;
@@ -35,13 +37,12 @@ use parquet::schema::types::SchemaDescPtr;
 
 use crate::io::read::block::parquet::RowGroupImplBuilder;
 
-type CachedReader = HybridCacheReader<FilterImpl, BloomFilterLoader>;
-
 /// Load the filter of a given bloom index column. Also
 /// - generates the proper cache key
 /// - takes cares of getting the correct cache instance from [CacheManager]
 pub struct BloomColumnFilterReader {
-    cached_reader: CachedReader,
+    cache: Option<BloomIndexFilterCache>,
+    loader: BloomFilterLoader,
     param: LoadParams,
 }
 
@@ -72,8 +73,6 @@ impl BloomColumnFilterReader {
             column_id,
         };
 
-        let cached_reader = CachedReader::new(FilterImpl::cache(), loader);
-
         let param = LoadParams {
             location: index_path,
             len_hint: None,
@@ -82,14 +81,33 @@ impl BloomColumnFilterReader {
         };
 
         BloomColumnFilterReader {
-            cached_reader,
+            cache: FilterImpl::cache(),
+            loader,
             param,
         }
     }
 
     #[async_backtrace::framed]
-    pub async fn read(&self) -> Result<Arc<FilterImpl>> {
-        self.cached_reader.read(&self.param).await
+    pub async fn read(&self, whole_file: Option<&Arc<Bytes>>) -> Result<Arc<FilterImpl>> {
+        let cache_key = self.loader.cache_key(&self.param);
+
+        if let Some(cache) = &self.cache {
+            if let Some(item) = cache.get(&cache_key) {
+                return Ok(item);
+            }
+        }
+
+        let filter = if let Some(data) = whole_file {
+            self.loader.load_from_source(data.as_ref())?
+        } else {
+            self.loader.load(&self.param).await?
+        };
+
+        if let Some(cache) = &self.cache {
+            Ok(cache.insert(cache_key, filter))
+        } else {
+            Ok(Arc::new(filter))
+        }
     }
 }
 
@@ -113,12 +131,27 @@ impl Loader<FilterImpl> for BloomFilterLoader {
             .read_with(&params.location)
             .range(self.offset..self.offset + self.len)
             .await?;
+        self.decode_filter(chunk.to_bytes())
+    }
+
+    fn cache_key(&self, _params: &LoadParams) -> CacheKey {
+        self.cache_key.clone()
+    }
+}
+
+impl BloomFilterLoader {
+    fn load_from_source(&self, data: &Bytes) -> Result<FilterImpl> {
+        let chunk = data.slice(self.offset as usize..(self.offset + self.len) as usize);
+        self.decode_filter(chunk)
+    }
+
+    fn decode_filter(&self, chunk: Bytes) -> Result<FilterImpl> {
         let mut builder = RowGroupImplBuilder::new(
             self.num_values as usize,
             &self.schema_desc,
             ParquetCompression::UNCOMPRESSED,
         );
-        builder.add_column_chunk(self.column_id as usize, chunk);
+        builder.add_column_chunk(self.column_id as usize, chunk.into());
         let row_group = Box::new(builder.build());
         let field_levels = parquet_to_arrow_field_levels(
             self.schema_desc.as_ref(),
@@ -146,9 +179,5 @@ impl Loader<FilterImpl> for BloomFilterLoader {
         metrics_inc_block_index_read_bytes(filter_bytes.len() as u64);
         let (filter, _size) = FilterImpl::from_bytes(filter_bytes)?;
         Ok(filter)
-    }
-
-    fn cache_key(&self, _params: &LoadParams) -> CacheKey {
-        self.cache_key.clone()
     }
 }

--- a/src/query/storages/fuse/src/operations/read/native_data_transform_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/native_data_transform_reader.rs
@@ -27,6 +27,7 @@ use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline_transforms::processors::AsyncTransform;
 use databend_common_pipeline_transforms::processors::AsyncTransformer;
 use databend_common_sql::IndexType;
+use databend_storages_common_io::ReadSettings;
 use log::debug;
 
 use super::native_data_source::NativeDataSource;
@@ -99,6 +100,7 @@ impl AsyncTransform for ReadNativeDataTransform {
                         self.func_ctx.clone(),
                         self.table_schema.clone(),
                         self.block_reader.operator(),
+                        ReadSettings::from_ctx(&self.context)?,
                         inlist_bloom_prune_threshold,
                         runtime_filters
                             .into_iter()

--- a/src/query/storages/fuse/src/operations/read/parquet_data_transform_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_transform_reader.rs
@@ -123,6 +123,7 @@ impl AsyncTransform for ReadParquetDataTransform {
                         self.func_ctx.clone(),
                         self.table_schema.clone(),
                         self.block_reader.operator(),
+                        ReadSettings::from_ctx(&self.context)?,
                         inlist_bloom_prune_threshold,
                         runtime_filters
                             .into_iter()

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -761,7 +761,12 @@ impl AggregationContext {
         // using load_bloom_filter_by_columns is attractive,
         // but it do not care about the version of the bloom filter index
         let block_filter = location
-            .read_block_filter(self.data_accessor.clone(), &col_names, index_len)
+            .read_block_filter(
+                self.data_accessor.clone(),
+                &self.read_settings,
+                &col_names,
+                index_len,
+            )
             .await?;
 
         // reorder the filter according to the order of bloom_on_conflict_field

--- a/src/query/storages/fuse/src/operations/table_index.rs
+++ b/src/query/storages/fuse/src/operations/table_index.rs
@@ -204,6 +204,7 @@ pub async fn do_refresh_table_index(
                 NgramIndexTransform::new(
                     ctx.clone(),
                     operator.clone(),
+                    settings,
                     ngram_index_arg.index_ngram_args.clone(),
                     ngram_index_arg.ngram_index_names.clone(),
                     ngram_index_arg.existing_names_prefix.clone(),
@@ -371,7 +372,7 @@ async fn check_ngram_index_generated(
         .map(|meta| meta.content_length())
     {
         let bloom_index_meta =
-            load_index_meta(operator.clone(), &index_location, content_length).await?;
+            load_index_meta(operator.clone(), &index_location, content_length, None).await?;
 
         let mut all_generated = true;
         for ngram_index_name in &ngram_index_arg.ngram_index_names {
@@ -534,6 +535,7 @@ impl AsyncSource for IndexSource {
 pub struct NgramIndexTransform {
     ctx: Arc<dyn TableContext>,
     operator: Operator,
+    settings: ReadSettings,
     index_ngram_args: Vec<NgramArgs>,
     ngram_index_names: Vec<String>,
     existing_names_prefix: Vec<String>,
@@ -543,6 +545,7 @@ impl NgramIndexTransform {
     pub fn new(
         ctx: Arc<dyn TableContext>,
         operator: Operator,
+        settings: ReadSettings,
         index_ngram_args: Vec<NgramArgs>,
         ngram_index_names: Vec<String>,
         existing_names_prefix: Vec<String>,
@@ -550,6 +553,7 @@ impl NgramIndexTransform {
         Self {
             ctx,
             operator,
+            settings,
             index_ngram_args,
             ngram_index_names,
             existing_names_prefix,
@@ -607,6 +611,7 @@ impl AsyncTransform for NgramIndexTransform {
 
                 let mut block_filter = load_bloom_filter_by_columns(
                     self.operator.clone(),
+                    &self.settings,
                     &index_columns,
                     &index_path,
                     block_meta.bloom_filter_index_size,

--- a/src/query/storages/fuse/src/pruning/bloom_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/bloom_pruner.rs
@@ -32,6 +32,7 @@ use databend_storages_common_index::BloomIndex;
 use databend_storages_common_index::FilterEvalResult;
 use databend_storages_common_index::NgramArgs;
 use databend_storages_common_index::filters::BlockFilter;
+use databend_storages_common_io::ReadSettings;
 use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::column_oriented_segment::BlockReadInfo;
@@ -60,6 +61,7 @@ pub trait BloomPruner {
 pub(crate) async fn should_prune_runtime_inlist_by_bloom_index(
     func_ctx: &FunctionContext,
     dal: &Operator,
+    settings: &ReadSettings,
     data_schema: &TableSchemaRef,
     expr: &Expr<String>,
     part: &FuseBlockPartInfo,
@@ -97,7 +99,12 @@ pub(crate) async fn should_prune_runtime_inlist_by_bloom_index(
         .map(|field| BloomIndex::build_filter_bloom_name(index_location.1, field))
         .collect::<Result<Vec<_>>>()?;
     let filter = index_location
-        .read_block_filter(dal.clone(), &index_columns, part.bloom_filter_index_size)
+        .read_block_filter(
+            dal.clone(),
+            settings,
+            &index_columns,
+            part.bloom_filter_index_size,
+        )
         .await?;
 
     let bloom_index = BloomIndex::from_filter_block(
@@ -141,6 +148,8 @@ pub struct BloomPrunerCreator {
     /// the data accessor
     dal: Operator,
 
+    settings: ReadSettings,
+
     /// the schema of data being indexed
     data_schema: TableSchemaRef,
 
@@ -153,6 +162,7 @@ impl BloomPrunerCreator {
         func_ctx: FunctionContext,
         schema: &TableSchemaRef,
         dal: Operator,
+        settings: ReadSettings,
         filter_expr: Option<&Expr<String>>,
         bloom_index_cols: BloomIndexColumns,
         ngram_args: Vec<NgramArgs>,
@@ -206,6 +216,7 @@ impl BloomPrunerCreator {
             like_scalar_map,
             ngram_args,
             dal,
+            settings,
             data_schema: schema.clone(),
             bloom_index_builder,
         })))
@@ -243,7 +254,12 @@ impl BloomPrunerCreator {
 
         // load the relevant index columns
         let maybe_filter = index_location
-            .read_block_filter(self.dal.clone(), &index_columns, index_length)
+            .read_block_filter(
+                self.dal.clone(),
+                &self.settings,
+                &index_columns,
+                index_length,
+            )
             .await;
 
         let maybe_filter = match (&maybe_filter, &self.bloom_index_builder) {

--- a/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
@@ -29,6 +29,7 @@ use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_index::statistics_to_domain;
+use databend_storages_common_io::ReadSettings;
 use log::info;
 use log::warn;
 use opendal::Operator;
@@ -41,6 +42,7 @@ pub struct ExprRuntimePruner {
     func_ctx: FunctionContext,
     table_schema: TableSchemaRef,
     dal: Operator,
+    settings: ReadSettings,
     inlist_bloom_prune_threshold: usize,
     exprs: Vec<RuntimeFilterExpr>,
 }
@@ -66,6 +68,7 @@ impl ExprRuntimePruner {
         func_ctx: FunctionContext,
         table_schema: TableSchemaRef,
         dal: Operator,
+        settings: ReadSettings,
         inlist_bloom_prune_threshold: usize,
         exprs: Vec<RuntimeFilterExpr>,
     ) -> Self {
@@ -73,6 +76,7 @@ impl ExprRuntimePruner {
             func_ctx,
             table_schema,
             dal,
+            settings,
             inlist_bloom_prune_threshold,
             exprs,
         }
@@ -191,6 +195,7 @@ impl ExprRuntimePruner {
         should_prune_runtime_inlist_by_bloom_index(
             &self.func_ctx,
             &self.dal,
+            &self.settings,
             &self.table_schema,
             filter,
             part,
@@ -203,6 +208,8 @@ impl ExprRuntimePruner {
 mod tests {
     use std::collections::BTreeMap;
     use std::sync::OnceLock;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use databend_common_base::base::GlobalInstance;
     use databend_common_base::base::tokio;
@@ -225,12 +232,21 @@ mod tests {
     use databend_storages_common_cache::CacheManager;
     use databend_storages_common_index::BloomIndexBuilder;
     use databend_storages_common_index::filters::BlockFilter;
+    use databend_storages_common_io::ReadSettings;
     use databend_storages_common_table_meta::meta::ColumnStatistics;
     use databend_storages_common_table_meta::meta::Compression;
     use databend_storages_common_table_meta::meta::Versioned;
     use databend_storages_common_table_meta::table::TableCompression;
 
     use super::*;
+
+    fn test_read_settings() -> ReadSettings {
+        ReadSettings {
+            max_gap_size: 0,
+            max_range_size: 0,
+            parquet_fast_read_bytes: u64::MAX,
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_runtime_inlist_prunes_by_bloom_index() -> Result<()> {
@@ -242,15 +258,20 @@ mod tests {
         let part = make_part(&schema, index_location, index_size, 10, 40);
         let expr = inlist_expr("y", &[11, 21, 31])?;
         let stats = Arc::new(RuntimeFilterStats::default());
-        let pruner = ExprRuntimePruner::new(FunctionContext::default(), schema, operator, 3, vec![
-            RuntimeFilterExpr {
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            3,
+            vec![RuntimeFilterExpr {
                 filter_id: 0,
                 kind: RuntimeFilterExprKind::Inlist,
                 inlist_value_count: 3,
                 expr,
                 stats: stats.clone(),
-            },
-        ]);
+            }],
+        );
 
         assert!(pruner.prune(&part).await?);
 
@@ -268,15 +289,20 @@ mod tests {
         let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
         let (index_location, index_size) = write_bloom_index(&operator, &schema, &block).await?;
         let part = make_part(&schema, index_location, index_size, 10, 40);
-        let pruner = ExprRuntimePruner::new(FunctionContext::default(), schema, operator, 3, vec![
-            RuntimeFilterExpr {
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            3,
+            vec![RuntimeFilterExpr {
                 filter_id: 0,
                 kind: RuntimeFilterExprKind::Inlist,
                 inlist_value_count: 3,
                 expr: inlist_expr("y", &[11, 20, 31])?,
                 stats: Arc::new(RuntimeFilterStats::default()),
-            },
-        ]);
+            }],
+        );
 
         assert!(!pruner.prune(&part).await?);
         Ok(())
@@ -288,15 +314,20 @@ mod tests {
         let schema = test_schema();
         let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
         let part = make_part(&schema, None, 0, 10, 40);
-        let pruner = ExprRuntimePruner::new(FunctionContext::default(), schema, operator, 3, vec![
-            RuntimeFilterExpr {
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            3,
+            vec![RuntimeFilterExpr {
                 filter_id: 0,
                 kind: RuntimeFilterExprKind::Inlist,
                 inlist_value_count: 3,
                 expr: inlist_expr("y", &[11, 21, 31])?,
                 stats: Arc::new(RuntimeFilterStats::default()),
-            },
-        ]);
+            }],
+        );
 
         assert!(!pruner.prune(&part).await?);
         Ok(())
@@ -391,6 +422,7 @@ mod tests {
         schema: &TableSchemaRef,
         block: &DataBlock,
     ) -> Result<(Option<(String, u64)>, u64)> {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
         let (_, field) = schema.column_with_name("y").unwrap();
         let bloom_columns_map = BTreeMap::from([(0usize, field.clone())]);
         let mut builder =
@@ -399,7 +431,10 @@ mod tests {
         let bloom_index = builder.finalize()?.unwrap();
 
         let index_block = bloom_index.serialize_to_data_block()?;
-        let location = ("block_bloom".to_string(), BlockFilter::VERSION);
+        let location = (
+            format!("block_bloom_{}", NEXT_ID.fetch_add(1, Ordering::Relaxed)),
+            BlockFilter::VERSION,
+        );
         let mut data = Vec::new();
         let _ = blocks_to_parquet(
             &bloom_index.filter_schema,
@@ -422,15 +457,20 @@ mod tests {
         let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
         let (index_location, index_size) = write_bloom_index(&operator, &schema, &block).await?;
         let part = make_part(&schema, index_location, index_size, 10, 40);
-        let pruner = ExprRuntimePruner::new(FunctionContext::default(), schema, operator, 2, vec![
-            RuntimeFilterExpr {
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            2,
+            vec![RuntimeFilterExpr {
                 filter_id: 0,
                 kind: RuntimeFilterExprKind::Inlist,
                 inlist_value_count: 3,
                 expr: inlist_expr("y", &[11, 21, 31])?,
                 stats: Arc::new(RuntimeFilterStats::default()),
-            },
-        ]);
+            }],
+        );
 
         assert!(!pruner.prune(&part).await?);
         Ok(())
@@ -447,16 +487,20 @@ mod tests {
         let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
         let (index_location, index_size) = write_bloom_index(&operator, &schema, &block).await?;
         let part = make_part_u64(&schema, index_location, index_size, 42, 99942);
-        let pruner =
-            ExprRuntimePruner::new(FunctionContext::default(), schema, operator, 10, vec![
-                RuntimeFilterExpr {
-                    filter_id: 0,
-                    kind: RuntimeFilterExprKind::Inlist,
-                    inlist_value_count: 10,
-                    expr: inlist_expr_u64("y", &(50000u64..50010).collect::<Vec<_>>())?,
-                    stats: Arc::new(RuntimeFilterStats::default()),
-                },
-            ]);
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            10,
+            vec![RuntimeFilterExpr {
+                filter_id: 0,
+                kind: RuntimeFilterExprKind::Inlist,
+                inlist_value_count: 10,
+                expr: inlist_expr_u64("y", &(50000u64..50010).collect::<Vec<_>>())?,
+                stats: Arc::new(RuntimeFilterStats::default()),
+            }],
+        );
 
         assert!(pruner.prune(&part).await?);
         Ok(())

--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -166,6 +166,7 @@ impl PruningContext {
             func_ctx.clone(),
             &table_schema,
             dal.clone(),
+            ReadSettings::from_ctx(ctx)?,
             filter_expr.as_ref(),
             bloom_index_cols,
             ngram_args,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Optimize small bloom index reads by loading eligible files once and decoding both metadata and filters from the same in-memory buffer
- Reuse read settings in bloom pruning and ngram index refresh so the optimization applies to runtime pruning paths too

## Changes

This PR reduces extra range reads for small bloom index files.

## Implementation

1. Read the full bloom index file when its size is below `parquet_fast_read_bytes` and the metadata cache is cold
2. Decode bloom index metadata directly from in-memory parquet bytes and slice column chunks from the same buffer
3. Pass `ReadSettings` through bloom pruning, runtime inlist pruning, and ngram index refresh paths
4. Add regression coverage for the small-file whole-read path and update existing tests to use the new read settings plumbing

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation commands:

```bash
cargo clippy -p databend-common-storages-fuse --tests -- -D warnings
cargo test -p databend-common-storages-fuse test_load_bloom_filter_by_columns_from_small_whole_file --lib
```

## Type of change

- [x] Performance improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19552)
<!-- Reviewable:end -->
