### PR TITLE
fix: unload allow `include_query_id=true use_raw_path=true` for compat.

### DIFF
--- a/src/query/sql/src/planner/binder/copy_into_location.rs
+++ b/src/query/sql/src/planner/binder/copy_into_location.rs
@@ -233,10 +233,15 @@ fn check_options(
     match (raw_options.include_query_id, raw_options.use_raw_path) {
         (Some(include_query_id), Some(use_raw_path)) => {
             if include_query_id == use_raw_path {
-                return Err(ErrorCode::InvalidArgument(format!(
-                    "conflict copy_options: include_query_id={} and use_raw_path={}",
-                    include_query_id, use_raw_path
-                )));
+                if use_raw_path {
+                    // for compat
+                    options.include_query_id = false;
+                } else {
+                    return Err(ErrorCode::InvalidArgument(format!(
+                        "conflict copy_options: include_query_id={} and use_raw_path={}",
+                        include_query_id, use_raw_path
+                    )));
+                }
             }
         }
         (None, Some(true)) => {

--- a/tests/sqllogictests/suites/stage/unload.test
+++ b/tests/sqllogictests/suites/stage/unload.test
@@ -138,6 +138,17 @@ select $1, $2 from @unload/a_raw_path.csv (file_format => 'csv');
 ----
 3 4
 
+# for compat
+query ???
+copy into @unload/a_raw_path.csv from (select 5,6) file_format=(type=csv) single=true include_query_id=true use_raw_path=true detailed_output=true overwrite=true;
+----
+a_raw_path.csv 4 1
+
+query ??
+select $1, $2 from @unload/a_raw_path.csv (file_format => 'csv');
+----
+5 6
+
 statement error 1006.*file already exists
 copy into @unload/a_raw_path.csv from (select 3,4) file_format=(type=csv) single=true include_query_id=false use_raw_path=true detailed_output=false overwrite=false;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The options include_query_id=true and use_raw_path=true are logically conflicting. However, this conflict was not validated prior to PR https://github.com/databendlabs/databend/pull/19495 ([related changes](
https://github.com/databendlabs/databend/pull/19495/changes#diff-e746d1af20f353e26c536fb58eb7ed6ddc93188f3e11f97db11eda32fdb9f90aL45-L49)), and some users have already inadvertently used these two options together in their configurations.


To maintain backward compatibility, this PR explicitly permits this combination — the behavior is defined as: when use_raw_path=true is set, the include_query_id option is silently ignored (regardless of its value).


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19583)
<!-- Reviewable:end -->
