### PR TITLE
fix(query): trim numeric and boolean string casts

### DIFF
--- a/src/query/functions/src/scalars/arithmetic/src/arithmetic.rs
+++ b/src/query/functions/src/scalars/arithmetic/src/arithmetic.rs
@@ -289,6 +289,7 @@ fn parse_number<T>(
 where
     T: FromStr + num_traits::Num,
 {
+    let s = s.trim();
     match s.parse::<T>() {
         Ok(v) => Ok(v),
         Err(e) => {

--- a/src/query/functions/src/scalars/boolean.rs
+++ b/src/query/functions/src/scalars/boolean.rs
@@ -477,9 +477,10 @@ fn eval_boolean_to_string(val: Value<BooleanType>, ctx: &mut EvalContext) -> Val
 
 fn eval_string_to_boolean(val: Value<StringType>, ctx: &mut EvalContext) -> Value<BooleanType> {
     vectorize_with_builder_1_arg::<StringType, BooleanType>(|val, output, ctx| {
-        if val.eq_ignore_ascii_case("true") {
+        let val = val.trim();
+        if val.eq_ignore_ascii_case("true") || val == "1" {
             output.push(true);
-        } else if val.eq_ignore_ascii_case("false") {
+        } else if val.eq_ignore_ascii_case("false") || val == "0" {
             output.push(false);
         } else {
             ctx.set_error(output.len(), "cannot parse to type `BOOLEAN`");

--- a/src/query/functions/tests/it/scalars/testdata/cast.txt
+++ b/src/query/functions/tests/it/scalars/testdata/cast.txt
@@ -898,20 +898,22 @@ error:
 
 
 
-error: 
-  --> SQL:1:1
-  |
-1 | CAST('0' AS BOOLEAN)
-  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `BOOLEAN` while evaluating function `to_boolean('0')` in expr `CAST('0' AS Boolean)`
+ast            : CAST('0' AS BOOLEAN)
+raw expr       : CAST('0' AS Boolean)
+checked expr   : CAST<String>("0" AS Boolean)
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
 
 
-
-error: 
-  --> SQL:1:1
-  |
-1 | CAST('1' AS BOOLEAN)
-  | ^^^^^^^^^^^^^^^^^^^^ cannot parse to type `BOOLEAN` while evaluating function `to_boolean('1')` in expr `CAST('1' AS Boolean)`
-
+ast            : CAST('1' AS BOOLEAN)
+raw expr       : CAST('1' AS Boolean)
+checked expr   : CAST<String>("1" AS Boolean)
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
 
 
 ast            : CAST('true' AS BOOLEAN)
@@ -3357,19 +3359,19 @@ output         : NULL
 ast            : TRY_CAST('0' AS BOOLEAN)
 raw expr       : TRY_CAST('0' AS Boolean)
 checked expr   : TRY_CAST<String>("0" AS Boolean NULL)
-optimized expr : NULL
+optimized expr : false
 output type    : Boolean NULL
-output domain  : {NULL}
-output         : NULL
+output domain  : {FALSE}
+output         : false
 
 
 ast            : TRY_CAST('1' AS BOOLEAN)
 raw expr       : TRY_CAST('1' AS Boolean)
 checked expr   : TRY_CAST<String>("1" AS Boolean NULL)
-optimized expr : NULL
+optimized expr : true
 output type    : Boolean NULL
-output domain  : {NULL}
-output         : NULL
+output domain  : {TRUE}
+output         : true
 
 
 ast            : TRY_CAST('true' AS BOOLEAN)

--- a/tests/sqllogictests/suites/duckdb/sql/cast/test_exponent_in_cast.test
+++ b/tests/sqllogictests/suites/duckdb/sql/cast/test_exponent_in_cast.test
@@ -16,8 +16,10 @@ SELECT CAST('  e1' AS DOUBLE)
 statement error 1006
 SELECT CAST('  E1' AS DOUBLE)
 
-statement error 1006
+query I
 SELECT CAST('  1e1' AS INTEGER)
+----
+10
 
 query R
 SELECT CAST('1e1' AS DOUBLE)

--- a/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
+++ b/tests/sqllogictests/suites/query/functions/02_0002_function_cast.test
@@ -117,6 +117,16 @@ SELECT '33'::unsigned = 33
 ----
 1
 
+query RI
+SELECT CAST('   1e1' AS DOUBLE), CAST('  1e1' AS INTEGER)
+----
+10.0 10
+
+query II
+SELECT CAST('  -42 ' AS INTEGER), CAST(' 42 ' AS UNSIGNED)
+----
+-42 42
+
 
 
 statement error 1006
@@ -143,6 +153,16 @@ query B
 select 'false'::boolean = not 'true'::boolean
 ----
 1
+
+query BBBB
+select '1'::boolean, '0'::boolean, ' true '::boolean, ' false '::boolean
+----
+1 0 1 0
+
+query BBBB
+select true='1', false='0', ' 1 '=true, ' 0 '=false
+----
+1 1 1 1
 
 query B
 SELECT  to_timestamp('2021-03-05 01:01:01') + 1 = to_timestamp('2021-03-05 01:01:01.000001')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Trim string inputs before numeric parsing so casts like `CAST('   1e1' AS DOUBLE)` and `CAST('  1e1' AS INTEGER)` succeed consistently.
- Trim string-to-boolean inputs and accept `'1'` / `'0'` in addition to `'true'` / `'false'`.
- Add Databend sqllogictest coverage in `tests/sqllogictests/suites/query/functions/02_0002_function_cast.test`.
- Keep DuckDB migrated test updates out of this Databend PR; those will be proposed separately in bendtest and can depend on this PR.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

```bash
cargo check -p databend-common-functions
```

```bash
cargo build --bin databend-query --bin databend-sqllogictests
```

```bash
target/debug/databend-sqllogictests --run 'tests/sqllogictests/suites/query/functions/02_0002_function_cast.test' --handlers http
```

```bash
target/debug/databend-sqllogictests --run 'tests/sqllogictests/suites/query/functions/02_0002_function_cast.test' --handlers mysql --port 3307
```

```bash
UPDATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::cast::test_cast -- --exact
```

```bash
cargo test -p databend-common-functions --test it scalars::cast::test_cast -- --exact
```

```bash
target/debug/databend-sqllogictests --run 'tests/sqllogictests/suites/duckdb/sql/cast/test_exponent_in_cast.test' --handlers http
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19809)
<!-- Reviewable:end -->

