### PR TITLE
ci(build-tool): add cargo-valgrind to build tools

### DIFF
--- a/scripts/setup/dev_setup.sh
+++ b/scripts/setup/dev_setup.sh
@@ -659,6 +659,17 @@ function install_typos_cli {
 	"${typos_bin}/typos" --version
 }
 
+function install_cargo_valgrind {
+	echo "==> installing cargo-valgrind..."
+	if cargo valgrind --version &>/dev/null; then
+		echo "cargo-valgrind is already installed"
+		return
+	fi
+
+	cargo install cargo-valgrind
+	cargo valgrind --version
+}
+
 function usage {
 	cat <<EOF
     usage: $0 [options]
@@ -694,6 +705,7 @@ Build tools (since -b or no option was provided):
   * protobuf-compiler
   * openjdk
   * python3-dev
+  * cargo-valgrind
 EOF
 	fi
 
@@ -881,6 +893,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 
 	install_sccache "v0.12.0"
 	install_cargo_nextest
+	install_cargo_valgrind
 fi
 
 if [[ "$INSTALL_CHECK_TOOLS" == "true" ]]; then


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `cargo-valgrind` to the build-tool image so it's available for memory leak detection in unit tests.

- refs: #5039
- related: #19800

## Tests

- [x] No Test - CI build-tool image change only

## Type of change

- [x] Other (please describe): Build tooling update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19831)
<!-- Reviewable:end -->
