### PR TITLE
chore(ci): pin rustfs image version and wait for readiness in iceberg tpch test

### DIFF
--- a/.github/actions/test_sqllogic_iceberg_tpch/action.yml
+++ b/.github/actions/test_sqllogic_iceberg_tpch/action.yml
@@ -23,6 +23,13 @@ runs:
       shell: bash
       run: |
         docker compose -f tests/sqllogictests/scripts/docker-compose-iceberg-tpch.yml up -d
+        # Wait for rustfs to be ready
+        for i in $(seq 1 30); do
+          curl -sf http://127.0.0.1:9002/health/ready && break
+          echo "Waiting for rustfs... ($i)"
+          sleep 2
+        done
+        curl -sf http://127.0.0.1:9002/health/ready || { echo "rustfs failed to start after 60s"; exit 1; }
 
         # Prepare Iceberg TPCH data
         data_dir="tests/sqllogictests/data"

--- a/tests/sqllogictests/scripts/docker-compose-iceberg-tpch.yml
+++ b/tests/sqllogictests/scripts/docker-compose-iceberg-tpch.yml
@@ -39,7 +39,7 @@ services:
       - 8181:8181
 
   rustfs:
-    image: rustfs/rustfs
+    image: rustfs/rustfs:1.0.0-alpha.91
     network_mode: "host"
     environment:
       - RUSTFS_ACCESS_KEY=admin
@@ -47,6 +47,11 @@ services:
       - RUSTFS_SERVER_DOMAINS=rustfs
       - RUSTFS_ADDRESS=0.0.0.0:9002
       - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9003
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9002/health/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   mc:
     depends_on:
       - rustfs


### PR DESCRIPTION



I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Pin rustfs image to `1.0.0-alpha.91` to fix iceberg tpch test failures.                                                                                                                                    
                                                                                                                                                                                                             
  `rustfs/rustfs:latest` currently resolves to `1.0.0-alpha.93`, which has a known bug                                                                                                                       
  (rustfs/rustfs#2506): HTTP Range GET requests return empty body for files > 2MB.
  This breaks all parquet range reads in iceberg queries, causing                                                                                                                                            
  `end of file before message length reached` errors.                                                                                                                                                        
                                                                                                                                                                                                             
  The bug was introduced in `1.0.0-alpha.92` by a series of object request refactors,                                                                                                                        
  and `alpha.93`'s attempted fix (`fix(get-object): harden GET fast path against mid-stream regressions`)                                                                                                    
  did not fullyresolve it. `1.0.0-alpha.91` (Apr 7) is the last known stable version.                                                                                                                        
                                                                  
  All `standalone_iceberg_tpch` CI jobs have been failing since Apr 11 across every PR branch. 


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19715)
<!-- Reviewable:end -->
