### PR TITLE
fix(query): centralize conversion safety checks

### DIFF
--- a/src/query/expression/src/conversion.rs
+++ b/src/query/expression/src/conversion.rs
@@ -1,0 +1,359 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::type_check::common_super_type;
+use crate::types::DataType;
+use crate::types::Decimal;
+use crate::types::DecimalSize;
+use crate::types::NumberDataType;
+use crate::types::i256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionClass {
+    /// Same logical type, no conversion needed.
+    Identity,
+    /// Conversion preserves distinct source values in the target type.
+    LosslessInjective,
+    /// Conversion is deterministic but can lose information or merge values.
+    Lossy,
+    /// Conversion semantics depend on runtime contents, for example String -> Number.
+    ValueDependent,
+    /// Conversion is represented by TRY_CAST or may turn failures into NULL.
+    TryOnly,
+    /// No supported conversion is known.
+    Unsupported,
+}
+
+impl ConversionClass {
+    pub fn is_lossless_injective(&self) -> bool {
+        matches!(self, Self::Identity | Self::LosslessInjective)
+    }
+
+    pub fn is_safe_for_equality_inference(&self) -> bool {
+        self.is_lossless_injective()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommonTypeConversion {
+    pub common_type: DataType,
+    pub left: ConversionClass,
+    pub right: ConversionClass,
+}
+
+impl CommonTypeConversion {
+    pub fn is_safe_for_equality_inference(&self) -> bool {
+        is_type_safe_for_equality_inference(&self.common_type)
+            && self.left.is_safe_for_equality_inference()
+            && self.right.is_safe_for_equality_inference()
+    }
+}
+
+impl From<&DataType> for DataType {
+    fn from(value: &DataType) -> Self {
+        value.clone()
+    }
+}
+
+pub fn classify_conversion(src: &DataType, dest: &DataType) -> ConversionClass {
+    if src == dest {
+        return ConversionClass::Identity;
+    }
+
+    match (src, dest) {
+        (DataType::Null, _) => ConversionClass::LosslessInjective,
+        (DataType::Nullable(_), DataType::Null) => ConversionClass::Lossy,
+        (_, DataType::Null) => ConversionClass::Unsupported,
+
+        (DataType::Nullable(src), DataType::Nullable(dest)) => classify_conversion(src, dest),
+        (DataType::Nullable(_), _) => ConversionClass::Unsupported,
+        (src, DataType::Nullable(dest)) => match classify_conversion(src, dest) {
+            ConversionClass::Identity => ConversionClass::LosslessInjective,
+            class => class,
+        },
+
+        (DataType::EmptyArray, DataType::Array(_)) => ConversionClass::LosslessInjective,
+        (DataType::EmptyMap, DataType::Map(_)) => ConversionClass::LosslessInjective,
+
+        (DataType::Array(src), DataType::Array(dest))
+        | (DataType::Map(src), DataType::Map(dest)) => classify_conversion(src, dest),
+        (DataType::Tuple(src), DataType::Tuple(dest)) if src.len() == dest.len() => {
+            combine_conversion_classes(
+                src.iter()
+                    .zip(dest)
+                    .map(|(src, dest)| classify_conversion(src, dest)),
+            )
+        }
+
+        (DataType::Number(src), DataType::Number(dest)) => classify_number_conversion(*src, *dest),
+        (DataType::Number(src), DataType::Decimal(dest)) => {
+            if let Some(src) = src.get_decimal_properties() {
+                match classify_decimal_conversion(src, *dest) {
+                    ConversionClass::Identity => ConversionClass::LosslessInjective,
+                    class => class,
+                }
+            } else {
+                ConversionClass::Lossy
+            }
+        }
+        (DataType::Decimal(src), DataType::Decimal(dest)) => {
+            classify_decimal_conversion(*src, *dest)
+        }
+        (DataType::Decimal(_), DataType::Number(dest)) if dest.is_float() => ConversionClass::Lossy,
+        (DataType::Decimal(_), DataType::Number(_)) => ConversionClass::Lossy,
+
+        (DataType::Boolean, DataType::String | DataType::Number(_) | DataType::Decimal(_)) => {
+            ConversionClass::LosslessInjective
+        }
+        (DataType::Number(_), DataType::String) | (DataType::Decimal(_), DataType::String) => {
+            ConversionClass::LosslessInjective
+        }
+
+        (DataType::Date, DataType::Timestamp) => ConversionClass::LosslessInjective,
+        (DataType::Timestamp, DataType::Date) => ConversionClass::Lossy,
+
+        (DataType::String, dest) if is_value_dependent_string_target(dest) => {
+            ConversionClass::ValueDependent
+        }
+        (DataType::Variant, dest) if is_variant_try_cast_target(dest) => ConversionClass::TryOnly,
+
+        _ => ConversionClass::Unsupported,
+    }
+}
+
+pub fn common_super_type_with_conversion(
+    left: impl Into<DataType>,
+    right: impl Into<DataType>,
+) -> Option<CommonTypeConversion> {
+    let left = left.into();
+    let right = right.into();
+    let common_type = common_type_for_conversion(left.clone(), right.clone())?;
+    let left_class = classify_conversion(&left, &common_type);
+    let right_class = classify_conversion(&right, &common_type);
+
+    if matches!(left_class, ConversionClass::Unsupported)
+        || matches!(right_class, ConversionClass::Unsupported)
+    {
+        return None;
+    }
+
+    Some(CommonTypeConversion {
+        common_type,
+        left: left_class,
+        right: right_class,
+    })
+}
+
+fn common_type_for_conversion(left: DataType, right: DataType) -> Option<DataType> {
+    match (left, right) {
+        (DataType::Null, DataType::Null) => Some(DataType::Null),
+        (DataType::Null, ty @ DataType::Nullable(_))
+        | (ty @ DataType::Nullable(_), DataType::Null) => Some(ty),
+        (DataType::Null, ty) | (ty, DataType::Null) => Some(DataType::Nullable(Box::new(ty))),
+
+        (DataType::Nullable(left), DataType::Nullable(right)) => {
+            Some(common_type_for_conversion(*left, *right)?.wrap_nullable())
+        }
+        (DataType::Nullable(left), right) => {
+            Some(common_type_for_conversion(*left, right)?.wrap_nullable())
+        }
+        (left, DataType::Nullable(right)) => {
+            Some(common_type_for_conversion(left, *right)?.wrap_nullable())
+        }
+
+        (DataType::EmptyArray, ty @ DataType::Array(_))
+        | (ty @ DataType::Array(_), DataType::EmptyArray) => Some(ty),
+        (DataType::Array(left), DataType::Array(right)) => Some(DataType::Array(Box::new(
+            common_type_for_conversion(*left, *right)?,
+        ))),
+
+        (DataType::EmptyMap, ty @ DataType::Map(_))
+        | (ty @ DataType::Map(_), DataType::EmptyMap) => Some(ty),
+        (DataType::Map(left), DataType::Map(right)) => Some(DataType::Map(Box::new(
+            common_type_for_conversion(*left, *right)?,
+        ))),
+
+        (DataType::Tuple(left), DataType::Tuple(right)) if left.len() == right.len() => {
+            let fields = left
+                .into_iter()
+                .zip(right)
+                .map(|(left, right)| common_type_for_conversion(left, right))
+                .collect::<Option<Vec<_>>>()?;
+            Some(DataType::Tuple(fields))
+        }
+
+        (DataType::Number(left), DataType::Number(right)) => Some(number_common_type(left, right)),
+
+        (left, right) => {
+            if let Some(common_type) = common_super_type(left.clone(), right.clone(), &[]) {
+                return Some(common_type);
+            }
+
+            match (left, right) {
+                (DataType::Date, DataType::Timestamp) | (DataType::Timestamp, DataType::Date) => {
+                    Some(DataType::Timestamp)
+                }
+
+                (DataType::String, ty) if is_value_dependent_string_target(&ty) => Some(ty),
+                (ty, DataType::String) if is_value_dependent_string_target(&ty) => Some(ty),
+
+                (DataType::Variant, ty) if is_variant_try_cast_target(&ty) => {
+                    Some(ty.wrap_nullable())
+                }
+                (ty, DataType::Variant) if is_variant_try_cast_target(&ty) => {
+                    Some(ty.wrap_nullable())
+                }
+
+                _ => None,
+            }
+        }
+    }
+}
+
+fn classify_number_conversion(src: NumberDataType, dest: NumberDataType) -> ConversionClass {
+    if src == dest {
+        return ConversionClass::Identity;
+    }
+
+    match (src.is_integer(), dest.is_integer()) {
+        (true, true) if src.can_lossless_cast_to(dest) => ConversionClass::LosslessInjective,
+        (true, true) => ConversionClass::Lossy,
+        (false, false) if src.can_lossless_cast_to(dest) => ConversionClass::LosslessInjective,
+        (false, false) => ConversionClass::Lossy,
+        (true, false) | (false, true) => ConversionClass::Lossy,
+    }
+}
+
+fn classify_decimal_conversion(src: DecimalSize, dest: DecimalSize) -> ConversionClass {
+    if src == dest {
+        return ConversionClass::Identity;
+    }
+
+    if src.scale() <= dest.scale() && src.leading_digits() <= dest.leading_digits() {
+        ConversionClass::LosslessInjective
+    } else {
+        ConversionClass::Lossy
+    }
+}
+
+fn number_common_type(left: NumberDataType, right: NumberDataType) -> DataType {
+    if left == right {
+        return DataType::Number(left);
+    }
+
+    if left.is_integer() && right.is_integer() {
+        if left.can_lossless_cast_to(right) {
+            return DataType::Number(right);
+        }
+        if right.can_lossless_cast_to(left) {
+            return DataType::Number(left);
+        }
+
+        let left = left.get_decimal_properties().unwrap();
+        let right = right.get_decimal_properties().unwrap();
+        return DataType::Decimal(decimal_common_size(left, right));
+    }
+
+    if left.is_float() && right.is_float() {
+        if left.can_lossless_cast_to(right) {
+            return DataType::Number(right);
+        }
+        return DataType::Number(left);
+    }
+
+    if left.is_float() {
+        DataType::Number(left)
+    } else {
+        DataType::Number(right)
+    }
+}
+
+fn decimal_common_size(left: DecimalSize, right: DecimalSize) -> DecimalSize {
+    let scale = left.scale().max(right.scale());
+    let precision = scale + left.leading_digits().max(right.leading_digits());
+    let precision =
+        if left.precision() <= i128::MAX_PRECISION && right.precision() <= i128::MAX_PRECISION {
+            precision.min(i128::MAX_PRECISION)
+        } else {
+            precision.min(i256::MAX_PRECISION)
+        };
+
+    DecimalSize::new_unchecked(precision, scale)
+}
+
+fn combine_conversion_classes(
+    classes: impl IntoIterator<Item = ConversionClass>,
+) -> ConversionClass {
+    let mut result = ConversionClass::Identity;
+    for class in classes {
+        result = match (result, class) {
+            (ConversionClass::Unsupported, _) | (_, ConversionClass::Unsupported) => {
+                ConversionClass::Unsupported
+            }
+            (ConversionClass::TryOnly, _) | (_, ConversionClass::TryOnly) => {
+                ConversionClass::TryOnly
+            }
+            (ConversionClass::ValueDependent, _) | (_, ConversionClass::ValueDependent) => {
+                ConversionClass::ValueDependent
+            }
+            (ConversionClass::Lossy, _) | (_, ConversionClass::Lossy) => ConversionClass::Lossy,
+            (ConversionClass::LosslessInjective, _) | (_, ConversionClass::LosslessInjective) => {
+                ConversionClass::LosslessInjective
+            }
+            (ConversionClass::Identity, ConversionClass::Identity) => ConversionClass::Identity,
+        };
+    }
+    result
+}
+
+fn is_value_dependent_string_target(ty: &DataType) -> bool {
+    match ty {
+        DataType::Nullable(ty) => is_value_dependent_string_target(ty),
+        DataType::Number(_)
+        | DataType::Decimal(_)
+        | DataType::Boolean
+        | DataType::Date
+        | DataType::Timestamp
+        | DataType::TimestampTz
+        | DataType::Interval => true,
+        _ => false,
+    }
+}
+
+fn is_variant_try_cast_target(ty: &DataType) -> bool {
+    match ty {
+        DataType::Nullable(ty) => is_variant_try_cast_target(ty),
+        DataType::Boolean
+        | DataType::Date
+        | DataType::Timestamp
+        | DataType::String
+        | DataType::Number(_) => true,
+        _ => false,
+    }
+}
+
+fn is_type_safe_for_equality_inference(ty: &DataType) -> bool {
+    !matches!(
+        ty.remove_nullable(),
+        DataType::Map(_)
+            | DataType::EmptyMap
+            | DataType::Binary
+            | DataType::Geometry
+            | DataType::Geography
+            | DataType::Vector(_)
+            | DataType::Opaque(_)
+            | DataType::Generic(_)
+            | DataType::StageLocation
+    )
+}

--- a/src/query/expression/src/lib.rs
+++ b/src/query/expression/src/lib.rs
@@ -56,6 +56,7 @@ mod block;
 pub mod aggregate;
 mod block_vec;
 mod constant_folder;
+pub mod conversion;
 pub mod converts;
 mod evaluator;
 mod expression;

--- a/src/query/expression/tests/it/conversion.rs
+++ b/src/query/expression/tests/it/conversion.rs
@@ -1,0 +1,648 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ConversionClass::*;
+use DataType::*;
+use NumberDataType::*;
+use databend_common_expression::conversion::ConversionClass;
+use databend_common_expression::conversion::classify_conversion;
+use databend_common_expression::conversion::common_super_type_with_conversion;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::VectorDataType;
+use pretty_assertions::assert_eq;
+
+macro_rules! assert_conversion_matrix {
+    ($($name:literal => $ty:expr),+ $(,)?) => {{
+        let types = vec![$(($name, $ty)),+];
+        for (left_name, left) in &types {
+            for (right_name, right) in &types {
+                assert_conversion_pair_is_consistent(left_name, left, right_name, right);
+            }
+        }
+    }};
+}
+
+#[test]
+fn test_identity_for_all_data_type_variants() {
+    for (name, ty) in all_data_type_variants() {
+        assert_eq!(
+            classify_conversion(&ty, &ty),
+            Identity,
+            "identity conversion for {name}: {ty}"
+        );
+
+        let common = common_super_type_with_conversion(&ty, &ty)
+            .unwrap_or_else(|| panic!("missing common type for identity {name}: {ty}"));
+        assert_eq!(common.common_type, ty, "common type for {name}: {ty}");
+        assert_eq!(common.left, Identity, "left class for {name}: {ty}");
+        assert_eq!(common.right, Identity, "right class for {name}: {ty}");
+    }
+}
+
+#[test]
+fn test_conversion_matrix_covers_representative_type_pairs() {
+    assert_conversion_matrix! {
+        "null" => Null,
+        "empty_array" => EmptyArray,
+        "empty_map" => EmptyMap,
+        "boolean" => Boolean,
+        "binary" => Binary,
+        "string" => String,
+        "timestamp" => Timestamp,
+        "timestamp_tz" => TimestampTz,
+        "date" => Date,
+        "bitmap" => Bitmap,
+        "variant" => Variant,
+        "geometry" => Geometry,
+        "interval" => Interval,
+        "geography" => Geography,
+        "uint8" => number(UInt8),
+        "uint16" => number(UInt16),
+        "uint32" => number(UInt32),
+        "uint64" => number(UInt64),
+        "int8" => number(Int8),
+        "int16" => number(Int16),
+        "int32" => number(Int32),
+        "int64" => number(Int64),
+        "float32" => number(Float32),
+        "float64" => number(Float64),
+        "decimal_i64" => decimal(9, 2),
+        "decimal_i128" => decimal(38, 4),
+        "decimal_i256" => decimal(76, 6),
+        "nullable_int64" => nullable(number(Int64)),
+        "nullable_string" => nullable(String),
+        "array_int64" => array(number(Int64)),
+        "array_string" => array(String),
+        "map_string_int64" => map(String, number(Int64)),
+        "tuple_string_int64" => tuple(vec![String, number(Int64)]),
+        "vector_int8" => Vector(VectorDataType::Int8(3)),
+        "vector_float32" => Vector(VectorDataType::Float32(3)),
+        "opaque" => Opaque(1),
+        "generic" => Generic(1),
+        "stage_location" => StageLocation,
+    };
+}
+
+#[test]
+fn test_null_and_nullable_conversions() {
+    assert_class(Null, String, LosslessInjective);
+    assert_class(String, Null, Unsupported);
+    assert_class(Null, nullable(String), LosslessInjective);
+    assert_class(nullable(String), Null, Lossy);
+    assert_class(String, nullable(String), LosslessInjective);
+    assert_class(nullable(String), String, Unsupported);
+
+    assert_class(
+        nullable(number(Int32)),
+        nullable(number(Int64)),
+        LosslessInjective,
+    );
+    assert_class(nullable(number(Int64)), nullable(number(Int32)), Lossy);
+    assert_class(nullable(String), nullable(number(Int64)), ValueDependent);
+    assert_class(nullable(number(Int32)), number(Int64), Unsupported);
+
+    assert_common(
+        Null,
+        String,
+        nullable(String),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        nullable(number(Int64)),
+        number(UInt64),
+        nullable(decimal(20, 0)),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        nullable(Null),
+        String,
+        nullable(String),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        nullable(Null),
+        nullable(String),
+        nullable(String),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        nullable(Variant),
+        String,
+        nullable(String),
+        TryOnly,
+        LosslessInjective,
+    );
+}
+
+#[test]
+fn test_number_conversion_classes_cover_all_number_types() {
+    for number_ty in all_number_types() {
+        assert_class(number(number_ty), number(number_ty), Identity);
+    }
+
+    let cases = [
+        (UInt8, UInt16, LosslessInjective),
+        (UInt16, UInt8, Lossy),
+        (UInt8, Int16, LosslessInjective),
+        (UInt32, Int64, LosslessInjective),
+        (UInt64, Int64, Lossy),
+        (Int8, Int16, LosslessInjective),
+        (Int64, Int32, Lossy),
+        (Int16, UInt16, Lossy),
+        (Float32, Float64, LosslessInjective),
+        (Float64, Float32, Lossy),
+        (Int32, Float64, Lossy),
+        (Float32, Int64, Lossy),
+    ];
+
+    for (src, dest, class) in cases {
+        assert_class(number(src), number(dest), class);
+    }
+}
+
+#[test]
+fn test_number_common_types() {
+    assert_common(
+        number(UInt8),
+        number(UInt16),
+        number(UInt16),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        number(UInt8),
+        number(Int16),
+        number(Int16),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        number(Int8),
+        number(UInt8),
+        decimal(3, 0),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        number(Int64),
+        number(UInt64),
+        decimal(20, 0),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        number(UInt64),
+        number(Int64),
+        decimal(20, 0),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        number(Float32),
+        number(Float64),
+        number(Float64),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        number(Int64),
+        number(Float64),
+        number(Float64),
+        Lossy,
+        Identity,
+    );
+    assert_common(
+        number(Float32),
+        number(Int64),
+        number(Float32),
+        Identity,
+        Lossy,
+    );
+}
+
+#[test]
+fn test_decimal_conversion_classes() {
+    assert_class(decimal(10, 2), decimal(10, 2), Identity);
+    assert_class(decimal(10, 2), decimal(12, 2), LosslessInjective);
+    assert_class(decimal(10, 2), decimal(12, 4), LosslessInjective);
+    assert_class(decimal(10, 2), decimal(10, 4), Lossy);
+    assert_class(decimal(10, 4), decimal(10, 2), Lossy);
+
+    assert_class(number(Int16), decimal(5, 0), LosslessInjective);
+    assert_class(number(UInt64), decimal(20, 0), LosslessInjective);
+    assert_class(number(Int64), decimal(18, 0), Lossy);
+    assert_class(number(Float64), decimal(20, 5), Lossy);
+    assert_class(decimal(10, 2), number(Int64), Lossy);
+    assert_class(decimal(10, 2), number(Float64), Lossy);
+}
+
+#[test]
+fn test_decimal_common_types() {
+    assert_common(
+        decimal(10, 2),
+        decimal(12, 4),
+        decimal(12, 4),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        decimal(12, 4),
+        decimal(10, 2),
+        decimal(12, 4),
+        Identity,
+        LosslessInjective,
+    );
+    assert_common(
+        decimal(38, 2),
+        decimal(76, 4),
+        decimal(76, 4),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        number(Int32),
+        decimal(12, 2),
+        decimal(12, 2),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        decimal(10, 2),
+        number(Float64),
+        number(Float64),
+        Lossy,
+        Identity,
+    );
+}
+
+#[test]
+fn test_temporal_string_and_variant_conversions() {
+    assert_class(Boolean, String, LosslessInjective);
+    assert_class(Boolean, number(Int64), LosslessInjective);
+    assert_class(Boolean, decimal(1, 0), LosslessInjective);
+    assert_class(number(Int64), String, LosslessInjective);
+    assert_class(decimal(18, 3), String, LosslessInjective);
+
+    assert_class(Date, Timestamp, LosslessInjective);
+    assert_class(Timestamp, Date, Lossy);
+    assert_class(Timestamp, TimestampTz, Unsupported);
+
+    for dest in [
+        Boolean,
+        Date,
+        Timestamp,
+        TimestampTz,
+        Interval,
+        number(Int64),
+        number(Float64),
+        decimal(18, 3),
+        nullable(number(Int64)),
+    ] {
+        assert_class(String, dest, ValueDependent);
+    }
+
+    assert_class(String, Variant, Unsupported);
+    assert_class(Variant, decimal(18, 3), Unsupported);
+
+    for dest in [
+        Boolean,
+        Date,
+        Timestamp,
+        String,
+        number(Int64),
+        nullable(String),
+    ] {
+        assert_class(Variant, dest, TryOnly);
+    }
+}
+
+#[test]
+fn test_temporal_string_and_variant_common_types() {
+    assert_common(Date, Timestamp, Timestamp, LosslessInjective, Identity);
+    assert_common(Timestamp, Date, Timestamp, Identity, LosslessInjective);
+    assert_common(String, Boolean, Boolean, ValueDependent, Identity);
+    assert_common(Boolean, String, Boolean, Identity, ValueDependent);
+    assert_common(
+        String,
+        number(Int64),
+        decimal(38, 5),
+        ValueDependent,
+        LosslessInjective,
+    );
+    assert_common(
+        number(Float64),
+        String,
+        number(Float64),
+        Identity,
+        ValueDependent,
+    );
+    assert_common(
+        Variant,
+        String,
+        nullable(String),
+        TryOnly,
+        LosslessInjective,
+    );
+    assert_common(
+        String,
+        Variant,
+        nullable(String),
+        LosslessInjective,
+        TryOnly,
+    );
+    assert_common(
+        number(Int64),
+        Variant,
+        nullable(number(Int64)),
+        LosslessInjective,
+        TryOnly,
+    );
+    assert_no_common(Variant, decimal(18, 3));
+}
+
+#[test]
+fn test_array_map_and_tuple_conversion_classes() {
+    assert_class(EmptyArray, array(number(Int64)), LosslessInjective);
+    assert_class(EmptyMap, map(String, number(Int64)), LosslessInjective);
+    assert_class(
+        array(number(Int32)),
+        array(number(Int64)),
+        LosslessInjective,
+    );
+    assert_class(array(number(Int64)), array(number(Int32)), Lossy);
+    assert_class(array(String), array(Date), ValueDependent);
+    assert_class(array(String), array(Binary), Unsupported);
+
+    assert_class(
+        map(String, number(Int32)),
+        map(String, number(Int64)),
+        LosslessInjective,
+    );
+    assert_class(
+        map(String, number(Int64)),
+        map(String, number(Int32)),
+        Lossy,
+    );
+    assert_class(
+        map(String, number(Int64)),
+        map(Date, number(Int64)),
+        ValueDependent,
+    );
+    assert_class(
+        map(String, number(Int64)),
+        map(Binary, number(Int64)),
+        Unsupported,
+    );
+
+    assert_class(
+        tuple(vec![number(Int32), String]),
+        tuple(vec![number(Int64), Date]),
+        ValueDependent,
+    );
+    assert_class(
+        tuple(vec![number(Int64), number(Int32)]),
+        tuple(vec![number(Int32), number(Int64)]),
+        Lossy,
+    );
+    assert_class(
+        tuple(vec![Variant, number(Int32)]),
+        tuple(vec![String, number(Int64)]),
+        TryOnly,
+    );
+    assert_class(
+        tuple(vec![number(Int32), String]),
+        tuple(vec![number(Int64)]),
+        Unsupported,
+    );
+    assert_class(
+        tuple(vec![number(Int64), String]),
+        tuple(vec![number(Int32), Binary]),
+        Unsupported,
+    );
+}
+
+#[test]
+fn test_array_map_and_tuple_common_types() {
+    assert_common(
+        array(number(Int64)),
+        array(number(UInt64)),
+        array(decimal(20, 0)),
+        LosslessInjective,
+        LosslessInjective,
+    );
+    assert_common(
+        map(String, number(Int32)),
+        map(String, number(Int64)),
+        map(String, number(Int64)),
+        LosslessInjective,
+        Identity,
+    );
+    assert_common(
+        tuple(vec![String, number(Int64)]),
+        tuple(vec![Date, number(UInt64)]),
+        tuple(vec![Date, decimal(20, 0)]),
+        ValueDependent,
+        LosslessInjective,
+    );
+
+    assert_no_common(array(String), array(Binary));
+    assert_no_common(tuple(vec![String, number(Int64)]), tuple(vec![String]));
+}
+
+#[test]
+fn test_representative_unsupported_conversions() {
+    let cases = [
+        (Binary, String),
+        (Bitmap, String),
+        (Geometry, Geography),
+        (
+            Vector(VectorDataType::Int8(3)),
+            Vector(VectorDataType::Float32(3)),
+        ),
+        (Opaque(1), Opaque(2)),
+        (Generic(1), Generic(2)),
+        (StageLocation, String),
+    ];
+
+    for (src, dest) in cases {
+        assert_class(src, dest, Unsupported);
+    }
+}
+
+fn assert_class(src: DataType, dest: DataType, expected: ConversionClass) {
+    assert_eq!(
+        classify_conversion(&src, &dest),
+        expected,
+        "{src} -> {dest}"
+    );
+}
+
+fn assert_common(
+    left: DataType,
+    right: DataType,
+    common_type: DataType,
+    left_class: ConversionClass,
+    right_class: ConversionClass,
+) {
+    let common = common_super_type_with_conversion(&left, &right)
+        .unwrap_or_else(|| panic!("missing common conversion for {left} and {right}"));
+    assert_eq!(
+        common.common_type, common_type,
+        "{left} / {right} common type"
+    );
+    assert_eq!(common.left, left_class, "{left} / {right} left class");
+    assert_eq!(common.right, right_class, "{left} / {right} right class");
+}
+
+fn assert_no_common(left: DataType, right: DataType) {
+    assert_eq!(
+        common_super_type_with_conversion(&left, &right),
+        None,
+        "{left} / {right}"
+    );
+}
+
+fn assert_conversion_pair_is_consistent(
+    left_name: &str,
+    left: &DataType,
+    right_name: &str,
+    right: &DataType,
+) {
+    let conversion_class = classify_conversion(left, right);
+    if left == right {
+        assert_eq!(
+            conversion_class, Identity,
+            "{left_name} should be identity-compatible with itself"
+        );
+    }
+
+    if conversion_class == Identity {
+        assert_eq!(
+            left, right,
+            "only equal logical types should classify as identity: {left_name} -> {right_name}"
+        );
+    }
+
+    match (
+        common_super_type_with_conversion(left, right),
+        common_super_type_with_conversion(right, left),
+    ) {
+        (Some(forward), Some(reverse)) => {
+            assert_eq!(
+                forward.common_type, reverse.common_type,
+                "common type should be symmetric for {left_name} and {right_name}"
+            );
+            assert_eq!(
+                forward.left,
+                classify_conversion(left, &forward.common_type),
+                "left classification should match common type for {left_name} / {right_name}"
+            );
+            assert_eq!(
+                forward.right,
+                classify_conversion(right, &forward.common_type),
+                "right classification should match common type for {left_name} / {right_name}"
+            );
+            assert_eq!(
+                reverse.left, forward.right,
+                "reverse left class should mirror forward right for {left_name} / {right_name}"
+            );
+            assert_eq!(
+                reverse.right, forward.left,
+                "reverse right class should mirror forward left for {left_name} / {right_name}"
+            );
+        }
+        (None, None) => {}
+        (forward, reverse) => {
+            panic!(
+                "common conversion should be symmetric for {left_name} and {right_name}: forward={forward:?}, reverse={reverse:?}"
+            );
+        }
+    }
+}
+
+fn number(ty: NumberDataType) -> DataType {
+    Number(ty)
+}
+
+fn decimal(precision: u8, scale: u8) -> DataType {
+    Decimal(DecimalSize::new_unchecked(precision, scale))
+}
+
+fn nullable(ty: DataType) -> DataType {
+    Nullable(Box::new(ty))
+}
+
+fn array(ty: DataType) -> DataType {
+    Array(Box::new(ty))
+}
+
+fn map(key: DataType, value: DataType) -> DataType {
+    Map(Box::new(tuple(vec![key, value])))
+}
+
+fn tuple(fields: Vec<DataType>) -> DataType {
+    Tuple(fields)
+}
+
+fn all_number_types() -> [NumberDataType; 10] {
+    [
+        UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64,
+    ]
+}
+
+fn all_data_type_variants() -> Vec<(std::string::String, DataType)> {
+    let mut types = vec![
+        ("null".to_string(), Null),
+        ("empty_array".to_string(), EmptyArray),
+        ("empty_map".to_string(), EmptyMap),
+        ("boolean".to_string(), Boolean),
+        ("binary".to_string(), Binary),
+        ("string".to_string(), String),
+        ("timestamp".to_string(), Timestamp),
+        ("timestamp_tz".to_string(), TimestampTz),
+        ("date".to_string(), Date),
+        ("bitmap".to_string(), Bitmap),
+        ("variant".to_string(), Variant),
+        ("geometry".to_string(), Geometry),
+        ("interval".to_string(), Interval),
+        ("geography".to_string(), Geography),
+        ("vector_int8".to_string(), Vector(VectorDataType::Int8(3))),
+        (
+            "vector_float32".to_string(),
+            Vector(VectorDataType::Float32(3)),
+        ),
+        ("opaque".to_string(), Opaque(1)),
+        ("generic".to_string(), Generic(1)),
+        ("stage_location".to_string(), StageLocation),
+        ("decimal_i64".to_string(), decimal(9, 2)),
+        ("decimal_i128".to_string(), decimal(38, 4)),
+        ("decimal_i256".to_string(), decimal(76, 6)),
+        ("nullable".to_string(), nullable(number(Int64))),
+        ("array".to_string(), array(number(Int64))),
+        ("map".to_string(), map(String, number(Int64))),
+        ("tuple".to_string(), tuple(vec![String, number(Int64)])),
+    ];
+
+    for number_ty in all_number_types() {
+        types.push((format!("{number_ty:?}"), number(number_ty)));
+    }
+
+    types
+}

--- a/src/query/expression/tests/it/main.rs
+++ b/src/query/expression/tests/it/main.rs
@@ -29,6 +29,7 @@ mod block_thresholds;
 mod block_vec;
 mod common;
 mod constant_folder;
+mod conversion;
 mod decimal;
 mod display;
 mod evaluator;

--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/equivalent_constants_visitor.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/operator/filter/equivalent_constants_visitor.rs
@@ -19,6 +19,7 @@ use databend_common_ast::parser::parse_expr;
 use databend_common_ast::parser::tokenize_sql;
 use databend_common_exception::Result;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
 use databend_common_sql::BindContext;
 use databend_common_sql::ColumnBinding;
 use databend_common_sql::Metadata;
@@ -40,22 +41,31 @@ async fn test_equivalent_constants() -> anyhow::Result<()> {
     let ctx = fixture.new_query_ctx().await?;
 
     let cases = [
-        ("a = 1 and b = a", "a = 1 and b = 1"),
+        ("n = 1 and m = n", "n = 1 and m = 1"),
+        (
+            "n = 1 and (m > n and m < (n + m))",
+            "n = 1 and (m > 1 and m < (1 + m))",
+        ),
+        (
+            "(m > n and m < (n + m)) and n = 1",
+            "(m > 1 and m < (1 + m)) and n = 1",
+        ),
+        (
+            "n = 1 or (m > n and m < (n + 2))",
+            "n = 1 or (m > n and m < (n + 2))",
+        ),
+        (
+            "n = 1 or (n = 2 and m > n and m < (n + m))",
+            "n = 1 or (n = 2 and m > 2 and m < (2 + m))",
+        ),
+        ("a = 1 and b = a", "a = 1 and b = a"),
         (
             "a = 1 and (b > a and b < (a + b))",
-            "a = 1 and (b > 1 and b < (1 + b))",
-        ),
-        (
-            "(b > a and b < (a + b)) and a = 1",
-            "(b > 1 and b < (1 + b)) and a = 1",
-        ),
-        (
-            "a = 1 or (b > a and b < (a + 2))",
-            "a = 1 or (b > a and b < (a + 2))",
+            "a = 1 and (b > a and b < (a + b))",
         ),
         (
             "a = 1 or (a = 2 and b > a and b < (a + b))",
-            "a = 1 or (a = 2 and b > 2 and b < (2 + b))",
+            "a = 1 or (a = 2 and b > a and b < (a + b))",
         ),
     ];
 
@@ -121,6 +131,32 @@ fn test_bind_context() -> BindContext {
         column_name: "b".to_string(),
         index: Symbol::new(1),
         data_type: Box::new(DataType::String),
+        visibility: Visibility::Visible,
+        virtual_expr: None,
+        is_srf: false,
+        column_name_lower: None,
+    });
+    bind_context.add_column_binding(ColumnBinding {
+        database_name: None,
+        table_name: None,
+        column_position: None,
+        table_index: None,
+        column_name: "n".to_string(),
+        index: Symbol::new(2),
+        data_type: Box::new(DataType::Number(NumberDataType::Int64)),
+        visibility: Visibility::Visible,
+        virtual_expr: None,
+        is_srf: false,
+        column_name_lower: None,
+    });
+    bind_context.add_column_binding(ColumnBinding {
+        database_name: None,
+        table_name: None,
+        column_position: None,
+        table_index: None,
+        column_name: "m".to_string(),
+        index: Symbol::new(3),
+        data_type: Box::new(DataType::Number(NumberDataType::Int64)),
         visibility: Visibility::Visible,
         virtual_expr: None,
         is_srf: false,

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/equivalent_constants_visitor.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/equivalent_constants_visitor.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use databend_common_exception::Result;
+use databend_common_expression::conversion::common_super_type_with_conversion;
 
 use crate::ScalarExpr;
 use crate::optimizer::optimizers::operator::filter::remove_trivial_type_cast;
@@ -126,6 +127,15 @@ impl VisitorMut<'_> for EquivalentConstantsVisitorInner {
                         ScalarExpr::BoundColumnRef(left_column),
                         ScalarExpr::BoundColumnRef(right_column),
                     ) => {
+                        if !common_super_type_with_conversion(
+                            left_column.column.data_type.as_ref(),
+                            right_column.column.data_type.as_ref(),
+                        )
+                        .is_some_and(|conversion| conversion.is_safe_for_equality_inference())
+                        {
+                            return Ok(());
+                        }
+
                         match (
                             self.eq_constants.get(&left_column).cloned(),
                             self.eq_constants.get(&right_column).cloned(),
@@ -147,7 +157,13 @@ impl VisitorMut<'_> for EquivalentConstantsVisitorInner {
                     }
                     (ScalarExpr::BoundColumnRef(column), expr)
                     | (expr, ScalarExpr::BoundColumnRef(column)) => {
-                        if expr.used_columns().is_empty() {
+                        if expr.used_columns().is_empty()
+                            && common_super_type_with_conversion(
+                                column.column.data_type.as_ref(),
+                                expr.data_type()?,
+                            )
+                            .is_some_and(|conversion| conversion.is_safe_for_equality_inference())
+                        {
                             self.eq_constants.insert(column, expr);
                         }
                     }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
@@ -18,9 +18,9 @@ use std::collections::HashSet;
 use databend_common_base::base::OrderedFloat;
 use databend_common_exception::Result;
 use databend_common_expression::Scalar;
+use databend_common_expression::conversion::common_super_type_with_conversion;
 use databend_common_expression::type_check::common_super_type;
 use databend_common_expression::types::DataType;
-use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -191,7 +191,9 @@ impl<'a> InferFilterOptimizer<'a> {
         let Ok(right_ty) = right.data_type() else {
             return false;
         };
-        if !Self::check_equal_expr_type(&left_ty, &right_ty) {
+        if !common_super_type_with_conversion(left_ty, right_ty)
+            .is_some_and(|conversion| conversion.is_safe_for_equality_inference())
+        {
             return false;
         }
         match self.expr_index.get(left) {
@@ -205,146 +207,6 @@ impl<'a> InferFilterOptimizer<'a> {
         };
 
         true
-    }
-
-    // Equality inference needs a conversion target that preserves equivalence,
-    // not just a type combination that Databend can evaluate with `eq`.
-    fn check_equal_expr_type(left_ty: &DataType, right_ty: &DataType) -> bool {
-        let left = left_ty.remove_nullable();
-        let right = right_ty.remove_nullable();
-        let Some(common_ty) = Self::safe_common_type(left.clone(), right.clone()) else {
-            return false;
-        };
-
-        Self::is_injective_cast(&left, &common_ty) && Self::is_injective_cast(&right, &common_ty)
-    }
-
-    fn safe_common_type(left: DataType, right: DataType) -> Option<DataType> {
-        match (&left, &right) {
-            (DataType::Null, ty) | (ty, DataType::Null) => Some(ty.clone()),
-            (DataType::Nullable(left_ty), DataType::Nullable(right_ty)) => {
-                Some(DataType::Nullable(Box::new(Self::safe_common_type(
-                    *left_ty.clone(),
-                    *right_ty.clone(),
-                )?)))
-            }
-            (DataType::Nullable(left_ty), right_ty) => Some(DataType::Nullable(Box::new(
-                Self::safe_common_type(*left_ty.clone(), right_ty.clone())?,
-            ))),
-            (left_ty, DataType::Nullable(right_ty)) => Some(DataType::Nullable(Box::new(
-                Self::safe_common_type(left_ty.clone(), *right_ty.clone())?,
-            ))),
-            (DataType::EmptyArray, ty @ DataType::Array(_))
-            | (ty @ DataType::Array(_), DataType::EmptyArray) => Some(ty.clone()),
-            (DataType::Array(left_ty), DataType::Array(right_ty)) => Some(DataType::Array(
-                Box::new(Self::safe_common_type(*left_ty.clone(), *right_ty.clone())?),
-            )),
-            (DataType::Map(left_ty), DataType::Map(right_ty)) if left_ty == right_ty => {
-                Some(left.clone())
-            }
-            (DataType::Tuple(left_tys), DataType::Tuple(right_tys))
-                if left_tys.len() == right_tys.len() =>
-            {
-                Some(DataType::Tuple(
-                    left_tys
-                        .iter()
-                        .cloned()
-                        .zip(right_tys.iter().cloned())
-                        .map(|(left_ty, right_ty)| Self::safe_common_type(left_ty, right_ty))
-                        .collect::<Option<Vec<_>>>()?,
-                ))
-            }
-            (DataType::Number(left_num), DataType::Number(right_num))
-                if left_num.is_integer() && right_num.is_integer() =>
-            {
-                Some(DataType::Decimal(Self::merge_decimal_size(
-                    left_num.get_decimal_properties()?,
-                    right_num.get_decimal_properties()?,
-                )?))
-            }
-            (DataType::Number(left_num), DataType::Number(right_num))
-                if left_num.is_float() && right_num.is_float() =>
-            {
-                if left_num.bit_width() >= right_num.bit_width() {
-                    Some(left.clone())
-                } else {
-                    Some(right.clone())
-                }
-            }
-            (DataType::Number(num_ty), DataType::Decimal(decimal))
-            | (DataType::Decimal(decimal), DataType::Number(num_ty))
-                if num_ty.is_integer() =>
-            {
-                let num_decimal = num_ty.get_decimal_properties()?;
-                Some(DataType::Decimal(Self::merge_decimal_size(
-                    *decimal,
-                    num_decimal,
-                )?))
-            }
-            (DataType::Decimal(left_decimal), DataType::Decimal(right_decimal)) => Some(
-                DataType::Decimal(Self::merge_decimal_size(*left_decimal, *right_decimal)?),
-            ),
-            (DataType::Date, DataType::Timestamp) | (DataType::Timestamp, DataType::Date) => {
-                Some(DataType::Timestamp)
-            }
-            _ if left == right && Self::is_safe_same_type(&left) => Some(left),
-            _ => None,
-        }
-    }
-
-    fn is_safe_same_type(data_type: &DataType) -> bool {
-        matches!(
-            data_type,
-            DataType::Boolean
-                | DataType::String
-                | DataType::Number(_)
-                | DataType::Decimal(_)
-                | DataType::Timestamp
-                | DataType::TimestampTz
-                | DataType::Date
-                | DataType::Bitmap
-                | DataType::Variant
-                | DataType::Interval
-        )
-    }
-
-    fn merge_decimal_size(left: DecimalSize, right: DecimalSize) -> Option<DecimalSize> {
-        let scale = left.scale().max(right.scale());
-        let precision = left.leading_digits().max(right.leading_digits()) + scale;
-        DecimalSize::new(precision, scale).ok()
-    }
-
-    fn is_injective_cast(src: &DataType, dest: &DataType) -> bool {
-        if src == dest {
-            return true;
-        }
-
-        match (src, dest) {
-            (DataType::Nullable(src), DataType::Nullable(dest)) => {
-                Self::is_injective_cast(src, dest)
-            }
-            (DataType::Nullable(src), dest) => Self::is_injective_cast(src, dest),
-            (src, DataType::Nullable(dest)) => Self::is_injective_cast(src, dest),
-            (DataType::Null, _) => true,
-            (DataType::EmptyArray, DataType::Array(_)) => true,
-            (DataType::Number(src), DataType::Number(dest)) => {
-                (src.is_integer() && dest.is_integer()) || src.can_lossless_cast_to(*dest)
-            }
-            (DataType::Number(src), DataType::Decimal(_)) if src.is_integer() => true,
-            (DataType::Decimal(src), DataType::Decimal(dest)) => {
-                src.scale() <= dest.scale() && src.leading_digits() <= dest.leading_digits()
-            }
-            (DataType::Date, DataType::Timestamp) => true,
-            (DataType::Array(src), DataType::Array(dest)) => Self::is_injective_cast(src, dest),
-            (DataType::Tuple(src_tys), DataType::Tuple(dest_tys)) => {
-                src_tys.len() == dest_tys.len()
-                    && src_tys
-                        .iter()
-                        .zip(dest_tys)
-                        .all(|(src, dest)| Self::is_injective_cast(src, dest))
-            }
-            _ => false,
-        }
     }
 
     fn add_expr_predicate(&mut self, expr: &ScalarExpr, new_predicate: Predicate) -> Result<()> {

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -20,11 +20,11 @@ use std::sync::Arc;
 
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
+use databend_common_expression::conversion::ConversionClass;
+use databend_common_expression::conversion::common_super_type_with_conversion;
 use databend_common_expression::stat_distribution::StatCount;
 use databend_common_expression::stat_distribution::StatEstimate;
-use databend_common_expression::type_check::common_super_type;
 use databend_common_expression::types::DataType;
-use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_statistics::DEFAULT_HISTOGRAM_BUCKETS;
 use databend_common_statistics::Datum;
 use databend_common_statistics::DatumKind;
@@ -1210,14 +1210,24 @@ fn mixed_numeric_stat_kind(
         return Ok(None);
     }
 
-    let cast_rules = &BUILTIN_FUNCTIONS.get_auto_cast_rules("eq");
-    let Some(common_type) = common_super_type(left_type.clone(), right_type.clone(), cast_rules)
-    else {
+    let Some(conversion) = common_super_type_with_conversion(left_type, right_type) else {
         return Ok(None);
     };
     if !matches!(
-        common_type.remove_nullable(),
+        conversion.common_type.remove_nullable(),
         DataType::Number(_) | DataType::Decimal(_)
+    ) {
+        return Ok(None);
+    }
+    if matches!(
+        (conversion.left, conversion.right),
+        (
+            ConversionClass::ValueDependent | ConversionClass::TryOnly,
+            _
+        ) | (
+            _,
+            ConversionClass::ValueDependent | ConversionClass::TryOnly
+        )
     ) {
         return Ok(None);
     }

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -45,6 +45,7 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::Value;
+use databend_common_expression::conversion::classify_conversion;
 use databend_common_expression::converts::datavalues::scalar_to_datavalue;
 use databend_common_expression::eval_function;
 use databend_common_expression::expr::*;
@@ -81,7 +82,6 @@ use parquet::file::metadata::ParquetMetaData;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::eliminate_cast::is_injective_cast;
 use super::index_common::index_columns_from_parquet_meta;
 use crate::Index;
 use crate::eliminate_cast::cast_const;
@@ -1329,7 +1329,9 @@ impl EqVisitor for RewriteVisitor<'_> {
 
         // For any injective function y = f(x), the eq(column, inverse_f(const)) is a necessary condition for eq(f(column), const).
         // For example, the result of col = '+1'::int contains col::string = '+1'.
-        if !Xor8Filter::supported_type(src_type) || !is_injective_cast(src_type, dest_type) {
+        if !Xor8Filter::supported_type(src_type)
+            || !classify_conversion(src_type, dest_type).is_lossless_injective()
+        {
             return Ok(ControlFlow::Break(None));
         }
 
@@ -1461,7 +1463,9 @@ impl EqVisitor for ShortListVisitor {
             let Some((i, field)) = Self::found_field(&self.bloom_fields, id) else {
                 return Ok(ControlFlow::Break(None));
             };
-            if !Xor8Filter::supported_type(src_type) || !is_injective_cast(src_type, dest_type) {
+            if !Xor8Filter::supported_type(src_type)
+                || !classify_conversion(src_type, dest_type).is_lossless_injective()
+            {
                 return Ok(ControlFlow::Break(None));
             }
 

--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -21,6 +21,7 @@ use databend_common_expression::ExprVisitor;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::FunctionRegistry;
 use databend_common_expression::Scalar;
+use databend_common_expression::conversion::classify_conversion;
 use databend_common_expression::expr::*;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::DataType;
@@ -28,38 +29,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::visit_expr;
 use databend_common_expression::with_integer_mapped_type;
 use databend_common_functions::BUILTIN_FUNCTIONS;
-
-pub(super) fn is_injective_cast(src: &DataType, dest: &DataType) -> bool {
-    if src == dest {
-        return true;
-    }
-
-    match (src, dest) {
-        (DataType::Boolean, DataType::String | DataType::Number(_) | DataType::Decimal(_)) => true,
-
-        (DataType::Number(src), DataType::Number(dest))
-            if src.is_integer() && dest.is_integer() =>
-        {
-            true
-        }
-        (DataType::Number(src), DataType::Decimal(_)) if src.is_integer() => true,
-        (DataType::Number(_), DataType::String) => true,
-        (DataType::Decimal(_), DataType::String) => true,
-
-        (DataType::Date, DataType::Timestamp) => true,
-
-        // (_, DataType::Boolean) => false,
-        // (DataType::String, _) => false,
-        // (DataType::Decimal(_), DataType::Number(_)) => false,
-        // (DataType::Number(src), DataType::Number(dest))
-        //     if src.is_float() && dest.is_integer() =>
-        // {
-        //     false
-        // }
-        (DataType::Nullable(src), DataType::Nullable(dest)) => is_injective_cast(src, dest),
-        _ => false,
-    }
-}
 
 pub(super) struct RewriteVisitor<'a> {
     pub input_domains: HashMap<String, Domain>,
@@ -102,7 +71,7 @@ impl RewriteVisitor<'_> {
             expr, dest_type, ..
         } = cast;
         let src_type = expr.data_type();
-        if !is_injective_cast(src_type, dest_type) {
+        if !classify_conversion(src_type, dest_type).is_lossless_injective() {
             return Ok(None);
         }
 

--- a/tests/sqllogictests/suites/query/filter.test
+++ b/tests/sqllogictests/suites/query/filter.test
@@ -14,6 +14,16 @@ select a, b from t where a = 1 and cast(b as int) >= 2;
 1 4
 1 4
 
+query I
+select count(*) from (select '01' as s1, '1' as s2, 1 as n) where s1 = n and s2 = n and s1 != s2;
+----
+1
+
+query I
+select count(*) from (select '01' as s1, '1' as s2, 1 as n) where s1 = n and s2 = s1;
+----
+0
+
 
 # AND filter short circuit
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Implement the conversion safety helper described by RFC #19828 for optimizer reasoning
- Replace duplicated conversion safety checks in filter inference, join statistics, and storage index cast elimination
- Fix `EquivalentConstantsVisitor` so equality-derived constant propagation only happens when both sides are safe for equality inference

## Changes

This PR adds `databend_common_expression::conversion` with conversion classification APIs:

- `classify_conversion(src, dest)` classifies conversions as identity, lossless injective, lossy, value-dependent, try-only, or unsupported
- `common_super_type_with_conversion(left, right)` returns the common type plus each side's conversion class

The helper is now used by:

- `InferFilter` equality inference
- mixed-type join statistics checks
- bloom index and cast elimination logic
- `EquivalentConstantsVisitor` constant propagation

The `EquivalentConstantsVisitor` change fixes an existing unsafe inference. For example, `String = Number` comparisons are value-dependent: `'01' = 1` and `'1' = 1` may both be true after numeric casts, but `'01' != '1'` as strings. The visitor now avoids propagating constants across such equality predicates.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation run locally:

```bash
cargo test -p databend-common-expression --test it conversion --no-default-features
cargo test -p databend-query --test it sql::planner::optimizer::optimizers::operator::filter::equivalent_constants_visitor::test_equivalent_constants --no-default-features
cargo test -p databend-common-sql planner::plans::join::tests:: --lib --no-default-features
cargo test -p databend-storages-common-index --test it eliminate_cast --no-default-features
cargo clippy -p databend-common-sql --lib --no-default-features -- -D warnings
cargo clippy -p databend-storages-common-index --test it --no-default-features -- -D warnings
cargo fmt --all
git diff --check
```

Added sqllogictest coverage in `tests/sqllogictests/suites/query/filter.test` for the value-dependent string/number equality case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19845)
<!-- Reviewable:end -->
