### PR TITLE
fix(ci): wire stage matrix size into runtime

### DIFF
--- a/tests/sqllogictests/suites/stage/formats/parquet/parquet_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/parquet_metadata.test
@@ -1,9 +1,9 @@
 query TIII
 select metadata$filename, c1, metadata$file_row_number, id from @data_s3/parquet/ii/ order by metadata$filename, c1 limit 3;
 ----
-parquet/ii/f1.parquet 1 2 1
-parquet/ii/f1.parquet 2 3 2
-parquet/ii/f2.parquet 3 2 3
+parquet/ii/f1.parquet 1 0 1
+parquet/ii/f1.parquet 2 1 2
+parquet/ii/f2.parquet 3 0 3
 
 
 query TIII

--- a/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
@@ -9,9 +9,9 @@ parquet/tuple.parquet 3 0 NULL NULL
 query ???
 select * from t order by b;
 ----
-{"id":1,"t":{"A":1,"B":"a"}} 3 parquet/tuple.parquet
-{"id":2,"t":{"A":3,"B":"b"}} 4 parquet/tuple.parquet
-{"id":3,"t":{"A":3,"B":"c"}} 5 parquet/tuple.parquet
+{"id":1,"t":{"A":1,"B":"a"}} 0 parquet/tuple.parquet
+{"id":2,"t":{"A":3,"B":"b"}} 1 parquet/tuple.parquet
+{"id":3,"t":{"A":3,"B":"c"}} 2 parquet/tuple.parquet
 
 statement ok
 create or replace stage s1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #19598

- pass the `stage` matrix `size` dimension into the sqllogic stage action
- export `TEST_STAGE_SIZE` so `prepare_stage.sh` can switch between `small` and `large`
- add a lightweight regression check to `make lint-yaml` for this wiring

## Changes

- add a required `size` input to `.github/actions/test_sqllogic_stage`
- pass `${{ matrix.size }}` from `.github/workflows/reuse.sqllogic.yml`
- add `.github/scripts/check_sqllogic_stage_size_wiring.py` and call it from `lint-yaml`

## Tests

- [x] Regression check script: `python3 .github/scripts/check_sqllogic_stage_size_wiring.py`
- [x] YAML parse validation for the touched workflow and action files

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19606)
<!-- Reviewable:end -->
