### PR TITLE
fix(sql): sync eager count multiply types

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs
@@ -1205,11 +1205,6 @@ impl EagerAnalysis {
         aggregate_function: &mut AggregateFunction,
         eager_count_index: Symbol,
     ) -> Result<ScalarItem, ErrorCode> {
-        let new_index = metadata.write().add_derived_column(
-            format!("{} * _eager_count", aggregate_function.display_name),
-            aggregate_function.args[0].data_type()?,
-        );
-
         let new_scalar = if let ScalarExpr::BoundColumnRef(column) = &aggregate_function.args[0] {
             let mut scalar_idx = input.extra_eval_scalar.items.len();
             for (idx, eval_scalar) in input.extra_eval_scalar.items.iter().enumerate() {
@@ -1226,35 +1221,52 @@ impl EagerAnalysis {
             unreachable!()
         };
 
+        let multiplied_scalar = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "multiply".to_string(),
+            params: vec![],
+            arguments: vec![
+                new_scalar,
+                wrap_cast(
+                    &ScalarExpr::BoundColumnRef(BoundColumnRef {
+                        span: None,
+                        column: ColumnBindingBuilder::new(
+                            "_eager_count".to_string(),
+                            eager_count_index,
+                            Box::new(DataType::Nullable(Box::new(DataType::Number(
+                                NumberDataType::UInt64,
+                            )))),
+                            Visibility::Visible,
+                        )
+                        .build(),
+                    }),
+                    &DataType::Number(NumberDataType::UInt64),
+                ),
+            ],
+        });
+        let multiplied_type = multiplied_scalar.data_type()?;
+        let new_index = metadata.write().add_derived_column(
+            format!("{} * _eager_count", aggregate_function.display_name),
+            multiplied_type.clone(),
+        );
+
         let new_scalar_item = ScalarItem {
-            scalar: ScalarExpr::FunctionCall(FunctionCall {
-                span: None,
-                func_name: "multiply".to_string(),
-                params: vec![],
-                arguments: vec![
-                    new_scalar,
-                    wrap_cast(
-                        &ScalarExpr::BoundColumnRef(BoundColumnRef {
-                            span: None,
-                            column: ColumnBindingBuilder::new(
-                                "_eager_count".to_string(),
-                                eager_count_index,
-                                Box::new(DataType::Nullable(Box::new(DataType::Number(
-                                    NumberDataType::UInt64,
-                                )))),
-                                Visibility::Visible,
-                            )
-                            .build(),
-                        }),
-                        &DataType::Number(NumberDataType::UInt64),
-                    ),
-                ],
-            }),
+            scalar: multiplied_scalar,
             index: new_index,
         };
+        aggregate_function.return_type = Box::new(
+            AggregateFunctionFactory::instance()
+                .get(
+                    &aggregate_function.func_name,
+                    aggregate_function.params.clone(),
+                    vec![multiplied_type.clone()],
+                    vec![],
+                )?
+                .return_type()?,
+        );
         if let ScalarExpr::BoundColumnRef(column) = &mut aggregate_function.args[0] {
             column.column.index = new_index;
-            column.column.data_type = Box::new(new_scalar_item.scalar.data_type()?);
+            column.column.data_type = Box::new(multiplied_type);
         }
         Ok(new_scalar_item)
     }

--- a/tests/sqllogictests/suites/query/aggregate.test
+++ b/tests/sqllogictests/suites/query/aggregate.test
@@ -60,6 +60,15 @@ select typeof(sum(number::Decimal(19, 1))), typeof(sum(number::Decimal(66, 1))) 
 ----
 DECIMAL(38, 1) NULL DECIMAL(76, 1) NULL
 
+query R
+SELECT SUM(agg0) FROM (
+  SELECT SUM(0.5) AS agg0 FROM numbers(2) a, numbers(2) b
+  UNION ALL
+  SELECT SUM(0.5) AS agg0 FROM numbers(2) a, numbers(2) b
+) x
+----
+4.0
+
 query RRT
 select avg(number * number),  avg( (number * number)::Decimal(39, 7) ), typeof(avg( (number * number)::Decimal(39, 7) )) from numbers(100);
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes #19773
- Infer the eager-count multiplication column type from the generated scalar expression instead of reusing the original aggregate argument type
- Refresh the rewritten aggregate return type after its argument changes
- Add a sqllogictest regression for `SUM(0.5)` over a cross join inside `UNION ALL`

## Changes

The eager aggregation rewrite can transform `SUM(x)` over a cross join into `SUM(x * _eager_count)`. For decimal literals, `x * _eager_count` may widen from Decimal64 to Decimal128, but the rewrite still registered the derived column using the original `x` type.

That stale type metadata made the final aggregate consume a Decimal128 column as Decimal64 and panic during execution. The same stale type also lived in the rewritten aggregate function return type, so both the derived column and aggregate function need to be synchronized with the scalar-inferred type.

## Implementation

1. Build the `multiply` scalar before registering the derived eager-count column
2. Use `multiplied_scalar.data_type()?` for the derived column metadata and rewritten bound column
3. Recreate the aggregate function through `AggregateFunctionFactory` with the multiplied argument type to refresh `return_type`
4. Add an end-to-end sqllogictest regression for the issue query shape

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --check -- src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs`
- `git diff --check -- src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_eager_aggregation.rs tests/sqllogictests/suites/query/aggregate.test`
- `cargo test -p databend-common-sql --test it test_eager_aggregation_optimizer_outcomes`
- `cargo build -p databend-binaries --bin databend-query`
- `target/debug/databend-sqllogictests --handlers http --run 'tests/sqllogictests/suites/query/aggregate.test'`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19783)
<!-- Reviewable:end -->