### PR TITLE
fix(query): split inflight query status count

### DIFF
--- a/src/query/service/src/servers/admin/v1/instance_status.rs
+++ b/src/query/service/src/servers/admin/v1/instance_status.rs
@@ -25,7 +25,9 @@ use crate::sessions::SessionManager;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct InstanceStatus {
-    // the active sessions count with running queries
+    // running queries plus HTTP queries waiting for result fetching
+    pub inflight_queries_count: u64,
+    // the number of running queries
     pub running_queries_count: u64,
     // the length of query queue
     pub queuing_queries_count: u64,
@@ -67,7 +69,8 @@ pub async fn instance_status_handler() -> poem::Result<impl IntoResponse> {
     };
 
     let status = InstanceStatus {
-        running_queries_count: status.running_queries_count.max(http_query_count),
+        running_queries_count: status.running_queries_count,
+        inflight_queries_count: status.running_queries_count.max(http_query_count),
         active_sessions_count: status.active_sessions_count,
         queuing_queries_count: queue_manager.length() as u64,
         last_query_started_at: status.last_query_started_at.map(unix_timestamp_secs),

--- a/src/query/service/tests/it/servers/admin/v1/status.rs
+++ b/src/query/service/tests/it/servers/admin/v1/status.rs
@@ -76,11 +76,12 @@ async fn test_status() -> anyhow::Result<()> {
     let status = get_status(&ep).await;
     assert_eq!(
         (
+            status.inflight_queries_count,
             status.running_queries_count,
             status.last_query_started_at.is_some(),
             status.last_query_finished_at.is_some(),
         ),
-        (0, false, false),
+        (0, 0, false, false),
         "before running"
     );
 
@@ -97,11 +98,12 @@ async fn test_status() -> anyhow::Result<()> {
         let status = get_status(&ep).await;
         assert_eq!(
             (
+                status.inflight_queries_count,
                 status.running_queries_count,
                 status.last_query_started_at.is_some(),
                 status.last_query_finished_at.is_some(),
             ),
-            (1, true, false),
+            (1, 1, true, false),
             "running"
         );
 
@@ -113,11 +115,12 @@ async fn test_status() -> anyhow::Result<()> {
     let status = get_status(&ep).await;
     assert_eq!(
         (
+            status.inflight_queries_count,
             status.running_queries_count,
             status.last_query_started_at.is_some(),
             status.last_query_finished_at.is_some(),
         ),
-        (0, true, true),
+        (0, 0, true, true),
         "finished"
     );
 

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -312,6 +312,23 @@ impl TestHttpQueryRequest {
     }
 }
 
+async fn wait_query_counts(req: &mut TestHttpQueryRequest, expected: (u64, u64)) {
+    let mut last = None;
+
+    for _ in 0..100 {
+        let status = req.status().await;
+        let counts = (status.running_queries_count, status.inflight_queries_count);
+        if counts == expected {
+            return;
+        }
+
+        last = Some(counts);
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    assert_eq!(last.unwrap(), expected);
+}
+
 fn decode_arrow_query_response(body: &[u8]) -> anyhow::Result<TestArrowQueryResponse> {
     let mut reader = StreamReader::try_new(Cursor::new(body), None)?;
     let schema = reader.schema();
@@ -769,15 +786,57 @@ async fn test_result_timeout() -> anyhow::Result<()> {
         "session": { "settings": {"http_handler_result_timeout_secs": "1"}}}
     );
     let mut req = TestHttpQueryRequest::new(json);
-    assert_eq!(req.status().await.running_queries_count, 0);
+    let status = req.status().await;
+    assert_eq!(
+        (status.running_queries_count, status.inflight_queries_count),
+        (0, 0)
+    );
     let (status, result, _) = req.fetch_begin().await?;
-    assert_eq!(req.status().await.running_queries_count, 1);
+    let query_status = req.status().await;
+    assert_eq!(query_status.inflight_queries_count, 1);
     assert_eq!(status, StatusCode::OK, "{:?}", result);
     assert_eq!(result.data.len(), 1);
 
     sleep(std::time::Duration::from_secs(6)).await;
     let status = req.status().await;
-    assert_eq!(status.running_queries_count, 0);
+    assert_eq!(
+        (status.running_queries_count, status.inflight_queries_count),
+        (0, 0)
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn test_final_releases_inflight_query() -> anyhow::Result<()> {
+    let config = ConfigBuilder::create()
+        .http_handler_result_timeout(60u64)
+        .build();
+    let _fixture = TestFixture::setup_with_config(&config).await?;
+
+    let json = serde_json::json!({
+        "sql": "SELECT * from numbers(5)",
+        "pagination": {"wait_time_secs": 5, "max_rows_per_page": 1},
+        "session": { "settings": {"http_handler_result_timeout_secs": "60"}}}
+    );
+    let mut req = TestHttpQueryRequest::new(json);
+    let (status, result, _) = req.fetch_begin().await?;
+    assert_eq!(status, StatusCode::OK, "{:?}", result);
+    assert_eq!(result.data.len(), 1);
+    let final_uri = result.final_uri.clone().unwrap();
+
+    wait_query_counts(&mut req, (0, 1)).await;
+
+    let (status, result, _) = req.do_request(Method::GET, &final_uri).await?;
+    let result = result.unwrap();
+    assert_eq!(status, StatusCode::OK, "{:?}", result);
+    assert!(result.next_uri.is_none(), "{:?}", result);
+    assert_eq!(result.state, ExecuteStateKind::Succeeded, "{:?}", result);
+
+    let status = req.status().await;
+    assert_eq!(
+        (status.running_queries_count, status.inflight_queries_count),
+        (0, 0)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- split admin instance status query counters so `running_queries_count` only reports running queries
- add `inflight_queries_count` for running queries plus HTTP queries waiting for result fetching
- cover both result timeout cleanup and explicit final cleanup for inflight HTTP queries

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Ran targeted integration tests:

- `cargo fmt --check`
- `cargo test -p databend-query --test it test_result_timeout`
- `cargo test -p databend-query --test it test_final_releases_inflight_query`
- `cargo test -p databend-query --test it test_status`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19826)
<!-- Reviewable:end -->
