### PR TITLE
fix(query): return semantic errors for invalid GROUPING()

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -433,6 +433,11 @@ impl<'a> AggregateRewriter<'a> {
                 "grouping can only be called in GROUP BY GROUPING SETS clauses",
             ));
         }
+        if function.arguments.is_empty() {
+            return Err(ErrorCode::SemanticError(
+                "grouping requires at least one argument",
+            ));
+        }
         let grouping_id_column = agg_info
             .grouping_sets
             .as_ref()

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1138,6 +1138,18 @@ impl<'a> TypeChecker<'a> {
 
                 let args: Vec<&Expr> = args.iter().collect();
 
+                if func_name.eq_ignore_ascii_case("grouping") {
+                    return self.resolve_grouping_function(
+                        *span,
+                        *distinct,
+                        params.len(),
+                        &args,
+                        order_by.len(),
+                        window.is_some(),
+                        lambda.is_some(),
+                    );
+                }
+
                 if GENERAL_WINDOW_FUNCTIONS.contains(&uni_case_func_name) {
                     // general window function
                     if window.is_none() {
@@ -3305,6 +3317,99 @@ impl<'a> TypeChecker<'a> {
         };
 
         Ok(Box::new((return_scalar, return_type)))
+    }
+
+    fn resolve_grouping_function(
+        &mut self,
+        span: Span,
+        distinct: bool,
+        params_len: usize,
+        args: &[&Expr],
+        order_by_len: usize,
+        has_window: bool,
+        has_lambda: bool,
+    ) -> Result<Box<(ScalarExpr, DataType)>> {
+        if distinct || params_len > 0 || order_by_len > 0 || has_window || has_lambda {
+            return Err(ErrorCode::SemanticError(
+                "grouping does not support DISTINCT, parameters, ORDER BY, lambda, or window syntax",
+            )
+            .set_span(span));
+        }
+
+        if self.in_aggregate_function {
+            return Err(ErrorCode::SemanticError(
+                "grouping function is not allowed inside aggregate functions",
+            )
+            .set_span(span));
+        }
+
+        if self.in_window_function {
+            return Err(ErrorCode::SemanticError(
+                "grouping function is not allowed inside window functions",
+            )
+            .set_span(span));
+        }
+
+        match self.bind_context.expr_context {
+            ExprContext::WhereClause => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in WHERE clause",
+                )
+                .set_span(span));
+            }
+            ExprContext::QualifyClause => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in QUALIFY clause",
+                )
+                .set_span(span));
+            }
+            ExprContext::GroupClaue => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in GROUP BY clause",
+                )
+                .set_span(span));
+            }
+            ExprContext::LimitClause => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in LIMIT clause",
+                )
+                .set_span(span));
+            }
+            ExprContext::InSetReturningFunction => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in set-returning functions",
+                )
+                .set_span(span));
+            }
+            ExprContext::InLambdaFunction => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in lambda expressions",
+                )
+                .set_span(span));
+            }
+            ExprContext::InAsyncFunction => {
+                return Err(ErrorCode::SemanticError(
+                    "grouping function is not allowed in async functions",
+                )
+                .set_span(span));
+            }
+            _ => {}
+        }
+
+        let arguments = args
+            .iter()
+            .map(|arg| self.resolve(arg).map(|boxed| boxed.0))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Box::new((
+            ScalarExpr::FunctionCall(FunctionCall {
+                span,
+                func_name: "grouping".to_string(),
+                params: vec![],
+                arguments,
+            }),
+            DataType::Number(NumberDataType::UInt32),
+        )))
     }
 
     /// Resolve function call.

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_sql_test_support::TestCase;
 use databend_common_sql_test_support::TestCaseRunner;
@@ -163,5 +164,53 @@ async fn run_test_case(
 
     let runner = LiteRunner(ctx.clone());
     run_test_case_core(case, mints.mint_for(case), &runner).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_invalid_grouping_queries_return_semantic_errors() -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_table_sql("CREATE TABLE students(course STRING, type STRING);")
+        .await?;
+
+    let semantic_error = ErrorCode::SemanticError("").code();
+    let bad_arguments = ErrorCode::BadArguments("").code();
+
+    for (sql, expected_code, expected_message) in [
+        (
+            "SELECT GROUPING()",
+            semantic_error,
+            "grouping can only be called in GROUP BY GROUPING SETS clauses",
+        ),
+        (
+            "SELECT GROUPING() FROM students",
+            semantic_error,
+            "grouping can only be called in GROUP BY GROUPING SETS clauses",
+        ),
+        (
+            "SELECT GROUPING(NULL) FROM students GROUP BY GROUPING SETS ((course))",
+            bad_arguments,
+            "Arguments of grouping should be group by expressions",
+        ),
+        (
+            "SELECT GROUPING() FROM students GROUP BY GROUPING SETS ((course))",
+            semantic_error,
+            "grouping requires at least one argument",
+        ),
+        (
+            "SELECT course FROM students WHERE GROUPING(course)=0 GROUP BY course",
+            semantic_error,
+            "grouping function is not allowed in WHERE clause",
+        ),
+    ] {
+        let err = ctx.bind_sql(sql).await.expect_err(sql);
+        assert_eq!(err.code(), expected_code, "{sql}: {}", err.display_text());
+        assert!(
+            err.message().contains(expected_message),
+            "{sql}: {}",
+            err.display_text()
+        );
+    }
+
     Ok(())
 }

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
@@ -168,6 +168,36 @@ a NULL 7 1 0 1 2
 b NULL 11 1 0 1 2
 NULL NULL 18 1 1 3 3
 
+statement ok
+create or replace table students(course string, type string);
+
+statement error
+SELECT GROUPING();
+
+statement error
+SELECT GROUPING() FROM students;
+
+statement error
+SELECT GROUPING(NULL) FROM students;
+
+statement error
+SELECT GROUPING(course) FROM students;
+
+statement error
+SELECT GROUPING(course) FROM students GROUP BY ();
+
+statement error
+SELECT GROUPING(type) FROM students GROUP BY course;
+
+statement error
+SELECT GROUPING(course) FROM students WHERE GROUPING(course)=0 GROUP BY course;
+
+statement error
+SELECT GROUPING(NULL) FROM students GROUP BY GROUPING SETS ((course));
+
+statement error
+SELECT GROUPING() FROM students GROUP BY GROUPING SETS ((course));
+
 # ISSUE-12852. Aggregation function argument is in grouping sets.
 query II
 SELECT arg_min(c, 10), c FROM t GROUP BY CUBE (c) ORDER BY c;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes #19554
- stop SQL semantic type checking from constant-folding raw `GROUPING` calls before aggregate rewriting validates them
- return semantic errors for invalid `GROUPING()` usage, including empty-argument and unsupported `WHERE` cases
- add planner and sqllogictest regression coverage for the invalid queries from the issue

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p databend-common-sql --test it --no-deps -- -D warnings`
- `cargo test -p databend-common-sql --test it planner::test_invalid_grouping_queries_return_semantic_errors -- --exact --nocapture`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19592)
<!-- Reviewable:end -->
