### PR TITLE
fix(ast): filter reserved keywords in all_reserved_keywords

### DIFF
--- a/src/query/ast/src/parser/error.rs
+++ b/src/query/ast/src/parser/error.rs
@@ -263,7 +263,6 @@ pub fn display_parser_error(error: Error, source: &str) -> String {
         let mut msg = if span_text.is_empty() {
             "unexpected end of input".to_string()
         } else if all_reserved_keywords()
-            .iter()
             .any(|keyword| keyword.to_lowercase() == span_text.to_lowercase())
             && has_suggestion.is_none()
         {

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1996,10 +1996,24 @@ impl TokenKind {
     }
 }
 
-pub fn all_reserved_keywords() -> Vec<String> {
-    let mut result = Vec::new();
-    for token in TokenKind::iter() {
-        result.push(format!("{:?}", token));
+pub fn all_reserved_keywords() -> impl Iterator<Item = String> {
+    TokenKind::iter()
+        .filter(TokenKind::is_keyword)
+        .filter(|token| token.is_reserved_ident(false) || token.is_reserved_function_name())
+        .map(|token| format!("{:?}", token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_reserved_keywords;
+
+    #[test]
+    fn test_all_reserved_keywords_only_returns_reserved_keywords() {
+        let keywords = all_reserved_keywords().collect::<Vec<_>>();
+
+        assert!(keywords.contains(&"SELECT".to_string()));
+        assert!(keywords.contains(&"TABLE".to_string()));
+        assert!(!keywords.contains(&"DATABASE".to_string()));
+        assert!(!keywords.contains(&"Whitespace".to_string()));
     }
-    result
 }

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -560,7 +560,7 @@ error:
   --> SQL:1:43
   |
 1 | alter table t1 create branch from_dev at (branch => dev)
-  | -----                                     ^^^^^^ unexpected `branch`. it's reserved keyword, you may avoid using it, expecting `STREAM`, `SNAPSHOT`, `TAG`, `TIMESTAMP`, or `OFFSET`
+  | -----                                     ^^^^^^ unexpected `branch`, expecting `STREAM`, `SNAPSHOT`, `TAG`, `TIMESTAMP`, or `OFFSET`
   | |                                          
   | while parsing `ALTER TABLE [<database>.]<table> <action>`
 
@@ -618,7 +618,7 @@ error:
   --> SQL:1:35
   |
 1 | SELECT * FROM t GROUP BY GROUPING SETS a, b
-  |                                   ^^^^ unexpected `SETS`. it's reserved keyword, you may avoid using it, expecting `SELECT`, `INTERSECT`, `WITH`, `EXCEPT`, `VALUES`, `OFFSET`, `IGNORE_RESULT`, `,`, `HAVING`, `WINDOW`, `QUALIFY`, `(`, `UNION`, `FROM`, `ORDER`, `LIMIT`, `FORMAT`, or `;`
+  |                                   ^^^^ unexpected `SETS`, expecting `SELECT`, `INTERSECT`, `WITH`, `EXCEPT`, `VALUES`, `OFFSET`, `IGNORE_RESULT`, `,`, `HAVING`, `WINDOW`, `QUALIFY`, `(`, `UNION`, `FROM`, `ORDER`, `LIMIT`, `FORMAT`, or `;`
 
 
 ---------- Input ----------
@@ -1006,7 +1006,7 @@ error:
   --> SQL:1:34
   |
 1 | GRANT OWNERSHIP ON d20_0014.* TO USER A;
-  | -----                            ^^^^ unexpected `USER`. it's reserved keyword, you may avoid using it, expecting `ROLE`
+  | -----                            ^^^^ unexpected `USER`, expecting `ROLE`
   | |                                 
   | while parsing GRANT OWNERSHIP ON <privileges_level> TO ROLE <role_name>
 
@@ -1018,7 +1018,7 @@ error:
   --> SQL:1:8
   |
 1 | REVOKE OWNERSHIP, SELECT ON d20_0014.* FROM ROLE 'd20_0015_owner';
-  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`. it's reserved keyword, you may avoid using it, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
+  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
   | |       
   | while parsing `REVOKE { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } FROM { [ROLE <role_name>] | [USER] <user> }`
 
@@ -1030,7 +1030,7 @@ error:
   --> SQL:1:8
   |
 1 | REVOKE OWNERSHIP ON d20_0014.* FROM USER A;
-  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`. it's reserved keyword, you may avoid using it, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
+  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
   | |       
   | while parsing `REVOKE { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } FROM { [ROLE <role_name>] | [USER] <user> }`
 
@@ -1042,7 +1042,7 @@ error:
   --> SQL:1:8
   |
 1 | REVOKE OWNERSHIP ON d20_0014.* FROM ROLE A;
-  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`. it's reserved keyword, you may avoid using it, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
+  | ------ ^^^^^^^^^ unexpected `OWNERSHIP`, expecting `INSERT`, `ALTER`, `SUPER`, `ROLE`, `ACCESS`, `WRITE`, `SET`, `SELECT`, `UPDATE`, `DELETE`, `DROP`, `READ`, `USAGE`, `GRANT`, `CREATE`, `ALL`, or `APPLY`
   | |       
   | while parsing `REVOKE { ROLE <role_name> | schemaObjectPrivileges | ALL [ PRIVILEGES ] ON <privileges_level> } FROM { [ROLE <role_name>] | [USER] <user> }`
 
@@ -1081,7 +1081,7 @@ error:
   --> SQL:1:85
   |
 1 | CREATE FUNCTION my_agg (INT) STATE { s STRING } RETURNS BOOLEAN LANGUAGE javascript HANDLER = 'my_agg' ADDRESS = 'http://0.0.0.0:8815';
-  | ------                 -                                                            ^^^^^^^ unexpected `HANDLER`. it's reserved keyword, you may avoid using it, expecting `HEADERS`, `ADDRESS`, `PACKAGES`, `AS`, or `IMPORTS`
+  | ------                 -                                                            ^^^^^^^ unexpected `HANDLER`, expecting `HEADERS`, `ADDRESS`, `PACKAGES`, `AS`, or `IMPORTS`
   | |                      |                                                             
   | |                      while parsing (<[arg_name] arg_type>, ...) STATE {<state_field>, ...} RETURNS <return_type> LANGUAGE <language> { ADDRESS=<udf_server_address> | AS <language_codes> } 
   | while parsing `CREATE [OR REPLACE] FUNCTION [IF NOT EXISTS] <udf_name> <udf_definition> [DESC = <description>]`

--- a/src/query/storages/information_schema/src/keywords_table.rs
+++ b/src/query/storages/information_schema/src/keywords_table.rs
@@ -31,8 +31,7 @@ pub struct KeywordsTable {}
 
 impl KeywordsTable {
     pub fn create(table_id: u64, ctl_name: &str) -> Arc<dyn Table> {
-        let all_keywords_vec = all_reserved_keywords();
-        let all_keywords = all_keywords_vec.join(", ");
+        let all_keywords = all_reserved_keywords().collect::<Vec<_>>().join(", ");
         let query = "SELECT '".to_owned() + &all_keywords + "' AS KEYWORDS, 1 AS RESERVED";
 
         let mut options = BTreeMap::new();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes #9485
- fixes #9047
- make `all_reserved_keywords()` return only parser-reserved keywords
- keep `information_schema.keywords` on the existing shape while letting it consume the filtered helper output
- add an AST unit test that checks reserved keywords are kept and non-reserved/internal tokens are excluded

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all`
- `cargo test -p databend-common-ast --lib`
- `cargo test -p databend-common-storages-information-schema --lib --no-run`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19749)
<!-- Reviewable:end -->
