### PR TITLE
refactor(functions): optimize bitmap aggregate serialized ops

### DIFF
--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -236,24 +236,29 @@ impl<'a> FromIterator<&'a u64> for HybridBitmap {
 
 impl std::ops::BitOrAssign for HybridBitmap {
     fn bitor_assign(&mut self, rhs: Self) {
-        match rhs {
-            HybridBitmap::Large(rhs_tree) => {
-                let lhs_tree = self.promote_to_tree();
+        match (&mut *self, rhs) {
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
                 lhs_tree.bitor_assign(rhs_tree);
             }
-            HybridBitmap::Small(rhs_set) => match self {
-                HybridBitmap::Large(lhs_tree) => {
-                    for value in rhs_set.iter().copied() {
-                        lhs_tree.insert(value);
-                    }
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(mut rhs_tree)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
+                    rhs_tree.extend(lhs_set.iter().copied());
                 }
-                HybridBitmap::Small(lhs_set) => {
+                *lhs = HybridBitmap::Large(rhs_tree);
+            }
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
+                for value in rhs_set.iter().copied() {
+                    lhs_tree.insert(value);
+                }
+            }
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Small(rhs_set)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
                     small_union(lhs_set, rhs_set.as_slice());
-                    if self.len() >= LARGE_THRESHOLD as u64 {
-                        let _ = self.promote_to_tree();
-                    }
                 }
-            },
+                if lhs.len() >= LARGE_THRESHOLD as u64 {
+                    let _ = lhs.promote_to_tree();
+                }
+            }
         }
     }
 }
@@ -269,25 +274,32 @@ impl std::ops::BitOr for HybridBitmap {
 
 impl std::ops::BitAndAssign for HybridBitmap {
     fn bitand_assign(&mut self, rhs: Self) {
-        match rhs {
-            HybridBitmap::Large(rhs_tree) => {
-                let lhs_tree = self.promote_to_tree();
+        match (&mut *self, rhs) {
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
                 lhs_tree.bitand_assign(rhs_tree);
-                self.try_demote();
             }
-            HybridBitmap::Small(mut rhs_set) => match self {
-                HybridBitmap::Large(lhs_tree) => {
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(rhs_tree)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
+                    lhs_set.retain(|value| rhs_tree.contains(*value));
+                }
+            }
+            (lhs @ HybridBitmap::Large(_), HybridBitmap::Small(rhs_set)) => {
+                if let HybridBitmap::Large(lhs_tree) = lhs {
                     let mut result = SmallBitmap::with_capacity(rhs_set.len());
                     for value in rhs_set.iter().copied() {
                         if lhs_tree.contains(value) {
                             result.push(value);
                         }
                     }
-                    *self = HybridBitmap::Small(result);
+                    *lhs = HybridBitmap::Small(result);
                 }
-                HybridBitmap::Small(lhs_set) => small_intersection(lhs_set, &mut rhs_set),
-            },
+                return;
+            }
+            (HybridBitmap::Small(lhs_set), HybridBitmap::Small(mut rhs_set)) => {
+                small_intersection(lhs_set, &mut rhs_set)
+            }
         }
+        self.try_demote();
     }
 }
 
@@ -302,27 +314,47 @@ impl std::ops::BitAnd for HybridBitmap {
 
 impl std::ops::BitXorAssign for HybridBitmap {
     fn bitxor_assign(&mut self, rhs: Self) {
-        match rhs {
-            HybridBitmap::Large(rhs_tree) => {
-                let lhs_tree = self.promote_to_tree();
+        match (&mut *self, rhs) {
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
                 lhs_tree.bitxor_assign(rhs_tree);
-                self.try_demote();
             }
-            HybridBitmap::Small(rhs_set) => match self {
-                // Disjoint data in the bitmap can cause lhs_tree expansion during XOR, making this path a significant performance bottleneck.
-                HybridBitmap::Large(lhs_tree) => {
-                    let rhs_tree = RoaringTreemap::from_iter(rhs_set.iter().copied());
-                    lhs_tree.bitxor_assign(rhs_tree);
-                    self.try_demote();
-                }
-                HybridBitmap::Small(lhs_set) => {
-                    small_symmetric_difference(lhs_set, rhs_set.as_slice());
-                    if self.len() >= LARGE_THRESHOLD as u64 {
-                        let _ = self.promote_to_tree();
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(mut rhs_tree)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
+                    for value in lhs_set.iter().copied() {
+                        if !rhs_tree.remove(value) {
+                            rhs_tree.insert(value);
+                        }
                     }
                 }
-            },
+                *lhs = HybridBitmap::from(rhs_tree);
+                return;
+            }
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
+                let mut removed = 0;
+                let mut inserted = 0;
+                for value in rhs_set.iter().copied() {
+                    if lhs_tree.remove(value) {
+                        removed += 1;
+                    } else {
+                        lhs_tree.insert(value);
+                        inserted += 1;
+                    }
+                }
+                if removed <= inserted {
+                    return;
+                }
+            }
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Small(rhs_set)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
+                    small_symmetric_difference(lhs_set, rhs_set.as_slice());
+                }
+                if lhs.len() >= LARGE_THRESHOLD as u64 {
+                    let _ = lhs.promote_to_tree();
+                }
+                return;
+            }
         }
+        self.try_demote();
     }
 }
 
@@ -337,24 +369,28 @@ impl std::ops::BitXor for HybridBitmap {
 
 impl std::ops::SubAssign for HybridBitmap {
     fn sub_assign(&mut self, rhs: Self) {
-        match rhs {
-            HybridBitmap::Large(rhs_tree) => {
-                let lhs_tree = self.promote_to_tree();
+        match (&mut *self, rhs) {
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
                 lhs_tree.sub_assign(rhs_tree);
-                self.try_demote();
             }
-            HybridBitmap::Small(rhs_set) => match self {
-                HybridBitmap::Large(lhs_tree) => {
-                    let rhs_tree = RoaringTreemap::from_iter(rhs_set.iter().copied());
-                    lhs_tree.sub_assign(rhs_tree);
-                    self.try_demote();
+            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(rhs_tree)) => {
+                if let HybridBitmap::Small(lhs_set) = lhs {
+                    lhs_set.retain(|value| !rhs_tree.contains(*value));
                 }
-                HybridBitmap::Small(lhs_set) => {
-                    let result = small_difference(lhs_set.as_slice(), rhs_set.as_slice());
-                    *lhs_set = result;
+                return;
+            }
+            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
+                for value in rhs_set.iter().copied() {
+                    lhs_tree.remove(value);
                 }
-            },
+            }
+            (HybridBitmap::Small(lhs_set), HybridBitmap::Small(rhs_set)) => {
+                let result = small_difference(lhs_set.as_slice(), rhs_set.as_slice());
+                *lhs_set = result;
+                return;
+            }
         }
+        self.try_demote();
     }
 }
 
@@ -509,11 +545,37 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
 }
 
 pub fn intersection_with_serialized(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
+    if buf.is_empty() {
+        *lhs = HybridBitmap::new();
+        return Ok(());
+    }
+
+    let is_hybrid_bitmap =
+        buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION;
+
+    if is_hybrid_bitmap && buf[3] == HYBRID_KIND_SMALL {
+        let (rhs_len, rhs_bytes) = decode_small_payload(&buf[HYBRID_HEADER_LEN..])?;
+        match lhs {
+            HybridBitmap::Small(lhs_set) => {
+                small_intersection_serialized_in_place(lhs_set, rhs_bytes)
+            }
+            HybridBitmap::Large(lhs_tree) => {
+                let mut result = SmallBitmap::with_capacity(rhs_len);
+                for chunk in rhs_bytes.chunks_exact(std::mem::size_of::<u64>()) {
+                    let value = read_u64_le(chunk);
+                    if lhs_tree.contains(value) {
+                        result.push(value);
+                    }
+                }
+                *lhs = HybridBitmap::Small(result);
+            }
+        }
+        return Ok(());
+    }
+
     if let HybridBitmap::Large(lhs) = lhs
-        && buf.len() > 3
+        && is_hybrid_bitmap
         && buf[3] == HYBRID_KIND_LARGE
-        && buf[..2] == HYBRID_MAGIC
-        && buf[2] == HYBRID_VERSION
     {
         Ok(reader::intersection_with_serialized(
             lhs,
@@ -561,6 +623,18 @@ fn try_decode_hybrid_bitmap(buf: &[u8]) -> Option<Result<HybridBitmap>> {
 }
 
 fn decode_small_bitmap(payload: &[u8]) -> Result<HybridBitmap> {
+    Ok(HybridBitmap::Small(decode_small_values(payload)?))
+}
+
+fn decode_small_values(payload: &[u8]) -> Result<SmallBitmap> {
+    let (_, bytes) = decode_small_payload(payload)?;
+    Ok(bytes
+        .chunks_exact(std::mem::size_of::<u64>())
+        .map(read_u64_le)
+        .collect())
+}
+
+fn decode_small_payload(payload: &[u8]) -> Result<(usize, &[u8])> {
     if payload.is_empty() {
         return Err(ErrorCode::BadBytes(
             "invalid hybrid bitmap payload: missing length".to_string(),
@@ -580,14 +654,13 @@ fn decode_small_bitmap(payload: &[u8]) -> Result<HybridBitmap> {
         )));
     }
 
-    let set: SmallBitmap = bytes
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(|chunk| {
-            let raw = unsafe { ptr::read_unaligned(chunk.as_ptr() as *const u64) };
-            u64::from_le(raw)
-        })
-        .collect();
-    Ok(HybridBitmap::Small(set))
+    Ok((len, bytes))
+}
+
+#[inline]
+fn read_u64_le(chunk: &[u8]) -> u64 {
+    let raw = unsafe { ptr::read_unaligned(chunk.as_ptr() as *const u64) };
+    u64::from_le(raw)
 }
 
 fn small_insert(set: &mut SmallBitmap, value: u64) -> bool {
@@ -691,6 +764,38 @@ fn small_intersection_in_place(target: &mut SmallBitmap, other: &[u64]) {
     while i < target_len && j < other.len() {
         let lv = target[i];
         let rv = other[j];
+        if lv < rv {
+            i += 1;
+        } else if rv < lv {
+            j += 1;
+        } else {
+            target[write] = lv;
+            write += 1;
+            i += 1;
+            j += 1;
+        }
+    }
+
+    target.truncate(write);
+}
+
+#[inline]
+fn small_intersection_serialized_in_place(target: &mut SmallBitmap, other: &[u8]) {
+    if other.is_empty() {
+        target.clear();
+        return;
+    }
+
+    let mut write = 0;
+    let mut i = 0;
+    let mut j = 0;
+    let target_len = target.len();
+    let other_len = other.len() / std::mem::size_of::<u64>();
+
+    while i < target_len && j < other_len {
+        let lv = target[i];
+        let offset = j * std::mem::size_of::<u64>();
+        let rv = read_u64_le(&other[offset..offset + std::mem::size_of::<u64>()]);
         if lv < rv {
             i += 1;
         } else if rv < lv {
@@ -955,6 +1060,70 @@ mod tests {
                 assert_eq!(set.as_slice(), &[1, 5, 7]);
             }
             _ => panic!("expected small hybrid bitmap after intersection"),
+        }
+    }
+
+    #[test]
+    fn bitand_small_with_large_stays_small() {
+        let mut small = HybridBitmap::from_iter([1_u64, 5, 7, 40]);
+        let large = HybridBitmap::from_iter(0_u64..64);
+        small.bitand_assign(large);
+
+        match small {
+            HybridBitmap::Small(set) => assert_eq!(set.as_slice(), &[1, 5, 7, 40]),
+            _ => panic!("expected small hybrid bitmap after intersection"),
+        }
+    }
+
+    #[test]
+    fn bitor_small_with_large_uses_large_rhs() {
+        let mut small = HybridBitmap::from_iter([100_u64, 101]);
+        let large = HybridBitmap::from_iter(0_u64..64);
+        small.bitor_assign(large);
+
+        assert!(matches!(small, HybridBitmap::Large(_)));
+        assert!(small.contains(1));
+        assert!(small.contains(100));
+        assert_eq!(small.len(), 66);
+    }
+
+    #[test]
+    fn bitxor_small_with_large_toggles_values() {
+        let mut small = HybridBitmap::from_iter([1_u64, 5, 100]);
+        let large = HybridBitmap::from_iter(0_u64..64);
+        small.bitxor_assign(large);
+
+        assert!(!small.contains(1));
+        assert!(!small.contains(5));
+        assert!(small.contains(2));
+        assert!(small.contains(100));
+        assert_eq!(small.len(), 63);
+    }
+
+    #[test]
+    fn sub_small_with_large_stays_small() {
+        let mut small = HybridBitmap::from_iter([1_u64, 5, 100]);
+        let large = HybridBitmap::from_iter(0_u64..64);
+        small.sub_assign(large);
+
+        match small {
+            HybridBitmap::Small(set) => assert_eq!(set.as_slice(), &[100]),
+            _ => panic!("expected small hybrid bitmap after difference"),
+        }
+    }
+
+    #[test]
+    fn intersection_with_serialized_small_rhs_uses_small_result() {
+        let mut lhs = HybridBitmap::from_iter(0_u64..64);
+        let rhs = HybridBitmap::from_iter([1_u64, 5, 100]);
+        let mut rhs_buf = Vec::new();
+        rhs.serialize_into(&mut rhs_buf).unwrap();
+
+        intersection_with_serialized(&mut lhs, &rhs_buf).unwrap();
+
+        match lhs {
+            HybridBitmap::Small(set) => assert_eq!(set.as_slice(), &[1, 5]),
+            _ => panic!("expected small hybrid bitmap after serialized intersection"),
         }
     }
 

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -40,6 +40,77 @@ pub const HYBRID_HEADER_LEN: usize = 4;
 
 type SmallBitmap = SmallVec<[u64; LARGE_THRESHOLD]>;
 
+#[allow(clippy::large_enum_variant)]
+pub enum BitmapRhs<'a> {
+    Bitmap(HybridBitmap),
+    Serialized(&'a [u8]),
+}
+
+#[derive(Clone, Copy)]
+enum BitmapOp {
+    And,
+    Or,
+    Xor,
+    Sub,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum BitmapRhsView<'a> {
+    Empty,
+    Small(SmallValues<'a>),
+    SerializedLarge(&'a [u8]),
+    Large(RoaringTreemap),
+}
+
+#[allow(clippy::large_enum_variant)]
+enum SmallValues<'a> {
+    Owned(SmallBitmap),
+    Serialized(&'a [u8]),
+}
+
+impl SmallValues<'_> {
+    fn len(&self) -> usize {
+        match self {
+            SmallValues::Owned(values) => values.len(),
+            SmallValues::Serialized(bytes) => bytes.len() / std::mem::size_of::<u64>(),
+        }
+    }
+
+    fn into_small_bitmap(self) -> SmallBitmap {
+        match self {
+            SmallValues::Owned(values) => values,
+            SmallValues::Serialized(bytes) => {
+                let mut values =
+                    SmallBitmap::with_capacity(bytes.len() / std::mem::size_of::<u64>());
+                for chunk in bytes.chunks_exact(std::mem::size_of::<u64>()) {
+                    small_insert(&mut values, read_u64_le(chunk));
+                }
+                values
+            }
+        }
+    }
+
+    fn for_each(self, mut func: impl FnMut(u64)) {
+        match self {
+            SmallValues::Owned(values) => {
+                for value in values.iter().copied() {
+                    func(value);
+                }
+            }
+            SmallValues::Serialized(bytes) => {
+                let mut values =
+                    SmallBitmap::with_capacity(bytes.len() / std::mem::size_of::<u64>());
+                for chunk in bytes.chunks_exact(std::mem::size_of::<u64>()) {
+                    let value = read_u64_le(chunk);
+                    if small_insert(&mut values, value) {
+                        func(value);
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Perf Tips:
 /// - The deserialization performance of HybridBitmap significantly impacts the performance of Bitmap-related calculations.
 /// - Calculations may frequently create new Bitmaps; reusing them as much as possible can effectively improve performance.
@@ -200,6 +271,225 @@ impl HybridBitmap {
     }
 }
 
+impl HybridBitmap {
+    pub fn bitor_assign_rhs(&mut self, rhs: BitmapRhs<'_>) -> Result<()> {
+        self.apply_assign(BitmapOp::Or, rhs)
+    }
+
+    pub fn bitand_assign_rhs(&mut self, rhs: BitmapRhs<'_>) -> Result<()> {
+        self.apply_assign(BitmapOp::And, rhs)
+    }
+
+    pub fn bitxor_assign_rhs(&mut self, rhs: BitmapRhs<'_>) -> Result<()> {
+        self.apply_assign(BitmapOp::Xor, rhs)
+    }
+
+    pub fn sub_assign_rhs(&mut self, rhs: BitmapRhs<'_>) -> Result<()> {
+        self.apply_assign(BitmapOp::Sub, rhs)
+    }
+
+    fn apply_assign(&mut self, op: BitmapOp, rhs: BitmapRhs<'_>) -> Result<()> {
+        if matches!(op, BitmapOp::And | BitmapOp::Sub) && self.is_empty() {
+            if let BitmapRhs::Serialized(buf) = rhs {
+                validate_serialized_bitmap(buf)?;
+            }
+            return Ok(());
+        }
+
+        let rhs = BitmapRhsView::try_from(rhs)?;
+        self.apply_rhs(op, rhs)
+    }
+
+    fn apply_rhs(&mut self, op: BitmapOp, rhs: BitmapRhsView<'_>) -> Result<()> {
+        match (op, rhs) {
+            (BitmapOp::And, BitmapRhsView::Empty) => *self = HybridBitmap::new(),
+            (_, BitmapRhsView::Empty) => {}
+            (BitmapOp::And, BitmapRhsView::Small(SmallValues::Serialized(rhs))) => {
+                self.bitand_assign_serialized_small(rhs)
+            }
+            (BitmapOp::And, BitmapRhsView::Small(rhs)) => self.bitand_assign_small(rhs),
+            (BitmapOp::Or, BitmapRhsView::Small(rhs)) => self.bitor_assign_small(rhs),
+            (BitmapOp::Xor, BitmapRhsView::Small(rhs)) => self.bitxor_assign_small(rhs),
+            (BitmapOp::Sub, BitmapRhsView::Small(rhs)) => self.sub_assign_small(rhs),
+            (BitmapOp::And, BitmapRhsView::SerializedLarge(rhs)) => {
+                self.bitand_assign_serialized_large(rhs)?
+            }
+            (op, BitmapRhsView::SerializedLarge(rhs)) => {
+                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
+                    let len = rhs.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+                self.apply_rhs(op, BitmapRhsView::Large(rhs))?;
+            }
+            (BitmapOp::And, BitmapRhsView::Large(rhs)) => self.bitand_assign_large(rhs),
+            (BitmapOp::Or, BitmapRhsView::Large(rhs)) => self.bitor_assign_large(rhs),
+            (BitmapOp::Xor, BitmapRhsView::Large(rhs)) => self.bitxor_assign_large(rhs),
+            (BitmapOp::Sub, BitmapRhsView::Large(rhs)) => self.sub_assign_large(rhs),
+        }
+        Ok(())
+    }
+
+    fn bitor_assign_small(&mut self, rhs: SmallValues<'_>) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => rhs.for_each(|value| {
+                lhs_tree.insert(value);
+            }),
+            HybridBitmap::Small(lhs_set) => {
+                small_union(lhs_set, rhs.into_small_bitmap().as_slice());
+                if lhs_set.len() >= LARGE_THRESHOLD {
+                    let _ = self.promote_to_tree();
+                }
+            }
+        }
+    }
+
+    fn bitor_assign_large(&mut self, mut rhs: RoaringTreemap) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => lhs_tree.bitor_assign(rhs),
+            HybridBitmap::Small(lhs_set) => {
+                rhs.extend(lhs_set.iter().copied());
+                *self = HybridBitmap::Large(rhs);
+            }
+        }
+    }
+
+    fn bitand_assign_small(&mut self, rhs: SmallValues<'_>) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                let mut result = SmallBitmap::with_capacity(rhs.len());
+                rhs.for_each(|value| {
+                    if lhs_tree.contains(value) {
+                        result.push(value);
+                    }
+                });
+                *self = HybridBitmap::Small(result);
+            }
+            HybridBitmap::Small(lhs_set) => match rhs {
+                SmallValues::Serialized(bytes) => {
+                    small_intersection_serialized_in_place(lhs_set, bytes)
+                }
+                values => {
+                    let mut values = values.into_small_bitmap();
+                    small_intersection(lhs_set, &mut values);
+                }
+            },
+        }
+    }
+
+    fn bitand_assign_serialized_small(&mut self, rhs: &[u8]) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                let mut result = SmallBitmap::with_capacity(rhs.len() / std::mem::size_of::<u64>());
+                for chunk in rhs.chunks_exact(std::mem::size_of::<u64>()) {
+                    let value = read_u64_le(chunk);
+                    if lhs_tree.contains(value) {
+                        result.push(value);
+                    }
+                }
+                *self = HybridBitmap::Small(result);
+            }
+            HybridBitmap::Small(lhs_set) => small_intersection_serialized_in_place(lhs_set, rhs),
+        }
+    }
+
+    fn bitand_assign_large(&mut self, rhs: RoaringTreemap) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                lhs_tree.bitand_assign(rhs);
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => lhs_set.retain(|value| rhs.contains(*value)),
+        }
+    }
+
+    fn bitand_assign_serialized_large(&mut self, rhs: &[u8]) -> Result<()> {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                reader::intersection_with_serialized(lhs_tree, rhs)?;
+            }
+            HybridBitmap::Small(lhs_set) => {
+                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
+                    let len = rhs.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+                lhs_set.retain(|value| rhs.contains(*value));
+            }
+        }
+        Ok(())
+    }
+
+    fn bitxor_assign_small(&mut self, rhs: SmallValues<'_>) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                let mut removed = 0;
+                let mut inserted = 0;
+                rhs.for_each(|value| {
+                    if lhs_tree.remove(value) {
+                        removed += 1;
+                    } else {
+                        lhs_tree.insert(value);
+                        inserted += 1;
+                    }
+                });
+                if removed > inserted {
+                    self.try_demote();
+                }
+            }
+            HybridBitmap::Small(lhs_set) => {
+                small_symmetric_difference(lhs_set, rhs.into_small_bitmap().as_slice());
+                if lhs_set.len() >= LARGE_THRESHOLD {
+                    let _ = self.promote_to_tree();
+                }
+            }
+        }
+    }
+
+    fn bitxor_assign_large(&mut self, mut rhs: RoaringTreemap) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                lhs_tree.bitxor_assign(rhs);
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => {
+                for value in lhs_set.iter().copied() {
+                    if !rhs.remove(value) {
+                        rhs.insert(value);
+                    }
+                }
+                *self = HybridBitmap::from(rhs);
+            }
+        }
+    }
+
+    fn sub_assign_small(&mut self, rhs: SmallValues<'_>) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                rhs.for_each(|value| {
+                    lhs_tree.remove(value);
+                });
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => {
+                let result =
+                    small_difference(lhs_set.as_slice(), rhs.into_small_bitmap().as_slice());
+                *lhs_set = result;
+            }
+        }
+    }
+
+    fn sub_assign_large(&mut self, rhs: RoaringTreemap) {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                lhs_tree.sub_assign(rhs);
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => lhs_set.retain(|value| !rhs.contains(*value)),
+        }
+    }
+}
+
 impl From<RoaringTreemap> for HybridBitmap {
     fn from(value: RoaringTreemap) -> Self {
         if (value.len() as usize) <= LARGE_THRESHOLD {
@@ -236,30 +526,7 @@ impl<'a> FromIterator<&'a u64> for HybridBitmap {
 
 impl std::ops::BitOrAssign for HybridBitmap {
     fn bitor_assign(&mut self, rhs: Self) {
-        match (&mut *self, rhs) {
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
-                lhs_tree.bitor_assign(rhs_tree);
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(mut rhs_tree)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    rhs_tree.extend(lhs_set.iter().copied());
-                }
-                *lhs = HybridBitmap::Large(rhs_tree);
-            }
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
-                for value in rhs_set.iter().copied() {
-                    lhs_tree.insert(value);
-                }
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Small(rhs_set)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    small_union(lhs_set, rhs_set.as_slice());
-                }
-                if lhs.len() >= LARGE_THRESHOLD as u64 {
-                    let _ = lhs.promote_to_tree();
-                }
-            }
-        }
+        self.bitor_assign_rhs(BitmapRhs::Bitmap(rhs)).unwrap();
     }
 }
 
@@ -274,32 +541,7 @@ impl std::ops::BitOr for HybridBitmap {
 
 impl std::ops::BitAndAssign for HybridBitmap {
     fn bitand_assign(&mut self, rhs: Self) {
-        match (&mut *self, rhs) {
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
-                lhs_tree.bitand_assign(rhs_tree);
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(rhs_tree)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    lhs_set.retain(|value| rhs_tree.contains(*value));
-                }
-            }
-            (lhs @ HybridBitmap::Large(_), HybridBitmap::Small(rhs_set)) => {
-                if let HybridBitmap::Large(lhs_tree) = lhs {
-                    let mut result = SmallBitmap::with_capacity(rhs_set.len());
-                    for value in rhs_set.iter().copied() {
-                        if lhs_tree.contains(value) {
-                            result.push(value);
-                        }
-                    }
-                    *lhs = HybridBitmap::Small(result);
-                }
-                return;
-            }
-            (HybridBitmap::Small(lhs_set), HybridBitmap::Small(mut rhs_set)) => {
-                small_intersection(lhs_set, &mut rhs_set)
-            }
-        }
-        self.try_demote();
+        self.bitand_assign_rhs(BitmapRhs::Bitmap(rhs)).unwrap();
     }
 }
 
@@ -314,47 +556,7 @@ impl std::ops::BitAnd for HybridBitmap {
 
 impl std::ops::BitXorAssign for HybridBitmap {
     fn bitxor_assign(&mut self, rhs: Self) {
-        match (&mut *self, rhs) {
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
-                lhs_tree.bitxor_assign(rhs_tree);
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(mut rhs_tree)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    for value in lhs_set.iter().copied() {
-                        if !rhs_tree.remove(value) {
-                            rhs_tree.insert(value);
-                        }
-                    }
-                }
-                *lhs = HybridBitmap::from(rhs_tree);
-                return;
-            }
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
-                let mut removed = 0;
-                let mut inserted = 0;
-                for value in rhs_set.iter().copied() {
-                    if lhs_tree.remove(value) {
-                        removed += 1;
-                    } else {
-                        lhs_tree.insert(value);
-                        inserted += 1;
-                    }
-                }
-                if removed <= inserted {
-                    return;
-                }
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Small(rhs_set)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    small_symmetric_difference(lhs_set, rhs_set.as_slice());
-                }
-                if lhs.len() >= LARGE_THRESHOLD as u64 {
-                    let _ = lhs.promote_to_tree();
-                }
-                return;
-            }
-        }
-        self.try_demote();
+        self.bitxor_assign_rhs(BitmapRhs::Bitmap(rhs)).unwrap();
     }
 }
 
@@ -369,28 +571,7 @@ impl std::ops::BitXor for HybridBitmap {
 
 impl std::ops::SubAssign for HybridBitmap {
     fn sub_assign(&mut self, rhs: Self) {
-        match (&mut *self, rhs) {
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Large(rhs_tree)) => {
-                lhs_tree.sub_assign(rhs_tree);
-            }
-            (lhs @ HybridBitmap::Small(_), HybridBitmap::Large(rhs_tree)) => {
-                if let HybridBitmap::Small(lhs_set) = lhs {
-                    lhs_set.retain(|value| !rhs_tree.contains(*value));
-                }
-                return;
-            }
-            (HybridBitmap::Large(lhs_tree), HybridBitmap::Small(rhs_set)) => {
-                for value in rhs_set.iter().copied() {
-                    lhs_tree.remove(value);
-                }
-            }
-            (HybridBitmap::Small(lhs_set), HybridBitmap::Small(rhs_set)) => {
-                let result = small_difference(lhs_set.as_slice(), rhs_set.as_slice());
-                *lhs_set = result;
-                return;
-            }
-        }
-        self.try_demote();
+        self.sub_assign_rhs(BitmapRhs::Bitmap(rhs)).unwrap();
     }
 }
 
@@ -482,6 +663,20 @@ impl IntoIterator for HybridBitmap {
     }
 }
 
+impl<'a> TryFrom<BitmapRhs<'a>> for BitmapRhsView<'a> {
+    type Error = ErrorCode;
+
+    fn try_from(rhs: BitmapRhs<'a>) -> Result<Self> {
+        match rhs {
+            BitmapRhs::Bitmap(HybridBitmap::Small(values)) => {
+                Ok(BitmapRhsView::Small(SmallValues::Owned(values)))
+            }
+            BitmapRhs::Bitmap(HybridBitmap::Large(tree)) => Ok(BitmapRhsView::Large(tree)),
+            BitmapRhs::Serialized(buf) => parse_bitmap_rhs(buf),
+        }
+    }
+}
+
 impl fmt::Debug for HybridBitmap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let values: Vec<u64> = self.iter().collect();
@@ -544,47 +739,59 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
     }
 }
 
-pub fn intersection_with_serialized(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
+fn parse_bitmap_rhs(buf: &[u8]) -> Result<BitmapRhsView<'_>> {
     if buf.is_empty() {
-        *lhs = HybridBitmap::new();
+        return Ok(BitmapRhsView::Empty);
+    }
+
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                let (_, bytes) = decode_small_payload(payload)?;
+                Ok(BitmapRhsView::Small(SmallValues::Serialized(bytes)))
+            }
+            HYBRID_KIND_LARGE => Ok(BitmapRhsView::SerializedLarge(payload)),
+            kind => Err(ErrorCode::BadBytes(format!(
+                "unknown hybrid bitmap kind: {kind}"
+            ))),
+        }
+    } else {
+        Ok(BitmapRhsView::try_from(BitmapRhs::Bitmap(
+            deserialize_bitmap(buf)?,
+        ))?)
+    }
+}
+
+fn validate_serialized_bitmap(buf: &[u8]) -> Result<()> {
+    if buf.is_empty() {
         return Ok(());
     }
 
-    let is_hybrid_bitmap =
-        buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION;
-
-    if is_hybrid_bitmap && buf[3] == HYBRID_KIND_SMALL {
-        let (rhs_len, rhs_bytes) = decode_small_payload(&buf[HYBRID_HEADER_LEN..])?;
-        match lhs {
-            HybridBitmap::Small(lhs_set) => {
-                small_intersection_serialized_in_place(lhs_set, rhs_bytes)
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                decode_small_payload(payload)?;
             }
-            HybridBitmap::Large(lhs_tree) => {
-                let mut result = SmallBitmap::with_capacity(rhs_len);
-                for chunk in rhs_bytes.chunks_exact(std::mem::size_of::<u64>()) {
-                    let value = read_u64_le(chunk);
-                    if lhs_tree.contains(value) {
-                        result.push(value);
-                    }
-                }
-                *lhs = HybridBitmap::Small(result);
+            HYBRID_KIND_LARGE => {
+                RoaringTreemap::deserialize_unchecked_from(payload).map_err(|e| {
+                    let len = payload.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+            }
+            kind => {
+                return Err(ErrorCode::BadBytes(format!(
+                    "unknown hybrid bitmap kind: {kind}"
+                )));
             }
         }
-        return Ok(());
+    } else {
+        deserialize_bitmap(buf).map(|_| ())?;
     }
 
-    if let HybridBitmap::Large(lhs) = lhs
-        && is_hybrid_bitmap
-        && buf[3] == HYBRID_KIND_LARGE
-    {
-        Ok(reader::intersection_with_serialized(
-            lhs,
-            &buf[HYBRID_HEADER_LEN..],
-        )?)
-    } else {
-        *lhs &= deserialize_bitmap(buf)?;
-        Ok(())
-    }
+    Ok(())
 }
 
 fn try_decode_hybrid_bitmap(buf: &[u8]) -> Option<Result<HybridBitmap>> {
@@ -628,10 +835,11 @@ fn decode_small_bitmap(payload: &[u8]) -> Result<HybridBitmap> {
 
 fn decode_small_values(payload: &[u8]) -> Result<SmallBitmap> {
     let (_, bytes) = decode_small_payload(payload)?;
-    Ok(bytes
-        .chunks_exact(std::mem::size_of::<u64>())
-        .map(read_u64_le)
-        .collect())
+    let mut values = SmallBitmap::with_capacity(bytes.len() / std::mem::size_of::<u64>());
+    for chunk in bytes.chunks_exact(std::mem::size_of::<u64>()) {
+        small_insert(&mut values, read_u64_le(chunk));
+    }
+    Ok(values)
 }
 
 fn decode_small_payload(payload: &[u8]) -> Result<(usize, &[u8])> {
@@ -1101,6 +1309,46 @@ mod tests {
     }
 
     #[test]
+    fn bitxor_large_with_serialized_small_deduplicates_rhs() {
+        let mut lhs = HybridBitmap::from_iter(0_u64..64);
+        let mut rhs = Vec::new();
+        rhs.extend_from_slice(&HYBRID_MAGIC);
+        rhs.push(HYBRID_VERSION);
+        rhs.push(HYBRID_KIND_SMALL);
+        rhs.push(3);
+        for value in [5_u64, 5, 100] {
+            rhs.extend_from_slice(&value.to_le_bytes());
+        }
+
+        lhs.bitxor_assign_rhs(BitmapRhs::Serialized(&rhs)).unwrap();
+
+        assert!(!lhs.contains(5));
+        assert!(lhs.contains(100));
+        assert_eq!(lhs.len(), 64);
+    }
+
+    #[test]
+    fn deserialize_small_lhs_deduplicates_before_large_rhs_xor() {
+        let mut lhs_buf = Vec::new();
+        lhs_buf.extend_from_slice(&HYBRID_MAGIC);
+        lhs_buf.push(HYBRID_VERSION);
+        lhs_buf.push(HYBRID_KIND_SMALL);
+        lhs_buf.push(2);
+        for value in [5_u64, 5] {
+            lhs_buf.extend_from_slice(&value.to_le_bytes());
+        }
+
+        let mut lhs = deserialize_bitmap(&lhs_buf).unwrap();
+        assert_eq!(lhs.len(), 1);
+
+        lhs.bitxor_assign(HybridBitmap::from_iter(0_u64..64));
+
+        assert!(!lhs.contains(5));
+        assert!(lhs.contains(0));
+        assert_eq!(lhs.len(), 63);
+    }
+
+    #[test]
     fn sub_small_with_large_stays_small() {
         let mut small = HybridBitmap::from_iter([1_u64, 5, 100]);
         let large = HybridBitmap::from_iter(0_u64..64);
@@ -1113,18 +1361,30 @@ mod tests {
     }
 
     #[test]
-    fn intersection_with_serialized_small_rhs_uses_small_result() {
+    fn bitand_assign_serialized_small_rhs_uses_small_result() {
         let mut lhs = HybridBitmap::from_iter(0_u64..64);
         let rhs = HybridBitmap::from_iter([1_u64, 5, 100]);
         let mut rhs_buf = Vec::new();
         rhs.serialize_into(&mut rhs_buf).unwrap();
 
-        intersection_with_serialized(&mut lhs, &rhs_buf).unwrap();
+        lhs.bitand_assign_rhs(BitmapRhs::Serialized(&rhs_buf))
+            .unwrap();
 
         match lhs {
             HybridBitmap::Small(set) => assert_eq!(set.as_slice(), &[1, 5]),
             _ => panic!("expected small hybrid bitmap after serialized intersection"),
         }
+    }
+
+    #[test]
+    fn empty_lhs_validates_serialized_rhs() {
+        let mut lhs = HybridBitmap::new();
+        let bad_rhs = [HYBRID_MAGIC[0], HYBRID_MAGIC[1], HYBRID_VERSION, 42];
+
+        assert!(
+            lhs.bitand_assign_rhs(BitmapRhs::Serialized(&bad_rhs))
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/query/functions/benches/bench.rs
+++ b/src/query/functions/benches/bench.rs
@@ -71,6 +71,11 @@ mod dummy {
 
 #[divan::bench_group(max_time = 2)]
 mod bitmap {
+    use std::ops::BitAndAssign;
+    use std::ops::BitOrAssign;
+    use std::ops::BitXorAssign;
+    use std::ops::SubAssign;
+
     use databend_common_expression::BlockEntry;
     use databend_common_expression::Column;
     use databend_common_expression::FromData;
@@ -141,6 +146,17 @@ mod bitmap {
     where F: FnMut(u64) -> u64 {
         let data: Vec<u64> = (0..rows as u64).map(generator).collect();
         UInt64Type::from_data(data)
+    }
+
+    fn mixed_small_large_pair() -> (HybridBitmap, HybridBitmap) {
+        let small = HybridBitmap::from_iter([1_u64, 5, 13, 100]);
+        let large = HybridBitmap::from_iter(0_u64..128);
+        (small, large)
+    }
+
+    fn mixed_large_small_pair() -> (HybridBitmap, HybridBitmap) {
+        let (small, large) = mixed_small_large_pair();
+        (large, small)
     }
 
     fn eval_bitmap_result(entry: &BlockEntry, rows: usize, agg_name: &'static str) {
@@ -229,6 +245,66 @@ mod bitmap {
         bencher.bench(|| {
             eval_bitmap_result(&entry, rows, "bitmap_construct_agg");
         });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_and_small_large(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_small_large_pair)
+            .bench_values(|(mut small, large)| {
+                small.bitand_assign(large);
+                small.len()
+            });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_or_small_large(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_small_large_pair)
+            .bench_values(|(mut small, large)| {
+                small.bitor_assign(large);
+                small.len()
+            });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_xor_small_large(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_small_large_pair)
+            .bench_values(|(mut small, large)| {
+                small.bitxor_assign(large);
+                small.len()
+            });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_sub_small_large(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_small_large_pair)
+            .bench_values(|(mut small, large)| {
+                small.sub_assign(large);
+                small.len()
+            });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_xor_large_small(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_large_small_pair)
+            .bench_values(|(mut large, small)| {
+                large.bitxor_assign(small);
+                large.len()
+            });
+    }
+
+    #[divan::bench]
+    fn bitmap_mixed_sub_large_small(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(mixed_large_small_pair)
+            .bench_values(|(mut large, small)| {
+                large.sub_assign(small);
+                large.len()
+            });
     }
 }
 

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -41,7 +41,7 @@ use databend_common_expression::with_decimal_mapped_type;
 use databend_common_expression::with_number_mapped_type;
 use databend_common_expression::with_unsigned_integer_mapped_type;
 use databend_common_io::HybridBitmap;
-use databend_common_io::bitmap::intersection_with_serialized;
+use databend_common_io::bitmap::BitmapRhs;
 use databend_common_io::prelude::BinaryWrite;
 use num_traits::AsPrimitive;
 
@@ -172,7 +172,7 @@ impl BitmapOperate for BitmapAndOp {
     }
 
     fn operate_buf(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
-        intersection_with_serialized(lhs, buf)
+        lhs.bitand_assign_rhs(BitmapRhs::Serialized(buf))
     }
 }
 
@@ -182,8 +182,7 @@ impl BitmapOperate for BitmapOrOp {
     }
 
     fn operate_buf(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
-        lhs.bitor_assign(deserialize_bitmap(buf)?);
-        Ok(())
+        lhs.bitor_assign_rhs(BitmapRhs::Serialized(buf))
     }
 }
 
@@ -193,8 +192,7 @@ impl BitmapOperate for BitmapXorOp {
     }
 
     fn operate_buf(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
-        lhs.bitxor_assign(deserialize_bitmap(buf)?);
-        Ok(())
+        lhs.bitxor_assign_rhs(BitmapRhs::Serialized(buf))
     }
 }
 
@@ -204,8 +202,7 @@ impl BitmapOperate for BitmapNotOp {
     }
 
     fn operate_buf(lhs: &mut HybridBitmap, buf: &[u8]) -> Result<()> {
-        lhs.sub_assign(deserialize_bitmap(buf)?);
-        Ok(())
+        lhs.sub_assign_rhs(BitmapRhs::Serialized(buf))
     }
 }
 

--- a/src/query/functions/src/aggregates/aggregate_bitmap.rs
+++ b/src/query/functions/src/aggregates/aggregate_bitmap.rs
@@ -231,6 +231,27 @@ impl BitmapAggState {
         }
     }
 
+    fn insert_many<I>(&mut self, values: I)
+    where I: IntoIterator<Item = u64> {
+        let mut values: Vec<u64> = values.into_iter().collect();
+        if values.is_empty() {
+            return;
+        }
+
+        let len = values.len();
+        values.sort_unstable();
+        values.dedup();
+        // Only use the batch path when dedup removes enough repeated values to pay for sorting.
+        if values.len() * 4 > len * 3 {
+            for value in values {
+                self.insert(value);
+            }
+            return;
+        }
+
+        self.add_bitmap::<BitmapOrOp>(HybridBitmap::from_iter(values));
+    }
+
     fn add<OP: BitmapOperate>(&mut self, other: &[u8]) -> Result<()> {
         match &mut self.rb {
             Some(v) => OP::operate_buf(v, other),
@@ -488,9 +509,7 @@ where
                 }
             }
         } else {
-            for value in view.iter() {
-                state.insert(value.as_());
-            }
+            state.insert_many(view.iter().map(|value| value.as_()));
         }
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Optimize bitmap aggregate paths around serialized RHS handling:

- avoid constructing temporary `SmallBitmap` for serialized small RHS in intersection paths, and calculate directly from bytes where possible
- make aggregate `operate_buf` pass serialized RHS into bitmap ops directly instead of eagerly deserializing into a temporary `HybridBitmap`
- keep large serialized AND on the existing roaring serialized intersection path; serialized RHS is still validated before empty-LHS fast return
- canonicalize serialized small values through small-set insertion semantics so duplicated values keep set behavior
- add mixed small/large bitmap benchmarks to cover representation transitions

To separate the impact of the two optimization commits, the table compares median results from serial bitmap benchmark runs:

- `base`: before this PR
- `606823`: after `perf(io): optimize hybrid bitmap small paths`
- `current`: current PR, including `perf(functions): optimize bitmap aggregate serialized ops`

| Benchmark | base | 606823 | Δ base→606823 | current | Δ 606823→current | Main source |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `bitmap_construct_agg_dense/100000` | 1.672 ms | 1.781 ms | -6.5% | 1.802 ms | -1.2% | small bitmap insert path |
| `bitmap_construct_agg_dense/1000000` | 22.62 ms | 24.06 ms | -6.4% | 24.18 ms | -0.5% | small bitmap insert path |
| `bitmap_construct_agg_repeating/100000` | 3.041 ms | 852 µs | 72.0% | 890.6 µs | -4.5% | small bitmap insert path |
| `bitmap_construct_agg_repeating/1000000` | 30.55 ms | 7.996 ms | 73.8% | 8.171 ms | -2.2% | small bitmap insert path |
| `bitmap_intersect/1000` | 6.362 ms | 5.931 ms | 6.8% | 5.57 ms | 6.1% | both commits |
| `bitmap_intersect/65535` | 424.1 ms | 385.6 ms | 9.1% | 371.9 ms | 3.6% | both commits |
| `bitmap_intersect_empty/100000` | 4.541 ms | 863.2 µs | 81.0% | 806.7 µs | 6.5% | small bitmap paths |
| `bitmap_intersect_empty/1000000` | 46.15 ms | 8.685 ms | 81.2% | 8.086 ms | 6.9% | small bitmap paths |
| `bitmap_union/1000` | 265.2 ms | 266.4 ms | -0.5% | 266.7 ms | -0.1% | not targeted / noise |
| `bitmap_union/3000` | 2.29 s | 2.28 s | 0.4% | 2.26 s | 0.9% | not targeted / noise |
| `bitmap_union/5000` | 9.93 s | 10.3 s | -3.4% | 9.8 s | 4.5% | not targeted / noise |
| `bitmap_union_disjoint/100000` | 6.87 ms | 9.547 ms | -39.0% | 8.17 ms | 14.4% | serialized `operate_buf` refactor |
| `bitmap_union_disjoint/1000000` | 78.58 ms | 107.2 ms | -36.4% | 93.54 ms | 12.7% | serialized `operate_buf` refactor |
| `bitmap_xor_agg/100000` | 37.49 ms | 12.79 ms | 65.9% | 11.3 ms | 11.6% | both commits |
| `bitmap_xor_agg/1000000` | 470.5 ms | 148.9 ms | 68.4% | 137.5 ms | 7.7% | both commits |
| `bitmap_xor_agg_overlap/1000` | 337.6 ms | 249.2 ms | 26.2% | 252.1 ms | -1.2% | small bitmap paths |
| `bitmap_xor_agg_overlap/3000` | 3.42 s | 2.63 s | 23.2% | 2.65 s | -0.7% | small bitmap paths |
| `bitmap_xor_agg_overlap/5000` | 15.4 s | 12.3 s | 20.2% | 12.2 s | 0.3% | small bitmap paths |

The strongest isolated evidence for the serialized `operate_buf` refactor is the `606823→current` step in `bitmap_union_disjoint` and `bitmap_xor_agg`. The mixed small/large bitmap benchmarks are newly added coverage, so they do not have before/after numbers:

| Benchmark | current median |
| --- | ---: |
| `bitmap_mixed_and_small_large` | 0.1558 µs |
| `bitmap_mixed_or_small_large` | 0.2018 µs |
| `bitmap_mixed_sub_large_small` | 0.2848 µs |
| `bitmap_mixed_sub_small_large` | 0.1327 µs |
| `bitmap_mixed_xor_large_small` | 0.2505 µs |
| `bitmap_mixed_xor_small_large` | 0.2425 µs |

## Tests

- [x] Unit Test
  - `cargo test -p databend-common-io bitmap --lib -j1`
- [ ] Logic Test
- [x] Benchmark Test
  - `cargo fmt --check`
  - `cargo clippy -p databend-common-io --lib --tests -j1 -- -D warnings`
  - `cargo clippy -p databend-common-functions --benches -j1 -- -D warnings`
  - `cargo bench -p databend-common-functions --bench bench --no-run -j1`
  - `bench --bench bitmap` for base, `606823`, and current bench binaries
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19771)
<!-- Reviewable:end -->
