### PR TITLE
feat(time-travel): add NO_CHECK for timestamp navigation via UUID v7

### DIFF
--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -32,6 +32,7 @@ use databend_storages_common_index::BloomIndex;
 use databend_storages_common_index::RangeIndex;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::meta::VACUUM2_OBJECT_KEY_PREFIX;
+use databend_storages_common_table_meta::meta::Versioned;
 use databend_storages_common_table_meta::table::OPT_KEY_APPROX_DISTINCT_COLUMNS;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 use databend_storages_common_table_meta::table::OPT_KEY_CLUSTER_TYPE;
@@ -240,12 +241,7 @@ impl FuseTable {
                     .await
             }
             NavigationPoint::TimePoint(time_point) => {
-                let Some(location) = self.snapshot_loc() else {
-                    return Err(ErrorCode::TableHistoricalDataNotFound(
-                        "Empty Table has no historical data",
-                    ));
-                };
-                self.navigate_to_time_point(ctx, location, *time_point)
+                self.navigate_to_time_point_unchecked(ctx, *time_point)
                     .await
             }
             _ => self.navigate_to_point(ctx, point).await,
@@ -285,6 +281,114 @@ impl FuseTable {
         Err(ErrorCode::TableHistoricalDataNotFound(
             "Snapshot not found with NO_CHECK",
         ))
+    }
+
+    #[async_backtrace::framed]
+    async fn navigate_to_time_point_unchecked(
+        &self,
+        ctx: &Arc<dyn TableContext>,
+        time_point: DateTime<Utc>,
+    ) -> Result<Arc<FuseTable>> {
+        let snapshot_prefix = self.snapshot_prefix();
+        let op = self.get_operator();
+        let s3_storage_class = ctx.get_settings().get_s3_storage_class()?;
+
+        // NO_CHECK only works with V4 snapshots (UUID v7 temporal ordering).
+        if let Some(loc) = self.snapshot_loc() {
+            if !loc.ends_with("_v4.mpk") {
+                return Err(ErrorCode::TableHistoricalDataNotFound(
+                    "NO_CHECK requires V4 format snapshots (UUID v7)",
+                ));
+            }
+        }
+
+        let ts_millis = time_point.timestamp_millis();
+        if ts_millis < 0 {
+            return Err(ErrorCode::TableHistoricalDataNotFound(
+                "NO_CHECK does not support timestamps before 1970-01-01",
+            ));
+        }
+        // Use all-zero random bytes to produce the minimum UUID for this millisecond.
+        // This is intentional: any snapshot at the same millisecond sorts after this
+        // boundary, so we always return its predecessor (ts < time_point semantics).
+        let target_uuid =
+            uuid::Builder::from_unix_timestamp_millis(ts_millis as u64, &[0u8; 10]).into_uuid();
+        let start_after_key = format!(
+            "{}{}{}",
+            snapshot_prefix,
+            VACUUM2_OBJECT_KEY_PREFIX,
+            target_uuid.as_simple()
+        );
+
+        let has_start_after = op.info().full_capability().list_with_start_after;
+
+        let mut lister = if has_start_after {
+            op.lister_with(&snapshot_prefix)
+                .start_after(&start_after_key)
+                .await?
+        } else {
+            op.lister_with(&snapshot_prefix).await?
+        };
+
+        let abort_checker = ctx.clone().get_abort_checker();
+        let mut first_snapshot_after = None;
+        while let Some(entry) = lister.try_next().await? {
+            abort_checker
+                .try_check_aborting()
+                .with_context(|| "navigate_to_time_point_unchecked")?;
+            if entry.metadata().mode() == EntryMode::FILE {
+                let path = entry.path().to_string();
+                if path.ends_with("_v4.mpk") {
+                    if !has_start_after && path.as_str() <= start_after_key.as_str() {
+                        continue;
+                    }
+                    first_snapshot_after = Some(path);
+                    break;
+                }
+            }
+        }
+
+        match first_snapshot_after {
+            Some(location) => {
+                let (snapshot, _format_version) =
+                    SnapshotsIO::read_snapshot(location, op.clone(), true).await?;
+
+                match snapshot.prev_snapshot_id {
+                    Some((prev_id, prev_ver)) => {
+                        if prev_ver < TableSnapshot::VERSION {
+                            return Err(ErrorCode::TableHistoricalDataNotFound(
+                                "NO_CHECK cannot navigate to pre-V4 snapshots \
+                                 in mixed-format tables",
+                            ));
+                        }
+                        let prev_location = self
+                            .meta_location_generator()
+                            .gen_snapshot_location(&prev_id, prev_ver)?;
+                        let (prev_snapshot, prev_format_version) =
+                            SnapshotsIO::read_snapshot(prev_location, op, true).await?;
+                        self.load_table_by_snapshot(
+                            prev_snapshot.as_ref(),
+                            prev_format_version,
+                            s3_storage_class,
+                        )
+                    }
+                    None => Err(ErrorCode::TableHistoricalDataNotFound(
+                        "No historical data found at given point \
+                         (timestamp is before the earliest snapshot)",
+                    )),
+                }
+            }
+            None => {
+                let Some(location) = self.snapshot_loc() else {
+                    return Err(ErrorCode::TableHistoricalDataNotFound(
+                        "Empty Table has no historical data",
+                    ));
+                };
+                let (snapshot, format_version) =
+                    SnapshotsIO::read_snapshot(location, op, true).await?;
+                self.load_table_by_snapshot(snapshot.as_ref(), format_version, s3_storage_class)
+            }
+        }
     }
 
     #[async_backtrace::framed]

--- a/tests/sqllogictests/suites/base/12_time_travel/12_0006_time_travel_no_check.test
+++ b/tests/sqllogictests/suites/base/12_time_travel/12_0006_time_travel_no_check.test
@@ -16,6 +16,13 @@ INSERT INTO t VALUES(1)
 statement ok
 INSERT INTO t VALUES(2)
 
+# NO_CHECK uses exclusive semantics (ts < time_point). The boundary UUID is the
+# minimum for the target millisecond, so a snapshot at the same millisecond would
+# be treated as "after" and its predecessor returned. sleep(1) ensures now() is
+# at least 1 second after the last snapshot, making the TIMESTAMP tests deterministic.
+statement ok
+SELECT sleep(1)
+
 # Test NO_CHECK with SNAPSHOT via subquery expression
 query I
 SELECT count() FROM t AT (SNAPSHOT => (SELECT snapshot_id FROM fuse_snapshot('db_12_0006', 't') LIMIT 1), NO_CHECK => true)
@@ -32,7 +39,13 @@ SELECT count() FROM t AT (SNAPSHOT => (SELECT snapshot_id FROM fuse_snapshot('db
 statement error 2013
 SELECT * FROM t AT (SNAPSHOT => '00000000000000000000000000000000', NO_CHECK => true)
 
-# Test NO_CHECK => false behaves same as default (uses chain traversal)
+# Test NO_CHECK with TIMESTAMP => now() should see all rows
+query I
+SELECT count() FROM t AT (TIMESTAMP => now()::TIMESTAMP, NO_CHECK => true)
+----
+2
+
+# Test NO_CHECK => false behaves same as default
 query I
 SELECT count() FROM t AT (TIMESTAMP => now()::TIMESTAMP, NO_CHECK => false)
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Follow-up to #19763. Adds `NO_CHECK` support for `TIMESTAMP` time travel:

```sql
SELECT * FROM t AT (TIMESTAMP => '2024-01-01'::TIMESTAMP, NO_CHECK => true)
```

When `NO_CHECK` is enabled with `TIMESTAMP`, `navigate_to_time_point_unchecked` constructs a deterministic UUID v7 boundary (all-zero random bytes, the minimum for the target millisecond) and uses OpenDAL's `lister_with().start_after()` to jump directly to the right region of the snapshot file list. The first V4 snapshot after the target time is read, and its `prev_snapshot_id` is used as the result.

This avoids the O(n) linked-list traversal for tables with UUID v7 snapshot IDs (where file name order preserves temporal order).

### Semantics

`NO_CHECK` timestamp navigation uses **exclusive** semantics (`ts < time_point`), unlike the checked path which uses inclusive (`ts <= time_point`). This is a deliberate tradeoff for determinism and safety in a fast path that skips chain verification. The one-snapshot difference only manifests when the target timestamp is sourced directly from `fuse_snapshot(...).timestamp` at exact millisecond precision.

### Safety checks

- Early rejection if the table's current snapshot is not V4 format
- Rejection of negative timestamps (before 1970-01-01)
- Rejection if the predecessor snapshot is pre-V4 (mixed-format tables)
- Only V4 snapshot files (`_v4.mpk`) are matched during listing

### Limitations

- **V4 snapshots only**: Only works with V4 format snapshots which use UUID v7. Older snapshot formats (V0-V3) use random UUID v4 and lack temporal ordering in file names. Tables with mixed V3/V4 history will error if the result would be a pre-V4 snapshot.
- **No chain verification**: `NO_CHECK` skips verification that the snapshot belongs to the current active snapshot chain. The result may be a snapshot on a fork abandoned by `ALTER TABLE FLASHBACK`.
- **Exclusive semantics**: Result snapshot timestamp is strictly less than the target timestamp.

### Changes

- `navigate_to_time_point_unchecked`: constructs deterministic UUID v7 boundary (all-zero random bytes), uses `start_after` to locate the target snapshot region
- Capability check for `list_with_start_after`, with fallback to manual filtering for backends that don't support it (e.g. local filesystem)
- Updated sqllogictest with TIMESTAMP NO_CHECK test cases

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19764)
<!-- Reviewable:end -->