### PR TITLE
chore: bump databend-meta to v260312.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5299,8 +5299,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5310,13 +5310,13 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260312.6.0",
- "databend-meta-kvapi 260312.6.0",
+ "databend-meta-client 260312.7.0",
+ "databend-meta-kvapi 260312.7.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260312.6.0",
+ "databend-meta-runtime-api 260312.7.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.6.0",
- "databend-meta-version 260312.6.0",
+ "databend-meta-types 260312.7.0",
+ "databend-meta-version 260312.7.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5378,8 +5378,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5482,8 +5482,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5492,10 +5492,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.6.0",
- "databend-meta-kvapi-test-suite 260312.6.0",
- "databend-meta-runtime-api 260312.6.0",
- "databend-meta-version 260312.6.0",
+ "databend-meta-kvapi 260312.7.0",
+ "databend-meta-kvapi-test-suite 260312.7.0",
+ "databend-meta-runtime-api 260312.7.0",
+ "databend-meta-version 260312.7.0",
  "derive_more 2.1.1",
  "display-more 0.2.5",
  "fastrace",
@@ -5516,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5563,8 +5563,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5595,12 +5595,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.6.0",
+ "databend-meta-kvapi 260312.7.0",
  "display-more 0.2.5",
  "fastrace",
  "futures-util",
@@ -5651,8 +5651,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5674,18 +5674,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260312.6.0",
- "databend-meta-runtime-api 260312.6.0",
+ "databend-meta-kvapi 260312.7.0",
+ "databend-meta-runtime-api 260312.7.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.6.0",
+ "databend-meta-types 260312.7.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.5",
@@ -5743,8 +5743,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5756,12 +5756,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260312.6.0",
+ "databend-meta-types 260312.7.0",
  "fastrace",
  "log",
  "serde",
@@ -5774,14 +5774,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260312.6.0",
- "databend-meta-types 260312.6.0",
+ "databend-meta-runtime-api 260312.7.0",
+ "databend-meta-types 260312.7.0",
  "fastrace",
  "log",
  "tempfile",
@@ -5819,8 +5819,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5862,8 +5862,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260312.6.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.6.0#a318365ed00b6122e2ae431df0c26fcbe53365d4"
+version = "260312.7.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "semver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,8 +166,8 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260312.6.0"
-databend-meta-test-harness = "260312.6.0"
+databend-meta = "260312.7.0"
+databend-meta-test-harness = "260312.7.0"
 
 # External meta client
 databend-meta-client = "260205.5.0"
@@ -619,9 +619,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.3.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.6.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.7.0" }
 databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.5.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.6.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.7.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: bump databend-meta to v260312.7.0
v260312.7.0 parallelizes MetaWorker request processing (read p50
29ms to 226us, 128x improvement) and reduces the compactor cooperative
yield interval from 5000 to 100 items to prevent task starvation.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19704)
<!-- Reviewable:end -->
