### PR TITLE
chore: upgrade openraft alpha.18, databend-base 0.4.0, databend-meta 260312.9.0 / client 260205.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2076,6 +2076,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2352,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -2851,6 +2868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,15 +3324,16 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "databend-base"
-version = "0.3.0"
-source = "git+https://github.com/databendlabs/databend-base?tag=v0.3.0#0b1ad93c7bed03f851988cd3fe08a739c071874a"
+version = "0.4.0"
+source = "git+https://github.com/databendlabs/databend-base?tag=v0.4.0#04fe7a5d4e2a9572072fa164f37fc2efa14b3eda"
 dependencies = [
  "async-trait",
  "ctrlc",
  "futures",
- "jwt-simple",
+ "jsonwebtoken",
  "log",
  "pin-project-lite",
+ "rand 0.9.2",
  "serde",
  "tokio",
  "uuid",
@@ -3330,7 +3357,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3516,7 +3543,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -3630,7 +3657,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "log",
  "serde",
  "serde_ignored",
@@ -3948,7 +3975,7 @@ version = "0.1.0"
 dependencies = [
  "databend-common-base",
  "databend-common-exception",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "jwt-simple",
  "serde",
  "serde_json",
@@ -3975,7 +4002,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -4003,8 +4030,8 @@ dependencies = [
  "databend-common-expression",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.5.0",
- "display-more 0.2.5",
+ "databend-meta-client 260205.6.0",
+ "display-more 0.2.6",
  "fastrace",
  "futures",
  "itertools 0.13.0",
@@ -4036,9 +4063,9 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "derive_more 1.0.0",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "encoding_rs",
  "enumflags2",
  "hex",
@@ -4079,12 +4106,11 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "futures",
  "mlua",
- "openraft",
  "prost",
  "reqwest",
  "serde",
@@ -4106,8 +4132,7 @@ dependencies = [
  "databend-common-proto-conv",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.5.0",
- "openraft",
+ "databend-meta-client 260205.6.0",
  "prost",
  "regex",
  "serde",
@@ -4126,7 +4151,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "fastrace",
  "log",
  "maplit",
@@ -4142,7 +4167,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4158,7 +4183,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4280,7 +4305,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "enumflags2",
  "fastrace",
  "log",
@@ -4386,7 +4411,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4505,7 +4530,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -4603,7 +4628,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -4663,7 +4688,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
  "fastrace",
@@ -4701,7 +4726,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -4907,7 +4932,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -4999,7 +5024,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5060,7 +5085,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
 ]
 
 [[package]]
@@ -5132,7 +5157,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5160,7 +5185,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
 ]
 
 [[package]]
@@ -5173,7 +5198,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "log",
  "tokio",
 ]
@@ -5327,8 +5352,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5338,16 +5363,16 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260312.7.0",
- "databend-meta-kvapi 260312.7.0",
+ "databend-meta-client 260312.9.0",
+ "databend-meta-kvapi 260312.9.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260312.7.0",
+ "databend-meta-runtime-api 260312.9.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.7.0",
- "databend-meta-version 260312.7.0",
+ "databend-meta-types 260312.9.0",
+ "databend-meta-version 260312.9.0",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "feature-set",
  "futures",
@@ -5393,7 +5418,6 @@ dependencies = [
  "http 1.3.1",
  "log",
  "maplit",
- "openraft-rt",
  "poem",
  "pretty_assertions",
  "reqwest",
@@ -5406,13 +5430,13 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "map-api",
  "seq-marked",
  "serde",
@@ -5440,17 +5464,16 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "futures",
  "log",
  "mlua",
  "num_cpus",
- "openraft",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5478,21 +5501,21 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "anyerror",
  "arrow-flight",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.5.0",
- "databend-meta-kvapi-test-suite 260205.5.0",
- "databend-meta-runtime-api 260205.5.0",
- "databend-meta-types 260205.5.0",
- "databend-meta-version 260205.5.0",
+ "databend-meta-kvapi 260205.6.0",
+ "databend-meta-kvapi-test-suite 260205.6.0",
+ "databend-meta-runtime-api 260205.6.0",
+ "databend-meta-types 260205.6.0",
+ "databend-meta-version 260205.6.0",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "futures",
  "itertools 0.13.0",
@@ -5510,8 +5533,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5520,12 +5543,12 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.7.0",
- "databend-meta-kvapi-test-suite 260312.7.0",
- "databend-meta-runtime-api 260312.7.0",
- "databend-meta-version 260312.7.0",
+ "databend-meta-kvapi 260312.9.0",
+ "databend-meta-kvapi-test-suite 260312.9.0",
+ "databend-meta-runtime-api 260312.9.0",
+ "databend-meta-version 260312.9.0",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "futures",
  "futures-util",
@@ -5544,8 +5567,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5568,21 +5591,21 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "databend-base",
- "databend-meta-types 260205.5.0",
- "display-more 0.2.5",
+ "databend-meta-types 260205.6.0",
+ "display-more 0.2.6",
  "futures-util",
  "log",
  "serde",
@@ -5591,14 +5614,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyhow",
  "async-trait",
  "databend-base",
  "databend-meta-client-types",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "futures-util",
  "log",
  "serde",
@@ -5607,13 +5630,13 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.5.0",
- "databend-meta-types 260205.5.0",
- "display-more 0.2.5",
+ "databend-meta-kvapi 260205.6.0",
+ "databend-meta-types 260205.6.0",
+ "display-more 0.2.6",
  "fastrace",
  "futures-util",
  "log",
@@ -5623,13 +5646,13 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260312.7.0",
- "display-more 0.2.5",
+ "databend-meta-kvapi 260312.9.0",
+ "display-more 0.2.6",
  "fastrace",
  "futures-util",
  "log",
@@ -5643,7 +5666,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -5661,10 +5684,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codeq",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "futures",
  "itertools 0.13.0",
@@ -5679,14 +5702,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "databend-meta-base",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "map-api",
  "num-derive",
  "num-traits",
@@ -5702,21 +5725,21 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260312.7.0",
- "databend-meta-runtime-api 260312.7.0",
+ "databend-meta-kvapi 260312.9.0",
+ "databend-meta-runtime-api 260312.9.0",
  "databend-meta-sled-store",
- "databend-meta-types 260312.7.0",
+ "databend-meta-types 260312.9.0",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fastrace",
  "fs_extra",
  "futures",
@@ -5750,7 +5773,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "fastrace",
  "tokio",
  "tonic 0.13.1",
@@ -5758,8 +5781,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5771,8 +5794,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5784,12 +5807,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260312.7.0",
+ "databend-meta-types 260312.9.0",
  "fastrace",
  "log",
  "serde",
@@ -5802,14 +5825,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260312.7.0",
- "databend-meta-types 260312.7.0",
+ "databend-meta-runtime-api 260312.9.0",
+ "databend-meta-types 260312.9.0",
  "fastrace",
  "log",
  "tempfile",
@@ -5819,13 +5842,13 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "anyerror",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "futures-util",
  "log",
  "map-api",
@@ -5847,15 +5870,15 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "anyerror",
  "databend-meta-base",
  "databend-meta-proto",
  "deepsize",
  "derive_more 2.1.1",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "futures-util",
  "log",
  "map-api",
@@ -5882,16 +5905,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.5.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
+version = "260205.6.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.6.0#bb165546c8854746d423856b1f1d22d7ddcd34c7"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260312.7.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
+version = "260312.9.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.9.0#5f8ca029545a2b4498d120087ebc45c6829dfe98"
 dependencies = [
  "semver",
 ]
@@ -5985,7 +6008,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6337,7 +6360,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.5.0",
+ "databend-meta-client 260205.6.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -6806,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "display-more"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e85d4429a3c743da69348828b4de799e5cfaa7f503c1a522a5bfa54fa03645"
+checksum = "bf8aaad655bf39f0691f6f4025a8b58f1ff46fb12cb70f6d69e4f0dd2eb717a8"
 dependencies = [
  "chrono",
  "chrono-tz 0.8.6",
@@ -8055,9 +8078,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -12271,22 +12308,28 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.17"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.17#d86454ebc5c98382bac7816f7bdd0a353b973f2a"
+version = "0.10.0-alpha.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f600d7c69fcd2fead0596885234df36bd8b93f15c852b2b7c3b2fae4d6c1d3c3"
 dependencies = [
  "anyerror",
+ "base2histogram",
  "byte-unit",
  "chrono",
  "clap",
  "derive_more 2.1.1",
+ "display-more 0.2.6",
  "futures-util",
+ "itertools 0.14.0",
  "maplit",
  "openraft-macros",
  "openraft-rt",
  "openraft-rt-tokio",
  "peel-off",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
+ "smallvec",
+ "tabled",
  "thiserror 2.0.18",
  "tracing",
  "validit",
@@ -12294,8 +12337,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.17"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.17#d86454ebc5c98382bac7816f7bdd0a353b973f2a"
+version = "0.10.0-alpha.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda46a3fbcc59b3b7ff8266e3277bcb6932e70877324aa71cbd8fc098539d4e"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -12306,23 +12350,26 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.17"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.17#d86454ebc5c98382bac7816f7bdd0a353b973f2a"
+version = "0.10.0-alpha.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe112eddd9a3ac82afa54aa6787602e1759c3f84acf7d4c897e8bd717498033"
 dependencies = [
  "futures-channel",
  "futures-util",
  "openraft-macros",
- "rand 0.9.2",
+ "pin-project-lite",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.17"
-source = "git+https://github.com/databendlabs/openraft?tag=v0.10.0-alpha.17#d86454ebc5c98382bac7816f7bdd0a353b973f2a"
+version = "0.10.0-alpha.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f769f44ec27ff08a63b464f6aecb6988a0146c5b73bc3fe89bae4df0383afe06"
 dependencies = [
  "futures-util",
  "openraft-rt",
- "rand 0.9.2",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -12674,6 +12721,17 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -13207,7 +13265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -14014,6 +14072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14027,7 +14091,7 @@ checksum = "c273df82ff5ef584c3b38ca603942b5c2b0b786f7bad70881c6d85b485f5778b"
 dependencies = [
  "byteorder",
  "codeq",
- "display-more 0.2.5",
+ "display-more 0.2.6",
  "fs2",
  "log",
  "thiserror 1.0.69",
@@ -14062,6 +14126,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -14102,6 +14177,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -15424,7 +15505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -15451,7 +15532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -16542,6 +16623,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16815,6 +16920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
 dependencies = [
  "testcontainers",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -17996,6 +18110,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18102,6 +18234,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18135,6 +18289,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
  "bitflags 2.9.0",
+ "indexmap 2.12.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.0",
+ "hashbrown 0.15.3",
  "indexmap 2.12.0",
  "semver",
 ]
@@ -18248,7 +18414,7 @@ dependencies = [
  "syn 2.0.106",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.219.2",
 ]
 
 [[package]]
@@ -18390,7 +18556,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.12.0",
- "wit-parser",
+ "wit-parser 0.219.2",
 ]
 
 [[package]]
@@ -19156,12 +19322,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.12.0",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.0",
+ "indexmap 2.12.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -19180,6 +19422,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,11 +168,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260312.7.0"
-databend-meta-test-harness = "260312.7.0"
+databend-meta = "260312.9.0"
+databend-meta-test-harness = "260312.9.0"
 
 # External meta client
-databend-meta-client = "260205.5.0"
+databend-meta-client = "260205.6.0"
 
 # Crates.io dependencies
 ahash = { version = "0.8", features = ["no-rng"] }
@@ -244,7 +244,7 @@ crossbeam-channel = "0.5.6"
 csv-core = "0.1.13"
 ctor = "0.2"
 dashmap = { version = "6.1.0", features = ["serde"] }
-databend-base = "0.3.0"
+databend-base = "0.4.0"
 defer = "0.2"
 deltalake = "0.26"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
@@ -380,11 +380,6 @@ opendal = { version = "0.54.1", features = [
     "services-webhdfs",
     "services-huggingface",
 ] }
-openraft = { version = "0.10.0-alpha.14", features = [
-    "serde",
-    "tracing-log",
-] }
-openraft-rt = "0.10.0-alpha.14"
 opensrv-mysql = { git = "https://github.com/databendlabs/opensrv.git", tag = "v0.10.0", features = ["tls"] }
 orc-rust = "0.6.0"
 ordered-float = { version = "5.1.0", default-features = false }
@@ -623,14 +618,12 @@ async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.gi
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
-databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.3.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.7.0" }
-databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.5.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.7.0" }
+databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.9.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.6.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260312.9.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
-openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
-openraft-rt = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc812ad7010" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }

--- a/src/meta/admin/Cargo.toml
+++ b/src/meta/admin/Cargo.toml
@@ -21,7 +21,6 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-openraft-rt = { workspace = true }
 poem = { workspace = true }
 serde = { workspace = true }
 serde_urlencoded = { workspace = true }

--- a/src/meta/admin/src/v1/ctrl.rs
+++ b/src/meta/admin/src/v1/ctrl.rs
@@ -15,12 +15,12 @@
 use std::sync::Arc;
 
 use databend_meta::meta_node::meta_handle::MetaHandle;
+use databend_meta::openraft::rt::watch::WatchReceiver;
 use databend_meta::runtime_api::SpawnApi;
 use databend_meta::types::raft_types::NodeId;
 use http::StatusCode;
 use log::info;
 use log::warn;
-use openraft_rt::watch::WatchReceiver;
 use poem::IntoResponse;
 use poem::Response;
 use poem::web::Json;

--- a/src/meta/admin/src/v1/features.rs
+++ b/src/meta/admin/src/v1/features.rs
@@ -16,12 +16,12 @@ use std::sync::Arc;
 
 use databend_meta::meta_node::errors::MetaNodeStopped;
 use databend_meta::meta_node::meta_handle::MetaHandle;
+use databend_meta::openraft::rt::watch::WatchReceiver;
 use databend_meta::raft_store::StateMachineFeature;
 use databend_meta::runtime_api::SpawnApi;
 use http::StatusCode;
 use log::info;
 use log::warn;
-use openraft_rt::watch::WatchReceiver;
 use poem::IntoResponse;
 use poem::Response;
 use poem::web::Json;

--- a/src/meta/admin/tests/it/features.rs
+++ b/src/meta/admin/tests/it/features.rs
@@ -16,6 +16,7 @@
 
 use std::time::Duration;
 
+use databend_meta::openraft::rt::watch::WatchReceiver;
 use databend_meta::raft_store::StateMachineFeature;
 use databend_meta_admin::HttpService;
 use databend_meta_admin::HttpServiceConfig;
@@ -24,7 +25,6 @@ use databend_meta_runtime::DatabendRuntime;
 use databend_meta_test_harness::meta_service_test_harness;
 use databend_meta_test_harness::start_metasrv_cluster;
 use log::info;
-use openraft_rt::watch::WatchReceiver;
 use pretty_assertions::assert_eq;
 use test_harness::test;
 use tokio::time::Instant;

--- a/src/meta/admin/tests/it/transfer_leader.rs
+++ b/src/meta/admin/tests/it/transfer_leader.rs
@@ -14,13 +14,13 @@
 
 use std::time::Duration;
 
+use databend_meta::openraft::rt::watch::WatchReceiver;
 use databend_meta_admin::HttpService;
 use databend_meta_admin::HttpServiceConfig;
 use databend_meta_runtime::DatabendRuntime;
 use databend_meta_test_harness::meta_service_test_harness;
 use databend_meta_test_harness::start_metasrv_cluster;
 use log::info;
-use openraft_rt::watch::WatchReceiver;
 use pretty_assertions::assert_eq;
 use test_harness::test;
 use tokio::time::Instant;

--- a/src/meta/binaries/Cargo.toml
+++ b/src/meta/binaries/Cargo.toml
@@ -43,7 +43,6 @@ futures = { workspace = true }
 log = { workspace = true }
 mlua = { workspace = true }
 num_cpus = { workspace = true }
-openraft = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/binaries/meta/entry.rs
+++ b/src/meta/binaries/meta/entry.rs
@@ -39,6 +39,7 @@ use databend_meta::meta_node::meta_worker::MetaWorker;
 use databend_meta::meta_service::MetaNode;
 use databend_meta::meta_service::meta_leader::MetaLeader;
 use databend_meta::metrics::server_metrics;
+use databend_meta::openraft::MessageSummary;
 use databend_meta::raft_store::config::RaftConfig;
 use databend_meta::raft_store::ondisk::DATA_VERSION;
 use databend_meta::raft_store::ondisk::OnDisk;
@@ -57,7 +58,6 @@ use databend_meta_cli_config::MetaConfig;
 use databend_meta_ver::MIN_QUERY_VER_FOR_METASRV;
 use log::info;
 use log::warn;
-use openraft::MessageSummary;
 use tokio::time::Instant;
 use tokio::time::sleep;
 

--- a/src/meta/control/Cargo.toml
+++ b/src/meta/control/Cargo.toml
@@ -20,7 +20,6 @@ clap = { workspace = true }
 display-more = { workspace = true }
 futures = { workspace = true }
 mlua = { workspace = true }
-openraft = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/control/src/import.rs
+++ b/src/meta/control/src/import.rs
@@ -23,6 +23,8 @@ use std::io::Lines;
 use std::path::Path;
 use std::str::FromStr;
 
+use databend_meta::openraft::storage::RaftLogStorageExt;
+use databend_meta::openraft::storage::RaftSnapshotBuilder;
 use databend_meta::raft_store::config::RaftConfig;
 use databend_meta::raft_store::ondisk::DataVersion;
 use databend_meta::raft_store::raft_log::api::raft_log_writer::RaftLogWriter;
@@ -42,8 +44,6 @@ use databend_meta::types::raft_types::NodeId;
 use databend_meta::types::raft_types::StoredMembership;
 use databend_meta::types::raft_types::new_log_id;
 use display_more::display_option::DisplayOptionExt;
-use openraft::storage::RaftLogStorageExt;
-use openraft::storage::RaftSnapshotBuilder;
 use url::Url;
 
 use crate::args::ImportArgs;

--- a/src/meta/process/Cargo.toml
+++ b/src/meta/process/Cargo.toml
@@ -16,7 +16,6 @@ databend-common-proto-conv = { workspace = true }
 databend-common-tracing = { workspace = true }
 databend-meta = { workspace = true }
 databend-meta-client = { workspace = true }
-openraft = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/process/src/kv_processor.rs
+++ b/src/meta/process/src/kv_processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::Error;
+use databend_meta::openraft::EntryPayload;
 use databend_meta::raft_store::key_spaces::RaftStoreEntry;
 use databend_meta::types::Cmd;
 use databend_meta::types::LogEntry;
@@ -26,7 +27,6 @@ use databend_meta::types::UpsertKV;
 use databend_meta::types::raft_types::Entry;
 use databend_meta::types::txn_condition::Target;
 use databend_meta::types::txn_op::Request;
-use openraft::EntryPayload;
 
 use crate::process::Process;
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: upgrade openraft alpha.18, databend-base 0.4.0, databend-meta 260312.9.0 / client 260205.6.0
Upgrade the tightly-coupled external meta deps together. The server
crate (`databend-meta` 260312.9.0) now re-exports `openraft` (and
transitively `openraft::rt` = openraft_rt), so databend reaches those
symbols via the server crate instead of carrying its own openraft
dependency.

Client line is bumped in lockstep to v260205.6.0 which picks up the
matching dep-bump plus the `MetaNode::get_leader` filter fix
(openraft alpha.18 started exposing raw vote leader ids that are not
yet in effective membership -- valid in openraft but violates
databend-meta's invariant). Public wire format and gRPC API of the
client are unchanged.

Changes:
- Bump `databend-base` `0.3.0` → `0.4.0` (swaps `jwt-simple` for
  `jsonwebtoken`, fixes RUSTSEC-2023-0071)
- Bump `databend-meta` / `databend-meta-test-harness` `260312.7.0` →
  `260312.9.0`
- Bump `databend-meta-client` `260205.5.0` → `260205.6.0`
- Drop `openraft` and `openraft-rt` from `[workspace.dependencies]`
  and `[patch.crates-io]`; consumers reach them through
  `databend_meta::openraft::*` and `databend_meta::openraft::rt::*`
- Drop direct `openraft` / `openraft-rt` deps from
  `src/meta/{admin,binaries,control,process}/Cargo.toml`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19772)
<!-- Reviewable:end -->
