### PR TITLE
refactor: meta: semaphore: distinguish semaphore permit loss

### DIFF
--- a/src/meta/plugins/semaphore/README.md
+++ b/src/meta/plugins/semaphore/README.md
@@ -53,7 +53,7 @@ let acquired_guard = Semaphore::new_acquired(
         Duration::from_secs(3)      // lease time
 ).await?;
 
-acquired_guard.await;
+acquired_guard.await?;
 // Released
 ```
 

--- a/src/meta/plugins/semaphore/src/acquirer/permit.rs
+++ b/src/meta/plugins/semaphore/src/acquirer/permit.rs
@@ -32,8 +32,8 @@ use crate::storage::PermitKey;
 
 /// An instance represents an acquired semaphore permit.
 ///
-/// This instance is a [`Future`] that will be ready when the semaphore permit is removed from meta-service.
-/// For example, the connection to meta-service is lost and failed to extend the lease.
+/// This instance is a [`Future`] that will be ready when the semaphore permit is removed from meta-service
+/// or when the watcher can no longer prove the permit is still held.
 ///
 /// The permit will be released (and the lease extending task will try to delete
 /// the [`PermitEntry`] from meta-service) when this instance is dropped intentionally.
@@ -52,8 +52,8 @@ pub struct Permit {
     // Hold it so that the lease extending task keep running.
     pub(crate) _leaser_cancel_tx: oneshot::Sender<()>,
 
-    /// Gets ready if the [`PermitEntry`] is removed from meta-service.
-    pub(crate) is_removed_rx: oneshot::Receiver<()>,
+    /// Gets ready if the [`PermitEntry`] is removed from meta-service or the watcher fails.
+    pub(crate) is_removed_rx: oneshot::Receiver<Result<(), ConnectionClosed>>,
 }
 
 impl std::fmt::Debug for Permit {
@@ -78,14 +78,18 @@ impl Drop for Permit {
 }
 
 impl Future for Permit {
-    type Output = ();
+    type Output = Result<(), ConnectionClosed>;
 
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
         match self.is_removed_rx.poll_unpin(cx) {
-            std::task::Poll::Ready(_) => std::task::Poll::Ready(()),
+            std::task::Poll::Ready(Ok(res)) => std::task::Poll::Ready(res),
+            std::task::Poll::Ready(Err(_)) => std::task::Poll::Ready(Err(
+                ConnectionClosed::new_str("permit removal watcher closed")
+                    .context(&self.acquirer_name),
+            )),
             std::task::Poll::Pending => std::task::Poll::Pending,
         }
     }
@@ -102,7 +106,7 @@ impl Permit {
         permit_entry: PermitEntry,
         leaser_cancel_tx: oneshot::Sender<()>,
     ) -> Self {
-        let (is_removed_tx, is_removed_rx) = oneshot::channel::<()>();
+        let (is_removed_tx, is_removed_rx) = oneshot::channel::<Result<(), ConnectionClosed>>();
 
         // There must be a standalone task that consumes incoming events so that it won't block the permit_event_rx sender
         let acquirer_name = acquirer.name.clone();
@@ -137,14 +141,14 @@ impl Permit {
     ///
     /// It can be used to detect when a [`Permit`] is no longer held and take appropriate action.
     ///
-    /// Note that if it returns `Err(ConnectionClosed)`, it does not mean the permit is lost,
-    /// in such case, the permit may still be valid.
+    /// If it returns `Err(ConnectionClosed)`, the watcher is no longer able to prove that
+    /// the permit is still held.
     pub(crate) async fn watch_for_remove(
         mut permit_event_rx: mpsc::Receiver<Result<PermitEvent, ConnectionClosed>>,
         acquirer_name: String,
         permit_key: PermitKey,
         permit_entry: PermitEntry,
-        is_removed_tx: oneshot::Sender<()>,
+        is_removed_tx: oneshot::Sender<Result<(), ConnectionClosed>>,
     ) {
         let ctx = format!("{}: {}->{}", acquirer_name, permit_key, permit_entry);
 
@@ -153,6 +157,7 @@ impl Permit {
                 Ok(x) => x,
                 Err(e) => {
                     warn!("{}: watch_for_remove recv error: {}", ctx, e);
+                    is_removed_tx.send(Err(e)).ok();
                     return;
                 }
             };
@@ -164,11 +169,18 @@ impl Permit {
                 PermitEvent::Removed((seq, _)) => {
                     if seq == permit_key.seq {
                         warn!("{}: PermitEntry is removed", ctx);
-                        is_removed_tx.send(()).ok();
+                        is_removed_tx.send(Ok(())).ok();
                         return;
                     }
                 }
             }
         }
+
+        is_removed_tx
+            .send(Err(ConnectionClosed::new_str(
+                "event channel closed before permit removal",
+            )
+            .context(ctx)))
+            .ok();
     }
 }

--- a/src/meta/plugins/semaphore/src/lib.rs
+++ b/src/meta/plugins/semaphore/src/lib.rs
@@ -28,7 +28,7 @@
 //!         Duration::from_secs(3)      // lease time
 //! ).await?;
 //!
-//! acquired_guard.await;
+//! acquired_guard.await?;
 //! // Released
 //! ```
 //!

--- a/src/meta/plugins/semaphore/src/meta_event_subscriber/subscriber.rs
+++ b/src/meta/plugins/semaphore/src/meta_event_subscriber/subscriber.rs
@@ -145,6 +145,14 @@ impl MetaEventSubscriber {
 
                 _ = timeout_fu.fuse() => {
                     warn!("{}: process_meta_event_loop timeout waiting for an event", self.watcher_name);
+
+                    let conn_error = ConnectionClosed::new_str("timeout").context(&self.watcher_name);
+                    self.processor
+                        .tx_to_acquirer
+                        .send(Err(conn_error))
+                        .await
+                        .ok();
+
                     return Err(ProcessorError::ConnectionClosed(
                         ConnectionClosed::new_str("timeout").context(&self.watcher_name)
                     ));
@@ -190,6 +198,14 @@ impl MetaEventSubscriber {
 
             let Some(watch_response) = watch_response else {
                 warn!("watch-stream closed: {}", self.watcher_name);
+
+                let conn_error =
+                    ConnectionClosed::new_str("watch-stream closed").context(&self.watcher_name);
+                self.processor
+                    .tx_to_acquirer
+                    .send(Err(conn_error))
+                    .await
+                    .ok();
 
                 return Err(ProcessorError::ConnectionClosed(
                     ConnectionClosed::new_str("watch-stream closed").context(&self.watcher_name),

--- a/src/meta/plugins/semaphore/tests/it/grpc_semaphore.rs
+++ b/src/meta/plugins/semaphore/tests/it/grpc_semaphore.rs
@@ -133,7 +133,11 @@ async fn test_semaphore_guard_future() -> anyhow::Result<()> {
         .await?;
 
     let res = timeout(Duration::from_millis(100), c.as_mut()).await;
-    assert!(res.is_ok(), "acquired guard become ready");
+    assert!(
+        matches!(res, Ok(Ok(()))),
+        "acquired guard become ready: {:?}",
+        res
+    );
 
     Ok(())
 }
@@ -258,8 +262,9 @@ async fn test_permit_removal_notification() -> anyhow::Result<()> {
     // Now the permit should be notified of removal
     let notification_result = timeout(Duration::from_secs(5), permit_future.as_mut()).await;
     assert!(
-        notification_result.is_ok(),
-        "Permit should be notified of removal"
+        matches!(notification_result, Ok(Ok(()))),
+        "Permit should be notified of removal: {:?}",
+        notification_result
     );
 
     Ok(())
@@ -440,6 +445,52 @@ async fn test_watch_stream_resilience() -> anyhow::Result<()> {
 
     // Test continues to work even with some connection variability
     // (In a real scenario, this would test reconnection after temporary failures)
+
+    Ok(())
+}
+
+/// The permit future should report an error when the watch stream is closed.
+#[test(harness = meta_service_test_harness::<DatabendRuntime, _, _>)]
+#[fastrace::trace]
+async fn test_acquired_permit_connection_closed_error() -> anyhow::Result<()> {
+    let mut tcs = start_metasrv_cluster::<DatabendRuntime>(&[0]).await?;
+
+    let mut tc = tcs.remove(0);
+
+    let address = tc.config.grpc.api_address().unwrap();
+
+    let cli = make_grpc_client::<DatabendRuntime>(vec![address])?;
+    let client = || cli.clone();
+    let secs = |n| Duration::from_secs(n);
+
+    let permit =
+        Semaphore::new_acquired(client(), "permit_connection_closed", 1, "permit", secs(10))
+            .await?;
+
+    let (tx, rx) = oneshot::channel();
+    DatabendRuntime::spawn(
+        async move {
+            let res = tokio::time::timeout(secs(5), permit).await;
+            tx.send(res).ok();
+        },
+        None,
+    );
+
+    tokio::time::sleep(secs(1)).await;
+
+    let mut srv = tc.grpc_srv.take().unwrap();
+    srv.do_stop(None).await;
+
+    let res = rx.await?;
+    let err = res
+        .expect("permit future should finish after watch stream is closed")
+        .expect_err("permit future should report connection closed");
+    assert!(
+        err.to_string()
+            .contains("distributed-Semaphore connection closed"),
+        "unexpected permit error: {}",
+        err
+    );
 
     Ok(())
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: semaphore: distinguish semaphore permit loss
Permit previously resolved to () both when its entry was removed and
when the watch path failed. That made callers treat connection loss as a
valid permit removal signal.

Return `Result<(), ConnectionClosed>` from Permit, forward terminal
watcher errors to the acquirer, and cover both removal and watch-closed
outcomes in integration tests.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19817)
<!-- Reviewable:end -->
