### PR TITLE
fix(query): avoid planner panic for invalid LIKE ESCAPE literals

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -1607,6 +1607,10 @@ impl<'a> TypeChecker<'a> {
         modifier: &SubqueryModifier,
         op: &BinaryOperator,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
+        if let BinaryOperator::Like(escape) = op {
+            Self::validate_like_escape(*span, escape)?;
+        }
+
         Ok(match modifier {
             SubqueryModifier::Any | SubqueryModifier::Some => {
                 let comparison_op = SubqueryComparisonOp::try_from(op)?;

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -152,6 +152,8 @@ async fn test_like_escape_rejects_non_single_character_literal() -> Result<()> {
         "SELECT 'a' LIKE 'a' ESCAPE ''",
         "SELECT 'a' LIKE 'a' ESCAPE 'ab'",
         "SELECT 'a' LIKE ANY ('a', 'b') ESCAPE ''",
+        "SELECT 'a' LIKE ANY (SELECT 'a') ESCAPE ''",
+        "SELECT 'a' LIKE ANY (SELECT 'a') ESCAPE 'ab'",
     ] {
         let err = ctx.bind_sql(sql).await.unwrap_err();
         assert_eq!(err.code(), ErrorCode::SEMANTIC_ERROR);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #19562

- validate `LIKE`/`NOT LIKE`/`LIKE ANY ... ESCAPE` literals during planner type checking so invalid escape strings return a semantic error instead of panicking
- add planner regression coverage for empty and multi-character `ESCAPE` literals

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19597)
<!-- Reviewable:end -->
