### PR TITLE
fix(sql): clone_outer_scan drops bind-time Scan metadata during decorrelation

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -1123,13 +1123,8 @@ impl SubqueryDecorrelatorOptimizer {
                 derived_index
             })
             .collect();
-        Scan {
-            table_index: scan.table_index,
-            columns,
-            scan_id: metadata.next_scan_id(),
-            ..Default::default()
-        }
-        .into()
+        let scan_id = metadata.next_scan_id();
+        scan.derive_decorrelated_scan(columns, scan_id).into()
     }
 
     fn clone_outer_recursive_cte_scan(&mut self, scan: &RecursiveCteScan) -> Result<RelOperator> {

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -155,6 +155,32 @@ impl Scan {
         }
     }
 
+    /// Create a derived scan for decorrelation with new columns and scan_id.
+    /// Only query-semantic read-path metadata (sample, indexes) is preserved.
+    /// Everything else is explicitly defaulted — the derived scan sits on the
+    /// build side of a decorrelated SEMI/ANTI join, not the mutation target.
+    pub fn derive_decorrelated_scan(&self, columns: ColumnSet, scan_id: usize) -> Self {
+        Scan {
+            table_index: self.table_index,
+            columns,
+            scan_id,
+            // Read-path metadata: preserve from the original scan.
+            sample: self.sample.clone(),
+            inverted_index: self.inverted_index.clone(),
+            vector_index: self.vector_index.clone(),
+            // Everything else: explicit default.
+            change_type: None,
+            update_stream_columns: false,
+            is_lazy_table: false,
+            push_down_predicates: None,
+            limit: None,
+            order_by: None,
+            prewhere: None,
+            agg_index: None,
+            statistics: Arc::new(Statistics::default()),
+        }
+    }
+
     pub fn set_update_stream_columns(&mut self, update_stream_columns: bool) {
         self.update_stream_columns = update_stream_columns;
     }
@@ -387,5 +413,57 @@ mod tests {
         );
 
         assert_eq!(reduced.value(), u64::MAX as f64);
+    }
+
+    #[test]
+    fn test_derive_scan_preserves_bind_time_metadata() {
+        let original = Scan {
+            table_index: 42,
+            columns: [Symbol::new(1), Symbol::new(2), Symbol::new(3)]
+                .into_iter()
+                .collect(),
+            scan_id: 10,
+            sample: Some(SampleConfig {
+                row_level: None,
+                block_level: Some(50.0),
+            }),
+            change_type: Some(ChangeType::Append),
+            update_stream_columns: true,
+            is_lazy_table: true,
+            // Optimizer-phase fields set to non-default to verify they get reset.
+            limit: Some(100),
+            order_by: Some(vec![]),
+            ..Default::default()
+        };
+
+        let new_columns = [Symbol::new(10), Symbol::new(20), Symbol::new(30)]
+            .into_iter()
+            .collect();
+        let derived = original.derive_decorrelated_scan(new_columns, 99);
+
+        // New columns and scan_id must be replaced.
+        assert_eq!(
+            derived.columns,
+            [Symbol::new(10), Symbol::new(20), Symbol::new(30)]
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(derived.scan_id, 99);
+        assert_eq!(derived.table_index, 42);
+
+        // Query-semantic read-path metadata must be preserved.
+        assert_eq!(derived.sample, original.sample);
+
+        // Everything else must be reset to default.
+        assert_eq!(derived.change_type, None);
+        assert!(!derived.update_stream_columns);
+        assert!(!derived.is_lazy_table);
+
+        // Optimizer-phase fields must be reset.
+        assert!(derived.push_down_predicates.is_none());
+        assert!(derived.limit.is_none());
+        assert!(derived.order_by.is_none());
+        assert!(derived.prewhere.is_none());
+        assert!(derived.agg_index.is_none());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

-  `clone_outer_scan()` in the subquery decorrelator used `Scan { ..Default::default() }` to construct derived scans, silently dropping bind-time metadata fields (`sample`, `inverted_index`, `vector_index`, `change_type`, etc.).                                                                                               
- Introduced `Scan::derive_scan()` helper that explicitly enumerates all fields — bind-time metadata is preserved, optimizer-phase fields are reset. Adding a new field to `Scan` now causes a compile error in `derive_scan()`, preventing silent regressions.                                                                   
- This is a prerequisite for the `eliminate-secure-filter-operator` RFC, where new security-critical fields (`has_row_access_policy`, `secure_push_down_predicates`) on `Scan` would also be silently dropped by the old pattern.

- fixes: #19693


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19694)
<!-- Reviewable:end -->
