### PR TITLE
chore: cover infer_schema direct uri paths

### DIFF
--- a/tests/sqllogictests/suites/stage/formats/parquet/infer_schema.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/infer_schema.test
@@ -61,11 +61,31 @@ drop CONNECTION IF EXISTS my_conn
 statement ok
 create CONNECTION my_conn STORAGE_TYPE = 's3' access_key_id='minioadmin' secret_access_key='minioadmin' endpoint_url='http://127.0.0.1:9900/' region='auto'
 
-# query
-# select * from INFER_SCHEMA(location => 's3://testbucket/data/parquet/tuple.parquet', connection_name => 'my_conn')
-# ----
-# id INT 0 parquet/tuple.parquet 0
-# t TUPLE(A INT32, B STRING) 0 parquet/tuple.parquet 1
+query TTBI
+select column_name, type, nullable, order_id
+from INFER_SCHEMA(location => 's3://testbucket/data/parquet/tuple.parquet', connection_name => 'my_conn')
+----
+id INT 0 0
+t TUPLE(A INT32, B STRING) 0 1
+
+statement ok
+drop stage if exists infer_schema_uri_fs
+
+statement ok
+create stage infer_schema_uri_fs url='fs:///tmp/infer_schema_uri/' file_format = (type = parquet)
+
+statement ok
+remove @infer_schema_uri_fs
+
+statement ok
+copy into @infer_schema_uri_fs from (select 1::int as id, 'alice'::string as name) file_format = (type = parquet)
+
+query TTBI
+select column_name, type, nullable, order_id
+from infer_schema(location => 'fs:///tmp/infer_schema_uri/', file_format => 'PARQUET');
+----
+id INT 0 0
+name VARCHAR 0 1
 
 query T
 select CASE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Closes #12458 by adding sqllogictest coverage for `infer_schema` on direct URI locations.

## Changes

- turn the existing `s3://...` + `connection_name` example in `infer_schema.test` into a real assertion
- add an `fs:///tmp/...` regression that writes a parquet file through an external fs stage and then calls `infer_schema` through the plain URI path
- keep the assertions focused on inferred schema columns so the test stays stable across path-prefix differences

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation:

```bash
STORAGE_ALLOW_INSECURE=true target/debug/databend-sqllogictests --handlers mysql,http --run 'tests/sqllogictests/suites/stage/formats/parquet/infer_schema.test' --parallel 1
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19756)
<!-- Reviewable:end -->
