### PR TITLE
ci: improve metachaos failure diagnostics

### DIFF
--- a/.github/actions/artifact_meta_container_failure/action.yml
+++ b/.github/actions/artifact_meta_container_failure/action.yml
@@ -11,11 +11,25 @@ runs:
       shell: bash
       run: |
         mkdir -p logs
+
+        echo "=== Collecting k8s diagnostics ==="
+
+        # Pod status and events
+        kubectl get pods -n databend -o wide > logs/pods-status.txt 2>&1 || true
+        kubectl describe pods -n databend > logs/pods-describe.txt 2>&1 || true
+        kubectl get events -n databend --sort-by='.lastTimestamp' > logs/events.txt 2>&1 || true
+
+        # Chaos mesh resources
+        kubectl get iochaos -n databend -o yaml > logs/iochaos.txt 2>&1 || true
+
+        # Container logs (kubectl logs) and file logs
         for name in "test-databend-meta-0" "test-databend-meta-1" "test-databend-meta-2" "databend-metaverifier"
         do
-          echo "cat logs of $name"
-          kubectl exec -i $name -n databend -- /cat-logs.sh > logs/$name.log
+          echo "collecting logs of $name"
+          kubectl logs "$name" -n databend --tail=2000 > "logs/${name}-kubectl.log" 2>&1 || true
+          kubectl exec -i "$name" -n databend -- /cat-logs.sh > "logs/${name}-file.log" 2>&1 || true
         done
+
         tar -zcf logs/failure-${{ inputs.name }}.tar.gz logs/*
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/io_delay_chaos/action.yml
+++ b/.github/actions/io_delay_chaos/action.yml
@@ -7,9 +7,3 @@ runs:
       shell: bash
       run: |
         ./scripts/ci/meta-chaos/ci-io-delay-meta-test.sh
-
-    - name: Upload failure
-      if: failure()
-      uses: ./.github/actions/artifact_meta_container_failure
-      with:
-        name: meta-io-delay-chaos

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -79,3 +79,8 @@ jobs:
           artifacts: meta,metactl,metaverifier
       - uses: ./.github/actions/io_delay_chaos
         timeout-minutes: 20
+      - name: Upload failure artifacts
+        if: failure() || cancelled()
+        uses: ./.github/actions/artifact_meta_container_failure
+        with:
+          name: meta-io-delay-chaos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -667,6 +667,11 @@ jobs:
           artifacts: meta,metactl,metaverifier
       - uses: ./.github/actions/io_delay_chaos
         timeout-minutes: 20
+      - name: Upload failure artifacts
+        if: failure() || cancelled()
+        uses: ./.github/actions/artifact_meta_container_failure
+        with:
+          name: meta-io-delay-chaos
       - name: Notify failure
         if: failure()
         uses: actions/github-script@v7

--- a/tests/metaverifier/chaos-meta.py
+++ b/tests/metaverifier/chaos-meta.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3
 import sys
 import getopt
-import os
 import random
+import subprocess
 import time
 import logging
 
 CHAOS_FILE = "/tmp/chaos.yaml"
+CMD_TIMEOUT = 30
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -35,6 +36,31 @@ class ChaosParams:
 
         content = content.replace("${NODE}", node)
         return content
+
+
+def run_cmd(cmd, timeout=CMD_TIMEOUT):
+    """Run a shell command with timeout, return stdout. Never raises."""
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=timeout
+        )
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        logging.warning("command timed out after %ds: %s", timeout, cmd)
+        return ""
+    except Exception as e:
+        logging.warning("command failed: %s, error: %s", cmd, e)
+        return ""
+
+
+def run_cmd_no_capture(cmd, timeout=CMD_TIMEOUT):
+    """Run a shell command with timeout, inherit stdout/stderr. Never raises."""
+    try:
+        subprocess.run(cmd, shell=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logging.warning("command timed out after %ds: %s", timeout, cmd)
+    except Exception as e:
+        logging.warning("command failed: %s, error: %s", cmd, e)
 
 
 class IoDelayParams(ChaosParams):
@@ -78,7 +104,7 @@ class MetaChaos:
         cmd = "kubectl exec -i databend-metaverifier -n databend -- "
         for node, addr in self.node_port_map.items():
             curl_cmd = cmd + "curl " + addr + "/v1/cluster/status"
-            content = os.popen(curl_cmd).read()
+            content = run_cmd(curl_cmd)
             logging.debug("curl cmd output:" + str(content))
             if get_leader:
                 if content.find('"state":"Leader"') != -1:
@@ -102,7 +128,7 @@ class MetaChaos:
 
     def exec_cat_meta_verifier(self):
         cmd = "kubectl exec -i databend-metaverifier -n databend -- cat /tmp/meta-verifier"
-        content = os.popen(cmd).read().strip()
+        content = run_cmd(cmd).strip()
         logging.debug("exec cat meta-verifier: " + str(content))
 
         return content
@@ -122,15 +148,29 @@ class MetaChaos:
         logging.error("databend-metaverifier has not started, exit")
         sys.exit(-1)
 
+    def dump_diagnostics(self):
+        """Dump k8s diagnostics before exiting on failure."""
+        logging.info("=== Dumping diagnostics ===")
+        for cmd_desc, cmd in [
+            ("pod status", "kubectl get pods -n databend -o wide"),
+            ("verifier logs (last 50)", "kubectl logs databend-metaverifier -n databend --tail=50"),
+            ("iochaos resources", "kubectl get iochaos -n databend -o yaml"),
+            ("events", "kubectl get events -n databend --sort-by='.lastTimestamp'"),
+        ]:
+            logging.info("--- %s ---", cmd_desc)
+            content = run_cmd(cmd)
+            logging.info("%s", content)
+
     def is_verifier_end(self):
-        cmd = "kubectl logs databend-metaverifier -n databend | tail -10"
-        content = os.popen(cmd).read()
+        cmd = "kubectl logs databend-metaverifier -n databend --tail=10"
+        content = run_cmd(cmd)
         logging.debug(
             "kubectl logs databend-metaverifier -n databend:\n" + str(content)
         )
         content = self.exec_cat_meta_verifier()
         if content == "ERROR":
             logging.error("databend-metaverifier return error")
+            self.dump_diagnostics()
             sys.exit(-1)
 
         return content == "END"
@@ -182,7 +222,7 @@ class MetaChaos:
 
             # apply chaos
             cmd = "kubectl apply -f " + CHAOS_FILE
-            os.system(cmd)
+            run_cmd_no_capture(cmd)
             logging.debug("apply chaos..")
 
             # wait some time
@@ -190,7 +230,7 @@ class MetaChaos:
 
             # delete chaos
             cmd = "kubectl delete -f " + CHAOS_FILE
-            os.system(cmd)
+            run_cmd_no_capture(cmd)
             logging.debug("remove chaos..")
 
             # wait some time
@@ -208,6 +248,7 @@ class MetaChaos:
                 logging.error(
                     "databend-metaverifier is not completed in total time, exit -1"
                 )
+                self.dump_diagnostics()
                 sys.exit(-1)
 
 

--- a/tests/metaverifier/start-verifier.sh
+++ b/tests/metaverifier/start-verifier.sh
@@ -8,7 +8,7 @@ echo "start databend-metaverifier with params client:${CLIENT}, number:${NUMBER}
 echo "START" >/tmp/meta-verifier
 # wait for chao-meta.py
 sleep 3
-databend-metaverifier --client ${CLIENT} --time 1800 --remove-percent 10 --number ${NUMBER} --grpc-api-address ${GRPC_ADDRESS} || true
+databend-metaverifier --client ${CLIENT} --time 1800 --remove-percent 10 --number ${NUMBER} --grpc-api-address ${GRPC_ADDRESS} --log-level "warn,databend_=info,databend_meta_client=debug" || true
 
 while true; do
   sleep 5


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Improve metachaos failure diagnostics so timeout and error scenarios produce actionable artifacts
- Fix chaos-meta.py kubectl commands hanging indefinitely by adding 30s subprocess timeout

## Changes

Metachaos has been failing 100% since March 12 across all release runs. Two failure modes:
1. Verifier crashes quickly (~20s) with pool connection errors
2. chaos-meta.py hangs on kubectl commands for 17+ minutes until the 20-min action timeout

The existing failure artifact collection was inside the composite action, which never runs on timeout (GitHub Actions kills the entire action, preventing internal `if: failure()` steps).

## Implementation

1. Moved failure artifact upload from `io_delay_chaos` action to workflow level with `if: failure() || cancelled()`
2. Enriched artifact contents: pod describe, events, iochaos status, kubectl logs (2000 lines) + file logs
3. Replaced `os.popen`/`os.system` with `subprocess.run` + 30s timeout in chaos-meta.py
4. Added `dump_diagnostics()` before ERROR and total timeout exits
5. Enabled `databend_meta_client=debug` logging in metaverifier via `start-verifier.sh`

Suspected root cause (for follow-up): meta-client `connection_ttl=20s` forces connection refresh during IO chaos, gRPC handshake in `build()` fails or hangs while holding pool mutex, blocking all clients.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - CI infrastructure change, will be validated by next release run

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19743)

<!-- Reviewable:end -->