### PR TITLE
chore: add regression coverage for subdir paths without trailing slash

### DIFF
--- a/tests/sqllogictests/suites/stage/formats/parquet/select_parquet.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/select_parquet.test
@@ -65,6 +65,22 @@ select count() from @data/parquet/no-stats.parquet (pattern => '') where line_it
 ----
 0
 
+# issue #10266: stage subdir without trailing slash should still work for select/list.
+query I
+select count() from @data/parquet/multi_page (pattern => '.*[.]parquet')
+----
+400
+
+query IIII
+select
+    count_if(name = 'parquet/multi_page/multi_page_1.parquet'),
+    count_if(name = 'parquet/multi_page/multi_page_2.parquet'),
+    count_if(name = 'parquet/multi_page/multi_page_3.parquet'),
+    count_if(name = 'parquet/multi_page/multi_page_4.parquet')
+from list_stage(location=>'@data/parquet/multi_page')
+----
+1 1 1 1
+
 query error gen
 settings (parquet_fast_read_bytes=0) select * from @data/parquet/diff_schema/ (files=>('f1.parquet', 'gen.py'));
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Refs #10266
- Add regression coverage for stage subdir paths that omit the trailing `/`
- Cover both `select ... from @stage/subdir (pattern => '.*[.]parquet')` and `list_stage(location=>'@stage/subdir')`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

```bash
target/debug/databend-sqllogictests --handlers mysql,http --run 'tests/sqllogictests/suites/stage/formats/parquet/select_parquet.test' --parallel 1
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19755)
<!-- Reviewable:end -->
