### PR TITLE
fix(query): pass explicit data schema to spill reader instead of inferring from parquet metadata

### DIFF
--- a/src/query/expression/src/aggregate/aggregate_function_state.rs
+++ b/src/query/expression/src/aggregate/aggregate_function_state.rs
@@ -198,7 +198,7 @@ impl StateSerdeType {
 pub struct StatesLayout {
     pub layout: Layout,
     pub states_loc: Vec<Box<[AggrStateLoc]>>,
-    pub(super) serialize_type: Vec<StateSerdeType>,
+    pub serialize_type: Vec<StateSerdeType>,
 }
 
 impl StatesLayout {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_params.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregator_params.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
+use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
+use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::types::DataType;
 use databend_common_functions::aggregates::AggregateFunctionRef;
 use databend_common_functions::aggregates::StatesLayout;
@@ -106,5 +108,21 @@ impl AggregatorParams {
 
     pub fn num_states(&self) -> usize {
         self.aggregate_functions.len()
+    }
+
+    pub fn spill_schema(&self) -> DataSchemaRef {
+        let mut fields = vec![];
+        if let Some(states_layout) = &self.states_layout {
+            for (idx, typ) in states_layout.serialize_type.iter().enumerate() {
+                let data_type = typ.data_type();
+                fields.push(DataField::new(&format!("agg_{}", idx), data_type));
+            }
+        }
+
+        for (idx, typ) in self.group_data_types.iter().enumerate() {
+            fields.push(DataField::new(&format!("group_{}", idx), typ.clone()));
+        }
+
+        DataSchemaRefExt::create(fields)
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/build_partition_bucket.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/build_partition_bucket.rs
@@ -51,11 +51,12 @@ fn build_partition_bucket_experimental(
     let mut final_parallelism = ctx.get_settings().get_max_threads()? as usize;
     match shuffle_mode {
         AggregateShuffleMode::Row => {
+            let schema = params.spill_schema();
             pipeline.add_transform(|input, output| {
                 Ok(ProcessorPtr::create(RowShuffleReaderTransform::create(
                     input,
                     output,
-                    NewAggregateSpillReader::try_create(ctx.clone())?,
+                    NewAggregateSpillReader::try_create(ctx.clone(), schema.clone())?,
                 )))
             })?;
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_aggregate_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_aggregate_spiller.rs
@@ -24,6 +24,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockPartitionStream;
 use databend_common_expression::DataBlock;
+use databend_common_expression::DataSchemaRef;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_pipeline_transforms::traits::Location;
 use databend_common_storage::DataOperator;
@@ -320,6 +321,7 @@ pub struct NewAggregateSpiller<P: PartitionStream = SharedPartitionStream> {
     pub memory_settings: MemorySettings,
     read_setting: ReadSettings,
     partition_stream: P,
+    data_schema: DataSchemaRef,
     payload_writers: AggregatePayloadWriters,
 }
 
@@ -327,6 +329,7 @@ impl<P: PartitionStream> NewAggregateSpiller<P> {
     pub fn try_create(
         ctx: Arc<QueryContext>,
         partition_count: usize,
+        data_schema: DataSchemaRef,
         partition_stream: P,
     ) -> Result<Self> {
         let memory_settings = MemorySettings::from_aggregate_settings(&ctx)?;
@@ -339,6 +342,7 @@ impl<P: PartitionStream> NewAggregateSpiller<P> {
         Ok(Self {
             memory_settings,
             read_setting,
+            data_schema,
             partition_stream,
             payload_writers,
         })
@@ -363,29 +367,34 @@ impl<P: PartitionStream> NewAggregateSpiller<P> {
     }
 
     pub fn restore(&self, payload: NewSpilledPayload) -> Result<AggregateMeta> {
-        restore_payload(self.read_setting, payload)
+        restore_payload(self.read_setting, payload, &self.data_schema)
     }
 }
 
 pub struct NewAggregateSpillReader {
     read_setting: ReadSettings,
+    data_schema: DataSchemaRef,
 }
 
 impl NewAggregateSpillReader {
-    pub fn try_create(ctx: Arc<QueryContext>) -> Result<Self> {
+    pub fn try_create(ctx: Arc<QueryContext>, schema: DataSchemaRef) -> Result<Self> {
         let table_ctx: Arc<dyn TableContext> = ctx;
         let read_setting = ReadSettings::from_settings(&table_ctx.get_settings())?;
-        Ok(Self { read_setting })
+        Ok(Self {
+            read_setting,
+            data_schema: schema,
+        })
     }
 
     pub fn restore(&self, payload: NewSpilledPayload) -> Result<AggregateMeta> {
-        restore_payload(self.read_setting, payload)
+        restore_payload(self.read_setting, payload, &self.data_schema)
     }
 }
 
 fn restore_payload(
     read_setting: ReadSettings,
     payload: NewSpilledPayload,
+    data_schema: &DataSchemaRef,
 ) -> Result<AggregateMeta> {
     let NewSpilledPayload {
         bucket,
@@ -401,6 +410,7 @@ fn restore_payload(
     let mut reader = buffer_pool.reader(
         operator.clone(),
         location.clone(),
+        data_schema.clone(),
         vec![row_group.clone()],
         target,
     )?;
@@ -449,9 +459,11 @@ fn flush_write_profile(ctx: &Arc<QueryContext>, stats: WriteStats) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::Arc;
 
     use databend_common_exception::Result;
     use databend_common_expression::DataBlock;
+    use databend_common_expression::DataSchema;
     use databend_common_expression::FromData;
     use databend_common_expression::types::Int32Type;
 
@@ -467,8 +479,12 @@ mod tests {
 
         let partition_count = 4;
         let partition_stream = SharedPartitionStream::new(1, 1024, 1024 * 1024, partition_count);
-        let mut spiller =
-            NewAggregateSpiller::try_create(ctx.clone(), partition_count, partition_stream)?;
+        let mut spiller = NewAggregateSpiller::try_create(
+            ctx.clone(),
+            partition_count,
+            Arc::new(DataSchema::empty()),
+            partition_stream,
+        )?;
 
         let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![1i32, 2, 3])]);
 
@@ -496,8 +512,12 @@ mod tests {
 
         let partition_count = 4;
         let partition_stream = LocalPartitionStream::new(1024, 1024 * 1024, partition_count);
-        let mut spiller =
-            NewAggregateSpiller::try_create(ctx.clone(), partition_count, partition_stream)?;
+        let mut spiller = NewAggregateSpiller::try_create(
+            ctx.clone(),
+            partition_count,
+            Arc::new(DataSchema::empty()),
+            partition_stream,
+        )?;
 
         let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![1i32, 2, 3])]);
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_transform_aggregate_partial.rs
@@ -21,6 +21,7 @@ use databend_common_exception::Result;
 use databend_common_expression::AggregateHashTable;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::DataBlock;
+use databend_common_expression::DataSchemaRef;
 use databend_common_expression::HashTableConfig;
 use databend_common_expression::PartitionedPayload;
 use databend_common_expression::ProbeState;
@@ -62,10 +63,12 @@ pub struct Spiller {
 impl Spiller {
     pub fn create(
         ctx: Arc<QueryContext>,
+        schema: DataSchemaRef,
         partition_streams: SharedPartitionStream,
         bucket_num: usize,
     ) -> Result<Self> {
-        let spiller = NewAggregateSpiller::try_create(ctx.clone(), bucket_num, partition_streams)?;
+        let spiller =
+            NewAggregateSpiller::try_create(ctx.clone(), bucket_num, schema, partition_streams)?;
         Ok(Self {
             inner: spiller,
             bucket_num,
@@ -140,7 +143,8 @@ impl NewTransformPartialAggregate {
         bucket_num: usize,
         is_row_shuffle: bool,
     ) -> Result<Box<dyn Processor>> {
-        let spillers = Spiller::create(ctx.clone(), partition_stream, bucket_num)?;
+        let spill_schema = params.spill_schema();
+        let spillers = Spiller::create(ctx.clone(), spill_schema, partition_stream, bucket_num)?;
 
         let arena = Arc::new(Bump::new());
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_transform_final_aggregate.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_transform_final_aggregate.rs
@@ -105,6 +105,7 @@ impl NewTransformFinalAggregate {
         let spiller = NewAggregateSpiller::try_create(
             ctx.clone(),
             SPILL_BUCKET_NUM,
+            params.spill_schema(),
             LocalPartitionStream::new(
                 params.max_block_rows,
                 params.max_block_bytes,

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
@@ -272,8 +272,13 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
 
         while let Some(data) = self.steal_restore_build_task() {
             let buffer_pool = SpillsBufferPool::instance();
-            let mut reader =
-                buffer_pool.reader(operator.clone(), data.path, data.row_groups, target)?;
+            let mut reader = buffer_pool.reader(
+                operator.clone(),
+                data.path,
+                self.desc.build_schema.clone(),
+                data.row_groups,
+                target,
+            )?;
 
             while let Some(data_block) = reader.read(self.read_settings)? {
                 self.memory_hash_join.add_block(Some(data_block))?;
@@ -475,8 +480,13 @@ impl<'a, T: GraceMemoryJoin> RestoreProbeStream<'a, T> {
                     let target = SpillTarget::from_storage_params(data_operator.spill_params());
                     let operator = data_operator.spill_operator();
                     let buffer_pool = SpillsBufferPool::instance();
-                    let reader =
-                        buffer_pool.reader(operator, data.path, data.row_groups, target)?;
+                    let reader = buffer_pool.reader(
+                        operator,
+                        data.path,
+                        self.join.desc.probe_schema.clone(),
+                        data.row_groups,
+                        target,
+                    )?;
                     self.spills_reader = Some(reader);
                     break;
                 }

--- a/src/query/service/src/spillers/async_buffer.rs
+++ b/src/query/service/src/spillers/async_buffer.rs
@@ -32,7 +32,6 @@ use databend_common_base::runtime::Runtime;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
-use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::infer_table_schema;
@@ -51,7 +50,6 @@ use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::arrow::arrow_reader::RowGroups;
 use parquet::arrow::parquet_to_arrow_field_levels;
-use parquet::arrow::parquet_to_arrow_schema;
 use parquet::basic::Compression;
 use parquet::file::metadata::RowGroupMetaData;
 use parquet::file::properties::EnabledStatistics;
@@ -254,10 +252,11 @@ impl SpillsBufferPool {
         self: &Arc<Self>,
         op: Operator,
         path: String,
+        data_schema: DataSchemaRef,
         row_groups: Vec<RowGroupMetaData>,
         target: SpillTarget,
     ) -> Result<SpillsDataReader> {
-        SpillsDataReader::create(path, op, row_groups, self.clone(), target)
+        SpillsDataReader::create(path, op, data_schema, row_groups, self.clone(), target)
     }
 
     pub fn fetch_ranges(
@@ -568,6 +567,7 @@ impl SpillsDataWriter {
                 let row_groups = writer.writer.flushed_row_groups().to_vec();
                 let bytes_written = writer.writer.bytes_written();
                 writer.writer.into_inner()?.close()?;
+
                 Ok((bytes_written, row_groups))
             }
         }
@@ -589,6 +589,7 @@ impl SpillsDataReader {
     pub fn create(
         location: String,
         operator: Operator,
+        data_schema: DataSchemaRef,
         row_groups: Vec<RowGroupMetaData>,
         spills_buffer_pool: Arc<SpillsBufferPool>,
         target: SpillTarget,
@@ -598,9 +599,6 @@ impl SpillsDataReader {
                 "Parquet reader cannot read empty row groups.",
             ));
         }
-
-        let arrow_schema = parquet_to_arrow_schema(row_groups[0].schema_descr(), None)?;
-        let data_schema = DataSchemaRef::new(DataSchema::try_from(&arrow_schema)?);
 
         let field_levels = parquet_to_arrow_field_levels(
             row_groups[0].schema_descr(),

--- a/tests/sqllogictests/suites/query/join/basic_spill.test
+++ b/tests/sqllogictests/suites/query/join/basic_spill.test
@@ -163,5 +163,35 @@ drop table if exists t2;
 statement ok
 set max_block_size = 65536;
 
+# Test left join spill with variant column cast
+statement ok
+drop table if exists t_spill_left;
+
+statement ok
+drop table if exists t_spill_right;
+
+statement ok
+create table t_spill_left(id bigint, flag int);
+
+statement ok
+create table t_spill_right(id bigint, flag int, scores variant);
+
+statement ok
+insert into t_spill_left values (1, 1);
+
+statement ok
+insert into t_spill_right values (1, 1, parse_json('[10,20,30]'));
+
+query T
+select t_spill_right.scores[0]::variant as val from t_spill_left left join t_spill_right using(id, flag);
+----
+10
+
+statement ok
+drop table t_spill_left;
+
+statement ok
+drop table t_spill_right;
+
 statement ok
 unset force_join_data_spill;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When spilling data with variant columns, the schema inferred from parquet metadata could lose type information, causing incorrect results on restore. This fix passes the original DataSchema explicitly through the spill write/read path for both aggregate spill and grace hash join spill.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19564)
<!-- Reviewable:end -->
