### PR TITLE
feat(query): local block_id repartition before RowFetch in MERGE INTO

### DIFF
--- a/src/query/service/src/physical_plans/physical_limit.rs
+++ b/src/query/service/src/physical_plans/physical_limit.rs
@@ -296,6 +296,7 @@ impl PhysicalPlanBuilder {
                 cols_to_fetch,
                 fetched_fields,
                 need_wrap_nullable: false,
+                is_mutation: false,
                 stat_info: Some(stat_info.clone()),
             });
         }

--- a/src/query/service/src/physical_plans/physical_limit.rs
+++ b/src/query/service/src/physical_plans/physical_limit.rs
@@ -296,7 +296,7 @@ impl PhysicalPlanBuilder {
                 cols_to_fetch,
                 fetched_fields,
                 need_wrap_nullable: false,
-                is_mutation: false,
+                enable_block_id_repartition: false,
                 stat_info: Some(stat_info.clone()),
             });
         }

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -809,6 +809,7 @@ fn build_mutation_row_fetch(
         cols_to_fetch,
         fetched_fields,
         need_wrap_nullable,
+        is_mutation: true,
         stat_info: None,
         meta: PhysicalPlanMeta::new("RowFetch"),
     })

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -453,28 +453,23 @@ impl PhysicalPlanBuilder {
 
         // If the mutation type is FullOperation, we use row_id column to split a block
         // into matched and not matched parts.
-        let has_lazy_columns = self
+        let lazy_columns = self
             .metadata
             .read()
             .get_table_lazy_columns(target_table_index)
-            .is_some_and(|cols| !cols.is_empty());
+            .filter(|cols| !cols.is_empty());
 
         if matches!(strategy, MutationStrategy::MixedMatched) {
             plan = PhysicalPlan::new(MutationSplit {
                 input: plan,
                 split_index: row_id_offset,
-                has_row_fetch: has_lazy_columns,
+                has_row_fetch: lazy_columns.is_some(),
                 meta: PhysicalPlanMeta::new("MutationSplit"),
             });
         }
 
         // Construct row fetch plan for lazy columns.
-        if has_lazy_columns {
-            let lazy_columns = self
-                .metadata
-                .read()
-                .get_table_lazy_columns(target_table_index)
-                .unwrap();
+        if let Some(lazy_columns) = lazy_columns {
             plan = build_mutation_row_fetch(
                 plan,
                 metadata.clone(),
@@ -816,7 +811,7 @@ fn build_mutation_row_fetch(
         cols_to_fetch,
         fetched_fields,
         need_wrap_nullable,
-        is_mutation: true,
+        enable_block_id_repartition: true,
         stat_info: None,
         meta: PhysicalPlanMeta::new("RowFetch"),
     })

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -453,21 +453,28 @@ impl PhysicalPlanBuilder {
 
         // If the mutation type is FullOperation, we use row_id column to split a block
         // into matched and not matched parts.
+        let has_lazy_columns = self
+            .metadata
+            .read()
+            .get_table_lazy_columns(target_table_index)
+            .is_some_and(|cols| !cols.is_empty());
+
         if matches!(strategy, MutationStrategy::MixedMatched) {
             plan = PhysicalPlan::new(MutationSplit {
                 input: plan,
                 split_index: row_id_offset,
+                has_row_fetch: has_lazy_columns,
                 meta: PhysicalPlanMeta::new("MutationSplit"),
             });
         }
 
         // Construct row fetch plan for lazy columns.
-        if let Some(lazy_columns) = self
-            .metadata
-            .read()
-            .get_table_lazy_columns(target_table_index)
-            && !lazy_columns.is_empty()
-        {
+        if has_lazy_columns {
+            let lazy_columns = self
+                .metadata
+                .read()
+                .get_table_lazy_columns(target_table_index)
+                .unwrap();
             plan = build_mutation_row_fetch(
                 plan,
                 metadata.clone(),

--- a/src/query/service/src/physical_plans/physical_mutation_into_split.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_into_split.rs
@@ -33,8 +33,8 @@ pub struct MutationSplit {
     pub meta: PhysicalPlanMeta,
     pub input: PhysicalPlan,
     pub split_index: IndexType,
-    /// Whether RowFetch follows this MutationSplit (lazy columns exist).
-    /// Block_id repartition is only beneficial when RowFetch is present.
+    /// When true, a block_id repartition is inserted before the split to reduce
+    /// duplicate block reads in the downstream RowFetch stage.
     pub has_row_fetch: bool,
 }
 
@@ -79,14 +79,13 @@ impl IPhysicalPlan for MutationSplit {
 
         let max_threads = builder.settings.get_max_threads()? as usize;
 
-        // Add block_id repartition before split so each downstream RowFetch
-        // processor sees rows from a disjoint set of blocks, eliminating
-        // duplicate block reads. Only useful when RowFetch follows.
+        // Repartition by block_id so each downstream RowFetch processor handles
+        // a disjoint set of blocks, reducing duplicate block reads.
         if self.has_row_fetch
             && max_threads > 1
             && builder
                 .settings
-                .get_enable_merge_into_block_id_repartition()?
+                .get_enable_mutation_block_id_repartition()?
         {
             let exchange = Arc::new(BlockIdPartitionExchange::create(self.split_index));
             builder.main_pipeline.exchange(max_threads, exchange)?;

--- a/src/query/service/src/physical_plans/physical_mutation_into_split.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_into_split.rs
@@ -33,6 +33,9 @@ pub struct MutationSplit {
     pub meta: PhysicalPlanMeta,
     pub input: PhysicalPlan,
     pub split_index: IndexType,
+    /// Whether RowFetch follows this MutationSplit (lazy columns exist).
+    /// Block_id repartition is only beneficial when RowFetch is present.
+    pub has_row_fetch: bool,
 }
 
 #[typetag::serde]
@@ -67,6 +70,7 @@ impl IPhysicalPlan for MutationSplit {
             meta: self.meta.clone(),
             input,
             split_index: self.split_index,
+            has_row_fetch: self.has_row_fetch,
         })
     }
 
@@ -77,8 +81,9 @@ impl IPhysicalPlan for MutationSplit {
 
         // Add block_id repartition before split so each downstream RowFetch
         // processor sees rows from a disjoint set of blocks, eliminating
-        // duplicate block reads.
-        if max_threads > 1
+        // duplicate block reads. Only useful when RowFetch follows.
+        if self.has_row_fetch
+            && max_threads > 1
             && builder
                 .settings
                 .get_enable_merge_into_block_id_repartition()?

--- a/src/query/service/src/physical_plans/physical_mutation_into_split.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_into_split.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use databend_common_exception::Result;
 use databend_common_pipeline::core::Pipe;
 use databend_common_sql::IndexType;
+use databend_common_storages_fuse::operations::BlockIdPartitionExchange;
 use databend_common_storages_fuse::operations::MutationSplitProcessor;
 
 use crate::physical_plans::format::MutationSplitFormatter;
@@ -71,9 +73,21 @@ impl IPhysicalPlan for MutationSplit {
     fn build_pipeline2(&self, builder: &mut PipelineBuilder) -> Result<()> {
         self.input.build_pipeline(builder)?;
 
-        builder
-            .main_pipeline
-            .try_resize(builder.settings.get_max_threads()? as usize)?;
+        let max_threads = builder.settings.get_max_threads()? as usize;
+
+        // Add block_id repartition before split so each downstream RowFetch
+        // processor sees rows from a disjoint set of blocks, eliminating
+        // duplicate block reads.
+        if max_threads > 1
+            && builder
+                .settings
+                .get_enable_merge_into_block_id_repartition()?
+        {
+            let exchange = Arc::new(BlockIdPartitionExchange::create(self.split_index));
+            builder.main_pipeline.exchange(max_threads, exchange)?;
+        } else {
+            builder.main_pipeline.try_resize(max_threads)?;
+        }
 
         // The MutationStrategy is FullOperation, use row_id_idx to split
         let mut items = Vec::with_capacity(builder.main_pipeline.output_len());

--- a/src/query/service/src/physical_plans/physical_row_fetch.rs
+++ b/src/query/service/src/physical_plans/physical_row_fetch.rs
@@ -130,8 +130,11 @@ impl IPhysicalPlan for RowFetch {
         )?;
 
         if !MutationSplit::check_physical_plan(&self.input) {
-            // SELECT+LIMIT path or MatchedOnly path without MutationSplit.
-            // For MatchedOnly with lazy columns, add block_id repartition before RowFetch.
+            // For MatchedOnly MERGE INTO, add block_id repartition before RowFetch
+            // to reduce duplicate block reads.
+            // Not applicable to SELECT+LIMIT: the exchange would destroy the sort
+            // order produced by Sort+Limit (MergePartitionProcessor uses Random
+            // strategy with non-deterministic output order).
             if self.is_mutation {
                 let max_threads = builder.settings.get_max_threads()? as usize;
                 if max_threads > 1

--- a/src/query/service/src/physical_plans/physical_row_fetch.rs
+++ b/src/query/service/src/physical_plans/physical_row_fetch.rs
@@ -51,9 +51,11 @@ pub struct RowFetch {
     pub row_id_col_offset: usize,
     pub fetched_fields: Vec<DataField>,
     pub need_wrap_nullable: bool,
-    /// True when this RowFetch is part of a MERGE INTO pipeline (not SELECT+LIMIT).
-    #[serde(default)]
-    pub is_mutation: bool,
+    /// When true, a block_id repartition is inserted before RowFetch to reduce
+    /// duplicate block reads. Applicable to join-based mutation paths (MERGE INTO,
+    /// UPDATE...FROM). Not applicable to SELECT+LIMIT where the exchange would
+    /// destroy sort order.
+    pub enable_block_id_repartition: bool,
 
     /// Only used for explain
     pub stat_info: Option<PlanStatsInfo>,
@@ -113,7 +115,7 @@ impl IPhysicalPlan for RowFetch {
             row_id_col_offset: self.row_id_col_offset,
             fetched_fields: self.fetched_fields.clone(),
             need_wrap_nullable: self.need_wrap_nullable,
-            is_mutation: self.is_mutation,
+            enable_block_id_repartition: self.enable_block_id_repartition,
             stat_info: self.stat_info.clone(),
         })
     }
@@ -132,15 +134,15 @@ impl IPhysicalPlan for RowFetch {
         if !MutationSplit::check_physical_plan(&self.input) {
             // For MatchedOnly MERGE INTO, add block_id repartition before RowFetch
             // to reduce duplicate block reads.
-            // Not applicable to SELECT+LIMIT: the exchange would destroy the sort
-            // order produced by Sort+Limit (MergePartitionProcessor uses Random
-            // strategy with non-deterministic output order).
-            if self.is_mutation {
+            // Not applicable to SELECT+LIMIT: pipeline.exchange() merges partitions
+            // with non-deterministic output order, which would destroy the sort
+            // order produced by Sort+Limit.
+            if self.enable_block_id_repartition {
                 let max_threads = builder.settings.get_max_threads()? as usize;
                 if max_threads > 1
                     && builder
                         .settings
-                        .get_enable_merge_into_block_id_repartition()?
+                        .get_enable_mutation_block_id_repartition()?
                 {
                     let exchange =
                         Arc::new(BlockIdPartitionExchange::create(self.row_id_col_offset));

--- a/src/query/service/src/physical_plans/physical_row_fetch.rs
+++ b/src/query/service/src/physical_plans/physical_row_fetch.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::Projection;
@@ -25,6 +26,7 @@ use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Pipe;
 use databend_common_pipeline::core::PipeItem;
 use databend_common_pipeline_transforms::create_dummy_item;
+use databend_common_storages_fuse::operations::BlockIdPartitionExchange;
 use databend_common_storages_fuse::operations::row_fetch_processor;
 use itertools::Itertools;
 
@@ -49,6 +51,9 @@ pub struct RowFetch {
     pub row_id_col_offset: usize,
     pub fetched_fields: Vec<DataField>,
     pub need_wrap_nullable: bool,
+    /// True when this RowFetch is part of a MERGE INTO pipeline (not SELECT+LIMIT).
+    #[serde(default)]
+    pub is_mutation: bool,
 
     /// Only used for explain
     pub stat_info: Option<PlanStatsInfo>,
@@ -108,6 +113,7 @@ impl IPhysicalPlan for RowFetch {
             row_id_col_offset: self.row_id_col_offset,
             fetched_fields: self.fetched_fields.clone(),
             need_wrap_nullable: self.need_wrap_nullable,
+            is_mutation: self.is_mutation,
             stat_info: self.stat_info.clone(),
         })
     }
@@ -124,8 +130,24 @@ impl IPhysicalPlan for RowFetch {
         )?;
 
         if !MutationSplit::check_physical_plan(&self.input) {
+            // SELECT+LIMIT path or MatchedOnly path without MutationSplit.
+            // For MatchedOnly with lazy columns, add block_id repartition before RowFetch.
+            if self.is_mutation {
+                let max_threads = builder.settings.get_max_threads()? as usize;
+                if max_threads > 1
+                    && builder
+                        .settings
+                        .get_enable_merge_into_block_id_repartition()?
+                {
+                    let exchange =
+                        Arc::new(BlockIdPartitionExchange::create(self.row_id_col_offset));
+                    builder.main_pipeline.exchange(max_threads, exchange)?;
+                }
+            }
             builder.main_pipeline.add_transform(processor)?;
         } else {
+            // MixedMatched path: MutationSplit is upstream.
+            // Repartition already happened in MutationSplit::build_pipeline2.
             let output_len = builder.main_pipeline.output_len();
             let mut pipe_items = Vec::with_capacity(output_len);
             for i in 0..output_len {

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -525,9 +525,9 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
-                ("enable_merge_into_block_id_repartition", DefaultSettingValue {
+                ("enable_mutation_block_id_repartition", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
-                    desc: "Enable local block_id repartition before row fetch in merge into to reduce duplicate block reads.",
+                    desc: "Enable local block_id repartition before row fetch in join-based mutations (MERGE INTO, UPDATE...FROM) to reduce duplicate block reads.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -525,6 +525,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_merge_into_block_id_repartition", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(1),
+                    desc: "Enable local block_id repartition before row fetch in merge into to reduce duplicate block reads.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("max_cte_recursive_depth", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1000),
                     desc: "Max recursive depth for recursive cte",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -470,8 +470,8 @@ impl Settings {
         Ok(self.try_get_u64("enable_merge_into_row_fetch")? != 0)
     }
 
-    pub fn get_enable_merge_into_block_id_repartition(&self) -> Result<bool> {
-        Ok(self.try_get_u64("enable_merge_into_block_id_repartition")? != 0)
+    pub fn get_enable_mutation_block_id_repartition(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_mutation_block_id_repartition")? != 0)
     }
 
     pub fn get_max_cte_recursive_depth(&self) -> Result<usize> {

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -470,6 +470,10 @@ impl Settings {
         Ok(self.try_get_u64("enable_merge_into_row_fetch")? != 0)
     }
 
+    pub fn get_enable_merge_into_block_id_repartition(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_merge_into_block_id_repartition")? != 0)
+    }
+
     pub fn get_max_cte_recursive_depth(&self) -> Result<usize> {
         Ok(self.try_get_u64("max_cte_recursive_depth")? as usize)
     }

--- a/src/query/storages/fuse/src/operations/merge_into/mod.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mod.rs
@@ -16,6 +16,7 @@ mod mutator;
 mod processors;
 
 pub use mutator::MatchedAggregator;
+pub use processors::BlockIdPartitionExchange;
 pub use processors::MatchedSplitProcessor;
 pub use processors::MergeIntoNotMatchedProcessor;
 pub use processors::MixRowIdKindAndLog;

--- a/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
@@ -25,11 +25,12 @@ use databend_common_pipeline::basic::Exchange;
 /// Partitions data blocks by block_id extracted from the `_row_id` column.
 ///
 /// This ensures that rows belonging to the same physical block are routed
-/// to the same downstream processor, eliminating duplicate block reads
+/// to the same downstream processor, reducing duplicate block reads
 /// in the RowFetch stage of MERGE INTO.
 pub struct BlockIdPartitionExchange {
     row_id_col_offset: usize,
-    /// Round-robin counter for NULL row_ids (unmatched rows in MixedMatched).
+    /// Incrementing counter used by `partition()` to spread NULL row_ids
+    /// (unmatched rows in MixedMatched) evenly across partitions.
     null_counter: AtomicU64,
 }
 

--- a/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
@@ -1,0 +1,99 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use databend_common_catalog::plan::split_row_id;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
+use databend_common_pipeline::basic::Exchange;
+
+/// Partitions data blocks by block_id extracted from the `_row_id` column.
+///
+/// This ensures that rows belonging to the same physical block are routed
+/// to the same downstream processor, eliminating duplicate block reads
+/// in the RowFetch stage of MERGE INTO.
+pub struct BlockIdPartitionExchange {
+    row_id_col_offset: usize,
+    /// Round-robin counter for NULL row_ids (unmatched rows in MixedMatched).
+    null_counter: AtomicU64,
+}
+
+impl BlockIdPartitionExchange {
+    pub fn create(row_id_col_offset: usize) -> Self {
+        Self {
+            row_id_col_offset,
+            null_counter: AtomicU64::new(0),
+        }
+    }
+
+    #[inline(always)]
+    fn partition_index(row_id: u64, n: usize) -> u8 {
+        let (prefix, _) = split_row_id(row_id);
+        (prefix % n as u64) as u8
+    }
+}
+
+impl Exchange for BlockIdPartitionExchange {
+    const NAME: &'static str = "BlockIdPartition";
+    const SKIP_EMPTY_DATA_BLOCK: bool = true;
+
+    fn partition(&self, data_block: DataBlock, n: usize) -> Result<Vec<DataBlock>> {
+        let num_rows = data_block.num_rows();
+        let entry = &data_block.columns()[self.row_id_col_offset];
+        let mut indices = Vec::with_capacity(num_rows);
+
+        match entry.data_type() {
+            DataType::Number(NumberDataType::UInt64) => {
+                let col = entry
+                    .to_column()
+                    .into_number()
+                    .unwrap()
+                    .into_u_int64()
+                    .unwrap();
+                for row_id in col.iter() {
+                    indices.push(Self::partition_index(*row_id, n));
+                }
+            }
+            DataType::Nullable(inner)
+                if matches!(inner.as_ref(), DataType::Number(NumberDataType::UInt64)) =>
+            {
+                let col = entry.to_column();
+                let nullable = col.into_nullable().unwrap();
+                let row_ids = nullable
+                    .column
+                    .into_number()
+                    .unwrap()
+                    .into_u_int64()
+                    .unwrap();
+                for (row_id, is_valid) in row_ids.iter().zip(nullable.validity.iter()) {
+                    if is_valid {
+                        indices.push(Self::partition_index(*row_id, n));
+                    } else {
+                        let counter = self.null_counter.fetch_add(1, Ordering::Relaxed);
+                        indices.push((counter % n as u64) as u8);
+                    }
+                }
+            }
+            _ => unreachable!(
+                "Row id column should be UInt64 or Nullable(UInt64) for block_id partition"
+            ),
+        }
+
+        DataBlock::scatter(&data_block, &indices, n)
+    }
+}

--- a/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/block_id_partition_exchange.rs
@@ -42,9 +42,9 @@ impl BlockIdPartitionExchange {
     }
 
     #[inline(always)]
-    fn partition_index(row_id: u64, n: usize) -> u8 {
+    fn partition_index(row_id: u64, n: usize) -> u16 {
         let (prefix, _) = split_row_id(row_id);
-        (prefix % n as u64) as u8
+        (prefix % n as u64) as u16
     }
 }
 
@@ -55,7 +55,7 @@ impl Exchange for BlockIdPartitionExchange {
     fn partition(&self, data_block: DataBlock, n: usize) -> Result<Vec<DataBlock>> {
         let num_rows = data_block.num_rows();
         let entry = &data_block.columns()[self.row_id_col_offset];
-        let mut indices = Vec::with_capacity(num_rows);
+        let mut indices: Vec<u16> = Vec::with_capacity(num_rows);
 
         match entry.data_type() {
             DataType::Number(NumberDataType::UInt64) => {
@@ -85,7 +85,7 @@ impl Exchange for BlockIdPartitionExchange {
                         indices.push(Self::partition_index(*row_id, n));
                     } else {
                         let counter = self.null_counter.fetch_add(1, Ordering::Relaxed);
-                        indices.push((counter % n as u64) as u8);
+                        indices.push((counter % n as u64) as u16);
                     }
                 }
             }

--- a/src/query/storages/fuse/src/operations/merge_into/processors/mod.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/processors/mod.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod block_id_partition_exchange;
 mod processor_merge_into_matched_and_split;
 mod processor_merge_into_not_matched;
 mod processor_merge_into_split;
 mod processor_merge_into_split_row_number_and_log;
 mod transform_matched_mutation_aggregator;
 
+pub use block_id_partition_exchange::BlockIdPartitionExchange;
 pub use processor_merge_into_matched_and_split::MatchedSplitProcessor;
 pub use processor_merge_into_matched_and_split::MixRowIdKindAndLog;
 pub(crate) use processor_merge_into_matched_and_split::RowIdKind;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_merge_into_block_id_repartition.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_merge_into_block_id_repartition.test
@@ -1,0 +1,207 @@
+statement ok
+DROP TABLE IF EXISTS t_repartition_target;
+
+statement ok
+DROP TABLE IF EXISTS t_repartition_source;
+
+statement ok
+CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00');
+
+statement ok
+CREATE TABLE t_repartition_source (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_source VALUES (1, 'a_new', 'y1', '2024-01-02 00:00:00'), (2, 'b_new', 'y2', '2024-01-02 00:00:00'), (3, 'c_old', 'y3', '2023-12-01 00:00:00'), (6, 'f_new', 'y6', '2024-01-02 00:00:00'), (7, 'g_new', 'y7', '2024-01-02 00:00:00');
+
+statement ok
+SET enable_merge_into_row_fetch = 1;
+
+statement ok
+SET enable_merge_into_block_id_repartition = 1;
+
+query II
+MERGE INTO t_repartition_target AS tar
+USING t_repartition_source AS sou
+ON tar.id = sou.id
+WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *
+WHEN NOT MATCHED THEN INSERT *;
+----
+2 2
+
+query ITTT
+SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+----
+1 a_new y1 2024-01-02 00:00:00.000000
+2 b_new y2 2024-01-02 00:00:00.000000
+3 c x3 2024-01-01 00:00:00.000000
+4 d x4 2024-01-01 00:00:00.000000
+5 e x5 2024-01-01 00:00:00.000000
+6 f_new y6 2024-01-02 00:00:00.000000
+7 g_new y7 2024-01-02 00:00:00.000000
+
+statement ok
+DROP TABLE t_repartition_target;
+
+statement ok
+CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00');
+
+statement ok
+SET enable_merge_into_block_id_repartition = 0;
+
+query II
+MERGE INTO t_repartition_target AS tar
+USING t_repartition_source AS sou
+ON tar.id = sou.id
+WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *
+WHEN NOT MATCHED THEN INSERT *;
+----
+2 2
+
+query ITTT
+SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+----
+1 a_new y1 2024-01-02 00:00:00.000000
+2 b_new y2 2024-01-02 00:00:00.000000
+3 c x3 2024-01-01 00:00:00.000000
+4 d x4 2024-01-01 00:00:00.000000
+5 e x5 2024-01-01 00:00:00.000000
+6 f_new y6 2024-01-02 00:00:00.000000
+7 g_new y7 2024-01-02 00:00:00.000000
+
+statement ok
+DROP TABLE t_repartition_target;
+
+statement ok
+CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+
+statement ok
+SET enable_merge_into_block_id_repartition = 1;
+
+query I
+MERGE INTO t_repartition_target AS tar
+USING t_repartition_source AS sou
+ON tar.id = sou.id
+WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *;
+----
+2
+
+query ITTT
+SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+----
+1 a_new y1 2024-01-02 00:00:00.000000
+2 b_new y2 2024-01-02 00:00:00.000000
+3 c x3 2024-01-01 00:00:00.000000
+
+statement ok
+DROP TABLE t_repartition_target;
+
+statement ok
+CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+
+statement ok
+SET enable_merge_into_block_id_repartition = 1;
+
+query I
+MERGE INTO t_repartition_target AS tar
+USING t_repartition_source AS sou
+ON tar.id = sou.id
+WHEN NOT MATCHED THEN INSERT *;
+----
+4
+
+query ITTT
+SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+----
+1 a x1 2024-01-01 00:00:00.000000
+2 b_new y2 2024-01-02 00:00:00.000000
+3 c_old y3 2023-12-01 00:00:00.000000
+6 f_new y6 2024-01-02 00:00:00.000000
+7 g_new y7 2024-01-02 00:00:00.000000
+
+statement ok
+DROP TABLE t_repartition_target;
+
+statement ok
+CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+
+statement ok
+INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+
+statement ok
+INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+
+statement ok
+SET enable_merge_into_block_id_repartition = 1;
+
+query II
+MERGE INTO t_repartition_target AS tar
+USING t_repartition_source AS sou
+ON tar.id = sou.id
+WHEN MATCHED AND tar.ts < sou.ts THEN DELETE
+WHEN NOT MATCHED THEN INSERT *;
+----
+2 2
+
+query ITTT
+SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+----
+3 c x3 2024-01-01 00:00:00.000000
+6 f_new y6 2024-01-02 00:00:00.000000
+7 g_new y7 2024-01-02 00:00:00.000000
+
+statement ok
+DROP TABLE IF EXISTS t_repartition_target;
+
+statement ok
+DROP TABLE IF EXISTS t_repartition_source;
+
+statement ok
+SET enable_merge_into_block_id_repartition = 1;
+
+statement ok
+SET enable_merge_into_row_fetch = 1;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_merge_into_block_id_repartition.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_merge_into_block_id_repartition.test
@@ -1,42 +1,60 @@
-statement ok
-DROP TABLE IF EXISTS t_repartition_target;
+## Test block_id repartition optimization for mutation RowFetch.
+## When enabled, rows are partitioned by block_id before RowFetch so each
+## processor handles a disjoint set of blocks, reducing duplicate block reads.
+## Applies to join-based mutations: MERGE INTO and UPDATE...WHERE (subquery).
 
 statement ok
-DROP TABLE IF EXISTS t_repartition_source;
+CREATE OR REPLACE DATABASE test_block_id_repartition
 
 statement ok
-CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+USE test_block_id_repartition
+
+## ==========================================================================
+## Setup: target table with multiple blocks (one INSERT per block),
+## and a source table with overlapping + new rows.
+## ==========================================================================
 
 statement ok
-INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
+
+## Each INSERT creates a separate block in storage.
+statement ok
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00')
 
 statement ok
-CREATE TABLE t_repartition_source (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+CREATE OR REPLACE TABLE source (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
 
 statement ok
-INSERT INTO t_repartition_source VALUES (1, 'a_new', 'y1', '2024-01-02 00:00:00'), (2, 'b_new', 'y2', '2024-01-02 00:00:00'), (3, 'c_old', 'y3', '2023-12-01 00:00:00'), (6, 'f_new', 'y6', '2024-01-02 00:00:00'), (7, 'g_new', 'y7', '2024-01-02 00:00:00');
+INSERT INTO source VALUES (1, 'a_new', 'y1', '2024-01-02 00:00:00'), (2, 'b_new', 'y2', '2024-01-02 00:00:00'), (3, 'c_old', 'y3', '2023-12-01 00:00:00'), (6, 'f_new', 'y6', '2024-01-02 00:00:00'), (7, 'g_new', 'y7', '2024-01-02 00:00:00')
+
+## ==========================================================================
+## Test 1: MixedMatched (WHEN MATCHED + WHEN NOT MATCHED), repartition ON.
+## Source ids 1,2 match and have newer ts => updated.
+## Source id 3 matches but has older ts => NOT updated (condition: tar.ts < sou.ts).
+## Source ids 6,7 don't match => inserted.
+## ==========================================================================
 
 statement ok
-SET enable_merge_into_row_fetch = 1;
+SET enable_merge_into_row_fetch = 1
 
 statement ok
-SET enable_merge_into_block_id_repartition = 1;
+SET enable_mutation_block_id_repartition = 1
 
 query II
-MERGE INTO t_repartition_target AS tar
-USING t_repartition_source AS sou
+MERGE INTO target AS tar
+USING source AS sou
 ON tar.id = sou.id
 WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *
 WHEN NOT MATCHED THEN INSERT *;
@@ -44,7 +62,7 @@ WHEN NOT MATCHED THEN INSERT *;
 2 2
 
 query ITTT
-SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+SELECT id, val, extra, ts FROM target ORDER BY id;
 ----
 1 a_new y1 2024-01-02 00:00:00.000000
 2 b_new y2 2024-01-02 00:00:00.000000
@@ -54,33 +72,34 @@ SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
 6 f_new y6 2024-01-02 00:00:00.000000
 7 g_new y7 2024-01-02 00:00:00.000000
 
-statement ok
-DROP TABLE t_repartition_target;
+## ==========================================================================
+## Test 2: Same scenario with repartition OFF. Results must be identical.
+## ==========================================================================
 
 statement ok
-CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
 
 statement ok
-INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (5, 'e', 'x5', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_block_id_repartition = 0;
+SET enable_mutation_block_id_repartition = 0
 
 query II
-MERGE INTO t_repartition_target AS tar
-USING t_repartition_source AS sou
+MERGE INTO target AS tar
+USING source AS sou
 ON tar.id = sou.id
 WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *
 WHEN NOT MATCHED THEN INSERT *;
@@ -88,7 +107,7 @@ WHEN NOT MATCHED THEN INSERT *;
 2 2
 
 query ITTT
-SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+SELECT id, val, extra, ts FROM target ORDER BY id;
 ----
 1 a_new y1 2024-01-02 00:00:00.000000
 2 b_new y2 2024-01-02 00:00:00.000000
@@ -98,61 +117,65 @@ SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
 6 f_new y6 2024-01-02 00:00:00.000000
 7 g_new y7 2024-01-02 00:00:00.000000
 
-statement ok
-DROP TABLE t_repartition_target;
+## ==========================================================================
+## Test 3: MatchedOnly (no NOT MATCHED clause), repartition ON.
+## Only ids 1,2 are updated (ts condition). Id 3 not updated.
+## ==========================================================================
 
 statement ok
-CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
 
 statement ok
-INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_block_id_repartition = 1;
+SET enable_mutation_block_id_repartition = 1
 
 query I
-MERGE INTO t_repartition_target AS tar
-USING t_repartition_source AS sou
+MERGE INTO target AS tar
+USING source AS sou
 ON tar.id = sou.id
 WHEN MATCHED AND tar.ts < sou.ts THEN UPDATE *;
 ----
 2
 
 query ITTT
-SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+SELECT id, val, extra, ts FROM target ORDER BY id;
 ----
 1 a_new y1 2024-01-02 00:00:00.000000
 2 b_new y2 2024-01-02 00:00:00.000000
 3 c x3 2024-01-01 00:00:00.000000
 
-statement ok
-DROP TABLE t_repartition_target;
+## ==========================================================================
+## Test 4: NotMatchedOnly (no MATCHED clause), repartition is a no-op
+## since there is no RowFetch in this path.
+## ==========================================================================
 
 statement ok
-CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
 
 statement ok
-INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_block_id_repartition = 1;
+SET enable_mutation_block_id_repartition = 1
 
 query I
-MERGE INTO t_repartition_target AS tar
-USING t_repartition_source AS sou
+MERGE INTO target AS tar
+USING source AS sou
 ON tar.id = sou.id
 WHEN NOT MATCHED THEN INSERT *;
 ----
 4
 
 query ITTT
-SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+SELECT id, val, extra, ts FROM target ORDER BY id;
 ----
 1 a x1 2024-01-01 00:00:00.000000
 2 b_new y2 2024-01-02 00:00:00.000000
@@ -160,27 +183,29 @@ SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
 6 f_new y6 2024-01-02 00:00:00.000000
 7 g_new y7 2024-01-02 00:00:00.000000
 
-statement ok
-DROP TABLE t_repartition_target;
+## ==========================================================================
+## Test 5: MixedMatched with DELETE instead of UPDATE, repartition ON.
+## Ids 1,2 matched with newer ts => deleted. Ids 6,7 not matched => inserted.
+## ==========================================================================
 
 statement ok
-CREATE TABLE t_repartition_target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP);
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
 
 statement ok
-INSERT INTO t_repartition_target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00')
 
 statement ok
-INSERT INTO t_repartition_target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00');
+INSERT INTO target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_block_id_repartition = 1;
+SET enable_mutation_block_id_repartition = 1
 
 query II
-MERGE INTO t_repartition_target AS tar
-USING t_repartition_source AS sou
+MERGE INTO target AS tar
+USING source AS sou
 ON tar.id = sou.id
 WHEN MATCHED AND tar.ts < sou.ts THEN DELETE
 WHEN NOT MATCHED THEN INSERT *;
@@ -188,20 +213,55 @@ WHEN NOT MATCHED THEN INSERT *;
 2 2
 
 query ITTT
-SELECT id, val, extra, ts FROM t_repartition_target ORDER BY id;
+SELECT id, val, extra, ts FROM target ORDER BY id;
 ----
 3 c x3 2024-01-01 00:00:00.000000
 6 f_new y6 2024-01-02 00:00:00.000000
 7 g_new y7 2024-01-02 00:00:00.000000
 
-statement ok
-DROP TABLE IF EXISTS t_repartition_target;
+## ==========================================================================
+## Test 6: UPDATE...WHERE (subquery) with lazy columns, repartition ON.
+## This path uses MatchedOnly strategy with RowFetch when the table has
+## enough columns for lazy materialization.
+## The subquery matches ids 1,2,3 from source; val is updated to 'updated'.
+## ==========================================================================
 
 statement ok
-DROP TABLE IF EXISTS t_repartition_source;
+CREATE OR REPLACE TABLE target (id INT, val VARCHAR, extra VARCHAR, ts TIMESTAMP)
+
+## Each INSERT creates a separate block.
+statement ok
+INSERT INTO target VALUES (1, 'a', 'x1', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_block_id_repartition = 1;
+INSERT INTO target VALUES (2, 'b', 'x2', '2024-01-01 00:00:00')
 
 statement ok
-SET enable_merge_into_row_fetch = 1;
+INSERT INTO target VALUES (3, 'c', 'x3', '2024-01-01 00:00:00')
+
+statement ok
+INSERT INTO target VALUES (4, 'd', 'x4', '2024-01-01 00:00:00')
+
+statement ok
+SET enable_mutation_block_id_repartition = 1
+
+statement ok
+SET enable_merge_into_row_fetch = 1
+
+statement ok
+UPDATE target SET val = 'updated' WHERE id IN (SELECT id FROM source WHERE id <= 3)
+
+query ITTT
+SELECT id, val, extra, ts FROM target ORDER BY id;
+----
+1 updated x1 2024-01-01 00:00:00.000000
+2 updated x2 2024-01-01 00:00:00.000000
+3 updated x3 2024-01-01 00:00:00.000000
+4 d x4 2024-01-01 00:00:00.000000
+
+## ==========================================================================
+## Cleanup
+## ==========================================================================
+
+statement ok
+DROP DATABASE test_block_id_repartition


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Problem

During join-based mutations (MERGE INTO, UPDATE...WHERE with subqueries) with lazy columns, the `TransformRowsFetcher` reads target table blocks by `_row_id`. Since Hash Join output order follows the probe side, rows from the same target block scatter across different RowFetch processors or batches. Each batch flushes its block data, causing the same physical block to be read from storage multiple times — a significant I/O overhead when the target table has many columns and the matched set is large.

In distributed mode, a cross-node shuffle by `block_id` already exists (`build_block_id_shuffle_exchange`), but within a single node no such grouping is performed.

### Solution

Add a **local** `pipeline.exchange()` by `block_id` (extracted from `_row_id`) before RowFetch, reusing the existing `PartitionProcessor` / `MergePartitionProcessor` infrastructure.

After repartition, each RowFetch processor handles a disjoint set of blocks, which eliminates cross-processor duplicate block reads. Within a single processor, same-block rows tend to arrive consecutively, greatly reducing cross-batch duplicates as well — though a residual duplicate read can still occur if a block's rows are split across a `BlockThreshold` flush boundary.

The existing per-batch deduplication inside `ParquetRowsFetcher::fetch()` (which groups row_ids by block_id within a single flush) remains effective. This PR complements it by ensuring the rows reaching each processor are block-local in the first place.

### Pipeline changes

**MixedMatched** (WHEN MATCHED + WHEN NOT MATCHED):

```
                    Before                                      After
                    ──────                                      ─────
              HashJoin output                             HashJoin output
                     │                                           │
             try_resize(N)                          Exchange(block_id, N)  ← NEW
                     │                                           │
               MutationSplit                               MutationSplit
              ╱             ╲                              ╱             ╲
     [even ports]     [odd ports]                [even ports]     [odd ports]
      matched          unmatched                  matched          unmatched
         │                 │                         │                 │
      RowFetch          dummy                     RowFetch          dummy
         │                 │                         │                 │
         └────────┬────────┘                         └────────┬────────┘
        MutationManipulate                          MutationManipulate
```

Exchange replaces `try_resize(N)` — same output port count, but data is partitioned by block_id.

**MatchedOnly** (MERGE INTO with only WHEN MATCHED, or UPDATE...WHERE with subquery):

```
                    Before                                      After
                    ──────                                      ─────
              HashJoin output                             HashJoin output
                     │                                           │
                  RowFetch                          Exchange(block_id, N)  ← NEW
                     │                                           │
            MutationManipulate                              RowFetch
                                                                 │
                                                        MutationManipulate
```

**NotMatchedOnly**: no RowFetch, no change.

### New setting: `enable_mutation_block_id_repartition`

| | |
|---|---|
| Default | `1` (on) |
| Scope | Session / Global |
| Purpose | Controls whether to insert a local block_id repartition before RowFetch in join-based mutation pipelines |

**When to disable:** If matched rows are heavily concentrated in a few large blocks, the repartition may cause load skew (one processor handles most of the work). In this case, `SET enable_mutation_block_id_repartition = 0` falls back to the original `try_resize` round-robin distribution, which provides better load balancing at the cost of more duplicate block reads.

**Affected paths:**
- MERGE INTO with lazy columns (MixedMatched and MatchedOnly strategies)
- UPDATE...WHERE with subqueries and lazy columns (MatchedOnly strategy)

**Not affected:**
- Plain UPDATE/DELETE without subqueries (`MutationStrategy::Direct`, returns early before RowFetch)
- DELETE with subqueries (lazy materialization is always skipped for deletes — only `_row_id` is needed)
- SELECT+LIMIT RowFetch (exchange would destroy sort order; `enable_block_id_repartition` flag is `false`)
- Single-threaded execution (`max_threads = 1`, guarded)

### Key changes

- `BlockIdPartitionExchange`: a new `Exchange` implementation that partitions rows by the block_id prefix of `_row_id`. For nullable row_ids (unmatched rows in MixedMatched), an incrementing counter spreads them evenly across partitions.
- For MixedMatched, the exchange is inserted in `MutationSplit::build_pipeline2` before the matched/unmatched split. Guarded by `has_row_fetch` flag so non-lazy workloads are not affected.
- For MatchedOnly, the exchange is inserted in `RowFetch::build_pipeline2`. An `enable_block_id_repartition` flag on `RowFetch` controls this.

### Performance impact

Reduces storage I/O in the RowFetch stage by avoiding redundant block reads across processors. The trade-off is that load balancing now depends on how matched rows are distributed across blocks (previously `try_resize` distributed rows evenly via round-robin). The overhead is one local scatter + merge per pipeline, operating on thin data (only join output columns, before lazy columns are materialized). Guarded by `max_threads > 1` so single-threaded execution has zero overhead.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

New sqllogictest `09_0051_merge_into_block_id_repartition.test` covers:
1. MixedMatched UPDATE (repartition ON)
2. MixedMatched UPDATE (repartition OFF, identical results)
3. MatchedOnly UPDATE
4. NotMatchedOnly INSERT (no-op)
5. MixedMatched DELETE
6. UPDATE...WHERE (subquery) with lazy columns

All existing merge_into tests pass without regression.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19689)
<!-- Reviewable:end -->
