### PR TITLE
fix(bendpy): allow CSV stage views

### DIFF
--- a/src/bendpy/tests/test_api_style.py
+++ b/src/bendpy/tests/test_api_style.py
@@ -49,3 +49,15 @@ def test_register_arrow_table_uses_register_parquet(tmp_path):
     register_parquet.assert_called_once()
     _, parquet_path = register_parquet.call_args.args
     assert Path(parquet_path).suffix == ".parquet"
+
+
+def test_register_csv_local_path_allows_select_star(tmp_path):
+    csv_path = tmp_path / "foods.csv"
+    csv_path.write_text("1,apple\n2,bread\n")
+    conn = databend.SessionContext(data_path=str(tmp_path / "embedded"))
+
+    conn.register_csv("foods", str(csv_path))
+
+    rows = conn.table("foods").fetchall()
+    assert len(rows) == 2
+    assert len(rows[0]) == 2

--- a/src/bendpy/tests/test_api_style.py
+++ b/src/bendpy/tests/test_api_style.py
@@ -61,3 +61,15 @@ def test_register_csv_local_path_allows_select_star(tmp_path):
     rows = conn.table("foods").fetchall()
     assert len(rows) == 2
     assert len(rows[0]) == 2
+
+
+def test_register_text_local_path_allows_select_star(tmp_path):
+    text_path = tmp_path / "foods.tsv"
+    text_path.write_text("1\tapple\n2\tbread\n")
+    conn = databend.SessionContext(data_path=str(tmp_path / "embedded"))
+
+    conn.register_text("foods_text", str(text_path))
+
+    rows = conn.table("foods_text").fetchall()
+    assert len(rows) == 2
+    assert len(rows[0]) == 2

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -153,6 +153,10 @@ impl Table for StageTable {
         DataSourceInfo::StageSource(self.table_info.clone())
     }
 
+    fn is_stage_table(&self) -> bool {
+        true
+    }
+
     #[async_backtrace::framed]
     async fn read_partitions(
         &self,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Mark generic `StageTable` as a stage table so `CREATE VIEW` validation does not try to resolve file scans as a physical `system.stage` table.
- Add a bendpy regression test for `SessionContext.register_csv()` on a local CSV path.

- fixes: #19443

## Changes

`register_csv()` creates a view over a file scan. The CSV file scan is represented by the generic `StageTable`, but that table did not override `is_stage_table()`. As a result, `CreateViewInterpreter` treated it as a normal table and failed the existence check with `table system.stage not exists` in bendpy embedded mode.

This PR makes `StageTable::is_stage_table()` return `true`, matching the existing behavior of Parquet/ORC stage-backed tables.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo fmt --check --package bendpy --package databend-common-storages-stage`
- `cargo check -p databend-common-storages-stage --profile dev`
- `cargo check -p bendpy --profile dev`
- `.venv/bin/python -m pytest tests/ -q`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19798)
<!-- Reviewable:end -->
