### PR TITLE
refactor: expose unclosed state from tokenizer for REPL consumers

### DIFF
--- a/src/query/ast/benches/bench.rs
+++ b/src/query/ast/benches/bench.rs
@@ -131,3 +131,96 @@ mod comment_heavy {
         divan::black_box(stmt);
     }
 }
+
+#[divan::bench_group(max_time = 0.5)]
+mod string_heavy {
+    use std::sync::OnceLock;
+
+    use databend_common_ast::parser::tokenize_sql;
+
+    fn single_quoted_sql() -> &'static str {
+        static CASE: OnceLock<String> = OnceLock::new();
+        CASE.get_or_init(|| {
+            let mut sql = String::from("SELECT ");
+            for i in 0..200 {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("'value_{i}'"));
+            }
+            sql
+        })
+        .as_str()
+    }
+
+    fn double_quoted_sql() -> &'static str {
+        static CASE: OnceLock<String> = OnceLock::new();
+        CASE.get_or_init(|| {
+            let mut sql = String::from("SELECT ");
+            for i in 0..200 {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("\"col_{i}\""));
+            }
+            sql.push_str(" FROM t");
+            sql
+        })
+        .as_str()
+    }
+
+    fn backtick_sql() -> &'static str {
+        static CASE: OnceLock<String> = OnceLock::new();
+        CASE.get_or_init(|| {
+            let mut sql = String::from("SELECT ");
+            for i in 0..200 {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("`col_{i}`"));
+            }
+            sql.push_str(" FROM t");
+            sql
+        })
+        .as_str()
+    }
+
+    fn escaped_single_quoted_sql() -> &'static str {
+        static CASE: OnceLock<String> = OnceLock::new();
+        CASE.get_or_init(|| {
+            let mut sql = String::from("SELECT ");
+            for i in 0..200 {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("'it''s value_{i} with \\' escape'"));
+            }
+            sql
+        })
+        .as_str()
+    }
+
+    #[divan::bench]
+    fn tokenize_single_quoted() {
+        let tokens = tokenize_sql(single_quoted_sql()).unwrap();
+        divan::black_box(tokens.len());
+    }
+
+    #[divan::bench]
+    fn tokenize_double_quoted() {
+        let tokens = tokenize_sql(double_quoted_sql()).unwrap();
+        divan::black_box(tokens.len());
+    }
+
+    #[divan::bench]
+    fn tokenize_backtick() {
+        let tokens = tokenize_sql(backtick_sql()).unwrap();
+        divan::black_box(tokens.len());
+    }
+
+    #[divan::bench]
+    fn tokenize_escaped_single_quoted() {
+        let tokens = tokenize_sql(escaped_single_quoted_sql()).unwrap();
+        divan::black_box(tokens.len());
+    }
+}

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -14,6 +14,7 @@
 
 use logos::Lexer;
 use logos::Logos;
+use memchr::memchr;
 use memchr::memchr_iter;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
@@ -22,6 +23,24 @@ pub use self::TokenKind::*;
 use crate::ParseError;
 use crate::Range;
 use crate::Result;
+
+/// The kind of unclosed construct detected at EOF.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnclosedKind {
+    SingleQuote,
+    DoubleQuote,
+    Backtick,
+    DollarQuote,
+    BlockComment,
+}
+
+/// Extra state carried through the `logos` lexer to track unclosed constructs.
+#[derive(Debug, Clone, Default)]
+pub struct TokenExtras {
+    /// If the tokenizer hit EOF inside an unclosed string/comment,
+    /// this records the kind and the byte offset where it started.
+    pub unclosed: Option<(UnclosedKind, usize)>,
+}
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Token<'a> {
@@ -61,10 +80,19 @@ impl<'a> Tokenizer<'a> {
     pub fn new(source: &'a str) -> Self {
         Tokenizer {
             source,
-            lexer: TokenKind::lexer(source),
+            lexer: TokenKind::lexer_with_extras(source, TokenExtras::default()),
             eoi: false,
             prev_token: None,
         }
+    }
+
+    /// Returns the unclosed construct detected at EOF, if any.
+    ///
+    /// Call this after the iterator is exhausted (or after an `Err`).
+    /// Returns `Some((kind, byte_offset))` where `byte_offset` is the
+    /// start of the unclosed string literal, backtick, or block comment.
+    pub fn unclosed(&self) -> Option<(UnclosedKind, usize)> {
+        self.lexer.extras.unclosed
     }
 
     pub fn contains_token(query: &str, target_kind: TokenKind) -> bool {
@@ -186,11 +214,89 @@ fn lex_comment_block(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
         }
     }
 
+    lex.extras.unclosed = Some((UnclosedKind::BlockComment, lex.span().start));
+    logos::FilterResult::Error
+}
+
+fn lex_single_quoted(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    let start = lex.span().start;
+    let bytes = lex.remainder().as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                // Doubled quote '' is an escape, not a close.
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                } else {
+                    lex.bump(i + 1);
+                    return logos::FilterResult::Emit(());
+                }
+            }
+            b'\\' => i += 2,
+            _ => i += 1,
+        }
+    }
+    lex.extras.unclosed = Some((UnclosedKind::SingleQuote, start));
+    logos::FilterResult::Error
+}
+
+fn lex_double_quoted(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    let start = lex.span().start;
+    let bytes = lex.remainder().as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                if bytes.get(i + 1) == Some(&b'"') {
+                    i += 2;
+                } else {
+                    lex.bump(i + 1);
+                    return logos::FilterResult::Emit(());
+                }
+            }
+            b'\\' => i += 2,
+            _ => i += 1,
+        }
+    }
+    lex.extras.unclosed = Some((UnclosedKind::DoubleQuote, start));
+    logos::FilterResult::Error
+}
+
+fn lex_backtick(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    let start = lex.span().start;
+    let bytes = lex.remainder().as_bytes();
+    // Backtick has no escape sequences — just find the closing `.
+    match memchr(b'`', bytes) {
+        Some(idx) => {
+            lex.bump(idx + 1);
+            logos::FilterResult::Emit(())
+        }
+        None => {
+            lex.extras.unclosed = Some((UnclosedKind::Backtick, start));
+            logos::FilterResult::Error
+        }
+    }
+}
+
+fn lex_dollar_quoted(lex: &mut Lexer<TokenKind>) -> logos::FilterResult<()> {
+    let start = lex.span().start;
+    let bytes = lex.remainder().as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'$') {
+            lex.bump(i + 2);
+            return logos::FilterResult::Emit(());
+        }
+        i += 1;
+    }
+    lex.extras.unclosed = Some((UnclosedKind::DollarQuote, start));
     logos::FilterResult::Error
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Logos, EnumIter, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[logos(extras = TokenExtras)]
 pub enum TokenKind {
     #[error]
     Error,
@@ -216,12 +322,12 @@ pub enum TokenKind {
     #[regex(r#"\$[0-9]+"#)]
     ColumnPosition,
 
-    #[regex(r#"`[^`]*`"#)]
-    #[regex(r#""([^"\\]|\\.|"")*""#)]
-    #[regex(r#"'([^'\\]|\\.|'')*'"#)]
+    #[token("`", lex_backtick)]
+    #[token("\"", lex_double_quoted)]
+    #[token("'", lex_single_quoted)]
     LiteralString,
 
-    #[regex(r#"\$\$([^\$]|(\$[^\$]))*\$\$"#)]
+    #[token("$$", lex_dollar_quoted)]
     LiteralCodeString,
 
     #[regex(r#"@([^\s,`;'"()]|\\\s|\\'|\\"|\\\\)+"#)]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  Convert LiteralString and LiteralCodeString from regex patterns to
  custom handlers so the tokenizer can detect unclosed quotes, backticks,
  dollar-quotes, and block comments at EOF. The unclosed state is stored
  in logos extras and exposed via Tokenizer::unclosed().

  This gives downstream REPL implementations (e.g. bendsql) a single
  source of truth for "is the inputincomplete?", eliminating the need
  for hand-written mini-parsers that must stay in sync with tokenizer
  semantics.
  Add string-heavy tokenizer benchmarks; no performance regression.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19573)
<!-- Reviewable:end -->
