### PR TITLE
fix(functions): avoid BIGINT multiply panic during constant folding

### DIFF
--- a/src/query/functions/src/scalars/numeric_basic_arithmetic/src/numeric_basic_arithmetic.rs
+++ b/src/query/functions/src/scalars/numeric_basic_arithmetic/src/numeric_basic_arithmetic.rs
@@ -179,9 +179,12 @@ where
     (L, R): ResultTypeOfBinary,
     AddMulResult<L, R>: ResultTypeOfUnary + std::ops::Mul<Output = AddMulResult<L, R>>,
 {
-    registry.register_2_arg::<NumberType<L>, NumberType<R>, NumberType<AddMulResult<L, R>>, _>(
-        "multiply",
-        |_, lhs, rhs| {
+    registry
+        .scalar_builder("multiply")
+        .function()
+        .typed_2_arg::<NumberType<L>, NumberType<R>, NumberType<AddMulResult<L, R>>>()
+        .passthrough_nullable()
+        .calc_domain(|_, lhs, rhs| {
             (|| {
                 let lm: AddMulResult<L, R> = num_traits::cast::cast(lhs.max)?;
                 let ln: AddMulResult<L, R> = num_traits::cast::cast(lhs.min)?;
@@ -198,13 +201,24 @@ where
                     max: x.max(y).max(m).max(n),
                 }))
             })()
-            .unwrap_or(FunctionDomain::Full)
-        },
-        |a, b, _| {
-            (AsPrimitive::<AddMulResult<L, R>>::as_(a))
-                * (AsPrimitive::<AddMulResult<L, R>>::as_(b))
-        },
-    );
+            .unwrap_or(FunctionDomain::MayThrow)
+        })
+        .vectorized(vectorize_with_builder_2_arg::<
+            NumberType<L>,
+            NumberType<R>,
+            NumberType<AddMulResult<L, R>>,
+        >(|a, b, output, ctx| {
+            let lhs = AsPrimitive::<AddMulResult<L, R>>::as_(a);
+            let rhs = AsPrimitive::<AddMulResult<L, R>>::as_(b);
+            match lhs.checked_mul(rhs) {
+                Some(value) => output.push(value),
+                None => {
+                    ctx.set_error(output.len(), "number overflowed");
+                    output.push(AddMulResult::<L, R>::default());
+                }
+            }
+        }))
+        .register();
 }
 
 pub fn divide_function<L: AsPrimitive<F64>, R: AsPrimitive<F64>>(

--- a/src/query/functions/tests/it/scalars/arithmetic.rs
+++ b/src/query/functions/tests/it/scalars/arithmetic.rs
@@ -14,15 +14,23 @@
 
 use std::io::Write;
 
+use databend_common_exception::ErrorCode;
 use databend_common_expression::Column;
+use databend_common_expression::ConstantFolder;
+use databend_common_expression::DataBlock;
+use databend_common_expression::Evaluator;
 use databend_common_expression::FromData;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::type_check;
 use databend_common_expression::types::Decimal64Type;
 use databend_common_expression::types::decimal::DecimalColumn;
 use databend_common_expression::types::decimal::DecimalSize;
 use databend_common_expression::types::i256;
 use databend_common_expression::types::number::*;
+use databend_common_functions::BUILTIN_FUNCTIONS;
 use goldenfile::Mint;
 
+use super::parser;
 use super::run_ast;
 
 #[test]
@@ -78,6 +86,27 @@ fn test_arithmetic() {
     test_bitwise_not(file, columns);
     test_bitwise_shift_left(file, columns);
     test_bitwise_shift_right(file, columns);
+}
+
+#[test]
+fn test_bigint_constant_multiply_overflow() {
+    let raw_expr = parser::parse_raw_expr(
+        "251658240::BIGINT * 1080863910568919040::BIGINT",
+        &[],
+        &BUILTIN_FUNCTIONS,
+    );
+    let expr = type_check::rewrite_function_to_cast(
+        type_check::check(&raw_expr, &BUILTIN_FUNCTIONS).unwrap(),
+    );
+    let func_ctx = FunctionContext::default();
+    let (optimized_expr, _) = ConstantFolder::fold(&expr, &func_ctx, &BUILTIN_FUNCTIONS);
+
+    let block = DataBlock::empty_with_rows(1);
+    let evaluator = Evaluator::new(&block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let err = evaluator.run(&optimized_expr).unwrap_err();
+
+    assert_eq!(err.code(), ErrorCode::BAD_ARGUMENTS);
+    assert!(err.message().contains("number overflowed"), "{err}");
 }
 
 fn test_add(file: &mut impl Write, columns: &[(&str, Column)]) {

--- a/tests/sqllogictests/suites/base/issues/issue_19575.test
+++ b/tests/sqllogictests/suites/base/issues/issue_19575.test
@@ -1,0 +1,4 @@
+# issue 19575
+
+query error number overflowed
+SELECT 251658240::BIGINT * 1080863910568919040::BIGINT;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fix integer `multiply` evaluation so overflowing BIGINT constant expressions return a regular `number overflowed` SQL error instead of panicking during constant folding
- mark multiply domain evaluation as `MayThrow` when overflow is possible so constant folding does not treat the overflowing path as a fully safe domain
- add a focused scalar regression and a sqllogic regression for issue #19575

Fixes #19575

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation run locally:
- `cargo test -p databend-common-functions --test it test_bigint_constant_multiply_overflow`
- `cargo test -p databend-common-functions --test it scalars::arithmetic::test_arithmetic`
- `cargo clippy -p databend-functions-scalar-numeric-basic-arithmetic --all-targets -- -D warnings`
- Added `tests/sqllogictests/suites/base/issues/issue_19575.test` (not run locally)

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19589)
<!-- Reviewable:end -->
