### PR TITLE
feat(auth): expand key-pair auth to support RS384 and RS512

### DIFF
--- a/src/query/users/src/jwt/key_pair.rs
+++ b/src/query/users/src/jwt/key_pair.rs
@@ -22,20 +22,34 @@ use jwt_simple::algorithms::ES384PublicKey;
 use jwt_simple::algorithms::Ed25519PublicKey;
 use jwt_simple::algorithms::EdDSAPublicKeyLike;
 use jwt_simple::algorithms::RS256PublicKey;
+use jwt_simple::algorithms::RS384PublicKey;
+use jwt_simple::algorithms::RS512PublicKey;
 use jwt_simple::algorithms::RSAPublicKeyLike;
 use jwt_simple::prelude::JWTClaims;
 use jwt_simple::prelude::NoCustomClaims;
 
+/// Minimum RSA key size in bits.
+const RSA_MIN_KEY_BITS: usize = 2048;
+
 pub enum PublicKeyType {
-    RSA256(Box<RS256PublicKey>),
+    RSA(String), // PEM string; parsed into RS256/RS384/RS512 at verify time
     ES256(ES256PublicKey),
     ES384(ES384PublicKey),
     Ed25519(Ed25519PublicKey),
 }
 
 pub fn parse_public_key_pem(pem: &str) -> Result<PublicKeyType> {
+    // Try RSA first (RS256/RS384/RS512 all parse from the same RSA PEM).
+    // We use RS256 for detection; the actual algorithm is selected at verify time.
     if let Ok(key) = RS256PublicKey::from_pem(pem) {
-        return Ok(PublicKeyType::RSA256(Box::new(key)));
+        let components = key.to_components();
+        let key_bits = components.n.len() * 8;
+        if key_bits < RSA_MIN_KEY_BITS {
+            return Err(ErrorCode::AuthenticateFailure(format!(
+                "RSA key must be at least {RSA_MIN_KEY_BITS} bits, got {key_bits} bits"
+            )));
+        }
+        return Ok(PublicKeyType::RSA(pem.to_string()));
     }
     if let Ok(key) = ES256PublicKey::from_pem(pem) {
         return Ok(PublicKeyType::ES256(key));
@@ -47,7 +61,7 @@ pub fn parse_public_key_pem(pem: &str) -> Result<PublicKeyType> {
         return Ok(PublicKeyType::Ed25519(key));
     }
     Err(ErrorCode::AuthenticateFailure(
-        "invalid public key: expected PEM-encoded RSA, ECDSA (P-256/P-384), or Ed25519 public key",
+        "invalid public key: expected PEM-encoded RSA (2048+ bits), ECDSA (P-256/P-384), or Ed25519 public key",
     ))
 }
 
@@ -72,7 +86,29 @@ fn verify_token_with_key(
     key: &PublicKeyType,
 ) -> std::result::Result<JWTClaims<NoCustomClaims>, jwt_simple::Error> {
     match key {
-        PublicKeyType::RSA256(pk) => pk.verify_token::<NoCustomClaims>(token, None),
+        PublicKeyType::RSA(pem) => {
+            // Try RS256, RS384, RS512 in order. The JWT's `alg` header determines
+            // which hash the signer used; we attempt all three since the underlying
+            // RSA key is the same.
+            if let Ok(k) = RS256PublicKey::from_pem(pem) {
+                if let Ok(claims) = k.verify_token::<NoCustomClaims>(token, None) {
+                    return Ok(claims);
+                }
+            }
+            if let Ok(k) = RS384PublicKey::from_pem(pem) {
+                if let Ok(claims) = k.verify_token::<NoCustomClaims>(token, None) {
+                    return Ok(claims);
+                }
+            }
+            if let Ok(k) = RS512PublicKey::from_pem(pem) {
+                if let Ok(claims) = k.verify_token::<NoCustomClaims>(token, None) {
+                    return Ok(claims);
+                }
+            }
+            Err(jwt_simple::Error::msg(
+                "RSA signature verification failed with RS256, RS384, and RS512",
+            ))
+        }
         PublicKeyType::ES256(pk) => pk.verify_token::<NoCustomClaims>(token, None),
         PublicKeyType::ES384(pk) => pk.verify_token::<NoCustomClaims>(token, None),
         PublicKeyType::Ed25519(pk) => pk.verify_token::<NoCustomClaims>(token, None),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Expand key-pair authentication to support RS384 and RS512 in addition to the existing RS256. Also adds RSA minimum 2048-bit key size validation during key registration.

Previously, clients signing JWTs with RS384 or RS512 would fail verification even with a valid RSA key. Now the server tries RS256 → RS384 → RS512 in sequence against the same stored RSA public key.

Supported algorithms after this change: RS256/RS384/RS512, ES256, ES384, EdDSA (Ed25519).

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Existing JWT tests pass; the change is additive (new algorithm paths) with no behavioral change for existing RS256/ES256/ES384/Ed25519 flows.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19812)
<!-- Reviewable:end -->
