### PR TITLE
fix: avoid single thread row fetch

### DIFF
--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -185,6 +185,7 @@ impl RowsFetcher for ParquetRowsFetcher {
             if blocks_bytes >= 50 * 1024 * 1024 || tasks_indices.peek().is_none() {
                 let tasks_handle = std::mem::take(&mut tasks_handle);
                 let tasks_block = future::try_join_all(tasks_handle).await.unwrap();
+                blocks_bytes = 0;
                 for task_block in tasks_block {
                     let (final_index, block) = task_block?;
                     final_blocks.insert(final_index, block);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes the batching logic in parquet row fetch.

  `blocks_bytes` was not reset after flushing a batch. Once the first batch crossed the 50 MB threshold, every following block was joined immediately, which effectively serialized the remaining row fetch work and reduced concurrency.

  This change resets `blocks_bytes` after each flush so row fetch can continue batching blocks as intended.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19677)
<!-- Reviewable:end -->
