### PR TITLE
fix: disable parquet prewhere by default

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
@@ -121,7 +121,12 @@ impl RuleFactory {
             RuleID::CommuteJoinBaseTable => Ok(Box::new(RuleCommuteJoinBaseTable::new())),
             RuleID::LeftExchangeJoin => Ok(Box::new(RuleLeftExchangeJoin::new())),
             RuleID::EagerAggregation => Ok(Box::new(RuleEagerAggregation::new(metadata))),
-            RuleID::PushDownPrewhere => Ok(Box::new(RulePushDownPrewhere::new(metadata))),
+            RuleID::PushDownPrewhere => Ok(Box::new(RulePushDownPrewhere::new(
+                metadata,
+                ctx.get_table_ctx()
+                    .get_settings()
+                    .get_enable_parquet_prewhere()?,
+            ))),
             RuleID::TryApplyAggIndex => Ok(Box::new(RuleTryApplyAggIndex::new(metadata))),
             RuleID::EliminateSelfJoin => Ok(Box::new(RuleEliminateSelfJoin::new(ctx))),
             RuleID::EliminateSort => Ok(Box::new(RuleEliminateSort::new())),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_prewhere.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_prewhere.rs
@@ -254,19 +254,6 @@ fn should_push_down_prewhere(
     support_prewhere && (!storage_format_as_parquet || enable_parquet_prewhere)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::should_push_down_prewhere;
-
-    #[test]
-    fn test_should_push_down_prewhere_respects_parquet_setting() {
-        assert!(!should_push_down_prewhere(true, true, false));
-        assert!(should_push_down_prewhere(true, true, true));
-        assert!(should_push_down_prewhere(true, false, false));
-        assert!(!should_push_down_prewhere(false, false, true));
-    }
-}
-
 impl Rule for RulePushDownPrewhere {
     fn id(&self) -> RuleID {
         self.id
@@ -285,5 +272,18 @@ impl Rule for RulePushDownPrewhere {
 
     fn matchers(&self) -> &[Matcher] {
         &self.matchers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_push_down_prewhere;
+
+    #[test]
+    fn test_should_push_down_prewhere_respects_parquet_setting() {
+        assert!(!should_push_down_prewhere(true, true, false));
+        assert!(should_push_down_prewhere(true, true, true));
+        assert!(should_push_down_prewhere(true, false, false));
+        assert!(!should_push_down_prewhere(false, false, true));
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_prewhere.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_prewhere.rs
@@ -56,10 +56,11 @@ pub struct RulePushDownPrewhere {
     id: RuleID,
     matchers: Vec<Matcher>,
     metadata: MetadataRef,
+    enable_parquet_prewhere: bool,
 }
 
 impl RulePushDownPrewhere {
-    pub fn new(metadata: MetadataRef) -> Self {
+    pub fn new(metadata: MetadataRef, enable_parquet_prewhere: bool) -> Self {
         Self {
             id: RuleID::PushDownPrewhere,
             matchers: vec![
@@ -82,6 +83,7 @@ impl RulePushDownPrewhere {
                 },
             ],
             metadata,
+            enable_parquet_prewhere,
         }
     }
 
@@ -175,7 +177,11 @@ impl RulePushDownPrewhere {
         let metadata = self.metadata.read().clone();
 
         let table = metadata.table(scan.table_index).table();
-        if !table.support_prewhere() {
+        if !should_push_down_prewhere(
+            table.support_prewhere(),
+            table.storage_format_as_parquet(),
+            self.enable_parquet_prewhere,
+        ) {
             // cannot optimize
             return Ok(s_expr.clone());
         }
@@ -237,6 +243,27 @@ impl RulePushDownPrewhere {
                 Arc::new(child_expr),
             ))
         }
+    }
+}
+
+fn should_push_down_prewhere(
+    support_prewhere: bool,
+    storage_format_as_parquet: bool,
+    enable_parquet_prewhere: bool,
+) -> bool {
+    support_prewhere && (!storage_format_as_parquet || enable_parquet_prewhere)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_push_down_prewhere;
+
+    #[test]
+    fn test_should_push_down_prewhere_respects_parquet_setting() {
+        assert!(!should_push_down_prewhere(true, true, false));
+        assert!(should_push_down_prewhere(true, true, true));
+        assert!(should_push_down_prewhere(true, false, false));
+        assert!(!should_push_down_prewhere(false, false, true));
     }
 }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0047_disable_parquet_prewhere.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0047_disable_parquet_prewhere.test
@@ -1,0 +1,36 @@
+statement ok
+drop table if exists t_disable_parquet_prewhere
+
+statement ok
+create table t_disable_parquet_prewhere (
+    bucket_num int,
+    bucket_scores array(int)
+) storage_format = 'parquet' row_per_block = 2
+
+statement ok
+insert into t_disable_parquet_prewhere values
+    (1, [10, 11, 12]),
+    (2, [20]),
+    (2, [21, 22]),
+    (3, [30, 31, 32, 33])
+
+statement ok
+set enable_parquet_prewhere = 1
+
+statement error Parquet argument error
+select count(*), sum(array_length(coalesce(bucket_scores, [])))
+from t_disable_parquet_prewhere
+where bucket_num = 2
+
+statement ok
+set enable_parquet_prewhere = 0
+
+query II
+select count(*), sum(array_length(coalesce(bucket_scores, [])))
+from t_disable_parquet_prewhere
+where bucket_num = 2
+----
+2 3
+
+statement ok
+drop table t_disable_parquet_prewhere


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Respect `enable_parquet_prewhere` when applying prewhere pushdown
- Skip prewhere pushdown for parquet-backed tables when the setting is disabled, including Fuse parquet tables

## Changes

1. Thread `enable_parquet_prewhere` from `RuleFactory` into `RulePushDownPrewhere`
2. Gate prewhere pushdown on both table support and parquet format setting
3. Add a unit test for the new gating helper
4. Add a sqllogictest covering the parquet prewhere setting with fail/success behavior

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)

## Risks

- When `enable_parquet_prewhere = 0`, parquet-backed tables will no longer use prewhere pushdown in the optimizer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19610)
<!-- Reviewable:end -->
