### PR TITLE
fix(config): rename local_writable_root

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -3599,7 +3599,7 @@ mod config_converters {
             .transpose()?;
 
         Ok(inner::SpillConfig {
-            local_writeable_root: None,
+            local_writable_root: None,
             path: spill.spill_local_disk_path,
             reserved_disk_ratio: spill.spill_local_disk_reserved_space_percentage / 100.0,
             global_bytes_limit: spill.spill_local_disk_max_bytes,

--- a/src/query/config/src/inner.rs
+++ b/src/query/config/src/inner.rs
@@ -407,7 +407,7 @@ impl Default for CatalogHiveConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpillConfig {
-    pub(crate) local_writeable_root: Option<String>,
+    pub(crate) local_writable_root: Option<String>,
     pub(crate) path: String,
 
     /// Ratio of the reserve of the disk space.
@@ -446,7 +446,7 @@ impl SpillConfig {
             return Some(self.path.clone().into());
         }
 
-        if let Some(root) = &self.local_writeable_root {
+        if let Some(root) = &self.local_writable_root {
             return Some(PathBuf::from(root).join("temp/_query_spill"));
         }
 
@@ -493,7 +493,7 @@ impl SpillConfig {
 
     pub fn new_for_test(path: String, reserved_disk_ratio: f64, global_bytes_limit: u64) -> Self {
         Self {
-            local_writeable_root: None,
+            local_writable_root: None,
             path,
             reserved_disk_ratio: OrderedFloat(reserved_disk_ratio),
             global_bytes_limit,
@@ -510,7 +510,7 @@ impl SpillConfig {
 impl Default for SpillConfig {
     fn default() -> Self {
         Self {
-            local_writeable_root: None,
+            local_writable_root: None,
             path: "".to_string(),
             reserved_disk_ratio: OrderedFloat(0.1),
             global_bytes_limit: u64::MAX,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #19687
- Rename the internal spill config field `local_writeable_root` to `local_writable_root`.
- Update the config conversion path so the corrected identifier is used consistently.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with `cargo test -p databend-common-config --lib` and `cargo clippy -p databend-common-config --lib --tests -- -D warnings`.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19688)
<!-- Reviewable:end -->
