### PR TITLE
fix(query): drain pending queue on exchange sink buffer close to prevent permit leak

### DIFF
--- a/src/query/service/src/servers/flight/v1/network/outbound_buffer.rs
+++ b/src/query/service/src/servers/flight/v1/network/outbound_buffer.rs
@@ -218,6 +218,19 @@ impl PingPongCallback for SinkBufferCallback {
         self.buffer
             .try_flush_remote(self.dest_idx, response.data.err());
     }
+
+    fn on_closed(&self) {
+        let remote = &self.buffer.remotes[self.dest_idx];
+        let state = remote.state.lock();
+
+        for channel in &state.channels {
+            channel.pending_queue.close();
+        }
+
+        for channel in &state.channels {
+            while channel.pending_queue.pop().is_ok() {}
+        }
+    }
 }
 
 pub struct ExchangeSinkBuffer {

--- a/src/query/service/src/servers/flight/v1/network/outbound_transport.rs
+++ b/src/query/service/src/servers/flight/v1/network/outbound_transport.rs
@@ -41,6 +41,7 @@ pub struct PingPongResponse {
 pub trait PingPongCallback: Send + Sync + 'static {
     fn has_pending(&self) -> bool;
     fn on_response(&self, response: PingPongResponse);
+    fn on_closed(&self);
 }
 
 pub struct PingPongExchangeInner {
@@ -178,6 +179,7 @@ impl PingPongExchange {
                         shutdown_fut = Box::pin(inner.shutdown.notified());
                     }
                     Either::Right((None, _)) => {
+                        callback.on_closed();
                         break;
                     }
                     Either::Right((Some(Ok(data)), next_shutdown)) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(query): drain pending queue on exchange sink buffer close to prevent permit leak

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19712)
<!-- Reviewable:end -->
