### PR TITLE
fix(sql): implement recursive cte hooks in lite planner ctx

### DIFF
--- a/src/query/sql/tests/it/planner/fixture.rs
+++ b/src/query/sql/tests/it/planner/fixture.rs
@@ -1396,6 +1396,16 @@ impl TableContext for LiteTableContext {
     async fn drop_m_cte_temp_table(&self) -> Result<()> {
         Ok(())
     }
+    fn add_recursive_cte_temp_table(
+        &self,
+        _catalog_name: &str,
+        _database_name: &str,
+        _table_name: &str,
+    ) {
+    }
+    async fn drop_recursive_cte_temp_table(&self) -> Result<()> {
+        Ok(())
+    }
     fn get_next_broadcast_id(&self) -> u32 {
         0
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix the `linux / check` failure on `main` caused by `LiteTableContext` missing the new recursive CTE temp table hooks required by `TableContext`.

## Changes

- Added no-op implementations for `add_recursive_cte_temp_table` and `drop_recursive_cte_temp_table` in the planner test fixture `LiteTableContext`.
- Kept the behavior aligned with the existing `m_cte` temp table helpers used by the same lightweight test context.

## Implementation

1. Located the failing GitHub Actions job: https://github.com/databendlabs/databend/actions/runs/23183524583/job/67361514317
2. Confirmed `cargo clippy --workspace --all-targets --all-features -- -D warnings` was failing because `src/query/sql/tests/it/planner/fixture.rs` no longer implemented all required `TableContext` items.
3. Added the missing recursive CTE temp table hooks as no-op methods in `LiteTableContext`, which is sufficient for planner fixture tests.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation commands:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19558)
<!-- Reviewable:end -->
