### PR TITLE
feat(sql): support UDF expressions in DML

### DIFF
--- a/src/query/service/src/physical_plans/physical_column_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_column_mutation.rs
@@ -162,17 +162,15 @@ impl IPhysicalPlan for ColumnMutation {
                 });
             }
 
-            // Keep the original order of the columns.
-            let num_output_columns =
-                self.input_num_columns - self.has_filter_column as usize - self.udf_col_num;
-            let mut projection = Vec::with_capacity(num_output_columns);
-            for idx in 0..num_output_columns {
-                if let Some(index) = schema_offset_to_new_offset.get(&idx) {
-                    projection.push(*index);
-                } else {
-                    projection.push(idx);
-                }
-            }
+            // Keep only table fields in their schema order. Mutation input may
+            // carry derived UDF argument/result columns that must not be
+            // serialized back into the table.
+            let mut projection = field_id_to_schema_index.iter().collect::<Vec<_>>();
+            projection.sort_by_key(|(field_id, _)| *field_id);
+            let projection = projection
+                .into_iter()
+                .map(|(_, schema_index)| *schema_index)
+                .collect::<Vec<_>>();
             block_operators.push(BlockOperator::Project { projection });
 
             builder.main_pipeline.add_transformer(|| {

--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -335,9 +335,9 @@ impl Binder {
     ) -> Result<MatchedEvaluator> {
         let condition = if let Some(expr) = &clause.selection {
             let (scalar_expr, _) = scalar_binder.bind(expr)?;
-            if !self.check_allowed_scalar_expr(&scalar_expr)? {
+            if !self.check_allowed_scalar_expr_with_udf(&scalar_expr)? {
                 return Err(ErrorCode::SemanticError(
-                    "matched clause's condition can't contain subquery|window|aggregate|udf functions|async functions"
+                    "matched clause's condition can't contain subquery|window|aggregate|async functions"
                         .to_string(),
                 )
                 .set_span(scalar_expr.span()));
@@ -421,9 +421,9 @@ impl Binder {
     ) -> Result<UnmatchedEvaluator> {
         let condition = if let Some(expr) = &clause.selection {
             let (scalar_expr, _) = scalar_binder.bind(expr)?;
-            if !self.check_allowed_scalar_expr(&scalar_expr)? {
+            if !self.check_allowed_scalar_expr_with_udf(&scalar_expr)? {
                 return Err(ErrorCode::SemanticError(
-                    "unmatched clause's condition can't contain subquery|window|aggregate|udf functions"
+                    "unmatched clause's condition can't contain subquery|window|aggregate|async functions"
                         .to_string(),
                 )
                 .set_span(scalar_expr.span()));
@@ -471,9 +471,9 @@ impl Binder {
             }
             for (idx, expr) in clause.insert_operation.values.iter().enumerate() {
                 let (mut scalar_expr, _) = scalar_binder.bind(expr)?;
-                if !self.check_allowed_scalar_expr(&scalar_expr)? {
+                if !self.check_allowed_scalar_expr_with_udf(&scalar_expr)? {
                     return Err(ErrorCode::SemanticError(
-                        "insert clause's can't contain subquery|window|aggregate|udf functions"
+                        "insert clause's can't contain subquery|window|aggregate|async functions"
                             .to_string(),
                     )
                     .set_span(scalar_expr.span()));

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -561,7 +561,7 @@ impl Binder {
             let (scalar, _) = scalar_binder.bind(expr)?;
             if !self.check_allowed_scalar_expr_with_subquery(&scalar)? {
                 return Err(ErrorCode::SemanticError(
-                    "filter in mutation statement can't contain window|aggregate|udf functions"
+                    "filter in mutation statement can't contain window|aggregate|async functions"
                         .to_string(),
                 )
                 .set_span(scalar.span()));
@@ -605,9 +605,7 @@ impl Binder {
         let f = |scalar: &ScalarExpr| {
             matches!(
                 scalar,
-                ScalarExpr::WindowFunction(_)
-                    | ScalarExpr::AsyncFunctionCall(_)
-                    | ScalarExpr::UDFCall(_)
+                ScalarExpr::WindowFunction(_) | ScalarExpr::AsyncFunctionCall(_)
             ) || scalar.is_aggregate()
         };
 

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -566,7 +566,7 @@ impl Binder {
                 )
                 .set_span(scalar.span()));
             }
-            let strategy = if !self.has_subquery(&scalar)? {
+            let strategy = if !self.has_subquery(&scalar)? && scalar.get_udf_names()?.is_empty() {
                 MutationStrategy::Direct
             } else {
                 MutationStrategy::MatchedOnly

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -1067,21 +1067,6 @@ impl Binder {
         Ok(finder.scalars().is_empty())
     }
 
-    pub(crate) fn check_allowed_scalar_expr(&self, scalar: &ScalarExpr) -> Result<bool> {
-        let f = |scalar: &ScalarExpr| {
-            matches!(
-                scalar,
-                ScalarExpr::WindowFunction(_)
-                    | ScalarExpr::UDFCall(_)
-                    | ScalarExpr::SubqueryExpr(_)
-                    | ScalarExpr::AsyncFunctionCall(_)
-            ) || scalar.is_aggregate()
-        };
-        let mut finder = Finder::new(&f);
-        finder.visit(scalar)?;
-        Ok(finder.scalars().is_empty())
-    }
-
     pub(crate) fn check_allowed_scalar_expr_with_subquery_for_copy_table(
         &self,
         scalar: &ScalarExpr,

--- a/src/query/sql/src/planner/semantic/udf_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/udf_rewriter.rs
@@ -113,6 +113,14 @@ impl UdfRewriter {
                         }
                     }
                 }
+                for unmatched_evaluator in plan.unmatched_evaluators.iter_mut() {
+                    if let Some(condition) = unmatched_evaluator.condition.as_mut() {
+                        self.visit(condition)?;
+                    }
+                    for scalar in unmatched_evaluator.values.iter_mut() {
+                        self.visit(scalar)?;
+                    }
+                }
                 let child_expr = self.create_udf_expr(s_expr.children[0].clone());
                 let new_expr = SExpr::create_unary(Arc::new(plan.into()), child_expr);
                 Ok(new_expr)

--- a/src/query/sql/tests/it/framework/lite_context.rs
+++ b/src/query/sql/tests/it/framework/lite_context.rs
@@ -67,6 +67,7 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::ROW_ID_COLUMN_ID;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
@@ -258,6 +259,11 @@ impl Table for FakeTable {
         } else {
             DistributionLevel::Local
         }
+    }
+
+    // for test MERGE INTO
+    fn supported_internal_column(&self, column_id: ColumnId) -> bool {
+        column_id == ROW_ID_COLUMN_ID
     }
 
     fn support_column_projection(&self) -> bool {

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -49,6 +49,15 @@ export function finish(state) {
 $$
 "#;
 
+const TEST_SCRIPT_UDF_SQL: &str = r#"
+CREATE OR REPLACE FUNCTION add_one (INT) RETURNS INT
+LANGUAGE javascript HANDLER = 'add_one' AS $$
+export function add_one(v) {
+    return v + 1;
+}
+$$
+"#;
+
 async fn bind_case(case: &SqlTestCase) -> Result<SqlTestOutcome> {
     let ctx = setup_context(case).await?;
     let outcome = match ctx.bind_sql(case.sql).await {
@@ -223,6 +232,46 @@ async fn test_binder_clauses_and_ordering() -> Result<()> {
     ];
 
     run_binder_cases("binder_clauses.txt", &cases).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_binder_mutation_udf() -> Result<()> {
+    let cases = [
+        SqlTestCase {
+            name: "update_where_accepts_script_udf",
+            description: "A mutation filter should allow script UDFs and rewrite them before the filter is evaluated.",
+            setup_sqls: &["CREATE TABLE t(a INT, b INT)", TEST_SCRIPT_UDF_SQL],
+            sql: "UPDATE t SET b = a WHERE add_one(a) > 1",
+        },
+        SqlTestCase {
+            name: "delete_where_accepts_script_udf",
+            description: "DELETE should allow script UDFs in the mutation filter.",
+            setup_sqls: &["CREATE TABLE t(a INT, b INT)", TEST_SCRIPT_UDF_SQL],
+            sql: "DELETE FROM t WHERE add_one(a) > 1",
+        },
+        SqlTestCase {
+            name: "merge_matched_condition_accepts_script_udf",
+            description: "MERGE matched conditions should allow script UDFs.",
+            setup_sqls: &[
+                "CREATE TABLE t(a INT, b INT)",
+                "CREATE TABLE s(a INT, b INT)",
+                TEST_SCRIPT_UDF_SQL,
+            ],
+            sql: "MERGE INTO t USING s ON t.a = s.a WHEN MATCHED AND add_one(s.b) > 1 THEN UPDATE SET b = add_one(s.b)",
+        },
+        SqlTestCase {
+            name: "merge_unmatched_accepts_script_udf",
+            description: "MERGE unmatched conditions and insert values should allow script UDFs.",
+            setup_sqls: &[
+                "CREATE TABLE t(a INT, b INT)",
+                "CREATE TABLE s(a INT, b INT)",
+                TEST_SCRIPT_UDF_SQL,
+            ],
+            sql: "MERGE INTO t USING s ON t.a = s.a WHEN NOT MATCHED AND add_one(s.b) > 1 THEN INSERT (a, b) VALUES (s.a, add_one(s.b))",
+        },
+    ];
+
+    run_binder_cases("binder_mutation_udf.txt", &cases).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/src/query/sql/tests/it/semantic/binder_mutation_udf.txt
+++ b/src/query/sql/tests/it/semantic/binder_mutation_udf.txt
@@ -9,12 +9,16 @@ target_table: default.default.t
 ├── can_try_update_column_only: true
 ├── matched update: [condition: None,update set b = t.a (#0)]
 └── Filter
-    ├── filters: [gt(add_one(a) (#2), 1)]
+    ├── filters: [gt(add_one(a) (#3), 1)]
     └── UdfScript
-        ├── scalars: [add_one(t.a (#0)) AS (#2)]
+        ├── scalars: [add_one(t.a (#0)) AS (#3)]
         └── EvalScalar
             ├── scalars: [t.a (#0) AS (#0)]
-            └── MutationSource(MutationSource { schema: TableSchema { fields: [TableField { name: "a", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 0, computed_expr: None, auto_increment_expr: None }, TableField { name: "b", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 1, computed_expr: None, auto_increment_expr: None }], metadata: {}, next_column_id: 2 }, columns: {0, 1}, table_index: 0, mutation_type: Update, secure_predicates: [], user_predicates: [], predicate_column_index: None, read_partition_columns: {} })
+            └── Scan
+                ├── table: default.t (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
 
 
 === delete_where_accepts_script_udf ===
@@ -28,12 +32,16 @@ target_table: default.default.t
 ├── can_try_update_column_only: false
 ├── matched delete: [condition: None]
 └── Filter
-    ├── filters: [gt(add_one(a) (#2), 1)]
+    ├── filters: [gt(add_one(a) (#3), 1)]
     └── UdfScript
-        ├── scalars: [add_one(t.a (#0)) AS (#2)]
+        ├── scalars: [add_one(t.a (#0)) AS (#3)]
         └── EvalScalar
             ├── scalars: [t.a (#0) AS (#0)]
-            └── MutationSource(MutationSource { schema: TableSchema { fields: [TableField { name: "a", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 0, computed_expr: None, auto_increment_expr: None }, TableField { name: "b", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 1, computed_expr: None, auto_increment_expr: None }], metadata: {}, next_column_id: 2 }, columns: {0, 1}, table_index: 0, mutation_type: Delete, secure_predicates: [], user_predicates: [], predicate_column_index: None, read_partition_columns: {} })
+            └── Scan
+                ├── table: default.t (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
 
 
 === merge_matched_condition_accepts_script_udf ===

--- a/src/query/sql/tests/it/semantic/binder_mutation_udf.txt
+++ b/src/query/sql/tests/it/semantic/binder_mutation_udf.txt
@@ -1,0 +1,98 @@
+=== update_where_accepts_script_udf ===
+description: A mutation filter should allow script UDFs and rewrite them before the filter is evaluated.
+sql: UPDATE t SET b = a WHERE add_one(a) > 1
+status: ok
+MergeInto:
+target_table: default.default.t
+├── distributed: false
+├── target_build_optimization: false
+├── can_try_update_column_only: true
+├── matched update: [condition: None,update set b = t.a (#0)]
+└── Filter
+    ├── filters: [gt(add_one(a) (#2), 1)]
+    └── UdfScript
+        ├── scalars: [add_one(t.a (#0)) AS (#2)]
+        └── EvalScalar
+            ├── scalars: [t.a (#0) AS (#0)]
+            └── MutationSource(MutationSource { schema: TableSchema { fields: [TableField { name: "a", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 0, computed_expr: None, auto_increment_expr: None }, TableField { name: "b", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 1, computed_expr: None, auto_increment_expr: None }], metadata: {}, next_column_id: 2 }, columns: {0, 1}, table_index: 0, mutation_type: Update, secure_predicates: [], user_predicates: [], predicate_column_index: None, read_partition_columns: {} })
+
+
+=== delete_where_accepts_script_udf ===
+description: DELETE should allow script UDFs in the mutation filter.
+sql: DELETE FROM t WHERE add_one(a) > 1
+status: ok
+MergeInto:
+target_table: default.default.t
+├── distributed: false
+├── target_build_optimization: false
+├── can_try_update_column_only: false
+├── matched delete: [condition: None]
+└── Filter
+    ├── filters: [gt(add_one(a) (#2), 1)]
+    └── UdfScript
+        ├── scalars: [add_one(t.a (#0)) AS (#2)]
+        └── EvalScalar
+            ├── scalars: [t.a (#0) AS (#0)]
+            └── MutationSource(MutationSource { schema: TableSchema { fields: [TableField { name: "a", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 0, computed_expr: None, auto_increment_expr: None }, TableField { name: "b", default_expr: None, data_type: Nullable(Number(Int32)), column_id: 1, computed_expr: None, auto_increment_expr: None }], metadata: {}, next_column_id: 2 }, columns: {0, 1}, table_index: 0, mutation_type: Delete, secure_predicates: [], user_predicates: [], predicate_column_index: None, read_partition_columns: {} })
+
+
+=== merge_matched_condition_accepts_script_udf ===
+description: MERGE matched conditions should allow script UDFs.
+sql: MERGE INTO t USING s ON t.a = s.a WHEN MATCHED AND add_one(s.b) > 1 THEN UPDATE SET b = add_one(s.b)
+status: ok
+MergeInto:
+target_table: default.default.t
+├── distributed: false
+├── target_build_optimization: false
+├── can_try_update_column_only: false
+├── matched update: [condition: gt(add_one(s.b) (#5), 1),update set b = add_one(s.b) (#5)]
+└── UdfScript
+    ├── scalars: [add_one(s.b (#1)) AS (#5)]
+    └── EvalScalar
+        ├── scalars: [s.b (#1) AS (#1)]
+        └── Join(Inner)
+            ├── build keys: [s.a (#0)]
+            ├── probe keys: [t.a (#2)]
+            ├── other filters: []
+            ├── Scan
+            │   ├── table: default.s (#0)
+            │   ├── filters: []
+            │   ├── order by: []
+            │   └── limit: NONE
+            └── Scan
+                ├── table: default.t (#1)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
+=== merge_unmatched_accepts_script_udf ===
+description: MERGE unmatched conditions and insert values should allow script UDFs.
+sql: MERGE INTO t USING s ON t.a = s.a WHEN NOT MATCHED AND add_one(s.b) > 1 THEN INSERT (a, b) VALUES (s.a, add_one(s.b))
+status: ok
+MergeInto:
+target_table: default.default.t
+├── distributed: false
+├── target_build_optimization: false
+├── can_try_update_column_only: false
+├── unmatched insert: [condition: gt(add_one(s.b) (#5), 1),insert into (a,b) values(CAST(s.a (#0) AS Int32 NULL),CAST(add_one(s.b) (#5) AS Int32 NULL))]
+└── UdfScript
+    ├── scalars: [add_one(s.b (#1)) AS (#5)]
+    └── EvalScalar
+        ├── scalars: [s.b (#1) AS (#1)]
+        └── Join(RightAnti)
+            ├── build keys: [s.a (#0)]
+            ├── probe keys: [t.a (#2)]
+            ├── other filters: []
+            ├── Scan
+            │   ├── table: default.s (#0)
+            │   ├── filters: []
+            │   ├── order by: []
+            │   └── limit: NONE
+            └── Scan
+                ├── table: default.t (#1)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+

--- a/tests/sqllogictests/suites/udf_server/udf_server_test.test
+++ b/tests/sqllogictests/suites/udf_server/udf_server_test.test
@@ -511,11 +511,31 @@ DROP FUNCTION wait;
 statement ok
 DROP FUNCTION wait_concurrent;
 
-statement error 1065
-update web_traffic_data set id = 2 where map_access(traffic_info, 'ip') = '192.168.1.2'
+## test update and delete with UDF expressions
+statement ok
+CREATE OR REPLACE FUNCTION dml_url_len (VARCHAR) RETURNS BIGINT LANGUAGE python HANDLER = 'url_len' ADDRESS = 'http://0.0.0.0:8815';
 
-statement error 1065
-delete from web_traffic_data where map_access(traffic_info, 'ip') = '192.168.1.2'
+statement ok
+update web_traffic_data set id = dml_url_len(map_access(traffic_info, 'url')) where map_access(traffic_info, 'ip') = '192.168.1.2'
+
+query IT
+select id, map_access(traffic_info, 'url') from web_traffic_data order by id, map_access(traffic_info, 'url');
+----
+1 example.com/home
+3 example.com/contact
+17 example.com/about
+
+statement ok
+delete from web_traffic_data where dml_url_len(map_access(traffic_info, 'url')) = 17
+
+query IT
+select id, map_access(traffic_info, 'ip') from web_traffic_data order by id;
+----
+1 192.168.1.1
+3 192.168.1.1
+
+statement ok
+DROP FUNCTION dml_url_len;
 
 statement ok
 DROP FUNCTION map_access;
@@ -530,11 +550,34 @@ create or replace table target_udf(a string,b string,c string);
 statement ok
 create or replace table source_udf(a2 string,b2 string,c2 string);
 
-statement error 1065
-merge into target_udf using source_udf on target_udf.a = source_udf.a2 when not matched then insert (a) values(split_and_join(source_udf.a2, '; ', ':'));
+statement ok
+insert into target_udf values('1', 'old1', 'old'), ('2', 'old2', 'old');
+
+statement ok
+insert into source_udf values('1', 'new; 1', 'update'), ('3', 'new; 3', 'insert'), ('4', 'new; 4', 'skip');
+
+query II
+merge into target_udf using source_udf on target_udf.a = source_udf.a2
+when matched and split_and_join(source_udf.c2, '; ', ':') = 'update' then update set target_udf.b = split_and_join(source_udf.b2, '; ', ':')
+when not matched and split_and_join(source_udf.c2, '; ', ':') = 'insert' then insert (a, b, c) values(source_udf.a2, split_and_join(source_udf.b2, '; ', ':'), split_and_join(source_udf.c2, '; ', ':'));
+----
+1 1
+
+query TTT
+select * from target_udf order by a;
+----
+1 new:1 old
+2 old2 old
+3 new:3 insert
 
 statement ok
 DROP FUNCTION split_and_join;
+
+statement ok
+DROP TABLE target_udf;
+
+statement ok
+DROP TABLE source_udf;
 
 ### enable udf for copy into table
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #18492
- Support UDF expressions in DML mutation expression positions evaluated after mutation input is produced: UPDATE/DELETE filters, MERGE matched and unmatched clause conditions, and MERGE unmatched insert values.
- Rewrite UDF calls inside MERGE unmatched evaluators into derived UDF columns before mutation evaluation.
- Keep MERGE ON UDF expressions out of this PR because they depend on the shared Join UDF rewrite path and should be discussed separately.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Ran locally:

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p databend-common-sql --test it semantic::binder -- --nocapture`
- `cargo build --bin=databend-query --bin=databend-meta --bin=databend-sqllogictests`
- `TEST_HANDLERS=http,hybrid TEST_PARALLEL=1 bash ./scripts/ci/ci-run-sqllogic-tests.sh udf_server`
- `TEST_HANDLERS=http,hybrid TEST_PARALLEL=1 TEST_EXT_ARGS='--skip_file tpcds_spill_1.test,tpcds_spill_2.test,tpcds_spill_3.test' bash ./scripts/ci/ci-run-sqllogic-tests-native.sh udf_server`

Added/updated coverage:

- Binder golden tests for UDF expressions in UPDATE/DELETE filters and MERGE matched/unmatched evaluators.
- UDF server sqllogictest cases for UPDATE, DELETE, and MERGE runtime paths.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19804)
<!-- Reviewable:end -->