### PR TITLE
fix(query): drop window aggregate state before reset

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/window/window_function.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/window/window_function.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::Cell;
 use std::sync::Arc;
 
 use databend_common_base::runtime::drop_guard;
@@ -55,6 +56,7 @@ pub struct WindowFuncAggImpl {
     addr: StateAddr,
     loc: Box<[AggrStateLoc]>,
     args: Vec<usize>,
+    initialized: Cell<bool>,
 }
 
 unsafe impl Send for WindowFuncAggImpl {}
@@ -62,7 +64,13 @@ unsafe impl Send for WindowFuncAggImpl {}
 impl WindowFuncAggImpl {
     #[inline]
     pub fn reset(&self) {
+        if self.initialized.replace(false) && self.agg.need_manual_drop_state() {
+            unsafe {
+                self.agg.drop_state(AggrState::new(self.addr, &self.loc));
+            }
+        }
         self.agg.init_state(AggrState::new(self.addr, &self.loc));
+        self.initialized.set(true);
     }
 
     #[inline]
@@ -86,7 +94,7 @@ impl WindowFuncAggImpl {
 impl Drop for WindowFuncAggImpl {
     fn drop(&mut self) {
         drop_guard(move || {
-            if self.agg.need_manual_drop_state() {
+            if self.initialized.get() && self.agg.need_manual_drop_state() {
                 unsafe {
                     self.agg.drop_state(AggrState::new(self.addr, &self.loc));
                 }
@@ -271,6 +279,7 @@ impl WindowFunctionImpl {
                     loc,
                     args,
                     _arena: arena,
+                    initialized: Cell::new(false),
                 };
                 agg.reset();
                 Self::Aggregate(agg)
@@ -304,5 +313,159 @@ impl WindowFunctionImpl {
         if let Self::Aggregate(agg) = self {
             agg.reset();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::alloc::Layout;
+    use std::fmt;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use databend_common_exception::Result;
+    use databend_common_expression::AggrStateRegistry;
+    use databend_common_expression::AggrStateType;
+    use databend_common_expression::BlockEntry;
+    use databend_common_expression::StateSerdeItem;
+    use databend_common_expression::types::Bitmap;
+    use databend_common_functions::aggregates::AggregateFunctionRef;
+
+    use super::*;
+
+    struct DropCountingState {
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Drop for DropCountingState {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct DropCountingAggregate {
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl fmt::Display for DropCountingAggregate {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "drop_counting_aggregate")
+        }
+    }
+
+    impl AggregateFunction for DropCountingAggregate {
+        fn name(&self) -> &str {
+            "DropCountingAggregate"
+        }
+
+        fn return_type(&self) -> Result<DataType> {
+            Ok(DataType::Null)
+        }
+
+        fn init_state(&self, place: AggrState) {
+            let drops = self.drops.clone();
+            place.write(|| DropCountingState { drops });
+        }
+
+        fn register_state(&self, registry: &mut AggrStateRegistry) {
+            registry.register(AggrStateType::Custom(Layout::new::<DropCountingState>()));
+        }
+
+        fn accumulate(
+            &self,
+            _place: AggrState,
+            _columns: ProjectedBlock,
+            _validity: Option<&Bitmap>,
+            _input_rows: usize,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn accumulate_row(
+            &self,
+            _place: AggrState,
+            _columns: ProjectedBlock,
+            _row: usize,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn serialize_type(&self) -> Vec<StateSerdeItem> {
+            vec![]
+        }
+
+        fn batch_serialize(
+            &self,
+            _places: &[StateAddr],
+            _loc: &[AggrStateLoc],
+            _builders: &mut [ColumnBuilder],
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn batch_merge(
+            &self,
+            _places: &[StateAddr],
+            _loc: &[AggrStateLoc],
+            _state: &BlockEntry,
+            _filter: Option<&Bitmap>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn merge_states(&self, _place: AggrState, _rhs: AggrState) -> Result<()> {
+            Ok(())
+        }
+
+        fn merge_result(
+            &self,
+            _place: AggrState,
+            _read_only: bool,
+            _builder: &mut ColumnBuilder,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn need_manual_drop_state(&self) -> bool {
+            true
+        }
+
+        unsafe fn drop_state(&self, place: AggrState) {
+            let state = place.get::<DropCountingState>();
+            unsafe { std::ptr::drop_in_place(state) };
+        }
+    }
+
+    #[test]
+    fn reset_drops_existing_manual_state_before_reinitializing() -> Result<()> {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let agg: AggregateFunctionRef = Arc::new(DropCountingAggregate {
+            drops: drops.clone(),
+        });
+        let arena = Arena::new();
+        let mut states_layout = get_states_layout(std::slice::from_ref(&agg))?;
+        let addr = arena.alloc_layout(states_layout.layout).into();
+        let loc = states_layout.states_loc.pop().unwrap();
+
+        let window_agg = WindowFuncAggImpl {
+            _arena: arena,
+            agg,
+            addr,
+            loc,
+            args: vec![],
+            initialized: Cell::new(false),
+        };
+
+        window_agg.reset();
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+        window_agg.reset();
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        drop(window_agg);
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Drop the existing manual aggregate state before `WindowFuncAggImpl::reset` reinitializes it.
- Track whether the window aggregate state has been initialized so first reset and drop paths do not touch uninitialized memory.
- Add a unit test with a drop-counting aggregate state to cover reset-time cleanup.

Window aggregate reset reused the same aggregate state slot by calling `init_state`, which writes into the slot. For manual-drop aggregate states, overwriting without first calling `drop_state` can leak the previous state. This became visible for read-only window aggregate result materialization, where the aggregate state is preserved after `merge_result`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Lightweight local checks only because local disk space is constrained:

- `rustfmt src/query/pipeline/transforms/src/processors/transforms/window/window_function.rs`
- `git diff --check HEAD~1 HEAD`

Not run locally: `cargo test`, `cargo build`.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19841)
<!-- Reviewable:end -->
