### PR TITLE
chore(storage): Support table-level auto compaction threshold after write

### DIFF
--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -26,6 +26,7 @@ use databend_common_io::constants::DEFAULT_BLOCK_ROW_COUNT;
 use databend_common_settings::Settings;
 use databend_common_sql::ApproxDistinctColumns;
 use databend_common_sql::BloomIndexColumns;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use databend_common_storages_fuse::FUSE_OPT_KEY_DATA_PAGE_BYTES;
@@ -77,6 +78,7 @@ pub static CREATE_FUSE_OPTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP);
     r.insert(FUSE_OPT_KEY_ENABLE_AUTO_VACUUM);
     r.insert(FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE);
+    r.insert(FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD);
 
     r.insert(OPT_KEY_BLOOM_INDEX_COLUMNS);
     r.insert(OPT_KEY_BLOOM_INDEX_TYPE);
@@ -141,6 +143,7 @@ pub static UNSET_TABLE_OPTIONS_WHITE_LIST: LazyLock<HashSet<&'static str>> = Laz
     r.insert(FUSE_OPT_KEY_FILE_SIZE);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP);
+    r.insert(FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD);
     r.insert(OPT_KEY_ENABLE_COPY_DEDUP_FULL_PATH);
     r.insert(FUSE_OPT_KEY_DATA_PAGE_ROWS);
     r.insert(FUSE_OPT_KEY_DATA_PAGE_BYTES);

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -43,6 +43,7 @@ use databend_common_pipeline::core::ExecutionInfo;
 use databend_common_pipeline::core::always_callback;
 use databend_common_sql::DefaultExprBinder;
 use databend_common_sql::plans::CreateTablePlan;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_VACUUM;
 use databend_common_storages_fuse::FuseSegmentFormat;
@@ -481,6 +482,10 @@ impl CreateTableInterpreter {
         is_valid_option_of_type::<u32>(&table_meta.options, FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)?;
         // check enable auto analyze.
         is_valid_option_of_type::<u32>(&table_meta.options, FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE)?;
+        is_valid_option_of_type::<u64>(
+            &table_meta.options,
+            FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD,
+        )?;
 
         for table_option in table_meta.options.iter() {
             let key = table_option.0.to_lowercase();

--- a/src/query/service/src/interpreters/interpreter_table_set_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_set_options.rs
@@ -26,6 +26,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_sql::plans::SetOptionsPlan;
 use databend_common_storages_factory::Table;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_VACUUM;
 use databend_common_storages_fuse::FuseSegmentFormat;
@@ -140,6 +141,10 @@ impl Interpreter for SetOptionsInterpreter {
 
         // Same as settings of FUSE_OPT_KEY_ENABLE_AUTO_VACUUM, expect value type is unsigned integer
         is_valid_option_of_type::<u32>(&self.plan.set_options, FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)?;
+        is_valid_option_of_type::<u64>(
+            &self.plan.set_options,
+            FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD,
+        )?;
 
         let catalog = self.ctx.get_catalog(self.plan.catalog.as_str()).await?;
         let database = self.plan.database.as_str();

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -937,7 +937,7 @@ impl DefaultSettings {
                 }),
                 ("auto_compaction_imperfect_blocks_threshold", DefaultSettingValue {
                     value: UserSettingValue::UInt64(25),
-                    desc: "Threshold for triggering auto compaction. This occurs when the number of imperfect blocks in a snapshot exceeds this value after write operations.",
+                    desc: "Threshold for triggering auto compaction after write. This occurs when the number of imperfect blocks in a snapshot exceeds this value after write operations. Set to 0 to disable auto compaction.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -23,6 +23,8 @@ pub const FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP: &str =
     "data_retention_num_snapshots_to_keep";
 pub const FUSE_OPT_KEY_ENABLE_AUTO_VACUUM: &str = "enable_auto_vacuum";
 pub const FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE: &str = "enable_auto_analyze";
+pub const FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD: &str =
+    "auto_compaction_imperfect_blocks_threshold";
 pub const FUSE_OPT_KEY_ATTACH_COLUMN_IDS: &str = "attach_column_ids";
 pub const FUSE_OPT_KEY_ENABLE_PARQUET_DICTIONARY: &str = "enable_parquet_dictionary";
 pub const FUSE_OPT_KEY_DATA_PAGE_ROWS: &str = "data_page_rows";

--- a/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
@@ -21,12 +21,12 @@ use databend_common_expression::TableSchema;
 use databend_common_meta_app::schema::TableInfo;
 use databend_storages_common_session::TxnManagerRef;
 use databend_storages_common_table_meta::meta::ClusterKey;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::table::ClusterType;
 use log::info;
 
+use crate::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use crate::operations::common::ConflictResolveContext;
 use crate::statistics::TableStatsGenerator;
 
@@ -103,26 +103,38 @@ pub fn decorate_snapshot(
 
 pub(crate) fn set_compaction_num_block_hint(
     ctx: &dyn TableContext,
-    table_name: &str,
-    summary: &Statistics,
+    table_info: &TableInfo,
+    imperfect_count: u64,
 ) {
-    if let Err(e) = try_set_compaction_num_block_hint(ctx, table_name, summary) {
+    if let Err(e) = try_set_compaction_num_block_hint(ctx, table_info, imperfect_count) {
         log::warn!("set_compaction_num_block_hint failed: {}", e);
     }
 }
 
 pub(crate) fn try_set_compaction_num_block_hint(
     ctx: &dyn TableContext,
-    table_name: &str,
-    summary: &Statistics,
+    table_info: &TableInfo,
+    imperfect_count: u64,
 ) -> Result<()> {
     // check if need to auto compact
     // the algorithm is: if the number of imperfect blocks is greater than the threshold, then auto compact.
-    // the threshold is set by the setting `auto_compaction_imperfect_blocks_threshold`, default is 25.
-    let imperfect_count = summary.block_count - summary.perfect_block_count;
-    let auto_compaction_imperfect_blocks_threshold = ctx
-        .get_settings()
-        .get_auto_compaction_imperfect_blocks_threshold()?;
+    // the threshold is set by the table option `auto_compaction_imperfect_blocks_threshold`.
+    // If the table option is not set, fall back to the setting.
+    let auto_compaction_imperfect_blocks_threshold = match table_info
+        .options()
+        .get(FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD)
+    {
+        Some(value) => value.parse::<u64>()?,
+        None => ctx
+            .get_settings()
+            .get_auto_compaction_imperfect_blocks_threshold()?,
+    };
+
+    // 0 means auto compaction after write is disabled.
+    if auto_compaction_imperfect_blocks_threshold == 0 {
+        return Ok(());
+    }
+
     if imperfect_count >= auto_compaction_imperfect_blocks_threshold {
         // If imperfect_count is larger, SLIGHTLY increase the number of blocks
         // eligible for auto-compaction, this adjustment is intended to help reduce
@@ -132,7 +144,7 @@ pub(crate) fn try_set_compaction_num_block_hint(
             (auto_compaction_imperfect_blocks_threshold as f64 * 1.5).ceil() as u64,
         );
         info!("set compact_num_block_hint to {compact_num_block_hint }");
-        ctx.set_compaction_num_block_hint(table_name, compact_num_block_hint);
+        ctx.set_compaction_num_block_hint(table_info.name.as_str(), compact_num_block_hint);
     }
     Ok(())
 }

--- a/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
@@ -97,6 +97,7 @@ impl AsyncSink for CommitMultiTableInsert {
         let mut update_temp_tables = Vec::with_capacity(self.commit_metas.len());
         let mut snapshot_generators = HashMap::with_capacity(self.commit_metas.len());
         let mut hlls = HashMap::with_capacity(self.commit_metas.len());
+        let mut imperfect_counts = HashMap::with_capacity(self.commit_metas.len());
         let insert_rows = {
             let stats = self.ctx.mutation_state().multi_table_insert_status();
             let status = stats.lock().unwrap();
@@ -108,30 +109,29 @@ impl AsyncSink for CommitMultiTableInsert {
             snapshot_generator.set_conflict_resolve_context(commit_meta.conflict_resolve_context);
             let table = self.tables.get(&table_id).unwrap();
             if table.is_temp() {
-                update_temp_tables.push(
-                    build_update_temp_table_req(
-                        table.as_ref(),
-                        &snapshot_generator,
-                        self.ctx.txn_mgr(),
-                        *self.table_meta_timestampss.get(&table_id).unwrap(),
-                        &commit_meta.hll,
-                        insert_rows.get(&table_id).cloned().unwrap_or_default(),
-                    )
-                    .await?,
-                );
+                let (req, imperfect_count) = build_update_temp_table_req(
+                    table.as_ref(),
+                    &snapshot_generator,
+                    self.ctx.txn_mgr(),
+                    *self.table_meta_timestampss.get(&table_id).unwrap(),
+                    &commit_meta.hll,
+                    insert_rows.get(&table_id).cloned().unwrap_or_default(),
+                )
+                .await?;
+                update_temp_tables.push(req);
+                imperfect_counts.insert(table_id, imperfect_count);
             } else {
-                update_table_metas.push((
-                    build_update_table_meta_req(
-                        table.as_ref(),
-                        &snapshot_generator,
-                        self.ctx.txn_mgr(),
-                        *self.table_meta_timestampss.get(&table.get_id()).unwrap(),
-                        &commit_meta.hll,
-                        insert_rows.get(&table_id).cloned().unwrap_or_default(),
-                    )
-                    .await?,
-                    table.get_table_info().clone(),
-                ));
+                let (req, imperfect_count) = build_update_table_meta_req(
+                    table.as_ref(),
+                    &snapshot_generator,
+                    self.ctx.txn_mgr(),
+                    *self.table_meta_timestampss.get(&table.get_id()).unwrap(),
+                    &commit_meta.hll,
+                    insert_rows.get(&table_id).cloned().unwrap_or_default(),
+                )
+                .await?;
+                update_table_metas.push((req, table.get_table_info().clone()));
+                imperfect_counts.insert(table_id, imperfect_count);
             }
             snapshot_generators.insert(table_id, snapshot_generator);
             hlls.insert(table_id, commit_meta.hll);
@@ -194,6 +194,15 @@ impl AsyncSink for CommitMultiTableInsert {
                     "update tables success (auto commit), tables updated {:?}, streams updated {:?}",
                     table_descriptions, stream_descriptions
                 );
+                for (table_id, imperfect_count) in imperfect_counts.iter() {
+                    if let Some(table) = self.tables.get(table_id) {
+                        set_compaction_num_block_hint(
+                            self.ctx.as_ref(),
+                            table.get_table_info(),
+                            *imperfect_count,
+                        );
+                    }
+                }
 
                 return Ok(());
             };
@@ -222,7 +231,7 @@ impl AsyncSink for CommitMultiTableInsert {
                             .await?;
                         for (req, _) in update_table_metas.iter_mut() {
                             if req.table_id == tid {
-                                *req = build_update_table_meta_req(
+                                let (new_req, imperfect_count) = build_update_table_meta_req(
                                     table.as_ref(),
                                     snapshot_generators.get(&tid).unwrap(),
                                     self.ctx.txn_mgr(),
@@ -231,6 +240,8 @@ impl AsyncSink for CommitMultiTableInsert {
                                     insert_rows.get(&tid).cloned().unwrap_or_default(),
                                 )
                                 .await?;
+                                *req = new_req;
+                                imperfect_counts.insert(tid, imperfect_count);
                                 break;
                             }
                         }
@@ -309,9 +320,9 @@ async fn build_update_temp_table_req(
     table_meta_timestamps: TableMetaTimestamps,
     insert_hll: &BlockHLL,
     insert_rows: u64,
-) -> Result<UpdateTempTableReq> {
+) -> Result<(UpdateTempTableReq, u64)> {
     let table_info = table.get_table_info();
-    let new_table_meta = write_new_snapshot_and_build_table_meta(
+    let (new_table_meta, imperfect_count) = write_new_snapshot_and_build_table_meta(
         table,
         snapshot_generator,
         txn_mgr,
@@ -321,12 +332,15 @@ async fn build_update_temp_table_req(
     )
     .await?;
 
-    Ok(UpdateTempTableReq {
-        table_id: table_info.ident.table_id,
-        new_table_meta,
-        copied_files: Default::default(),
-        desc: table_info.desc.clone(),
-    })
+    Ok((
+        UpdateTempTableReq {
+            table_id: table_info.ident.table_id,
+            new_table_meta,
+            copied_files: Default::default(),
+            desc: table_info.desc.clone(),
+        },
+        imperfect_count,
+    ))
 }
 
 async fn build_update_table_meta_req(
@@ -336,9 +350,9 @@ async fn build_update_table_meta_req(
     table_meta_timestamps: TableMetaTimestamps,
     insert_hll: &BlockHLL,
     insert_rows: u64,
-) -> Result<UpdateTableMetaReq> {
+) -> Result<(UpdateTableMetaReq, u64)> {
     let fuse_table = FuseTable::try_from_table(table)?;
-    let new_table_meta = write_new_snapshot_and_build_table_meta(
+    let (new_table_meta, imperfect_count) = write_new_snapshot_and_build_table_meta(
         table,
         snapshot_generator,
         txn_mgr,
@@ -357,7 +371,7 @@ async fn build_update_table_meta_req(
         base_snapshot_location: fuse_table.snapshot_loc(),
         lvt_check: None,
     };
-    Ok(req)
+    Ok((req, imperfect_count))
 }
 
 async fn write_new_snapshot_and_build_table_meta(
@@ -367,7 +381,7 @@ async fn write_new_snapshot_and_build_table_meta(
     table_meta_timestamps: TableMetaTimestamps,
     insert_hll: &BlockHLL,
     insert_rows: u64,
-) -> Result<TableMeta> {
+) -> Result<(TableMeta, u64)> {
     let fuse_table = FuseTable::try_from_table(table)?;
     let previous = fuse_table.read_table_snapshot().await?;
     let table_stats_gen = fuse_table
@@ -384,11 +398,7 @@ async fn write_new_snapshot_and_build_table_meta(
         table_stats_gen,
     )?;
     snapshot.ensure_segments_unique()?;
-    set_compaction_num_block_hint(
-        snapshot_generator.ctx.as_ref(),
-        table_info.name.as_str(),
-        &snapshot.summary,
-    );
+    let imperfect_count = snapshot.summary.block_count - snapshot.summary.perfect_block_count;
 
     let dal = fuse_table.get_operator();
     let location_generator = &fuse_table.meta_location_generator;
@@ -396,10 +406,9 @@ async fn write_new_snapshot_and_build_table_meta(
         location_generator.gen_snapshot_location(&snapshot.snapshot_id, TableSnapshot::VERSION)?;
     dal.write(&location, snapshot.to_bytes()?).await?;
 
-    Ok(FuseTable::build_new_table_meta(
-        &fuse_table.table_info.meta,
-        &location,
-        &snapshot,
+    Ok((
+        FuseTable::build_new_table_meta(&fuse_table.table_info.meta, &location, &snapshot),
+        imperfect_count,
     ))
 }
 

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -514,11 +514,6 @@ where F: SnapshotGenerator + Send + Sync + 'static
                     table_stats_gen,
                 ) {
                     Ok(snapshot) => {
-                        set_compaction_num_block_hint(
-                            self.ctx.as_ref(),
-                            table_info.name.as_str(),
-                            &snapshot.summary,
-                        );
                         self.state = State::TryCommit {
                             data: snapshot.to_bytes()?,
                             snapshot,
@@ -630,6 +625,8 @@ where F: SnapshotGenerator + Send + Sync + 'static
                     .location_gen
                     .gen_snapshot_location(&snapshot.snapshot_id, TableSnapshot::VERSION)?;
                 self.dal.write(&location, data).await?;
+                let imperfect_count =
+                    snapshot.summary.block_count - snapshot.summary.perfect_block_count;
 
                 // enable auto analyze.
                 let mut enable_auto_analyze = false;
@@ -661,6 +658,12 @@ where F: SnapshotGenerator + Send + Sync + 'static
                     .await
                 {
                     Ok(_) => {
+                        set_compaction_num_block_hint(
+                            self.ctx.as_ref(),
+                            &table_info,
+                            imperfect_count,
+                        );
+
                         if self.need_truncate() {
                             // Truncate table operation should be executed in the context of ddl,
                             // which implies auto commit mode.

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
@@ -129,5 +129,75 @@ select block_count, row_count from fuse_segment('i15760', 't2');
 ----
 3 17
 
+# table-level auto compaction threshold overrides session/global threshold
+statement ok
+set auto_compaction_imperfect_blocks_threshold = 50;
+
+statement ok
+create table t3(a int) row_per_block=5 auto_compaction_imperfect_blocks_threshold=3;
+
+statement ok
+insert into t3 values(0);
+
+statement ok
+insert into t3 select number from numbers(12);
+
+statement ok
+insert into t3 select number from numbers(2);
+
+statement ok
+insert into t3 select number from numbers(2);
+
+query I
+select count() from fuse_segment('i15760', 't3');
+----
+1
+
+statement ok
+set auto_compaction_imperfect_blocks_threshold = 1;
+
+statement ok
+create table t4(a int) row_per_block=5 auto_compaction_imperfect_blocks_threshold=0;
+
+statement ok
+insert into t4 values(0);
+
+statement ok
+insert into t4 select number from numbers(12);
+
+statement ok
+insert into t4 select number from numbers(2);
+
+statement ok
+insert into t4 select number from numbers(2);
+
+query B
+select count() > 1 from fuse_segment('i15760', 't4');
+----
+1
+
+statement ok
+set auto_compaction_imperfect_blocks_threshold = 0;
+
+statement ok
+create table t5(a int) row_per_block=5;
+
+statement ok
+insert into t5 values(0);
+
+statement ok
+insert into t5 select number from numbers(12);
+
+statement ok
+insert into t5 select number from numbers(2);
+
+statement ok
+insert into t5 select number from numbers(2);
+
+query B
+select count() > 1 from fuse_segment('i15760', 't5');
+----
+1
+
 statement ok
 drop database i15760;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  - Add Fuse table option `auto_compaction_imperfect_blocks_threshold`, matching the existing setting name.
  - Give the table option higher priority than session/global settings, with fallback to the setting when absent.
  - Treat `auto_compaction_imperfect_blocks_threshold = 0` as `disabling auto compaction hint` setup.
  - Set the compaction hint only after commit succeeds to avoid stale hints from failed commits.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19842)
<!-- Reviewable:end -->
