### PR TITLE
ci: add valgrind stateless test for check memory leak

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,49 @@
+[test-groups]
+skip-memcheck = {max-threads = 1}
+
+# TODO: Investigate the failures and unmask these tests or add explainatiaon
+#       on why it is skipped.
+[[profile.memcheck.overrides]]
+filter = "test(txn::backoff::tests::test_backoff)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(grpc_semaphore::)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(test_schema_api::)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(test_auto_increment_api::test_auto_increment_api_single_node)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(http_service::)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(metrics::test_metrics)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(features::test_features)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(grpc_cache::)"
+test-group = "skip-memcheck"
+
+[[profile.memcheck.overrides]]
+filter = "test(transfer_leader::test_transfer_leader)"
+test-group = "skip-memcheck"
+
+[profile.memcheck]
+# group is not allowed in default-filter, workaround is
+# use `cargo nextest -E "not group(skip-memcheck)"`
+#default-filter = "not group(skip-memcheck)"
+
+# valgrind could be very slow, be patient
+slow-timeout = "5m"
+

--- a/.github/actions/setup_build_tool/action.yml
+++ b/.github/actions/setup_build_tool/action.yml
@@ -90,9 +90,9 @@ runs:
 
         cat <<EOF >>$BIN_LOCAL/build-tool
         if [[ \${script_name} == "build-tool" ]]; then
-          scripts/setup/run_build_tool.sh \$@
+          scripts/setup/run_build_tool.sh "\$@"
         else
-          scripts/setup/run_build_tool.sh \${script_name} \$@
+          scripts/setup/run_build_tool.sh \${script_name} "\$@"
         fi
         EOF
 

--- a/.github/actions/test_unit_valgrind/action.yml
+++ b/.github/actions/test_unit_valgrind/action.yml
@@ -1,0 +1,33 @@
+name: "Test Unit Valgrind"
+description: "Running unit tests with memory check using valgrind"
+
+inputs:
+  target:
+    description: "Build target to use"
+    required: true
+    default: x86_64-unknown-linux-gnu
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Build Tool
+      uses: ./.github/actions/setup_build_tool
+      with:
+        target: ${{ inputs.target }}
+        bypass_env_vars: RUSTFLAGS,RUSTDOCFLAGS,RUST_TEST_THREADS,RUST_LOG,RUST_BACKTRACE
+
+    - shell: bash
+      run: |
+        cargo valgrind nextest run \
+          -E "not group(skip-memcheck)" --profile memcheck
+      env:
+        RUST_LOG: ERROR
+        # 1GiB
+        # RUST_MIN_STACK: 1073741824
+        # RUST_BACKTRACE: 1
+
+    - name: Upload failure
+      if: failure()
+      uses: ./.github/actions/artifact_failure
+      with:
+        name: test-unit-valgrind

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -120,6 +120,24 @@ jobs:
         with:
           target: ${{ needs.info.outputs.target }}
 
+  test_unit_valgrind:
+    needs: info
+    runs-on:
+      - self-hosted
+      - "${{ inputs.runner_arch }}"
+      - Linux
+      - 16c
+      - "${{ inputs.runner_provider }}"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # fetch all tags, metasrv and metaclient need tag as its version.
+          fetch-depth: 0
+      - uses: ./.github/actions/test_unit_valgrind
+        timeout-minutes: 60
+        with:
+          target: ${{ needs.info.outputs.target }}
+
   test_metactl:
     needs: [info, build, check]
     runs-on:

--- a/docker/build-tool/debian/Dockerfile
+++ b/docker/build-tool/debian/Dockerfile
@@ -4,7 +4,8 @@ ENV TERM=dumb
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yq && \
-    apt-get install -yq locales sudo unzip file lsb-release wget software-properties-common gnupg && \
+    apt-get install -yq locales sudo unzip file lsb-release wget valgrind \
+        software-properties-common gnupg && \
     printf 'en_US.UTF-8 UTF-8\n' > /etc/locale.gen && \
     locale-gen && \
     rm -rf /var/lib/apt/lists/*

--- a/scripts/ci/ci-run-unit-tests.sh
+++ b/scripts/ci/ci-run-unit-tests.sh
@@ -9,3 +9,17 @@ cd "$SCRIPT_PATH/../../" || exit
 
 echo "Starting unit tests"
 env "MACOSX_DEPLOYMENT_TARGET=10.13" "RUST_TEST_THREADS=2" cargo nextest run
+
+# Do not add leading space as indent to below flags, it will cause `cargo
+# valgrind` to fail with `valgrind: command not found` error.
+export VALGRINDFLAGS="--show-leak-kinds=definite \
+--errors-for-leak-kinds=definite \
+--max-threads=1024"
+
+if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "x86_64" ]]; then
+    # If your test case is failing due to memory leak check, you may
+    # mark test case as skip-memcheck in `.config/nextest.toml` file
+    env "MACOSX_DEPLOYMENT_TARGET=10.13" "RUST_TEST_THREADS=2" \
+        cargo valgrind nextest run -E 'not group(skip-memcheck)' \
+        --profile memcheck
+fi

--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -659,6 +659,63 @@ function install_typos_cli {
 	"${typos_bin}/typos" --version
 }
 
+function install_cargo_valgrind {
+	REPO="jfrimmel/cargo-valgrind"
+	CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
+	CARGO_BIN_DIR="${CARGO_HOME}/bin"
+	tmpdir="$(mktemp -d)"
+	archive_path="$tmpdir/cargo-valgrind.tar.gz"
+	if [[ "$(uname -s)" != "Linux" ]] || \
+	   [[ "$(uname -m)" != "x86_64" ]]; then
+		rm -rf "$tmpdir"
+		echo "Only run cargo-valgrind on x86_64 Linux, ignoring"
+		return
+	elif cargo valgrind --version &>/dev/null; then
+		rm -rf "$tmpdir"
+		echo "cargo-valgrind is already installed"
+		cargo valgrind --version
+		return
+	fi
+	install_pkg valgrind "$PACKAGE_MANAGER"
+	# using latest pre-build tarball from
+	# https://github.com/jfrimmel/cargo-valgrind/releases
+	# and install it to cargo bin directory
+	release_json="$(
+		curl -fsSL \
+		"https://api.github.com/repos/${REPO}/releases/latest")"
+	asset_url="$(
+	python3 -c '
+import json, re, sys
+
+data = json.loads(sys.stdin.read())
+for asset in data.get("assets", []):
+    if re.search(
+        r"^cargo-valgrind-.*-x86_64-unknown-linux-musl\.tar\.gz$",
+        asset.get("name", "")
+    ):
+        print(asset["browser_download_url"])
+        break
+else:
+    raise SystemExit("No matching release asset found")
+	' <<<"$release_json"
+	)"
+	curl -fL "$asset_url" -o "$archive_path"
+	mkdir -p "$tmpdir/extract"
+	tar -xzf "$archive_path" -C "$tmpdir/extract"
+	binary_path="$(
+		find "$tmpdir/extract" -type f -name 'cargo-valgrind' | \
+		head -n 1)"
+	if [[ -z "$binary_path" ]]; then
+		echo "Error: cargo-valgrind binary not found in archive" >&2
+		rm -rf "$tmpdir"
+		return 1
+	fi
+
+	install -m 0755 "$binary_path" "$CARGO_BIN_DIR/cargo-valgrind"
+	rm -rf "$tmpdir"
+	cargo valgrind --version
+}
+
 function usage {
 	cat <<EOF
     usage: $0 [options]
@@ -881,6 +938,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 
 	install_sccache "v0.12.0"
 	install_cargo_nextest
+	install_cargo_valgrind
 fi
 
 if [[ "$INSTALL_CHECK_TOOLS" == "true" ]]; then

--- a/scripts/setup/run_build_tool.sh
+++ b/scripts/setup/run_build_tool.sh
@@ -13,7 +13,7 @@ CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 BYPASS_ENV_VARS="${BYPASS_ENV_VARS:-RUSTFLAGS,RUST_LOG}"
 ENABLE_SCCACHE="${ENABLE_SCCACHE:-false}"
 COMMAND=$1
-COMMAND_ARGS="$*"
+COMMAND_ARGS=$(printf '%q ' "$@")
 
 TOOLCHAIN_VERSION=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain.toml)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

By using https://github.com/jfrimmel/cargo-valgrind , all unit test will
be invoked with valgrind check.

Using this command to do memory check on unit test cases:

```bash
cargo valgrind \
    nextest run -E 'not group(skip-memcheck)' --profile memcheck
```

These are the valgrind arugments for `cargo valgrind`:

```
--show-leak-kinds=definite
--errors-for-leak-kinds=definite
--max-threads=1024"
```

Some test cases are known to fail this valgrind test, instead of fixing
the in this patch, those test cases are marked as `skip-memcheck` in
`.config/nextest.toml` and pending for further investigation.

The memory leak check is only enabled on Linux x86_64 for now.

- fixes: https://github.com/databendlabs/databend/issues/5039

## Tests

- [x] No Test - Expand existing unit test to run under valgrind watch.

## Type of change

- [x] Other: Add memory leak check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19800)
<!-- Reviewable:end -->
