### PR TITLE
chore(query): add missing runtime filter logs

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/merge.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/merge.rs
@@ -38,7 +38,12 @@ pub fn merge_join_runtime_filter_packets(
 
     // If any packet is incomplete (disable_all_due_to_spill), the merged result is also incomplete
     if packets.iter().any(|packet| packet.disable_all_due_to_spill) {
-        return Ok(JoinRuntimeFilterPacket::disable_all(total_build_rows));
+        let result = JoinRuntimeFilterPacket::disable_all(total_build_rows);
+        log::info!(
+            "RUNTIME-FILTER: merge_join_runtime_filter_packets output: build_rows={}, disable_all_due_to_spill=true",
+            total_build_rows
+        );
+        return Ok(result);
     }
 
     let should_merge_inlist = total_build_rows < inlist_threshold;

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/transform_hash_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/transform_hash_join.rs
@@ -231,14 +231,12 @@ impl Processor for TransformHashJoin {
                 if wait_res.is_leader() {
                     let spilled = self.join.is_spill_happened();
                     let packet = self.join.build_runtime_filter()?;
-                    if let Some(packets) = &packet.packets {
-                        info!(
-                            "spilled: {}, globalize runtime filter: total {}, disable_all_due_to_spill: {}",
-                            spilled,
-                            packets.len(),
-                            packet.disable_all_due_to_spill
-                        );
-                    };
+                    info!(
+                        "spilled: {}, globalize runtime filter: total {}, disable_all_due_to_spill: {}",
+                        spilled,
+                        packet.packets.as_ref().map_or(0, |p| p.len()),
+                        packet.disable_all_due_to_spill
+                    );
 
                     self.rf_desc.globalization(packet).await?;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


When spill happens, the merge early-return and the leader info log were
both silent — the merge had no output log, and the leader log was gated
behind `if let Some(packets)` which is None on the disable_all path.
This made it impossible to trace disable_all_due_to_spill=true in
production logs.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Add more logs to help debugging

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (chore):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19565)
<!-- Reviewable:end -->
