### PR TITLE
fix: explain analyze m-cte should work

### DIFF
--- a/src/query/catalog/src/table_context/materialization.rs
+++ b/src/query/catalog/src/table_context/materialization.rs
@@ -32,6 +32,14 @@ pub trait TableContextCte: Send + Sync {
     );
 
     async fn drop_recursive_cte_temp_table(&self) -> Result<()>;
+
+    fn begin_materialized_cte_capture(&self) {}
+
+    fn is_materialized_cte_capture_active(&self) -> bool {
+        false
+    }
+
+    fn finalize_materialized_cte_capture(&self, _cte_name: &str, _temp_table_name: &str) {}
 }
 
 pub trait TableContextStream: Send + Sync {

--- a/src/query/pipeline/src/core/finished_chain.rs
+++ b/src/query/pipeline/src/core/finished_chain.rs
@@ -37,11 +37,33 @@ pub enum CallbackType {
 pub struct ExecutionInfo {
     pub res: Result<()>,
     pub profiling: HashMap<u32, PlanProfile>,
+    // Identifies the executor instance that produced `profiling`. When set,
+    // the finish hook routes the batch through per-execution offset remapping
+    // (see `QueryProfiles::add_with_execution`) so plan_ids from multiple
+    // executors sharing a QueryContext (outer query + nested CTAS + CTE
+    // sub-pipelines) don't collide.
+    pub profile_execution_id: Option<String>,
 }
 
 impl ExecutionInfo {
     pub fn create(res: Result<()>, profiling: HashMap<u32, PlanProfile>) -> ExecutionInfo {
-        ExecutionInfo { res, profiling }
+        ExecutionInfo {
+            res,
+            profiling,
+            profile_execution_id: None,
+        }
+    }
+
+    pub fn create_with_profile_execution_id(
+        res: Result<()>,
+        profiling: HashMap<u32, PlanProfile>,
+        profile_execution_id: String,
+    ) -> ExecutionInfo {
+        ExecutionInfo {
+            res,
+            profiling,
+            profile_execution_id: Some(profile_execution_id),
+        }
     }
 }
 

--- a/src/query/service/src/interpreters/common/finish_hook.rs
+++ b/src/query/service/src/interpreters/common/finish_hook.rs
@@ -24,7 +24,6 @@ use crate::interpreters::hook::vacuum_hook::hook_disk_temp_dir;
 use crate::interpreters::hook::vacuum_hook::hook_vacuum_temp_files;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextPerf;
-use crate::sessions::TableContextQueryProfile;
 
 fn run_hooks(query_ctx: Arc<QueryContext>) -> Result<()> {
     hook_clear_m_cte_temp_table(&query_ctx)?;
@@ -37,11 +36,14 @@ fn run_hooks(query_ctx: Arc<QueryContext>) -> Result<()> {
 /// Use [`QueryFinishHooks::top_level`] for normal user-facing queries,
 /// [`QueryFinishHooks::nested_with_hooks`] for internal sub-executions that may
 /// create temporary artifacts (e.g. EXPLAIN ANALYZE, EXPLAIN PERF inner pipelines),
-/// and [`QueryFinishHooks::nested`] for lightweight internal pipelines that don't
-/// need cleanup (e.g. recursive CTE inner pipeline).
+/// and [`QueryFinishHooks::nested`] for lightweight internal statement executions
+/// where the outer query owns cleanup and logging.
+#[derive(Clone, Copy)]
 pub struct QueryFinishHooks {
     /// Collect pipeline execution profiles into the query context.
     pub collect_profiles: bool,
+    /// Keep profile plan ids in the current physical-plan namespace.
+    pub use_profile_execution_id: bool,
     /// Run post-query cleanup hooks (CTE temp tables, spill files, disk temp dirs).
     pub run_hooks: bool,
     /// Emit the query-finish log, metrics, and profile JSON.
@@ -53,6 +55,7 @@ impl QueryFinishHooks {
     pub fn top_level() -> Self {
         Self {
             collect_profiles: true,
+            use_profile_execution_id: true,
             run_hooks: true,
             log_finished: true,
         }
@@ -64,6 +67,19 @@ impl QueryFinishHooks {
     pub fn nested() -> Self {
         Self {
             collect_profiles: true,
+            use_profile_execution_id: true,
+            run_hooks: false,
+            log_finished: false,
+        }
+    }
+
+    /// Profiles only in the current physical-plan namespace. Use for internal
+    /// pipelines whose plan ids are part of the outer plan tree (e.g. recursive
+    /// CTE step pipelines).
+    pub fn nested_in_current_profile_namespace() -> Self {
+        Self {
+            collect_profiles: true,
+            use_profile_execution_id: false,
             run_hooks: false,
             log_finished: false,
         }
@@ -76,6 +92,7 @@ impl QueryFinishHooks {
     pub fn nested_with_hooks() -> Self {
         Self {
             collect_profiles: true,
+            use_profile_execution_id: true,
             run_hooks: true,
             log_finished: false,
         }
@@ -93,7 +110,17 @@ impl QueryFinishHooks {
                 ctx.collect_local_perf_counters(node_id);
             }
             if self.collect_profiles {
-                ctx.add_query_profiles(&info.profiling);
+                if self.use_profile_execution_id {
+                    match info.profile_execution_id.as_deref() {
+                        Some(profile_execution_id) => ctx.add_query_profiles_with_execution(
+                            profile_execution_id,
+                            &info.profiling,
+                        ),
+                        None => ctx.add_query_profiles(&info.profiling),
+                    }
+                } else {
+                    ctx.add_query_profiles(&info.profiling)
+                }
             }
             let hooks_res = if self.run_hooks {
                 run_hooks(ctx.clone())

--- a/src/query/service/src/interpreters/interpreter_explain.rs
+++ b/src/query/service/src/interpreters/interpreter_explain.rs
@@ -63,11 +63,11 @@ use crate::pipelines::executor::QueryPipelineExecutor;
 use crate::schedulers::Fragmenter;
 use crate::schedulers::QueryFragmentsActions;
 use crate::schedulers::build_query_pipeline;
+use crate::sessions::CapturedCteExecution;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
 use crate::sessions::TableContextPartitionStats;
 use crate::sessions::TableContextQueryIdentity;
-use crate::sessions::TableContextQueryProfile;
 use crate::sessions::TableContextRuntimeFilter;
 use crate::sessions::TableContextSettings;
 use crate::sql::optimizer::ir::SExpr;
@@ -185,6 +185,7 @@ impl Interpreter for ExplainInterpreter {
                         metadata: &metadata,
                         scan_id_to_runtime_filters: HashMap::new(),
                         runtime_filter_reports: HashMap::new(),
+                        materialized_cte_temp_to_name: HashMap::new(),
                     };
 
                     let formatter = plan.formatter()?;
@@ -480,6 +481,11 @@ impl ExplainInterpreter {
         mutation_build_info: Option<MutationBuildInfo>,
         ignore_result: bool,
     ) -> Result<Vec<DataBlock>> {
+        // The materialized-CTE capture slot was opened by the binder before
+        // binding the inner statement (so that producer CTAS runs executed
+        // during binding are captured). We just read it back here.
+        let capture_slot = self.ctx.materialized_cte_capture();
+
         let mut builder = PhysicalPlanBuilder::new(metadata.clone(), self.ctx.clone(), true);
         if let Some(build_info) = mutation_build_info {
             builder.set_mutation_build_info(build_info);
@@ -497,6 +503,18 @@ impl ExplainInterpreter {
 
         let runtime_filter_reports = self.ctx.runtime_filter_reports();
 
+        // Take all captured CTE producers BEFORE we format the main plan. We
+        // also build a temp-table -> cte-name map so the main plan renders
+        // scans of those temp tables as `MaterializedCTERef`.
+        let captured = capture_slot
+            .finish()
+            .map(|c| c.into_parts())
+            .unwrap_or_default();
+        let temp_to_name: HashMap<String, String> = captured
+            .iter()
+            .map(|c| (c.temp_table_name.clone(), c.cte_name.clone()))
+            .collect();
+
         let result = match self.partial {
             true => {
                 let metadata = metadata.read();
@@ -505,6 +523,7 @@ impl ExplainInterpreter {
                     metadata: &metadata,
                     scan_id_to_runtime_filters: HashMap::new(),
                     runtime_filter_reports: runtime_filter_reports.clone(),
+                    materialized_cte_temp_to_name: temp_to_name.clone(),
                 };
 
                 let formatter = plan.formatter()?;
@@ -518,10 +537,17 @@ impl ExplainInterpreter {
                     metadata: &metadata,
                     scan_id_to_runtime_filters: HashMap::new(),
                     runtime_filter_reports: runtime_filter_reports.clone(),
+                    materialized_cte_temp_to_name: temp_to_name.clone(),
                 };
                 let formatter = plan.formatter()?;
                 let format_node = formatter.dispatch(&mut context)?;
-                format_node.format_pretty()?
+                let mut sections = vec![format_node.format_pretty()?];
+                sections.extend(format_captured_cte_sections(
+                    &captured,
+                    &temp_to_name,
+                    Some(&self.ctx),
+                )?);
+                sections.join("")
             }
         };
 
@@ -545,6 +571,8 @@ impl ExplainInterpreter {
         let settings = self.ctx.get_settings();
         build_res.set_max_threads(settings.get_max_threads()? as usize);
         let settings = ExecutorSettings::try_create(self.ctx.clone())?;
+
+        let profile_execution_id = settings.profile_execution_id.clone();
         let ctx = self.ctx.clone();
         build_res.main_pipeline.set_on_finished(always_callback(
             QueryFinishHooks::nested_with_hooks().into_callback(ctx.clone()),
@@ -565,11 +593,7 @@ impl ExplainInterpreter {
         }
         Ok(self
             .ctx
-            .get_query_profiles()
-            .into_iter()
-            .filter(|x| x.id.is_some())
-            .map(|x| (x.id.unwrap(), x))
-            .collect::<HashMap<_, _>>())
+            .get_query_profiles_for_execution(&profile_execution_id))
     }
 
     async fn explain_query(
@@ -580,6 +604,11 @@ impl ExplainInterpreter {
         formatted_ast: &Option<String>,
     ) -> Result<Vec<DataBlock>> {
         let ctx = self.ctx.clone();
+        // If a capture slot is active, render captured materialized CTE
+        // producers alongside the main plan. Plain EXPLAIN normally has no
+        // active capture and falls back to formatting the main plan below.
+        let capture_slot = self.ctx.materialized_cte_capture();
+
         // If `formatted_ast` is Some, it means we may use query result cache.
         // If we use result cache for this query,
         // we should not use `dry_run` mode to build the physical plan.
@@ -587,8 +616,43 @@ impl ExplainInterpreter {
         let mut builder = PhysicalPlanBuilder::new(metadata.clone(), ctx, formatted_ast.is_none());
         let mut plan = builder.build(s_expr, bind_context.column_set()).await?;
         self.inject_pruned_partitions_stats(&mut plan, metadata)?;
-        self.explain_physical_plan(&plan, metadata, formatted_ast)
-            .await
+
+        let captured = capture_slot
+            .finish()
+            .map(|c| c.into_parts())
+            .unwrap_or_default();
+
+        if captured.is_empty() {
+            return self
+                .explain_physical_plan(&plan, metadata, formatted_ast)
+                .await;
+        }
+
+        let temp_to_name: HashMap<String, String> = captured
+            .iter()
+            .map(|c| (c.temp_table_name.clone(), c.cte_name.clone()))
+            .collect();
+
+        let metadata_guard = metadata.read();
+        let mut main_context = FormatContext {
+            profs: HashMap::new(),
+            metadata: &metadata_guard,
+            scan_id_to_runtime_filters: HashMap::new(),
+            runtime_filter_reports: HashMap::new(),
+            materialized_cte_temp_to_name: temp_to_name.clone(),
+        };
+        let formatter = plan.formatter()?;
+        let mut sections = vec![formatter.dispatch(&mut main_context)?.format_pretty()?];
+        sections.extend(format_captured_cte_sections(
+            &captured,
+            &temp_to_name,
+            None,
+        )?);
+
+        let joined = sections.join("");
+        let line_split_result: Vec<&str> = joined.lines().collect();
+        let formatted_plan = StringType::from_data(line_split_result);
+        Ok(vec![DataBlock::new_from_columns(vec![formatted_plan])])
     }
 
     async fn explain_merge_fragments(
@@ -679,4 +743,43 @@ impl ExplainInterpreter {
         }
         Ok(None)
     }
+}
+
+/// Format captured materialized CTE producers into pretty-printed sections.
+///
+/// When `ctx` is `Some`, profiles are fetched per-CTE from the query context
+/// (the EXPLAIN ANALYZE path). When `None`, empty profiles are used (the plain
+/// EXPLAIN path).
+fn format_captured_cte_sections(
+    captured: &[CapturedCteExecution],
+    temp_to_name: &HashMap<String, String>,
+    ctx: Option<&Arc<QueryContext>>,
+) -> Result<Vec<String>> {
+    let mut sections = Vec::with_capacity(captured.len());
+    for cte in captured {
+        let cte_metadata = cte.metadata.read();
+        let cte_profs = match ctx {
+            Some(ctx) => cte
+                .profile_execution_id
+                .as_deref()
+                .map(|id| ctx.get_query_profiles_with_execution_id(id))
+                .unwrap_or_default(),
+            None => HashMap::new(),
+        };
+        let mut cte_context = FormatContext {
+            profs: cte_profs,
+            metadata: &cte_metadata,
+            scan_id_to_runtime_filters: HashMap::new(),
+            runtime_filter_reports: HashMap::new(),
+            materialized_cte_temp_to_name: temp_to_name.clone(),
+        };
+        let formatter = cte.plan.formatter()?;
+        let format_node = formatter.dispatch(&mut cte_context)?;
+        let tree =
+            FormatTreeNode::with_children(format!("MaterializedCTE: {}", cte.cte_name), vec![
+                format_node,
+            ]);
+        sections.push(tree.format_pretty()?);
+    }
+    Ok(sections)
 }

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -259,9 +259,31 @@ impl Interpreter for InsertInterpreter {
                 };
 
                 insert_select_plan.adjust_plan_id(&mut 0);
+
+                let capture_slot = self.ctx.materialized_cte_capture();
+                if capture_slot.is_active() {
+                    capture_slot.set_pending(crate::sessions::PendingCtasCapture {
+                        plan: insert_select_plan.clone(),
+                        metadata: metadata.clone(),
+                        profile_execution_id: None,
+                    });
+                }
+
                 let mut build_res =
                     build_query_pipeline_without_render_result_set(&self.ctx, &insert_select_plan)
                         .await?;
+
+                if capture_slot.is_active() {
+                    let slot = capture_slot.clone();
+                    build_res.main_pipeline.lift_on_finished(
+                        move |info: &databend_common_pipeline::core::ExecutionInfo| {
+                            slot.with_pending(|p| {
+                                p.profile_execution_id = info.profile_execution_id.clone();
+                            });
+                            Ok(())
+                        },
+                    );
+                }
 
                 table.commit_insertion(
                     self.ctx.clone(),

--- a/src/query/service/src/physical_plans/format/common.rs
+++ b/src/query/service/src/physical_plans/format/common.rs
@@ -36,6 +36,11 @@ pub struct FormatContext<'a> {
     pub profs: HashMap<u32, PlanProfile>,
     pub scan_id_to_runtime_filters: HashMap<IndexType, Vec<PhysicalRuntimeFilter>>,
     pub runtime_filter_reports: HashMap<IndexType, Vec<RuntimeFilterReport>>,
+    /// Mapping from the generated materialized-CTE temp table name
+    /// (e.g. `t$abc123`) back to the user-visible CTE name (`t`). Used by
+    /// the TableScan formatter to render `MaterializedCTERef: t` instead of
+    /// the internal temp-table scan when formatting the main query plan.
+    pub materialized_cte_temp_to_name: HashMap<String, String>,
 }
 
 pub fn pretty_display_agg_desc(desc: &AggregateFunctionDesc, metadata: &Metadata) -> String {

--- a/src/query/service/src/physical_plans/format/format_table_scan.rs
+++ b/src/query/service/src/physical_plans/format/format_table_scan.rs
@@ -60,6 +60,28 @@ impl<'a> PhysicalFormat for TableScanFormatter<'a> {
                 table.qualified_name()
             }
         };
+
+        // If this scan is actually a read from a materialized-CTE temp table
+        // produced earlier in this query, collapse the whole TableScan into a
+        // single `MaterializedCTERef: <cte_name>` line. Matches on the bare
+        // table name suffix — the metadata stores `db.tablename`, while the
+        // capture map is keyed by `tablename`.
+        let bare_table_name = table_name
+            .rsplit_once('.')
+            .map(|(_, n)| n)
+            .unwrap_or(table_name.as_str());
+        if let Some(cte_name) = ctx
+            .materialized_cte_temp_to_name
+            .get(bare_table_name)
+            .cloned()
+        {
+            let mut children = vec![FormatTreeNode::new(format!("cte_name: {cte_name}"))];
+            append_output_rows_info(&mut children, &ctx.profs, self.inner.get_id());
+            return Ok(FormatTreeNode::with_children(
+                "MaterializedCTERef".to_string(),
+                children,
+            ));
+        }
         let filters = self
             .inner
             .source

--- a/src/query/service/src/physical_plans/physical_plan.rs
+++ b/src/query/service/src/physical_plans/physical_plan.rs
@@ -360,6 +360,7 @@ impl PhysicalPlan {
             metadata,
             scan_id_to_runtime_filters: HashMap::new(),
             runtime_filter_reports: HashMap::new(),
+            materialized_cte_temp_to_name: HashMap::new(),
         };
 
         self.formatter()?.format(&mut context)

--- a/src/query/service/src/pipelines/executor/executor_settings.rs
+++ b/src/query/service/src/pipelines/executor/executor_settings.rs
@@ -18,12 +18,17 @@ use std::time::Duration;
 use databend_common_base::runtime::PerfEvent;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
+use uuid::Uuid;
 
 use crate::sessions::TableContext;
 
 #[derive(Clone)]
 pub struct ExecutorSettings {
     pub query_id: Arc<String>,
+    // Unique per executor instance. The finish hook carries
+    // this id along with the profile batch so QueryProfiles can map
+    // executor-local plan_ids into a disjoint global id range per execution
+    pub profile_execution_id: String,
     pub max_threads: u64,
     pub enable_queries_executor: bool,
     pub max_execute_time_in_seconds: Duration,
@@ -54,6 +59,7 @@ impl ExecutorSettings {
         Ok(ExecutorSettings {
             enable_queries_executor,
             query_id: Arc::new(query_id),
+            profile_execution_id: Uuid::new_v4().to_string(),
             max_execute_time_in_seconds: Duration::from_secs(max_execute_time_in_seconds),
             max_threads,
             executor_node_id: ctx.get_cluster().local_id.clone(),

--- a/src/query/service/src/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/pipeline_executor.rs
@@ -199,13 +199,21 @@ impl PipelineExecutor {
                 match may_error {
                     None => {
                         let mut finished_chain = query_wrapper.on_finished_chain.lock();
-                        let info = ExecutionInfo::create(Ok(()), self.fetch_profiling(true));
+                        let info = ExecutionInfo::create_with_profile_execution_id(
+                            Ok(()),
+                            self.fetch_profiling(true),
+                            self.profile_execution_id().to_string(),
+                        );
                         finished_chain.apply(info)
                     }
                     Some(cause) => {
                         let mut finished_chain = query_wrapper.on_finished_chain.lock();
                         let profiling = self.fetch_profiling(true);
-                        let info = ExecutionInfo::create(Err(cause.clone()), profiling);
+                        let info = ExecutionInfo::create_with_profile_execution_id(
+                            Err(cause.clone()),
+                            profiling,
+                            self.profile_execution_id().to_string(),
+                        );
                         finished_chain.apply(info).and_then(|_| Err(cause))
                     }
                 }
@@ -285,6 +293,13 @@ impl PipelineExecutor {
                     .fetch_profiling(Some(v.settings.executor_node_id.clone())),
                 false => v.graph.fetch_profiling(None),
             },
+        }
+    }
+
+    pub fn profile_execution_id(&self) -> &str {
+        match self {
+            PipelineExecutor::QueryPipelineExecutor(executor) => executor.profile_execution_id(),
+            PipelineExecutor::QueriesPipelineExecutor(v) => &v.settings.profile_execution_id,
         }
     }
 

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -294,7 +294,11 @@ impl QueryPipelineExecutor {
                     drop(finished_error_guard);
 
                     let profiling = self.fetch_plans_profile(true);
-                    self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
+                    self.on_finished(ExecutionInfo::create_with_profile_execution_id(
+                        Err(may_error.clone()),
+                        profiling,
+                        self.profile_execution_id().to_string(),
+                    ))?;
                     return Err(may_error);
                 }
             }
@@ -303,19 +307,31 @@ impl QueryPipelineExecutor {
             if matches!(&thread_res, Err(error) if error.code() != ErrorCode::ABORTED_QUERY) {
                 let may_error = thread_res.unwrap_err();
                 let profiling = self.fetch_plans_profile(true);
-                self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
+                self.on_finished(ExecutionInfo::create_with_profile_execution_id(
+                    Err(may_error.clone()),
+                    profiling,
+                    self.profile_execution_id().to_string(),
+                ))?;
                 return Err(may_error);
             }
         }
 
         if let Err(error) = self.graph.assert_finished_graph() {
             let profiling = self.fetch_plans_profile(true);
-            self.on_finished(ExecutionInfo::create(Err(error.clone()), profiling))?;
+            self.on_finished(ExecutionInfo::create_with_profile_execution_id(
+                Err(error.clone()),
+                profiling,
+                self.profile_execution_id().to_string(),
+            ))?;
             return Err(error);
         }
 
         let profiling = self.fetch_plans_profile(true);
-        self.on_finished(ExecutionInfo::create(Ok(()), profiling))?;
+        self.on_finished(ExecutionInfo::create_with_profile_execution_id(
+            Ok(()),
+            profiling,
+            self.profile_execution_id().to_string(),
+        ))?;
         Ok(())
     }
 
@@ -509,6 +525,10 @@ impl QueryPipelineExecutor {
         }
     }
 
+    pub fn profile_execution_id(&self) -> &str {
+        &self.settings.profile_execution_id
+    }
+
     pub fn get_query_execution_stats(&self) -> ExecutorStatsSnapshot {
         self.graph.get_query_execution_stats()
     }
@@ -531,7 +551,11 @@ impl Drop for QueryPipelineExecutor {
         let tracking_payload = ThreadTracker::new_tracking_payload();
         let _guard = ThreadTracker::tracking(tracking_payload);
         let profiling = self.fetch_plans_profile(true);
-        let info = ExecutionInfo::create(Err(cause), profiling);
+        let info = ExecutionInfo::create_with_profile_execution_id(
+            Err(cause),
+            profiling,
+            self.profile_execution_id().to_string(),
+        );
         if let Err(cause) = on_finished_chain.apply(info) {
             warn!("Shutdown failure: {:?}", cause);
         }

--- a/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
+++ b/src/query/service/src/pipelines/processors/transforms/transform_recursive_cte_source.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use databend_common_ast::ast::Engine;
 use databend_common_base::runtime::Runtime;
+use databend_common_base::runtime::profile::ProfileLabel;
 use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -37,6 +38,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_pipeline::core::OutputPort;
+use databend_common_pipeline::core::PlanScope;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline::core::always_callback;
 use databend_common_pipeline::sources::AsyncSource;
@@ -52,14 +54,16 @@ use md5::Md5;
 use crate::interpreters::CreateTableInterpreter;
 use crate::interpreters::Interpreter;
 use crate::interpreters::QueryFinishHooks;
+use crate::physical_plans::IPhysicalPlan;
 use crate::physical_plans::PhysicalPlan;
 use crate::physical_plans::PhysicalPlanCast;
 use crate::physical_plans::PhysicalPlanVisitor;
 use crate::physical_plans::RecursiveCteScan;
 use crate::physical_plans::UnionAll;
+use crate::pipelines::PipelineBuilder;
+use crate::pipelines::attach_runtime_filter_logger;
 use crate::pipelines::executor::ExecutorSettings;
 use crate::pipelines::executor::PipelinePullingExecutor;
-use crate::schedulers::build_query_pipeline_without_render_result_set;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextCte;
 use crate::sessions::TableContextProgress;
@@ -207,9 +211,21 @@ impl TransformRecursiveCteSource {
             union_plan.right.clone()
         };
         ctx.clear_runtime_filter();
-        let mut build_res = build_query_pipeline_without_render_result_set(&ctx, &plan).await?;
+        let union_scope = create_union_plan_scope(&union_plan)?;
+        let mut build_res = {
+            let _guard = union_scope.enter_scope_guard();
+            let pipeline = PipelineBuilder::create(
+                ctx.get_function_context()?,
+                ctx.get_settings(),
+                ctx.clone(),
+            );
+            pipeline.finalize(&plan)?
+        };
+        let settings = ctx.get_settings();
+        build_res.set_max_threads(settings.get_max_threads()? as usize);
+        attach_runtime_filter_logger(ctx.clone(), &mut build_res.main_pipeline);
         build_res.main_pipeline.set_on_finished(always_callback(
-            QueryFinishHooks::nested().into_callback(ctx.clone()),
+            QueryFinishHooks::nested_in_current_profile_namespace().into_callback(ctx.clone()),
         ));
         let settings = ExecutorSettings::try_create(ctx.clone())?;
         let pulling_executor = PipelinePullingExecutor::from_pipelines(build_res, settings)?;
@@ -222,6 +238,24 @@ impl TransformRecursiveCteSource {
         let data_blocks = join_handle.await??;
         Ok((data_blocks, cte_scan_tables))
     }
+}
+
+fn create_union_plan_scope(union_plan: &UnionAll) -> Result<Arc<PlanScope>> {
+    // Recursive CTE runs anchor/recursive inputs as internal step pipelines, so
+    // they are built outside the original UnionAll scope. Re-enter that scope
+    // here to keep child plan profiles attached to the recursive UnionAll.
+    let plan_labels = union_plan.get_labels()?;
+    let mut profile_labels = Vec::with_capacity(plan_labels.len());
+    for (name, value) in plan_labels {
+        profile_labels.push(ProfileLabel::create(name, value));
+    }
+
+    Ok(PlanScope::create(
+        union_plan.get_id(),
+        union_plan.get_name(),
+        Arc::new(union_plan.get_desc()?),
+        Arc::new(profile_labels),
+    ))
 }
 
 fn make_rcte_prefix(ctx: &Arc<QueryContext>, union_plan: &UnionAll) -> Result<String> {

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -827,20 +827,35 @@ impl DataExchangeManager {
 
                 let exchanges = std::mem::take(&mut query_coordinator.statistics_exchanges);
                 let statistics_receiver = StatisticsReceiver::spawn_receiver(&ctx, exchanges)?;
+                let remote_query_profiles = statistics_receiver.query_profiles();
 
                 let statistics_receiver: Mutex<StatisticsReceiver> =
                     Mutex::new(statistics_receiver);
 
                 // Interrupting the execution of finished callback if network error
+                let query_ctx = ctx.clone();
                 build_res.main_pipeline.set_on_finished(basic_callback(
                     move |info: &ExecutionInfo| {
-                        let query_id = ctx.get_id();
+                        let query_id = query_ctx.get_id();
                         let mut statistics_receiver = statistics_receiver.lock();
 
                         statistics_receiver.shutdown(info.res.is_err());
-                        ctx.get_exchange_manager()
+                        query_ctx
+                            .get_exchange_manager()
                             .on_finished_query(&query_id, info.res.clone().err());
-                        statistics_receiver.wait_shutdown()
+                        let shutdown_res = statistics_receiver.wait_shutdown();
+                        let profiles = remote_query_profiles.read().clone();
+                        if !profiles.is_empty() {
+                            match info.profile_execution_id.as_deref() {
+                                Some(profile_execution_id) => query_ctx
+                                    .add_query_profiles_with_execution(
+                                        profile_execution_id,
+                                        &profiles,
+                                    ),
+                                None => query_ctx.add_query_profiles(&profiles),
+                            }
+                        }
+                        shutdown_res
                     },
                 ));
 

--- a/src/query/service/src/servers/flight/v1/exchange/statistics_receiver.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/statistics_receiver.rs
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use databend_common_base::JoinHandle;
 use databend_common_base::runtime::Runtime;
 use databend_common_exception::Result;
+use databend_common_pipeline::core::PlanProfile;
 use futures_util::future::Either;
 use futures_util::future::select;
+use parking_lot::RwLock;
 use tokio::sync::broadcast::Sender;
 use tokio::sync::broadcast::channel;
 
@@ -32,13 +35,13 @@ use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
 use crate::sessions::TableContextPartitionStats;
 use crate::sessions::TableContextPerf;
-use crate::sessions::TableContextQueryProfile;
 use crate::sessions::TableContextTelemetry;
 
 pub struct StatisticsReceiver {
     _runtime: Runtime,
     shutdown_tx: Option<Sender<bool>>,
     exchange_handler: Vec<JoinHandle<Result<()>>>,
+    query_profiles: Arc<RwLock<HashMap<u32, PlanProfile>>>,
 }
 
 impl StatisticsReceiver {
@@ -49,6 +52,7 @@ impl StatisticsReceiver {
         let (shutdown_tx, _shutdown_rx) = channel(2);
         let mut exchange_handler = Vec::with_capacity(statistics_exchanges.len());
         let runtime = Runtime::with_worker_threads(2, Some(String::from("StatisticsReceiver")))?;
+        let query_profiles = Arc::new(RwLock::new(HashMap::new()));
 
         for (source_target, exchange) in statistics_exchanges.into_iter() {
             let rx = exchange.convert_to_receiver();
@@ -56,6 +60,7 @@ impl StatisticsReceiver {
                 let ctx = ctx.clone();
                 let shutdown_rx = shutdown_tx.subscribe();
                 let node_memory_updater = ctx.get_node_memory_updater(&source_target);
+                let query_profiles = query_profiles.clone();
 
                 async move {
                     let mut shutdown_rx = shutdown_rx;
@@ -73,6 +78,7 @@ impl StatisticsReceiver {
                                     &ctx,
                                     &source_target,
                                     &node_memory_updater,
+                                    &query_profiles,
                                     recv.await,
                                 ) {
                                     Ok(true) => {
@@ -87,6 +93,7 @@ impl StatisticsReceiver {
                                             &ctx,
                                             &source_target,
                                             &node_memory_updater,
+                                            &query_profiles,
                                             rx.recv().await,
                                         ) {
                                             Ok(true) => {
@@ -107,6 +114,7 @@ impl StatisticsReceiver {
                                     &ctx,
                                     &source_target,
                                     &node_memory_updater,
+                                    &query_profiles,
                                     res,
                                 ) {
                                     Ok(true) => {
@@ -132,13 +140,19 @@ impl StatisticsReceiver {
             exchange_handler,
             _runtime: runtime,
             shutdown_tx: Some(shutdown_tx),
+            query_profiles,
         })
+    }
+
+    pub fn query_profiles(&self) -> Arc<RwLock<HashMap<u32, PlanProfile>>> {
+        self.query_profiles.clone()
     }
 
     fn recv_data(
         ctx: &Arc<QueryContext>,
         source_target: &str,
         node_memory_usage: &Arc<MemoryUpdater>,
+        query_profiles: &Arc<RwLock<HashMap<u32, PlanProfile>>>,
         recv_data: Result<Option<DataPacket>>,
     ) -> Result<bool> {
         match recv_data {
@@ -167,7 +181,17 @@ impl StatisticsReceiver {
                 Ok(false)
             }
             Ok(Some(DataPacket::QueryProfiles(profiles))) => {
-                ctx.add_query_profiles(&profiles);
+                let mut merged_profiles = query_profiles.write();
+                for (id, profile) in profiles {
+                    match merged_profiles.entry(id) {
+                        Entry::Vacant(v) => {
+                            v.insert(profile);
+                        }
+                        Entry::Occupied(mut v) => {
+                            v.get_mut().merge(&profile);
+                        }
+                    };
+                }
                 Ok(false)
             }
             Ok(Some(DataPacket::CopyStatus(status))) => {

--- a/src/query/service/src/sessions/materialized_cte_capture.rs
+++ b/src/query/service/src/sessions/materialized_cte_capture.rs
@@ -1,0 +1,121 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_sql::MetadataRef;
+use parking_lot::Mutex;
+
+use crate::physical_plans::PhysicalPlan;
+
+/// One captured materialized-CTE producer execution.
+///
+/// The producer's profiling batch is NOT stored inline here. It lives in the
+/// shared `QueryProfiles` map keyed by `profile_execution_id`; consumers
+/// (EXPLAIN ANALYZE formatter) fetch it on demand via
+/// `QueryContext::get_query_profiles_with_execution_id(&self.profile_execution_id)`.
+/// This keeps a single source of truth for profile data and lets the outer
+/// `databend::log::profile` record include CTE producers automatically.
+pub struct CapturedCteExecution {
+    pub cte_name: String,
+    pub temp_table_name: String,
+    pub plan: PhysicalPlan,
+    pub metadata: MetadataRef,
+    /// Executor-instance id that produced this CTAS; `None` for plain EXPLAIN
+    /// (no pipeline was executed, so no profile was emitted).
+    pub profile_execution_id: Option<String>,
+}
+
+/// Scratch slot the CTAS interpreter writes to and the binder drains after
+/// `execute_query_with_sql_string` returns. Only the bits that can't be
+/// reconstructed afterwards live here.
+pub struct PendingCtasCapture {
+    pub plan: PhysicalPlan,
+    pub metadata: MetadataRef,
+    pub profile_execution_id: Option<String>,
+}
+
+/// Capture state attached to `QueryContextShared` — ordered list of
+/// completed producers plus a single-slot staging area for the CTAS currently
+/// running.
+pub struct MaterializedCteCapture {
+    captured: Vec<CapturedCteExecution>,
+    pending: Option<PendingCtasCapture>,
+}
+
+impl MaterializedCteCapture {
+    pub fn new() -> Self {
+        Self {
+            captured: Vec::new(),
+            pending: None,
+        }
+    }
+
+    pub fn into_parts(self) -> Vec<CapturedCteExecution> {
+        self.captured
+    }
+}
+
+impl Default for MaterializedCteCapture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Handle the binder / interpreter share. `Mutex` because writes happen both
+/// from the interpreter's `on_finished` (may be on an executor thread) and
+/// from `block_on` inside `m_cte_to_temp_table`.
+#[derive(Clone, Default)]
+pub struct MaterializedCteCaptureSlot {
+    inner: Arc<Mutex<Option<MaterializedCteCapture>>>,
+}
+
+impl MaterializedCteCaptureSlot {
+    pub fn begin(&self) {
+        *self.inner.lock() = Some(MaterializedCteCapture::new());
+    }
+
+    pub fn finish(&self) -> Option<MaterializedCteCapture> {
+        self.inner.lock().take()
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.inner.lock().is_some()
+    }
+
+    pub fn set_pending(&self, pending: PendingCtasCapture) {
+        if let Some(capture) = self.inner.lock().as_mut() {
+            capture.pending = Some(pending);
+        }
+    }
+
+    pub fn with_pending<F>(&self, f: F)
+    where F: FnOnce(&mut PendingCtasCapture) {
+        if let Some(capture) = self.inner.lock().as_mut()
+            && let Some(pending) = capture.pending.as_mut()
+        {
+            f(pending);
+        }
+    }
+
+    pub fn take_pending(&self) -> Option<PendingCtasCapture> {
+        self.inner.lock().as_mut().and_then(|c| c.pending.take())
+    }
+
+    pub fn push_captured(&self, entry: CapturedCteExecution) {
+        if let Some(capture) = self.inner.lock().as_mut() {
+            capture.captured.push(entry);
+        }
+    }
+}

--- a/src/query/service/src/sessions/mod.rs
+++ b/src/query/service/src/sessions/mod.rs
@@ -14,9 +14,11 @@
 
 databend_common_tracing::register_module_tag!("[SESSION]");
 
+mod materialized_cte_capture;
 mod query_affect;
 pub mod query_ctx;
 mod query_ctx_shared;
+mod query_profiles;
 mod queue_mgr;
 mod runtime_filter_state;
 mod session;
@@ -30,11 +32,16 @@ mod session_status;
 
 pub use databend_common_base::base::BuildInfoRef;
 pub use databend_common_catalog::table_context::prelude::*;
+pub use materialized_cte_capture::CapturedCteExecution;
+pub use materialized_cte_capture::MaterializedCteCapture;
+pub use materialized_cte_capture::MaterializedCteCaptureSlot;
+pub use materialized_cte_capture::PendingCtasCapture;
 pub use query_affect::QueryAffect;
 pub use query_ctx::QueryContext;
 pub use query_ctx::convert_query_log_timestamp;
 pub use query_ctx_shared::MemoryUpdater;
 pub use query_ctx_shared::QueryContextShared;
+pub use query_profiles::QueryProfiles;
 pub use queue_mgr::AcquireQueueGuard;
 pub use queue_mgr::QueriesQueueManager;
 pub use queue_mgr::QueryEntry;

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -509,6 +509,35 @@ impl QueryContext {
         self.shared.set_executor(weak_ptr)
     }
 
+    pub fn add_query_profiles(&self, profiles: &HashMap<u32, PlanProfile>) {
+        self.shared.add_query_profiles(profiles);
+    }
+
+    pub fn add_query_profiles_with_execution(
+        &self,
+        profile_execution_id: &str,
+        profiles: &HashMap<u32, PlanProfile>,
+    ) {
+        self.shared
+            .add_query_profiles_with_execution(profile_execution_id, profiles);
+    }
+
+    pub fn get_query_profiles_for_execution(
+        &self,
+        profile_execution_id: &str,
+    ) -> HashMap<u32, PlanProfile> {
+        self.shared
+            .get_query_profiles_for_execution(profile_execution_id)
+    }
+
+    pub fn get_query_profiles_with_execution_id(
+        &self,
+        profile_execution_id: &str,
+    ) -> HashMap<u32, PlanProfile> {
+        self.shared
+            .get_query_profiles_with_execution_id(profile_execution_id)
+    }
+
     pub fn attach_stage(&self, attachment: StageAttachment) {
         self.shared.attach_stage(attachment);
     }
@@ -952,6 +981,12 @@ impl QueryContext {
         let mut receivers = self.shared.materialized_cte_receivers.lock();
         let receivers = receivers.get_mut(cte_name).unwrap();
         receivers.pop().unwrap()
+    }
+
+    /// Slot used by EXPLAIN / EXPLAIN ANALYZE to collect the physical plan
+    /// (and, for ANALYZE, the profile) of materialized-CTE producer CTAS runs.
+    pub fn materialized_cte_capture(&self) -> crate::sessions::MaterializedCteCaptureSlot {
+        self.shared.materialized_cte_capture.clone()
     }
 }
 

--- a/src/query/service/src/sessions/query_ctx/table.rs
+++ b/src/query/service/src/sessions/query_ctx/table.rs
@@ -222,6 +222,33 @@ impl TableContextCte for QueryContext {
         self.shared.recursive_cte_temp_tables.write().clear();
         Ok(())
     }
+
+    fn is_materialized_cte_capture_active(&self) -> bool {
+        self.materialized_cte_capture().is_active()
+    }
+
+    fn begin_materialized_cte_capture(&self) {
+        self.materialized_cte_capture().begin();
+    }
+
+    fn finalize_materialized_cte_capture(&self, cte_name: &str, temp_table_name: &str) {
+        let slot = self.materialized_cte_capture();
+        let Some(pending) = slot.take_pending() else {
+            log::warn!(
+                "finalize_materialized_cte_capture: no pending entry for CTE '{}' \
+                 (capture active but CTAS did not publish a plan)",
+                cte_name,
+            );
+            return;
+        };
+        slot.push_captured(crate::sessions::CapturedCteExecution {
+            cte_name: cte_name.to_string(),
+            temp_table_name: temp_table_name.to_string(),
+            plan: pending.plan,
+            metadata: pending.metadata,
+            profile_execution_id: pending.profile_execution_id,
+        });
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -70,6 +70,7 @@ use crate::clusters::ClusterDiscovery;
 use crate::pipelines::executor::PipelineExecutor;
 use crate::servers::flight::v1::packets::NodePerfCounters;
 use crate::sessions::BuildInfoRef;
+use crate::sessions::QueryProfiles;
 use crate::sessions::Session;
 use crate::sessions::query_affect::QueryAffect;
 use crate::sessions::runtime_filter_state::RuntimeFilterState;
@@ -140,7 +141,7 @@ pub struct QueryContextShared {
     // Client User-Agent
     pub(super) user_agent: Arc<RwLock<String>>,
 
-    pub(super) query_profiles: Arc<RwLock<HashMap<Option<u32>, PlanProfile>>>,
+    query_profiles: Arc<Mutex<QueryProfiles>>,
 
     pub(super) runtime_filter_state: RuntimeFilterState,
 
@@ -172,6 +173,10 @@ pub struct QueryContextShared {
     pub(super) nodes_perf_counters: Arc<Mutex<HashMap<String, NodePerfCounters>>>,
 
     pub(super) materialized_cte_receivers: Arc<Mutex<HashMap<String, Vec<Receiver<DataBlock>>>>>,
+    // Capture slot for EXPLAIN / EXPLAIN ANALYZE of materialized CTE producers.
+    // Set by the outer explain interpreter before planning; populated by the
+    // inner CTAS interpreter; drained after formatting.
+    pub(super) materialized_cte_capture: crate::sessions::MaterializedCteCaptureSlot,
     // Temp tables created for recursive CTE cleanup.
     // This must be shared across QueryContext instances created from the same query,
     // otherwise cleanup hooks running on the parent context cannot see registrations
@@ -228,7 +233,7 @@ impl QueryContextShared {
             group_by_spill_progress: Arc::new(Progress::create()),
             window_partition_spill_progress: Arc::new(Progress::create()),
             query_cache_metrics: DataCacheMetrics::new(),
-            query_profiles: Arc::new(RwLock::new(HashMap::new())),
+            query_profiles: Arc::new(Mutex::new(QueryProfiles::default())),
             runtime_filter_state: Default::default(),
             merge_into_join: Default::default(),
             query_queued_duration: Arc::new(RwLock::new(Duration::from_secs(0))),
@@ -246,6 +251,7 @@ impl QueryContextShared {
             nodes_perf: Arc::new(Mutex::new(HashMap::new())),
             nodes_perf_counters: Arc::new(Mutex::new(HashMap::new())),
             materialized_cte_receivers: Arc::new(Mutex::new(HashMap::new())),
+            materialized_cte_capture: Default::default(),
             recursive_cte_temp_tables: Arc::new(RwLock::new(Vec::new())),
             logical_recursive_cte_runtime_ids: Arc::new(RwLock::new(HashMap::new())),
         }))
@@ -694,26 +700,56 @@ impl QueryContextShared {
     }
 
     pub fn get_query_profiles(&self) -> Vec<PlanProfile> {
-        if let Some(executor) = self.executor.read().upgrade() {
-            self.add_query_profiles(&executor.fetch_profiling(false));
+        let current_profiling = self.executor.read().upgrade().map(|executor| {
+            (
+                executor.profile_execution_id().to_string(),
+                executor.fetch_profiling(false),
+            )
+        });
+
+        let mut query_profiles = self.query_profiles.lock();
+        if let Some((profile_execution_id, profiling)) = current_profiling {
+            query_profiles.add_with_execution(&profile_execution_id, &profiling);
         }
 
-        self.query_profiles.read().values().cloned().collect()
+        query_profiles.get()
+    }
+
+    /// Return the normal EXPLAIN ANALYZE profile view for one execution,
+    /// overlaid with profiles collected in the current physical-plan namespace.
+    pub fn get_query_profiles_for_execution(
+        &self,
+        profile_execution_id: &str,
+    ) -> HashMap<u32, PlanProfile> {
+        self.query_profiles
+            .lock()
+            .get_for_execution(profile_execution_id)
+    }
+
+    /// Return only the profiles collected under a concrete execution id.
+    /// Used for materialized-CTE producer sections whose plan ids are isolated
+    /// from the outer query.
+    pub fn get_query_profiles_with_execution_id(
+        &self,
+        profile_execution_id: &str,
+    ) -> HashMap<u32, PlanProfile> {
+        self.query_profiles
+            .lock()
+            .get_with_execution_id(profile_execution_id)
     }
 
     pub fn add_query_profiles(&self, profiles: &HashMap<u32, PlanProfile>) {
-        let mut merged_profiles = self.query_profiles.write();
+        self.query_profiles.lock().add(profiles);
+    }
 
-        for query_profile in profiles.values() {
-            match merged_profiles.entry(query_profile.id) {
-                Entry::Vacant(v) => {
-                    v.insert(query_profile.clone());
-                }
-                Entry::Occupied(mut v) => {
-                    v.get_mut().merge(query_profile);
-                }
-            };
-        }
+    pub fn add_query_profiles_with_execution(
+        &self,
+        profile_execution_id: &str,
+        profiles: &HashMap<u32, PlanProfile>,
+    ) {
+        self.query_profiles
+            .lock()
+            .add_with_execution(profile_execution_id, profiles);
     }
 
     pub fn get_query_execution_stats(&self) -> Option<ExecutorStatsSnapshot> {

--- a/src/query/service/src/sessions/query_profiles.rs
+++ b/src/query/service/src/sessions/query_profiles.rs
@@ -1,0 +1,392 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use databend_common_pipeline::core::PlanProfile;
+
+type ProfilesByPlanId = HashMap<Option<u32>, PlanProfile>;
+type Profiles = HashMap<Option<String>, ProfilesByPlanId>;
+
+#[derive(Default)]
+pub struct QueryProfiles {
+    profiles: Profiles,
+    execution_ranges: ExecutionRangeState,
+}
+
+#[derive(Default)]
+struct ExecutionRangeState {
+    ranges: HashMap<String, ProfileExecutionRange>,
+    next_id: u32,
+}
+
+#[derive(Clone, Copy)]
+struct ProfileExecutionRange {
+    offset: u32,
+    id_count: u32,
+}
+
+impl QueryProfiles {
+    pub fn get(&self) -> Vec<PlanProfile> {
+        let mut profiles = HashMap::new();
+
+        for (namespace, namespace_profiles) in self.profiles.iter() {
+            match namespace {
+                Some(profile_execution_id) => {
+                    let Some(range) = self
+                        .execution_ranges
+                        .ranges
+                        .get(profile_execution_id)
+                        .copied()
+                    else {
+                        continue;
+                    };
+                    merge_into(
+                        &mut profiles,
+                        namespace_profiles
+                            .values()
+                            .map(|profile| offset_profile(profile, range.offset)),
+                    );
+                }
+                None => {
+                    merge_into(&mut profiles, namespace_profiles.values().cloned());
+                }
+            }
+        }
+
+        profiles.into_values().collect()
+    }
+
+    pub fn get_for_execution(&self, profile_execution_id: &str) -> HashMap<u32, PlanProfile> {
+        let mut profiles = self.get_with_execution_id(profile_execution_id);
+        if let Some(unscoped_profiles) = self.profiles.get(&None) {
+            for profile in unscoped_profiles.values() {
+                let Some(id) = profile.id else {
+                    continue;
+                };
+                match profiles.entry(id) {
+                    Entry::Vacant(v) => {
+                        v.insert(profile.clone());
+                    }
+                    Entry::Occupied(mut v) => {
+                        v.get_mut().merge(profile);
+                    }
+                };
+            }
+        }
+        profiles
+    }
+
+    pub fn get_with_execution_id(&self, profile_execution_id: &str) -> HashMap<u32, PlanProfile> {
+        let Some(execution_profiles) = self.profiles.get(&Some(profile_execution_id.to_string()))
+        else {
+            return HashMap::new();
+        };
+
+        let mut profiles = HashMap::new();
+        for profile in execution_profiles.values() {
+            let Some(id) = profile.id else {
+                continue;
+            };
+            profiles.insert(id, profile.clone());
+        }
+        profiles
+    }
+
+    pub fn add(&mut self, profiles: &HashMap<u32, PlanProfile>) {
+        merge_into(
+            self.profiles.entry(None).or_default(),
+            profiles.values().cloned(),
+        );
+    }
+
+    pub fn add_with_execution(
+        &mut self,
+        profile_execution_id: &str,
+        profiles: &HashMap<u32, PlanProfile>,
+    ) {
+        if self
+            .execution_range(profile_execution_id, profiles)
+            .is_none()
+        {
+            return;
+        };
+
+        merge_into(
+            self.profiles
+                .entry(Some(profile_execution_id.to_string()))
+                .or_default(),
+            profiles.values().cloned(),
+        );
+    }
+
+    fn execution_range(
+        &mut self,
+        profile_execution_id: &str,
+        profiles: &HashMap<u32, PlanProfile>,
+    ) -> Option<ProfileExecutionRange> {
+        let id_count = Self::id_count(profiles)?;
+        Some(self.reserve_execution_range(profile_execution_id, id_count))
+    }
+
+    fn id_count(profiles: &HashMap<u32, PlanProfile>) -> Option<u32> {
+        profiles
+            .values()
+            .filter_map(|profile| profile.id)
+            .max()
+            .map(|id| id + 1)
+    }
+
+    fn reserve_execution_range(
+        &mut self,
+        profile_execution_id: &str,
+        id_count: u32,
+    ) -> ProfileExecutionRange {
+        let state = &mut self.execution_ranges;
+        if let Some(range) = state.ranges.get(profile_execution_id).copied() {
+            if id_count <= range.id_count {
+                return range;
+            }
+
+            let current_end = range.offset + range.id_count;
+            if state.next_id == current_end {
+                state.next_id = range.offset + id_count;
+                let new_range = ProfileExecutionRange {
+                    offset: range.offset,
+                    id_count,
+                };
+                state
+                    .ranges
+                    .insert(profile_execution_id.to_string(), new_range);
+                return new_range;
+            }
+
+            let offset = state.next_id;
+            state.next_id += id_count;
+            let new_range = ProfileExecutionRange { offset, id_count };
+            state
+                .ranges
+                .insert(profile_execution_id.to_string(), new_range);
+            return new_range;
+        }
+
+        let offset = state.next_id;
+        state.next_id += id_count;
+        let range = ProfileExecutionRange { offset, id_count };
+        state.ranges.insert(profile_execution_id.to_string(), range);
+        range
+    }
+}
+
+fn offset_profile(profile: &PlanProfile, offset: u32) -> PlanProfile {
+    let mut profile = profile.clone();
+    if offset != 0 {
+        profile.id = profile.id.map(|id| id + offset);
+        profile.parent_id = profile.parent_id.map(|id| id + offset);
+    }
+    profile
+}
+
+fn merge_into(merged_profiles: &mut ProfilesByPlanId, profiles: impl Iterator<Item = PlanProfile>) {
+    for query_profile in profiles {
+        match merged_profiles.entry(query_profile.id) {
+            Entry::Vacant(v) => {
+                v.insert(query_profile);
+            }
+            Entry::Occupied(mut v) => {
+                v.get_mut().merge(&query_profile);
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use databend_common_base::runtime::profile::ProfileLabel;
+
+    use super::*;
+
+    fn plan_profile(id: u32, parent_id: Option<u32>, statistic: usize) -> PlanProfile {
+        let mut statistics = std::array::from_fn(|_| 0);
+        statistics[0] = statistic;
+
+        PlanProfile {
+            id: Some(id),
+            name: Some(format!("plan-{id}")),
+            parent_id,
+            title: Arc::new(format!("plan-{id}")),
+            labels: Arc::new(Vec::<ProfileLabel>::new()),
+            metrics: BTreeMap::new(),
+            statistics,
+            errors: vec![],
+        }
+    }
+
+    fn profiles_by_id(profiles: Vec<PlanProfile>) -> HashMap<u32, PlanProfile> {
+        profiles
+            .into_iter()
+            .map(|profile| (profile.id.unwrap(), profile))
+            .collect()
+    }
+
+    #[test]
+    fn query_profiles_reuses_execution_offset_for_repeated_batches() {
+        let mut query_profiles = QueryProfiles::default();
+        let first_batch =
+            profiles_by_id(vec![plan_profile(0, None, 1), plan_profile(1, Some(0), 2)]);
+        let second_batch =
+            profiles_by_id(vec![plan_profile(0, None, 3), plan_profile(1, Some(0), 4)]);
+
+        query_profiles.add_with_execution("exec-a", &first_batch);
+        query_profiles.add_with_execution("exec-a", &second_batch);
+
+        let profiles = profiles_by_id(query_profiles.get());
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[&0].statistics[0], 4);
+        assert_eq!(profiles[&1].statistics[0], 6);
+        assert_eq!(profiles[&1].parent_id, Some(0));
+
+        let raw_profiles = query_profiles.get_with_execution_id("exec-a");
+        assert_eq!(raw_profiles.len(), 2);
+        assert_eq!(raw_profiles[&0].statistics[0], 4);
+        assert_eq!(raw_profiles[&1].statistics[0], 6);
+        assert_eq!(raw_profiles[&1].parent_id, Some(0));
+    }
+
+    #[test]
+    fn query_profiles_remaps_distinct_executions() {
+        let mut query_profiles = QueryProfiles::default();
+        let first_batch =
+            profiles_by_id(vec![plan_profile(0, None, 1), plan_profile(1, Some(0), 2)]);
+        let second_batch =
+            profiles_by_id(vec![plan_profile(0, None, 3), plan_profile(1, Some(0), 4)]);
+
+        query_profiles.add_with_execution("exec-a", &first_batch);
+        query_profiles.add_with_execution("exec-b", &second_batch);
+
+        let profiles = profiles_by_id(query_profiles.get());
+        assert_eq!(profiles.len(), 4);
+        assert_eq!(profiles[&0].statistics[0], 1);
+        assert_eq!(profiles[&1].statistics[0], 2);
+        assert_eq!(profiles[&2].statistics[0], 3);
+        assert_eq!(profiles[&3].statistics[0], 4);
+        assert_eq!(profiles[&1].parent_id, Some(0));
+        assert_eq!(profiles[&3].parent_id, Some(2));
+
+        let raw_profiles = query_profiles.get_with_execution_id("exec-b");
+        assert_eq!(raw_profiles.len(), 2);
+        assert_eq!(raw_profiles[&0].statistics[0], 3);
+        assert_eq!(raw_profiles[&1].statistics[0], 4);
+        assert_eq!(raw_profiles[&1].parent_id, Some(0));
+    }
+
+    #[test]
+    fn query_profiles_ignores_empty_execution_batches() {
+        let mut query_profiles = QueryProfiles::default();
+        let empty_batch = HashMap::new();
+        let first_batch = profiles_by_id(vec![plan_profile(0, None, 1)]);
+        let second_batch = profiles_by_id(vec![plan_profile(0, None, 2)]);
+
+        query_profiles.add_with_execution("exec-a", &empty_batch);
+        query_profiles.add_with_execution("exec-b", &first_batch);
+        query_profiles.add_with_execution("exec-a", &second_batch);
+
+        let profiles = profiles_by_id(query_profiles.get());
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[&0].statistics[0], 1);
+        assert_eq!(profiles[&1].statistics[0], 2);
+    }
+
+    #[test]
+    fn query_profiles_expands_execution_range_from_later_batch() {
+        let mut query_profiles = QueryProfiles::default();
+        let first_batch = profiles_by_id(vec![plan_profile(0, None, 1)]);
+        let other_execution = profiles_by_id(vec![plan_profile(0, None, 2)]);
+        let later_batch = profiles_by_id(vec![plan_profile(2, Some(0), 3)]);
+
+        query_profiles.add_with_execution("exec-a", &first_batch);
+        query_profiles.add_with_execution("exec-b", &other_execution);
+        query_profiles.add_with_execution("exec-a", &later_batch);
+
+        let raw_profiles = query_profiles.get_with_execution_id("exec-a");
+        assert_eq!(raw_profiles.len(), 2);
+        assert_eq!(raw_profiles[&0].statistics[0], 1);
+        assert_eq!(raw_profiles[&2].statistics[0], 3);
+        assert_eq!(raw_profiles[&2].parent_id, Some(0));
+
+        let other_profiles = query_profiles.get_with_execution_id("exec-b");
+        assert_eq!(other_profiles.len(), 1);
+        assert_eq!(other_profiles[&0].statistics[0], 2);
+
+        let profiles = profiles_by_id(query_profiles.get());
+        assert_eq!(profiles.len(), 3);
+        assert_eq!(profiles[&1].statistics[0], 2);
+        assert_eq!(profiles[&2].statistics[0], 1);
+        assert_eq!(profiles[&4].statistics[0], 3);
+        assert_eq!(profiles[&4].parent_id, Some(2));
+    }
+
+    #[test]
+    fn query_profiles_can_overlay_unscoped_profiles_on_one_execution() {
+        let mut query_profiles = QueryProfiles::default();
+        let cte_producer =
+            profiles_by_id(vec![plan_profile(0, None, 1), plan_profile(1, Some(0), 2)]);
+        let main_query = profiles_by_id(vec![plan_profile(0, None, 3)]);
+        let recursive_steps = profiles_by_id(vec![
+            plan_profile(1, Some(0), 4),
+            plan_profile(2, Some(1), 5),
+        ]);
+
+        query_profiles.add_with_execution("cte-producer", &cte_producer);
+        query_profiles.add_with_execution("main-query", &main_query);
+        query_profiles.add(&recursive_steps);
+
+        let cte_profiles = query_profiles.get_with_execution_id("cte-producer");
+        assert_eq!(cte_profiles.len(), 2);
+        assert_eq!(cte_profiles[&0].statistics[0], 1);
+        assert_eq!(cte_profiles[&1].statistics[0], 2);
+
+        let main_profiles = query_profiles.get_with_execution_id("main-query");
+        assert_eq!(main_profiles.len(), 1);
+        assert_eq!(main_profiles[&0].statistics[0], 3);
+
+        let main_profiles = query_profiles.get_for_execution("main-query");
+        assert_eq!(main_profiles.len(), 3);
+        assert_eq!(main_profiles[&0].statistics[0], 3);
+        assert_eq!(main_profiles[&1].statistics[0], 4);
+        assert_eq!(main_profiles[&2].statistics[0], 5);
+    }
+
+    #[test]
+    fn query_profiles_keeps_multiple_zero_based_executions() {
+        let mut query_profiles = QueryProfiles::default();
+        let cte_a = profiles_by_id(vec![plan_profile(0, None, 1)]);
+        let cte_b = profiles_by_id(vec![plan_profile(0, None, 2)]);
+        let main_query = profiles_by_id(vec![plan_profile(0, None, 3)]);
+
+        query_profiles.add_with_execution("cte-a", &cte_a);
+        query_profiles.add_with_execution("cte-b", &cte_b);
+        query_profiles.add_with_execution("main-query", &main_query);
+
+        let profiles = profiles_by_id(query_profiles.get());
+        assert_eq!(profiles.len(), 3);
+        assert_eq!(profiles[&0].statistics[0], 1);
+        assert_eq!(profiles[&1].statistics[0], 2);
+        assert_eq!(profiles[&2].statistics[0], 3);
+    }
+}

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -558,6 +558,7 @@ async fn create_executor_with_simple_pipeline(
     pipeline.set_max_threads(size);
     let settings = ExecutorSettings {
         query_id: Arc::new("".to_string()),
+        profile_execution_id: String::new(),
         max_execute_time_in_seconds: Default::default(),
         enable_queries_executor: false,
         max_threads: 8,

--- a/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
@@ -43,6 +43,7 @@ async fn test_always_call_on_finished() -> anyhow::Result<()> {
 
     let settings = ExecutorSettings {
         query_id: Arc::new("".to_string()),
+        profile_execution_id: String::new(),
         max_execute_time_in_seconds: Default::default(),
         enable_queries_executor: false,
         max_threads: 8,

--- a/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
@@ -55,6 +55,7 @@ fn create_pipeline(
 
     let settings = ExecutorSettings {
         query_id: Arc::new("".to_string()),
+        profile_execution_id: String::new(),
         max_execute_time_in_seconds: Default::default(),
         enable_queries_executor: false,
         max_threads: 8,

--- a/src/query/service/tests/it/storages/fuse/pruning_column_oriented_segment.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_column_oriented_segment.rs
@@ -120,6 +120,7 @@ async fn apply_snapshot_pruning(
 
     let settings = ExecutorSettings {
         query_id: Arc::new("".to_string()),
+        profile_execution_id: String::new(),
         max_execute_time_in_seconds: Default::default(),
         enable_queries_executor: false,
         max_threads: 8,

--- a/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
@@ -121,6 +121,7 @@ async fn apply_snapshot_pruning(
 
     let settings = ExecutorSettings {
         query_id: Arc::new("".to_string()),
+        profile_execution_id: String::new(),
         max_execute_time_in_seconds: Default::default(),
         enable_queries_executor: false,
         max_threads: 8,

--- a/src/query/sql/src/planner/binder/bind_query/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind.rs
@@ -314,11 +314,18 @@ impl Binder {
         let create_table_sql = create_table_stmt.to_string();
         log::info!("[CTE]create_table_sql: {create_table_sql}");
         if let Some(subquery_executor) = &self.subquery_executor {
-            let _ = databend_common_base::runtime::block_on(async move {
+            let ctas_result = databend_common_base::runtime::block_on(async move {
                 subquery_executor
                     .execute_query_with_sql_string(&create_table_sql)
                     .await
-            })?;
+            });
+            if self.ctx.is_materialized_cte_capture_active() {
+                self.ctx.finalize_materialized_cte_capture(
+                    &normalize_identifier(&cte.alias.name, &self.name_resolution_ctx).name,
+                    &table_name,
+                );
+            }
+            let _ = ctas_result?;
         } else {
             return Err(ErrorCode::Internal("Binder's Subquery executor is not set"));
         };

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -210,6 +210,11 @@ impl Binder {
                         "[SQL-BINDER] Invalid statement: nested EXPLAIN not supported",
                     ));
                 }
+                // Open the materialized-CTE capture slot BEFORE binding.
+                // Binding drives `m_cte_to_temp_table` → CTAS execution, so
+                // the slot must already be active when that CTAS fires,
+                // otherwise the producer plan + profile snapshots are lost.
+                self.ctx.begin_materialized_cte_capture();
                 let plan = self.bind_statement(bind_context, query).await?;
                 Plan::ExplainAnalyze {
                     partial: *partial,

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
@@ -220,6 +220,278 @@ HashJoin
     ├── apply join filters: [#0]
     └── estimated rows: 6.00
 
+query T
+explain analyze WITH RECURSIVE t(n) AS (SELECT 5 UNION ALL SELECT n + 1 FROM t WHERE n < 9) SELECT * FROM t;
+----
+UnionAll(recursive cte)
+├── cpu time: <slt:ignore>
+├── wait time: <slt:ignore>
+├── output rows: <slt:ignore>
+├── output bytes: <slt:ignore>
+├── bytes scanned: <slt:ignore>
+├── output columns: <slt:ignore>
+├── estimated rows: <slt:ignore>
+├── EvalScalar
+│   ├── cpu time: <slt:ignore>
+│   ├── output rows: <slt:ignore>
+│   ├── output bytes: <slt:ignore>
+│   ├── output columns: <slt:ignore>
+│   ├── expressions: <slt:ignore>
+│   ├── estimated rows: <slt:ignore>
+│   └── DummyTableScan
+│       ├── cpu time: <slt:ignore>
+│       ├── output rows: <slt:ignore>
+│       ├── output bytes: <slt:ignore>
+│       └── bytes scanned: <slt:ignore>
+└── EvalScalar
+    ├── cpu time: <slt:ignore>
+    ├── output rows: <slt:ignore>
+    ├── output bytes: <slt:ignore>
+    ├── output columns: <slt:ignore>
+    ├── expressions: <slt:ignore>
+    ├── estimated rows: <slt:ignore>
+    └── Filter
+        ├── cpu time: <slt:ignore>
+        ├── output rows: <slt:ignore>
+        ├── output bytes: <slt:ignore>
+        ├── output columns: <slt:ignore>
+        ├── filters: <slt:ignore>
+        ├── estimated rows: <slt:ignore>
+        └── RecursiveCteScan
+            ├── cpu time: <slt:ignore>
+            ├── wait time: <slt:ignore>
+            ├── output rows: <slt:ignore>
+            ├── output bytes: <slt:ignore>
+            └── bytes scanned: <slt:ignore>
+
+query T
+EXPLAIN ANALYZE WITH t1 AS ( SELECT number % 5 AS a, COUNT(*) AS cnt, SUM(number) AS total FROM numbers(100) GROUP BY number % 5 ), t2 AS ( SELECT number AS b FROM numbers(20) ORDER BY number DESC LIMIT 10 ) SELECT t1.a, t1.cnt, t1.total, t2.b FROM t1 JOIN t2 ON t1.a = t2.b ORDER BY t1.a;
+----
+Sort(Single)
+├── cpu time: <slt:ignore>
+├── output columns: <slt:ignore>
+├── sort keys: <slt:ignore>
+├── estimated rows: <slt:ignore>
+└── HashJoin
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    ├── output columns: <slt:ignore>
+    ├── join type: <slt:ignore>
+    ├── build keys: <slt:ignore>
+    ├── probe keys: <slt:ignore>
+    ├── keys is null equal: <slt:ignore>
+    ├── filters: <slt:ignore>
+    ├── estimated rows: <slt:ignore>
+    ├── Limit(Build)
+    │   ├── cpu time: <slt:ignore>
+    │   ├── output rows: <slt:ignore>
+    │   ├── output bytes: <slt:ignore>
+    │   ├── output columns: <slt:ignore>
+    │   ├── limit: <slt:ignore>
+    │   ├── offset: <slt:ignore>
+    │   ├── estimated rows: <slt:ignore>
+    │   └── Sort(Single)
+    │       ├── cpu time: <slt:ignore>
+    │       ├── output rows: <slt:ignore>
+    │       ├── output bytes: <slt:ignore>
+    │       ├── output columns: <slt:ignore>
+    │       ├── sort keys: <slt:ignore>
+    │       ├── estimated rows: <slt:ignore>
+    │       └── TableScan
+    │           ├── cpu time: <slt:ignore>
+    │           ├── output rows: <slt:ignore>
+    │           ├── output bytes: <slt:ignore>
+    │           ├── bytes scanned: <slt:ignore>
+    │           ├── table: <slt:ignore>
+    │           ├── scan id: <slt:ignore>
+    │           ├── output columns: <slt:ignore>
+    │           ├── read rows: <slt:ignore>
+    │           ├── read size: <slt:ignore>
+    │           ├── partitions total: <slt:ignore>
+    │           ├── partitions scanned: <slt:ignore>
+    │           ├── push downs: <slt:ignore>
+    │           └── estimated rows: <slt:ignore>
+    └── EvalScalar(Probe)
+        ├── cpu time: <slt:ignore>
+        ├── output rows: <slt:ignore>
+        ├── output bytes: <slt:ignore>
+        ├── output columns: <slt:ignore>
+        ├── expressions: <slt:ignore>
+        ├── estimated rows: <slt:ignore>
+        └── AggregateFinal
+            ├── cpu time: <slt:ignore>
+            ├── wait time: <slt:ignore>
+            ├── output rows: <slt:ignore>
+            ├── output bytes: <slt:ignore>
+            ├── output columns: <slt:ignore>
+            ├── group by: <slt:ignore>
+            ├── aggregate functions: <slt:ignore>
+            ├── estimated rows: <slt:ignore>
+            └── AggregatePartial
+                ├── cpu time: <slt:ignore>
+                ├── output rows: <slt:ignore>
+                ├── output bytes: <slt:ignore>
+                ├── group by: <slt:ignore>
+                ├── aggregate functions: <slt:ignore>
+                ├── estimated rows: <slt:ignore>
+                └── EvalScalar
+                    ├── cpu time: <slt:ignore>
+                    ├── output rows: <slt:ignore>
+                    ├── output bytes: <slt:ignore>
+                    ├── output columns: <slt:ignore>
+                    ├── expressions: <slt:ignore>
+                    ├── estimated rows: <slt:ignore>
+                    └── TableScan
+                        ├── cpu time: <slt:ignore>
+                        ├── output rows: <slt:ignore>
+                        ├── output bytes: <slt:ignore>
+                        ├── bytes scanned: <slt:ignore>
+                        ├── table: <slt:ignore>
+                        ├── scan id: <slt:ignore>
+                        ├── output columns: <slt:ignore>
+                        ├── read rows: <slt:ignore>
+                        ├── read size: <slt:ignore>
+                        ├── partitions total: <slt:ignore>
+                        ├── partitions scanned: <slt:ignore>
+                        ├── push downs: <slt:ignore>
+                        └── estimated rows: <slt:ignore>
+
+query T
+EXPLAIN ANALYZE WITH t1 AS MATERIALIZED ( SELECT number % 5 AS a, COUNT(*) AS cnt, SUM(number) AS total FROM numbers(100) GROUP BY number % 5 ), t2 AS MATERIALIZED ( SELECT number AS b FROM numbers(20) ORDER BY number DESC LIMIT 10 ) SELECT t1.a, t1.cnt, t1.total, t2.b FROM t1 JOIN t2 ON t1.a = t2.b ORDER BY t1.a;
+----
+Sort(Single)
+├── cpu time: <slt:ignore>
+├── output columns: <slt:ignore>
+├── sort keys: <slt:ignore>
+├── estimated rows: <slt:ignore>
+└── HashJoin
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    ├── output columns: <slt:ignore>
+    ├── join type: <slt:ignore>
+    ├── build keys: <slt:ignore>
+    ├── probe keys: <slt:ignore>
+    ├── keys is null equal: <slt:ignore>
+    ├── filters: <slt:ignore>
+    ├── build join filters:
+    │   └── filter id:<slt:ignore>
+    ├── estimated rows: <slt:ignore>
+    ├── TableScan(Build)
+    │   ├── cpu time: <slt:ignore>
+    │   ├── wait time: <slt:ignore>
+    │   ├── output rows: <slt:ignore>
+    │   ├── output bytes: <slt:ignore>
+    │   ├── bytes scanned: <slt:ignore>
+    │   ├── read from remote: <slt:ignore>
+    │   ├── runtime filter bloom time: <slt:ignore>
+    │   ├── runtime filter inlist/min-max time: <slt:ignore>
+    │   ├── table: <slt:ignore>
+    │   ├── scan id: <slt:ignore>
+    │   ├── output columns: <slt:ignore>
+    │   ├── read rows: <slt:ignore>
+    │   ├── read size: <slt:ignore>
+    │   ├── partitions total: <slt:ignore>
+    │   ├── partitions scanned: <slt:ignore>
+    │   ├── pruning stats: <slt:ignore>
+    │   ├── push downs: <slt:ignore>
+    │   └── estimated rows: <slt:ignore>
+    └── TableScan(Probe)
+        ├── cpu time: <slt:ignore>
+        ├── wait time: <slt:ignore>
+        ├── parts pruned by runtime filter: <slt:ignore>
+        ├── runtime filter inlist/min-max time: <slt:ignore>
+        ├── table: <slt:ignore>
+        ├── scan id: <slt:ignore>
+        ├── output columns: <slt:ignore>
+        ├── read rows: <slt:ignore>
+        ├── read size: <slt:ignore>
+        ├── partitions total: <slt:ignore>
+        ├── partitions scanned: <slt:ignore>
+        ├── pruning stats: <slt:ignore>
+        ├── push downs: <slt:ignore>
+        ├── apply join filters: <slt:ignore>
+        └── estimated rows: <slt:ignore>
+MaterializedCTE: t1
+└── DistributedInsertSelect
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    └── EvalScalar
+        ├── cpu time: <slt:ignore>
+        ├── output rows: <slt:ignore>
+        ├── output bytes: <slt:ignore>
+        ├── output columns: <slt:ignore>
+        ├── expressions: <slt:ignore>
+        ├── estimated rows: <slt:ignore>
+        └── AggregateFinal
+            ├── cpu time: <slt:ignore>
+            ├── wait time: <slt:ignore>
+            ├── output rows: <slt:ignore>
+            ├── output bytes: <slt:ignore>
+            ├── output columns: <slt:ignore>
+            ├── group by: <slt:ignore>
+            ├── aggregate functions: <slt:ignore>
+            ├── estimated rows: <slt:ignore>
+            └── AggregatePartial
+                ├── cpu time: <slt:ignore>
+                ├── output rows: <slt:ignore>
+                ├── output bytes: <slt:ignore>
+                ├── group by: <slt:ignore>
+                ├── aggregate functions: <slt:ignore>
+                ├── estimated rows: <slt:ignore>
+                └── EvalScalar
+                    ├── cpu time: <slt:ignore>
+                    ├── output rows: <slt:ignore>
+                    ├── output bytes: <slt:ignore>
+                    ├── output columns: <slt:ignore>
+                    ├── expressions: <slt:ignore>
+                    ├── estimated rows: <slt:ignore>
+                    └── TableScan
+                        ├── cpu time: <slt:ignore>
+                        ├── output rows: <slt:ignore>
+                        ├── output bytes: <slt:ignore>
+                        ├── bytes scanned: <slt:ignore>
+                        ├── table: <slt:ignore>
+                        ├── scan id: <slt:ignore>
+                        ├── output columns: <slt:ignore>
+                        ├── read rows: <slt:ignore>
+                        ├── read size: <slt:ignore>
+                        ├── partitions total: <slt:ignore>
+                        ├── partitions scanned: <slt:ignore>
+                        ├── push downs: <slt:ignore>
+                        └── estimated rows: <slt:ignore>
+MaterializedCTE: t2
+└── DistributedInsertSelect
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    └── Limit
+        ├── cpu time: <slt:ignore>
+        ├── output rows: <slt:ignore>
+        ├── output bytes: <slt:ignore>
+        ├── output columns: <slt:ignore>
+        ├── limit: <slt:ignore>
+        ├── offset: <slt:ignore>
+        ├── estimated rows: <slt:ignore>
+        └── Sort(Single)
+            ├── cpu time: <slt:ignore>
+            ├── output rows: <slt:ignore>
+            ├── output bytes: <slt:ignore>
+            ├── output columns: <slt:ignore>
+            ├── sort keys: <slt:ignore>
+            ├── estimated rows: <slt:ignore>
+            └── TableScan
+                ├── cpu time: <slt:ignore>
+                ├── output rows: <slt:ignore>
+                ├── output bytes: <slt:ignore>
+                ├── bytes scanned: <slt:ignore>
+                ├── table: <slt:ignore>
+                ├── scan id: <slt:ignore>
+                ├── output columns: <slt:ignore>
+                ├── read rows: <slt:ignore>
+                ├── read size: <slt:ignore>
+                ├── partitions total: <slt:ignore>
+                ├── partitions scanned: <slt:ignore>
+                ├── push downs: <slt:ignore>
+                └── estimated rows: <slt:ignore>
 
 statement ok
 drop table if exists article;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: m-cte profiles miss 



Before this PR, `EXPLAIN ANALYZE` could lose or mis-attach profile information for nested query executions.

The main problem was that profile collection used plan ids as if they were globally unique inside one `QueryContext`. However, nested executors, materialized CTE producer CTAS runs, and recursive CTE step pipelines each emit executor-local plan ids. As a result:

- profiles from different executions could collide or overwrite each other
- materialized CTE producer plans/profiles were not rendered with the outer explain result
- recursive CTE step profiles were not attached back under the recursive `UnionAll` scope


```
-[ EXPLAIN ]-----------------------------------
Sort(Single)
├── cpu time: 974.872µs
├── output rows: 5
├── output bytes: 88.00 B
├── output columns: [t1.a (#0), t1.cnt (#1), t1.total (#2)]
├── sort keys: [a ASC NULLS LAST]
├── estimated rows: 5.00
└── TableScan
    ├── cpu time: 453.624µs
    ├── wait time: 570.751µs
    ├── output rows: 5
    ├── output bytes: 88.00 B
    ├── bytes scanned: 88.00 B
    ├── read from remote: 159.00 B
    ├── runtime filter bloom time: 1.125µs
    ├── runtime filter inlist/min-max time: 541ns
    ├── table: default.default.t1
    ├── scan id: 0
    ├── output columns: [a (#0), cnt (#1), total (#2)]
    ├── read rows: 5
    ├── read size: < 1 KiB
    ├── partitions total: 1
    ├── partitions scanned: 1
    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
    ├── push downs: [filters: [], limit: NONE]
    └── estimated rows: 5.00
MaterializedCTE: t1
└── DistributedInsertSelect
    ├── cpu time: 1.615789ms
    ├── wait time: 7.808586ms
    └── EvalScalar
        ├── cpu time: 41.292µs
        ├── output rows: 5
        ├── output bytes: 90.00 B
        ├── output columns: [COUNT(*) (#2), SUM(number) (#3), a (#4)]
        ├── expressions: [group_item (#1)]
        ├── estimated rows: 33.33
        └── AggregateFinal
            ├── cpu time: 11.273494ms
            ├── wait time: 15.014122ms
            ├── output rows: 5
            ├── output bytes: 90.00 B
            ├── output columns: [COUNT(*) (#2), SUM(number) (#3), number % 5 (#1)]
            ├── group by: [number % 5]
            ├── aggregate functions: [count(), sum(number)]
            ├── estimated rows: 33.33
            └── AggregatePartial
                ├── cpu time: 143.958µs
                ├── output rows: 5
                ├── output bytes: 85.00 B
                ├── group by: [number % 5]
                ├── aggregate functions: [count(), sum(number)]
                ├── estimated rows: 33.33
                └── EvalScalar
                    ├── cpu time: 49.292µs
                    ├── output rows: 100
                    ├── output bytes: 900.00 B
                    ├── output columns: [numbers.number (#0), number % 5 (#1)]
                    ├── expressions: [numbers.number (#0) % 5]
                    ├── estimated rows: 100.00
                    └── TableScan
                        ├── cpu time: 20.5µs
                        ├── output rows: 100
                        ├── output bytes: 800.00 B
                        ├── bytes scanned: 800.00 B
                        ├── table: default.system.numbers
                        ├── scan id: 0
                        ├── output columns: [number (#0)]
                        ├── read rows: 100
                        ├── read size: < 1 KiB
                        ├── partitions total: 1
                        ├── partitions scanned: 1
                        ├── push downs: [filters: [], limit: NONE]
                        └── estimated rows: 100.00
```


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19797)
<!-- Reviewable:end -->
