### PR TITLE
feat: speed up equi ASOF joins

### DIFF
--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -39,8 +39,15 @@ enum PhysicalJoinType {
 fn asof_hash_join_type(join_type: JoinType) -> JoinType {
     match join_type {
         JoinType::Asof => JoinType::Inner,
-        JoinType::LeftAsof => JoinType::Left,
-        JoinType::RightAsof => JoinType::Right,
+        // ASOF rewrite swaps children to:
+        //   probe = window(original right)
+        //   build = original left
+        //
+        // HashJoin preserves the probe side for LEFT joins and the build side
+        // for RIGHT joins, so outer ASOF joins need the opposite mapping here
+        // to preserve the original SQL null-preserving side.
+        JoinType::LeftAsof => JoinType::Right,
+        JoinType::RightAsof => JoinType::Left,
         _ => join_type,
     }
 }

--- a/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
+++ b/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
@@ -68,6 +68,21 @@ order by t.id
 5 NULL
 6 NULL
 
+# Right ASOF should preserve unmatched build-side rows from the original
+# `prices` table after the ASOF rewrite swaps the physical children.
+query II
+select p.price, t.id
+from asof_eq_trades t
+asof right join asof_eq_prices p
+    on t.symbol = p.symbol and t.wh >= p.wh
+order by p.price, t.id
+----
+10 1
+11 4
+20 2
+20 3
+21 NULL
+
 statement ok
 drop table asof_eq_trades
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- reuse the hash-join path for `ASOF JOIN` when equality keys are present
- preserve the original SQL outer side for equi `ASOF LEFT/RIGHT JOIN` after the ASOF binder rewrite swaps the physical children
- keep the `ASOF` residual predicates in place so the optimization only changes the physical fast path
- add a focused sqllogictest that checks nearest-predecessor semantics, key partition isolation, and outer-join null preservation for both left and right ASOF cases

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19654)
<!-- Reviewable:end -->
