### PR TITLE
fix(query): avoid deep filter predicate trees

### DIFF
--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter_test.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter_test.rs
@@ -48,29 +48,29 @@ fn expr_to_string(expr: &ScalarExpr) -> String {
                     }
                 }
                 "column(?)".to_string()
-            } else if func.func_name == "and" {
+            } else if matches!(func.func_name.as_str(), "and" | "and_filters") {
                 if func.arguments.is_empty() {
                     "true".to_string() // Empty AND is true
                 } else if func.arguments.len() == 1 {
                     expr_to_string(&func.arguments[0])
                 } else {
-                    format!(
-                        "({} AND {})",
-                        expr_to_string(&func.arguments[0]),
-                        expr_to_string(&func.arguments[1])
-                    )
+                    func.arguments
+                        .iter()
+                        .map(expr_to_string)
+                        .reduce(|lhs, rhs| format!("({lhs} AND {rhs})"))
+                        .expect("handled empty arguments")
                 }
-            } else if func.func_name == "or" {
+            } else if matches!(func.func_name.as_str(), "or" | "or_filters") {
                 if func.arguments.is_empty() {
                     "false".to_string() // Empty OR is false
                 } else if func.arguments.len() == 1 {
                     expr_to_string(&func.arguments[0])
                 } else {
-                    format!(
-                        "({} OR {})",
-                        expr_to_string(&func.arguments[0]),
-                        expr_to_string(&func.arguments[1])
-                    )
+                    func.arguments
+                        .iter()
+                        .map(expr_to_string)
+                        .reduce(|lhs, rhs| format!("({lhs} OR {rhs})"))
+                        .expect("handled empty arguments")
                 }
             } else if func.func_name == "=" {
                 format!(
@@ -231,7 +231,7 @@ fn test_different_table_columns() -> anyhow::Result<()> {
 
     // Check if the second expression is (t2.b OR t2.c)
     if let ScalarExpr::FunctionCall(func) = &after[1] {
-        assert_eq!(func.func_name, "or");
+        assert!(matches!(func.func_name.as_str(), "or" | "or_filters"));
         assert_eq!(func.arguments.len(), 2);
 
         // Check t2.b

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -120,15 +120,71 @@ pub fn reject_grouping_functions<'a>(
 }
 
 pub fn split_conjunctions(scalar: &ScalarExpr) -> Vec<ScalarExpr> {
-    match scalar {
-        ScalarExpr::FunctionCall(func) if func.func_name == "and" => [
-            split_conjunctions(&func.arguments[0]),
-            split_conjunctions(&func.arguments[1]),
-        ]
-        .concat(),
-        _ => {
-            vec![scalar.clone()]
+    let mut predicates = Vec::new();
+    let mut stack = vec![scalar];
+
+    while let Some(scalar) = stack.pop() {
+        match scalar {
+            ScalarExpr::FunctionCall(func)
+                if matches!(func.func_name.as_str(), "and" | "and_filters") =>
+            {
+                stack.extend(func.arguments.iter().rev());
+            }
+            _ => {
+                predicates.push(scalar.clone());
+            }
         }
+    }
+
+    predicates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bool_constant(value: bool) -> ScalarExpr {
+        ScalarExpr::ConstantExpr(ConstantExpr {
+            span: None,
+            value: Scalar::Boolean(value),
+        })
+    }
+
+    fn and(lhs: ScalarExpr, rhs: ScalarExpr) -> ScalarExpr {
+        ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "and".to_string(),
+            params: vec![],
+            arguments: vec![lhs, rhs],
+        })
+    }
+
+    #[test]
+    fn test_split_conjunctions_handles_deep_and_chain() {
+        let mut expr = bool_constant(true);
+        for _ in 0..1024 {
+            expr = and(expr, bool_constant(true));
+        }
+
+        let predicates = split_conjunctions(&expr);
+        assert_eq!(predicates.len(), 1025);
+    }
+
+    #[test]
+    fn test_split_conjunctions_handles_and_filters() {
+        let expr = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "and_filters".to_string(),
+            params: vec![],
+            arguments: vec![
+                bool_constant(true),
+                and(bool_constant(true), bool_constant(true)),
+                bool_constant(false),
+            ],
+        });
+
+        let predicates = split_conjunctions(&expr);
+        assert_eq!(predicates.len(), 4);
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
@@ -110,33 +110,74 @@ fn normalize_predicate_scalar(predicate_scalar: PredicateScalar) -> ScalarExpr {
     match predicate_scalar {
         PredicateScalar::And(args) => {
             assert!(args.len() >= 2);
-            args.into_iter()
-                .map(normalize_predicate_scalar)
-                .reduce(|lhs, rhs| {
-                    ScalarExpr::FunctionCall(FunctionCall {
-                        span: None,
-                        func_name: "and".to_string(),
-                        params: vec![],
-                        arguments: vec![lhs, rhs],
-                    })
-                })
-                .expect("has at least two args")
+            ScalarExpr::FunctionCall(FunctionCall {
+                span: None,
+                func_name: "and_filters".to_string(),
+                params: vec![],
+                arguments: args.into_iter().map(normalize_predicate_scalar).collect(),
+            })
         }
         PredicateScalar::Or(args) => {
             assert!(args.len() >= 2);
-            args.into_iter()
-                .map(normalize_predicate_scalar)
-                .reduce(|lhs, rhs| {
-                    ScalarExpr::FunctionCall(FunctionCall {
-                        span: None,
-                        func_name: "or".to_string(),
-                        params: vec![],
-                        arguments: vec![lhs, rhs],
-                    })
-                })
-                .expect("has at least two args")
+            ScalarExpr::FunctionCall(FunctionCall {
+                span: None,
+                func_name: "or_filters".to_string(),
+                params: vec![],
+                arguments: args.into_iter().map(normalize_predicate_scalar).collect(),
+            })
         }
         PredicateScalar::Other(expr) => *expr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::Scalar;
+    use databend_common_expression::types::NumberScalar;
+
+    use super::*;
+
+    fn bool_constant(value: bool) -> ScalarExpr {
+        ScalarExpr::ConstantExpr(ConstantExpr {
+            span: None,
+            value: Scalar::Boolean(value),
+        })
+    }
+
+    fn int_constant(value: i64) -> ScalarExpr {
+        ScalarExpr::ConstantExpr(ConstantExpr {
+            span: None,
+            value: Scalar::Number(NumberScalar::Int64(value)),
+        })
+    }
+
+    fn binary_filter(func_name: &str, lhs: ScalarExpr, rhs: ScalarExpr) -> ScalarExpr {
+        ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: func_name.to_string(),
+            params: vec![],
+            arguments: vec![lhs, rhs],
+        })
+    }
+
+    #[test]
+    fn test_normalize_predicate_scalar_keeps_flat_filters() {
+        let mut expr = bool_constant(false);
+        for i in 0..256 {
+            let term = binary_filter("and", bool_constant(true), int_constant(i));
+            expr = binary_filter("or", expr, term);
+        }
+
+        let predicates = NormalizeDisjunctiveFilterOptimizer::new()
+            .optimize(vec![expr])
+            .unwrap();
+
+        assert_eq!(predicates.len(), 1);
+        let ScalarExpr::FunctionCall(func) = &predicates[0] else {
+            panic!("expected normalized predicate to remain a function call");
+        };
+        assert_eq!(func.func_name, "or_filters");
+        assert!(func.arguments.len() > 2);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Avoid stack overflow when planning queries with deeply nested boolean predicates, such as large generated `HAVING` / filter expressions.

  ## Changes

  - Normalize disjunctive filter output into flat `and_filters` / `or_filters` calls instead of rebuilding deeply nested binary `and` / `or` trees.
  - Make `split_conjunctions` iterative and teach it to split both `and` and `and_filters`.
  - Add regression coverage for deep predicate normalization and conjunction splitting.
  - Update optimizer tests to treat flat filter functions as equivalent boolean predicate forms.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19776)
<!-- Reviewable:end -->
