### PR TITLE
feat(ast): support EXPLAIN VERBOSE alias

### DIFF
--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -79,9 +79,19 @@ fn query_statement(i: Input) -> IResult<Statement> {
 }
 
 pub fn statement_body(i: Input) -> IResult<Statement> {
+    let explain_options = map(
+        rule! {
+            "(" ~ #comma_separated_list1(explain_option) ~ ")"
+        },
+        |(a, opts, b)| (merge_span(Some(a.span), Some(b.span)), opts),
+    );
+    let explain_verbose_alias = map(rule! { VERBOSE }, |verbose| {
+        (Some(verbose.span), vec![ExplainOption::Verbose])
+    });
+
     let explain = map_res(
         rule! {
-            EXPLAIN ~ ( "(" ~ #comma_separated_list1(explain_option) ~ ")" )? ~ ( AST | SYNTAX | PIPELINE | JOIN | GRAPH | FRAGMENTS | RAW | OPTIMIZED | MEMO | DECORRELATED | PERF)? ~ #statement
+            EXPLAIN ~ ( #explain_options | #explain_verbose_alias )? ~ ( AST | SYNTAX | PIPELINE | JOIN | GRAPH | FRAGMENTS | RAW | OPTIMIZED | MEMO | DECORRELATED | PERF)? ~ #statement
         },
         |(_, options, opt_kind, statement)| {
             Ok(Statement::Explain {
@@ -105,9 +115,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
                     None => ExplainKind::Plan,
                     _ => unreachable!(),
                 },
-                options: options
-                    .map(|(a, opts, b)| (merge_span(Some(a.span), Some(b.span)), opts))
-                    .unwrap_or_default(),
+                options: options.unwrap_or_default(),
                 query: Box::new(statement.stmt),
             })
         },
@@ -2783,7 +2791,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
         HintPrefix | LParen | FROM => query_statement(i),
         EXPLAIN => rule!(
             #explain_perf : "`EXPLAIN PERF [(events='<event>,...')] <statement>`"
-            | #explain : "`EXPLAIN [PIPELINE | GRAPH] <statement>`"
+            | #explain : "`EXPLAIN [VERBOSE | (<option>, ...)] [PIPELINE | GRAPH] <statement>`"
             | #explain_analyze : "`EXPLAIN ANALYZE <statement>`"
         ).parse(i),
         REPORT => rule!(#report: "`REPORT ISSUE <statement>`").parse(i),

--- a/src/query/ast/tests/it/display.rs
+++ b/src/query/ast/tests/it/display.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_ast::ast::ExplainKind;
+use databend_common_ast::ast::ExplainOption;
+use databend_common_ast::ast::Statement;
 use databend_common_ast::parser::Dialect;
 use databend_common_ast::parser::parse_sql;
 use databend_common_ast::parser::tokenize_sql;
@@ -81,4 +84,25 @@ fn test_parse_sql_nested_join_conditions_without_panic() {
         let tokens = tokenize_sql(sql).unwrap();
         parse_sql(&tokens, Dialect::PostgreSQL).unwrap();
     }
+}
+
+#[test]
+fn test_explain_verbose_alias_display() {
+    let tokens = tokenize_sql("EXPLAIN VERBOSE SELECT * FROM t").unwrap();
+    let (stmt, _) = parse_sql(&tokens, Dialect::PostgreSQL).unwrap();
+
+    match &stmt {
+        Statement::Explain {
+            kind,
+            options: (_, options),
+            ..
+        } => {
+            assert_eq!(kind, &ExplainKind::Plan);
+            assert_eq!(options, &vec![ExplainOption::Verbose]);
+        }
+        _ => panic!("expected EXPLAIN statement"),
+    }
+
+    assert_eq!(stmt.to_string(), "EXPLAIN(VERBOSE) SELECT * FROM t");
+    test_stmt_display("EXPLAIN VERBOSE SELECT * FROM t");
 }

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -38,6 +38,34 @@ TableScan
 └── estimated rows: 0.00
 
 query T
+explain(verbose) select * from numbers(0)
+----
+TableScan
+├── table: default.system.numbers
+├── scan id: 0
+├── output columns: [number (#0)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 0.00
+
+query T
+explain verbose select * from numbers(0)
+----
+TableScan
+├── table: default.system.numbers
+├── scan id: 0
+├── output columns: [number (#0)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 0.00
+
+query T
 explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a and t2.a > 5 and t1.a > 1)
 ----
 Filter


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fixes #16161
- Support PostgreSQL-style `EXPLAIN VERBOSE <statement>` as an alias in `databend-common-ast`
- Keep the existing explain semantics unchanged by mapping the new syntax to the existing `VERBOSE` explain option
- Add AST coverage and place the SQL alias regression in the existing `explain.test` suite

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation run locally:

- `cargo test -p databend-common-ast --test it display::test_explain_verbose_alias_display -- --nocapture`
- `cargo test -p databend-common-ast --test it parser::test_statement -- --nocapture`
- `cargo fmt --all --check`

Added sqllogictest coverage in `tests/sqllogictests/suites/mode/standalone/explain/explain.test`, but did not run the full sqllogictest harness locally.

## Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19726)
<!-- Reviewable:end -->
