### PR TITLE
fix: restore enable_merge_into_row_fetch

### DIFF
--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -152,8 +152,10 @@ impl MutationExpression {
                     update_stream_columns = false;
                 }
                 let is_lazy_table = {
+                    let settings = binder.ctx.get_settings();
                     let metadata = binder.metadata.read();
                     *mutation_strategy != MutationStrategy::NotMatchedOnly
+                        && settings.get_enable_merge_into_row_fetch()?
                         && metadata
                             .table(target_table_index)
                             .table()

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -21,6 +21,97 @@ MERGE INTO salaries2 USING (SELECT * FROM employees2) as employees2 ON salaries2
 ----
 2 2
 
+statement ok
+set enable_merge_into_row_fetch = 0;
+
+query T
+explain MERGE INTO salaries2 USING (SELECT * FROM employees2) as employees2 ON salaries2.employee_id = employees2.employee_id WHEN MATCHED AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00 WHEN NOT MATCHED THEN INSERT (employee_id, salary) VALUES (employees2.employee_id, 55000.00);
+----
+CommitSink
+└── DataMutation
+    ├── target table: default.default.salaries2
+    └── MutationManipulate
+        ├── matched update: [condition: employees2.department (#2) = 'HR', update set salary = if(CAST(_predicate (#18446744073709551615) AS Boolean NULL), CAST(salaries2.salary (#4) + 1000.00 AS Decimal(10, 2) NULL), salaries2.salary (#4))]
+        ├── matched update: [condition: None, update set salary = if(CAST(_predicate (#18446744073709551615) AS Boolean NULL), CAST(salaries2.salary (#4) + 500.00 AS Decimal(10, 2) NULL), salaries2.salary (#4))]
+        ├── unmatched insert: [condition: None, insert into (employee_id,salary) values(employees2.employee_id (#0),55000.00)]
+        └── HashJoin
+            ├── output columns: [employees2.employee_id (#0), employees2.employee_name (#1), employees2.department (#2), salaries2.employee_id (#3), salaries2.salary (#4), salaries2._row_id (#5)]
+            ├── join type: LEFT OUTER
+            ├── build keys: [salaries2.employee_id (#3)]
+            ├── probe keys: [employees2.employee_id (#0)]
+            ├── keys is null equal: [false]
+            ├── filters: []
+            ├── estimated rows: 4.00
+            ├── TableScan(Build)
+            │   ├── table: default.default.salaries2
+            │   ├── scan id: 1
+            │   ├── output columns: [employee_id (#3), salary (#4), _row_id (#5)]
+            │   ├── read rows: 4
+            │   ├── read size: < 1 KiB
+            │   ├── partitions total: 1
+            │   ├── partitions scanned: 1
+            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── push downs: [filters: [], limit: NONE]
+            │   └── estimated rows: 4.00
+            └── TableScan(Probe)
+                ├── table: default.default.employees2
+                ├── scan id: 0
+                ├── output columns: [employee_id (#0), employee_name (#1), department (#2)]
+                ├── read rows: 4
+                ├── read size: < 1 KiB
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── push downs: [filters: [], limit: NONE]
+                └── estimated rows: 4.00
+
+statement ok
+set enable_merge_into_row_fetch = 1;
+
+query T
+explain MERGE INTO salaries2 USING (SELECT * FROM employees2) as employees2 ON salaries2.employee_id = employees2.employee_id WHEN MATCHED AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00 WHEN NOT MATCHED THEN INSERT (employee_id, salary) VALUES (employees2.employee_id, 55000.00);
+----
+CommitSink
+└── DataMutation
+    ├── target table: default.default.salaries2
+    └── MutationManipulate
+        ├── matched update: [condition: employees2.department (#2) = 'HR', update set salary = if(CAST(_predicate (#18446744073709551615) AS Boolean NULL), CAST(salaries2.salary (#4) + 1000.00 AS Decimal(10, 2) NULL), salaries2.salary (#4))]
+        ├── matched update: [condition: None, update set salary = if(CAST(_predicate (#18446744073709551615) AS Boolean NULL), CAST(salaries2.salary (#4) + 500.00 AS Decimal(10, 2) NULL), salaries2.salary (#4))]
+        ├── unmatched insert: [condition: None, insert into (employee_id,salary) values(employees2.employee_id (#0),55000.00)]
+        └── RowFetch
+            ├── output columns: [employees2.employee_id (#0), employees2.employee_name (#1), employees2.department (#2), salaries2.employee_id (#3), salaries2._row_id (#5), salaries2.salary (#4)]
+            ├── columns to fetch: [salary]
+            └── HashJoin
+                ├── output columns: [employees2.employee_id (#0), employees2.employee_name (#1), employees2.department (#2), salaries2.employee_id (#3), salaries2._row_id (#5)]
+                ├── join type: LEFT OUTER
+                ├── build keys: [salaries2.employee_id (#3)]
+                ├── probe keys: [employees2.employee_id (#0)]
+                ├── keys is null equal: [false]
+                ├── filters: []
+                ├── estimated rows: 4.00
+                ├── TableScan(Build)
+                │   ├── table: default.default.salaries2
+                │   ├── scan id: 1
+                │   ├── output columns: [employee_id (#3), _row_id (#5)]
+                │   ├── read rows: 4
+                │   ├── read size: < 1 KiB
+                │   ├── partitions total: 1
+                │   ├── partitions scanned: 1
+                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── push downs: [filters: [], limit: NONE]
+                │   └── estimated rows: 4.00
+                └── TableScan(Probe)
+                    ├── table: default.default.employees2
+                    ├── scan id: 0
+                    ├── output columns: [employee_id (#0), employee_name (#1), department (#2)]
+                    ├── read rows: 4
+                    ├── read size: < 1 KiB
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 4.00
+
 ## issue 16588
 query T
 explain merge into salaries2 using employees2 on 1 != 1 when matched AND employees2.department = 'HR' THEN UPDATE SET salaries2.salary = salaries2.salary + 1000.00 WHEN MATCHED THEN UPDATE SET salaries2.salary = salaries2.salary + 500.00 WHEN NOT MATCHED THEN INSERT (employee_id, salary) VALUES (employees2.employee_id, 55000.00)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR restores `enable_merge_into_row_fetch` for MERGE planning so disabling the setting stops the planner from producing lazy target scans and `RowFetch` plans.
It also adds an explain sqllogictest that covers both setting states to prevent regressions.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation: `cargo check -p databend-common-sql --lib`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19624)
<!-- Reviewable:end -->
