### PR TITLE
ci: pin bendsql version to 0.33.6.

### DIFF
--- a/.github/actions/setup_bendsql/action.yml
+++ b/.github/actions/setup_bendsql/action.yml
@@ -11,19 +11,9 @@ runs:
           bendsql --version
           exit 0
         fi
-        case $RUNNER_PROVIDER in
-          aws)
-            aws s3 cp s3://databend-ci/packages/bendsql_$(dpkg --print-architecture).deb /tmp/bendsql.deb --no-progress
-            sudo dpkg -i /tmp/bendsql.deb
-            ;;
-          gcp)
-            gsutil cp gs://databend-ci/packages/bendsql_$(dpkg --print-architecture).deb /tmp/bendsql.deb --no-progress
-            sudo dpkg -i /tmp/bendsql.deb
-            ;;
-          *)
-            curl -fsSL https://repo.databend.com/install/bendsql.sh | bash -s -- -y --prefix /usr/local
-            ;;
-        esac
+
+        export BENDSQL_VERSION="v0.33.6"
+        curl -fsSL https://repo.databend.com/install/bendsql.sh | bash -s -- -y --prefix /usr/local
         bendsql --version
 
     - name: Install for macOS
@@ -34,5 +24,6 @@ runs:
           bendsql --version
           exit 0
         fi
+
         brew install databendcloud/homebrew-tap/bendsql
         bendsql --version


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 error info in bendsql change, lead to  many stateless/stateful tests based on error message fail.
macos seems to using a fixed old version 
https://github.com/databendcloud/homebrew-tap/blob/main/bendsql.rb



## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): ci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19719)
<!-- Reviewable:end -->
