### PR TITLE
fix(query): enforce row access policy for Direct UPDATE and split predicate fields

### DIFF
--- a/src/query/service/src/physical_plans/format/format_mutation_source.rs
+++ b/src/query/service/src/physical_plans/format/format_mutation_source.rs
@@ -34,6 +34,22 @@ impl<'a> MutationSourceFormatter<'a> {
     pub fn create(inner: &'a MutationSource) -> Box<dyn PhysicalFormat + 'a> {
         Box::new(MutationSourceFormatter { inner })
     }
+
+    fn format_filters(&self) -> String {
+        let mut filters = Vec::new();
+        if self.inner.has_hidden_secure_filters {
+            filters.push("SECURE POLICY REDACTED".to_string());
+        }
+        if let Some(display_filters) = &self.inner.display_filters {
+            filters.push(
+                display_filters
+                    .filter
+                    .as_expr(&BUILTIN_FUNCTIONS)
+                    .sql_display(),
+            );
+        }
+        filters.join(", ")
+    }
 }
 
 impl<'a> PhysicalFormat for MutationSourceFormatter<'a> {
@@ -46,12 +62,7 @@ impl<'a> PhysicalFormat for MutationSourceFormatter<'a> {
         let table = ctx.metadata.table(self.inner.table_index);
         let table_name = table.qualified_name();
 
-        let filters = self
-            .inner
-            .filters
-            .as_ref()
-            .map(|filters| filters.filter.as_expr(&BUILTIN_FUNCTIONS).sql_display())
-            .unwrap_or_default();
+        let filters = self.format_filters();
 
         let mut node_children = vec![
             FormatTreeNode::new(format!("table: {table_name}")),
@@ -86,8 +97,8 @@ impl<'a> PhysicalFormat for MutationSourceFormatter<'a> {
         let table = ctx.metadata.table(self.inner.table_index).clone();
         let table_name = table.qualified_name();
         let mut children = vec![FormatTreeNode::new(format!("table: {table_name}"))];
-        if let Some(filters) = &self.inner.filters {
-            let filter = filters.filter.as_expr(&BUILTIN_FUNCTIONS).sql_display();
+        let filter = self.format_filters();
+        if !filter.is_empty() {
             children.push(FormatTreeNode::new(format!("filters: [{filter}]")));
         }
 

--- a/src/query/service/src/physical_plans/physical_mutation_source.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_source.rs
@@ -66,6 +66,9 @@ pub struct MutationSource {
     pub table_index: IndexType,
     pub table_info: TableInfo,
     pub filters: Option<Filters>,
+    pub display_filters: Option<Filters>,
+    #[serde(default)]
+    pub has_hidden_secure_filters: bool,
     pub output_schema: DataSchemaRef,
     pub input_type: MutationType,
     pub read_partition_columns: ColumnSet,
@@ -108,6 +111,8 @@ impl IPhysicalPlan for MutationSource {
             table_index: self.table_index,
             table_info: self.table_info.clone(),
             filters: self.filters.clone(),
+            display_filters: self.display_filters.clone(),
+            has_hidden_secure_filters: self.has_hidden_secure_filters,
             output_schema: self.output_schema.clone(),
             input_type: self.input_type.clone(),
             read_partition_columns: self.read_partition_columns.clone(),
@@ -233,10 +238,24 @@ impl PhysicalPlanBuilder {
         &mut self,
         mutation_source: &databend_common_sql::plans::MutationSource,
     ) -> Result<PhysicalPlan> {
-        let filters = if !mutation_source.predicates.is_empty() {
+        let all_predicates: Vec<ScalarExpr> = mutation_source
+            .secure_predicates
+            .iter()
+            .chain(mutation_source.user_predicates.iter())
+            .cloned()
+            .collect();
+        let filters = if !all_predicates.is_empty() {
             Some(create_push_down_filters(
                 &self.ctx.get_function_context()?,
-                &mutation_source.predicates,
+                &all_predicates,
+            )?)
+        } else {
+            None
+        };
+        let display_filters = if !mutation_source.user_predicates.is_empty() {
+            Some(create_push_down_filters(
+                &self.ctx.get_function_context()?,
+                &mutation_source.user_predicates,
             )?)
         } else {
             None
@@ -278,6 +297,8 @@ impl PhysicalPlanBuilder {
             output_schema,
             table_info: mutation_info.table_info.clone(),
             filters,
+            display_filters,
+            has_hidden_secure_filters: !mutation_source.secure_predicates.is_empty(),
             input_type: mutation_source.mutation_type.clone(),
             read_partition_columns: mutation_source.read_partition_columns.clone(),
             truncate_table,

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -27,6 +27,7 @@ use databend_common_exception::Result;
 use databend_common_expression::ROW_ID_COL_NAME;
 use databend_common_expression::Symbol;
 use databend_common_expression::TableSchema;
+use log::error;
 
 use crate::BindContext;
 use crate::ColumnBinding;
@@ -50,6 +51,7 @@ use crate::plans::Filter;
 use crate::plans::Join;
 use crate::plans::JoinType;
 use crate::plans::MutationSource;
+use crate::plans::Operator;
 use crate::plans::RelOperator;
 use crate::plans::SubqueryExpr;
 use crate::plans::Visitor;
@@ -259,13 +261,20 @@ impl MutationExpression {
                         columns: bind_context.column_set(),
                         table_index: target_table_index,
                         mutation_type: mutation_type.clone(),
-                        predicates: vec![],
+                        secure_predicates: vec![],
+                        user_predicates: vec![],
                         predicate_column_index: None,
                         read_partition_columns: Default::default(),
                     };
 
-                    s_expr =
-                        SExpr::create_leaf(Arc::new(RelOperator::MutationSource(mutation_source)));
+                    // Direct mutation must evaluate row-access predicates inside MutationSource.
+                    // Keeping SecureFilter outside would filter rewritten blocks instead of
+                    // constraining the target rows that participate in the mutation.
+                    s_expr = Self::replace_scan_with_mutation_source(
+                        &s_expr,
+                        mutation_source,
+                        Vec::new(),
+                    )?;
 
                     if !predicates.is_empty() {
                         s_expr = SExpr::create_unary(
@@ -455,6 +464,61 @@ impl MutationExpression {
                     children.push(Arc::new(child));
                 }
                 Ok(s_expr.replace_children(children))
+            }
+        }
+    }
+
+    /// Replace the Scan leaf node with a MutationSource while removing SecureFilter wrappers.
+    fn replace_scan_with_mutation_source(
+        s_expr: &SExpr,
+        mutation_source: MutationSource,
+        mut secure_predicates: Vec<ScalarExpr>,
+    ) -> Result<SExpr> {
+        match s_expr.plan() {
+            RelOperator::Scan(_) => {
+                let mut mutation_source = mutation_source;
+                mutation_source.secure_predicates = secure_predicates;
+                Ok(SExpr::create_leaf(Arc::new(RelOperator::MutationSource(
+                    mutation_source,
+                ))))
+            }
+            RelOperator::SecureFilter(secure_filter) => {
+                if s_expr.arity() != 1 {
+                    error!(
+                        "Expected unary SecureFilter above Scan in mutation target, \
+                         got arity {} for {:?}",
+                        s_expr.arity(),
+                        s_expr.plan().rel_op(),
+                    );
+                    return Err(ErrorCode::Internal(
+                        "Expected unary SecureFilter above Scan in mutation target".to_string(),
+                    ));
+                }
+                secure_predicates.extend(secure_filter.predicates.clone());
+                Self::replace_scan_with_mutation_source(
+                    s_expr.unary_child(),
+                    mutation_source,
+                    secure_predicates,
+                )
+            }
+            _ => {
+                if s_expr.arity() != 1 {
+                    error!(
+                        "Expected unary operator above Scan in mutation target, \
+                         got {:?} with arity {}",
+                        s_expr.plan().rel_op(),
+                        s_expr.arity(),
+                    );
+                    return Err(ErrorCode::Internal(
+                        "Expected unary operator above Scan in mutation target".to_string(),
+                    ));
+                }
+                let child = Self::replace_scan_with_mutation_source(
+                    s_expr.unary_child(),
+                    mutation_source,
+                    secure_predicates,
+                )?;
+                Ok(s_expr.replace_children(vec![Arc::new(child)]))
             }
         }
     }

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -18,9 +18,12 @@ use async_recursion::async_recursion;
 use databend_common_ast::ast::ExplainKind;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::Symbol;
 use log::info;
 
 use crate::InsertInputSource;
+use crate::MetadataRef;
+use crate::ScalarExpr;
 use crate::binder::MutationStrategy;
 use crate::binder::MutationType;
 use crate::binder::target_probe;
@@ -51,7 +54,6 @@ use crate::plans::Join;
 use crate::plans::JoinType;
 use crate::plans::MatchedEvaluator;
 use crate::plans::Mutation;
-use crate::plans::MutationSource;
 use crate::plans::Operator;
 use crate::plans::Plan;
 use crate::plans::RelOp;
@@ -415,29 +417,63 @@ async fn optimize_mutation(opt_ctx: Arc<OptimizerContext>, s_expr: SExpr) -> Res
             }
         }
         MutationType::Update | MutationType::Delete => {
-            // Helper function to find MutationSource in a chain of operators
-            fn find_mutation_source(s_expr: &SExpr) -> Option<&MutationSource> {
+            #[allow(clippy::type_complexity)]
+            fn finalize_mutation_source(
+                s_expr: &SExpr,
+                metadata: &MetadataRef,
+            ) -> Result<Option<(SExpr, bool, Vec<ScalarExpr>, Option<Symbol>)>> {
                 match s_expr.plan() {
-                    RelOperator::MutationSource(rel) => Some(rel),
-                    RelOperator::Udf(_) | RelOperator::EvalScalar(_) => {
-                        if s_expr.arity() == 1 {
-                            find_mutation_source(s_expr.unary_child())
+                    RelOperator::MutationSource(rel) => {
+                        let mut rel = rel.clone();
+                        rel.refresh_read_partition_columns();
+                        let is_truncate =
+                            rel.mutation_type == MutationType::Delete && !rel.has_predicates();
+                        let direct_filter = rel.all_predicates_cloned();
+                        let predicate_column_index =
+                            rel.ensure_mutation_predicate_column_if_needed(metadata);
+                        let new_s_expr =
+                            SExpr::create_leaf(Arc::new(RelOperator::MutationSource(rel)));
+                        Ok(Some((
+                            new_s_expr,
+                            is_truncate,
+                            direct_filter,
+                            predicate_column_index,
+                        )))
+                    }
+                    RelOperator::Udf(_) | RelOperator::EvalScalar(_) if s_expr.arity() == 1 => {
+                        if let Some((child, is_truncate, direct_filter, pred_idx)) =
+                            finalize_mutation_source(s_expr.unary_child(), metadata)?
+                        {
+                            Ok(Some((
+                                s_expr.replace_children(vec![Arc::new(child)]),
+                                is_truncate,
+                                direct_filter,
+                                pred_idx,
+                            )))
                         } else {
-                            None
+                            Ok(None)
                         }
                     }
-                    _ => None,
+                    _ => Ok(None),
                 }
             }
 
-            if let Some(rel) = find_mutation_source(&input_s_expr) {
-                if rel.mutation_type == MutationType::Delete && rel.predicates.is_empty() {
-                    mutation.truncate_table = true;
-                }
-                mutation.direct_filter = rel.predicates.clone();
-                if let Some(index) = rel.predicate_column_index {
-                    mutation.required_columns.insert(index);
-                    mutation.predicate_column_index = Some(index);
+            // finalize_mutation_source only applies to Direct strategy where the
+            // plan tree contains a MutationSource leaf. Non-direct mutations
+            // (e.g., UPDATE ... FROM, subquery cases) have Join/Filter roots
+            // with no MutationSource node.
+            if mutation.strategy == MutationStrategy::Direct {
+                let metadata = opt_ctx.get_metadata();
+                if let Some((new_s_expr, is_truncate, direct_filter, pred_idx)) =
+                    finalize_mutation_source(&input_s_expr, &metadata)?
+                {
+                    input_s_expr = new_s_expr;
+                    mutation.truncate_table = is_truncate;
+                    mutation.direct_filter = direct_filter;
+                    if let Some(index) = pred_idx {
+                        mutation.required_columns.insert(index);
+                        mutation.predicate_column_index = Some(index);
+                    }
                 }
             }
             input_s_expr

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/factory.rs
@@ -127,9 +127,7 @@ impl RuleFactory {
             RuleID::EliminateSort => Ok(Box::new(RuleEliminateSort::new())),
             RuleID::DeduplicateSort => Ok(Box::new(RuleDeduplicateSort::new())),
             RuleID::SemiToInnerJoin => Ok(Box::new(RuleSemiToInnerJoin::new())),
-            RuleID::MergeFilterIntoMutation => {
-                Ok(Box::new(RuleMergeFilterIntoMutation::new(metadata)))
-            }
+            RuleID::MergeFilterIntoMutation => Ok(Box::new(RuleMergeFilterIntoMutation::new())),
         }
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_merge_filter_into_mutation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_merge_filter_into_mutation.rs
@@ -15,10 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 
-use crate::MetadataRef;
-use crate::binder::MutationType;
 use crate::optimizer::ir::Matcher;
 use crate::optimizer::ir::SExpr;
 use crate::optimizer::optimizers::rule::Rule;
@@ -32,11 +29,16 @@ use crate::plans::RelOperator;
 pub struct RuleMergeFilterIntoMutation {
     id: RuleID,
     matchers: Vec<Matcher>,
-    metadata: MetadataRef,
+}
+
+impl Default for RuleMergeFilterIntoMutation {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RuleMergeFilterIntoMutation {
-    pub fn new(metadata: MetadataRef) -> Self {
+    pub fn new() -> Self {
         Self {
             id: RuleID::MergeFilterIntoMutation,
             // Filter
@@ -49,7 +51,6 @@ impl RuleMergeFilterIntoMutation {
                     children: vec![],
                 }],
             }],
-            metadata,
         }
     }
 }
@@ -62,21 +63,11 @@ impl Rule for RuleMergeFilterIntoMutation {
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let filter: Filter = s_expr.plan().clone().try_into()?;
         let mut mutation: MutationSource = s_expr.child(0)?.plan().clone().try_into()?;
-        mutation
-            .read_partition_columns
-            .extend(filter.predicates.iter().flat_map(|v| v.used_columns()));
-        mutation.predicates = filter.predicates;
+        mutation.user_predicates.extend(filter.predicates);
 
-        if mutation.mutation_type == MutationType::Update {
-            let column_index = self
-                .metadata
-                .write()
-                .add_derived_column("_predicate".to_string(), DataType::Boolean);
-            mutation.predicate_column_index = Some(column_index);
-        }
-
-        let new_expr = SExpr::create_leaf(Arc::new(RelOperator::MutationSource(mutation)));
-        state.add_result(new_expr);
+        state.add_result(SExpr::create_leaf(Arc::new(RelOperator::MutationSource(
+            mutation,
+        ))));
         Ok(())
     }
 

--- a/src/query/sql/src/planner/plans/mutation_source.rs
+++ b/src/query/sql/src/planner/plans/mutation_source.rs
@@ -17,12 +17,15 @@ use std::sync::Arc;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::PREDICATE_COLUMN_NAME;
 use databend_common_expression::Symbol;
 use databend_common_expression::TableSchema;
+use databend_common_expression::types::DataType;
 
 use super::ScalarExpr;
 use crate::ColumnSet;
 use crate::IndexType;
+use crate::MetadataRef;
 use crate::binder::MutationType;
 use crate::optimizer::ir::Distribution;
 use crate::optimizer::ir::PhysicalProperty;
@@ -40,7 +43,8 @@ pub struct MutationSource {
     pub columns: ColumnSet,
     pub table_index: IndexType,
     pub mutation_type: MutationType,
-    pub predicates: Vec<ScalarExpr>,
+    pub secure_predicates: Vec<ScalarExpr>,
+    pub user_predicates: Vec<ScalarExpr>,
     pub predicate_column_index: Option<Symbol>,
     pub read_partition_columns: ColumnSet,
 }
@@ -72,7 +76,11 @@ impl Operator for MutationSource {
     }
 
     fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
-        Box::new(self.predicates.iter())
+        Box::new(
+            self.secure_predicates
+                .iter()
+                .chain(self.user_predicates.iter()),
+        )
     }
 
     fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
@@ -112,5 +120,45 @@ impl Operator for MutationSource {
         Err(ErrorCode::Internal(
             "Cannot compute required property for children of MutationSource".to_string(),
         ))
+    }
+}
+
+impl MutationSource {
+    pub fn all_predicates(&self) -> impl Iterator<Item = &ScalarExpr> + '_ {
+        self.secure_predicates
+            .iter()
+            .chain(self.user_predicates.iter())
+    }
+
+    pub fn has_predicates(&self) -> bool {
+        !self.secure_predicates.is_empty() || !self.user_predicates.is_empty()
+    }
+
+    pub fn refresh_read_partition_columns(&mut self) {
+        self.read_partition_columns = self
+            .all_predicates()
+            .flat_map(|predicate| predicate.used_columns())
+            .collect();
+    }
+
+    /// Return all predicates (secure + user) as an owned Vec.
+    /// Used to populate `Mutation::direct_filter` for push-down.
+    pub fn all_predicates_cloned(&self) -> Vec<ScalarExpr> {
+        self.all_predicates().cloned().collect()
+    }
+
+    pub fn ensure_mutation_predicate_column_if_needed(
+        &mut self,
+        metadata: &MetadataRef,
+    ) -> Option<Symbol> {
+        if self.mutation_type != MutationType::Update || !self.has_predicates() {
+            return None;
+        }
+
+        Some(*self.predicate_column_index.get_or_insert_with(|| {
+            metadata
+                .write()
+                .add_derived_column(PREDICATE_COLUMN_NAME.to_string(), DataType::Boolean)
+        }))
     }
 }

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0012_row_policy_dml_coverage.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0012_row_policy_dml_coverage.test
@@ -1,0 +1,251 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+set global enable_experimental_row_access_policy = 1;
+
+statement ok
+set enable_planner_cache = 0;
+
+statement ok
+drop table if exists rap_dml_test;
+
+statement ok
+drop table if exists rap_dml_aux;
+
+statement ok
+drop table if exists rap_dml_src;
+
+statement ok
+drop row access policy if exists rap_dml_policy;
+
+statement ok
+create row access policy rap_dml_policy as (dept string) returns boolean -> dept = 'sales';
+
+statement ok
+create table rap_dml_test(id int, dept string, val int);
+
+statement ok
+insert into rap_dml_test values (1, 'sales', 100), (2, 'eng', 200), (3, 'sales', 300);
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## SELECT should only see policy-visible rows
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 100 sales
+3 300 sales
+
+## Direct UPDATE without WHERE should only affect policy-visible rows
+statement ok
+update rap_dml_test set val = 444;
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 444 sales
+2 200 eng
+3 444 sales
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Direct UPDATE should not affect invisible rows
+statement ok
+update rap_dml_test set val = 999 where dept = 'eng';
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 444 sales
+2 200 eng
+3 444 sales
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Direct DELETE should not affect invisible rows
+statement ok
+delete from rap_dml_test where dept = 'eng';
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 444 sales
+2 200 eng
+3 444 sales
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Direct UPDATE should still affect visible rows
+statement ok
+update rap_dml_test set val = 111 where id = 1;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 111 sales
+3 444 sales
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 111 sales
+2 200 eng
+3 444 sales
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Direct DELETE should still affect visible rows
+statement ok
+delete from rap_dml_test where id = 3;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 111 sales
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 111 sales
+2 200 eng
+
+statement ok
+insert into rap_dml_test values (3, 'sales', 300);
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## DELETE without WHERE must not truncate invisible rows
+statement ok
+delete from rap_dml_test;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+2 200 eng
+
+statement ok
+truncate table rap_dml_test;
+
+statement ok
+insert into rap_dml_test values (1, 'sales', 100), (2, 'eng', 200), (3, 'sales', 300);
+
+statement ok
+create table rap_dml_aux(id int, dept string);
+
+statement ok
+insert into rap_dml_aux values (2, 'eng'), (3, 'sales');
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Non-Direct UPDATE with subquery should not affect invisible rows
+statement ok
+update rap_dml_test
+set val = 555
+where id in (select id from rap_dml_aux where dept = 'eng');
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 100 sales
+2 200 eng
+3 300 sales
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## Non-Direct DELETE with subquery should not affect invisible rows
+statement ok
+delete from rap_dml_test
+where id in (select id from rap_dml_aux where dept = 'eng');
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 100 sales
+2 200 eng
+3 300 sales
+
+statement ok
+create table rap_dml_src(id int, new_val int);
+
+statement ok
+insert into rap_dml_src values (2, 777), (3, 888);
+
+statement ok
+alter table rap_dml_test add row access policy rap_dml_policy on (dept);
+
+## MERGE should not affect invisible target rows
+statement ok
+merge into rap_dml_test as t
+using rap_dml_src as s
+on t.id = s.id
+when matched then update set t.val = s.new_val;
+
+statement ok
+alter table rap_dml_test drop row access policy rap_dml_policy;
+
+query IIT
+select id, val, dept from rap_dml_test order by id;
+----
+1 100 sales
+2 200 eng
+3 888 sales
+
+statement ok
+drop table rap_dml_src;
+
+statement ok
+drop table rap_dml_aux;
+
+statement ok
+drop table rap_dml_test;
+
+statement ok
+drop row access policy rap_dml_policy;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Direct UPDATE with row access policy but no user WHERE clause left predicate_column_index as None. The storage-layer MutationSource processor appends a predicate boolean column to the data block, but ColumnMutation did not expect it (has_filter_column: false), and mutation_update_expr generated if(true, new_val, old_val) — unconditionally updating ALL rows in matched blocks, including rows that should be invisible under the row access policy.

Fix: set predicate_column_index in replace_scan_with_mutation_source when secure predicates exist and mutation_type is Update,so the row-level boolean column is properly wired through the pipeline.

Also replace the fragile predicates + secure_predicates_len convention with two explicit fields (secure_predicates, user_predicates) to enforce the security boundary via the type system rather than an array index that any optimizer pass could silently break.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19625)
<!-- Reviewable:end -->
