### PR TITLE
fix(query): publish http stream errors before abort

### DIFF
--- a/src/query/service/src/servers/http/v1/query/execute_state.rs
+++ b/src/query/service/src/servers/http/v1/query/execute_state.rs
@@ -552,8 +552,10 @@ impl ExecuteState {
                                 .with_context(make_error)?;
                         }
                         Err(err) => {
+                            let err = err.with_context(make_error());
+                            Executor::stop(&executor, Err(err.clone()));
                             sender.abort();
-                            return Err(err.with_context(make_error()));
+                            return Err(err);
                         }
                     };
                 }

--- a/src/query/service/tests/it/servers/http/http_query_handlers.rs
+++ b/src/query/service/tests/it/servers/http/http_query_handlers.rs
@@ -1591,6 +1591,40 @@ async fn test_func_object_keys() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stream_error_returns_json_error() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let sqls = vec![
+        "create or replace table t02(id int, c1 varchar)",
+        "create or replace table t01(id int, c1 int)",
+        "insert into t01 values(1,1),(2,2)",
+        "insert into t02 values(1,1),(2,2)",
+        "insert into t02 values(3,'a')",
+    ];
+
+    for sql in sqls {
+        let json = serde_json::json!({"sql": sql, "pagination": {"wait_time_secs": 3}});
+        let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+        assert!(
+            reply.error().is_none(),
+            "setup SQL '{sql}' failed: {:?}",
+            reply.error()
+        );
+    }
+
+    let json = serde_json::json!({
+        "sql": "select a.id from t01 a join t02 b on a.c1=b.c1",
+        "pagination": {"wait_time_secs": 3, "max_rows_per_page": 1}
+    });
+    let reply = TestHttpQueryRequest::new(json).fetch_total().await?;
+    assert_eq!(reply.state(), ExecuteStateKind::Failed);
+    let error = reply.error().expect("query should return a JSON error");
+    assert_eq!(error.code, 1006);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_multi_partition() -> anyhow::Result<()> {
     let _fixture = TestFixture::setup().await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Publish HTTP query failed state before aborting the result channel when a data stream returns an error after producing blocks.
- Add a regression test for HTTP JSON error propagation when join execution fails mid-stream with code 1006.

## Motivation

The HTTP handler can receive `Err` from `Stream<Item = Result<DataBlock>>` after some result blocks have already been produced. In that path, the result channel was aborted before the executor failed state was published. A waiting HTTP page request could observe the closed result channel before seeing the failed executor state, which made clients sometimes receive an incomplete/non-JSON body instead of the expected JSON error response.

This fixes the race by publishing `Executor::Stopped(Err(...))` before waking/closing the result receiver.


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19839)
<!-- Reviewable:end -->
