### PR TITLE
fix: make runtime filter wait exit on finish or abort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,6 @@ dependencies = [
  "lexical-core",
  "match-template",
  "micromarshal",
- "num",
  "num-traits",
  "pretty_assertions",
  "serde",

--- a/src/query/formats/Cargo.toml
+++ b/src/query/formats/Cargo.toml
@@ -30,7 +30,6 @@ jsonb = { workspace = true }
 lexical-core = { workspace = true }
 match-template = { workspace = true }
 micromarshal = { workspace = true }
-num = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/query/storages/fuse/src/operations/read/runtime_filter_wait.rs
+++ b/src/query/storages/fuse/src/operations/read/runtime_filter_wait.rs
@@ -15,7 +15,9 @@
 use std::any::Any;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
+use databend_common_base::base::WatchNotify;
 use databend_common_catalog::runtime_filter_info::RuntimeFilterReady;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
@@ -26,7 +28,60 @@ use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_sql::IndexType;
-use tokio::time::timeout;
+
+const RUNTIME_FILTER_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const RUNTIME_FILTER_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+async fn wait_runtime_filters(
+    scan_id: IndexType,
+    input: &Arc<InputPort>,
+    output: &Arc<OutputPort>,
+    abort_notify: Arc<WatchNotify>,
+    runtime_filter_ready: &[Arc<RuntimeFilterReady>],
+) -> Result<()> {
+    for runtime_filter_ready in runtime_filter_ready {
+        let mut rx = runtime_filter_ready.runtime_filter_watcher.subscribe();
+        if (*rx.borrow()).is_some() {
+            continue;
+        }
+
+        let deadline = Instant::now() + RUNTIME_FILTER_WAIT_TIMEOUT;
+        loop {
+            if output.is_finished() {
+                input.finish();
+                return Ok(());
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                log::warn!(
+                    "Runtime filter wait timeout after {:?} for scan_id: {}",
+                    RUNTIME_FILTER_WAIT_TIMEOUT,
+                    scan_id
+                );
+                break;
+            }
+
+            let wait_duration = (deadline - now).min(RUNTIME_FILTER_WAIT_POLL_INTERVAL);
+            tokio::select! {
+                changed = rx.changed() => {
+                    match changed {
+                        Ok(()) => break,
+                        Err(_) => return Err(ErrorCode::TokioError("watcher's sender is dropped")),
+                    }
+                }
+                _ = abort_notify.notified() => {
+                    return Err(ErrorCode::AbortedQuery(
+                        "query aborted while waiting for runtime filter",
+                    ));
+                }
+                _ = tokio::time::sleep(wait_duration) => {}
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub struct TransformRuntimeFilterWait {
     ctx: Arc<dyn TableContext>,
@@ -111,30 +166,104 @@ impl Processor for TransformRuntimeFilterWait {
             self.runtime_filter_ready.len()
         );
 
-        let timeout_duration = Duration::from_secs(30);
-        for runtime_filter_ready in &self.runtime_filter_ready {
-            let mut rx = runtime_filter_ready.runtime_filter_watcher.subscribe();
-            if (*rx.borrow()).is_some() {
-                continue;
-            }
-
-            match timeout(timeout_duration, rx.changed()).await {
-                Ok(Ok(())) => {}
-                Ok(Err(_)) => {
-                    return Err(ErrorCode::TokioError("watcher's sender is dropped"));
-                }
-                Err(_) => {
-                    log::warn!(
-                        "Runtime filter wait timeout after {:?} for scan_id: {}",
-                        timeout_duration,
-                        self.scan_id
-                    );
-                }
-            }
-        }
+        wait_runtime_filters(
+            self.scan_id,
+            &self.input,
+            &self.output,
+            self.ctx.get_abort_notify(),
+            &self.runtime_filter_ready,
+        )
+        .await?;
 
         self.runtime_filter_ready.clear();
         self.wait_finished = true;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use databend_common_base::base::WatchNotify;
+    use databend_common_base::runtime::spawn;
+    use databend_common_pipeline::core::InputPort;
+    use databend_common_pipeline::core::OutputPort;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_wait_runtime_filters_returns_when_output_finished() {
+        let input = InputPort::create();
+        let output = OutputPort::create();
+        let ready = Arc::new(RuntimeFilterReady::default());
+        let abort_notify = Arc::new(WatchNotify::new());
+
+        let output_cloned = output.clone();
+        spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            output_cloned.finish();
+        });
+
+        tokio::time::timeout(
+            Duration::from_millis(300),
+            wait_runtime_filters(0, &input, &output, abort_notify, &[ready]),
+        )
+        .await
+        .expect("runtime filter wait should stop after branch finish")
+        .expect("branch finish should not return an error");
+
+        assert!(input.is_finished());
+    }
+
+    #[tokio::test]
+    async fn test_wait_runtime_filters_returns_when_query_aborted() {
+        let input = InputPort::create();
+        let output = OutputPort::create();
+        let ready = Arc::new(RuntimeFilterReady::default());
+        let abort_notify = Arc::new(WatchNotify::new());
+
+        let abort_notify_cloned = abort_notify.clone();
+        spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            abort_notify_cloned.notify_waiters();
+        });
+
+        let err = tokio::time::timeout(
+            Duration::from_millis(300),
+            wait_runtime_filters(0, &input, &output, abort_notify, &[ready]),
+        )
+        .await
+        .expect("runtime filter wait should stop after query abort")
+        .expect_err("query abort should propagate as an error");
+
+        assert_eq!(err.name(), "AbortedQuery");
+    }
+
+    #[tokio::test]
+    async fn test_wait_runtime_filters_returns_when_filter_notified() {
+        let input = InputPort::create();
+        let output = OutputPort::create();
+        let ready = Arc::new(RuntimeFilterReady::default());
+        let abort_notify = Arc::new(WatchNotify::new());
+
+        let ready_cloned = ready.clone();
+        spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            ready_cloned
+                .runtime_filter_watcher
+                .send(Some(()))
+                .expect("watcher should stay open");
+        });
+
+        tokio::time::timeout(
+            Duration::from_millis(300),
+            wait_runtime_filters(0, &input, &output, abort_notify, &[ready]),
+        )
+        .await
+        .expect("runtime filter wait should stop after filter notification")
+        .expect("filter notification should not return an error");
+
+        assert!(!input.is_finished());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

#19668

This PR replaces the single 30-second blocking wait on the runtime-filter watcher with a short polling loop that still honors the same overall timeout, but also checks whether the downstream branch has already finished and listens for query-abort notifications; tests were added for runtime-filter ready, branch finish, and query abort.
```SQL
root@localhost:8000/default/default> select a, b from (
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
    ) t
    limit 5 ignore_result;

select
  a,
  b
from
  (
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
  ) t
limit
  5 ignore_result

0 row read in 1.525 sec. Processed 5 thousand row, 132.38 KiB (3.28 thousand rows/s, 86.81 KiB/s)

root@localhost:8000/default/default> select a, b from (
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
        union all
        select t_probe.a, t_build.b from t_probe inner join t_build on t_probe.a = t_build.a
    ) t ignore_result;

select
  a,
  b
from
  (
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
    union
    all
    select
      t_probe.a,
      t_build.b
    from
      t_probe
      inner join t_build on t_probe.a = t_build.a
  ) t ignore_result

0 row read in 1.949 sec. Processed 8 thousand row, 144.10 KiB (4.1 thousand rows/s, 73.94 KiB/s)
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19669)
<!-- Reviewable:end -->
