### PR TITLE
feat: enable TCP_NODELAY on gRPC listener sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5295,8 +5295,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5305,13 +5305,13 @@ dependencies = [
  "backon",
  "chrono",
  "databend-base",
- "databend-meta-client 260312.2.0",
- "databend-meta-kvapi 260312.2.0",
+ "databend-meta-client 260312.5.0",
+ "databend-meta-kvapi 260312.5.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260312.2.0",
+ "databend-meta-runtime-api 260312.5.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.2.0",
- "databend-meta-version 260312.2.0",
+ "databend-meta-types 260312.5.0",
+ "databend-meta-version 260312.5.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5330,7 +5330,6 @@ dependencies = [
  "prost",
  "raft-log",
  "rustls 0.23.36",
- "semver",
  "seq-marked",
  "serde",
  "serde_json",
@@ -5374,8 +5373,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5478,8 +5477,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5488,10 +5487,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.2.0",
- "databend-meta-kvapi-test-suite 260312.2.0",
- "databend-meta-runtime-api 260312.2.0",
- "databend-meta-version 260312.2.0",
+ "databend-meta-kvapi 260312.5.0",
+ "databend-meta-kvapi-test-suite 260312.5.0",
+ "databend-meta-runtime-api 260312.5.0",
+ "databend-meta-version 260312.5.0",
  "derive_more 2.1.1",
  "display-more 0.2.5",
  "fastrace",
@@ -5512,8 +5511,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5559,8 +5558,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5591,12 +5590,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.2.0",
+ "databend-meta-kvapi 260312.5.0",
  "display-more 0.2.5",
  "fastrace",
  "futures-util",
@@ -5647,8 +5646,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5670,18 +5669,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260312.2.0",
- "databend-meta-runtime-api 260312.2.0",
+ "databend-meta-kvapi 260312.5.0",
+ "databend-meta-runtime-api 260312.5.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.2.0",
+ "databend-meta-types 260312.5.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5739,8 +5738,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5752,12 +5751,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260312.2.0",
+ "databend-meta-types 260312.5.0",
  "fastrace",
  "log",
  "serde",
@@ -5770,14 +5769,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260312.2.0",
- "databend-meta-types 260312.2.0",
+ "databend-meta-runtime-api 260312.5.0",
+ "databend-meta-types 260312.5.0",
  "fastrace",
  "log",
  "tempfile",
@@ -5815,8 +5814,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5858,8 +5857,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260312.2.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.2.0#8afe3c8f17e73cfb561df7d5155902212705acb3"
+version = "260312.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
 dependencies = [
  "semver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,8 +163,8 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260312.2.0"
-databend-meta-test-harness = "260312.2.0"
+databend-meta = "260312.5.0"
+databend-meta-test-harness = "260312.5.0"
 
 # External meta client
 databend-meta-client = "260205.4.0"
@@ -614,9 +614,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.2.10" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.2.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.5.0" }
 databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.4.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.2.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.5.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 jsonb = { git = "https://github.com/databendlabs/jsonb", rev = "fc84214" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: enable TCP_NODELAY on gRPC listener sockets
Upgrade databend-meta from v260312.2.0 to v260312.4.0 to pick up the
TCP_NODELAY fix. Without this, Nagle's algorithm buffers small gRPC
response frames (TRAILERS) and introduces ~40ms delay per meta RPC,
causing ~13x regression on operations like TRUNCATE TABLE that issue
multiple meta RPCs.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19619)
<!-- Reviewable:end -->
