### PR TITLE
fix: vacuum temp files not respect duration

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
@@ -27,6 +27,7 @@ use futures_util::TryStreamExt;
 use log::info;
 use opendal::Buffer;
 use opendal::ErrorKind;
+use opendal::Operator;
 
 // Default retention duration for temporary files: 3 days.
 const DEFAULT_RETAIN_DURATION: Duration = Duration::from_secs(60 * 60 * 24 * 3);
@@ -60,6 +61,24 @@ pub async fn do_vacuum_temporary_files(
     }
 }
 
+/// Vacuum temporary spill files by retention duration.
+///
+/// Background:
+/// - On object stores like S3, a directory entry may not expose a reliable `last_modified`.
+/// - Treating such directories as expired is unsafe because an active query's spill directory can
+///   be deleted while the query is still running.
+///
+/// Decision order for directories:
+/// - Prefer the directory's own `last_modified` when available.
+/// - Otherwise, use the paired spill meta file that ends with `.list`, because it is a better
+///   signal for spill activity on remote storage.
+/// - If the meta file is also unavailable, probe only the first file in the directory and use its
+///   `last_modified` as a conservative fallback.
+///
+/// Cost control:
+/// - `list` on remote storage is expensive, so the extra probe is only used in the final fallback.
+/// - If probing decides the directory is expired, the same lister is reused to finish deletion so
+///   we don't pay for an additional probe list.
 async fn vacuum_by_duration(
     abort_checker: AbortChecker,
     temporary_dir: &str,
@@ -82,8 +101,6 @@ async fn vacuum_by_duration(
     let mut temp_files = Vec::new();
     let mut gc_metas = HashSet::new();
 
-    // We may delete next entries during iteration
-    // So we can't use
     loop {
         let de = ds.try_next().await;
         match de {
@@ -93,30 +110,29 @@ async fn vacuum_by_duration(
                     continue;
                 }
                 let name = de.name();
-                let meta = if de.metadata().last_modified().is_none() {
-                    operator.stat(de.path()).await
-                } else {
-                    Ok(de.metadata().clone())
-                };
+                if de.metadata().is_file() {
+                    let Some(last_modified) =
+                        resolve_file_last_modified(&operator, de.path(), de.metadata()).await
+                    else {
+                        continue;
+                    };
 
-                if meta.is_err() {
-                    continue;
-                }
-                let meta = meta.unwrap();
-
-                if let Some(modified) = meta.last_modified() {
-                    if timestamp - modified.timestamp_millis() < expire_time {
+                    if timestamp - last_modified < expire_time {
                         continue;
                     }
-                }
-                if meta.is_file() {
+
                     if name.ends_with(SPILL_META_SUFFIX) {
                         if gc_metas.contains(name) {
                             continue;
                         }
-                        let removed =
-                            vacuum_by_meta(&temporary_dir, de.path(), limit, &mut removed_total)
-                                .await?;
+                        let removed = vacuum_by_meta_with_operator(
+                            &operator,
+                            &temporary_dir,
+                            de.path(),
+                            limit,
+                            &mut removed_total,
+                        )
+                        .await?;
                         limit = limit.saturating_sub(removed);
                         gc_metas.insert(name.to_owned());
                     } else {
@@ -126,27 +142,58 @@ async fn vacuum_by_duration(
                         }
                     }
                 } else {
-                    let removed = vacuum_by_meta(
-                        &temporary_dir,
-                        &format!("{}{}", de.path().trim_end_matches('/'), SPILL_META_SUFFIX),
-                        limit,
-                        &mut removed_total,
-                    )
-                    .await?;
-                    // by meta
-                    if removed > 0 {
-                        let meta_name = format!("{}{}", name, SPILL_META_SUFFIX);
-                        if gc_metas.contains(&meta_name) {
+                    let meta_path =
+                        format!("{}{}", de.path().trim_end_matches('/'), SPILL_META_SUFFIX);
+                    if let Some(last_modified) =
+                        resolve_dir_last_modified(&operator, de.path(), de.metadata(), &meta_path)
+                            .await
+                    {
+                        if timestamp - last_modified < expire_time {
                             continue;
                         }
 
-                        limit = limit.saturating_sub(removed);
-                        gc_metas.insert(meta_name);
+                        let removed = vacuum_by_meta_with_operator(
+                            &operator,
+                            &temporary_dir,
+                            &meta_path,
+                            limit,
+                            &mut removed_total,
+                        )
+                        .await?;
+                        if removed > 0 {
+                            let meta_name = format!("{}{}", name, SPILL_META_SUFFIX);
+                            if gc_metas.contains(&meta_name) {
+                                continue;
+                            }
+
+                            limit = limit.saturating_sub(removed);
+                            gc_metas.insert(meta_name);
+                        } else {
+                            let removed = vacuum_by_list_dir_with_operator(
+                                &operator,
+                                de.path(),
+                                limit,
+                                &mut removed_total,
+                            )
+                            .await?;
+                            limit = limit.saturating_sub(removed);
+                        }
                     } else {
-                        // by list
-                        let removed =
-                            vacuum_by_list_dir(de.path(), limit, &mut removed_total).await?;
+                        let removed = vacuum_dir_with_probe(
+                            &operator,
+                            &temporary_dir,
+                            de.path(),
+                            &meta_path,
+                            timestamp,
+                            expire_time,
+                            limit,
+                            &mut removed_total,
+                        )
+                        .await?;
                         limit = limit.saturating_sub(removed);
+                        if removed > 0 {
+                            gc_metas.insert(format!("{}{}", name, SPILL_META_SUFFIX));
+                        }
                     }
                 }
                 if limit == 0 {
@@ -171,6 +218,142 @@ async fn vacuum_by_duration(
         start_time.elapsed().as_secs()
     );
     Ok(removed_total)
+}
+
+/// Read `last_modified` for a single object path via `stat`.
+async fn stat_last_modified(operator: &Operator, path: &str) -> Option<i64> {
+    operator
+        .stat(path)
+        .await
+        .ok()
+        .and_then(|meta| meta.last_modified().map(|v| v.timestamp_millis()))
+}
+
+/// Resolve a file's `last_modified`, preferring list metadata and falling back to `stat`.
+async fn resolve_file_last_modified(
+    operator: &Operator,
+    path: &str,
+    metadata: &opendal::Metadata,
+) -> Option<i64> {
+    if let Some(last_modified) = metadata.last_modified() {
+        return Some(last_modified.timestamp_millis());
+    }
+
+    if let Some(last_modified) = stat_last_modified(operator, path).await {
+        return Some(last_modified);
+    }
+
+    None
+}
+
+/// Resolve a directory's `last_modified` from the dir itself first, then from its `.list` file.
+async fn resolve_dir_last_modified(
+    operator: &Operator,
+    dir_path: &str,
+    metadata: &opendal::Metadata,
+    meta_path: &str,
+) -> Option<i64> {
+    if let Some(last_modified) = metadata.last_modified() {
+        return Some(last_modified.timestamp_millis());
+    }
+
+    if let Some(last_modified) = stat_last_modified(operator, dir_path).await {
+        return Some(last_modified);
+    }
+
+    stat_last_modified(operator, meta_path).await
+}
+
+/// Probe only the first file in a directory to decide whether the whole directory can be vacuumed.
+/// If it is expired, reuse the same lister to finish deletion and avoid an extra probe list.
+async fn vacuum_dir_with_probe(
+    operator: &Operator,
+    temporary_dir: &str,
+    dir_path: &str,
+    meta_path: &str,
+    timestamp: i64,
+    expire_time: i64,
+    limit: usize,
+    removed_total: &mut usize,
+) -> Result<usize> {
+    let start_time = Instant::now();
+    let mut lister = match operator.lister_with(dir_path).recursive(true).await {
+        Ok(lister) => lister,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e.into()),
+    };
+    let mut paths = Vec::new();
+    let mut first_file_last_modified = None;
+
+    loop {
+        let entry = match lister.try_next().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) if e.kind() == ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+
+        if entry.path() == dir_path {
+            continue;
+        }
+
+        paths.push(entry.path().to_string());
+        if !entry.metadata().is_file() {
+            continue;
+        }
+
+        first_file_last_modified = if let Some(last_modified) = entry.metadata().last_modified() {
+            Some(last_modified.timestamp_millis())
+        } else {
+            stat_last_modified(operator, entry.path()).await
+        };
+        break;
+    }
+
+    let Some(first_file_last_modified) = first_file_last_modified else {
+        return Ok(0);
+    };
+
+    if timestamp - first_file_last_modified < expire_time {
+        return Ok(0);
+    }
+
+    let removed =
+        vacuum_by_meta_with_operator(operator, temporary_dir, meta_path, limit, removed_total)
+            .await?;
+    if removed > 0 {
+        return Ok(removed);
+    }
+
+    loop {
+        let entry = match lister.try_next().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) if e.kind() == ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+
+        if entry.path() == dir_path {
+            continue;
+        }
+        paths.push(entry.path().to_string());
+    }
+
+    paths.push(dir_path.to_owned());
+
+    let cur_removed = paths.len().min(limit);
+    let _ = operator.delete_iter(paths.into_iter().take(limit)).await;
+
+    *removed_total += cur_removed;
+    info!(
+        "Vacuum temporary files progress(by probed dir): Total removed: {}, Current batch: {} (from '{}'), Time: {} sec",
+        *removed_total,
+        cur_removed,
+        dir_path,
+        start_time.elapsed().as_secs(),
+    );
+
+    Ok(cur_removed)
 }
 
 // Vacuum temporary files by query hook
@@ -200,7 +383,9 @@ async fn vacuum_query_hook(
         .filter_map(|x| x.is_ok().then(|| x.unwrap()));
 
     for (meta_file_path, buffer) in metas {
-        let removed = vacuum_by_meta_buffer(
+        let operator = DataOperator::instance().spill_operator();
+        let removed = vacuum_by_meta_buffer_with_operator(
+            &operator,
             &meta_file_path,
             temporary_dir,
             buffer,
@@ -214,14 +399,15 @@ async fn vacuum_query_hook(
     Ok(removed_total)
 }
 
-async fn vacuum_by_meta_buffer(
+/// Delete temporary files recorded in a spill meta buffer with the provided operator.
+async fn vacuum_by_meta_buffer_with_operator(
+    operator: &Operator,
     meta_file_path: &str,
     temporary_dir: &str,
     meta: Buffer,
     limit: usize,
     removed_total: &mut usize,
 ) -> Result<usize> {
-    let operator = DataOperator::instance().spill_operator();
     let start_time = Instant::now();
     let meta = meta.to_bytes();
     let files: Vec<String> = meta.lines().map(|x| Ok(x?)).collect::<Result<Vec<_>>>()?;
@@ -259,13 +445,14 @@ async fn vacuum_by_meta_buffer(
     Ok(cur_removed)
 }
 
-async fn vacuum_by_meta(
+/// Delete temporary files through a spill meta file with the provided operator.
+async fn vacuum_by_meta_with_operator(
+    operator: &Operator,
     temporary_dir: &str,
     meta_file_path: &str,
     limit: usize,
     removed_total: &mut usize,
 ) -> Result<usize> {
-    let operator = DataOperator::instance().spill_operator();
     let meta: Buffer;
     let r = operator.read(meta_file_path).await;
     match r {
@@ -273,16 +460,25 @@ async fn vacuum_by_meta(
         Err(e) if e.kind() == ErrorKind::NotFound => return Ok(0),
         Err(e) => return Err(e.into()),
     }
-    vacuum_by_meta_buffer(meta_file_path, temporary_dir, meta, limit, removed_total).await
+    vacuum_by_meta_buffer_with_operator(
+        operator,
+        meta_file_path,
+        temporary_dir,
+        meta,
+        limit,
+        removed_total,
+    )
+    .await
 }
 
-async fn vacuum_by_list_dir(
+/// Delete all files under a temporary directory with the provided operator.
+async fn vacuum_by_list_dir_with_operator(
+    operator: &Operator,
     dir_path: &str,
     limit: usize,
     removed_total: &mut usize,
 ) -> Result<usize> {
     let start_time = Instant::now();
-    let operator = DataOperator::instance().spill_operator();
     let mut r = operator.lister_with(dir_path).recursive(true).await?;
     let mut batches = vec![];
 

--- a/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_temporary_files.rs
@@ -181,9 +181,7 @@ async fn vacuum_by_duration(
                     } else {
                         let removed = vacuum_dir_with_probe(
                             &operator,
-                            &temporary_dir,
                             de.path(),
-                            &meta_path,
                             timestamp,
                             expire_time,
                             limit,
@@ -268,9 +266,7 @@ async fn resolve_dir_last_modified(
 /// If it is expired, reuse the same lister to finish deletion and avoid an extra probe list.
 async fn vacuum_dir_with_probe(
     operator: &Operator,
-    temporary_dir: &str,
     dir_path: &str,
-    meta_path: &str,
     timestamp: i64,
     expire_time: i64,
     limit: usize,
@@ -283,8 +279,9 @@ async fn vacuum_dir_with_probe(
         Err(e) => return Err(e.into()),
     };
     let mut paths = Vec::new();
-    let mut first_file_last_modified = None;
 
+    // Probe a file to check last_modified
+    let mut first_entry_last_modified = None;
     loop {
         let entry = match lister.try_next().await {
             Ok(Some(entry)) => entry,
@@ -298,11 +295,7 @@ async fn vacuum_dir_with_probe(
         }
 
         paths.push(entry.path().to_string());
-        if !entry.metadata().is_file() {
-            continue;
-        }
-
-        first_file_last_modified = if let Some(last_modified) = entry.metadata().last_modified() {
+        first_entry_last_modified = if let Some(last_modified) = entry.metadata().last_modified() {
             Some(last_modified.timestamp_millis())
         } else {
             stat_last_modified(operator, entry.path()).await
@@ -310,21 +303,15 @@ async fn vacuum_dir_with_probe(
         break;
     }
 
-    let Some(first_file_last_modified) = first_file_last_modified else {
+    let Some(first_entry_last_modified) = first_entry_last_modified else {
         return Ok(0);
     };
 
-    if timestamp - first_file_last_modified < expire_time {
+    if timestamp - first_entry_last_modified < expire_time {
         return Ok(0);
     }
 
-    let removed =
-        vacuum_by_meta_with_operator(operator, temporary_dir, meta_path, limit, removed_total)
-            .await?;
-    if removed > 0 {
-        return Ok(removed);
-    }
-
+    // delete by lister
     loop {
         let entry = match lister.try_next().await {
             Ok(Some(entry)) => entry,

--- a/src/query/ee/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/mod.rs
@@ -15,6 +15,7 @@
 mod computed_columns;
 mod vacuum;
 mod vacuum2;
+mod vacuum_temporary_files;
 mod virtual_column_pruner_reader;
 mod virtual_columns;
 mod virtual_columns_builder;

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
@@ -1,0 +1,436 @@
+// Copyright 2023 Databend Cloud
+//
+// Licensed under the Elastic License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.elastic.co/licensing/elastic-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod unit {
+    #![allow(dead_code)]
+
+    include!("../../../../../src/storages/fuse/operations/vacuum_temporary_files.rs");
+
+    use std::collections::HashMap;
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use chrono::Duration as ChronoDuration;
+    use chrono::Utc;
+    use opendal::EntryMode;
+    use opendal::Metadata;
+    use opendal::OperatorBuilder;
+    use opendal::raw::Access;
+    use opendal::raw::AccessorInfo;
+    use opendal::raw::MaybeSend;
+    use opendal::raw::OpDelete;
+    use opendal::raw::OpList;
+    use opendal::raw::OpRead;
+    use opendal::raw::OpStat;
+    use opendal::raw::RpDelete;
+    use opendal::raw::RpList;
+    use opendal::raw::RpRead;
+    use opendal::raw::RpStat;
+    use opendal::raw::oio;
+    use opendal::raw::oio::Entry;
+
+    #[derive(Clone, Debug)]
+    enum StatResult {
+        Meta(Metadata),
+        NotFound,
+    }
+
+    #[derive(Clone, Debug)]
+    enum ReadResult {
+        Buffer(Buffer),
+        NotFound,
+    }
+
+    #[derive(Debug)]
+    struct VecLister(Vec<(String, Metadata)>);
+
+    impl oio::List for VecLister {
+        fn next(&mut self) -> impl Future<Output = opendal::Result<Option<Entry>>> + MaybeSend {
+            let me = &mut self.0;
+            async move { Ok(me.pop().map(|(path, metadata)| Entry::new(&path, metadata))) }
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingDeleter {
+        deleted: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl oio::Delete for RecordingDeleter {
+        fn delete(&mut self, path: &str, _args: OpDelete) -> opendal::Result<()> {
+            self.deleted.lock().unwrap().push(path.to_string());
+            Ok(())
+        }
+
+        async fn flush(&mut self) -> opendal::Result<usize> {
+            Ok(self.deleted.lock().unwrap().len())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockVacuumAccessor {
+        list_entries: HashMap<String, Vec<(String, Metadata)>>,
+        stat_results: HashMap<String, StatResult>,
+        read_results: HashMap<String, ReadResult>,
+        deleted: Arc<Mutex<Vec<String>>>,
+        list_calls: AtomicUsize,
+        read_calls: AtomicUsize,
+    }
+
+    impl MockVacuumAccessor {
+        fn new(
+            list_entries: HashMap<String, Vec<(String, Metadata)>>,
+            stat_results: HashMap<String, StatResult>,
+            read_results: HashMap<String, ReadResult>,
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                list_entries,
+                stat_results,
+                read_results,
+                deleted: Arc::new(Mutex::new(Vec::new())),
+                list_calls: AtomicUsize::new(0),
+                read_calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn deleted_paths(&self) -> Vec<String> {
+            self.deleted.lock().unwrap().clone()
+        }
+
+        fn list_call_count(&self) -> usize {
+            self.list_calls.load(Ordering::Acquire)
+        }
+
+        fn read_call_count(&self) -> usize {
+            self.read_calls.load(Ordering::Acquire)
+        }
+    }
+
+    impl Access for MockVacuumAccessor {
+        type Reader = Buffer;
+        type Writer = ();
+        type Lister = VecLister;
+        type Deleter = RecordingDeleter;
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            let info = AccessorInfo::default();
+            info.set_native_capability(opendal::Capability {
+                stat: true,
+                read: true,
+                list: true,
+                delete: true,
+                delete_max_size: Some(1000),
+                ..Default::default()
+            });
+            info.into()
+        }
+
+        async fn stat(&self, path: &str, _args: OpStat) -> opendal::Result<RpStat> {
+            match self
+                .stat_results
+                .get(path)
+                .cloned()
+                .unwrap_or(StatResult::NotFound)
+            {
+                StatResult::Meta(meta) => Ok(RpStat::new(meta)),
+                StatResult::NotFound => Err(opendal::Error::new(
+                    opendal::ErrorKind::NotFound,
+                    "mock stat not found",
+                )),
+            }
+        }
+
+        async fn read(&self, path: &str, _args: OpRead) -> opendal::Result<(RpRead, Self::Reader)> {
+            self.read_calls.fetch_add(1, Ordering::AcqRel);
+            match self
+                .read_results
+                .get(path)
+                .cloned()
+                .unwrap_or(ReadResult::NotFound)
+            {
+                ReadResult::Buffer(buf) => Ok((RpRead::new(), buf)),
+                ReadResult::NotFound => Err(opendal::Error::new(
+                    opendal::ErrorKind::NotFound,
+                    "mock read not found",
+                )),
+            }
+        }
+
+        async fn delete(&self) -> opendal::Result<(RpDelete, Self::Deleter)> {
+            Ok((RpDelete::default(), RecordingDeleter {
+                deleted: self.deleted.clone(),
+            }))
+        }
+
+        async fn list(&self, path: &str, _args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+            self.list_calls.fetch_add(1, Ordering::AcqRel);
+            let mut entries = self.list_entries.get(path).cloned().unwrap_or_default();
+            entries.reverse();
+            Ok((RpList::default(), VecLister(entries)))
+        }
+    }
+
+    fn file_meta(last_modified_millis: Option<i64>) -> Metadata {
+        let mut meta = Metadata::new(EntryMode::FILE).with_content_length(0);
+        if let Some(last_modified_millis) = last_modified_millis {
+            meta = meta.with_last_modified(
+                chrono::DateTime::<Utc>::from_timestamp_millis(last_modified_millis).unwrap(),
+            );
+        }
+        meta
+    }
+
+    fn dir_meta(last_modified_millis: Option<i64>) -> Metadata {
+        let mut meta = Metadata::new(EntryMode::DIR);
+        if let Some(last_modified_millis) = last_modified_millis {
+            meta = meta.with_last_modified(
+                chrono::DateTime::<Utc>::from_timestamp_millis(last_modified_millis).unwrap(),
+            );
+        }
+        meta
+    }
+
+    async fn run_dir_vacuum_for_test(
+        operator: &Operator,
+        temporary_dir: &str,
+        dir_path: &str,
+        metadata: &Metadata,
+        timestamp: i64,
+        expire_time: i64,
+        limit: usize,
+        removed_total: &mut usize,
+    ) -> Result<usize> {
+        let meta_path = format!("{}{}", dir_path.trim_end_matches('/'), SPILL_META_SUFFIX);
+        if let Some(last_modified) =
+            resolve_dir_last_modified(operator, dir_path, metadata, &meta_path).await
+        {
+            if timestamp - last_modified < expire_time {
+                return Ok(0);
+            }
+
+            let removed = vacuum_by_meta_with_operator(
+                operator,
+                temporary_dir,
+                &meta_path,
+                limit,
+                removed_total,
+            )
+            .await?;
+            if removed > 0 {
+                return Ok(removed);
+            }
+
+            return vacuum_by_list_dir_with_operator(operator, dir_path, limit, removed_total)
+                .await;
+        }
+
+        vacuum_dir_with_probe(
+            operator,
+            temporary_dir,
+            dir_path,
+            &meta_path,
+            timestamp,
+            expire_time,
+            limit,
+            removed_total,
+        )
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_resolve_dir_last_modified_from_meta_file() -> anyhow::Result<()> {
+        let meta_ts = (Utc::now() - ChronoDuration::hours(2)).timestamp_millis();
+        let accessor = MockVacuumAccessor::new(
+            HashMap::new(),
+            HashMap::from([
+                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir.list".to_string(),
+                    StatResult::Meta(file_meta(Some(meta_ts))),
+                ),
+            ]),
+            HashMap::new(),
+        );
+        let operator = OperatorBuilder::new(accessor).finish();
+
+        let last_modified =
+            resolve_dir_last_modified(&operator, "spill/dir/", &dir_meta(None), "spill/dir.list")
+                .await;
+
+        assert_eq!(last_modified, Some(meta_ts));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_meta_fresh_skips_directory_without_listing() -> anyhow::Result<()> {
+        let now = Utc::now().timestamp_millis();
+        let accessor = MockVacuumAccessor::new(
+            HashMap::from([("spill/dir/".to_string(), vec![(
+                "spill/dir/file1".to_string(),
+                file_meta(Some(now - 10_000)),
+            )])]),
+            HashMap::from([
+                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir.list".to_string(),
+                    StatResult::Meta(file_meta(Some(now))),
+                ),
+            ]),
+            HashMap::new(),
+        );
+        let operator = OperatorBuilder::new(accessor.clone()).finish();
+        let mut removed_total = 0;
+
+        let removed = run_dir_vacuum_for_test(
+            &operator,
+            "spill/",
+            "spill/dir/",
+            &dir_meta(None),
+            now,
+            Duration::from_secs(60).as_millis() as i64,
+            100,
+            &mut removed_total,
+        )
+        .await?;
+
+        assert_eq!(removed, 0);
+        assert_eq!(removed_total, 0);
+        assert_eq!(accessor.deleted_paths(), Vec::<String>::new());
+        assert_eq!(accessor.list_call_count(), 0);
+        assert_eq!(accessor.read_call_count(), 0);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_meta_old_prefers_meta_delete_over_probe_or_list() -> anyhow::Result<()> {
+        let now = Utc::now().timestamp_millis();
+        let old_ts = (Utc::now() - ChronoDuration::hours(2)).timestamp_millis();
+        let accessor = MockVacuumAccessor::new(
+            HashMap::from([("spill/dir/".to_string(), vec![
+                ("spill/dir/file1".to_string(), file_meta(Some(old_ts))),
+                ("spill/dir/file2".to_string(), file_meta(Some(old_ts))),
+            ])]),
+            HashMap::from([
+                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir.list".to_string(),
+                    StatResult::Meta(file_meta(Some(old_ts))),
+                ),
+            ]),
+            HashMap::from([(
+                "spill/dir.list".to_string(),
+                ReadResult::Buffer(Buffer::from("spill/dir/file1\nspill/dir/file2")),
+            )]),
+        );
+        let operator = OperatorBuilder::new(accessor.clone()).finish();
+        let mut removed_total = 0;
+
+        let removed = run_dir_vacuum_for_test(
+            &operator,
+            "spill/",
+            "spill/dir/",
+            &dir_meta(None),
+            now,
+            Duration::from_secs(60).as_millis() as i64,
+            100,
+            &mut removed_total,
+        )
+        .await?;
+
+        assert_eq!(removed, 2);
+        assert_eq!(removed_total, 2);
+        assert_eq!(accessor.deleted_paths(), vec![
+            "spill/dir/file1".to_string(),
+            "spill/dir/file2".to_string()
+        ]);
+        assert_eq!(accessor.list_call_count(), 0);
+        assert_eq!(accessor.read_call_count(), 1);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_vacuum_dir_with_probe_skips_fresh_directory() -> anyhow::Result<()> {
+        let now = Utc::now().timestamp_millis();
+        let accessor = MockVacuumAccessor::new(
+            HashMap::from([("spill/dir/".to_string(), vec![(
+                "spill/dir/file1".to_string(),
+                file_meta(Some(now)),
+            )])]),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let operator = OperatorBuilder::new(accessor.clone()).finish();
+        let mut removed_total = 0;
+
+        let removed = vacuum_dir_with_probe(
+            &operator,
+            "spill/",
+            "spill/dir/",
+            "spill/dir.list",
+            now,
+            Duration::from_secs(60).as_millis() as i64,
+            100,
+            &mut removed_total,
+        )
+        .await?;
+
+        assert_eq!(removed, 0);
+        assert_eq!(removed_total, 0);
+        assert_eq!(accessor.deleted_paths(), Vec::<String>::new());
+        assert_eq!(accessor.list_call_count(), 1);
+        assert_eq!(accessor.read_call_count(), 0);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_vacuum_dir_with_probe_reuses_probe_list_for_deletion() -> anyhow::Result<()> {
+        let old_ts = (Utc::now() - ChronoDuration::hours(2)).timestamp_millis();
+        let accessor = MockVacuumAccessor::new(
+            HashMap::from([("spill/dir/".to_string(), vec![
+                ("spill/dir/file1".to_string(), file_meta(Some(old_ts))),
+                ("spill/dir/file2".to_string(), file_meta(Some(old_ts))),
+            ])]),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let operator = OperatorBuilder::new(accessor.clone()).finish();
+        let mut removed_total = 0;
+
+        let removed = vacuum_dir_with_probe(
+            &operator,
+            "spill/",
+            "spill/dir/",
+            "spill/dir.list",
+            Utc::now().timestamp_millis(),
+            Duration::from_secs(60).as_millis() as i64,
+            100,
+            &mut removed_total,
+        )
+        .await?;
+
+        assert_eq!(removed, 3);
+        assert_eq!(removed_total, 3);
+        assert_eq!(accessor.deleted_paths(), vec![
+            "spill/dir/file1".to_string(),
+            "spill/dir/file2".to_string(),
+            "spill/dir/".to_string(),
+        ]);
+        assert_eq!(accessor.list_call_count(), 1);
+        assert_eq!(accessor.read_call_count(), 1);
+        Ok(())
+    }
+}

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
@@ -45,7 +45,7 @@ mod unit {
 
     #[derive(Clone, Debug)]
     enum StatResult {
-        Meta(Metadata),
+        Meta(Box<Metadata>),
         NotFound,
     }
 
@@ -146,7 +146,7 @@ mod unit {
                 .cloned()
                 .unwrap_or(StatResult::NotFound)
             {
-                StatResult::Meta(meta) => Ok(RpStat::new(meta)),
+                StatResult::Meta(meta) => Ok(RpStat::new(*meta)),
                 StatResult::NotFound => Err(opendal::Error::new(
                     opendal::ErrorKind::NotFound,
                     "mock stat not found",
@@ -257,10 +257,13 @@ mod unit {
         let accessor = MockVacuumAccessor::new(
             HashMap::new(),
             HashMap::from([
-                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir/".to_string(),
+                    StatResult::Meta(Box::new(dir_meta(None))),
+                ),
                 (
                     "spill/dir.list".to_string(),
-                    StatResult::Meta(file_meta(Some(meta_ts))),
+                    StatResult::Meta(Box::new(file_meta(Some(meta_ts)))),
                 ),
             ]),
             HashMap::new(),
@@ -284,10 +287,13 @@ mod unit {
                 file_meta(Some(now - 10_000)),
             )])]),
             HashMap::from([
-                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir/".to_string(),
+                    StatResult::Meta(Box::new(dir_meta(None))),
+                ),
                 (
                     "spill/dir.list".to_string(),
-                    StatResult::Meta(file_meta(Some(now))),
+                    StatResult::Meta(Box::new(file_meta(Some(now)))),
                 ),
             ]),
             HashMap::new(),
@@ -325,10 +331,13 @@ mod unit {
                 ("spill/dir/file2".to_string(), file_meta(Some(old_ts))),
             ])]),
             HashMap::from([
-                ("spill/dir/".to_string(), StatResult::Meta(dir_meta(None))),
+                (
+                    "spill/dir/".to_string(),
+                    StatResult::Meta(Box::new(dir_meta(None))),
+                ),
                 (
                     "spill/dir.list".to_string(),
-                    StatResult::Meta(file_meta(Some(old_ts))),
+                    StatResult::Meta(Box::new(file_meta(Some(old_ts)))),
                 ),
             ]),
             HashMap::from([(

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum_temporary_files.rs
@@ -240,9 +240,7 @@ mod unit {
 
         vacuum_dir_with_probe(
             operator,
-            temporary_dir,
             dir_path,
-            &meta_path,
             timestamp,
             expire_time,
             limit,
@@ -387,9 +385,7 @@ mod unit {
 
         let removed = vacuum_dir_with_probe(
             &operator,
-            "spill/",
             "spill/dir/",
-            "spill/dir.list",
             now,
             Duration::from_secs(60).as_millis() as i64,
             100,
@@ -421,9 +417,7 @@ mod unit {
 
         let removed = vacuum_dir_with_probe(
             &operator,
-            "spill/",
             "spill/dir/",
-            "spill/dir.list",
             Utc::now().timestamp_millis(),
             Duration::from_secs(60).as_millis() as i64,
             100,
@@ -439,7 +433,7 @@ mod unit {
             "spill/dir/".to_string(),
         ]);
         assert_eq!(accessor.list_call_count(), 1);
-        assert_eq!(accessor.read_call_count(), 1);
+        assert_eq!(accessor.read_call_count(), 0);
         Ok(())
     }
 }

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_temporary_files.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_temporary_files.test
@@ -55,7 +55,7 @@ SELECT COUNT() > 0 as c FROM system.temp_files
 1
 
 statement ok
-VACUUM TEMPORARY FILES RETAIN 1 DAY;
+VACUUM TEMPORARY FILES RETAIN 1 DAYS;
 
 query ?
 SELECT COUNT() > 0 as c FROM system.temp_files

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_temporary_files.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0000_vacuum_temporary_files.test
@@ -47,6 +47,22 @@ SELECT sleep(2) from numbers(1);
 0
 
 statement ok
+VACUUM TEMPORARY FILES;
+
+query ?
+SELECT COUNT() > 0 as c FROM system.temp_files
+----
+1
+
+statement ok
+VACUUM TEMPORARY FILES RETAIN 1 DAY;
+
+query ?
+SELECT COUNT() > 0 as c FROM system.temp_files
+----
+1
+
+statement ok
 VACUUM TEMPORARY FILES RETAIN 2 SECONDS;
 
 query ?


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: vacuum temp files not respect duration

How to reproduce:

```
statement ok
set max_vacuum_temp_files_after_query = 1;

query ?
SELECT COUNT() FROM (SELECT number::string, count() FROM numbers_mt(100000) group by number::string order by 1 desc);
----
100000

query ?
SELECT COUNT() > 0 as c FROM system.temp_files
----
1

statement ok
VACUUM TEMPORARY FILES RETAIN 1 DAY; 
or
VACUUM TEMPORARY FILES;


We expect no files will be deleted, but the retation policy is not work:
❌
query ?
SELECT COUNT() > 0 as c FROM system.temp_files
----
1

```


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19685)
<!-- Reviewable:end -->
