### PR TITLE
fix(query): use jiff to_zoned for naive datetime timezone resolution

### DIFF
--- a/src/query/expression/src/types/timestamp_tz.rs
+++ b/src/query/expression/src/types/timestamp_tz.rs
@@ -23,7 +23,6 @@ use databend_common_io::datetime::parse_standard_timestamp as parse_iso_timestam
 use jiff::civil::Date;
 use jiff::civil::Time;
 use jiff::fmt;
-use jiff::tz;
 use jiff::tz::TimeZone;
 
 use super::ArgType;
@@ -237,12 +236,11 @@ pub fn string_to_timestamp_tz<'a, F: FnOnce() -> &'a TimeZone>(
     match time.offset() {
         None => {
             let datetime = time.to_datetime()?;
-            let timestamp = tz::offset(0).to_timestamp(datetime)?;
-            let offset = fn_tz().to_offset(timestamp);
+            let zoned = datetime.to_zoned(fn_tz().clone())?;
 
             Ok(timestamp_tz::new(
-                timestamp.as_microsecond() - (offset.seconds() as i64 * 1_000_000),
-                offset.seconds(),
+                zoned.timestamp().as_microsecond(),
+                zoned.offset().seconds(),
             ))
         }
         Some(offset) => {

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes_tz.test
@@ -1219,3 +1219,9 @@ select to_date('9999/12/31','%Y/%m/%d');
 
 statement ok
 unset timezone;
+
+query TT
+settings (timezone='America/New_York') select try_to_timestamp('2024-11-03 05:30:00'), try_to_timestamp_tz('2024-11-03 05:30:00');
+----
+2024-11-03 05:30:00.000000 2024-11-03 05:30:00.000000 -0500
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

string_to_timestamp_tz used a "fake UTC" approach to resolve timezone
offset for naive datetime inputs: it treated the naive datetime as UTC,
then looked up the timezone offset at that (wrong) UTC instant. This
produced incorrect results when the fake and real UTC instants straddled
a DST transition.

For example, '2024-11-03 05:30:00' in America/New_York should resolve
to EST (-0500), giving real UTC 10:30. But the old code treated 05:30
as UTC to look up the offset, and since 05:30 UTC is before the 06:00
UTC transition, it got EDT (-0400) instead of EST (-0500).

Fix: replace the manual fake-UTC-then-lookup with jiff's
DateTime::to_zoned(), which correctly interprets a naive datetime in
the target timezone and handles DST disambiguation natively.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19647)
<!-- Reviewable:end -->
