### PR TITLE
fix(query): avoid group by alias shadowing

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
+use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::GroupBy;
 use databend_common_ast::ast::Literal;
@@ -1182,11 +1183,9 @@ impl Binder {
         }
         let preferred_aliases = group_by_aliases.preferred_aliases();
         let available_aliases = group_by_aliases.available_aliases();
-        // GROUP BY binds names with column-first resolution. The first pass
-        // uses the preferred alias set, then falls back to the full alias set
-        // only when the expression cannot be resolved. This keeps SRF and
-        // aggregate aliases available without letting them shadow same-name
-        // input columns.
+        // Keep alias-first binding for simple `GROUP BY <alias>` items. For
+        // complex expressions, resolve input columns first and only use SELECT
+        // aliases for names that are not present in the input scope.
         for expr in group_by.iter() {
             // If expr is a number literal, then this is a index group item.
             if let Expr::Literal {
@@ -1219,26 +1218,51 @@ impl Binder {
                 continue;
             }
 
-            let mut scalar_binder = ScalarBinder::new(
-                bind_context,
-                self.ctx.clone(),
-                &self.name_resolution_ctx,
-                self.metadata.clone(),
-                preferred_aliases,
-            );
-            let (mut scalar_expr, _) = if preferred_aliases == available_aliases {
-                scalar_binder.bind(expr)?
+            let is_simple_column_ref = matches!(expr, Expr::ColumnRef {
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    ..
+                },
+                ..
+            });
+
+            let (mut scalar_expr, _) = if is_simple_column_ref {
+                let mut scalar_binder = ScalarBinder::new(
+                    bind_context,
+                    self.ctx.clone(),
+                    &self.name_resolution_ctx,
+                    self.metadata.clone(),
+                    preferred_aliases,
+                );
+                if preferred_aliases == available_aliases {
+                    scalar_binder.bind(expr)?
+                } else {
+                    scalar_binder.bind(expr).or_else(|_| {
+                        let mut fallback_scalar_binder = ScalarBinder::new(
+                            bind_context,
+                            self.ctx.clone(),
+                            &self.name_resolution_ctx,
+                            self.metadata.clone(),
+                            available_aliases,
+                        );
+                        fallback_scalar_binder.bind(expr)
+                    })?
+                }
             } else {
-                scalar_binder.bind(expr).or_else(|_| {
-                    let mut fallback_scalar_binder = ScalarBinder::new(
-                        bind_context,
-                        self.ctx.clone(),
-                        &self.name_resolution_ctx,
-                        self.metadata.clone(),
-                        available_aliases,
-                    );
-                    fallback_scalar_binder.bind(expr)
-                })?
+                bind_context.with_expr_context(
+                    ExprContext::SelectClause,
+                    |bind_context| -> Result<(ScalarExpr, DataType)> {
+                        let mut scalar_binder = ScalarBinder::new(
+                            bind_context,
+                            self.ctx.clone(),
+                            &self.name_resolution_ctx,
+                            self.metadata.clone(),
+                            available_aliases,
+                        );
+                        scalar_binder.bind(expr)
+                    },
+                )?
             };
 
             let mut analyzer = SetReturningAnalyzer::new(bind_context, self.metadata.clone());

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -537,6 +537,18 @@ async fn test_binder_grouping_and_srf_paths() -> Result<()> {
             sql: "SELECT * FROM (SELECT sum(number) AS number FROM t GROUP BY number) AS s",
         },
         SqlTestCase {
+            name: "group_by_complex_expr_does_not_shadow_column_with_same_name_alias",
+            description: "A complex GROUP BY expression should resolve internal column refs from FROM, not from a same-name SELECT alias.",
+            setup_sqls: &["CREATE TABLE t(type Int32)"],
+            sql: "SELECT CASE WHEN type = 0 THEN 'A' ELSE 'B' END AS type, count(*) FROM t GROUP BY CASE WHEN type = 0 THEN 'A' ELSE 'B' END",
+        },
+        SqlTestCase {
+            name: "group_by_complex_expr_falls_back_to_select_alias",
+            description: "A complex GROUP BY expression should still resolve SELECT aliases when no input column matches.",
+            setup_sqls: &["CREATE TABLE t(i Int32)"],
+            sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)",
+        },
+        SqlTestCase {
             name: "group_by_all_collects_non_aggregate_select_items",
             description: "GROUP BY ALL should expand to the non-aggregate SELECT items only.",
             setup_sqls: &["CREATE TABLE t(number UInt64)"],

--- a/src/query/sql/tests/it/semantic/binder_grouping.txt
+++ b/src/query/sql/tests/it/semantic/binder_grouping.txt
@@ -130,6 +130,42 @@ EvalScalar
                 └── limit: NONE
 
 
+=== group_by_complex_expr_does_not_shadow_column_with_same_name_alias ===
+description: A complex GROUP BY expression should resolve internal column refs from FROM, not from a same-name SELECT alias.
+sql: SELECT CASE WHEN type = 0 THEN 'A' ELSE 'B' END AS type, count(*) FROM t GROUP BY CASE WHEN type = 0 THEN 'A' ELSE 'B' END
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#2) AS (#2), CASE WHEN type = 0 THEN 'A' ELSE 'B' END (#1) AS (#3)]
+└── Aggregate(Initial)
+    ├── group items: [if(eq(t.type (#0), 0), 'A', 'B') AS (#1)]
+    ├── aggregate functions: [count() AS (#2)]
+    └── EvalScalar
+        ├── scalars: [if(eq(t.type (#0), 0), 'A', 'B') AS (#1)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== group_by_complex_expr_falls_back_to_select_alias ===
+description: A complex GROUP BY expression should still resolve SELECT aliases when no input column matches.
+sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)
+status: ok
+EvalScalar
+├── scalars: [t.i (#0) AS (#0), COUNT(*) (#2) AS (#2), abs(t.i (#0)) AS (#3)]
+└── Aggregate(Initial)
+    ├── group items: [t.i (#0) AS (#0)]
+    ├── aggregate functions: [count() AS (#2)]
+    └── EvalScalar
+        ├── scalars: [t.i (#0) AS (#0)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
 === group_by_all_collects_non_aggregate_select_items ===
 description: GROUP BY ALL should expand to the non-aggregate SELECT items only.
 sql: SELECT number % 2 AS a, sum(number) FROM t GROUP BY ALL

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/test_group_by_alias.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/test_group_by_alias.test
@@ -22,6 +22,20 @@ SELECT i % 2 AS k, SUM(i) FROM integers WHERE i IS NOT NULL GROUP BY 1 HAVING i%
 ----
 1 4
 
+query TI
+SELECT CASE WHEN i = 1 THEN 'one' ELSE 'other' END AS i, COUNT(*) FROM integers GROUP BY CASE WHEN i = 1 THEN 'one' ELSE 'other' END ORDER BY i
+----
+one 1
+other 3
+
+query III
+SELECT i AS k, abs(i) AS ak, COUNT(*) FROM integers GROUP BY k, abs(k) ORDER BY k
+----
+1 1 1
+2 2 1
+3 3 1
+NULL NULL 1
+
 # SELECT i, i % 2 AS i, SUM(i) FROM integers GROUP BY i ORDER BY i, 3
 # SELECT i, i % 2 AS k, SUM(i) FROM integers GROUP BY i ORDER BY k, 3
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes a compatibility regression in `GROUP BY` alias handling.

Before `v1.2.901-nightly` (for example in `v1.2.900-nightly` and many older releases), the following SQL is accepted:

```sql
CREATE TABLE t(type Int32);

SELECT
    CASE WHEN type = 0 THEN 'A' ELSE 'B' END AS type,
    count(*)
FROM t
GROUP BY CASE WHEN type = 0 THEN 'A' ELSE 'B' END;
```

After commit `73814d249f` (`refactor(binder): consolidate binder alias semantics and split type_check (#19750)`), first included in `v1.2.901-nightly`, the same query can fail with an aggregate semantic error pointing at the `type` reference in the SELECT expression:

```text
ERROR 1105 (HY000): SemanticError. Code: 1065, Text = error:
  --> SQL:1:18
  |
1 | SELECT CASE WHEN type = 0 THEN 'A' ELSE 'B' END AS type, count(*) FROM t GROUP BY CASE WHEN type = 0 THEN 'A' ELSE 'B' END
  |                  ^^^^ column "type" must appear in the GROUP BY clause or be used in an aggregate function
```

The regression was introduced by #19750 (`73814d249f`), which changed name resolution for complex `GROUP BY` expressions. In affected versions, while binding `GROUP BY CASE ...`, the `type` reference can resolve to the SELECT alias `type` rather than the input column. This makes the bound GROUP BY item differ from the `CASE` expression in the SELECT list, where `type` is still an input-column reference. When the aggregate checker validates the SELECT list against the bound GROUP BY items, it cannot find a matching group item for that input-column reference, so the error is reported on the SELECT expression.

This PR keeps alias-first resolution for simple `GROUP BY <alias>` items, while resolving names inside complex `GROUP BY` expressions from input columns first and falling back to SELECT aliases only when no input column matches. This also preserves non-conflicting alias compatibility, for example:

```sql
SELECT i AS k, abs(i) AS ak, count(*)
FROM t
GROUP BY k, abs(k);
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added binder golden coverage and sqllogic regressions for the same-name alias compatibility case and for non-conflicting complex `GROUP BY` alias fallback.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19814)
<!-- Reviewable:end -->
