### PR TITLE
fix(bloom-index): cast string integer probes

### DIFF
--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -68,6 +68,7 @@ use databend_common_expression::types::ValueType;
 use databend_common_expression::types::boolean::BooleanDomain;
 use databend_common_expression::types::nullable::NullableDomain;
 use databend_common_expression::visit_expr;
+use databend_common_expression::with_integer_mapped_type;
 use databend_common_expression::with_number_mapped_type;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::scalars::CityHasher64;
@@ -916,6 +917,49 @@ impl BloomIndexBuilder {
     }
 }
 
+fn eq_bloom_scalar_for_column(
+    scalar: &Scalar,
+    scalar_type: &DataType,
+    column_type: &DataType,
+) -> Option<Scalar> {
+    if scalar_type == column_type {
+        return Some(scalar.clone());
+    }
+    if scalar.is_null() || !Xor8Filter::supported_type(column_type) {
+        return None;
+    }
+
+    // Keep the rewrite one-way: integer column = string constant. The reverse
+    // direction is not safe because string-number comparison can match strings
+    // that are not the canonical cast output, such as "0123" = 123.
+    match (scalar_type.remove_nullable(), column_type.remove_nullable()) {
+        (DataType::String, DataType::Number(num_ty)) if num_ty.is_integer() => {
+            if !string_scalar_parses_as_integer_type(scalar, &num_ty) {
+                return None;
+            }
+
+            let scalar = cast_const(&FunctionContext::default(), column_type.clone(), Constant {
+                span: None,
+                scalar: scalar.clone(),
+                data_type: scalar_type.clone(),
+            })?;
+            (!scalar.is_null()).then_some(scalar)
+        }
+        _ => None,
+    }
+}
+
+fn string_scalar_parses_as_integer_type(scalar: &Scalar, num_ty: &NumberDataType) -> bool {
+    let Some(value) = scalar.as_string() else {
+        return false;
+    };
+
+    with_integer_mapped_type!(|NUM_TYPE| match num_ty {
+        NumberDataType::NUM_TYPE => value.parse::<NUM_TYPE>().is_ok(),
+        _ => false,
+    })
+}
+
 struct Visitor<T: EqVisitor>(T);
 
 impl<T> ExprVisitor<String> for Visitor<T>
@@ -1004,17 +1048,13 @@ where T: EqVisitor
                         data_type: column_type,
                         ..
                     }),
-                ] => {
-                    // decimal don't respect datatype equal
-                    // debug_assert_eq!(scalar_type, column_type);
-                    // If the visitor returns a new expression, then replace with the current expression.
-                    if scalar_type == column_type {
+                ] => match eq_bloom_scalar_for_column(scalar, scalar_type, column_type) {
+                    Some(scalar) => {
                         self.0
-                            .enter_target(*span, id, scalar, column_type, return_type, false)?
-                    } else {
-                        ControlFlow::Continue(None)
+                            .enter_target(*span, id, &scalar, column_type, return_type, false)?
                     }
-                }
+                    None => ControlFlow::Continue(None),
+                },
                 // patterns like `MapColumn[<key>] = <constant>`, `<constant> = MapColumn[<key>]`
                 [
                     Expr::FunctionCall(FunctionCall { id, args, .. }),

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -73,6 +73,157 @@ fn test_bloom_filter() {
     test_cast(file);
 }
 
+#[test]
+fn test_bloom_filter_casts_string_literal_to_integer_column_type() {
+    let column_type = DataType::Number(NumberDataType::Int32);
+    let field = TableField::new("x", TableDataType::Number(NumberDataType::Int32));
+    let expr = eq_expr_with_string_constant(column_type.clone(), "20240604");
+
+    let result = BloomIndex::filter_index_field(&expr, vec![field.clone()], vec![]).unwrap();
+
+    assert_eq!(result.bloom_fields, vec![field]);
+    assert_eq!(result.bloom_scalars, vec![(
+        0,
+        Scalar::Number(NumberScalar::Int32(20240604)),
+        column_type
+    )]);
+}
+
+#[test]
+fn test_bloom_filter_does_not_cast_number_literal_to_string_column_type() {
+    let column_type = DataType::String;
+    let field = TableField::new("x", TableDataType::String);
+    let expr = check_function(
+        None,
+        "eq",
+        &[],
+        &[
+            Expr::ColumnRef(ColumnRef {
+                span: None,
+                id: "x".to_string(),
+                data_type: column_type,
+                display_name: "x".to_string(),
+            }),
+            Expr::Constant(Constant {
+                span: None,
+                scalar: Scalar::Number(NumberScalar::Int32(123)),
+                data_type: DataType::Number(NumberDataType::Int32),
+            }),
+        ],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+
+    let result = BloomIndex::filter_index_field(&expr, vec![field], vec![]).unwrap();
+
+    assert!(result.bloom_fields.is_empty());
+    assert!(result.bloom_scalars.is_empty());
+}
+
+#[test]
+fn test_bloom_filter_does_not_cast_string_literal_to_float_column_type() {
+    let column_type = DataType::Number(NumberDataType::Float64);
+    let field = TableField::new("x", TableDataType::Number(NumberDataType::Float64));
+    let expr = eq_expr_with_string_constant(column_type, "0");
+
+    let result = BloomIndex::filter_index_field(&expr, vec![field], vec![]).unwrap();
+
+    assert!(result.bloom_fields.is_empty());
+    assert!(result.bloom_scalars.is_empty());
+}
+
+#[test]
+fn test_bloom_filter_rewrites_string_literal_integer_comparison() {
+    let func_ctx = FunctionContext::default();
+    let column_type = DataType::Number(NumberDataType::Int32);
+    let field = TableField::new("x", TableDataType::Number(NumberDataType::Int32));
+    let schema = Arc::new(TableSchema::new(vec![field.clone()]));
+    let bloom_columns = bloom_columns_map(&schema, &[0]);
+    let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![1, 2])]);
+    let expr = eq_expr_with_string_constant(column_type, "20240604");
+
+    let result =
+        BloomIndex::filter_index_field(&expr, bloom_columns.values().cloned().collect(), vec![])
+            .unwrap();
+    let mut eq_scalar_map = HashMap::<Scalar, u64>::new();
+    for (_, scalar, ty) in result.bloom_scalars.into_iter() {
+        eq_scalar_map.entry(scalar).or_insert_with_key(|scalar| {
+            BloomIndex::calculate_scalar_digest(&func_ctx, scalar, &ty).unwrap()
+        });
+    }
+
+    let mut builder = BloomIndexBuilder::create(
+        func_ctx.clone(),
+        BloomIndexType::default(),
+        bloom_columns.clone(),
+        &[],
+    )
+    .unwrap();
+    builder.add_block(&block).unwrap();
+    let index = builder.finalize().unwrap().unwrap();
+
+    let column_stats = block
+        .columns()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, entry)| {
+            let field = bloom_columns.get(&i)?;
+            let column = entry.as_column().unwrap();
+            let (min, max) = column.domain().to_minmax();
+            Some((field.column_id, ColumnStatistics {
+                min,
+                max,
+                null_count: 0,
+                in_memory_size: 0,
+                distinct_of_values: None,
+            }))
+        })
+        .collect();
+
+    let (expr, domains) = index
+        .rewrite_expr(
+            expr,
+            &eq_scalar_map,
+            &HashMap::new(),
+            &[],
+            &column_stats,
+            schema,
+        )
+        .unwrap();
+    let folded = ConstantFolder::fold_with_domain(&expr, &domains, &func_ctx, &BUILTIN_FUNCTIONS).0;
+
+    assert!(matches!(
+        folded,
+        Expr::Constant(Constant {
+            scalar: Scalar::Boolean(false),
+            ..
+        })
+    ));
+}
+
+fn eq_expr_with_string_constant(column_type: DataType, value: &str) -> Expr<String> {
+    check_function(
+        None,
+        "eq",
+        &[],
+        &[
+            Expr::ColumnRef(ColumnRef {
+                span: None,
+                id: "x".to_string(),
+                data_type: column_type,
+                display_name: "x".to_string(),
+            }),
+            Expr::Constant(Constant {
+                span: None,
+                scalar: Scalar::String(value.to_string()),
+                data_type: DataType::String,
+            }),
+        ],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap()
+}
+
 fn test_base(file: &mut impl Write) {
     let schema = Arc::new(TableSchema::new(vec![
         TableField::new("0", TableDataType::Number(NumberDataType::UInt8)),

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -33,6 +33,25 @@ EvalScalar
     ├── push downs: [filters: [is_true(bloom_test_t.c1 (#0) = 5)], limit: NONE]
     └── estimated rows: 1.50
 
+query T
+explain select 1 from bloom_test_t where c1 = '5'
+----
+EvalScalar
+├── output columns: [1 (#2)]
+├── expressions: [1]
+├── estimated rows: 1.50
+└── TableScan
+    ├── table: default.default.bloom_test_t
+    ├── scan id: 0
+    ├── output columns: []
+    ├── read rows: 3
+    ├── read size: < 1 KiB
+    ├── partitions total: 2
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+    ├── push downs: [filters: [is_true(bloom_test_t.c1 (#0) = '5')], limit: NONE]
+    └── estimated rows: 1.50
+
 query I
 select 1 from bloom_test_t where c1 = 5
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Enable bloom pruning for integer columns compared with string constants by casting precisely parseable literals to the column type for the bloom probe.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19782)
<!-- Reviewable:end -->