### PR TITLE
fix(query): escape LIKE ESCAPE literals in display

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -646,7 +646,7 @@ impl Display for Expr {
                     write_expr(expr, Some(affix), true, f)?;
                     write!(f, " LIKE {modifier} ({subquery})")?;
                     if let Some(escape) = escape {
-                        write!(f, " ESCAPE '{escape}'")?;
+                        write!(f, " ESCAPE {}", QuotedString(escape, '\''))?;
                     }
                 }
                 Expr::LikeAnyWithEscape {
@@ -656,7 +656,7 @@ impl Display for Expr {
                     ..
                 } => {
                     write_expr(left, Some(affix), true, f)?;
-                    write!(f, " LIKE ANY {right} ESCAPE '{escape}'")?;
+                    write!(f, " LIKE ANY {right} ESCAPE {}", QuotedString(escape, '\''))?;
                 }
                 Expr::LikeWithEscape {
                     left,
@@ -669,7 +669,7 @@ impl Display for Expr {
                     if *is_not {
                         write!(f, " NOT")?;
                     }
-                    write!(f, " LIKE {right} ESCAPE '{escape}'")?;
+                    write!(f, " LIKE {right} ESCAPE {}", QuotedString(escape, '\''))?;
                 }
                 Expr::Between {
                     expr,

--- a/src/query/ast/tests/it/display.rs
+++ b/src/query/ast/tests/it/display.rs
@@ -44,3 +44,14 @@ fn test_multi_table_insert_parse_error() {
         assert!(parse_sql(&tokens, Dialect::PostgreSQL).is_err());
     }
 }
+
+#[test]
+fn test_like_escape_display_escapes_escape_literal() {
+    for sql in [
+        r#"SELECT 'a' LIKE 'a' ESCAPE '''';"#,
+        r#"SELECT 'a' LIKE ANY ('a', 'b') ESCAPE '''';"#,
+        r#"SELECT 'a' LIKE ANY (SELECT 'a') ESCAPE '''';"#,
+    ] {
+        test_stmt_display(sql);
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This fixes the `LIKE ... ESCAPE` formatter roundtrip bug for escape literals that contain single quotes. Statements such as `SELECT 'a' LIKE 'a' ESCAPE '''';` now serialize back to valid SQL, so the parser's debug reparse assertion no longer panics.

## Changes

- render `Expr::LikeSubquery`, `Expr::LikeAnyWithEscape`, and `Expr::LikeWithEscape` escape literals with the shared `QuotedString` SQL string formatter
- add a regression test covering plain `LIKE`, `LIKE ANY (...)`, and `LIKE ANY (SELECT ...)` with `ESCAPE ''''`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation:

- `cargo test -p databend-common-ast`
- `cargo clippy -p databend-common-ast --tests -- -D warnings`

## Type of change

- [x] Bug fix

Fixes #19563

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19596)
<!-- Reviewable:end -->
