### PR TITLE
fix(query): refine infer filter type compatibility

### DIFF
--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/infer_filter_test.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/infer_filter_test.rs
@@ -14,8 +14,12 @@
 
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::VectorDataType;
+use databend_common_sql::Symbol;
 use databend_common_sql::optimizer::optimizers::operator::InferFilterOptimizer;
+use databend_common_sql::planner::plans::FunctionCall;
 use databend_common_sql::planner::plans::ScalarExpr;
 
 use crate::sql::planner::optimizer::test_utils::ExprBuilder;
@@ -935,6 +939,474 @@ fn test_contradiction_detection() -> anyhow::Result<()> {
             "Should infer B < 10 predicate through equality"
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_equal_type_compatibility_uses_explicit_type_cases() -> anyhow::Result<()> {
+    for case in equal_compatibility_cases() {
+        let left = create_table_bound_column_ref(
+            Symbol::new(0),
+            "left",
+            case.left_ty.clone(),
+            Some("t"),
+            Some(0),
+        );
+        let right = create_table_bound_column_ref(
+            Symbol::new(1),
+            "right",
+            case.right_ty.clone(),
+            Some("t"),
+            Some(0),
+        );
+
+        let mut optimizer = InferFilterOptimizer::new(None);
+        assert_eq!(
+            optimizer.add_equal_expr(&left, &right),
+            case.expected,
+            "{}: left={:?}, right={:?}",
+            case.name,
+            case.left_ty,
+            case.right_ty,
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_equal_type_compatibility_propagates_number_decimal_predicates() -> anyhow::Result<()> {
+    let mut builder = ExprBuilder::new();
+
+    let int_col = builder.column(
+        "int_col",
+        0,
+        "int_col",
+        DataType::Number(NumberDataType::Int64),
+        "",
+        0,
+    );
+    let decimal_col = builder.column(
+        "decimal_col",
+        1,
+        "decimal_col",
+        DataType::Decimal(DecimalSize::new_unchecked(18, 2)),
+        "",
+        0,
+    );
+
+    let result = run_optimizer(vec![
+        builder.eq(int_col.clone(), decimal_col),
+        builder.eq(int_col, builder.int(10)),
+    ])?;
+
+    assert!(
+        builder.find_predicate(&result, "eq", 1, Some(10)),
+        "Should propagate constants through Number/Decimal equality"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_equal_type_compatibility_rejects_number_float_predicates() -> anyhow::Result<()> {
+    let mut builder = ExprBuilder::new();
+
+    let int_col = builder.column(
+        "int_col",
+        0,
+        "int_col",
+        DataType::Number(NumberDataType::Int64),
+        "",
+        0,
+    );
+    let float_col = builder.column(
+        "float_col",
+        1,
+        "float_col",
+        DataType::Number(NumberDataType::Float64),
+        "",
+        0,
+    );
+
+    let result = run_optimizer(vec![
+        builder.eq(int_col.clone(), float_col),
+        builder.eq(int_col, builder.int(10)),
+    ])?;
+
+    assert!(
+        !builder.find_predicate(&result, "eq", 1, Some(10)),
+        "Should not propagate constants through Number/Float equality"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_equal_type_compatibility_rejects_string_number_transitivity() -> anyhow::Result<()> {
+    let mut builder = ExprBuilder::new();
+
+    let string_col_1 = builder.column("s1", 0, "s1", DataType::String, "", 0);
+    let string_col_2 = builder.column("s2", 1, "s2", DataType::String, "", 0);
+    let number_col = builder.column("n", 2, "n", DataType::Number(NumberDataType::Int64), "", 0);
+
+    let result = run_optimizer(vec![
+        builder.eq(string_col_1.clone(), number_col.clone()),
+        builder.eq(string_col_2.clone(), number_col),
+    ])?;
+
+    assert!(
+        !result.iter().any(|predicate| {
+            if let ScalarExpr::FunctionCall(func) = predicate {
+                if func.func_name != "eq" {
+                    return false;
+                }
+                let left_index = get_column_index(&func.arguments[0]);
+                let right_index = get_column_index(&func.arguments[1]);
+                (left_index == Some(Symbol::new(0)) && right_index == Some(Symbol::new(1)))
+                    || (left_index == Some(Symbol::new(1)) && right_index == Some(Symbol::new(0)))
+            } else {
+                false
+            }
+        }),
+        "String/Number equality should not infer String/String equality"
+    );
+
+    Ok(())
+}
+
+struct EqualCompatibilityCase {
+    name: &'static str,
+    left_ty: DataType,
+    right_ty: DataType,
+    expected: bool,
+}
+
+fn equal_compatibility_cases() -> Vec<EqualCompatibilityCase> {
+    fn case(
+        name: &'static str,
+        left_ty: DataType,
+        right_ty: DataType,
+        expected: bool,
+    ) -> EqualCompatibilityCase {
+        EqualCompatibilityCase {
+            name,
+            left_ty,
+            right_ty,
+            expected,
+        }
+    }
+
+    let int64 = DataType::Number(NumberDataType::Int64);
+    let uint64 = DataType::Number(NumberDataType::UInt64);
+    let float64 = DataType::Number(NumberDataType::Float64);
+    let decimal_18_2 = DataType::Decimal(DecimalSize::new_unchecked(18, 2));
+    let decimal_38_4 = DataType::Decimal(DecimalSize::new_unchecked(38, 4));
+    let string = DataType::String;
+    let boolean = DataType::Boolean;
+    let date = DataType::Date;
+    let timestamp = DataType::Timestamp;
+    let timestamp_tz = DataType::TimestampTz;
+    let variant = DataType::Variant;
+    let binary = DataType::Binary;
+    let interval = DataType::Interval;
+    let geometry = DataType::Geometry;
+    let geography = DataType::Geography;
+    let bitmap = DataType::Bitmap;
+    let vector = DataType::Vector(VectorDataType::Float32(3));
+    let array_int64 = DataType::Array(Box::new(int64.clone()));
+    let array_decimal = DataType::Array(Box::new(decimal_18_2.clone()));
+    let empty_array = DataType::EmptyArray;
+    let map_string_int64 = DataType::Map(Box::new(DataType::Tuple(vec![
+        string.clone(),
+        int64.clone(),
+    ])));
+    let map_string_decimal = DataType::Map(Box::new(DataType::Tuple(vec![
+        string.clone(),
+        decimal_18_2.clone(),
+    ])));
+    let empty_map = DataType::EmptyMap;
+    let tuple_int_string = DataType::Tuple(vec![int64.clone(), string.clone()]);
+    let tuple_decimal_string = DataType::Tuple(vec![decimal_18_2.clone(), string.clone()]);
+    let tuple_nested = DataType::Tuple(vec![
+        DataType::Nullable(Box::new(int64.clone())),
+        array_int64.clone(),
+        map_string_int64.clone(),
+    ]);
+
+    vec![
+        case(
+            "null coerces to number",
+            DataType::Null,
+            int64.clone(),
+            true,
+        ),
+        case(
+            "empty array coerces to typed array",
+            empty_array,
+            array_int64.clone(),
+            true,
+        ),
+        case(
+            "empty map is not comparable",
+            empty_map,
+            map_string_int64.clone(),
+            false,
+        ),
+        case("boolean with boolean", boolean.clone(), boolean, true),
+        case("string with string", string.clone(), string.clone(), true),
+        case(
+            "string with number is not inferred",
+            string.clone(),
+            int64.clone(),
+            false,
+        ),
+        case(
+            "string with boolean is not inferred",
+            string.clone(),
+            DataType::Boolean,
+            false,
+        ),
+        case(
+            "string with date is not inferred",
+            string.clone(),
+            date.clone(),
+            false,
+        ),
+        case(
+            "string with timestamp is not inferred",
+            string.clone(),
+            timestamp.clone(),
+            false,
+        ),
+        case(
+            "string with timestamp_tz is not inferred",
+            string.clone(),
+            timestamp_tz.clone(),
+            false,
+        ),
+        case("signed with unsigned number", int64.clone(), uint64, true),
+        case(
+            "integer with float is not inferred",
+            int64.clone(),
+            float64.clone(),
+            false,
+        ),
+        case(
+            "integer with decimal",
+            int64.clone(),
+            decimal_18_2.clone(),
+            true,
+        ),
+        case(
+            "decimal with larger decimal",
+            decimal_18_2.clone(),
+            decimal_38_4,
+            true,
+        ),
+        case(
+            "decimal with float is not inferred",
+            decimal_18_2.clone(),
+            float64,
+            false,
+        ),
+        case("date with timestamp", date.clone(), timestamp.clone(), true),
+        case(
+            "timestamp with timestamp",
+            timestamp.clone(),
+            timestamp,
+            true,
+        ),
+        case(
+            "timestamp_tz with timestamp_tz",
+            timestamp_tz.clone(),
+            timestamp_tz,
+            true,
+        ),
+        case(
+            "nullable number with number",
+            DataType::Nullable(Box::new(int64.clone())),
+            int64.clone(),
+            true,
+        ),
+        case(
+            "nullable decimal with integer",
+            DataType::Nullable(Box::new(decimal_18_2.clone())),
+            int64.clone(),
+            true,
+        ),
+        case(
+            "variant with number is not inferred",
+            DataType::Nullable(Box::new(variant.clone())),
+            int64.clone(),
+            false,
+        ),
+        case(
+            "variant with string is not inferred",
+            variant.clone(),
+            string.clone(),
+            false,
+        ),
+        case(
+            "variant with boolean is not inferred",
+            variant.clone(),
+            DataType::Boolean,
+            false,
+        ),
+        case(
+            "variant with date is not inferred",
+            variant.clone(),
+            date.clone(),
+            false,
+        ),
+        case(
+            "variant with timestamp is not inferred",
+            variant.clone(),
+            DataType::Timestamp,
+            false,
+        ),
+        case(
+            "variant with decimal is not inferred",
+            variant.clone(),
+            decimal_18_2.clone(),
+            false,
+        ),
+        case(
+            "variant with variant",
+            variant.clone(),
+            variant.clone(),
+            true,
+        ),
+        case(
+            "array element decimal widening",
+            array_int64.clone(),
+            array_decimal,
+            true,
+        ),
+        case(
+            "array variant with array number is not comparable",
+            DataType::Array(Box::new(DataType::Nullable(Box::new(variant.clone())))),
+            array_int64.clone(),
+            false,
+        ),
+        case(
+            "map is not comparable",
+            map_string_int64.clone(),
+            map_string_decimal,
+            false,
+        ),
+        case(
+            "map variant value is not comparable",
+            DataType::Map(Box::new(DataType::Tuple(vec![
+                string.clone(),
+                DataType::Nullable(Box::new(variant.clone())),
+            ]))),
+            map_string_int64.clone(),
+            false,
+        ),
+        case(
+            "tuple field decimal widening",
+            tuple_int_string.clone(),
+            tuple_decimal_string,
+            true,
+        ),
+        case(
+            "nested tuple with itself",
+            tuple_nested.clone(),
+            tuple_nested,
+            true,
+        ),
+        case(
+            "interval with interval",
+            interval.clone(),
+            interval.clone(),
+            true,
+        ),
+        case("bitmap with bitmap", bitmap.clone(), bitmap.clone(), true),
+        case("binary is not comparable", binary.clone(), binary, false),
+        case(
+            "string does not compare as binary",
+            string.clone(),
+            DataType::Binary,
+            false,
+        ),
+        case(
+            "geometry is not comparable",
+            geometry.clone(),
+            geometry,
+            false,
+        ),
+        case(
+            "geography is not comparable",
+            geography.clone(),
+            geography,
+            false,
+        ),
+        case("vector is not comparable", vector.clone(), vector, false),
+        case(
+            "opaque is not comparable",
+            DataType::Opaque(1),
+            DataType::Opaque(1),
+            false,
+        ),
+        case(
+            "stage location is not comparable",
+            DataType::StageLocation,
+            DataType::StageLocation,
+            false,
+        ),
+        case("bitmap with string", bitmap, DataType::String, false),
+        case("interval with number", interval, int64.clone(), false),
+        case("array with tuple", array_int64, tuple_int_string, false),
+        case(
+            "map with tuple",
+            map_string_int64,
+            DataType::Tuple(vec![string.clone(), int64]),
+            false,
+        ),
+    ]
+}
+
+#[test]
+fn test_replaced_remaining_predicate_must_still_type_check() -> anyhow::Result<()> {
+    let mut builder = ExprBuilder::new();
+
+    let int_col = builder.column(
+        "int_col",
+        0,
+        "int_col",
+        DataType::Number(NumberDataType::Int64),
+        "",
+        0,
+    );
+    let variant_col = builder.column(
+        "variant_col",
+        1,
+        "variant_col",
+        DataType::Nullable(Box::new(DataType::Variant)),
+        "",
+        0,
+    );
+    let strip_null_value = ScalarExpr::FunctionCall(FunctionCall {
+        span: None,
+        func_name: "strip_null_value".to_string(),
+        params: vec![],
+        arguments: vec![variant_col.clone()],
+    });
+    let is_not_null = ScalarExpr::FunctionCall(FunctionCall {
+        span: None,
+        func_name: "is_not_null".to_string(),
+        params: vec![],
+        arguments: vec![strip_null_value],
+    });
+
+    let result = run_optimizer(vec![builder.eq(int_col, variant_col), is_not_null])?;
+
+    assert!(
+        result.iter().all(|expr| expr.data_type().is_ok()),
+        "Inferred predicates should not contain invalid function arguments"
+    );
 
     Ok(())
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
@@ -20,6 +20,7 @@ use databend_common_exception::Result;
 use databend_common_expression::Scalar;
 use databend_common_expression::type_check::common_super_type;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -206,23 +207,143 @@ impl<'a> InferFilterOptimizer<'a> {
         true
     }
 
-    // equal expr must have the same type, otherwise the function may fail on execution.
+    // Equality inference needs a conversion target that preserves equivalence,
+    // not just a type combination that Databend can evaluate with `eq`.
     fn check_equal_expr_type(left_ty: &DataType, right_ty: &DataType) -> bool {
-        match (left_ty.remove_nullable(), right_ty.remove_nullable()) {
-            (DataType::Number(l), DataType::Number(r)) => {
-                (l.is_integer() && r.is_integer()) || (l.is_float() && r.is_float())
+        let left = left_ty.remove_nullable();
+        let right = right_ty.remove_nullable();
+        let Some(common_ty) = Self::safe_common_type(left.clone(), right.clone()) else {
+            return false;
+        };
+
+        Self::is_injective_cast(&left, &common_ty) && Self::is_injective_cast(&right, &common_ty)
+    }
+
+    fn safe_common_type(left: DataType, right: DataType) -> Option<DataType> {
+        match (&left, &right) {
+            (DataType::Null, ty) | (ty, DataType::Null) => Some(ty.clone()),
+            (DataType::Nullable(left_ty), DataType::Nullable(right_ty)) => {
+                Some(DataType::Nullable(Box::new(Self::safe_common_type(
+                    *left_ty.clone(),
+                    *right_ty.clone(),
+                )?)))
             }
-            (DataType::Decimal(_), DataType::Decimal(_)) => true,
-            (DataType::Array(box l), DataType::Array(box r)) => Self::check_equal_expr_type(&l, &r),
-            (DataType::Map(box l), DataType::Map(box r)) => Self::check_equal_expr_type(&l, &r),
-            (DataType::Tuple(l_tys), DataType::Tuple(r_tys)) => {
-                l_tys.len() == r_tys.len()
-                    && l_tys
+            (DataType::Nullable(left_ty), right_ty) => Some(DataType::Nullable(Box::new(
+                Self::safe_common_type(*left_ty.clone(), right_ty.clone())?,
+            ))),
+            (left_ty, DataType::Nullable(right_ty)) => Some(DataType::Nullable(Box::new(
+                Self::safe_common_type(left_ty.clone(), *right_ty.clone())?,
+            ))),
+            (DataType::EmptyArray, ty @ DataType::Array(_))
+            | (ty @ DataType::Array(_), DataType::EmptyArray) => Some(ty.clone()),
+            (DataType::Array(left_ty), DataType::Array(right_ty)) => Some(DataType::Array(
+                Box::new(Self::safe_common_type(*left_ty.clone(), *right_ty.clone())?),
+            )),
+            (DataType::Map(left_ty), DataType::Map(right_ty)) if left_ty == right_ty => {
+                Some(left.clone())
+            }
+            (DataType::Tuple(left_tys), DataType::Tuple(right_tys))
+                if left_tys.len() == right_tys.len() =>
+            {
+                Some(DataType::Tuple(
+                    left_tys
                         .iter()
-                        .zip(r_tys.iter())
-                        .all(|(l_ty, r_ty)| Self::check_equal_expr_type(l_ty, r_ty))
+                        .cloned()
+                        .zip(right_tys.iter().cloned())
+                        .map(|(left_ty, right_ty)| Self::safe_common_type(left_ty, right_ty))
+                        .collect::<Option<Vec<_>>>()?,
+                ))
             }
-            (_, _) => left_ty.eq(right_ty),
+            (DataType::Number(left_num), DataType::Number(right_num))
+                if left_num.is_integer() && right_num.is_integer() =>
+            {
+                Some(DataType::Decimal(Self::merge_decimal_size(
+                    left_num.get_decimal_properties()?,
+                    right_num.get_decimal_properties()?,
+                )?))
+            }
+            (DataType::Number(left_num), DataType::Number(right_num))
+                if left_num.is_float() && right_num.is_float() =>
+            {
+                if left_num.bit_width() >= right_num.bit_width() {
+                    Some(left.clone())
+                } else {
+                    Some(right.clone())
+                }
+            }
+            (DataType::Number(num_ty), DataType::Decimal(decimal))
+            | (DataType::Decimal(decimal), DataType::Number(num_ty))
+                if num_ty.is_integer() =>
+            {
+                let num_decimal = num_ty.get_decimal_properties()?;
+                Some(DataType::Decimal(Self::merge_decimal_size(
+                    *decimal,
+                    num_decimal,
+                )?))
+            }
+            (DataType::Decimal(left_decimal), DataType::Decimal(right_decimal)) => Some(
+                DataType::Decimal(Self::merge_decimal_size(*left_decimal, *right_decimal)?),
+            ),
+            (DataType::Date, DataType::Timestamp) | (DataType::Timestamp, DataType::Date) => {
+                Some(DataType::Timestamp)
+            }
+            _ if left == right && Self::is_safe_same_type(&left) => Some(left),
+            _ => None,
+        }
+    }
+
+    fn is_safe_same_type(data_type: &DataType) -> bool {
+        matches!(
+            data_type,
+            DataType::Boolean
+                | DataType::String
+                | DataType::Number(_)
+                | DataType::Decimal(_)
+                | DataType::Timestamp
+                | DataType::TimestampTz
+                | DataType::Date
+                | DataType::Bitmap
+                | DataType::Variant
+                | DataType::Interval
+        )
+    }
+
+    fn merge_decimal_size(left: DecimalSize, right: DecimalSize) -> Option<DecimalSize> {
+        let scale = left.scale().max(right.scale());
+        let precision = left.leading_digits().max(right.leading_digits()) + scale;
+        DecimalSize::new(precision, scale).ok()
+    }
+
+    fn is_injective_cast(src: &DataType, dest: &DataType) -> bool {
+        if src == dest {
+            return true;
+        }
+
+        match (src, dest) {
+            (DataType::Nullable(src), DataType::Nullable(dest)) => {
+                Self::is_injective_cast(src, dest)
+            }
+            (DataType::Nullable(src), dest) => Self::is_injective_cast(src, dest),
+            (src, DataType::Nullable(dest)) => Self::is_injective_cast(src, dest),
+            (DataType::Null, _) => true,
+            (DataType::EmptyArray, DataType::Array(_)) => true,
+            (DataType::Number(src), DataType::Number(dest)) => {
+                (src.is_integer() && dest.is_integer()) || src.can_lossless_cast_to(*dest)
+            }
+            (DataType::Number(src), DataType::Decimal(_)) if src.is_integer() => true,
+            (DataType::Decimal(src), DataType::Decimal(dest)) => {
+                src.scale() <= dest.scale() && src.leading_digits() <= dest.leading_digits()
+            }
+            (DataType::Date, DataType::Timestamp) => true,
+            (DataType::Array(src), DataType::Array(dest)) => Self::is_injective_cast(src, dest),
+            (DataType::Tuple(src_tys), DataType::Tuple(dest_tys)) => {
+                src_tys.len() == dest_tys.len()
+                    && src_tys
+                        .iter()
+                        .zip(dest_tys)
+                        .all(|(src, dest)| Self::is_injective_cast(src, dest))
+            }
+            _ => false,
         }
     }
 
@@ -842,7 +963,7 @@ impl<'a> InferFilterOptimizer<'a> {
                 continue;
             }
 
-            if new_predicate != predicate {
+            if new_predicate != predicate && new_predicate.data_type().is_ok() {
                 result_predicates.push(new_predicate);
             }
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -679,6 +679,20 @@ TableScan
 └── estimated rows: 0.00
 
 query T
+explain select * from t4 where b = a and b = 5;
+----
+TableScan
+├── table: default.default.t4
+├── scan id: 0
+├── output columns: [a (#0), b (#1)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 0
+├── partitions scanned: 0
+├── push downs: [filters: [TRY_CAST(t4.b (#1) AS Int32 NULL) = CAST(t4.a (#0) AS Int32 NULL) and TRY_CAST(t4.b (#1) AS UInt8 NULL) = 5], limit: NONE]
+└── estimated rows: 0.00
+
+query T
 explain select * from t3 join t4 on t3.b = t4.b where strip_null_value(t4.b) is not null;
 ----
 HashJoin
@@ -768,6 +782,23 @@ HashJoin
     ├── push downs: [filters: [t1.id (#0) = 869550529], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00
+
+statement ok
+create or replace table t1(i BIGINT NOT NULL, d DECIMAL(18, 2) NULL);
+
+query T
+explain SELECT * FROM t1 where i = d and i = 10;
+----
+TableScan
+├── table: default.default.t1
+├── scan id: 0
+├── output columns: [i (#0), d (#1)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 0
+├── partitions scanned: 0
+├── push downs: [filters: [t1.i (#0) = 10 and t1.d (#1) = 10 and true], limit: NONE]
+└── estimated rows: 0.00
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test
@@ -679,6 +679,20 @@ TableScan
 └── estimated rows: 0.00
 
 query T
+explain select * from t4 where b = a and b = 5;
+----
+TableScan
+├── table: default.default.t4
+├── scan id: 0
+├── output columns: [a (#0), b (#1)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 0
+├── partitions scanned: 0
+├── push downs: [filters: [TRY_CAST(t4.b (#1) AS Int32 NULL) = CAST(t4.a (#0) AS Int32 NULL) and TRY_CAST(t4.b (#1) AS UInt8 NULL) = 5], limit: NONE]
+└── estimated rows: 0.00
+
+query T
 explain select * from t3 join t4 on t3.b = t4.b where strip_null_value(t4.b) is not null;
 ----
 HashJoin
@@ -774,6 +788,23 @@ HashJoin
     ├── push downs: [filters: [t1.id (#0) = 869550529], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00
+
+statement ok
+create or replace table t1(i BIGINT NOT NULL, d DECIMAL(18, 2) NULL);
+
+query T
+explain SELECT * FROM t1 where i = d and i = 10;
+----
+TableScan
+├── table: default.default.t1
+├── scan id: 0
+├── output columns: [i (#0), d (#1)]
+├── read rows: 0
+├── read size: 0
+├── partitions total: 0
+├── partitions scanned: 0
+├── push downs: [filters: [t1.i (#0) = 10 and t1.d (#1) = 10 and true], limit: NONE]
+└── estimated rows: 0.00
 
 statement ok
 drop table if exists t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #17933
- Refine InferFilter equality inference so an equality edge must be safe for equivalence-class reasoning, not merely executable by Databend's `eq` function.
- Centralize the inference decision in `safe_common_type`: compute an inference-safe common type, then require both sides to cast to that type through injective/lossless-enough conversions.
- Allow inference through same-type equality for the scalar types currently covered by InferFilter, nullable wrappers, `Null`, integer-to-integer casts, integer-to-Decimal casts, Decimal widening, `Date` to `Timestamp`, Float-to-wider-Float, exact same Map types, and recursive Array/Tuple casts when their elements/fields are also safe.
- Keep signed/unsigned integer inference to preserve existing optimizer behavior, such as propagating constants across `BIGINT = BIGINT UNSIGNED` join keys.
- Reject mixed String equality, mixed Variant equality, mixed/empty Map equality, Number/Decimal to Float equality, and unsafe nested combinations so InferFilter does not derive predicates that are not implied by the original SQL.
- Types outside the explicit inference-safe set are left unchanged by this PR rather than being used as new equivalence-class edges without dedicated coverage.
- Keep inferred replacement predicates type-checkable, and add explicit coverage for String, Boolean, Date/Timestamp, Variant, Decimal, Float, arrays, tuples, maps, and nested equality-facing types.

## Tips

The safe common type path intentionally avoids Databend's normal `eq` auto-cast and `TRY_CAST` rules. Those rules are valid for expression evaluation, but failed conversions can become `NULL`, so the comparison is not a safe equivalence relation for deriving transitive predicates.

String and numeric equality is intentionally rejected. For example, `'01' = 1` and `'1' = 1` can both evaluate to true, while `'01' = '1'` is false, so using those edges to infer `'01' = '1'` would be incorrect.

Float equality is intentionally not used as an inference edge when it requires converting an integer or Decimal into Float. Integer/Decimal values can collapse after conversion to Float, so the conversion is not injective/lossless enough for equivalence-class inference.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation commands:

```shell
cargo fmt --check
git diff --check
cargo test -p databend-query --test it infer_filter
cargo build --bin databend-query --bin databend-sqllogictests
target/debug/databend-sqllogictests --handlers http --run 'tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test'
target/debug/databend-sqllogictests --handlers http --run 'tests/sqllogictests/suites/mode/standalone/explain_native/infer_filter.test'
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19816)
<!-- Reviewable:end -->
