### PR TITLE
fix(ast): unreserve PROPERTIES keyword to allow it as identifier

### DIFF
--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1974,7 +1974,6 @@ impl TokenKind {
             | TokenKind::ORDER
             | TokenKind::OVER
             | TokenKind::PARTITION
-            | TokenKind::PROPERTIES
             | TokenKind::QUALIFY
             | TokenKind::ROWS
             // | TokenKind::OVERLAPS

--- a/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0000_ddl_create_tables.test
@@ -13,6 +13,9 @@ DROP TABLE IF EXISTS t4
 statement ok
 DROP TABLE IF EXISTS issue_11031
 
+statement ok
+DROP TABLE IF EXISTS test_properties_as_ident
+
 statement error 1302
 CREATE TABLE IF NOT EXISTS t(c1 int) ENGINE = iceberg
 
@@ -82,6 +85,21 @@ SELECT radio, range, samples FROM issue_11031
 ----
 lte 10 1
 
+# PROPERTIES should be usable as an identifier (column name, table name)
+statement ok
+CREATE TABLE test_properties_as_ident (
+    properties STRING,
+    value INT32
+)
+
+statement ok
+INSERT INTO test_properties_as_ident (properties, value) VALUES ('key1', 100)
+
+query TI
+SELECT properties, value FROM test_properties_as_ident
+----
+key1 100
+
 statement ok
 DROP TABLE IF EXISTS t
 
@@ -96,6 +114,9 @@ DROP TABLE IF EXISTS t4
 
 statement ok
 DROP TABLE IF EXISTS issue_11031
+
+statement ok
+DROP TABLE IF EXISTS test_properties_as_ident
 
 statement ok
 DROP DATABASE IF EXISTS db1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Remove `PROPERTIES` from the reserved keywords list so it can be used as an identifier (column name, table name, alias, etc.).

Since **v1.2.730-nightly** (PR #17812, 2025-04-23), `PROPERTIES` was added as a reserved keyword to support `CREATE TABLE ... PROPERTIES(...)` syntax for iceberg tables. This broke backward compatibility for SQL that uses `properties` as an identifier.

**Example of the incompatibility:**

```sql
-- This worked before v1.2.730-nightly but fails after:
CREATE TABLE t (properties STRING, value INT);
-- Error: expected column definition, got keyword PROPERTIES

SELECT properties FROM t;
-- Error: unexpected token PROPERTIES
```

After this fix, `PROPERTIES` remains a valid token and continues to work in `CREATE TABLE ... PROPERTIES(...)` syntax for iceberg tables — it is simply no longer reserved, so the parser also accepts it as an identifier.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19834)
<!-- Reviewable:end -->
