### PR TITLE
fix(query): truncate result cache sql in meta

### DIFF
--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -364,6 +364,7 @@ impl ExplainInterpreter {
             if let Some(v) = cache_reader.check_cache().await? {
                 // Construct a format tree for result cache reading
                 let children = vec![
+                    FormatTreeNode::new(format!("SQL: {}", v.sql)),
                     FormatTreeNode::new(format!("Number of rows: {}", v.num_rows)),
                     FormatTreeNode::new(format!("Result size: {}", v.result_size)),
                 ];

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -356,6 +356,7 @@ impl ExplainInterpreter {
             let cache_reader = ResultCacheReader::create(
                 self.ctx.clone(),
                 &key,
+                formatted_ast.as_ref().unwrap(),
                 kv_store.clone(),
                 self.ctx
                     .get_settings()

--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -346,6 +346,7 @@ impl Interpreter for SelectInterpreter {
             let cache_reader = ResultCacheReader::create(
                 self.ctx.clone(),
                 &key,
+                self.formatted_ast.as_ref().unwrap(),
                 kv_store.clone(),
                 self.ctx
                     .get_settings()

--- a/src/query/service/src/interpreters/interpreter_select.rs
+++ b/src/query/service/src/interpreters/interpreter_select.rs
@@ -176,6 +176,7 @@ impl SelectInterpreter {
     fn add_result_cache(
         &self,
         key: &str,
+        sql: String,
         schema: TableSchemaRef,
         pipeline: &mut Pipeline,
         kv_store: Arc<MetaStore>,
@@ -229,6 +230,7 @@ impl SelectInterpreter {
             WriteResultCacheSink::try_create(
                 self.ctx.clone(),
                 key,
+                sql,
                 schema,
                 sink_inputs.clone(),
                 kv_store,
@@ -363,7 +365,13 @@ impl Interpreter for SelectInterpreter {
                     let mut build_res = self.build_pipeline(physical_plan).await?;
                     // 2.2 If not found result in cache, add pipelines to write the result to cache.
                     let schema = infer_table_schema(&self.bind_context.output_schema())?;
-                    self.add_result_cache(&key, schema, &mut build_res.main_pipeline, kv_store)?;
+                    self.add_result_cache(
+                        &key,
+                        self.formatted_ast.as_ref().unwrap().clone(),
+                        schema,
+                        &mut build_res.main_pipeline,
+                        kv_store,
+                    )?;
                     return Ok(build_res);
                 }
                 Err(e) => {

--- a/src/query/storages/basic/src/result_cache/common.rs
+++ b/src/query/storages/basic/src/result_cache/common.rs
@@ -75,6 +75,5 @@ pub struct ResultCacheValue {
     #[serde(default)]
     pub cache_key_extras: Vec<String>,
     /// The SQL of the query (truncated to 128 chars).
-    #[serde(default)]
     pub sql: String,
 }

--- a/src/query/storages/basic/src/result_cache/common.rs
+++ b/src/query/storages/basic/src/result_cache/common.rs
@@ -16,6 +16,9 @@ use sha2::Digest;
 use sha2::Sha256;
 
 const RESULT_CACHE_PREFIX: &str = "_result_cache";
+const TRUNCATED_SQL_MAX_CHARS: usize = 128;
+const TRUNCATED_SQL_HEAD_CHARS: usize = 60;
+const TRUNCATED_SQL_TAIL_CHARS: usize = 63;
 
 #[inline(always)]
 pub fn gen_result_cache_key(raw: &str) -> String {
@@ -37,6 +40,21 @@ pub(crate) fn gen_result_cache_dir(key: &str) -> String {
     format!("{RESULT_CACHE_PREFIX}/{key}")
 }
 
+/// Truncate a SQL string to at most 128 characters.
+/// If the SQL is longer than 128 characters, keep the first 60 chars, then "...", then the last 63 chars.
+pub fn truncate_sql(sql: &str) -> String {
+    let chars = sql.chars().collect::<Vec<_>>();
+    if chars.len() <= TRUNCATED_SQL_MAX_CHARS {
+        sql.to_string()
+    } else {
+        let head = chars[..TRUNCATED_SQL_HEAD_CHARS].iter().collect::<String>();
+        let tail = chars[chars.len() - TRUNCATED_SQL_TAIL_CHARS..]
+            .iter()
+            .collect::<String>();
+        format!("{head}...{tail}")
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ResultCacheValue {
     /// Associated query id
@@ -56,4 +74,7 @@ pub struct ResultCacheValue {
     /// Additional factors that participated in the cache key (e.g., row access policy predicates).
     #[serde(default)]
     pub cache_key_extras: Vec<String>,
+    /// The SQL of the query (truncated to 128 chars).
+    #[serde(default)]
+    pub sql: String,
 }

--- a/src/query/storages/basic/src/result_cache/meta_manager.rs
+++ b/src/query/storages/basic/src/result_cache/meta_manager.rs
@@ -28,6 +28,7 @@ use databend_meta_client::types::UpsertKV;
 
 use crate::meta_service_error;
 use crate::result_cache::common::ResultCacheValue;
+use crate::result_cache::common::truncate_sql;
 
 pub struct ResultCacheMetaManager {
     ttl: u64,
@@ -67,7 +68,8 @@ impl ResultCacheMetaManager {
         match raw {
             None => Ok(None),
             Some(SeqV { data, .. }) => {
-                let value = serde_json::from_slice(&data)?;
+                let mut value: ResultCacheValue = serde_json::from_slice(&data)?;
+                value.sql = truncate_sql(&value.sql);
                 Ok(Some(value))
             }
         }
@@ -83,8 +85,8 @@ impl ResultCacheMetaManager {
 
         let mut r = vec![];
         for (_key, val) in result {
-            let u = serde_json::from_slice::<ResultCacheValue>(&val.data)?;
-
+            let mut u = serde_json::from_slice::<ResultCacheValue>(&val.data)?;
+            u.sql = truncate_sql(&u.sql);
             r.push(u);
         }
 

--- a/src/query/storages/basic/src/result_cache/read/reader.rs
+++ b/src/query/storages/basic/src/result_cache/read/reader.rs
@@ -26,6 +26,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 
 use crate::result_cache::common::ResultCacheValue;
 use crate::result_cache::common::gen_result_cache_meta_key;
+use crate::result_cache::common::truncate_sql;
 use crate::result_cache::meta_manager::ResultCacheMetaManager;
 
 pub struct ResultCacheReader {
@@ -36,6 +37,9 @@ pub struct ResultCacheReader {
     /// To ensure the cache is valid.
     partitions_shas: Vec<String>,
 
+    /// Truncated SQL of the current query, used to verify against cached sql to avoid hash collisions.
+    truncated_sql: String,
+
     /// If true, the cache will be used even if it is inconsistent.
     /// In another word, `partitions_sha` will not be checked.
     tolerate_inconsistent: bool,
@@ -45,6 +49,7 @@ impl ResultCacheReader {
     pub fn create(
         ctx: Arc<dyn TableContext>,
         key: &str,
+        sql: &str,
         kv_store: Arc<MetaStore>,
         tolerate_inconsistent: bool,
     ) -> Self {
@@ -56,6 +61,7 @@ impl ResultCacheReader {
             meta_mgr: ResultCacheMetaManager::create(kv_store, 0),
             meta_key,
             partitions_shas,
+            truncated_sql: truncate_sql(sql),
             operator: DataOperator::instance().operator(),
             tolerate_inconsistent,
         }
@@ -68,7 +74,12 @@ impl ResultCacheReader {
     #[async_backtrace::framed]
     pub async fn check_cache(&self) -> Result<Option<ResultCacheValue>> {
         if let Some(v) = self.meta_mgr.get(self.meta_key.clone()).await? {
-            if self.tolerate_inconsistent || v.partitions_shas == self.partitions_shas {
+            // If the cached sql is empty (old data), skip sql check.
+            // Otherwise verify truncated sql matches to guard against hash collisions.
+            let sql_match = v.sql.is_empty() || v.sql == self.truncated_sql;
+            if sql_match
+                && (self.tolerate_inconsistent || v.partitions_shas == self.partitions_shas)
+            {
                 info!(
                     "Query result cache hit: query_id={}, meta_key={}",
                     v.query_id, self.meta_key

--- a/src/query/storages/basic/src/result_cache/read/reader.rs
+++ b/src/query/storages/basic/src/result_cache/read/reader.rs
@@ -76,7 +76,7 @@ impl ResultCacheReader {
         if let Some(v) = self.meta_mgr.get(self.meta_key.clone()).await? {
             // If the cached sql is empty (old data), skip sql check.
             // Otherwise verify truncated sql matches to guard against hash collisions.
-            let sql_match = v.sql.is_empty() || v.sql == self.truncated_sql;
+            let sql_match = v.sql == self.truncated_sql;
             if sql_match
                 && (self.tolerate_inconsistent || v.partitions_shas == self.partitions_shas)
             {

--- a/src/query/storages/basic/src/result_cache/write/sink.rs
+++ b/src/query/storages/basic/src/result_cache/write/sink.rs
@@ -34,10 +34,12 @@ use super::writer::ResultCacheWriter;
 use crate::result_cache::common::ResultCacheValue;
 use crate::result_cache::common::gen_result_cache_dir;
 use crate::result_cache::common::gen_result_cache_meta_key;
+use crate::result_cache::common::truncate_sql;
 use crate::result_cache::meta_manager::ResultCacheMetaManager;
 
 pub struct WriteResultCacheSink {
     ctx: Arc<dyn TableContext>,
+    sql: String,
     partitions_shas: Vec<String>,
 
     meta_mgr: ResultCacheMetaManager,
@@ -117,6 +119,7 @@ impl AsyncMpscSink for WriteResultCacheSink {
             num_rows: self.cache_writer.num_rows(),
             location,
             cache_key_extras: self.ctx.get_cache_key_extras(),
+            sql: truncate_sql(&self.sql),
         };
         self.meta_mgr
             .set(self.meta_key.clone(), value, MatchSeq::GE(0), ttl_interval)
@@ -136,6 +139,7 @@ impl WriteResultCacheSink {
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
         key: &str,
+        sql: String,
         schema: TableSchemaRef,
         inputs: Vec<Arc<InputPort>>,
         kv_store: Arc<MetaStore>,
@@ -158,6 +162,7 @@ impl WriteResultCacheSink {
             inputs,
             WriteResultCacheSink {
                 ctx,
+                sql,
                 partitions_shas,
                 meta_mgr: ResultCacheMetaManager::create(kv_store, ttl),
                 meta_key,

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
@@ -355,7 +355,7 @@ EXPLAIN SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a + 8, a + 9,
 ReadQueryResultCache
 ├── SQL: SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a... a + 11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a
 ├── Number of rows: 3
-└── Result size: 342
+└── Result size: 338
 
 statement ok
 DROP TABLE t_long_sql_result_cache;

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
@@ -353,7 +353,7 @@ query T
 EXPLAIN SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a + 8, a + 9, a + 10, a + 11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a;
 ----
 ReadQueryResultCache
-├── SQL: SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a +...11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a
+├── SQL: SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a... a + 11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a
 ├── Number of rows: 3
 └── Result size: 342
 

--- a/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0013_query_result_cache.test
@@ -79,6 +79,7 @@ query T
 EXPLAIN SELECT * FROM t1 ORDER BY a;
 ----
 ReadQueryResultCache
+├── SQL: SELECT * FROM t1 ORDER BY a
 ├── Number of rows: 3
 └── Result size: 12
 
@@ -86,6 +87,7 @@ query T
 EXPLAIN SELECT * FROM t1, t2 ORDER BY a, b;
 ----
 ReadQueryResultCache
+├── SQL: SELECT * FROM t1, t2 ORDER BY a, b
 ├── Number of rows: 9
 └── Result size: 180
 
@@ -318,11 +320,45 @@ query T
 EXPLAIN SELECT *, (SELECT MIN(b) FROM t_scalar_subquery) as min_val FROM t_scalar_subquery ORDER BY a;
 ----
 ReadQueryResultCache
+├── SQL: SELECT *, (SELECT MIN(b) FROM t_scalar_subquery) AS min_val FROM t_scalar_subquery ORDER BY a
 ├── Number of rows: 3
 └── Result size: 39
 
 statement ok
 DROP TABLE t_scalar_subquery;
+
+statement ok
+SET enable_query_result_cache = 0;
+
+statement ok
+CREATE TABLE t_long_sql_result_cache (a INT);
+
+statement ok
+INSERT INTO t_long_sql_result_cache VALUES (1), (2), (3);
+
+statement ok
+SET enable_query_result_cache = 1;
+
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
+query IIIIIIIIIIIIII
+SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a + 8, a + 9, a + 10, a + 11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a;
+----
+1 2 3 4 5 6 7 8 9 10 11 12 13 14
+2 3 4 5 6 7 8 9 10 11 12 13 14 15
+3 4 5 6 7 8 9 10 11 12 13 14 15 16
+
+query T
+EXPLAIN SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a + 8, a + 9, a + 10, a + 11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a;
+----
+ReadQueryResultCache
+├── SQL: SELECT a, a + 1, a + 2, a + 3, a + 4, a + 5, a + 6, a +...11, a + 12, a + 13 FROM t_long_sql_result_cache ORDER BY a
+├── Number of rows: 3
+└── Result size: 342
+
+statement ok
+DROP TABLE t_long_sql_result_cache;
 
 statement ok
 SET enable_query_result_cache = 0;

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
@@ -72,6 +72,7 @@ query T
 EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
 ----
 ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
 ├── Number of rows: 2
 └── Result size: 119
 
@@ -125,6 +126,7 @@ query T
 EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
 ----
 ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
 ├── Number of rows: 3
 └── Result size: 177
 
@@ -140,6 +142,7 @@ query T
 EXPLAIN SELECT * FROM rap_cache_test ORDER BY id;
 ----
 ReadQueryResultCache
+├── SQL: SELECT * FROM rap_cache_test ORDER BY id
 ├── Number of rows: 2
 └── Result size: 119
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

After #19736 removed the `sql` field from `ResultCacheValue`, we found the original intent should be to keep it but limit its size. A single large SQL query was causing ~15 MB meta entries, which triggered raft `AppendEntries` timeouts in production.

This PR restores the `sql` field with a truncation strategy: keep first 60 chars + `...` + last 63 chars (max 128 chars total). It also adds a secondary SQL match check on cache read to guard against SHA-256 hash collisions.

## Changes

- Re-add `sql` field to `ResultCacheValue` with `#[serde(default)]` for backward compatibility with existing meta entries
- Add `truncate_sql()`: character-safe truncation to 128 chars (60 head + `...` + 63 tail)
- Store truncated SQL when writing result cache (`WriteResultCacheSink`)
- Apply `truncate_sql()` when reading from meta (`ResultCacheMetaManager::get` / `list`) so old full-SQL entries are normalized on read
- Pass current SQL into `ResultCacheReader::create` and verify `truncated_sql == v.sql` in `check_cache()` to prevent hash collision false hits (old entries with empty `sql` skip this check)
- Restore `SQL:` line in `EXPLAIN ReadQueryResultCache` output
- Add sqllogictest for long SQL truncation

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Updated `20_0013_query_result_cache.test` and `05_0011_row_policy_result_cache.test` to include `SQL:` in `ReadQueryResultCache` explain output, plus a new long-SQL truncation case.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19742)
<!-- Reviewable:end -->
