### PR TITLE
fix(query): prefer columns in group by resolution

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -1175,11 +1175,11 @@ impl Binder {
         }
         let preferred_aliases = group_by_aliases.preferred_aliases();
         let available_aliases = group_by_aliases.available_aliases();
-        // GROUP BY first uses the preferred alias set, then falls back to the
-        // full alias set only when the expression cannot be resolved. This
-        // keeps the main binding path centralized while allowing SRF and
-        // aggregate aliases to remain available without letting them shadow
-        // same-name input columns.
+        // GROUP BY binds names with column-first resolution. The first pass
+        // uses the preferred alias set, then falls back to the full alias set
+        // only when the expression cannot be resolved. This keeps SRF and
+        // aggregate aliases available without letting them shadow same-name
+        // input columns.
         for expr in group_by.iter() {
             // If expr is a number literal, then this is a index group item.
             if let Expr::Literal {

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -87,7 +87,10 @@ pub enum ExprContext {
 
 impl ExprContext {
     pub fn prefer_resolve_alias(&self) -> bool {
-        !matches!(self, ExprContext::SelectClause | ExprContext::WhereClause)
+        !matches!(
+            self,
+            ExprContext::SelectClause | ExprContext::WhereClause | ExprContext::GroupClaue
+        )
     }
 
     pub fn allow_resolve_alias(&self) -> bool {
@@ -425,6 +428,38 @@ impl BindContext {
                 column_case_sensitive,
                 &mut result,
             );
+        } else if self.expr_context == ExprContext::GroupClaue {
+            Self::search_bound_columns_in_context(
+                self,
+                database,
+                table,
+                column,
+                column_case_sensitive,
+                &mut result,
+            );
+
+            if result.is_empty() {
+                for (alias, scalar) in available_aliases {
+                    if database.is_none() && table.is_none() && name == alias {
+                        result.push(NameResolutionResult::Alias {
+                            alias: alias.clone(),
+                            scalar: scalar.clone(),
+                        });
+                    }
+                }
+            }
+
+            if result.is_empty()
+                && let Some(ref parent) = self.parent
+            {
+                parent.search_bound_columns_recursively(
+                    database,
+                    table,
+                    column,
+                    column_case_sensitive,
+                    &mut result,
+                );
+            }
         } else if self.expr_context.prefer_resolve_alias() {
             for (alias, scalar) in available_aliases {
                 if database.is_none() && table.is_none() && name == alias {
@@ -529,41 +564,14 @@ impl BindContext {
     ) {
         let mut bind_context: &BindContext = self;
         loop {
-            for column_binding in bind_context.columns.iter() {
-                if let Some(lower) = &column_binding.column_name_lower {
-                    if !column_case_sensitive
-                        && &column.name == lower
-                        && Self::match_column_binding_case_insensitive(
-                            database,
-                            table,
-                            column_binding,
-                        )
-                    {
-                        let mut binding = column_binding.clone();
-                        binding.column_name = lower.clone();
-                        result.push(NameResolutionResult::Column(binding));
-                        continue;
-                    }
-                }
-                if Self::match_column_binding(database, table, &column.name, column_binding) {
-                    result.push(NameResolutionResult::Column(column_binding.clone()));
-                }
-            }
-
-            if !result.is_empty() {
-                return;
-            }
-
-            // look up internal column
-            if let Some(internal_column) = INTERNAL_COLUMN_FACTORY.get_internal_column(&column.name)
-            {
-                let column_binding = InternalColumnBinding {
-                    database_name: database.map(|n| n.to_owned()),
-                    table_name: table.map(|n| n.to_owned()),
-                    internal_column,
-                };
-                result.push(NameResolutionResult::InternalColumn(column_binding));
-            }
+            Self::search_bound_columns_in_context(
+                bind_context,
+                database,
+                table,
+                column,
+                column_case_sensitive,
+                result,
+            );
 
             if !result.is_empty() {
                 return;
@@ -574,6 +582,46 @@ impl BindContext {
             } else {
                 break;
             }
+        }
+    }
+
+    fn search_bound_columns_in_context(
+        bind_context: &BindContext,
+        database: Option<&str>,
+        table: Option<&str>,
+        column: &Identifier,
+        column_case_sensitive: bool,
+        result: &mut Vec<NameResolutionResult>,
+    ) {
+        for column_binding in bind_context.columns.iter() {
+            if let Some(lower) = &column_binding.column_name_lower {
+                if !column_case_sensitive
+                    && &column.name == lower
+                    && Self::match_column_binding_case_insensitive(database, table, column_binding)
+                {
+                    let mut binding = column_binding.clone();
+                    binding.column_name = lower.clone();
+                    result.push(NameResolutionResult::Column(binding));
+                    continue;
+                }
+            }
+            if Self::match_column_binding(database, table, &column.name, column_binding) {
+                result.push(NameResolutionResult::Column(column_binding.clone()));
+            }
+        }
+
+        if !result.is_empty() {
+            return;
+        }
+
+        // look up internal column
+        if let Some(internal_column) = INTERNAL_COLUMN_FACTORY.get_internal_column(&column.name) {
+            let column_binding = InternalColumnBinding {
+                database_name: database.map(|n| n.to_owned()),
+                table_name: table.map(|n| n.to_owned()),
+                internal_column,
+            };
+            result.push(NameResolutionResult::InternalColumn(column_binding));
         }
     }
 

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -518,10 +518,19 @@ async fn test_binder_grouping_and_srf_paths() -> Result<()> {
             sql: "SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col2 FROM t_str AS t GROUP BY col1, col2 ORDER BY col2",
         },
         SqlTestCase {
-            name: "group_by_prefers_select_alias_over_same_name_base_column",
-            description: "GROUP BY should keep resolving an unqualified name to the SELECT alias before the input column when both names exist.",
-            setup_sqls: &["CREATE TABLE t(a UInt64, b UInt64)"],
-            sql: "SELECT a AS b, count(*) FROM t GROUP BY b",
+            name: "group_by_prefers_input_column_over_same_name_select_alias",
+            description: "GROUP BY should resolve an unqualified name to the input column before a same-name SELECT alias.",
+            setup_sqls: &["CREATE TABLE t(i UInt64, j UInt64)"],
+            sql: "SELECT 1 AS i, sum(i) FROM t GROUP BY i",
+        },
+        SqlTestCase {
+            name: "group_by_prefers_alias_over_outer_column",
+            description: "GROUP BY should resolve a SELECT alias before falling back to a same-name outer column.",
+            setup_sqls: &[
+                "CREATE TABLE t_outer(b UInt64)",
+                "CREATE TABLE t_inner(a UInt64)",
+            ],
+            sql: "SELECT * FROM t_outer WHERE EXISTS (SELECT t_inner.a AS b FROM t_inner GROUP BY b)",
         },
         SqlTestCase {
             name: "group_by_prefers_input_column_over_aggregate_alias",

--- a/src/query/sql/tests/it/semantic/binder_grouping.txt
+++ b/src/query/sql/tests/it/semantic/binder_grouping.txt
@@ -67,22 +67,52 @@ Sort
                     └── limit: NONE
 
 
-=== group_by_prefers_select_alias_over_same_name_base_column ===
-description: GROUP BY should keep resolving an unqualified name to the SELECT alias before the input column when both names exist.
-sql: SELECT a AS b, count(*) FROM t GROUP BY b
+=== group_by_prefers_input_column_over_same_name_select_alias ===
+description: GROUP BY should resolve an unqualified name to the input column before a same-name SELECT alias.
+sql: SELECT 1 AS i, sum(i) FROM t GROUP BY i
 status: ok
 EvalScalar
-├── scalars: [t.a (#0) AS (#0), COUNT(*) (#2) AS (#2)]
+├── scalars: [sum(i) (#2) AS (#2), 1 AS (#3)]
 └── Aggregate(Initial)
-    ├── group items: [t.a (#0) AS (#0)]
-    ├── aggregate functions: [count() AS (#2)]
+    ├── group items: [t.i (#0) AS (#0)]
+    ├── aggregate functions: [sum(t.i (#0)) AS (#2)]
     └── EvalScalar
-        ├── scalars: [t.a (#0) AS (#0)]
+        ├── scalars: [t.i (#0) AS (#0)]
         └── Scan
             ├── table: default.t (#0)
             ├── filters: []
             ├── order by: []
             └── limit: NONE
+
+
+=== group_by_prefers_alias_over_outer_column ===
+description: GROUP BY should resolve a SELECT alias before falling back to a same-name outer column.
+sql: SELECT * FROM t_outer WHERE EXISTS (SELECT t_inner.a AS b FROM t_inner GROUP BY b)
+status: ok
+EvalScalar
+├── scalars: [t_outer.b (#0) AS (#0)]
+└── Filter
+    ├── filters: [SUBQUERY AS (#1)]
+    ├── subquerys
+    │   └── Subquery (Exists)
+    │       ├── output_column: t_inner.a (#1)
+    │       └── EvalScalar
+    │           ├── scalars: [t_inner.a (#1) AS (#1)]
+    │           └── Aggregate(Initial)
+    │               ├── group items: [t_inner.a (#1) AS (#1)]
+    │               ├── aggregate functions: []
+    │               └── EvalScalar
+    │                   ├── scalars: [t_inner.a (#1) AS (#1)]
+    │                   └── Scan
+    │                       ├── table: default.t_inner (#1)
+    │                       ├── filters: []
+    │                       ├── order by: []
+    │                       └── limit: NONE
+    └── Scan
+        ├── table: default.t_outer (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
 
 
 === group_by_prefers_input_column_over_aggregate_alias ===

--- a/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
@@ -21,6 +21,26 @@ SELECT number%3 as c1 FROM numbers_mt(10) where number > 2 group by number%3 ord
 1
 2
 
+statement error must appear in the GROUP BY clause or be used in an aggregate function
+SELECT i, SUM(j), j FROM (SELECT 3 AS i, 4 AS j UNION ALL SELECT 3, 4 UNION ALL SELECT 2, 4) AS integers GROUP BY i ORDER BY i
+
+query II
+SELECT 1 AS k, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY k ORDER BY 2
+----
+1 8
+
+query II
+SELECT 1 AS i, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY i ORDER BY 2
+----
+1 2
+1 6
+
+query II
+SELECT i % 2 AS k, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY k, k ORDER BY 1
+----
+0 2
+1 6
+
 query TI
 SELECT try_cast(number % 3 as string) c1, count()  FROM numbers_mt(10) where number > 2 group by c1 order by c1
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prefer input columns over SELECT aliases when resolving unqualified names in `GROUP BY`
- Keep alias fallback for non-conflicting `GROUP BY` aliases, including existing SRF/aggregate alias paths
- Add regression coverage in Databend's own sqllogictest suite instead of modifying DuckDB e2e files in this repo

Fixes #19806

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation commands:

```bash
cargo fmt --check -p databend-common-sql
cargo test -p databend-common-sql --test it semantic::binder -- --nocapture
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19810)
<!-- Reviewable:end -->
