### PR TITLE
ci: truncate release notes when exceeding GitHub size limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,29 @@ jobs:
           script: |
             const script = require('./.github/scripts/bump_version.js')
             await script({ github, context, core })
+      - name: Generate release notes
+        id: notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            const previous = '${{ steps.bump.outputs.previous }}';
+            const sha = '${{ steps.bump.outputs.sha }}';
+            const { data } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              target_commitish: sha,
+              previous_tag_name: previous,
+            });
+            const MAX_LEN = 124000;
+            let body = data.body;
+            if (body.length > MAX_LEN) {
+              core.warning(`Release notes too long (${body.length} chars), truncating to ${MAX_LEN}`);
+              body = body.substring(0, MAX_LEN) + '\n\n> **Note**: changelog truncated due to GitHub size limits. See commit history for full details.';
+            }
+            const fs = require('fs');
+            fs.writeFileSync('/tmp/release_notes.md', body);
       - name: Create release
         env:
           # we need workflow:write permission to create release if there were any workflow changes
@@ -73,13 +96,13 @@ jobs:
         run: |
           case "${{ steps.bump.outputs.type }}" in
             nightly)
-              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --generate-notes --notes-start-tag ${{ steps.bump.outputs.previous }} --prerelease --draft
+              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --prerelease --draft
               ;;
             stable)
-              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --generate-notes --notes-start-tag ${{ steps.bump.outputs.previous }} --latest --draft
+              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --latest --draft
               ;;
             patch)
-              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --generate-notes --notes-start-tag ${{ steps.bump.outputs.previous }} --prerelease --draft
+              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --prerelease --draft
               ;;
             *)
               echo "Invalid release type: ${{ steps.bump.outputs.type }}"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The stable release v1.2.881 failed because auto-generated release notes from v1.2.725 (156 nightly versions) exceeded GitHub's 125000 character limit:

```
HTTP 422: Validation Failed
body is too long (maximum is 125000 characters)
```

ref: https://github.com/databendlabs/databend/actions/runs/24543874830/job/71755226225

Split the `Create release` step into two steps:
1. **Generate release notes** — calls `generateReleaseNotes` API, truncates body to 124000 chars if needed
2. **Create release** — uses `--notes-file` instead of `--generate-notes`

## Tests

- [x] No Test - CI workflow change, verified by re-running the release job

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19730)
<!-- Reviewable:end -->
