### PR TITLE
chore: upgrade databend-meta stack to land rotbl 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base2histogram"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74d05707c315a6c0601b1089186476cf11ee5fe8d6e035ea43c44ae1a0215cd"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,8 +3298,8 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "databend-base"
-version = "0.2.10"
-source = "git+https://github.com/databendlabs/databend-base?tag=v0.2.10#ce5c6751a11935e3be118e301ebe156103844ae7"
+version = "0.3.0"
+source = "git+https://github.com/databendlabs/databend-base?tag=v0.3.0#0b1ad93c7bed03f851988cd3fe08a739c071874a"
 dependencies = [
  "async-trait",
  "ctrlc",
@@ -3324,7 +3330,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3500,7 +3506,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -3600,7 +3606,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "log",
  "serde",
  "serde_ignored",
@@ -3945,7 +3951,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -3973,7 +3979,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "display-more 0.2.5",
  "fastrace",
  "futures",
@@ -4006,7 +4012,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "derive_more 1.0.0",
  "display-more 0.2.5",
  "encoding_rs",
@@ -4049,7 +4055,7 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "display-more 0.2.5",
  "futures",
@@ -4076,7 +4082,7 @@ dependencies = [
  "databend-common-proto-conv",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "openraft",
  "prost",
  "regex",
@@ -4096,7 +4102,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "fastrace",
  "log",
  "maplit",
@@ -4112,7 +4118,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4128,7 +4134,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4250,7 +4256,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "enumflags2",
  "fastrace",
  "log",
@@ -4356,7 +4362,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4475,7 +4481,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "opendal",
@@ -4572,7 +4578,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -4632,7 +4638,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
  "fastrace",
@@ -4670,7 +4676,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -4876,7 +4882,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -4968,7 +4974,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5029,7 +5035,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
 ]
 
 [[package]]
@@ -5101,7 +5107,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5129,7 +5135,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
 ]
 
 [[package]]
@@ -5141,7 +5147,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
 ]
 
 [[package]]
@@ -5293,23 +5299,24 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "anyhow",
  "arrow-flight",
  "async-trait",
  "backon",
+ "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260312.5.0",
- "databend-meta-kvapi 260312.5.0",
+ "databend-meta-client 260312.6.0",
+ "databend-meta-kvapi 260312.6.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260312.5.0",
+ "databend-meta-runtime-api 260312.6.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.5.0",
- "databend-meta-version 260312.5.0",
+ "databend-meta-types 260312.6.0",
+ "databend-meta-version 260312.6.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5371,8 +5378,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5405,7 +5412,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
@@ -5443,19 +5450,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "anyerror",
  "arrow-flight",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.4.0",
- "databend-meta-kvapi-test-suite 260205.4.0",
- "databend-meta-runtime-api 260205.4.0",
- "databend-meta-types 260205.4.0",
- "databend-meta-version 260205.4.0",
+ "databend-meta-kvapi 260205.5.0",
+ "databend-meta-kvapi-test-suite 260205.5.0",
+ "databend-meta-runtime-api 260205.5.0",
+ "databend-meta-types 260205.5.0",
+ "databend-meta-version 260205.5.0",
  "derive_more 2.1.1",
  "display-more 0.2.5",
  "fastrace",
@@ -5475,8 +5482,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5485,10 +5492,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.5.0",
- "databend-meta-kvapi-test-suite 260312.5.0",
- "databend-meta-runtime-api 260312.5.0",
- "databend-meta-version 260312.5.0",
+ "databend-meta-kvapi 260312.6.0",
+ "databend-meta-kvapi-test-suite 260312.6.0",
+ "databend-meta-runtime-api 260312.6.0",
+ "databend-meta-version 260312.6.0",
  "derive_more 2.1.1",
  "display-more 0.2.5",
  "fastrace",
@@ -5509,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5533,20 +5540,20 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "anyhow",
  "async-trait",
  "databend-base",
- "databend-meta-types 260205.4.0",
+ "databend-meta-types 260205.5.0",
  "display-more 0.2.5",
  "futures-util",
  "log",
@@ -5556,8 +5563,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5572,12 +5579,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.4.0",
- "databend-meta-types 260205.4.0",
+ "databend-meta-kvapi 260205.5.0",
+ "databend-meta-types 260205.5.0",
  "display-more 0.2.5",
  "fastrace",
  "futures-util",
@@ -5588,12 +5595,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.5.0",
+ "databend-meta-kvapi 260312.6.0",
  "display-more 0.2.5",
  "fastrace",
  "futures-util",
@@ -5608,7 +5615,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -5626,7 +5633,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codeq",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.5",
@@ -5644,8 +5651,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5667,18 +5674,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260312.5.0",
- "databend-meta-runtime-api 260312.5.0",
+ "databend-meta-kvapi 260312.6.0",
+ "databend-meta-runtime-api 260312.6.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.5.0",
+ "databend-meta-types 260312.6.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5715,7 +5722,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "fastrace",
  "tokio",
  "tonic 0.13.1",
@@ -5723,8 +5730,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5736,8 +5743,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5749,12 +5756,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260312.5.0",
+ "databend-meta-types 260312.6.0",
  "fastrace",
  "log",
  "serde",
@@ -5767,14 +5774,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260312.5.0",
- "databend-meta-types 260312.5.0",
+ "databend-meta-runtime-api 260312.6.0",
+ "databend-meta-types 260312.6.0",
  "fastrace",
  "log",
  "tempfile",
@@ -5784,8 +5791,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5812,8 +5819,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5847,16 +5854,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.4.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.4.0#a516c3cf4d4ab7e03eb93caa9f77e477ba6ff1fd"
+version = "260205.5.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260312.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.5.0#06a747fe90afa48c495f19ab95137acac13e32f3"
+version = "260312.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
 dependencies = [
  "semver",
 ]
@@ -5951,7 +5958,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6306,7 +6313,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.4.0",
+ "databend-meta-client 260205.5.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -11206,16 +11213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache-map"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227ef6c03002a1a4e03948ed0c7ba71375962a7e6be06ea6880c5ad96b847f85"
-dependencies = [
- "hashbrown 0.14.5",
- "hashlink 0.8.4",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14630,9 +14627,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rotbl"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a074786ac3e7b62338fd3c2cdf4ea7bb9b95f6f90011501e25f78ecd7d0312"
+checksum = "bf37e1298a4aaeaf19f7f9aaa4ef56088459016403127e51787c7031c013aab3"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -14642,7 +14639,7 @@ dependencies = [
  "futures",
  "futures-async-stream",
  "log",
- "lru-cache-map",
+ "moka",
  "num-format",
  "seq-marked",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,11 +166,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260312.5.0"
-databend-meta-test-harness = "260312.5.0"
+databend-meta = "260312.6.0"
+databend-meta-test-harness = "260312.6.0"
 
 # External meta client
-databend-meta-client = "260205.4.0"
+databend-meta-client = "260205.5.0"
 
 # Crates.io dependencies
 ahash = { version = "0.8", features = ["no-rng"] }
@@ -242,7 +242,7 @@ crossbeam-channel = "0.5.6"
 csv-core = "0.1.13"
 ctor = "0.2"
 dashmap = { version = "6.1.0", features = ["serde"] }
-databend-base = "0.2.10"
+databend-base = "0.3.0"
 defer = "0.2"
 deltalake = "0.26"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
@@ -618,10 +618,10 @@ async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.gi
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
-databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.2.10" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.5.0" }
-databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.4.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.5.0" }
+databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.3.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.6.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.5.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.6.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }

--- a/src/meta/cli-config/src/lib.rs
+++ b/src/meta/cli-config/src/lib.rs
@@ -386,13 +386,12 @@ pub struct RaftConfig {
     #[clap(long, default_value = "8000")]
     pub snapshot_db_block_keys: u64,
 
-    /// The total block to cache.
-    #[clap(long, default_value = "1024")]
-    pub snapshot_db_block_cache_item: u64,
-
-    /// The total cache size for snapshot blocks.
+    /// The total cache size for snapshot blocks in bytes.
     ///
-    /// By default, it is 1GB.
+    /// Since rotbl 0.2.10 the block cache is weight-bounded by bytes only
+    /// (the underlying `moka::sync::Cache` with a byte-based weigher cannot
+    /// enforce an independent item-count bound), so this is the single knob
+    /// for snapshot cache sizing. Defaults to 1 GiB.
     #[clap(long, default_value = "1073741824")]
     pub snapshot_db_block_cache_size: u64,
 
@@ -487,7 +486,6 @@ impl From<RaftConfig> for InnerRaftConfig {
 
             snapshot_db_debug_check: x.snapshot_db_debug_check,
             snapshot_db_block_keys: x.snapshot_db_block_keys,
-            snapshot_db_block_cache_item: x.snapshot_db_block_cache_item,
             snapshot_db_block_cache_size: x.snapshot_db_block_cache_size,
 
             compact_immutables_ms: x.compact_immutables_ms,
@@ -525,7 +523,6 @@ impl From<InnerRaftConfig> for RaftConfig {
 
             snapshot_db_debug_check: inner.snapshot_db_debug_check,
             snapshot_db_block_keys: inner.snapshot_db_block_keys,
-            snapshot_db_block_cache_item: inner.snapshot_db_block_cache_item,
             snapshot_db_block_cache_size: inner.snapshot_db_block_cache_size,
 
             compact_immutables_ms: inner.compact_immutables_ms,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: upgrade databend-meta stack to land rotbl 0.2.10
Bump `databend-meta` to `260312.6.0`, `databend-meta-client` to
`260205.5.0`, and `databend-base` to `0.3.0`. The three move in
lockstep because both the server and client trees consume
`rotbl 0.2.10`, which eliminates `Mutex<File>` serialization in the
block reader (pread-based `ReaderAt`) and switches the block cache
from a hand-rolled LRU to `moka::sync::Cache` with singleflight
loading — ~78-95x throughput improvement under contention.

`databend-base 0.3.0` is part of the same cascade: the new
`databend-meta` server pins `databend-base ^0.3.0` because the
`histogram` module was extracted into the standalone `base2histogram`
crate. `databend-meta-client 260205.5.0` is the corresponding release
of the r-260205 client line carrying the same `databend-base` floor,
so the two trees coexist under a single `[patch.crates-io]` entry.

Drop `snapshot_db_block_cache_item` from `RaftConfig`: rotbl 0.2.10's
`moka::sync::Cache` cannot enforce an item count and a byte weight
independently, so byte capacity is now the single sizing knob.
`--snapshot-db-block-cache-size` remains and still defaults to 1 GiB.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19703)
<!-- Reviewable:end -->
