### PR TITLE
fix(storage): backport snapshot retry segment dedup

### DIFF
--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -112,6 +112,7 @@ use parking_lot::Mutex;
 
 use crate::fuse_column::FuseTableColumnStatisticsProvider;
 use crate::fuse_type::FuseTableType;
+use crate::io::normalize_snapshot;
 use crate::io::MetaReaders;
 use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
@@ -371,7 +372,7 @@ impl FuseTable {
         let reader = MetaReaders::table_snapshot_reader(self.get_operator());
         let loc = self.snapshot_loc();
         let ver = self.snapshot_format_version(loc.clone())?;
-        Self::read_table_snapshot_with_reader(reader, loc, ver).await
+        Self::read_table_snapshot_with_reader(reader, loc, ver, self.get_operator()).await
     }
 
     #[fastrace::trace]
@@ -382,7 +383,7 @@ impl FuseTable {
     ) -> Result<Option<Arc<TableSnapshot>>> {
         let reader = MetaReaders::table_snapshot_reader(self.get_operator());
         let ver = self.snapshot_format_version(loc.clone())?;
-        Self::read_table_snapshot_with_reader(reader, loc, ver).await
+        Self::read_table_snapshot_with_reader(reader, loc, ver, self.get_operator()).await
     }
 
     #[fastrace::trace]
@@ -391,13 +392,14 @@ impl FuseTable {
         let reader = MetaReaders::table_snapshot_reader_without_cache(self.get_operator());
         let loc = self.snapshot_loc();
         let ver = self.snapshot_format_version(loc.clone())?;
-        Self::read_table_snapshot_with_reader(reader, loc, ver).await
+        Self::read_table_snapshot_with_reader(reader, loc, ver, self.get_operator()).await
     }
 
     pub async fn read_table_snapshot_with_reader(
         reader: TableSnapshotReader,
         snapshot_location: Option<String>,
         ver: u64,
+        operator: Operator,
     ) -> Result<Option<Arc<TableSnapshot>>> {
         if let Some(location) = snapshot_location {
             let params = LoadParams {
@@ -406,7 +408,8 @@ impl FuseTable {
                 ver,
                 put_cache: true,
             };
-            Ok(Some(reader.read(&params).await?))
+            let snapshot = reader.read(&params).await?;
+            Ok(Some(normalize_snapshot(snapshot, operator).await?))
         } else {
             Ok(None)
         }
@@ -628,8 +631,13 @@ impl FuseTable {
                     let begin = Instant::now();
                     let reader = MetaReaders::table_snapshot_reader_without_cache(operator.clone());
                     let ver = TableMetaLocationGenerator::snapshot_version(loc.as_str());
-                    let snapshot =
-                        Self::read_table_snapshot_with_reader(reader, Some(loc), ver).await?;
+                    let snapshot = Self::read_table_snapshot_with_reader(
+                        reader,
+                        Some(loc),
+                        ver,
+                        operator.clone(),
+                    )
+                    .await?;
                     info!(
                         "[FUSE-TABLE] Table snapshot refreshed, elapsed: {:?}",
                         begin.elapsed()

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -15,6 +15,7 @@
 mod locations;
 pub mod read;
 mod segments;
+mod snapshot_normalizer;
 mod snapshots;
 mod write;
 
@@ -34,6 +35,7 @@ pub use read::VirtualBlockReadResult;
 pub use read::VirtualColumnReader;
 pub use segments::SegmentsIO;
 pub use segments::SerializedSegment;
+pub(crate) use snapshot_normalizer::normalize_snapshot;
 pub use snapshots::SnapshotLiteExtended;
 pub use snapshots::SnapshotsIO;
 pub use write::build_column_hlls;

--- a/src/query/storages/fuse/src/io/snapshot_normalizer.rs
+++ b/src/query/storages/fuse/src/io/snapshot_normalizer.rs
@@ -1,0 +1,215 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_storages_common_cache::LoadParams;
+use databend_storages_common_table_meta::meta::AdditionalStatsMeta;
+use databend_storages_common_table_meta::meta::Location;
+use databend_storages_common_table_meta::meta::Statistics;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+use log::warn;
+use opendal::Operator;
+
+use super::MetaReaders;
+use crate::statistics::reducers::deduct_statistics_mut;
+
+#[derive(Debug, PartialEq, Eq)]
+struct SnapshotSegmentDedupInfo {
+    deduped_segments: Vec<Location>,
+    duplicated_segments: Vec<(Location, usize)>,
+}
+
+pub(crate) async fn normalize_snapshot(
+    snapshot: Arc<TableSnapshot>,
+    operator: Operator,
+) -> Result<Arc<TableSnapshot>> {
+    let dedup_info = dedup_snapshot_segments(&snapshot.segments);
+    if dedup_info.duplicated_segments.is_empty() {
+        return Ok(snapshot);
+    }
+
+    let reader = MetaReaders::segment_info_reader(operator, snapshot.schema.clone().into());
+    let mut normalized_snapshot = snapshot.as_ref().clone();
+    let mut duplicate_refs = 0;
+
+    for (location, duplicate_count) in &dedup_info.duplicated_segments {
+        let params = LoadParams {
+            location: location.0.clone(),
+            len_hint: None,
+            ver: location.1,
+            put_cache: true,
+        };
+        let segment = reader.read(&params).await?;
+        deduct_duplicated_segment_summary(
+            &mut normalized_snapshot.summary,
+            &segment.summary,
+            *duplicate_count,
+        );
+        duplicate_refs += *duplicate_count;
+    }
+
+    normalized_snapshot.segments = dedup_info.deduped_segments;
+    warn!(
+        "[FUSE-TABLE] deduplicated {} duplicate segment references while reading snapshot {}, segments {} -> {}",
+        duplicate_refs,
+        normalized_snapshot.snapshot_id,
+        snapshot.segments.len(),
+        normalized_snapshot.segments.len()
+    );
+    Ok(Arc::new(normalized_snapshot))
+}
+
+fn dedup_snapshot_segments(segments: &[Location]) -> SnapshotSegmentDedupInfo {
+    let mut seen = HashSet::with_capacity(segments.len());
+    let mut first_locations = HashMap::with_capacity(segments.len());
+    let mut deduped_segments = Vec::with_capacity(segments.len());
+    let mut duplicated_segments: HashMap<String, (Location, usize)> = HashMap::new();
+
+    for segment in segments {
+        let key = segment.0.clone();
+        if seen.insert(key.clone()) {
+            first_locations.insert(key, segment.clone());
+            deduped_segments.push(segment.clone());
+            continue;
+        }
+
+        let first_location = first_locations
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| segment.clone());
+        duplicated_segments
+            .entry(key)
+            .and_modify(|(_, count)| *count += 1)
+            .or_insert((first_location, 1));
+    }
+
+    let mut duplicated_segments = duplicated_segments.into_values().collect::<Vec<_>>();
+    duplicated_segments.sort_by(|(left, _), (right, _)| left.0.cmp(&right.0));
+
+    SnapshotSegmentDedupInfo {
+        deduped_segments,
+        duplicated_segments,
+    }
+}
+
+fn deduct_duplicated_segment_summary(
+    summary: &mut Statistics,
+    duplicated_segment_summary: &Statistics,
+    duplicate_count: usize,
+) {
+    for _ in 0..duplicate_count {
+        deduct_statistics_mut(summary, duplicated_segment_summary);
+    }
+
+    deduct_duplicated_additional_stats_meta(
+        &mut summary.additional_stats_meta,
+        duplicated_segment_summary.additional_stats_meta.as_ref(),
+        duplicate_count,
+    );
+}
+
+fn deduct_duplicated_additional_stats_meta(
+    summary_meta: &mut Option<AdditionalStatsMeta>,
+    duplicated_meta: Option<&AdditionalStatsMeta>,
+    duplicate_count: usize,
+) {
+    let (Some(summary_meta), Some(duplicated_meta)) = (summary_meta.as_mut(), duplicated_meta)
+    else {
+        return;
+    };
+
+    let duplicate_count = duplicate_count as u64;
+    summary_meta.row_count = summary_meta
+        .row_count
+        .saturating_sub(duplicated_meta.row_count.saturating_mul(duplicate_count));
+    summary_meta.unstats_rows = summary_meta
+        .unstats_rows
+        .saturating_sub(duplicated_meta.unstats_rows.saturating_mul(duplicate_count));
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_storages_common_table_meta::meta::AdditionalStatsMeta;
+
+    use super::*;
+
+    #[test]
+    fn test_dedup_snapshot_segments_preserves_first_occurrence_order() {
+        let dedup_info = dedup_snapshot_segments(&[
+            ("a".to_string(), 1),
+            ("b".to_string(), 1),
+            ("a".to_string(), 1),
+            ("c".to_string(), 1),
+            ("b".to_string(), 1),
+        ]);
+
+        assert_eq!(dedup_info.deduped_segments, vec![
+            ("a".to_string(), 1),
+            ("b".to_string(), 1),
+            ("c".to_string(), 1),
+        ]);
+        assert_eq!(dedup_info.duplicated_segments, vec![
+            (("a".to_string(), 1), 1),
+            (("b".to_string(), 1), 1),
+        ]);
+    }
+
+    #[test]
+    fn test_deduct_duplicated_segment_summary_updates_stats() {
+        let mut summary = Statistics {
+            row_count: 30,
+            block_count: 3,
+            perfect_block_count: 3,
+            uncompressed_byte_size: 300,
+            compressed_byte_size: 150,
+            index_size: 60,
+            additional_stats_meta: Some(AdditionalStatsMeta {
+                row_count: 30,
+                unstats_rows: 6,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let duplicated_segment_summary = Statistics {
+            row_count: 10,
+            block_count: 1,
+            perfect_block_count: 1,
+            uncompressed_byte_size: 100,
+            compressed_byte_size: 50,
+            index_size: 20,
+            additional_stats_meta: Some(AdditionalStatsMeta {
+                row_count: 10,
+                unstats_rows: 2,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        deduct_duplicated_segment_summary(&mut summary, &duplicated_segment_summary, 2);
+
+        assert_eq!(summary.row_count, 10);
+        assert_eq!(summary.block_count, 1);
+        assert_eq!(summary.perfect_block_count, 1);
+        assert_eq!(summary.uncompressed_byte_size, 100);
+        assert_eq!(summary.compressed_byte_size, 50);
+        assert_eq!(summary.index_size, 20);
+        let additional_stats_meta = summary.additional_stats_meta.unwrap();
+        assert_eq!(additional_stats_meta.row_count, 10);
+        assert_eq!(additional_stats_meta.unstats_rows, 2);
+    }
+}

--- a/src/query/storages/fuse/src/io/snapshot_normalizer.rs
+++ b/src/query/storages/fuse/src/io/snapshot_normalizer.rs
@@ -76,30 +76,23 @@ pub(crate) async fn normalize_snapshot(
 
 fn dedup_snapshot_segments(segments: &[Location]) -> SnapshotSegmentDedupInfo {
     let mut seen = HashSet::with_capacity(segments.len());
-    let mut first_locations = HashMap::with_capacity(segments.len());
     let mut deduped_segments = Vec::with_capacity(segments.len());
-    let mut duplicated_segments: HashMap<String, (Location, usize)> = HashMap::new();
+    let mut duplicated_segments: HashMap<Location, usize> = HashMap::new();
 
     for segment in segments {
-        let key = segment.0.clone();
-        if seen.insert(key.clone()) {
-            first_locations.insert(key, segment.clone());
+        if seen.insert(segment.clone()) {
             deduped_segments.push(segment.clone());
             continue;
         }
 
-        let first_location = first_locations
-            .get(&key)
-            .cloned()
-            .unwrap_or_else(|| segment.clone());
         duplicated_segments
-            .entry(key)
-            .and_modify(|(_, count)| *count += 1)
-            .or_insert((first_location, 1));
+            .entry(segment.clone())
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
     }
 
-    let mut duplicated_segments = duplicated_segments.into_values().collect::<Vec<_>>();
-    duplicated_segments.sort_by(|(left, _), (right, _)| left.0.cmp(&right.0));
+    let mut duplicated_segments = duplicated_segments.into_iter().collect::<Vec<_>>();
+    duplicated_segments.sort_by(|(left, _), (right, _)| left.cmp(right));
 
     SnapshotSegmentDedupInfo {
         deduped_segments,

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -570,6 +570,7 @@ impl FuseTable {
                             reader,
                             Some(snapshot_loc),
                             TableSnapshot::VERSION,
+                            self.get_operator(),
                         )
                         .await
                         .ok()

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -39,6 +40,8 @@ use crate::statistics::merge_statistics;
 use crate::statistics::reducers::deduct_statistics;
 use crate::FuseTable;
 
+const FUSE_ENGINE: &str = "FUSE";
+
 pub async fn commit_with_backoff(
     ctx: Arc<dyn TableContext>,
     mut req: UpdateMultiTableMetaReq,
@@ -46,6 +49,11 @@ pub async fn commit_with_backoff(
     let catalog = ctx.get_default_catalog()?;
     let mut backoff = set_backoff(None, None, None);
     let mut retries = 0;
+
+    // Compute segments diff before the retry loop so each retry replays the original
+    // transaction delta instead of diffing from an already merged snapshot again.
+    let (table_segments_diffs, table_original_snapshots) =
+        compute_table_segments_diffs(ctx.clone(), &req).await?;
 
     loop {
         let ret = catalog
@@ -63,14 +71,83 @@ pub async fn commit_with_backoff(
         };
         sleep(duration).await;
         retries += 1;
-        try_rebuild_req(ctx.clone(), &mut req, update_failed_tbls).await?;
+        try_rebuild_req(
+            ctx.clone(),
+            &mut req,
+            update_failed_tbls,
+            &table_segments_diffs,
+            &table_original_snapshots,
+        )
+        .await?;
     }
+}
+
+async fn compute_table_segments_diffs(
+    ctx: Arc<dyn TableContext>,
+    req: &UpdateMultiTableMetaReq,
+) -> Result<(
+    HashMap<u64, SegmentsDiff>,
+    HashMap<u64, Option<Arc<TableSnapshot>>>,
+)> {
+    let txn_mgr = ctx.txn_mgr();
+    let storage_class = ctx.get_settings().get_s3_storage_class()?;
+    let mut table_segments_diffs = HashMap::new();
+    let mut table_original_snapshots = HashMap::new();
+
+    for (update_table_meta_req, _) in &req.update_table_metas {
+        let tid = update_table_meta_req.table_id;
+        let engine = update_table_meta_req.new_table_meta.engine.as_str();
+
+        if engine != FUSE_ENGINE {
+            info!(
+                "Skipping segments diff pre-compute for table {} with engine {}",
+                tid, engine
+            );
+            continue;
+        }
+
+        let base_snapshot_location = txn_mgr.lock().get_base_snapshot_location(tid);
+        let new_table = FuseTable::from_table_meta(
+            update_table_meta_req.table_id,
+            0,
+            update_table_meta_req.new_table_meta.clone(),
+            storage_class,
+        )?;
+
+        let base_snapshot = new_table
+            .read_table_snapshot_with_location(base_snapshot_location)
+            .await?;
+        let new_snapshot = new_table.read_table_snapshot().await?;
+
+        let base_segments = base_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.segments.as_slice())
+            .unwrap_or(&[]);
+        let new_segments = new_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.segments.as_slice())
+            .unwrap_or(&[]);
+
+        info!(
+            "Computing segments diff for table {} (base: {} segments, txn: {} segments)",
+            tid,
+            base_segments.len(),
+            new_segments.len()
+        );
+
+        table_segments_diffs.insert(tid, SegmentsDiff::new(base_segments, new_segments));
+        table_original_snapshots.insert(tid, new_snapshot);
+    }
+
+    Ok((table_segments_diffs, table_original_snapshots))
 }
 
 async fn try_rebuild_req(
     ctx: Arc<dyn TableContext>,
     req: &mut UpdateMultiTableMetaReq,
     update_failed_tbls: Vec<(u64, u64, TableMeta)>,
+    table_segments_diffs: &HashMap<u64, SegmentsDiff>,
+    table_original_snapshots: &HashMap<u64, Option<Arc<TableSnapshot>>>,
 ) -> Result<()> {
     info!(
         "try_rebuild_req: update_failed_tbls={:?}",
@@ -98,25 +175,30 @@ async fn try_rebuild_req(
             .iter_mut()
             .find(|(meta, _)| meta.table_id == tid)
             .unwrap();
-        let new_table = FuseTable::from_table_meta(
-            update_table_meta_req.table_id,
-            0,
-            update_table_meta_req.new_table_meta.clone(),
-            storage_class,
-        )?;
-        let new_snapshot = new_table.read_table_snapshot().await?;
         let base_snapshot_location = txn_mgr.lock().get_base_snapshot_location(tid);
-        let base_snapshot = new_table
-            .read_table_snapshot_with_location(base_snapshot_location)
+        let base_snapshot = latest_table
+            .read_table_snapshot_with_location(base_snapshot_location.clone())
             .await?;
 
-        let segments_diff = SegmentsDiff::new(base_snapshot.segments(), new_snapshot.segments());
-        let Some(merged_segments) = segments_diff.apply(latest_snapshot.segments().to_vec()) else {
+        let segments_diff = table_segments_diffs.get(&tid).ok_or_else(|| {
+            ErrorCode::Internal(format!("Missing segments diff for table {}", tid))
+        })?;
+        let Some(merged_segments) = segments_diff
+            .clone()
+            .apply(latest_snapshot.segments().to_vec())
+        else {
             return Err(ErrorCode::UnresolvableConflict(format!(
                 "Unresolvable conflict detected for table {}",
                 tid
             )));
         };
+
+        let new_snapshot = table_original_snapshots
+            .get(&tid)
+            .ok_or_else(|| {
+                ErrorCode::Internal(format!("Missing original snapshot for table {}", tid))
+            })?
+            .clone();
 
         let s = merge_statistics(
             new_snapshot.summary(),

--- a/src/query/storages/fuse/src/retry/diff.rs
+++ b/src/query/storages/fuse/src/retry/diff.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 
 use databend_storages_common_table_meta::meta::Location;
 
+#[derive(Clone)]
 pub struct SegmentsDiff {
     appended: Vec<Location>,
     replaced: HashMap<Location, Vec<Location>>,

--- a/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.py
+++ b/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from random import Random
+
+import mysql.connector
+from mysql.connector import errors as mysql_errors
+
+
+TABLE_NAME = "txn_snapshot_retry_concurrency"
+NUM_THREADS = 8
+TRANSACTIONS_PER_THREAD = 3
+ROWS_PER_TRANSACTION = 2
+MAX_RETRIES = 8
+RETRY_SLEEP_RANGE = (0.01, 0.05)
+VALUE_GAP = 1_000_000
+
+HOST = os.getenv("QUERY_MYSQL_HANDLER_HOST", "127.0.0.1")
+PORT = int(os.getenv("QUERY_MYSQL_HANDLER_PORT", "3307"))
+USER = os.getenv("QUERY_MYSQL_HANDLER_USER", "root")
+PASSWORD = os.getenv("QUERY_MYSQL_HANDLER_PASSWORD", "root")
+
+
+def create_connection():
+    conn = mysql.connector.connect(
+        host=HOST, port=PORT, user=USER, passwd=PASSWORD, autocommit=False
+    )
+    cursor = conn.cursor()
+    return conn, cursor
+
+
+def drain(cursor):
+    try:
+        cursor.fetchall()
+    except mysql_errors.InterfaceError:
+        pass
+
+
+def run_transaction_batch(thread_id: int) -> None:
+    conn, cursor = create_connection()
+    rng = Random(thread_id)
+
+    try:
+        for tx_index in range(TRANSACTIONS_PER_THREAD):
+            base_value = thread_id * VALUE_GAP + tx_index * ROWS_PER_TRANSACTION
+            values_clause = ", ".join(
+                f"({base_value + offset})" for offset in range(ROWS_PER_TRANSACTION)
+            )
+
+            attempts = 0
+            while True:
+                attempts += 1
+                try:
+                    cursor.execute("BEGIN")
+                    drain(cursor)
+
+                    cursor.execute(f"INSERT INTO {TABLE_NAME} VALUES {values_clause}")
+                    drain(cursor)
+
+                    cursor.execute("COMMIT")
+                    drain(cursor)
+                    break
+                except Exception:
+                    try:
+                        cursor.execute("ROLLBACK")
+                        drain(cursor)
+                    except Exception:
+                        pass
+
+                    cursor.close()
+                    conn.close()
+
+                    if attempts >= MAX_RETRIES:
+                        raise
+
+                    time.sleep(rng.uniform(*RETRY_SLEEP_RANGE))
+                    conn, cursor = create_connection()
+    finally:
+        cursor.close()
+        conn.close()
+
+
+def main() -> None:
+    setup_conn, setup_cursor = create_connection()
+    try:
+        setup_cursor.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+        drain(setup_cursor)
+        setup_cursor.execute(f"CREATE TABLE {TABLE_NAME} (id BIGINT)")
+        drain(setup_cursor)
+    finally:
+        setup_cursor.close()
+        setup_conn.close()
+
+    with ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
+        futures = [
+            executor.submit(run_transaction_batch, thread_id)
+            for thread_id in range(NUM_THREADS)
+        ]
+        for future in as_completed(futures):
+            future.result()
+
+    verify_conn, verify_cursor = create_connection()
+    try:
+        expected_rows = NUM_THREADS * TRANSACTIONS_PER_THREAD * ROWS_PER_TRANSACTION
+
+        verify_cursor.execute(
+            f"SELECT COUNT(*) AS cnt, COUNT(DISTINCT id) AS uniq FROM {TABLE_NAME}"
+        )
+        counts = verify_cursor.fetchall()[0]
+        total_count, distinct_count = counts[0], counts[1]
+
+        if total_count != expected_rows or distinct_count != expected_rows:
+            raise AssertionError(
+                f"Expected {expected_rows} rows, got total={total_count}, distinct={distinct_count}"
+            )
+
+        verify_cursor.execute(
+            f"SELECT id FROM {TABLE_NAME} GROUP BY id HAVING COUNT(*) > 1 LIMIT 1"
+        )
+        duplicates = verify_cursor.fetchall()
+        if duplicates:
+            raise AssertionError(f"found duplicated segments: {duplicates}")
+
+        verify_cursor.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+        drain(verify_cursor)
+    finally:
+        verify_cursor.close()
+        verify_conn.close()
+
+    print("Transaction snapshot retry looks good")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.result
+++ b/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.result
@@ -1,0 +1,1 @@
+Transaction snapshot retry looks good


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Backport the snapshot retry fix from #18934 to `release/833-patch`
- Deduplicate duplicated FUSE snapshot segment references while reading snapshots so the next transaction rewrites a clean snapshot instead of preserving historical duplicates

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19710)
<!-- Reviewable:end -->
