### PR TITLE
fix(ci): drop duplicate --quote-style in tpch/tpcds prepare scripts

### DIFF
--- a/tests/sqllogictests/scripts/prepare_tpcds_data.sh
+++ b/tests/sqllogictests/scripts/prepare_tpcds_data.sh
@@ -38,10 +38,10 @@ tables=(
 
 force=${2:-"1"}
 if [ "$force" == "0" ]; then
-    table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'call_center'" | $BENDSQL_CLIENT_CONNECT --output tsv --quote-style never)
+    table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'call_center'" | $BENDSQL_CLIENT_CONNECT --output tsv)
     table_exists=$(echo "$table_exists" | tr -d '\r\n[:space:]')
     if [ -n "$table_exists" ] && [ "$table_exists" -gt 0 ]; then
-        res=$(echo "SELECT COUNT() from ${db}.call_center" | $BENDSQL_CLIENT_CONNECT --output tsv --quote-style never)
+        res=$(echo "SELECT COUNT() from ${db}.call_center" | $BENDSQL_CLIENT_CONNECT --output tsv)
         res=$(echo "$res" | tr -d '\r\n[:space:]')
         if [ -n "$res" ] && [ "$res" -gt 0 ]; then
             echo "Table $db.call_center already exists and is not empty, size: ${res}. Use force=1 to override it."

--- a/tests/sqllogictests/scripts/prepare_tpch_data.sh
+++ b/tests/sqllogictests/scripts/prepare_tpch_data.sh
@@ -9,10 +9,10 @@ db=${1:-"tpch_test"}
 force=${2:-"1"}
 
 if [ "$force" == "0" ]; then
-    table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'nation'" | $BENDSQL_CLIENT_CONNECT --output tsv --quote-style never)
+    table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'nation'" | $BENDSQL_CLIENT_CONNECT --output tsv)
     table_exists=$(echo "$table_exists" | tr -d '\r\n[:space:]')
     if [ -n "$table_exists" ] && [ "$table_exists" -gt 0 ]; then
-        res=$(echo "SELECT COUNT() from ${db}.nation" | $BENDSQL_CLIENT_CONNECT --output tsv --quote-style never)
+        res=$(echo "SELECT COUNT() from ${db}.nation" | $BENDSQL_CLIENT_CONNECT --output tsv)
         res=$(echo "$res" | tr -d '\r\n[:space:]')
         if [ -n "$res" ] && [ "$res" -gt 0 ]; then
             echo "Table $db.nation already exists and is not empty, size: ${res}. Use force=1 to override it."


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`bendsql_client_connect` in `tests/shell_env.sh` already passes `--quote-style=never`. The TPC-H / TPC-DS prepare scripts also appended `--quote-style never` when reusing `$BENDSQL_CLIENT_CONNECT`, which made newer bendsql fail with:

```
error: the argument '--quote-style <QUOTE_STYLE>' cannot be used multiple times
```

Removed the redundant flag from `prepare_tpch_data.sh` and `prepare_tpcds_data.sh`.

## Tests

- [x] No Test - shell script fix for existing CI scripts

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19832)
<!-- Reviewable:end -->
