### PR TITLE
fix: meta: bump databend-meta patch tag to v260428.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,8 +5361,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5372,13 +5372,13 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260428.1.0",
- "databend-meta-kvapi 260428.1.0",
+ "databend-meta-client 260428.3.0",
+ "databend-meta-kvapi 260428.3.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260428.1.0",
+ "databend-meta-runtime-api 260428.3.0",
  "databend-meta-sled-store",
- "databend-meta-types 260428.1.0",
- "databend-meta-version 260428.1.0",
+ "databend-meta-types 260428.3.0",
+ "databend-meta-version 260428.3.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -5439,8 +5439,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5542,8 +5542,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5552,10 +5552,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260428.1.0",
- "databend-meta-kvapi-test-suite 260428.1.0",
- "databend-meta-runtime-api 260428.1.0",
- "databend-meta-version 260428.1.0",
+ "databend-meta-kvapi 260428.3.0",
+ "databend-meta-kvapi-test-suite 260428.3.0",
+ "databend-meta-runtime-api 260428.3.0",
+ "databend-meta-version 260428.3.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5576,8 +5576,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5621,8 +5621,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5652,12 +5652,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260428.1.0",
+ "databend-meta-kvapi 260428.3.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -5708,8 +5708,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5731,18 +5731,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260428.1.0",
- "databend-meta-runtime-api 260428.1.0",
+ "databend-meta-kvapi 260428.3.0",
+ "databend-meta-runtime-api 260428.3.0",
  "databend-meta-sled-store",
- "databend-meta-types 260428.1.0",
+ "databend-meta-types 260428.3.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -5800,8 +5800,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -5813,12 +5813,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260428.1.0",
+ "databend-meta-types 260428.3.0",
  "fastrace",
  "log",
  "serde",
@@ -5831,14 +5831,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260428.1.0",
- "databend-meta-types 260428.1.0",
+ "databend-meta-runtime-api 260428.3.0",
+ "databend-meta-types 260428.3.0",
  "fastrace",
  "log",
  "tempfile",
@@ -5876,8 +5876,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5919,8 +5919,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260428.1.0"
-source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.1.0#b3cbfd505c0f536c60d3c8bfc9b45201258d09b4"
+version = "260428.3.0"
+source = "git+https://github.com/databendlabs/databend-meta?tag=v260428.3.0#1c53212131d7ff7a8d0c9e137f1582c3b6f41c38"
 dependencies = [
  "semver",
 ]
@@ -14092,9 +14092,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "raft-log"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c273df82ff5ef584c3b38ca603942b5c2b0b786f7bad70881c6d85b485f5778b"
+checksum = "9b13c64d8e24f1791caae6ec10f1f3e90299ad0e0af7d006fda7db4382178d2e"
 dependencies = [
  "byteorder",
  "codeq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,8 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260428.1.0"
-databend-meta-test-harness = "260428.1.0"
+databend-meta = "260428.3.0"
+databend-meta-test-harness = "260428.3.0"
 
 # External meta client
 databend-meta-client = "260205.8.0"
@@ -620,9 +620,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260428.1.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta", tag = "v260428.3.0" }
 databend-meta-client = { git = "https://github.com/databendlabs/databend-meta", tag = "v260205.8.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260428.1.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta", tag = "v260428.3.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc812ad7010" }

--- a/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
+++ b/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
@@ -100,8 +100,7 @@ ChunkId(00_000_000_000_000_000_000)
   R-00014: [000_001_203, 000_001_249) Size(46): Commit(T1-N1.5)
   R-00015: [000_001_249, 000_001_517) Size(268): Append(log_id: T1-N1.6, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/db/port >= seq(0)] then:[Put(Put key=app/db/port)] else:[Get(Get key=app/db/port)]})
   R-00016: [000_001_517, 000_001_563) Size(46): Commit(T1-N1.6)
-  R-00017: [000_001_563, 000_001_850) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})
-  R-00018: [000_001_850, 000_001_896) Size(46): Commit(T1-N1.7)"""
+  R-00017: [000_001_563, 000_001_850) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})"""
 
     expected2 = """RaftLog:
 ChunkId(00_000_000_000_000_000_000)
@@ -122,8 +121,7 @@ ChunkId(00_000_000_000_000_000_000)
   R-00014: [000_001_203, 000_001_249) Size(46): Commit(T1-N1.5)
   R-00015: [000_001_249, 000_001_517) Size(268): Append(log_id: T1-N1.6, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/db/port >= seq(0)] then:[Put(Put key=app/db/port)] else:[Get(Get key=app/db/port)]})
   R-00016: [000_001_517, 000_001_563) Size(46): Commit(T1-N1.6)
-  R-00017: [000_001_563, 000_001_850) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})
-  R-00018: [000_001_850, 000_001_896) Size(46): Commit(T1-N1.7)"""
+  R-00017: [000_001_563, 000_001_850) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})"""
 
     expected3 = """RaftLog:
 ChunkId(00_000_000_000_000_000_000)
@@ -143,8 +141,7 @@ ChunkId(00_000_000_000_000_000_000)
   R-00013: [000_001_157, 000_001_203) Size(46): Commit(T1-N1.5)
   R-00014: [000_001_203, 000_001_471) Size(268): Append(log_id: T1-N1.6, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/db/port >= seq(0)] then:[Put(Put key=app/db/port)] else:[Get(Get key=app/db/port)]})
   R-00015: [000_001_471, 000_001_517) Size(46): Commit(T1-N1.6)
-  R-00016: [000_001_517, 000_001_804) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})
-  R-00017: [000_001_804, 000_001_850) Size(46): Commit(T1-N1.7)"""
+  R-00016: [000_001_517, 000_001_804) Size(287): Append(log_id: T1-N1.7, payload: normal:time: <TIME> cmd: txn:TxnRequest{if:[app/config/timeout >= seq(0)] then:[Put(Put key=app/config/timeout)] else:[Get(Get key=app/config/timeout)]})"""
 
     assert_match_any(result, [expected, expected2, expected3])
 

--- a/tests/metactl/subcommands/cmd_export_from_raft_dir.py
+++ b/tests/metactl/subcommands/cmd_export_from_raft_dir.py
@@ -50,7 +50,7 @@ def test_export_from_raft_dir():
     want = """["header",{"DataHeader":{"key":"header","value":{"version":"V004"}}}]
 ["raft_log",{"NodeId":1}]
 ["raft_log",{"Vote":{"leader_id":{"term":1,"node_id":1},"committed":true}}]
-["raft_log",{"Committed":{"leader_id":{"term":1,"node_id":1},"index":7}}]
+["raft_log",{"Committed":{"leader_id":{"term":1,"node_id":1},"index":6}}]
 ["raft_log",{"Purged":null}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":0,"node_id":1},"index":0},"payload":{"Membership":{"configs":[[1]],"nodes":{"1":{}}}}}}]
 ["raft_log",{"LogEntry":{"log_id":{"leader_id":{"term":1,"node_id":1},"index":1},"payload":"Blank"}}]


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: meta: bump databend-meta patch tag to v260428.3.0
# Summary

Pulls in databend-meta v260428.3.0, which carries the
AppendEntries-delay regression fix for mixed-version clusters running
raft-log 0.3.0+.

# Details

Between v260428.1.0 and v260428.3.0 the relevant changes are:

- v260428.2.0 drops an unconditional `log.flush(None)` from
  `save_committed`, which on raft-log 0.3.0's worker-thread model was
  enqueueing a fsync per commit advance and surfaced as a follower-side
  slow-IO spike (+89%) and throughput drop (-31.2%) in a mixed-version
  2-node bench against a v1.2.819 leader.
- v260428.3.0 bumps raft-log to 0.4.0 (whose `flush(sync, callback)`
  now makes the no-fsync path explicit at the API level) and drops the
  no-sync `flush(false, None)` from `save_committed` entirely. The
  Commit record sits in `pending_data` and is flushed by the next
  `append`'s batch, since openraft's contract for `save_committed`
  classifies persistence as best-effort.

The mixed-version repro confirms the regression is gone: throughput
-1.8% and follower slow-IO at the theoretical floor (71 events) under
the same workload that originally produced -31.2%.

No databend-side code changes; this is purely a tag bump in
`workspace.dependencies` and `[patch.crates-io]` for `databend-meta`
and `databend-meta-test-harness`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19825)
<!-- Reviewable:end -->
