### PR TITLE
feat(sql): support expressions  in AT (SNAPSHOT => ...)

### DIFF
--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -566,7 +566,7 @@ impl Display for Indirection {
 /// Time Travel specification
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub enum TimeTravelPoint {
-    Snapshot(String),
+    Snapshot(Box<Expr>),
     Timestamp(Box<Expr>),
     Offset(Box<Expr>),
     Stream {
@@ -580,8 +580,8 @@ pub enum TimeTravelPoint {
 impl Display for TimeTravelPoint {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            TimeTravelPoint::Snapshot(sid) => {
-                write!(f, "(SNAPSHOT => '{sid}')")?;
+            TimeTravelPoint::Snapshot(expr) => {
+                write!(f, "(SNAPSHOT => {expr})")?;
             }
             TimeTravelPoint::Timestamp(ts) => {
                 write!(f, "(TIMESTAMP => {ts})")?;

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -573,8 +573,8 @@ pub fn travel_point(i: Input) -> IResult<TimeTravelPoint> {
 
 pub fn at_snapshot_or_ts(i: Input) -> IResult<TimeTravelPoint> {
     let at_snapshot = map(
-        rule! { "(" ~ SNAPSHOT ~ "=>" ~ #literal_string ~ ")" },
-        |(_, _, _, s, _)| TimeTravelPoint::Snapshot(s),
+        rule! { "(" ~ SNAPSHOT ~ "=>" ~ #expr ~ ")" },
+        |(_, _, _, e, _)| TimeTravelPoint::Snapshot(Box::new(e)),
     );
     let at_timestamp = map(
         rule! { "(" ~ TIMESTAMP ~ "=>" ~ #expr ~ ")" },

--- a/src/query/ast/src/visit/table_reference.rs
+++ b/src/query/ast/src/visit/table_reference.rs
@@ -261,8 +261,9 @@ impl Walk for TimeTravelPoint {
         visitor: &mut V,
     ) -> Result<VisitControl<V::Break>, V::Error> {
         match self {
-            TimeTravelPoint::Snapshot(_) => {}
-            TimeTravelPoint::Timestamp(expr) | TimeTravelPoint::Offset(expr) => {
+            TimeTravelPoint::Snapshot(expr)
+            | TimeTravelPoint::Timestamp(expr)
+            | TimeTravelPoint::Offset(expr) => {
                 try_walk!(expr.walk(visitor));
             }
             TimeTravelPoint::Stream {
@@ -293,8 +294,9 @@ impl WalkMut for TimeTravelPoint {
         visitor: &mut V,
     ) -> Result<VisitControl<V::Break>, V::Error> {
         match self {
-            TimeTravelPoint::Snapshot(_) => {}
-            TimeTravelPoint::Timestamp(expr) | TimeTravelPoint::Offset(expr) => {
+            TimeTravelPoint::Snapshot(expr)
+            | TimeTravelPoint::Timestamp(expr)
+            | TimeTravelPoint::Offset(expr) => {
                 try_walk!(expr.walk_mut(visitor));
             }
             TimeTravelPoint::Stream {

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1378,6 +1378,7 @@ fn test_query() {
         r#"select * from customer with consume as s"#,
         r#"select * from t12_0004 at (TIMESTAMP => 'xxxx') as t"#,
         r#"select count(t.c) from t12_0004 at (snapshot => 'xxxx') as t"#,
+        r#"select * from t at (snapshot => (select snapshot_id from fuse_snapshot('db', 't') limit 1))"#,
         r#"select * from customer inner join orders"#,
         r#"select * from customer cross join orders"#,
         r#"select * from customer inner join orders on (a = b)"#,

--- a/src/query/ast/tests/it/testdata/query.txt
+++ b/src/query/ast/tests/it/testdata/query.txt
@@ -1070,7 +1070,190 @@ Query {
                     temporal: Some(
                         TimeTravel(
                             Snapshot(
-                                "xxxx",
+                                Literal {
+                                    span: Some(
+                                        48..54,
+                                    ),
+                                    value: String(
+                                        "xxxx",
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    with_options: None,
+                    pivot: None,
+                    unpivot: None,
+                    sample: None,
+                },
+            ],
+            selection: None,
+            group_by: None,
+            having: None,
+            window_list: None,
+            qualify: None,
+        },
+    ),
+    order_by: [],
+    limit: [],
+    offset: None,
+    ignore_result: false,
+}
+
+
+---------- Input ----------
+select * from t at (snapshot => (select snapshot_id from fuse_snapshot('db', 't') limit 1))
+---------- Output ---------
+SELECT * FROM t AT (SNAPSHOT => (SELECT snapshot_id FROM fuse_snapshot('db', 't') LIMIT 1))
+---------- AST ------------
+Query {
+    span: Some(
+        0..91,
+    ),
+    with: None,
+    body: Select(
+        SelectStmt {
+            span: Some(
+                0..91,
+            ),
+            hints: None,
+            distinct: false,
+            top_n: None,
+            select_list: [
+                StarColumns {
+                    qualified: [
+                        Star(
+                            Some(
+                                7..8,
+                            ),
+                        ),
+                    ],
+                    column_filter: None,
+                },
+            ],
+            from: [
+                Table {
+                    span: Some(
+                        14..91,
+                    ),
+                    table: TableRef {
+                        catalog: None,
+                        database: None,
+                        table: Identifier {
+                            span: Some(
+                                14..15,
+                            ),
+                            name: "t",
+                            quote: None,
+                            ident_type: None,
+                        },
+                        branch: None,
+                    },
+                    alias: None,
+                    temporal: Some(
+                        TimeTravel(
+                            Snapshot(
+                                Subquery {
+                                    span: Some(
+                                        32..90,
+                                    ),
+                                    modifier: None,
+                                    subquery: Query {
+                                        span: Some(
+                                            33..81,
+                                        ),
+                                        with: None,
+                                        body: Select(
+                                            SelectStmt {
+                                                span: Some(
+                                                    33..81,
+                                                ),
+                                                hints: None,
+                                                distinct: false,
+                                                top_n: None,
+                                                select_list: [
+                                                    AliasedExpr {
+                                                        expr: ColumnRef {
+                                                            span: Some(
+                                                                40..51,
+                                                            ),
+                                                            column: ColumnRef {
+                                                                database: None,
+                                                                table: None,
+                                                                column: Name(
+                                                                    Identifier {
+                                                                        span: Some(
+                                                                            40..51,
+                                                                        ),
+                                                                        name: "snapshot_id",
+                                                                        quote: None,
+                                                                        ident_type: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                        alias: None,
+                                                    },
+                                                ],
+                                                from: [
+                                                    TableFunction {
+                                                        span: Some(
+                                                            57..81,
+                                                        ),
+                                                        lateral: false,
+                                                        name: Identifier {
+                                                            span: Some(
+                                                                57..70,
+                                                            ),
+                                                            name: "fuse_snapshot",
+                                                            quote: None,
+                                                            ident_type: None,
+                                                        },
+                                                        params: [
+                                                            Literal {
+                                                                span: Some(
+                                                                    71..75,
+                                                                ),
+                                                                value: String(
+                                                                    "db",
+                                                                ),
+                                                            },
+                                                            Literal {
+                                                                span: Some(
+                                                                    77..80,
+                                                                ),
+                                                                value: String(
+                                                                    "t",
+                                                                ),
+                                                            },
+                                                        ],
+                                                        named_params: [],
+                                                        alias: None,
+                                                        sample: None,
+                                                    },
+                                                ],
+                                                selection: None,
+                                                group_by: None,
+                                                having: None,
+                                                window_list: None,
+                                                qualify: None,
+                                            },
+                                        ),
+                                        order_by: [],
+                                        limit: [
+                                            Literal {
+                                                span: Some(
+                                                    88..89,
+                                                ),
+                                                value: UInt64(
+                                                    1,
+                                                ),
+                                            },
+                                        ],
+                                        offset: None,
+                                        ignore_result: false,
+                                    },
+                                },
                             ),
                         ),
                     ),

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -6858,7 +6858,14 @@ CreateStream(
         },
         travel_point: Some(
             Snapshot(
-                "9828b23f74664ff3806f44bbc1925ea5",
+                Literal {
+                    span: Some(
+                        69..103,
+                    ),
+                    value: String(
+                        "9828b23f74664ff3806f44bbc1925ea5",
+                    ),
+                },
             ),
         ),
         append_only: true,
@@ -16528,7 +16535,14 @@ OptimizeTable(
         action: Purge {
             before: Some(
                 Snapshot(
-                    "9828b23f74664ff3806f44bbc1925ea5",
+                    Literal {
+                        span: Some(
+                            43..77,
+                        ),
+                        value: String(
+                            "9828b23f74664ff3806f44bbc1925ea5",
+                        ),
+                    },
                 ),
             ),
         },
@@ -18622,7 +18636,14 @@ AlterTable(
         },
         action: FlashbackTo {
             point: Snapshot(
-                "9828b23f74664ff3806f44bbc1925ea5",
+                Literal {
+                    span: Some(
+                        40..74,
+                    ),
+                    value: String(
+                        "9828b23f74664ff3806f44bbc1925ea5",
+                    ),
+                },
             ),
         },
     },
@@ -18673,7 +18694,14 @@ AlterTable(
                 },
                 travel_point: Some(
                     Snapshot(
-                        "9828b23f74664ff3806f44bbc1925ea5",
+                        Literal {
+                            span: Some(
+                                47..81,
+                            ),
+                            value: String(
+                                "9828b23f74664ff3806f44bbc1925ea5",
+                            ),
+                        },
                     ),
                 ),
                 retain: Some(

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -82,6 +82,7 @@ use crate::binder::CteInfo;
 use crate::binder::ExprContext;
 use crate::binder::Visibility;
 use crate::binder::split_conjunctions;
+use crate::binder::table_args::execute_subquery_for_scalar;
 use crate::optimizer::ir::SExpr;
 use crate::planner::semantic::TypeChecker;
 use crate::planner::semantic::normalize_identifier;
@@ -688,30 +689,68 @@ impl Binder {
         }
     }
 
+    fn fold_travel_point_expr(
+        &self,
+        bind_context: &mut BindContext,
+        expr: &Expr,
+    ) -> Result<databend_common_expression::Expr<crate::ColumnBinding>> {
+        let mut type_checker = TypeChecker::try_create(
+            bind_context,
+            self.ctx.clone(),
+            &self.name_resolution_ctx,
+            self.metadata.clone(),
+            &[],
+            false,
+        )?;
+        let box (scalar, _) = type_checker.resolve(expr)?;
+        let scalar_expr = scalar.as_expr()?;
+        let (new_expr, _) = ConstantFolder::fold(
+            &scalar_expr,
+            &self.ctx.get_function_context()?,
+            &BUILTIN_FUNCTIONS,
+        );
+        Ok(new_expr)
+    }
+
     pub(crate) fn resolve_data_travel_point(
         &self,
         bind_context: &mut BindContext,
         travel_point: &TimeTravelPoint,
     ) -> Result<NavigationPoint> {
         match travel_point {
-            TimeTravelPoint::Snapshot(s) => Ok(NavigationPoint::SnapshotID(s.to_owned())),
-            TimeTravelPoint::Timestamp(expr) => {
-                let mut type_checker = TypeChecker::try_create(
-                    bind_context,
-                    self.ctx.clone(),
-                    &self.name_resolution_ctx,
-                    self.metadata.clone(),
-                    &[],
-                    false,
-                )?;
-                let box (scalar, _) = type_checker.resolve(expr)?;
-                let scalar_expr = scalar.as_expr()?;
+            TimeTravelPoint::Snapshot(expr) => {
+                let new_expr = self.fold_travel_point_expr(bind_context, expr)?;
 
-                let (new_expr, _) = ConstantFolder::fold(
-                    &scalar_expr,
-                    &self.ctx.get_function_context()?,
-                    &BUILTIN_FUNCTIONS,
-                );
+                match new_expr {
+                    databend_common_expression::Expr::Constant(Constant {
+                        scalar: databend_common_expression::Scalar::String(s),
+                        ..
+                    }) => Ok(NavigationPoint::SnapshotID(s)),
+                    _ => {
+                        if let Some(executor) = &self.subquery_executor {
+                            let result = execute_subquery_for_scalar(executor, expr)?;
+                            match result {
+                                databend_common_expression::Scalar::String(s) => {
+                                    Ok(NavigationPoint::SnapshotID(s))
+                                }
+                                _ => Err(ErrorCode::InvalidArgument(format!(
+                                    "TimeTravelPoint for 'Snapshot' must resolve to a string value, \
+                                    got: {}",
+                                    result
+                                ))),
+                            }
+                        } else {
+                            Err(ErrorCode::InvalidArgument(format!(
+                                "TimeTravelPoint for 'Snapshot' must resolve to a constant string value. \
+                                Provided expression '{}' is not a constant string",
+                                expr
+                            )))
+                        }
+                    }
+                }
+            }
+            TimeTravelPoint::Timestamp(expr) => {
+                let new_expr = self.fold_travel_point_expr(bind_context, expr)?;
 
                 match new_expr {
                     databend_common_expression::Expr::Constant(Constant {
@@ -734,22 +773,7 @@ impl Binder {
                 }
             }
             TimeTravelPoint::Offset(expr) => {
-                let mut type_checker = TypeChecker::try_create(
-                    bind_context,
-                    self.ctx.clone(),
-                    &self.name_resolution_ctx,
-                    self.metadata.clone(),
-                    &[],
-                    false,
-                )?;
-                let box (scalar, _) = type_checker.resolve(expr)?;
-                let scalar_expr = scalar.as_expr()?;
-
-                let (new_expr, _) = ConstantFolder::fold(
-                    &scalar_expr,
-                    &self.ctx.get_function_context()?,
-                    &BUILTIN_FUNCTIONS,
-                );
+                let new_expr = self.fold_travel_point_expr(bind_context, expr)?;
 
                 let v: i64 = check_number(
                     None,

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -32,7 +32,7 @@ use crate::planner::QueryExecutor;
 use crate::plans::ConstantExpr;
 
 /// Check if an AST expression contains a subquery
-fn contains_subquery(expr: &Expr) -> bool {
+pub(crate) fn contains_subquery(expr: &Expr) -> bool {
     match expr {
         Expr::Subquery { .. } => true,
         Expr::InSubquery { .. } => true,
@@ -72,7 +72,7 @@ fn contains_subquery(expr: &Expr) -> bool {
 }
 
 /// Execute a subquery and extract a single scalar value from the result
-fn execute_subquery_for_scalar(
+pub(crate) fn execute_subquery_for_scalar(
     subquery_executor: &Arc<dyn QueryExecutor>,
     expr: &Expr,
 ) -> Result<Scalar> {

--- a/tests/sqllogictests/suites/base/12_time_travel/12_0005_time_travel_snapshot_expr.test
+++ b/tests/sqllogictests/suites/base/12_time_travel/12_0005_time_travel_snapshot_expr.test
@@ -1,0 +1,62 @@
+statement ok
+DROP DATABASE IF EXISTS db_12_0005
+
+statement ok
+CREATE DATABASE db_12_0005
+
+statement ok
+USE db_12_0005
+
+statement ok
+CREATE TABLE t(c1 int)
+
+statement ok
+insert into t values(1)
+
+statement ok
+insert into t values(2)
+
+query I
+select count() from fuse_snapshot('db_12_0005', 't')
+----
+2
+
+# scalar subquery: first snapshot
+query I
+select * from t at(snapshot => (select snapshot_id from fuse_snapshot('db_12_0005', 't') order by timestamp limit 1))
+----
+1
+
+# scalar subquery: latest snapshot
+query I
+select * from t at(snapshot => (select snapshot_id from fuse_snapshot('db_12_0005', 't') order by timestamp desc limit 1)) order by c1
+----
+1
+2
+
+# function wrapping a scalar subquery
+query I
+select * from t at(snapshot => substring((select snapshot_id from fuse_snapshot('db_12_0005', 't') order by timestamp limit 1), 1)) order by c1
+----
+1
+
+# string literal still works
+query I
+select * from t at(snapshot => (select snapshot_id from fuse_snapshot('db_12_0005', 't') order by timestamp desc limit 1)) order by c1
+----
+1
+2
+
+# error: non-string result
+statement error
+select * from t at(snapshot => (select 123))
+
+# error: unresolvable expression
+statement error
+select * from t at(snapshot => c1)
+
+statement ok
+DROP TABLE t ALL
+
+statement ok
+DROP DATABASE db_12_0005


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Previously, the `AT (SNAPSHOT => ...)` time travel clause only accepted string literals. This change allows arbitrary scalar expressions including subqueries, consistent with how `TIMESTAMP =>` and `OFFSET =>` already work.

For example, these are now supported:

```sql
-- scalar subquery
SELECT * FROM t AT (SNAPSHOT => (SELECT snapshot_id FROM fuse_snapshot('db', 't') LIMIT 1));

-- function wrapping a scalar subquery
SELECT * FROM t AT (SNAPSHOT => SUBSTRING((SELECT snapshot_id FROM fuse_snapshot('db', 't') LIMIT 1), 1));
```

When the expression cannot be constant-folded (e.g. it contains a subquery), the binder falls back to executing it via `subquery_executor` — the same approach used for table function arguments in `bind_table_args`.

- fixes: #19761

## Known Limitations

1. **Subquery execution happens at bind time**: The snapshot expression is evaluated during the binder phase because the snapshot ID is needed to resolve the table schema. A cleaner design would defer evaluation to the execution phase, but that requires broader refactoring of the time travel navigation pipeline.

2. **Subquery loses original binder scope**: `execute_subquery_for_scalar` converts the expression to a string and runs it as a fresh `SELECT`, which drops the original binder scope (CTEs, correlated bindings). For example, `WITH s AS (...) SELECT * FROM t AT (SNAPSHOT => (SELECT snapshot_id FROM s))` would fail because `s` is not known in the new execution context. This is inherited from the existing `table_args.rs` pattern and requires evaluating the already-bound expression in-context to fix properly.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19762)
<!-- Reviewable:end -->
