### PR TITLE
feat(query): add decimal sum widening setting

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1255,6 +1255,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_decimal_sum_widening", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Automatically widen SUM arguments from Decimal(19..38, scale) to Decimal(76, scale).",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("statement_queued_timeout_in_seconds", DefaultSettingValue {
                     value: UserSettingValue::UInt64(0),
                     desc: "The maximum waiting seconds in the queue. The default value is 0(no limit).",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -907,6 +907,10 @@ impl Settings {
         Ok(self.try_get_u64("use_legacy_query_executor")? == 1)
     }
 
+    pub fn get_enable_decimal_sum_widening(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_decimal_sum_widening")? != 0)
+    }
+
     pub fn get_statement_queued_timeout(&self) -> Result<u64> {
         self.try_get_u64("statement_queued_timeout_in_seconds")
     }

--- a/src/query/sql/src/planner/semantic/type_check/aggregate.rs
+++ b/src/query/sql/src/planner/semantic/type_check/aggregate.rs
@@ -21,7 +21,10 @@ use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
 use databend_common_expression::type_check::check_number;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::Decimal;
 use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::decimal::DecimalSize;
+use databend_common_expression::types::i256;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::aggregates::AggregateFunctionFactory;
 
@@ -30,7 +33,9 @@ use crate::binder::ExprContext;
 use crate::planner::metadata::optimize_remove_count_args;
 use crate::plans::AggregateFunction;
 use crate::plans::AggregateFunctionScalarSortDesc;
+use crate::plans::CastExpr;
 use crate::plans::ConstantExpr;
+use crate::plans::ScalarExpr;
 
 impl<'a> TypeChecker<'a> {
     /// Resolve aggregation function call.
@@ -97,6 +102,8 @@ impl<'a> TypeChecker<'a> {
         }
         self.in_aggregate_function = false;
         let (mut arguments, mut arg_types) = arguments_result?;
+
+        self.try_widen_sum_decimal_argument(func_name, &mut arguments, &mut arg_types)?;
 
         let sort_descs = order_by
             .iter()
@@ -201,5 +208,46 @@ impl<'a> TypeChecker<'a> {
         let data_type = agg_func.return_type()?;
 
         Ok((new_agg_func, data_type))
+    }
+
+    fn try_widen_sum_decimal_argument(
+        &self,
+        func_name: &str,
+        arguments: &mut [ScalarExpr],
+        arg_types: &mut [DataType],
+    ) -> Result<()> {
+        if !func_name.eq_ignore_ascii_case("sum")
+            || arguments.len() != 1
+            || !self.ctx.get_settings().get_enable_decimal_sum_widening()?
+        {
+            return Ok(());
+        }
+
+        let input_is_nullable = arg_types[0].is_nullable();
+        let DataType::Decimal(size) = arg_types[0].remove_nullable() else {
+            return Ok(());
+        };
+
+        if !size.can_carried_by_128() || size.precision() <= i64::MAX_PRECISION {
+            return Ok(());
+        }
+
+        let mut target_type = DataType::Decimal(DecimalSize::new_unchecked(
+            i256::MAX_PRECISION,
+            size.scale(),
+        ));
+        if input_is_nullable {
+            target_type = target_type.wrap_nullable();
+        }
+
+        arguments[0] = ScalarExpr::CastExpr(CastExpr {
+            span: arguments[0].span(),
+            is_try: false,
+            argument: Box::new(arguments[0].clone()),
+            target_type: Box::new(target_type.clone()),
+        });
+        arg_types[0] = target_type;
+
+        Ok(())
     }
 }

--- a/tests/sqllogictests/suites/query/aggregate.test
+++ b/tests/sqllogictests/suites/query/aggregate.test
@@ -69,6 +69,24 @@ SELECT SUM(agg0) FROM (
 ----
 4.0
 
+query TT
+select typeof(sum(number::Decimal(18, 1))), typeof(sum(number::Decimal(19, 1))) from numbers(1000);
+----
+DECIMAL(18, 1) NULL DECIMAL(38, 1) NULL
+
+query TT
+settings(enable_decimal_sum_widening=1) select typeof(sum(number::Decimal(18, 1))), typeof(sum(number::Decimal(19, 1))) from numbers(1000);
+----
+DECIMAL(18, 1) NULL DECIMAL(76, 1) NULL
+
+statement error Decimal overflow
+select sum(a) from (select '99999999999999999999999999999999999999'::Decimal(38, 0) as a union all select 1::Decimal(38, 0) as a)
+
+query RT
+settings(enable_decimal_sum_widening=1) select sum(a), typeof(sum(a)) from (select '99999999999999999999999999999999999999'::Decimal(38, 0) as a union all select 1::Decimal(38, 0) as a);
+----
+100000000000000000000000000000000000000 DECIMAL(76, 0) NULL
+
 query RRT
 select avg(number * number),  avg( (number * number)::Decimal(39, 7) ), typeof(avg( (number * number)::Decimal(39, 7) )) from numbers(100);
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add a new session setting `enable_decimal_sum_widening` that automatically widens SUM arguments from `Decimal(19..38, scale)` to `Decimal(76, scale)` to prevent overflow errors when aggregating large decimal values.

When enabled, the planner inserts a CAST to `Decimal(76, scale)` before SUM for inputs with precision between 19 and 38, allowing accumulation without overflow.

**Default value: `0` (disabled).** Existing behavior is unchanged unless the user explicitly sets `enable_decimal_sum_widening=1`.

### Problem

When summing a `Decimal(p, s)` column with `p` in 19..=38, Databend today keeps the accumulator at `Decimal(38, s)`. Once the running sum exceeds `10^38 - 1`, the query fails with a `Decimal overflow` error — even though the true result is representable in a wider decimal type.

Example (reproduced in the added sqllogictest):

```sql
-- Default behavior: overflows at the 38-digit boundary
SELECT SUM(a) FROM (
    SELECT '99999999999999999999999999999999999999'::Decimal(38, 0) AS a
    UNION ALL
    SELECT 1::Decimal(38, 0) AS a
);
-- Error: Decimal overflow

-- With the new setting, SUM widens to Decimal(76, 0) and succeeds
SET enable_decimal_sum_widening = 1;
SELECT SUM(a) FROM (
    SELECT '99999999999999999999999999999999999999'::Decimal(38, 0) AS a
    UNION ALL
    SELECT 1::Decimal(38, 0) AS a
);
-- 100000000000000000000000000000000000000

-- Result type is widened only when input precision is in 19..=38
SELECT typeof(SUM(number::Decimal(18, 1))),
       typeof(SUM(number::Decimal(19, 1)))
FROM numbers(1000);
-- Default:      DECIMAL(38, 1) NULL | DECIMAL(38, 1) NULL
-- With setting: DECIMAL(38, 1) NULL | DECIMAL(76, 1) NULL
```

This gives users an opt-in way to aggregate large decimals without rewriting queries to pre-cast every SUM argument.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19836)
<!-- Reviewable:end -->
