### PR TITLE
fix(stage): correct parquet file row number offsets

### DIFF
--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -320,9 +320,10 @@ impl ParquetVariantSource {
         let mut start_row = 0;
         let mut readers = VecDeque::with_capacity(meta.num_row_groups());
         for (rowgroup_idx, rg) in meta.row_groups().iter().enumerate() {
-            start_row += rg.num_rows() as u64;
+            let row_group_start = start_row;
             // filter by bucket option
             if !should_read(rowgroup_idx, part.bucket_option) {
+                start_row += rg.num_rows() as u64;
                 continue;
             }
             let mut row_group =
@@ -334,7 +335,8 @@ impl ParquetVariantSource {
                 self.batch_size,
                 None,
             )?;
-            readers.push_back((reader, start_row, typ.clone(), data_schema.clone()));
+            readers.push_back((reader, row_group_start, typ.clone(), data_schema.clone()));
+            start_row += rg.num_rows() as u64;
         }
         Ok(readers)
     }

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -429,15 +429,16 @@ impl ParquetSource {
         let delete_info = delete_files.as_ref().map(|tasks| (meta.as_ref(), *tasks));
 
         for (rowgroup_idx, rg) in meta.row_groups().iter().enumerate() {
-            start_row += rg.num_rows() as u64;
+            let row_group_start = start_row;
             // filter by bucket option
             if !should_read(rowgroup_idx, part.bucket_option) {
+                start_row += rg.num_rows() as u64;
                 continue;
             }
 
             let part = ParquetRowGroupPart {
                 location: part.file.clone(),
-                start_row,
+                start_row: row_group_start,
                 meta: rg.clone(),
                 schema_index: 0,
                 uncompressed_size: rg.total_byte_size() as u64,
@@ -462,6 +463,7 @@ impl ParquetSource {
             if let Some(reader) = reader {
                 readers.push_back((reader, part.start_row));
             }
+            start_row += rg.num_rows() as u64;
         }
         Ok(readers)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This fixes incorrect metadata$file_row_number values when reading parquet files from stage in row-group mode.

  The bug was in parquet stage source planning: the row-group start_row offset was incremented before building the current ParquetRowGroupPart, so the metadata column used the
  row-group end offset instead of the start offset. As a result, metadata$file_row_number was shifted by the row-group size in large stage runs where parquet_fast_read_bytes=0.

  This patch preserves the current row-group start offset for the active part and only advances the accumulated offset after the reader for that row group is created.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19732)
<!-- Reviewable:end -->
