### PR TITLE
fix(io): correct BitmapReader BITMAP_LENGTH from 1024 to 8192

### DIFF
--- a/src/common/io/src/bitmap/reader.rs
+++ b/src/common/io/src/bitmap/reader.rs
@@ -114,7 +114,7 @@ impl BitmapReader<'_> {
         let last_offset = reader.read_u32::<LittleEndian>()?;
 
         const ARRAY_LIMIT: usize = 4096;
-        const BITMAP_LENGTH: usize = 1024;
+        const BITMAP_LENGTH: usize = 8192;
 
         let size = 4
             + last_offset as usize

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_bitmap.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_bitmap.test
@@ -135,3 +135,33 @@ SELECT to_string(bitmap_construct_agg(id::UNSIGNED)) from agg_bitmap_test
 
 statement ok
 DROP TABLE agg_bitmap_test
+
+# Test bitmap functions with bitmap containers (>4096 elements per container).
+# Previously BitmapReader::decode used BITMAP_LENGTH=1024 instead of 8192,
+# causing truncated data and panics in intersection_with_serialized_unchecked.
+
+statement ok
+DROP TABLE IF EXISTS agg_bitmap_large_test
+
+statement ok
+CREATE TABLE agg_bitmap_large_test(id Int, v Bitmap)
+
+statement ok
+INSERT INTO agg_bitmap_large_test SELECT 1, bitmap_or_agg(to_bitmap(number)) FROM numbers(5000) UNION ALL SELECT 1, bitmap_or_agg(to_bitmap(number + 100)) FROM numbers(5000)
+
+statement ok
+INSERT INTO agg_bitmap_large_test SELECT 2, bitmap_or_agg(to_bitmap(number)) FROM numbers(5000) UNION ALL SELECT 2, bitmap_or_agg(to_bitmap(number)) FROM numbers(5000)
+
+query II
+SELECT id, bitmap_and_count(v) FROM agg_bitmap_large_test GROUP BY id ORDER BY id
+----
+1 4900
+2 5000
+
+query I
+SELECT bitmap_count(bitmap_or_agg(to_bitmap(number))) FROM numbers(5000)
+----
+5000
+
+statement ok
+DROP TABLE agg_bitmap_large_test


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(io): correct BitmapReader BITMAP_LENGTH from 1024 to 8192

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19702)
<!-- Reviewable:end -->
