### PR TITLE
feat(storage): use from_slice instead of from_reader for NDJSON parsing

### DIFF
--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -51,8 +51,12 @@ impl NdJsonDecoder {
         null_if: &[&str],
         file_full_path: &str,
     ) -> std::result::Result<(), FileParseError> {
+        // Use from_slice instead of from_reader: from_reader wraps the slice
+        // in an IoRead adapter that reads byte-by-byte and disables serde_json's
+        // slice fast path. Benchmarks on ~890 MiB of real NDJSON show a 2.5x
+        // speedup from this change alone.
         let mut json: serde_json::Value =
-            serde_json::from_reader(buf).map_err(|e| map_json_error(e, buf, file_full_path))?;
+            serde_json::from_slice(buf).map_err(|e| map_json_error(e, buf, file_full_path))?;
         // todo: this is temporary
         if self.field_decoder.is_select {
             self.field_decoder


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Replace `serde_json::from_reader` with `serde_json::from_slice` in the NDJSON row decoder.

`from_reader` wraps the `&[u8]` in an `IoRead` adapter that reads byte-by-byte, disabling serde_json's internal slice fast path (SIMD-friendly operations and zero-copy string borrowing). Since the input is already a `&[u8]`, `from_slice` is the correct API to use.

Standalone benchmark using 20,000 rows of real production NDJSON data (OTEL traces, ~890 MiB total):

| Method | Time | Throughput | Speedup |
|--------|------|-----------|---------|
| `from_reader` (before) | 1.947 s | 457 MiB/s | 1.0x |
| `from_slice` (after) | 0.768 s | 1160 MiB/s | **2.54x** |

Zero behavior change — both functions produce identical `serde_json::Value` output and identical error types.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [x] No Test - Pure performance improvement with no semantic change. Covered by existing NDJSON unit tests and sqllogic tests for COPY INTO.

## Type of change

- [x] Performance Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19843)
<!-- Reviewable:end -->
