### PR TITLE
fix(query): escape LIKE ESCAPE literals

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -646,7 +646,7 @@ impl Display for Expr {
                     write_expr(expr, Some(affix), true, f)?;
                     write!(f, " LIKE {modifier} ({subquery})")?;
                     if let Some(escape) = escape {
-                        write!(f, " ESCAPE '{escape}'")?;
+                        write!(f, " ESCAPE {}", QuotedString(escape, '\''))?;
                     }
                 }
                 Expr::LikeAnyWithEscape {
@@ -656,7 +656,7 @@ impl Display for Expr {
                     ..
                 } => {
                     write_expr(left, Some(affix), true, f)?;
-                    write!(f, " LIKE ANY {right} ESCAPE '{escape}'")?;
+                    write!(f, " LIKE ANY {right} ESCAPE {}", QuotedString(escape, '\''))?;
                 }
                 Expr::LikeWithEscape {
                     left,
@@ -669,7 +669,7 @@ impl Display for Expr {
                     if *is_not {
                         write!(f, " NOT")?;
                     }
-                    write!(f, " LIKE {right} ESCAPE '{escape}'")?;
+                    write!(f, " LIKE {right} ESCAPE {}", QuotedString(escape, '\''))?;
                 }
                 Expr::Between {
                     expr,

--- a/src/query/ast/tests/it/display.rs
+++ b/src/query/ast/tests/it/display.rs
@@ -44,3 +44,16 @@ fn test_multi_table_insert_parse_error() {
         assert!(parse_sql(&tokens, Dialect::PostgreSQL).is_err());
     }
 }
+
+#[test]
+fn test_like_escape_quote_display() {
+    let sqls = [
+        "SELECT 'a' LIKE 'a' ESCAPE '''';",
+        "SELECT 'a' LIKE ANY ('a', 'b') ESCAPE '''';",
+        "SELECT 'a' LIKE ANY (SELECT 'a') ESCAPE '''';",
+    ];
+
+    for sql in sqls {
+        test_stmt_display(sql);
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #19563

- render `ESCAPE` literals in `Expr::LikeWithEscape`, `Expr::LikeAnyWithEscape`, and `Expr::LikeSubquery` with the shared quoted-string formatter
- preserve valid SQL when the escape character itself is a single quote so parser round-trip checks do not panic
- add a regression test that exercises the three affected `LIKE ... ESCAPE` display variants through `parse_sql()`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Verification

- `cargo test -p databend-common-ast --test it`
- `cargo clippy -p databend-common-ast --tests -- -D warnings`
- `cargo fmt --all --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19593)
<!-- Reviewable:end -->
