### PR TITLE
fix(bendpy): detect python3 in release wheel builds

### DIFF
--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -51,25 +51,17 @@ runs:
       if: inputs.version
       shell: bash
       run: |
-        PYTHON_BIN="$(command -v python3 || command -v python)"
-        if [[ -z "$PYTHON_BIN" ]]; then
-          echo "python3/python is required for release wheel build normalization" >&2
-          exit 1
+        marker="[target.'cfg(target_os = \"linux\")']"
+        if ! grep -Fq "$marker" .cargo/config.toml; then
+          echo "No Linux-specific cargo target override found"
+        else
+          awk -v marker="$marker" '
+            index($0, marker) == 1 { exit }
+            { print }
+          ' .cargo/config.toml > .cargo/config.toml.tmp
+          mv .cargo/config.toml.tmp .cargo/config.toml
+          echo "Removed Linux-specific linker overrides for release wheel builds"
         fi
-        "$PYTHON_BIN" - <<'PY'
-        from pathlib import Path
-
-        path = Path(".cargo/config.toml")
-        content = path.read_text()
-        marker = "\n[target.'cfg(target_os = \"linux\")']\n"
-
-        if marker not in content:
-            print("No Linux-specific cargo target override found")
-        else:
-            content = content.split(marker, 1)[0].rstrip() + "\n"
-            path.write_text(content)
-            print("Removed Linux-specific linker overrides for release wheel builds")
-        PY
 
     - name: Cross setup for macOS
       if: endsWith(inputs.target, '-darwin')

--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -51,7 +51,12 @@ runs:
       if: inputs.version
       shell: bash
       run: |
-        python - <<'PY'
+        PYTHON_BIN="$(command -v python3 || command -v python)"
+        if [[ -z "$PYTHON_BIN" ]]; then
+          echo "python3/python is required for release wheel build normalization" >&2
+          exit 1
+        fi
+        "$PYTHON_BIN" - <<'PY'
         from pathlib import Path
 
         path = Path(".cargo/config.toml")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fix the release wheel build normalization step to use an available Python interpreter on Linux runners

## Implementation

1. Replace the hardcoded `python` invocation in the release-wheel cargo-config normalization step
2. Detect `python3` first and fall back to `python`
3. Fail early with a clear message if neither interpreter exists

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Pair with the reviewer to explain why

Validation performed:

- inspected the failing `Build Linux Wheels (aarch64, ARM64)` log from run `24285204342`
- verified the failure was `python: command not found` in the normalization step

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19701)
<!-- Reviewable:end -->
