### PR TITLE
fix(storage): limit unclustered block selection in recluster compact phase

### DIFF
--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -47,6 +47,7 @@ use fastrace::func_path;
 use fastrace::future::FutureExt;
 use indexmap::IndexSet;
 use log::debug;
+use log::info;
 use log::warn;
 use opendal::Operator;
 
@@ -67,6 +68,11 @@ use crate::statistics::sort_by_cluster_stats;
 /// For two-block layouts, repeated reclustering beyond this level
 /// rarely improves data locality and may cause task churn.
 const MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS: i32 = 2;
+
+/// Maximum number of unclustered blocks to select for compaction in a single
+/// recluster round. Keeps the compact phase bounded so recluster can make
+/// incremental progress without excessive memory/time cost per invocation.
+const MAX_UNCLUSTERED_BLOCKS_PER_RECLUSTER: u64 = 1000;
 
 pub enum ReclusterMode {
     Recluster,
@@ -425,7 +431,10 @@ impl ReclusterMutator {
         &self,
         compact_segments: Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>,
     ) -> Result<(u64, ReclusterParts)> {
-        debug!("recluster: generate compact tasks");
+        info!(
+            "recluster: found {} unclustered segments, compacting them before re-clustering",
+            compact_segments.len()
+        );
         let settings = self.ctx.get_settings();
         let num_block_limit = settings.get_compact_max_block_selection()? as usize;
         let num_segment_limit = compact_segments.len();
@@ -535,8 +544,14 @@ impl ReclusterMutator {
         let mut indices = IndexSet::new();
         let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
         let mut unclustered_segments = IndexSet::new();
+        let mut unclustered_block_num = 0;
         let mut small_segments = IndexSet::new();
+
         let block_per_seg = self.block_thresholds.block_per_segment;
+        let max_uncluster_blocks = std::cmp::min(
+            self.ctx.get_settings().get_compact_max_block_selection()?,
+            MAX_UNCLUSTERED_BLOCKS_PER_RECLUSTER,
+        );
 
         // Iterate over all segments
         for (i, (loc, compact_segment)) in compact_segments.iter().enumerate() {
@@ -557,7 +572,11 @@ impl ReclusterMutator {
                     "recluster: segment '{}' is unclustered, needs to be compacted",
                     loc.location.0
                 );
+                unclustered_block_num += compact_segment.summary.block_count;
                 unclustered_segments.insert(i);
+                if unclustered_block_num >= max_uncluster_blocks {
+                    break;
+                }
                 continue;
             }
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
@@ -108,17 +108,55 @@ insert into t4 select number % 2, to_string(number) from numbers(500)
 statement ok
 alter table t4 recluster final
 
+## test recluster with compact task.
 statement ok
-DROP Table t1 all
+create table t5(a int, b int);
 
 statement ok
-DROP Table t2 all
+set compact_max_block_selection = 2;
 
 statement ok
-DROP Table t3 all
+insert into t5 values(1, 1),(6, 6);
 
 statement ok
-DROP Table t4 all
+insert into t5 values(0, 0),(3, 3);
+
+statement ok
+insert into t5 values(2, 2),(4, 4);
+
+statement ok
+alter table t5 cluster by(a);
+
+statement ok
+alter table t5 recluster;
+
+query T
+select info from clustering_information('db_09_0016','t5');
+----
+{"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"total_block_count":2}
+
+query TTI
+select min, max, level from clustering_statistics('db_09_0016','t5') order by segment_name;
+----
+NULL NULL NULL
+[0] [4] 0
+
+statement ok
+alter table t5 recluster;
+
+query TTI
+select min, max, level from clustering_statistics('db_09_0016','t5') order by segment_name;
+----
+[0] [4] 0
+[1] [6] 0
+
+statement ok
+alter table t5 recluster;
+
+query TTI
+select min, max, level from clustering_statistics('db_09_0016','t5') order by segment_name;
+----
+[0] [6] 1
 
 statement ok
 DROP DATABASE db_09_0016


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Recluster now caps the number of unclustered blocks selected for compaction per round, preventing the compact phase from becoming a bottleneck when tables have many unclustered segments.                          
                                                                                                                                                            
  - Added **MAX_UNCLUSTERED_BLOCKS_PER_RECLUSTER** (1000) as the upper bound, further capped by `compact_max_block_selection` setting                             
  - Recluster `select_segments` now tracks `unclustered_block_num` and breaks early once the limit is reached, allowing incremental progress across multiple invocations

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19641)
<!-- Reviewable:end -->
