### PR TITLE
fix(storage): clean vacuum2 orphan files

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -22,17 +22,22 @@ use chrono::DateTime;
 use chrono::Utc;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::ListIndexesByIdReq;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::io::SegmentsIO;
+use databend_common_storages_fuse::io::SnapshotsIO;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheManager;
 use databend_storages_common_io::Files;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::Location;
+use databend_storages_common_table_meta::meta::SegmentInfo;
+use databend_storages_common_table_meta::meta::Versioned;
 use log::info;
+use log::warn;
 
 /// GC root context derived from the owner table before ref-aware cleanup starts.
 ///
@@ -43,6 +48,7 @@ struct GcRootSnapshotCtx {
     gc_root_timestamp: DateTime<Utc>,
     gc_root_meta_ts: DateTime<Utc>,
     protected_segments: HashSet<Location>,
+    protected_table_statistics: HashSet<String>,
     snapshots_to_gc: Vec<String>,
 }
 
@@ -68,6 +74,7 @@ pub async fn do_vacuum2(
         gc_root_timestamp,
         gc_root_meta_ts,
         protected_segments,
+        protected_table_statistics,
         snapshots_to_gc,
     }) = vacuum_base_snapshot_phase(fuse_table, &ctx, respect_flash_back).await?
     else {
@@ -183,19 +190,19 @@ pub async fn do_vacuum2(
         ))
         .await?;
     let inverted_indexes = &table_info.meta.indexes;
-    let mut indexes_to_gc = Vec::with_capacity(
-        blocks_to_gc.len() * (table_agg_index_ids.len() + inverted_indexes.len() + 1),
+    let mut indexes_to_gc = HashSet::with_capacity(
+        blocks_to_gc.len() * (table_agg_index_ids.len() + inverted_indexes.len() + 3),
     );
     for loc in &blocks_to_gc {
         for index_id in &table_agg_index_ids {
-            indexes_to_gc.push(
+            indexes_to_gc.insert(
                 TableMetaLocationGenerator::gen_agg_index_location_from_block_location(
                     loc, *index_id,
                 ),
             );
         }
         for idx in inverted_indexes.values() {
-            indexes_to_gc.push(
+            indexes_to_gc.insert(
                 TableMetaLocationGenerator::gen_inverted_index_location_from_block_location(
                     loc,
                     idx.name.as_str(),
@@ -204,8 +211,17 @@ pub async fn do_vacuum2(
             );
         }
         indexes_to_gc
-            .push(TableMetaLocationGenerator::gen_bloom_index_location_from_block_location(loc));
+            .insert(TableMetaLocationGenerator::gen_bloom_index_location_from_block_location(loc));
     }
+
+    collect_block_meta_index_locations(
+        &segments_io,
+        &segments_to_gc,
+        &blocks_to_gc,
+        &mut indexes_to_gc,
+    )
+    .await?;
+    let indexes_to_gc = indexes_to_gc.into_iter().collect::<Vec<_>>();
 
     ctx.set_status_info(&format!(
         "Collected indexes_to_gc for table {}, elapsed: {:?}, indexes_to_gc: {:?}",
@@ -215,6 +231,9 @@ pub async fn do_vacuum2(
     ));
 
     let start = std::time::Instant::now();
+    let table_statistics_to_gc =
+        collect_table_statistics_to_gc(fuse_table, &snapshots_to_gc, &protected_table_statistics)
+            .await?;
     let subject_files_to_gc: Vec<_> = segments_to_gc
         .into_iter()
         .chain(blocks_to_gc.into_iter())
@@ -227,6 +246,14 @@ pub async fn do_vacuum2(
     // subject_files should be removed before snapshots, because gc of subject_files depend on gc root
     op.remove_file_in_batch(&indexes_to_gc).await?;
     op.remove_file_in_batch(&subject_files_to_gc).await?;
+    if let Some(snapshot_statistics_cache) =
+        CacheManager::instance().get_table_snapshot_statistics_cache()
+    {
+        for path in table_statistics_to_gc.iter() {
+            snapshot_statistics_cache.evict(path);
+        }
+    }
+    op.remove_file_in_batch(&table_statistics_to_gc).await?;
 
     // Evict snapshot caches from the local node.
     //
@@ -255,6 +282,7 @@ pub async fn do_vacuum2(
 
     let files_to_gc: Vec<_> = subject_files_to_gc
         .into_iter()
+        .chain(table_statistics_to_gc.into_iter())
         .chain(snapshots_to_gc.into_iter())
         .chain(indexes_to_gc.into_iter())
         .collect();
@@ -290,22 +318,113 @@ async fn vacuum_base_snapshot_phase(
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
-    let _ = fuse_table
-        .process_tags_for_purge(
-            &catalog,
-            &selection.gc_root_path,
-            &mut selection.snapshots_to_gc,
-            &mut protected_segments,
-            false,
-        )
-        .await?;
+    let mut protected_table_statistics = selection
+        .gc_root
+        .table_statistics_location()
+        .into_iter()
+        .collect::<HashSet<_>>();
+    protected_table_statistics.extend(
+        fuse_table
+            .process_tags_for_purge(
+                &catalog,
+                &selection.gc_root_path,
+                &mut selection.snapshots_to_gc,
+                &mut protected_segments,
+                false,
+            )
+            .await?,
+    );
 
     Ok(Some(GcRootSnapshotCtx {
         gc_root_timestamp: selection.gc_root.timestamp.unwrap(),
         gc_root_meta_ts: selection.gc_root_meta_ts,
         protected_segments,
+        protected_table_statistics,
         snapshots_to_gc: selection.snapshots_to_gc,
     }))
+}
+
+#[async_backtrace::framed]
+async fn collect_block_meta_index_locations(
+    segments_io: &SegmentsIO,
+    segments_to_gc: &[String],
+    blocks_to_gc: &[String],
+    indexes_to_gc: &mut HashSet<String>,
+) -> Result<()> {
+    if segments_to_gc.is_empty() || blocks_to_gc.is_empty() {
+        return Ok(());
+    }
+
+    let blocks_to_gc = blocks_to_gc.iter().cloned().collect::<HashSet<_>>();
+    let segment_locations = segments_to_gc
+        .iter()
+        .map(|loc| (loc.clone(), segment_version_from_location(loc)))
+        .collect::<Vec<_>>();
+    let segments = segments_io
+        .read_segments::<Arc<CompactSegmentInfo>>(&segment_locations, false)
+        .await?;
+
+    for (idx, segment) in segments.into_iter().enumerate() {
+        let segment = match segment {
+            Ok(segment) => segment,
+            Err(e) if e.code() == ErrorCode::STORAGE_NOT_FOUND => {
+                warn!(
+                    "concurrent gc: segment of location {} already collected while collecting vacuum2 index locations",
+                    segment_locations[idx].0
+                );
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+
+        for block_meta in segment.block_metas()? {
+            if !blocks_to_gc.contains(&block_meta.location.0) {
+                continue;
+            }
+
+            if let Some(bloom_loc) = &block_meta.bloom_filter_index_location {
+                indexes_to_gc.insert(bloom_loc.0.clone());
+            }
+            if let Some(vector_loc) = &block_meta.vector_index_location {
+                indexes_to_gc.insert(vector_loc.0.clone());
+            }
+            if let Some(spatial_loc) = &block_meta.spatial_index_location {
+                indexes_to_gc.insert(spatial_loc.0.clone());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[async_backtrace::framed]
+async fn collect_table_statistics_to_gc(
+    fuse_table: &FuseTable,
+    snapshots_to_gc: &[String],
+    protected_table_statistics: &HashSet<String>,
+) -> Result<Vec<String>> {
+    let mut table_statistics_to_gc = HashSet::new();
+    for snapshot_loc in snapshots_to_gc {
+        if let Some(snapshot) =
+            SnapshotsIO::read_snapshot_for_vacuum(fuse_table.get_operator(), snapshot_loc).await?
+        {
+            if let Some(stats_loc) = snapshot.table_statistics_location()
+                && !protected_table_statistics.contains(&stats_loc)
+            {
+                table_statistics_to_gc.insert(stats_loc);
+            }
+        }
+    }
+
+    Ok(table_statistics_to_gc.into_iter().collect())
+}
+
+fn segment_version_from_location(location: &str) -> u64 {
+    location
+        .rsplit_once("_v")
+        .and_then(|(_, suffix)| suffix.split('.').next())
+        .and_then(|version| version.parse().ok())
+        .unwrap_or(SegmentInfo::VERSION)
 }
 
 fn slice_summary<T: std::fmt::Debug>(s: &[T]) -> String {

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::OsStr;
 use std::path::Path;
+use std::path::PathBuf;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -20,6 +22,43 @@ use databend_enterprise_query::test_kits::context::EESetup;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContextTableAccess;
 use databend_query::test_kits::TestFixture;
+
+async fn table_storage_path(
+    ctx: &QueryContext,
+    storage_root: &str,
+    db_name: &str,
+    tbl_name: &str,
+) -> Result<PathBuf> {
+    let tenant = ctx.get_tenant();
+    let table = ctx
+        .get_default_catalog()?
+        .get_table(&tenant, db_name, tbl_name)
+        .await?;
+
+    let db = ctx
+        .get_default_catalog()?
+        .get_database(&tenant, db_name)
+        .await?;
+
+    Ok(Path::new(storage_root)
+        .join(db.get_db_info().database_id.db_id.to_string())
+        .join(table.get_id().to_string()))
+}
+
+fn count_files_under_component(path: &Path, component: &str) -> usize {
+    let component = OsStr::new(component);
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .filter(|entry| {
+            entry
+                .path()
+                .components()
+                .any(|path_component| path_component.as_os_str() == component)
+        })
+        .count()
+}
 
 // TODO investigate this
 // NOTE: SHOULD specify flavor = "multi_thread", otherwise query execution might be hanged
@@ -72,20 +111,7 @@ async fn test_vacuum2_all() -> anyhow::Result<()> {
         db_name: &str,
         tbl_name: &str,
     ) -> Result<()> {
-        let tenant = ctx.get_tenant();
-        let table = ctx
-            .get_default_catalog()?
-            .get_table(&tenant, db_name, tbl_name)
-            .await?;
-
-        let db = ctx
-            .get_default_catalog()?
-            .get_database(&tenant, db_name)
-            .await?;
-
-        let path = Path::new(storage_root)
-            .join(db.get_db_info().database_id.db_id.to_string())
-            .join(table.get_id().to_string());
+        let path = table_storage_path(ctx, storage_root, db_name, tbl_name).await?;
 
         let walker = walkdir::WalkDir::new(path).into_iter();
 
@@ -113,6 +139,107 @@ async fn test_vacuum2_all() -> anyhow::Result<()> {
 
     check_files_left(&ctx, storage_root, "db1", "t1").await?;
     check_files_left(&ctx, storage_root, "default", "t1").await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_removes_vector_and_spatial_indexes() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    let session = fixture.default_session();
+    session.get_settings().set_data_retention_time_in_days(0)?;
+    let ctx = fixture.new_query_ctx().await?;
+
+    fixture
+        .execute_command(
+            "create table default.vacuum2_index_cleanup(
+                id int,
+                embedding vector(4),
+                geom geometry,
+                vector index v_idx(embedding) distance = 'cosine',
+                spatial index s_idx(geom)
+            )",
+        )
+        .await?;
+    fixture
+        .execute_command(
+            "insert into default.vacuum2_index_cleanup values
+            (1, [0.1, 0.2, 0.3, 0.4], to_geometry('POINT(1 1)'))",
+        )
+        .await?;
+    fixture
+        .execute_command(
+            "insert into default.vacuum2_index_cleanup values
+            (2, [0.2, 0.3, 0.4, 0.5], to_geometry('POINT(2 2)'))",
+        )
+        .await?;
+    fixture
+        .execute_command("optimize table default.vacuum2_index_cleanup compact")
+        .await?;
+
+    let path = table_storage_path(
+        &ctx,
+        fixture.storage_root(),
+        "default",
+        "vacuum2_index_cleanup",
+    )
+    .await?;
+    let vector_indexes_before = count_files_under_component(&path, "_i_v");
+    let spatial_indexes_before = count_files_under_component(&path, "_i_s");
+    assert!(vector_indexes_before > 1);
+    assert!(spatial_indexes_before > 1);
+
+    fixture
+        .execute_command("call system$fuse_vacuum2('default', 'vacuum2_index_cleanup')")
+        .await?;
+
+    assert_eq!(count_files_under_component(&path, "_i_v"), 1);
+    assert_eq!(count_files_under_component(&path, "_i_s"), 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_removes_snapshot_statistics() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    let session = fixture.default_session();
+    session.get_settings().set_data_retention_time_in_days(0)?;
+    let ctx = fixture.new_query_ctx().await?;
+
+    fixture
+        .execute_command("set enable_table_snapshot_stats = 1")
+        .await?;
+    fixture
+        .execute_command("create table default.vacuum2_snapshot_stats(a int)")
+        .await?;
+    fixture
+        .execute_command("insert into default.vacuum2_snapshot_stats values (1), (2)")
+        .await?;
+    fixture
+        .execute_command("analyze table default.vacuum2_snapshot_stats")
+        .await?;
+    fixture
+        .execute_command("insert into default.vacuum2_snapshot_stats values (3)")
+        .await?;
+    fixture
+        .execute_command("analyze table default.vacuum2_snapshot_stats")
+        .await?;
+
+    let path = table_storage_path(
+        &ctx,
+        fixture.storage_root(),
+        "default",
+        "vacuum2_snapshot_stats",
+    )
+    .await?;
+    let stats_before = count_files_under_component(&path, "_ts");
+    assert!(stats_before > 1);
+
+    fixture
+        .execute_command("call system$fuse_vacuum2('default', 'vacuum2_snapshot_stats')")
+        .await?;
+
+    assert_eq!(count_files_under_component(&path, "_ts"), 1);
 
     Ok(())
 }

--- a/src/query/service/src/table_functions/fuse_vacuum2/fuse_vacuum2_table.rs
+++ b/src/query/service/src/table_functions/fuse_vacuum2/fuse_vacuum2_table.rs
@@ -142,7 +142,7 @@ impl SimpleTableFunc for FuseVacuum2Table {
             }
             _ => {
                 return Err(ErrorCode::NumberArgumentsNotMatch(
-                    "Expected 0 or 2 arguments".to_string(),
+                    "Expected 0, 2 or 3 arguments".to_string(),
                 ));
             }
         };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Clean up orphaned snapshot statistics in vacuum2 while preserving GC-root and tag-protected statistics.
- Collect actual bloom/vector/spatial index locations from GC segment block metadata so vacuum2 removes index files that cannot be derived from block paths alone.
- Fix the fuse_vacuum2 argument count error text to include the 3-argument form.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Ran:

- `cargo test -p databend-enterprise-query --test it vacuum2 -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19820)
<!-- Reviewable:end -->
