### PR TITLE
feat: negotiate HTTP arrow features and stringify variant schema

### DIFF
--- a/src/common/io/src/format_settings.rs
+++ b/src/common/io/src/format_settings.rs
@@ -148,6 +148,8 @@ pub struct OutputFormatSettings {
     pub headers: u8,
     // used only for compat with old bendSQL driver.
     pub http_arrow_use_jsonb: bool,
+    // used only in http arrow response to gate decimal64 physical type output.
+    pub http_arrow_use_decimal64: bool,
 
     pub json_compact: bool,
     pub json_strings: bool,
@@ -165,6 +167,7 @@ impl Default for OutputFormatSettings {
             http_json_result_mode: HttpHandlerDataFormat::Display,
             headers: 0,
             http_arrow_use_jsonb: false,
+            http_arrow_use_decimal64: true,
             json_compact: false,
             json_strings: false,
             format_null_as_str: false,

--- a/src/query/service/Cargo.toml
+++ b/src/query/service/Cargo.toml
@@ -32,6 +32,7 @@ storage-hdfs = ["opendal/services-hdfs", "databend-common-storage/storage-hdfs"]
 anyhow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-flight = { workspace = true }
 arrow-ipc = { workspace = true }
 arrow-json = { workspace = true }
@@ -185,7 +186,6 @@ uuid = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
-arrow-cast = { workspace = true }
 databend-common-sql-test-support = { workspace = true }
 databend-storages-common-pruner = { workspace = true }
 geo = { workspace = true }

--- a/src/query/service/src/servers/http/v1/http_query_handlers.rs
+++ b/src/query/service/src/servers/http/v1/http_query_handlers.rs
@@ -68,6 +68,7 @@ use super::query::HttpQuery;
 use super::query::HttpQueryRequest;
 use super::query::HttpQueryResponseInternal;
 use super::query::ResponseState;
+use super::query::execute_state::ARROW_FEATURE_NEGOTIATION_VERSION;
 use super::query::execute_state::LEGACY_ARROW_RESULT_VERSION;
 use super::query::execute_state::SERVER_MAX_ARROW_RESULT_VERSION;
 use super::query::execute_state::legacy_bendsql_python_arrow_result_version;
@@ -156,6 +157,28 @@ pub struct QueryResponseSettings {
     pub http_json_result_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arrow_result_version: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arrow_features: Option<ArrowFeatures>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArrowFeatures {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decimal64: Option<bool>,
+}
+
+impl ArrowFeatures {
+    pub(crate) fn decimal64_enabled() -> Self {
+        Self {
+            decimal64: Some(true),
+        }
+    }
+
+    fn visible_enabled_only(&self) -> Option<Self> {
+        self.decimal64
+            .filter(|enabled| *enabled)
+            .map(|_| Self::decimal64_enabled())
+    }
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -211,6 +234,7 @@ impl QueryResponse {
                     warnings,
                     response_settings,
                     arrow_result_version: _,
+                    arrow_features: _,
                 },
         }: HttpQueryResponseInternal,
         is_final: bool,
@@ -263,7 +287,8 @@ impl QueryResponse {
                 || encoding.arrow_result_version.is_some()
         );
         let response_settings = response_settings.map(|mut settings| {
-            settings.arrow_result_version = visible_arrow_result_version(encoding);
+            settings.arrow_result_version = visible_arrow_result_version(&encoding);
+            settings.arrow_features = visible_arrow_features(&encoding);
             settings
         });
 
@@ -324,13 +349,29 @@ impl QueryResponse {
     }
 }
 
-fn visible_arrow_result_version(encoding: ResponseEncoding) -> Option<u64> {
+fn visible_arrow_result_version(encoding: &ResponseEncoding) -> Option<u64> {
     match encoding.format {
         QueryResultFormat::Json => None,
         QueryResultFormat::Arrow => encoding
             .arrow_result_version
             .filter(|version| *version != LEGACY_ARROW_RESULT_VERSION),
     }
+}
+
+fn visible_arrow_features(encoding: &ResponseEncoding) -> Option<ArrowFeatures> {
+    if matches!(encoding.format, QueryResultFormat::Json) {
+        return None;
+    }
+
+    encoding
+        .arrow_result_version
+        .filter(|version| *version >= ARROW_FEATURE_NEGOTIATION_VERSION)
+        .and_then(|_| {
+            encoding
+                .arrow_features
+                .as_ref()
+                .and_then(ArrowFeatures::visible_enabled_only)
+        })
 }
 
 fn negotiate_arrow_result_version(
@@ -360,6 +401,28 @@ fn negotiate_arrow_result_version(
     )))
 }
 
+fn negotiate_arrow_features(
+    req: &HttpQueryRequest,
+    arrow_result_version: Option<u64>,
+) -> Option<ArrowFeatures> {
+    if arrow_result_version? < ARROW_FEATURE_NEGOTIATION_VERSION {
+        return None;
+    }
+
+    Some(
+        match req
+            .arrow_features
+            .as_ref()
+            .and_then(|features| features.decimal64)
+        {
+            Some(false) => ArrowFeatures {
+                decimal64: Some(false),
+            },
+            _ => ArrowFeatures::decimal64_enabled(),
+        },
+    )
+}
+
 fn require_negotiated_arrow_result_version(
     query_id: &str,
     query_result_format: QueryResultFormat,
@@ -382,10 +445,11 @@ pub struct StateResponse {
     pub stats: QueryStats,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ResponseEncoding {
     format: QueryResultFormat,
     arrow_result_version: Option<u64>,
+    arrow_features: Option<ArrowFeatures>,
 }
 
 impl StateResponse {
@@ -477,6 +541,7 @@ async fn query_final_handler(
                         response.state.arrow_result_version,
                     )
                     .map_err(HttpErrorCode::bad_request)?,
+                    arrow_features: response.state.arrow_features.clone(),
                 };
                 // it is safe to set these 2 fields to None, because client now check for null/None first.
                 response.session = None;
@@ -610,6 +675,7 @@ async fn query_page_handler(
                         resp.state.arrow_result_version,
                     )
                     .map_err(HttpErrorCode::bad_request)?,
+                    arrow_features: resp.state.arrow_features.clone(),
                 };
                 query
                     .update_expire_time(false, resp.is_data_drained())
@@ -699,6 +765,7 @@ pub(crate) async fn query_handler(
                             resp.state.arrow_result_version,
                         )
                         .map_err(HttpErrorCode::bad_request)?,
+                        arrow_features: resp.state.arrow_features.clone(),
                     };
                     Ok(QueryResponse::from_internal(
                         ctx.query_id.clone(),
@@ -713,8 +780,16 @@ pub(crate) async fn query_handler(
         let arrow_result_version =
             negotiate_arrow_result_version(&req, query_result_format, ctx.user_agent.as_deref())
                 .map_err(HttpErrorCode::bad_request)?;
+        let arrow_features = negotiate_arrow_features(&req, arrow_result_version);
 
-        match HttpQuery::try_create(ctx, req.clone(), arrow_result_version).await {
+        match HttpQuery::try_create(
+            ctx,
+            req.clone(),
+            arrow_result_version,
+            arrow_features.clone(),
+        )
+        .await
+        {
             Err(err) => {
                 let err = err.display_with_sql(&sql);
                 error!("Failed to start SQL query, error: {:?}", err);
@@ -774,6 +849,7 @@ pub(crate) async fn query_handler(
                     ResponseEncoding {
                         format: query_result_format,
                         arrow_result_version,
+                        arrow_features,
                     },
                 )
                 .into_response())
@@ -1198,5 +1274,53 @@ impl<'a> FromRequest<'a> for QueryResultFormat {
             .headers()
             .typed_get::<Self>()
             .unwrap_or(QueryResultFormat::Json))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::servers::http::v1::query::HttpQueryRequest;
+
+    fn dummy_request(arrow_features: Option<ArrowFeatures>) -> HttpQueryRequest {
+        HttpQueryRequest {
+            session_id: None,
+            session: None,
+            sql: "select 1".to_string(),
+            pagination: Default::default(),
+            string_fields: true,
+            stage_attachment: None,
+            params: None,
+            arrow_result_version_max: None,
+            arrow_features,
+        }
+    }
+
+    #[test]
+    fn test_negotiate_arrow_features_preserves_explicit_decimal64_disable() {
+        let features = negotiate_arrow_features(
+            &dummy_request(Some(ArrowFeatures {
+                decimal64: Some(false),
+            })),
+            Some(ARROW_FEATURE_NEGOTIATION_VERSION),
+        );
+        assert_eq!(
+            features,
+            Some(ArrowFeatures {
+                decimal64: Some(false),
+            })
+        );
+    }
+
+    #[test]
+    fn test_visible_arrow_features_hides_disabled_entries() {
+        let encoding = ResponseEncoding {
+            format: QueryResultFormat::Arrow,
+            arrow_result_version: Some(ARROW_FEATURE_NEGOTIATION_VERSION),
+            arrow_features: Some(ArrowFeatures {
+                decimal64: Some(false),
+            }),
+        };
+        assert_eq!(visible_arrow_features(&encoding), None);
     }
 }

--- a/src/query/service/src/servers/http/v1/query/blocks_serializer.rs
+++ b/src/query/service/src/servers/http/v1/query/blocks_serializer.rs
@@ -12,19 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use arrow_array::Array;
+use arrow_array::LargeListArray;
+use arrow_array::LargeStringArray;
+use arrow_array::MapArray;
+use arrow_array::RecordBatch;
+use arrow_array::StructArray;
+use arrow_array::cast::AsArray;
+use arrow_array::make_array;
+use arrow_buffer::OffsetBuffer;
+use arrow_buffer::ScalarBuffer;
+use arrow_cast::cast;
 use arrow_ipc::CompressionType;
 use arrow_ipc::MetadataVersion;
 use arrow_ipc::writer::IpcWriteOptions;
 use arrow_ipc::writer::StreamWriter;
+use arrow_schema::DataType as ArrowDataType;
+use arrow_schema::Field as ArrowField;
+use arrow_schema::Fields as ArrowFields;
+use arrow_schema::Schema as ArrowSchema;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchema;
-use databend_common_expression::types::array::ArrayColumn;
+use databend_common_expression::converts::arrow::ARROW_EXT_TYPE_VARIANT;
+use databend_common_expression::converts::arrow::EXTENSION_KEY;
 use databend_common_expression::types::binary::BinaryColumn;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::geography::GeographyColumn;
@@ -116,22 +134,18 @@ impl BlocksSerializer {
         data_schema: &DataSchema,
         ext_meta: Vec<(String, String)>,
     ) -> Result<Vec<u8>> {
-        let mut schema = arrow_schema::Schema::from(data_schema);
+        let mut schema = build_arrow_ipc_schema(data_schema, self.format.as_ref());
         schema.metadata.extend(ext_meta);
+        let schema = Arc::new(schema);
 
         let mut buf = Vec::new();
         let opts = IpcWriteOptions::try_new(8, false, MetadataVersion::V5)?
             .try_with_compression(Some(CompressionType::LZ4_FRAME))?;
-        let mut writer = StreamWriter::try_new_with_options(&mut buf, &schema, opts)?;
+        let mut writer = StreamWriter::try_new_with_options(&mut buf, schema.as_ref(), opts)?;
 
-        for (block, _) in &self.columns {
-            let columns = if let Some(format) = &self.format {
-                format_arrow_ipc_columns(block, format)?
-            } else {
-                block.clone()
-            };
-            let block = DataBlock::new_from_columns(columns);
-            let batch = block.to_record_batch_with_dataschema(data_schema)?;
+        for (columns, num_rows) in &self.columns {
+            let batch =
+                format_arrow_ipc_batch(columns, *num_rows, schema.clone(), self.format.as_ref())?;
             writer.write(&batch)?;
         }
         writer.finish()?;
@@ -139,65 +153,247 @@ impl BlocksSerializer {
     }
 }
 
-fn format_arrow_ipc_columns(
-    columns: &[Column],
-    format: &OutputFormatSettings,
-) -> Result<Vec<Column>> {
-    columns
-        .iter()
-        .map(|column| format_arrow_ipc_column(column, format))
-        .collect()
+fn build_arrow_ipc_schema(
+    data_schema: &DataSchema,
+    format: Option<&OutputFormatSettings>,
+) -> arrow_schema::Schema {
+    let schema = arrow_schema::Schema::from(data_schema);
+    rewrite_arrow_ipc_schema(&schema, format)
 }
 
-fn format_arrow_ipc_column(column: &Column, format: &OutputFormatSettings) -> Result<Column> {
-    let geometry_format = format.geometry_format;
-    match column {
-        Column::Geometry(column) => Ok(Column::Geometry(format_geometry_column(
-            column,
-            geometry_format,
-        )?)),
-        Column::Geography(column) => Ok(Column::Geography(format_geography_column(
-            column,
-            geometry_format,
-        )?)),
-        Column::Variant(column) => Ok(Column::Variant(if format.http_arrow_use_jsonb {
-            column.clone()
-        } else {
-            format_variant_column(column)
-        })),
-        Column::Nullable(column) => format_nullable_arrow_ipc_column(column, format),
-        Column::Array(column) => Ok(Column::Array(Box::new(ArrayColumn::new(
-            format_arrow_ipc_column(&column.underlying_column(), format)?,
-            column.underlying_offsets(),
-        )))),
-        Column::Map(column) => Ok(Column::Map(Box::new(ArrayColumn::new(
-            format_arrow_ipc_column(&column.underlying_column(), format)?,
-            column.underlying_offsets(),
-        )))),
-        Column::Tuple(fields) => Ok(Column::Tuple(
+fn rewrite_arrow_ipc_schema(
+    schema: &arrow_schema::Schema,
+    format: Option<&OutputFormatSettings>,
+) -> arrow_schema::Schema {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)))
+        .collect::<Vec<_>>();
+    arrow_schema::Schema::new_with_metadata(ArrowFields::from(fields), schema.metadata.clone())
+}
+
+fn rewrite_arrow_ipc_field(
+    field: &ArrowField,
+    format: Option<&OutputFormatSettings>,
+) -> ArrowField {
+    let is_variant_json_string = field
+        .metadata()
+        .get(EXTENSION_KEY)
+        .is_some_and(|ext| ext == ARROW_EXT_TYPE_VARIANT)
+        && format.is_some_and(|format| !format.http_arrow_use_jsonb);
+
+    let data_type = if is_variant_json_string {
+        ArrowDataType::LargeUtf8
+    } else {
+        rewrite_arrow_ipc_data_type(field.data_type(), format)
+    };
+
+    ArrowField::new(field.name(), data_type, field.is_nullable())
+        .with_metadata(field.metadata().clone())
+}
+
+fn rewrite_arrow_ipc_data_type(
+    data_type: &ArrowDataType,
+    format: Option<&OutputFormatSettings>,
+) -> ArrowDataType {
+    match data_type {
+        ArrowDataType::Decimal64(precision, scale)
+            if format.is_some_and(|format| !format.http_arrow_use_decimal64) =>
+        {
+            ArrowDataType::Decimal128(*precision, *scale)
+        }
+        ArrowDataType::Struct(fields) => ArrowDataType::Struct(ArrowFields::from(
             fields
                 .iter()
-                .map(|field| format_arrow_ipc_column(field, format))
-                .collect::<Result<Vec<_>>>()?,
+                .map(|field| Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)))
+                .collect::<Vec<_>>(),
         )),
-        _ => Ok(column.clone()),
+        ArrowDataType::List(field) => {
+            ArrowDataType::List(Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)))
+        }
+        ArrowDataType::LargeList(field) => {
+            ArrowDataType::LargeList(Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)))
+        }
+        ArrowDataType::FixedSizeList(field, size) => ArrowDataType::FixedSizeList(
+            Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)),
+            *size,
+        ),
+        ArrowDataType::Map(field, ordered) => ArrowDataType::Map(
+            Arc::new(rewrite_arrow_ipc_field(field.as_ref(), format)),
+            *ordered,
+        ),
+        other => other.clone(),
     }
 }
 
-fn format_nullable_arrow_ipc_column(
-    column: &NullableColumn<databend_common_expression::types::AnyType>,
-    format: &OutputFormatSettings,
-) -> Result<Column> {
-    match &column.column {
-        Column::Variant(inner) if !format.http_arrow_use_jsonb => Ok(NullableColumn::new_column(
-            Column::Variant(format_nullable_variant_column(inner, &column.validity)),
-            column.validity.clone(),
-        )),
-        _ => Ok(NullableColumn::new_column(
-            format_arrow_ipc_column(&column.column, format)?,
-            column.validity.clone(),
-        )),
+fn format_arrow_ipc_batch(
+    columns: &[Column],
+    num_rows: usize,
+    target_schema: Arc<ArrowSchema>,
+    format: Option<&OutputFormatSettings>,
+) -> Result<RecordBatch> {
+    if columns.len() != target_schema.fields.len() {
+        return Err(ErrorCode::Internal(format!(
+            "The number of columns in the data block does not match the number of fields in the table schema, block_columns: {}, table_schema_fields: {}",
+            columns.len(),
+            target_schema.fields.len(),
+        )));
     }
+
+    if target_schema.fields.is_empty() {
+        return Ok(RecordBatch::try_new_with_options(
+            Arc::new(ArrowSchema::empty()),
+            vec![],
+            &arrow_array::RecordBatchOptions::default().with_row_count(Some(num_rows)),
+        )?);
+    }
+
+    let arrays = columns
+        .iter()
+        .zip(target_schema.fields())
+        .map(|(column, field)| format_arrow_ipc_array(column, field.as_ref(), format))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(target_schema, arrays)?)
+}
+
+fn format_arrow_ipc_array(
+    column: &Column,
+    target_field: &ArrowField,
+    format: Option<&OutputFormatSettings>,
+) -> Result<Arc<dyn Array>> {
+    match (column, target_field.data_type()) {
+        (Column::Tuple(fields), ArrowDataType::Struct(target_fields)) => {
+            let inner_arrays = fields
+                .iter()
+                .zip(target_fields.iter())
+                .map(|(field, target_field)| {
+                    format_arrow_ipc_array(field, target_field.as_ref(), format)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let array = StructArray::new(target_fields.clone(), inner_arrays, None);
+            Ok(Arc::new(array) as _)
+        }
+        (Column::Array(column), ArrowDataType::LargeList(target_field)) => {
+            let values =
+                format_arrow_ipc_array(&column.underlying_column(), target_field.as_ref(), format)?;
+            let offsets = OffsetBuffer::new(ScalarBuffer::from(
+                column
+                    .underlying_offsets()
+                    .into_iter()
+                    .map(|v| v as i64)
+                    .collect::<Vec<_>>(),
+            ));
+            let array = LargeListArray::new(target_field.clone(), offsets, values, None);
+            Ok(Arc::new(array) as _)
+        }
+        (Column::Map(column), ArrowDataType::Map(target_field, ordered)) => {
+            let entry =
+                format_arrow_ipc_array(&column.underlying_column(), target_field.as_ref(), format)?;
+            let offsets = OffsetBuffer::new(ScalarBuffer::from(
+                column
+                    .underlying_offsets()
+                    .into_iter()
+                    .map(|v| v as i32)
+                    .collect::<Vec<_>>(),
+            ));
+            let array = MapArray::new(
+                target_field.clone(),
+                offsets,
+                entry.as_struct().clone(),
+                None,
+                *ordered,
+            );
+            Ok(Arc::new(array) as _)
+        }
+        (Column::Nullable(column), _) => {
+            format_nullable_arrow_ipc_array(column, target_field, format)
+        }
+        _ => format_arrow_ipc_leaf_array(column, target_field, format),
+    }
+}
+
+fn format_nullable_arrow_ipc_array(
+    column: &NullableColumn<databend_common_expression::types::AnyType>,
+    target_field: &ArrowField,
+    format: Option<&OutputFormatSettings>,
+) -> Result<Arc<dyn Array>> {
+    if let Column::Variant(inner) = &column.column
+        && is_variant_json_string_field(target_field, format)
+    {
+        return Ok(Arc::new(format_nullable_variant_string_array(
+            inner,
+            &column.validity,
+        )) as _);
+    }
+
+    let array = format_arrow_ipc_array(&column.column, target_field, format)?;
+    apply_arrow_ipc_validity(array, &column.validity)
+}
+
+fn format_arrow_ipc_leaf_array(
+    column: &Column,
+    target_field: &ArrowField,
+    format: Option<&OutputFormatSettings>,
+) -> Result<Arc<dyn Array>> {
+    let array = match (column, target_field.data_type(), format) {
+        (Column::Variant(column), ArrowDataType::LargeUtf8, format)
+            if is_variant_json_string_field(target_field, format) =>
+        {
+            Arc::new(format_variant_string_array(column)) as _
+        }
+        (Column::Geometry(column), _, Some(format)) => {
+            Column::Geometry(format_geometry_column(column, format.geometry_format)?)
+                .maybe_gc()
+                .into_arrow_rs()
+        }
+        (Column::Geography(column), _, Some(format)) => {
+            Column::Geography(format_geography_column(column, format.geometry_format)?)
+                .maybe_gc()
+                .into_arrow_rs()
+        }
+        _ => column.clone().maybe_gc().into_arrow_rs(),
+    };
+
+    if array.data_type() == target_field.data_type() {
+        return Ok(array);
+    }
+
+    match (array.data_type(), target_field.data_type()) {
+        (
+            ArrowDataType::Decimal64(actual_precision, actual_scale),
+            ArrowDataType::Decimal128(target_precision, target_scale),
+        ) if actual_precision == target_precision && actual_scale == target_scale => {
+            cast(array.as_ref(), target_field.data_type()).map_err(ErrorCode::from)
+        }
+        _ => Err(ErrorCode::Internal(format!(
+            "unexpected HTTP Arrow IPC type rewrite mismatch: actual={:?}, target={:?}",
+            array.data_type(),
+            target_field.data_type()
+        ))),
+    }
+}
+
+fn is_variant_json_string_field(
+    target_field: &ArrowField,
+    format: Option<&OutputFormatSettings>,
+) -> bool {
+    matches!(target_field.data_type(), ArrowDataType::LargeUtf8)
+        && target_field
+            .metadata()
+            .get(EXTENSION_KEY)
+            .is_some_and(|ext| ext == ARROW_EXT_TYPE_VARIANT)
+        && format.is_some_and(|format| !format.http_arrow_use_jsonb)
+}
+
+fn apply_arrow_ipc_validity(
+    array: Arc<dyn Array>,
+    validity: &databend_common_column::bitmap::Bitmap,
+) -> Result<Arc<dyn Array>> {
+    let builder = array.to_data().into_builder();
+    let nulls = validity.clone().into();
+    let data = unsafe { builder.nulls(Some(nulls)).build_unchecked() };
+    Ok(make_array(data))
 }
 
 fn format_geometry_column(
@@ -232,32 +428,24 @@ fn format_geography_column(
     )?))
 }
 
-fn format_variant_column(column: &BinaryColumn) -> BinaryColumn {
-    format_binary_column(
-        column.len(),
-        column.total_bytes_len(),
-        column.iter(),
-        |value| Ok(format_variant_value(value)),
-    )
-    .expect("formatting variant column to json string should not fail")
+fn format_variant_string_array(column: &BinaryColumn) -> LargeStringArray {
+    LargeStringArray::from_iter_values(column.iter().map(format_variant_string_value))
 }
 
-fn format_nullable_variant_column(
+fn format_nullable_variant_string_array(
     column: &BinaryColumn,
     validity: &databend_common_column::bitmap::Bitmap,
-) -> BinaryColumn {
-    let mut builder = BinaryColumnBuilder::with_capacity(column.len(), column.total_bytes_len());
-    for (is_valid, value) in validity.iter().zip(column.iter()) {
-        if is_valid {
-            builder.put_slice(&format_variant_value(value));
-        }
-        builder.commit_row();
-    }
-    builder.build()
+) -> LargeStringArray {
+    LargeStringArray::from_iter(
+        validity
+            .iter()
+            .zip(column.iter())
+            .map(|(is_valid, value)| is_valid.then(|| format_variant_string_value(value))),
+    )
 }
 
-fn format_variant_value(value: &[u8]) -> Vec<u8> {
-    RawJsonb::new(value).to_string().into_bytes()
+fn format_variant_string_value(value: &[u8]) -> String {
+    RawJsonb::new(value).to_string()
 }
 
 fn format_binary_column<T>(

--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -45,6 +45,7 @@ use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterFactory;
 use crate::interpreters::InterpreterQueryLog;
 use crate::interpreters::interpreter_plan_sql;
+use crate::servers::http::v1::http_query_handlers::ArrowFeatures;
 use crate::servers::http::v1::http_query_handlers::QueryResponseSettings;
 use crate::sessions::AcquireQueueGuard;
 use crate::sessions::QueryAffect;
@@ -63,7 +64,8 @@ use crate::spillers::SpillerType;
 type Sender = SizedChannelSender<LiteSpiller>;
 
 pub(crate) const LEGACY_ARROW_RESULT_VERSION: u64 = 1;
-pub(crate) const SERVER_MAX_ARROW_RESULT_VERSION: u64 = 2;
+pub(crate) const ARROW_FEATURE_NEGOTIATION_VERSION: u64 = 3;
+pub(crate) const SERVER_MAX_ARROW_RESULT_VERSION: u64 = ARROW_FEATURE_NEGOTIATION_VERSION;
 
 pub struct ExecutionError;
 
@@ -131,6 +133,7 @@ pub struct ExecuteStarting {
     pub(crate) ctx: Arc<QueryContext>,
     pub(crate) sender: Option<Sender>,
     pub(crate) arrow_result_version: Option<u64>,
+    pub(crate) arrow_features: Option<ArrowFeatures>,
 }
 
 pub struct ExecuteRunning {
@@ -221,6 +224,12 @@ impl Executor {
                 .as_ref()
                 .and_then(|settings| settings.arrow_result_version),
         };
+        let arrow_features = match &self.state {
+            Starting(s) => s.arrow_features.clone(),
+            Running(_) | Stopped(_) => response_settings
+                .as_ref()
+                .and_then(|settings| settings.arrow_features.clone()),
+        };
 
         ResponseState {
             running_time_ms: self.get_query_duration_ms(),
@@ -229,6 +238,7 @@ impl Executor {
             error: err,
             response_settings,
             arrow_result_version,
+            arrow_features,
             warnings: self.get_warnings(),
             affect: self.get_affect(),
             schema,
@@ -394,6 +404,7 @@ impl ExecuteState {
         session: Arc<Session>,
         ctx: Arc<QueryContext>,
         arrow_result_version: Option<u64>,
+        arrow_features: Option<ArrowFeatures>,
         mut block_sender: Sender,
     ) -> Result<(), ExecutionError> {
         let make_error = || format!("failed to start query: {sql}");
@@ -406,8 +417,13 @@ impl ExecuteState {
             .map_err(|err| err.display_with_sql(&sql))
             .with_context(make_error)?;
 
-        Self::apply_settings(&ctx, arrow_result_version, &mut block_sender)
-            .with_context(make_error)?;
+        Self::apply_settings(
+            &ctx,
+            arrow_result_version,
+            arrow_features.as_ref(),
+            &mut block_sender,
+        )
+        .with_context(make_error)?;
 
         let interpreter = InterpreterFactory::get(ctx.clone(), &plan)
             .await
@@ -443,6 +459,7 @@ impl ExecuteState {
             binary_output_format,
             http_json_result_mode,
             arrow_result_version,
+            arrow_features,
         });
 
         let running_state = ExecuteRunning {
@@ -565,6 +582,7 @@ impl ExecuteState {
     fn apply_settings(
         ctx: &Arc<QueryContext>,
         arrow_result_version: Option<u64>,
+        arrow_features: Option<&ArrowFeatures>,
         block_sender: &mut Sender,
     ) -> Result<()> {
         let settings = ctx.get_settings();
@@ -597,8 +615,23 @@ impl ExecuteState {
         let mut format_settings = ctx.get_output_format_settings()?;
         format_settings.http_arrow_use_jsonb =
             arrow_result_version == Some(LEGACY_ARROW_RESULT_VERSION);
+        format_settings.http_arrow_use_decimal64 =
+            use_decimal64_for_arrow_result(arrow_result_version, arrow_features);
         block_sender.plan_ready(format_settings, spiller);
         Ok(())
+    }
+}
+
+fn use_decimal64_for_arrow_result(
+    arrow_result_version: Option<u64>,
+    arrow_features: Option<&ArrowFeatures>,
+) -> bool {
+    match arrow_result_version {
+        Some(version) if version >= ARROW_FEATURE_NEGOTIATION_VERSION => !matches!(
+            arrow_features.and_then(|features| features.decimal64),
+            Some(false)
+        ),
+        _ => true,
     }
 }
 

--- a/src/query/service/src/servers/http/v1/query/http_query.rs
+++ b/src/query/service/src/servers/http/v1/query/http_query.rs
@@ -72,6 +72,7 @@ use crate::servers::http::v1::ClientSessionManager;
 use crate::servers::http::v1::HttpQueryManager;
 use crate::servers::http::v1::QueryResponse;
 use crate::servers::http::v1::QueryStats;
+use crate::servers::http::v1::http_query_handlers::ArrowFeatures;
 use crate::servers::http::v1::http_query_handlers::QueryResponseSettings;
 use crate::sessions::QueryAffect;
 use crate::sessions::Session;
@@ -94,6 +95,7 @@ pub struct HttpQueryRequest {
     #[serde(default)]
     pub params: Option<serde_json::Value>,
     pub arrow_result_version_max: Option<u64>,
+    pub arrow_features: Option<ArrowFeatures>,
 }
 
 impl HttpQueryRequest {
@@ -164,6 +166,7 @@ impl Debug for HttpQueryRequest {
             .field("stage_attachment", &self.stage_attachment)
             .field("params", &self.params)
             .field("arrow_result_version_max", &self.arrow_result_version_max)
+            .field("arrow_features", &self.arrow_features)
             .finish()
     }
 }
@@ -504,6 +507,7 @@ pub struct ResponseState {
     pub schema: DataSchemaRef,
     pub response_settings: Option<QueryResponseSettings>,
     pub arrow_result_version: Option<u64>,
+    pub arrow_features: Option<ArrowFeatures>,
     pub running_time_ms: i64,
     pub progresses: Progresses,
     pub state: ExecuteStateKind,
@@ -636,6 +640,7 @@ impl HttpQuery {
         http_ctx: &HttpQueryContext,
         req: HttpQueryRequest,
         arrow_result_version: Option<u64>,
+        arrow_features: Option<ArrowFeatures>,
     ) -> Result<HttpQuery> {
         http_ctx.try_set_worksheet_session(&req.session).await?;
         let (session, ctx) = http_ctx
@@ -670,6 +675,7 @@ impl HttpQuery {
                 ctx: ctx.clone(),
                 sender: Some(sender),
                 arrow_result_version,
+                arrow_features,
             }),
         }));
 
@@ -832,7 +838,7 @@ impl HttpQuery {
         sql: String,
         params: Option<serde_json::Value>,
     ) -> Result<()> {
-        let (block_sender, query_context, arrow_result_version) = {
+        let (block_sender, query_context, arrow_result_version, arrow_features) = {
             let state = &mut self.execute_state.lock().state;
             let ExecuteState::Starting(state) = state else {
                 return Err(ErrorCode::Internal(
@@ -844,6 +850,7 @@ impl HttpQuery {
                 state.sender.take().unwrap(),
                 state.ctx.clone(),
                 state.arrow_result_version,
+                state.arrow_features.clone(),
             )
         };
 
@@ -864,6 +871,7 @@ impl HttpQuery {
                         query_session,
                         query_context.clone(),
                         arrow_result_version,
+                        arrow_features,
                         block_sender,
                     ))
                     .await

--- a/src/query/service/src/servers/http/v1/session/login_handler.rs
+++ b/src/query/service/src/servers/http/v1/session/login_handler.rs
@@ -24,6 +24,8 @@ use poem::web::Query;
 use crate::auth::Credential;
 use crate::servers::http::error::HttpErrorCode;
 use crate::servers::http::v1::HttpQueryContext;
+use crate::servers::http::v1::http_query_handlers::ArrowFeatures;
+use crate::servers::http::v1::query::execute_state::ARROW_FEATURE_NEGOTIATION_VERSION;
 use crate::servers::http::v1::query::execute_state::SERVER_MAX_ARROW_RESULT_VERSION;
 use crate::servers::http::v1::session::client_session_manager::ClientSessionManager;
 use crate::sessions::TableContextTableAccess;
@@ -47,6 +49,8 @@ pub struct LoginResponse {
     version: String,
     session_id: String,
     server_max_arrow_result_version: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_arrow_features: Option<ArrowFeatures>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tokens: Option<TokensInfo>,
 }
@@ -102,11 +106,15 @@ pub async fn login_handler(
         .await
         .map_err(HttpErrorCode::bad_request)?;
     let version = &ctx.version.semantic;
+    let server_arrow_features = (SERVER_MAX_ARROW_RESULT_VERSION
+        >= ARROW_FEATURE_NEGOTIATION_VERSION)
+        .then_some(ArrowFeatures::decimal64_enabled());
     let id_only = || {
         Ok(Json(LoginResponse {
             version: version.to_string(),
             session_id: session_id.clone(),
             server_max_arrow_result_version: SERVER_MAX_ARROW_RESULT_VERSION,
+            server_arrow_features: server_arrow_features.clone(),
             tokens: None,
         }))
     };
@@ -123,6 +131,7 @@ pub async fn login_handler(
                 version: version.to_string(),
                 session_id,
                 server_max_arrow_result_version: SERVER_MAX_ARROW_RESULT_VERSION,
+                server_arrow_features: server_arrow_features.clone(),
                 tokens: Some(TokensInfo {
                     session_token_ttl_in_secs: ClientSessionManager::instance()
                         .max_idle_time

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -20,6 +20,8 @@ use std::io::Read;
 use std::time::Duration;
 
 use arrow_ipc::reader::StreamReader;
+use arrow_schema::DataType as ArrowDataType;
+use arrow_schema::SchemaRef;
 use base64::engine::general_purpose;
 use base64::prelude::*;
 use databend_common_base::base::get_free_tcp_port;
@@ -143,6 +145,7 @@ pub struct TestQueryResponse {
 #[derive(Deserialize, Debug, Clone)]
 pub struct TestResultFormatSettings {
     pub arrow_result_version: Option<u64>,
+    pub arrow_features: Option<TestArrowFeatures>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -150,11 +153,18 @@ struct TestLoginResponse {
     version: String,
     session_id: String,
     server_max_arrow_result_version: u64,
+    server_arrow_features: Option<TestArrowFeatures>,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct TestArrowFeatures {
+    decimal64: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
 struct TestArrowQueryResponse {
     header: TestQueryResponse,
+    schema: SchemaRef,
     num_rows: usize,
 }
 
@@ -304,6 +314,7 @@ impl TestHttpQueryRequest {
 
 fn decode_arrow_query_response(body: &[u8]) -> anyhow::Result<TestArrowQueryResponse> {
     let mut reader = StreamReader::try_new(Cursor::new(body), None)?;
+    let schema = reader.schema();
     let header = serde_json::from_str::<TestQueryResponse>(
         reader
             .schema()
@@ -315,7 +326,11 @@ fn decode_arrow_query_response(body: &[u8]) -> anyhow::Result<TestArrowQueryResp
     for batch in &mut reader {
         num_rows += batch?.num_rows();
     }
-    Ok(TestArrowQueryResponse { header, num_rows })
+    Ok(TestArrowQueryResponse {
+        header,
+        schema,
+        num_rows,
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -2031,6 +2046,7 @@ async fn test_arrow_query_legacy_bendsql_python_ua_fallback() -> anyhow::Result<
         response
             .header
             .settings
+            .clone()
             .and_then(|settings| settings.arrow_result_version),
         None
     );
@@ -2078,6 +2094,7 @@ async fn test_arrow_query_negotiates_result_format_version_in_metadata() -> anyh
         response
             .header
             .settings
+            .clone()
             .and_then(|settings| settings.arrow_result_version),
         Some(login.server_max_arrow_result_version)
     );
@@ -2107,8 +2124,18 @@ async fn test_arrow_query_page_keeps_negotiated_result_format_version() -> anyho
         response
             .header
             .settings
+            .clone()
             .and_then(|settings| settings.arrow_result_version),
         Some(2)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        None
     );
 
     let ep = create_endpoint()?;
@@ -2125,8 +2152,19 @@ async fn test_arrow_query_page_keeps_negotiated_result_format_version() -> anyho
             .1
             .header
             .settings
+            .clone()
             .and_then(|settings| settings.arrow_result_version),
         Some(2)
+    );
+    assert_eq!(
+        response
+            .1
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        None
     );
 
     let (status, response) = get_uri_checked(&ep, &final_uri).await?;
@@ -2217,6 +2255,206 @@ async fn test_login_returns_server_max_arrow_result_version() -> anyhow::Result<
     assert_eq!(login.version, DATABEND_SEMVER.to_string());
     assert!(!login.session_id.is_empty());
     assert!(login.server_max_arrow_result_version >= 1);
+    if login.server_max_arrow_result_version >= 3 {
+        assert_eq!(
+            login
+                .server_arrow_features
+                .and_then(|features| features.decimal64),
+            Some(true)
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_arrow_query_v3_defaults_decimal64_feature_enabled() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        "application/vnd.apache.arrow.stream".parse().unwrap(),
+    );
+
+    let req = TestHttpQueryRequest::new(serde_json::json!({
+        "sql": "select cast(1.23 as decimal(10, 2)) as d",
+        "arrow_result_version_max": 3
+    }))
+    .with_headers(headers);
+    let (status, response) = req.do_arrow_request(Method::POST, "/v1/query").await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(response.num_rows, 1);
+    assert_eq!(
+        response.schema.field(0).data_type(),
+        &ArrowDataType::Decimal64(10, 2)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_result_version),
+        Some(3)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        Some(true)
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_arrow_query_v3_allows_disabling_decimal64_feature() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        "application/vnd.apache.arrow.stream".parse().unwrap(),
+    );
+
+    let req = TestHttpQueryRequest::new(serde_json::json!({
+        "sql": "select cast(1.23 as decimal(10, 2)) as d",
+        "arrow_result_version_max": 3,
+        "arrow_features": {
+            "decimal64": false
+        }
+    }))
+    .with_headers(headers);
+    let (status, response) = req.do_arrow_request(Method::POST, "/v1/query").await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(response.num_rows, 1);
+    assert_eq!(
+        response.schema.field(0).data_type(),
+        &ArrowDataType::Decimal128(10, 2)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_result_version),
+        Some(3)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        None
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_arrow_query_page_keeps_disabled_decimal64_feature() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        "application/vnd.apache.arrow.stream".parse().unwrap(),
+    );
+
+    let req = TestHttpQueryRequest::new(serde_json::json!({
+        "sql": "select cast(number + 123 as decimal(10, 2)) as d from numbers(10)",
+        "pagination": {"wait_time_secs": 6, "max_rows_per_page": 2},
+        "arrow_result_version_max": 3,
+        "arrow_features": {
+            "decimal64": false
+        }
+    }))
+    .with_headers(headers.clone());
+    let (status, response) = req.do_arrow_request(Method::POST, "/v1/query").await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        response.schema.field(0).data_type(),
+        &ArrowDataType::Decimal128(10, 2)
+    );
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        None
+    );
+
+    let ep = create_endpoint()?;
+    let next_uri = response.header.next_uri.clone().expect("expected next uri");
+    let response = get_arrow_uri(&ep, &next_uri, headers).await?;
+    assert_eq!(response.0, StatusCode::OK);
+    assert_eq!(
+        response.1.schema.field(0).data_type(),
+        &ArrowDataType::Decimal128(10, 2)
+    );
+    assert_eq!(
+        response
+            .1
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        None
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_arrow_query_page_keeps_negotiated_decimal64_feature() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        "application/vnd.apache.arrow.stream".parse().unwrap(),
+    );
+
+    let req = TestHttpQueryRequest::new(serde_json::json!({
+        "sql": "select * from numbers(10)",
+        "pagination": {"wait_time_secs": 6, "max_rows_per_page": 2},
+        "arrow_result_version_max": 3
+    }))
+    .with_headers(headers.clone());
+    let (status, response) = req.do_arrow_request(Method::POST, "/v1/query").await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        response
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        Some(true)
+    );
+
+    let ep = create_endpoint()?;
+    let next_uri = response.header.next_uri.clone().expect("expected next uri");
+    let response = get_arrow_uri(&ep, &next_uri, headers).await?;
+    assert_eq!(response.0, StatusCode::OK);
+    assert_eq!(
+        response
+            .1
+            .header
+            .settings
+            .clone()
+            .and_then(|settings| settings.arrow_features)
+            .and_then(|features| features.decimal64),
+        Some(true)
+    );
 
     Ok(())
 }

--- a/src/query/service/tests/it/servers/http/json_block.rs
+++ b/src/query/service/tests/it/servers/http/json_block.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use arrow_array::RecordBatch;
 use arrow_ipc::reader::StreamReader;
+use arrow_schema::DataType as ArrowDataType;
 use databend_common_column::bitmap::Bitmap;
 use databend_common_column::types::timestamp_tz;
 use databend_common_exception::Result;
@@ -40,6 +41,8 @@ use databend_common_expression::types::VariantType;
 use databend_common_expression::types::array::ArrayColumn;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::date::date_to_string;
+use databend_common_expression::types::decimal::Decimal64Type;
+use databend_common_expression::types::decimal::DecimalSize;
 use databend_common_expression::types::geography::GeographyColumn;
 use databend_common_expression::types::geography::GeographyRef;
 use databend_common_expression::types::geography::GeographyType;
@@ -353,6 +356,7 @@ fn test_arrow_ipc_variant_json_string_payloads() -> anyhow::Result<()> {
             .map(String::as_str),
         Some(ARROW_EXT_TYPE_VARIANT)
     );
+    assert_eq!(arrow_schema.field(0).data_type(), &ArrowDataType::LargeUtf8);
 
     match Column::from_arrow_rs(batch.column(0).clone(), schema.field(0).data_type())? {
         Column::Variant(column) => {
@@ -424,7 +428,30 @@ fn test_arrow_ipc_nested_variant_json_string_payloads() -> anyhow::Result<()> {
     let buf = collector
         .into_serializer(OutputFormatSettings::default())
         .to_arrow_ipc(&schema, vec![])?;
-    let (_, batch) = read_first_arrow_batch(buf)?;
+    let (arrow_schema, batch) = read_first_arrow_batch(buf)?;
+
+    match arrow_schema.field(0).data_type() {
+        ArrowDataType::LargeList(field) => {
+            assert_eq!(field.data_type(), &ArrowDataType::LargeUtf8);
+        }
+        other => panic!("expected large list arrow type, got {other:?}"),
+    }
+    match arrow_schema.field(1).data_type() {
+        ArrowDataType::Struct(fields) => {
+            assert_eq!(fields[0].data_type(), &ArrowDataType::LargeUtf8);
+        }
+        other => panic!("expected struct arrow type, got {other:?}"),
+    }
+    match arrow_schema.field(2).data_type() {
+        ArrowDataType::Map(field, _) => match field.data_type() {
+            ArrowDataType::Struct(fields) => {
+                assert_eq!(fields[1].data_type(), &ArrowDataType::LargeUtf8);
+            }
+            other => panic!("expected map entry struct arrow type, got {other:?}"),
+        },
+        other => panic!("expected map arrow type, got {other:?}"),
+    }
+    assert_eq!(arrow_schema.field(3).data_type(), &ArrowDataType::LargeUtf8);
 
     match Column::from_arrow_rs(batch.column(0).clone(), schema.field(0).data_type())? {
         Column::Array(column) => match column.values() {
@@ -691,6 +718,48 @@ fn test_arrow_ipc_nested_variant_jsonb_payloads_for_legacy_bendsql_python() -> a
         },
         other => panic!("expected nullable column, got {other:?}"),
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_arrow_ipc_decimal64_feature_toggle() -> anyhow::Result<()> {
+    let decimal_size = DecimalSize::new_unchecked(10, 2);
+    let schema = DataSchema::new(vec![DataField::new("d", DataType::Decimal(decimal_size))]);
+
+    let mut collector = BlocksCollector::new();
+    collector.append_columns(
+        vec![Decimal64Type::from_data_with_size(
+            vec![123_i64],
+            Some(decimal_size),
+        )],
+        1,
+    );
+
+    let decimal64_buf = collector
+        .clone()
+        .into_serializer(OutputFormatSettings {
+            http_arrow_use_decimal64: true,
+            ..Default::default()
+        })
+        .to_arrow_ipc(&schema, vec![])?;
+    let (decimal64_schema, _) = read_first_arrow_batch(decimal64_buf)?;
+    assert_eq!(
+        decimal64_schema.field(0).data_type(),
+        &ArrowDataType::Decimal64(decimal_size.precision(), decimal_size.scale() as i8)
+    );
+
+    let decimal128_buf = collector
+        .into_serializer(OutputFormatSettings {
+            http_arrow_use_decimal64: false,
+            ..Default::default()
+        })
+        .to_arrow_ipc(&schema, vec![])?;
+    let (decimal128_schema, _) = read_first_arrow_batch(decimal128_buf)?;
+    assert_eq!(
+        decimal128_schema.field(0).data_type(),
+        &ArrowDataType::Decimal128(decimal_size.precision(), decimal_size.scale() as i8)
+    );
 
     Ok(())
 }

--- a/src/query/settings/src/settings.rs
+++ b/src/query/settings/src/settings.rs
@@ -118,6 +118,7 @@ impl Settings {
             http_json_result_mode,
             headers: 0,
             http_arrow_use_jsonb: false,
+            http_arrow_use_decimal64: true,
             json_compact: false,
             json_strings: false,
             format_null_as_str,

--- a/tests/nox/noxfile.py
+++ b/tests/nox/noxfile.py
@@ -61,7 +61,7 @@ def run_jdbc_test(session, driver_version, main_version):
 
 
 @nox.session
-@nox.parametrize("driver_version", ["v100.0.0", "v0.8.3"])
+@nox.parametrize("driver_version", ["v100.0.0"])
 def go_client(session, driver_version):
     env = {"DATABEND_GO_VERSION": driver_version}
     test_dir = f"cache/databend-go/tests"

--- a/tests/nox/suites/http_handler/test_token.py
+++ b/tests/nox/suites/http_handler/test_token.py
@@ -148,7 +148,7 @@ def fake_expired_token(ty):
     """ 
 ---- do_login()
 200
-['server_max_arrow_result_version', 'session_id', 'tokens', 'version']
+['server_arrow_features', 'server_max_arrow_result_version', 'session_id', 'tokens', 'version']
 ---- do_query('select 1',)
 200
 [['1']]
@@ -228,7 +228,7 @@ False
 )
 def test_token():
     login_resp = do_login()
-    pprint(sorted(login_resp.keys()))
+    print(sorted(login_resp.keys()))
     session_token = login_resp.get("tokens").get("session_token")
     refresh_token = login_resp.get("tokens").get("refresh_token")
     # print(session_token)
@@ -264,7 +264,7 @@ def test_token():
     do_query("select 5", refresh_token)
 
     renew_resp = do_refresh(1, refresh_token, session_token)
-    pprint(sorted(renew_resp.keys()))
+    print(sorted(renew_resp.keys()))
     new_session_token = renew_resp.get("tokens").get("session_token")
     new_refresh_token = renew_resp.get("tokens").get("refresh_token")
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

 ## Summary

  This change extends HTTP Arrow result negotiation from a single linear `arrow_result_version` to a mixed model:

  - `arrow_result_version` still negotiates the Databend Arrow result profile
  - `arrow_result_version >= 3` means client/server understand `arrow_features`
  - `arrow_features` negotiates independent Arrow capabilities, starting with `decimal64`

  It also changes `Variant` Arrow output in JSON-string mode to use string schema instead of binary, so schema and payload now match. It is more friendly if we export Arrow RecordBatch to user directly later. 

  ## What changed

  ### Arrow protocol negotiation

  - Bump `SERVER_MAX_ARROW_RESULT_VERSION` to `3`
  - Add `arrow_features` to `/v1/query` request body
  - Add negotiated `arrow_features` to `QueryResponseSettings`
  - Persist negotiated Arrow features in query state so page/final/retry responses keep the same format
  - Add `server_arrow_features` to `/v1/session/login` response for client-side preflight

  ### Decimal64 feature gating

  - Add HTTP-only output setting `http_arrow_use_decimal64`
  - Default `decimal64` to enabled for `arrow_result_version >= 3`
  - Allow clients to explicitly disable it with:

    ```json
    {
      "arrow_features": {
        "decimal64": false
      }
    }

  - When disabled, small decimals fall back to Decimal128 in HTTP Arrow output （to support Arrow Java）

  ### Variant Arrow schema alignment

  - In HTTP Arrow JSON-string mode, Variant fields now use LargeUtf8 instead of LargeBinary
  - This applies recursively for nested Variant fields in array / tuple / map / nullable structures
  - Legacy JSONB mode is unchanged and still uses binary payloads

  ### Arrow record batch alignment

  - Fix to_record_batch_with_arrow_schema so produced arrays are aligned with the target Arrow schema, including nested fields and leaf physical types
  - This is required for both:
      - Decimal64 vs Decimal128 physical type switching
      - Variant string schema output

  ## Compatibility

  - Legacy bendsql python JSONB fallback remains unchanged
  - arrow_result_version < 3 ignores arrow_features
  - For arrow_result_version >= 3, decimal64 is enabled by default unless the client explicitly sets decimal64: false
  - Login response advertises feature upper bounds via server_arrow_features, but start-query negotiation remains authoritative

  ## Tests

  Added or updated coverage for:

  - login returning server_max_arrow_result_version and server_arrow_features
  - arrow_result_version = 3 default feature negotiation
  - explicit decimal64: false override
  - negotiated features staying stable across page requests
  - Arrow serializer switching small decimal schema between Decimal64 and Decimal128
  - Variant JSON-string Arrow payloads using string schema
  - token-suite expected login response keys

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19780)
<!-- Reviewable:end -->
