### PR TITLE
fix(bendpy): stabilize release builds and local publish

### DIFF
--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -47,6 +47,25 @@ runs:
           echo "BUILD_ARGS=--release --strip --out dist" >> $GITHUB_OUTPUT
         fi
 
+    - name: Normalize cargo config for release wheel builds
+      if: inputs.version
+      shell: bash
+      run: |
+        python - <<'PY'
+        from pathlib import Path
+
+        path = Path(".cargo/config.toml")
+        content = path.read_text()
+        marker = "\n[target.'cfg(target_os = \"linux\")']\n"
+
+        if marker not in content:
+            print("No Linux-specific cargo target override found")
+        else:
+            content = content.split(marker, 1)[0].rstrip() + "\n"
+            path.write_text(content)
+            print("Removed Linux-specific linker overrides for release wheel builds")
+        PY
+
     - name: Cross setup for macOS
       if: endsWith(inputs.target, '-darwin')
       shell: bash
@@ -76,6 +95,9 @@ runs:
     - name: Build wheels
       if: inputs.version
       uses: PyO3/maturin-action@v1
+      env:
+        CARGO_PROFILE_RELEASE_LTO: "off"
+        CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
       with:
         rust-toolchain: ${{ steps.toolchain.outputs.RUST_TOOLCHAIN }}
         working-directory: src/bendpy

--- a/src/bendpy/README.md
+++ b/src/bendpy/README.md
@@ -151,3 +151,30 @@ source .venv/bin/activate
 uvx maturin develop -E test
 pytest tests/
 ```
+
+## Local Publish Without Docker
+
+```bash
+cd src/bendpy
+
+# Build only
+./scripts/local_publish.sh --python python3.12  --skip-upload
+
+# Build only and clean old artifacts first
+./scripts/local_publish.sh --python python3.12 --clean --skip-upload
+
+# Build multiple Linux targets on the current host
+./scripts/local_publish.sh --python python3.12 --clean --skip-upload \
+  --target x86_64-unknown-linux-gnu \
+  --target aarch64-unknown-linux-gnu
+
+# Build and upload to PyPI
+PYPI_TOKEN=your-token ./scripts/local_publish.sh --python python3.12
+
+# Optional: override the package version for this build
+PYPI_TOKEN=your-token ./scripts/local_publish.sh --python python3.12 --version 0.1.1
+```
+
+This script builds a wheel on the current host with `maturin` and uploads it with `twine`.
+It does not use Docker and does not produce a manylinux wheel. Cross-target builds also depend on
+the host having a working linker/toolchain for the requested target.

--- a/src/bendpy/scripts/local_publish.sh
+++ b/src/bendpy/scripts/local_publish.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Datafuse Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
+REPOSITORY_URL="${REPOSITORY_URL:-https://upload.pypi.org/legacy/}"
+SKIP_BUILD=0
+SKIP_UPLOAD=0
+CLEAN_DIST=0
+VERSION=""
+TARGETS=()
+
+usage() {
+    cat <<'EOF'
+Build and optionally upload bendpy from the local host without Docker.
+
+Usage:
+  ./scripts/local_publish.sh [options]
+
+Options:
+  --python <path>          Python interpreter to use. Default: python3
+  --version <semver>       Override version in Cargo.toml and pyproject.toml for this build
+  --target <triple>        Rust target triple to build. Repeatable. Default: host target only
+  --dist-dir <path>        Output directory for built wheels. Default: dist
+  --repository-url <url>   Twine repository URL. Default: PyPI legacy upload URL
+  --skip-build             Upload existing wheels in dist dir without rebuilding
+  --skip-upload            Only build wheels, do not upload
+  --clean                  Remove existing databend wheel artifacts in dist dir before build
+  -h, --help               Show this help
+
+Environment:
+  PYPI_TOKEN               Required for upload. Used as twine password.
+  TWINE_USERNAME           Optional. Default: __token__
+  TWINE_PASSWORD           Optional override for PYPI_TOKEN
+  MATURIN_EXTRA_ARGS       Extra args appended to maturin build
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --python)
+            PYTHON_BIN="$2"
+            shift 2
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --target)
+            TARGETS+=("$2")
+            shift 2
+            ;;
+        --dist-dir)
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        --repository-url)
+            REPOSITORY_URL="$2"
+            shift 2
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            shift
+            ;;
+        --skip-upload)
+            SKIP_UPLOAD=1
+            shift
+            ;;
+        --clean)
+            CLEAN_DIST=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+ensure_python_pip() {
+    if "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "pip is not available for $PYTHON_BIN, bootstrapping with ensurepip"
+    "$PYTHON_BIN" -m ensurepip --upgrade
+
+    if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+        echo "Failed to bootstrap pip for $PYTHON_BIN" >&2
+        exit 1
+    fi
+}
+
+update_version_file() {
+    local file="$1"
+    local version="$2"
+    local tmp
+    tmp="$(mktemp)"
+    sed "s/^version = \".*\"/version = \"$version\"/" "$file" >"$tmp"
+    mv "$tmp" "$file"
+}
+
+restore_version_files() {
+    if [[ -n "${CARGO_BACKUP:-}" && -f "${CARGO_BACKUP:-}" ]]; then
+        mv "$CARGO_BACKUP" "$ROOT_DIR/Cargo.toml"
+    fi
+    if [[ -n "${PYPROJECT_BACKUP:-}" && -f "${PYPROJECT_BACKUP:-}" ]]; then
+        mv "$PYPROJECT_BACKUP" "$ROOT_DIR/pyproject.toml"
+    fi
+}
+
+ensure_rust_target() {
+    local target="$1"
+    if rustup target list --installed | grep -Fx "$target" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "Installing Rust target: $target"
+    rustup target add "$target"
+}
+
+require_command "$PYTHON_BIN"
+require_command rustup
+ensure_python_pip
+
+cd "$ROOT_DIR"
+mkdir -p "$DIST_DIR"
+
+if [[ "$CLEAN_DIST" -eq 1 ]]; then
+    echo "Cleaning existing wheel artifacts in $DIST_DIR"
+    find "$DIST_DIR" -maxdepth 1 \( -name 'databend-*.whl' -o -name 'databend-*.tar.gz' \) -print -delete
+fi
+
+if [[ -n "$VERSION" ]]; then
+    CARGO_BACKUP="$(mktemp)"
+    PYPROJECT_BACKUP="$(mktemp)"
+    cp Cargo.toml "$CARGO_BACKUP"
+    cp pyproject.toml "$PYPROJECT_BACKUP"
+    trap restore_version_files EXIT
+    update_version_file Cargo.toml "$VERSION"
+    update_version_file pyproject.toml "$VERSION"
+    echo "Using overridden version: $VERSION"
+fi
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+    "$PYTHON_BIN" -m pip install --upgrade pip
+    "$PYTHON_BIN" -m pip install maturin twine
+
+    if [[ "${#TARGETS[@]}" -eq 0 ]]; then
+        echo "Building bendpy wheel with $PYTHON_BIN for host target"
+        # Local host build only. This does not attempt a manylinux or Docker-based build.
+        "$PYTHON_BIN" -m maturin build --release --strip --out "$DIST_DIR" ${MATURIN_EXTRA_ARGS:-}
+    else
+        for target in "${TARGETS[@]}"; do
+            ensure_rust_target "$target"
+            echo "Building bendpy wheel with $PYTHON_BIN for target $target"
+            "$PYTHON_BIN" -m maturin build --release --strip --target "$target" --out "$DIST_DIR" ${MATURIN_EXTRA_ARGS:-}
+        done
+    fi
+fi
+
+if ! find "$DIST_DIR" -maxdepth 1 -name '*.whl' | grep -q .; then
+    echo "No wheel files found in $DIST_DIR" >&2
+    exit 1
+fi
+
+ls -lh "$DIST_DIR"
+
+if [[ "$SKIP_UPLOAD" -eq 1 ]]; then
+    echo "Skipping upload"
+    exit 0
+fi
+
+TWINE_USERNAME="${TWINE_USERNAME:-__token__}"
+TWINE_PASSWORD="${TWINE_PASSWORD:-${PYPI_TOKEN:-}}"
+
+if [[ -z "$TWINE_PASSWORD" ]]; then
+    echo "Missing PYPI_TOKEN or TWINE_PASSWORD for upload" >&2
+    exit 1
+fi
+
+echo "Uploading wheel(s) to $REPOSITORY_URL"
+"$PYTHON_BIN" -m twine upload \
+    --skip-existing \
+    --repository-url "$REPOSITORY_URL" \
+    -u "$TWINE_USERNAME" \
+    -p "$TWINE_PASSWORD" \
+    "$DIST_DIR"/*.whl


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fix Python wheel release builds that were failing in the release workflow
- add a local bendpy publish helper that does not depend on Docker
- document local build and publish usage in the bendpy README

## Implementation

1. Normalize cargo config for bendpy release wheel builds so the Linux manylinux container does not inherit the repo's `mold` linker override
2. Disable release LTO for wheel packaging jobs to avoid the macOS cross-target linker/bitcode incompatibility seen in CI
3. Add `src/bendpy/scripts/local_publish.sh` for host-native build/upload flows with optional version override, upload skipping, cleaning, and repeatable `--target`
4. Document the local publish workflow in `src/bendpy/README.md`

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Pair with the reviewer to explain why

Validation performed:

- inspected failing release job logs for Linux x86_64, Linux aarch64, and macOS aarch64
- verified the new local publish helper argument parsing with `--help`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19700)

<!-- Reviewable:end -->