### PR TITLE
fix(sql): skip unsafe eager rewrite for avg-style aggregates

### DIFF
--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -490,6 +490,16 @@ impl Metadata {
         }
     }
 
+    pub fn change_derived_column_data_type(&mut self, index: Symbol, data_type: DataType) {
+        let derived_column = self
+            .columns
+            .get_mut(index.as_usize())
+            .expect("metadata must contain column");
+        if let ColumnEntry::DerivedColumn(column) = derived_column {
+            column.data_type = data_type;
+        }
+    }
+
     pub fn set_max_column_position(&mut self, max_pos: usize) {
         self.max_column_position = max_pos
     }

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -490,16 +490,6 @@ impl Metadata {
         }
     }
 
-    pub fn change_derived_column_data_type(&mut self, index: Symbol, data_type: DataType) {
-        let derived_column = self
-            .columns
-            .get_mut(index.as_usize())
-            .expect("metadata must contain column");
-        if let ColumnEntry::DerivedColumn(column) = derived_column {
-            column.data_type = data_type;
-        }
-    }
-
     pub fn set_max_column_position(&mut self, max_pos: usize) {
         self.max_column_position = max_pos
     }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -1171,11 +1171,6 @@ impl EagerAnalysis {
         aggregate_function: &mut AggregateFunction,
         eager_count_index: Symbol,
     ) -> Result<ScalarItem, ErrorCode> {
-        let new_index = metadata.write().add_derived_column(
-            format!("{} * _eager_count", aggregate_function.display_name),
-            aggregate_function.args[0].data_type()?,
-        );
-
         let new_scalar = if let ScalarExpr::BoundColumnRef(column) = &aggregate_function.args[0] {
             let mut scalar_idx = input.extra_eval_scalar.items.len();
             for (idx, eval_scalar) in input.extra_eval_scalar.items.iter().enumerate() {
@@ -1192,35 +1187,41 @@ impl EagerAnalysis {
             unreachable!()
         };
 
+        let scalar = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "multiply".to_string(),
+            params: vec![],
+            arguments: vec![
+                new_scalar,
+                wrap_cast(
+                    &ScalarExpr::BoundColumnRef(BoundColumnRef {
+                        span: None,
+                        column: ColumnBindingBuilder::new(
+                            "_eager_count".to_string(),
+                            eager_count_index,
+                            Box::new(DataType::Nullable(Box::new(DataType::Number(
+                                NumberDataType::UInt64,
+                            )))),
+                            Visibility::Visible,
+                        )
+                        .build(),
+                    }),
+                    &DataType::Number(NumberDataType::UInt64),
+                ),
+            ],
+        });
+        let scalar_type = scalar.data_type()?;
+        let new_index = metadata.write().add_derived_column(
+            format!("{} * _eager_count", aggregate_function.display_name),
+            scalar_type.clone(),
+        );
         let new_scalar_item = ScalarItem {
-            scalar: ScalarExpr::FunctionCall(FunctionCall {
-                span: None,
-                func_name: "multiply".to_string(),
-                params: vec![],
-                arguments: vec![
-                    new_scalar,
-                    wrap_cast(
-                        &ScalarExpr::BoundColumnRef(BoundColumnRef {
-                            span: None,
-                            column: ColumnBindingBuilder::new(
-                                "_eager_count".to_string(),
-                                eager_count_index,
-                                Box::new(DataType::Nullable(Box::new(DataType::Number(
-                                    NumberDataType::UInt64,
-                                )))),
-                                Visibility::Visible,
-                            )
-                            .build(),
-                        }),
-                        &DataType::Number(NumberDataType::UInt64),
-                    ),
-                ],
-            }),
+            scalar,
             index: new_index,
         };
         if let ScalarExpr::BoundColumnRef(column) = &mut aggregate_function.args[0] {
             column.column.index = new_index;
-            column.column.data_type = Box::new(new_scalar_item.scalar.data_type()?);
+            column.column.data_type = Box::new(scalar_type);
         }
         Ok(new_scalar_item)
     }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -258,6 +258,10 @@ impl<'a> EagerInput<'a> {
             .flat_map(|item| item.scalar.used_columns())
             .collect::<ColumnSet>();
 
+        if self.has_mixed_sum_and_count_aggregates(&eval_scalar_used_columns) {
+            return Ok(vec![]);
+        }
+
         let function_factory = AggregateFunctionFactory::instance();
         let eager_candidates = EagerCandidates::collect(
             &self.final_agg,
@@ -353,6 +357,36 @@ impl<'a> EagerInput<'a> {
                 )
             })
             .collect())
+    }
+
+    fn has_mixed_sum_and_count_aggregates(&self, eval_scalar_used_columns: &ColumnSet) -> bool {
+        let mut has_sum = false;
+        let mut has_count = false;
+
+        for aggregate in &self.final_agg.aggregate_functions {
+            if !eval_scalar_used_columns.contains(&aggregate.index) {
+                continue;
+            }
+
+            let ScalarExpr::AggregateFunction(aggregate_function) = &aggregate.scalar else {
+                continue;
+            };
+
+            match aggregate_function.func_name.as_str() {
+                "sum" => has_sum = true,
+                "count" => has_count = true,
+                _ => {}
+            }
+
+            if has_sum && has_count {
+                // Mixed sum/count outputs are used by rewrites such as AVG = SUM / COUNT.
+                // The current eager-count rewrite only preserves semantics for pure SUM or
+                // pure COUNT flows, so keep the original plan for mixed expressions.
+                return true;
+            }
+        }
+
+        false
     }
 
     fn expand_analyses(

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -717,7 +717,7 @@ impl EagerAnalysis {
         });
 
         for agg in final_eager_split.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar {
                 if aggregate_function.func_name != "sum" {
                     continue;
                 }
@@ -808,7 +808,7 @@ impl EagerAnalysis {
 
         let mut eager_groupby_count_count_sum = EvalScalar { items: vec![] };
         for agg in final_eager_groupby_count.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar {
                 if aggregate_function.func_name != "sum"
                     || rewrites.source_side(agg.index) == Some(d)
                 {
@@ -908,13 +908,13 @@ impl EagerAnalysis {
         }
 
         let mut final_eager_count = self.final_agg.clone();
+        let mut eager_count_eval_scalar = input.eval_scalar.clone();
         let mut eager_count = self.pruned_aggregate_for_side(d.opposite());
         let (eager_count_index, _) = Self::add_eager_count(metadata, &mut eager_count);
 
         let mut eager_count_sum = EvalScalar { items: vec![] };
-        let mut eager_count_eval_scalar = input.eval_scalar.clone();
         for agg in final_eager_count.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar
                 && aggregate_function.func_name == "sum"
             {
                 eager_count_sum
@@ -992,7 +992,7 @@ impl EagerAnalysis {
         let (eager_count_index, _) = Self::add_eager_count(metadata, &mut eager_count);
         let mut double_eager_count_sum = EvalScalar { items: vec![] };
         for agg in final_double_eager.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar
                 && aggregate_function.func_name == "sum"
             {
                 double_eager_count_sum

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -717,7 +717,7 @@ impl EagerAnalysis {
         });
 
         for agg in final_eager_split.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar {
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
                 if aggregate_function.func_name != "sum" {
                     continue;
                 }
@@ -729,9 +729,17 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        aggregate_function,
+                        agg,
                         eager_group_by_and_eager_count[agg_side.opposite()].1,
                     )?);
+                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+                    Self::refresh_eval_scalar_binding_type(
+                        metadata,
+                        &mut eager_split_eval_scalar,
+                        agg.index,
+                        &aggregate_function.return_type,
+                    )?;
+                }
             }
         }
 
@@ -800,7 +808,7 @@ impl EagerAnalysis {
 
         let mut eager_groupby_count_count_sum = EvalScalar { items: vec![] };
         for agg in final_eager_groupby_count.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar {
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
                 if aggregate_function.func_name != "sum"
                     || rewrites.source_side(agg.index) == Some(d)
                 {
@@ -810,10 +818,18 @@ impl EagerAnalysis {
                     Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        aggregate_function,
+                        agg,
                         eager_count_index,
                     )?,
                 );
+                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+                    Self::refresh_eval_scalar_binding_type(
+                        metadata,
+                        &mut eager_groupby_count_scalar,
+                        agg.index,
+                        &aggregate_function.return_type,
+                    )?;
+                }
             }
         }
 
@@ -896,8 +912,9 @@ impl EagerAnalysis {
         let (eager_count_index, _) = Self::add_eager_count(metadata, &mut eager_count);
 
         let mut eager_count_sum = EvalScalar { items: vec![] };
+        let mut eager_count_eval_scalar = input.eval_scalar.clone();
         for agg in final_eager_count.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar
                 && aggregate_function.func_name == "sum"
             {
                 eager_count_sum
@@ -905,9 +922,17 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        aggregate_function,
+                        agg,
                         eager_count_index,
                     )?);
+                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+                    Self::refresh_eval_scalar_binding_type(
+                        metadata,
+                        &mut eager_count_eval_scalar,
+                        agg.index,
+                        &aggregate_function.return_type,
+                    )?;
+                }
             }
         }
 
@@ -928,7 +953,7 @@ impl EagerAnalysis {
             input,
             new_join.build_unary(eager_count_sum),
             final_eager_count,
-            input.eval_scalar.clone(),
+            eager_count_eval_scalar,
         )))
     }
 
@@ -967,7 +992,7 @@ impl EagerAnalysis {
         let (eager_count_index, _) = Self::add_eager_count(metadata, &mut eager_count);
         let mut double_eager_count_sum = EvalScalar { items: vec![] };
         for agg in final_double_eager.aggregate_functions.iter_mut() {
-            if let ScalarExpr::AggregateFunction(aggregate_function) = &mut agg.scalar
+            if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar
                 && aggregate_function.func_name == "sum"
             {
                 double_eager_count_sum
@@ -975,9 +1000,17 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        aggregate_function,
+                        agg,
                         eager_count_index,
                     )?);
+                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
+                    Self::refresh_eval_scalar_binding_type(
+                        metadata,
+                        &mut double_eager_eval_scalar,
+                        agg.index,
+                        &aggregate_function.return_type,
+                    )?;
+                }
             }
         }
 
@@ -1096,6 +1129,13 @@ impl EagerAnalysis {
             format!("_eager_final_{}", agg.func_name),
             *(agg.return_type).clone(),
         );
+        let rewritten_output_column = ColumnBindingBuilder::new(
+            metadata.read().column(new_index).name(),
+            new_index,
+            agg.return_type.clone(),
+            Visibility::Visible,
+        )
+        .build();
 
         Self::modify_final_aggregate_function(agg, old_index);
         aggr_function.index = new_index;
@@ -1113,7 +1153,9 @@ impl EagerAnalysis {
                     .scalar
                     .replace_column_with_scalar(old_index, count_output)?;
             } else {
-                scalar_item.scalar.replace_column(old_index, new_index)?;
+                scalar_item
+                    .scalar
+                    .replace_column_binding(old_index, &rewritten_output_column)?;
             }
             success = true;
         }
@@ -1168,9 +1210,12 @@ impl EagerAnalysis {
     fn create_eager_count_multiply_scalar_item(
         metadata: &MetadataRef,
         input: &EagerInput,
-        aggregate_function: &mut AggregateFunction,
+        aggregate_item: &mut ScalarItem,
         eager_count_index: Symbol,
     ) -> Result<ScalarItem, ErrorCode> {
+        let ScalarExpr::AggregateFunction(aggregate_function) = &mut aggregate_item.scalar else {
+            unreachable!()
+        };
         let new_scalar = if let ScalarExpr::BoundColumnRef(column) = &aggregate_function.args[0] {
             let mut scalar_idx = input.extra_eval_scalar.items.len();
             for (idx, eval_scalar) in input.extra_eval_scalar.items.iter().enumerate() {
@@ -1223,7 +1268,53 @@ impl EagerAnalysis {
             column.column.index = new_index;
             column.column.data_type = Box::new(scalar_type);
         }
+        let new_return_type = Self::refresh_aggregate_return_type(aggregate_function)?;
+        metadata
+            .write()
+            .change_derived_column_data_type(aggregate_item.index, new_return_type);
         Ok(new_scalar_item)
+    }
+
+    fn refresh_aggregate_return_type(
+        aggregate_function: &mut AggregateFunction,
+    ) -> Result<DataType, ErrorCode> {
+        let arg_types = aggregate_function
+            .args
+            .iter()
+            .map(ScalarExpr::data_type)
+            .collect::<Result<Vec<_>, _>>()?;
+        let function = AggregateFunctionFactory::instance().get(
+            &aggregate_function.func_name,
+            aggregate_function.params.clone(),
+            arg_types,
+            vec![],
+        )?;
+        let return_type = function.return_type()?;
+        aggregate_function.return_type = Box::new(return_type.clone());
+        Ok(return_type)
+    }
+
+    fn refresh_eval_scalar_binding_type(
+        metadata: &MetadataRef,
+        eval_scalar: &mut EvalScalar,
+        index: Symbol,
+        data_type: &DataType,
+    ) -> Result<(), ErrorCode> {
+        let column_binding = ColumnBindingBuilder::new(
+            metadata.read().column(index).name(),
+            index,
+            Box::new(data_type.clone()),
+            Visibility::Visible,
+        )
+        .build();
+
+        for item in &mut eval_scalar.items {
+            if item.scalar.used_columns().contains(&index) {
+                item.scalar.replace_column_binding(index, &column_binding)?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -380,8 +380,8 @@ impl<'a> EagerInput<'a> {
 
             if has_sum && has_count {
                 // Mixed sum/count outputs are used by rewrites such as AVG = SUM / COUNT.
-                // The current eager-count rewrite only preserves semantics for pure SUM or
-                // pure COUNT flows, so keep the original plan for mixed expressions.
+                // The current eager-count rewrite does not preserve this shape, so keep the
+                // original aggregate plan instead of applying eager aggregation.
                 return true;
             }
         }
@@ -763,17 +763,9 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        agg,
+                        aggregate_function,
                         eager_group_by_and_eager_count[agg_side.opposite()].1,
                     )?);
-                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
-                    Self::refresh_eval_scalar_binding_type(
-                        metadata,
-                        &mut eager_split_eval_scalar,
-                        agg.index,
-                        &aggregate_function.return_type,
-                    )?;
-                }
             }
         }
 
@@ -852,18 +844,10 @@ impl EagerAnalysis {
                     Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        agg,
+                        aggregate_function,
                         eager_count_index,
                     )?,
                 );
-                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
-                    Self::refresh_eval_scalar_binding_type(
-                        metadata,
-                        &mut eager_groupby_count_scalar,
-                        agg.index,
-                        &aggregate_function.return_type,
-                    )?;
-                }
             }
         }
 
@@ -942,7 +926,6 @@ impl EagerAnalysis {
         }
 
         let mut final_eager_count = self.final_agg.clone();
-        let mut eager_count_eval_scalar = input.eval_scalar.clone();
         let mut eager_count = self.pruned_aggregate_for_side(d.opposite());
         let (eager_count_index, _) = Self::add_eager_count(metadata, &mut eager_count);
 
@@ -956,17 +939,9 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        agg,
+                        aggregate_function,
                         eager_count_index,
                     )?);
-                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
-                    Self::refresh_eval_scalar_binding_type(
-                        metadata,
-                        &mut eager_count_eval_scalar,
-                        agg.index,
-                        &aggregate_function.return_type,
-                    )?;
-                }
             }
         }
 
@@ -987,7 +962,7 @@ impl EagerAnalysis {
             input,
             new_join.build_unary(eager_count_sum),
             final_eager_count,
-            eager_count_eval_scalar,
+            input.eval_scalar.clone(),
         )))
     }
 
@@ -1034,17 +1009,9 @@ impl EagerAnalysis {
                     .push(Self::create_eager_count_multiply_scalar_item(
                         metadata,
                         input,
-                        agg,
+                        aggregate_function,
                         eager_count_index,
                     )?);
-                if let ScalarExpr::AggregateFunction(aggregate_function) = &agg.scalar {
-                    Self::refresh_eval_scalar_binding_type(
-                        metadata,
-                        &mut double_eager_eval_scalar,
-                        agg.index,
-                        &aggregate_function.return_type,
-                    )?;
-                }
             }
         }
 
@@ -1163,13 +1130,6 @@ impl EagerAnalysis {
             format!("_eager_final_{}", agg.func_name),
             *(agg.return_type).clone(),
         );
-        let rewritten_output_column = ColumnBindingBuilder::new(
-            metadata.read().column(new_index).name(),
-            new_index,
-            agg.return_type.clone(),
-            Visibility::Visible,
-        )
-        .build();
 
         Self::modify_final_aggregate_function(agg, old_index);
         aggr_function.index = new_index;
@@ -1187,9 +1147,7 @@ impl EagerAnalysis {
                     .scalar
                     .replace_column_with_scalar(old_index, count_output)?;
             } else {
-                scalar_item
-                    .scalar
-                    .replace_column_binding(old_index, &rewritten_output_column)?;
+                scalar_item.scalar.replace_column(old_index, new_index)?;
             }
             success = true;
         }
@@ -1244,12 +1202,14 @@ impl EagerAnalysis {
     fn create_eager_count_multiply_scalar_item(
         metadata: &MetadataRef,
         input: &EagerInput,
-        aggregate_item: &mut ScalarItem,
+        aggregate_function: &mut AggregateFunction,
         eager_count_index: Symbol,
     ) -> Result<ScalarItem, ErrorCode> {
-        let ScalarExpr::AggregateFunction(aggregate_function) = &mut aggregate_item.scalar else {
-            unreachable!()
-        };
+        let new_index = metadata.write().add_derived_column(
+            format!("{} * _eager_count", aggregate_function.display_name),
+            aggregate_function.args[0].data_type()?,
+        );
+
         let new_scalar = if let ScalarExpr::BoundColumnRef(column) = &aggregate_function.args[0] {
             let mut scalar_idx = input.extra_eval_scalar.items.len();
             for (idx, eval_scalar) in input.extra_eval_scalar.items.iter().enumerate() {
@@ -1266,89 +1226,37 @@ impl EagerAnalysis {
             unreachable!()
         };
 
-        let scalar = ScalarExpr::FunctionCall(FunctionCall {
-            span: None,
-            func_name: "multiply".to_string(),
-            params: vec![],
-            arguments: vec![
-                new_scalar,
-                wrap_cast(
-                    &ScalarExpr::BoundColumnRef(BoundColumnRef {
-                        span: None,
-                        column: ColumnBindingBuilder::new(
-                            "_eager_count".to_string(),
-                            eager_count_index,
-                            Box::new(DataType::Nullable(Box::new(DataType::Number(
-                                NumberDataType::UInt64,
-                            )))),
-                            Visibility::Visible,
-                        )
-                        .build(),
-                    }),
-                    &DataType::Number(NumberDataType::UInt64),
-                ),
-            ],
-        });
-        let scalar_type = scalar.data_type()?;
-        let new_index = metadata.write().add_derived_column(
-            format!("{} * _eager_count", aggregate_function.display_name),
-            scalar_type.clone(),
-        );
         let new_scalar_item = ScalarItem {
-            scalar,
+            scalar: ScalarExpr::FunctionCall(FunctionCall {
+                span: None,
+                func_name: "multiply".to_string(),
+                params: vec![],
+                arguments: vec![
+                    new_scalar,
+                    wrap_cast(
+                        &ScalarExpr::BoundColumnRef(BoundColumnRef {
+                            span: None,
+                            column: ColumnBindingBuilder::new(
+                                "_eager_count".to_string(),
+                                eager_count_index,
+                                Box::new(DataType::Nullable(Box::new(DataType::Number(
+                                    NumberDataType::UInt64,
+                                )))),
+                                Visibility::Visible,
+                            )
+                            .build(),
+                        }),
+                        &DataType::Number(NumberDataType::UInt64),
+                    ),
+                ],
+            }),
             index: new_index,
         };
         if let ScalarExpr::BoundColumnRef(column) = &mut aggregate_function.args[0] {
             column.column.index = new_index;
-            column.column.data_type = Box::new(scalar_type);
+            column.column.data_type = Box::new(new_scalar_item.scalar.data_type()?);
         }
-        let new_return_type = Self::refresh_aggregate_return_type(aggregate_function)?;
-        metadata
-            .write()
-            .change_derived_column_data_type(aggregate_item.index, new_return_type);
         Ok(new_scalar_item)
-    }
-
-    fn refresh_aggregate_return_type(
-        aggregate_function: &mut AggregateFunction,
-    ) -> Result<DataType, ErrorCode> {
-        let arg_types = aggregate_function
-            .args
-            .iter()
-            .map(ScalarExpr::data_type)
-            .collect::<Result<Vec<_>, _>>()?;
-        let function = AggregateFunctionFactory::instance().get(
-            &aggregate_function.func_name,
-            aggregate_function.params.clone(),
-            arg_types,
-            vec![],
-        )?;
-        let return_type = function.return_type()?;
-        aggregate_function.return_type = Box::new(return_type.clone());
-        Ok(return_type)
-    }
-
-    fn refresh_eval_scalar_binding_type(
-        metadata: &MetadataRef,
-        eval_scalar: &mut EvalScalar,
-        index: Symbol,
-        data_type: &DataType,
-    ) -> Result<(), ErrorCode> {
-        let column_binding = ColumnBindingBuilder::new(
-            metadata.read().column(index).name(),
-            index,
-            Box::new(data_type.clone()),
-            Visibility::Visible,
-        )
-        .build();
-
-        for item in &mut eval_scalar.items {
-            if item.scalar.used_columns().contains(&index) {
-                item.scalar.replace_column_binding(index, &column_binding)?;
-            }
-        }
-
-        Ok(())
     }
 }
 

--- a/tests/sqllogictests/suites/query/aggregate.test
+++ b/tests/sqllogictests/suites/query/aggregate.test
@@ -105,6 +105,24 @@ SELECT AVG(1 + a), sum(1 + a), count(1 + a) FROM tc;
 ----
 3.0 9 3
 
+statement ok
+create or replace table t0(c0 int);
+
+statement ok
+create or replace table t1(c0 int);
+
+statement ok
+insert into t0 values (1), (2);
+
+statement ok
+insert into t1 values (1), (2);
+
+# https://github.com/databendlabs/databend/issues/19738
+query R
+select avg(0.5) from t0, t1;
+----
+0.5000000
+
 ## Aggregate with alias and window function
 statement ok
 select avg(1+a) score, a, percent_rank() over (partition by a % 3 order by score) d, d + 3 from tc group by a;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes #19738
- Skip eager aggregation rewrites when the top aggregate expression mixes `sum` and `count` outputs, such as `avg(...)` after rewrite to `sum(...) / count(...)`
- Add a sqllogictest regression for `select avg(0.5) from t0, t1`

## Changes

`AVG` is rewritten to `SUM / COUNT` before eager aggregation runs. The eager aggregation rule can rewrite the `SUM` side through eager count multiplication, but it does not preserve the paired `COUNT` semantics for this mixed aggregate shape.

That is what made this bug awkward: the visible failure showed up as a decimal type mismatch first, but the real issue was that this rewrite shape itself was unsafe for `AVG`-style expressions. Once we validated it with a real `meta` + `query` sqllogictest run, the minimal fix was to stop applying eager aggregation to top-level expressions that depend on both `sum` and `count` aggregate outputs.

## Implementation

1. Detect aggregate outputs referenced by the top `EvalScalar` in `RuleEagerAggregation`
2. If the expression depends on both `sum` and `count`, skip eager aggregation and keep the original aggregate plan
3. Add an end-to-end sqllogictest regression with the issue link in `tests/sqllogictests/suites/query/aggregate.test`

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-sql test_eager_aggregation_optimizer_outcomes -- --nocapture`
- `cargo build -p databend-binaries --bin databend-query`
- `./target/debug/databend-sqllogictests --handlers mysql,http --run 'tests/sqllogictests/suites/query/aggregate.test' --enable_sandbox --parallel 1`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19740)
<!-- Reviewable:end -->