### PR TITLE
fix(query): Fix window aggregate function result materialization

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_array_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_array_agg.rs
@@ -69,7 +69,7 @@ use super::assert_unary_arguments;
 use super::batch_merge1;
 use super::batch_serialize1;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ArrayAggStateAny<T>
 where T: ValueType
 {
@@ -170,7 +170,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ArrayAggStateSimple<T>
 where T: SimpleType
 {
@@ -288,7 +288,7 @@ where T: SimpleType
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ArrayAggStateZST<const IS_NULL: bool> {
     validity: MutableBitmap,
 }
@@ -387,7 +387,7 @@ impl<const IS_NULL: bool> StateSerde for ArrayAggStateZST<IS_NULL> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ArrayAggStateBinary<T>
 where T: ArgType
 {
@@ -565,7 +565,7 @@ struct AggregateArrayAggFunction<T, State> {
 impl<T, State> AggregateFunction for AggregateArrayAggFunction<T, State>
 where
     T: AccessType,
-    State: ScalarStateFunc<T>,
+    State: Clone + ScalarStateFunc<T>,
 {
     fn name(&self) -> &str {
         "AggregateArrayAggFunction"
@@ -686,11 +686,16 @@ where
     fn merge_result(
         &self,
         place: AggrState,
-        _read_only: bool,
+        read_only: bool,
         builder: &mut ColumnBuilder,
     ) -> Result<()> {
         let state = place.get::<State>();
-        state.merge_result(builder)
+        if read_only {
+            let mut state = state.clone();
+            state.merge_result(builder)
+        } else {
+            state.merge_result(builder)
+        }
     }
 
     fn need_manual_drop_state(&self) -> bool {
@@ -712,7 +717,7 @@ impl<T, State> fmt::Display for AggregateArrayAggFunction<T, State> {
 impl<T, State> AggregateArrayAggFunction<T, State>
 where
     T: ValueType,
-    State: ScalarStateFunc<T>,
+    State: Clone + ScalarStateFunc<T>,
 {
     fn create(display_name: &str, return_type: DataType) -> Result<Arc<dyn AggregateFunction>> {
         let func = AggregateArrayAggFunction::<T, State> {

--- a/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_json_array_agg.rs
@@ -55,7 +55,7 @@ use super::assert_params;
 use super::assert_unary_arguments;
 use super::batch_merge1;
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct JsonArrayAggState<T>
 where
     T: ValueType,
@@ -184,7 +184,7 @@ struct AggregateJsonArrayAggFunction<T> {
 impl<T> AggregateFunction for AggregateJsonArrayAggFunction<T>
 where
     T: ValueType,
-    T::Scalar: borsh::BorshSerialize + borsh::BorshDeserialize,
+    T::Scalar: borsh::BorshSerialize + borsh::BorshDeserialize + Clone,
 {
     fn name(&self) -> &str {
         "AggregateJsonArrayAggFunction"
@@ -307,11 +307,16 @@ where
     fn merge_result(
         &self,
         place: AggrState,
-        _read_only: bool,
+        read_only: bool,
         builder: &mut ColumnBuilder,
     ) -> Result<()> {
         let state = place.get::<JsonArrayAggState<T>>();
-        state.merge_result(builder)
+        if read_only {
+            let mut state = state.clone();
+            state.merge_result(builder)
+        } else {
+            state.merge_result(builder)
+        }
     }
 
     fn need_manual_drop_state(&self) -> bool {

--- a/src/query/functions/src/aggregates/aggregate_json_object_agg.rs
+++ b/src/query/functions/src/aggregates/aggregate_json_object_agg.rs
@@ -54,7 +54,7 @@ use super::borsh_partial_deserialize;
 use crate::aggregates::AggregateFunctionFeatures;
 
 pub(super) trait BinaryScalarStateFunc<V: ValueType>:
-    BorshSerialize + BorshDeserialize + Send + 'static
+    Clone + BorshSerialize + BorshDeserialize + Send + 'static
 {
     fn new() -> Self;
     fn add(&mut self, other: Option<(&str, V::ScalarRef<'_>)>) -> Result<()>;
@@ -68,7 +68,7 @@ pub(super) trait BinaryScalarStateFunc<V: ValueType>:
     fn merge_result(&mut self, builder: &mut ColumnBuilder) -> Result<()>;
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct JsonObjectAggState<V>
 where
     V: ValueType,
@@ -347,11 +347,16 @@ where
     fn merge_result(
         &self,
         place: AggrState,
-        _read_only: bool,
+        read_only: bool,
         builder: &mut ColumnBuilder,
     ) -> Result<()> {
         let state = place.get::<State>();
-        state.merge_result(builder)
+        if read_only {
+            let mut state = state.clone();
+            state.merge_result(builder)
+        } else {
+            state.merge_result(builder)
+        }
     }
 
     fn need_manual_drop_state(&self) -> bool {

--- a/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
+++ b/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
@@ -174,10 +174,16 @@ impl AggregateFunction for MarkovTarin {
     fn merge_result(
         &self,
         place: AggrState,
-        _read_only: bool,
+        read_only: bool,
         builder: &mut ColumnBuilder,
     ) -> Result<()> {
-        let model = place.get::<MarkovModel>();
+        let mut model;
+        let model = if read_only {
+            model = place.get::<MarkovModel>().clone();
+            &mut model
+        } else {
+            place.get::<MarkovModel>()
+        };
         model.finalize(&self.params);
 
         let ColumnBuilder::Array(box array_builder) = builder else {
@@ -303,7 +309,7 @@ impl Histogram {
     }
 }
 
-#[derive(Default, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Default, BorshSerialize, BorshDeserialize)]
 struct MarkovModel {
     table: BTreeMap<NGramHash, Histogram>,
 }

--- a/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
+++ b/src/query/functions/src/aggregates/aggregate_markov_tarin.rs
@@ -177,15 +177,29 @@ impl AggregateFunction for MarkovTarin {
         read_only: bool,
         builder: &mut ColumnBuilder,
     ) -> Result<()> {
-        let mut model;
-        let model = if read_only {
-            model = place.get::<MarkovModel>().clone();
-            &mut model
+        if read_only {
+            let mut model = place.get::<MarkovModel>().clone();
+            model.finalize(&self.params);
+            self.append_model_result(&model, builder)
         } else {
-            place.get::<MarkovModel>()
-        };
-        model.finalize(&self.params);
+            let model = place.get::<MarkovModel>();
+            model.finalize(&self.params);
+            self.append_model_result(model, builder)
+        }
+    }
 
+    fn need_manual_drop_state(&self) -> bool {
+        true
+    }
+
+    unsafe fn drop_state(&self, place: AggrState) {
+        let state = place.get::<MarkovModel>();
+        unsafe { std::ptr::drop_in_place(state) };
+    }
+}
+
+impl MarkovTarin {
+    fn append_model_result(&self, model: &MarkovModel, builder: &mut ColumnBuilder) -> Result<()> {
         let ColumnBuilder::Array(box array_builder) = builder else {
             unreachable!()
         };
@@ -212,15 +226,6 @@ impl AggregateFunction for MarkovTarin {
         }
         array_builder.commit_row();
         Ok(())
-    }
-
-    fn need_manual_drop_state(&self) -> bool {
-        true
-    }
-
-    unsafe fn drop_state(&self, place: AggrState) {
-        let state = place.get::<MarkovModel>();
-        unsafe { std::ptr::drop_in_place(state) };
     }
 }
 

--- a/src/query/functions/src/aggregates/aggregate_range_bound.rs
+++ b/src/query/functions/src/aggregates/aggregate_range_bound.rs
@@ -170,13 +170,12 @@ where
     ) -> Result<()> {
         let step = self.total_rows as f64 / range_bound_data.partitions as f64;
 
-        let values = std::mem::take(&mut self.values);
         let mut data = Vec::with_capacity(self.total_samples);
         let mut weights = Vec::with_capacity(self.total_samples);
-        for (num, values) in values.into_iter() {
-            let weight = num as f64 / values.len() as f64;
-            values.into_iter().for_each(|v| {
-                data.push(v);
+        for (num, values) in self.values.iter() {
+            let weight = *num as f64 / values.len() as f64;
+            values.iter().for_each(|v| {
+                data.push(v.clone());
                 weights.push(weight);
             });
         }

--- a/tests/sqllogictests/suites/query/window_function/window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/window_basic.test
@@ -60,6 +60,41 @@ SELECT sum(salary) OVER (PARTITION BY depname ORDER BY salary) ss FROM empsalary
 9600
 14600
 
+query T
+SELECT array_agg(v) OVER (PARTITION BY k) FROM (SELECT 1 AS k, ['a'] AS v UNION ALL SELECT 1, ['b'] UNION ALL SELECT 1, ['c'])
+----
+[["a"],["b"],["c"]]
+[["a"],["b"],["c"]]
+[["a"],["b"],["c"]]
+
+query T rowsort
+SELECT json_array_agg(v) OVER (PARTITION BY k) FROM (SELECT 1 AS k, 'a' AS v UNION ALL SELECT 1, 'b' UNION ALL SELECT 1, 'c')
+----
+["a","b","c"]
+["a","b","c"]
+["a","b","c"]
+
+query T
+SELECT json_object_agg(v, n) OVER (PARTITION BY k) FROM (SELECT 1 AS k, 'a' AS v, 10 AS n UNION ALL SELECT 1, 'b', 20 UNION ALL SELECT 1, 'c', 30)
+----
+{"a":10,"b":20,"c":30}
+{"a":10,"b":20,"c":30}
+{"a":10,"b":20,"c":30}
+
+query T
+SELECT range_bound(3)(v) OVER (PARTITION BY k) FROM (SELECT 1 AS k, 10 AS v UNION ALL SELECT 1, 20 UNION ALL SELECT 1, 30)
+----
+[10,20]
+[10,20]
+[10,20]
+
+query T
+SELECT m FROM (SELECT markov_train(1, 0, 0, 1, 0)(v) OVER (PARTITION BY k) AS m FROM (SELECT 1 AS k, 'ab' AS v UNION ALL SELECT 1, 'ac' UNION ALL SELECT 1, 'ad'));
+----
+[(0,6,4,{97:4,98:2,99:2,100:2})]
+[(0,6,4,{97:4,98:2,99:2,100:2})]
+[(0,6,4,{97:4,98:2,99:2,100:2})]
+
 # row_number
 query I
 SELECT row_number() OVER (PARTITION BY depname ORDER BY salary) rn FROM empsalary ORDER BY depname, rn


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix window aggregate result materialization for aggregate functions whose `merge_result(read_only = true)` path mutated aggregate state.

- Make `array_agg`, `json_array_agg` and `json_object_agg` preserve its state when used as a window aggregate.
- Make `range_bound` build results without consuming sampled state.
- Make `markov_train` clone the model before finalize when window execution reads the result in read-only mode.

fixes: #19822

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19823)
<!-- Reviewable:end -->
