### PR TITLE
fix(query): improve empty stage select error

### DIFF
--- a/src/query/catalog/src/table_context/table_management.rs
+++ b/src/query/catalog/src/table_context/table_management.rs
@@ -51,6 +51,7 @@ pub trait TableContextTableManagement: Send + Sync {
         files_info: StageFilesInfo,
         files_to_copy: Option<Vec<StageFileInfo>>,
         max_column_position: usize,
+        has_column_name_ref: bool,
         on_error_mode: Option<OnErrorMode>,
     ) -> Result<Arc<dyn Table>> {
         let _ = (
@@ -58,6 +59,7 @@ pub trait TableContextTableManagement: Send + Sync {
             files_info,
             files_to_copy,
             max_column_position,
+            has_column_name_ref,
             on_error_mode,
         );
         unimplemented!()

--- a/src/query/service/src/sessions/query_ctx/table.rs
+++ b/src/query/service/src/sessions/query_ctx/table.rs
@@ -490,6 +490,7 @@ impl TableContextTableManagement for QueryContext {
         files_info: StageFilesInfo,
         files_to_copy: Option<Vec<StageFileInfo>>,
         max_column_position: usize,
+        has_column_name_ref: bool,
         on_error_mode: Option<OnErrorMode>,
     ) -> Result<Arc<dyn Table>> {
         let copy_options = CopyIntoTableOptions {
@@ -534,6 +535,7 @@ impl TableContextTableManagement for QueryContext {
                         self.get_settings(),
                         self.get_query_kind(),
                         fmt,
+                        has_column_name_ref,
                     )
                     .await
                 } else {
@@ -579,7 +581,7 @@ impl TableContextTableManagement for QueryContext {
                     copy_into_table_options: copy_options.clone(),
                     ..Default::default()
                 };
-                OrcTable::try_create(self, info).await
+                OrcTable::try_create(self, info, has_column_name_ref).await
             }
             FileFormatParams::NdJson(..) | FileFormatParams::Avro(..) => {
                 let schema = Arc::new(TableSchema::new(vec![TableField::new(
@@ -657,6 +659,7 @@ impl TableContextTableManagement for QueryContext {
         _files_info: StageFilesInfo,
         _files_to_copy: Option<Vec<StageFileInfo>>,
         _max_column_position: usize,
+        _has_column_name_ref: bool,
         _on_error_mode: Option<OnErrorMode>,
     ) -> Result<Arc<dyn Table>> {
         Err(ErrorCode::Unimplemented(

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -140,9 +140,10 @@ impl Binder {
 
         let mut max_column_position = MaxColumnPosition::default();
         stmt.walk(&mut max_column_position)?;
-        self.metadata
-            .write()
-            .set_max_column_position(max_column_position.max_pos);
+        self.metadata.write().set_stage_column_references(
+            max_column_position.max_pos,
+            max_column_position.has_name_ref,
+        );
 
         let cross_joins = stmt
             .from
@@ -1052,21 +1053,21 @@ impl SelectRewriter {
 #[derive(Default)]
 pub struct MaxColumnPosition {
     pub max_pos: usize,
+    pub has_name_ref: bool,
 }
 
 impl Visitor for MaxColumnPosition {
     fn visit_expr(&mut self, expr: &Expr) -> std::result::Result<VisitControl, !> {
-        if let Expr::ColumnRef {
-            column:
-                ColumnRef {
-                    column: ColumnID::Position(pos),
-                    ..
-                },
-            ..
-        } = expr
-            && pos.pos > self.max_pos
-        {
-            self.max_pos = pos.pos;
+        if let Expr::ColumnRef { column, .. } = expr {
+            match &column.column {
+                ColumnID::Position(pos) if pos.pos > self.max_pos => {
+                    self.max_pos = pos.pos;
+                }
+                ColumnID::Name(_) => {
+                    self.has_name_ref = true;
+                }
+                _ => {}
+            }
         }
         Ok(VisitControl::Continue)
     }

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -109,9 +109,10 @@ impl Binder {
                         expr.walk(&mut max_column_position)?;
                     }
                 }
-                self.metadata
-                    .write()
-                    .set_max_column_position(max_column_position.max_pos);
+                self.metadata.write().set_stage_column_references(
+                    max_column_position.max_pos,
+                    max_column_position.has_name_ref,
+                );
                 let plan = self.bind_copy_into_table_common(stmt, from, true).await?;
 
                 let alias = alias_name.as_ref().map(|name| TableAlias {

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -132,13 +132,20 @@ impl Binder {
         on_error_mode: Option<OnErrorMode>,
     ) -> Result<(SExpr, BindContext)> {
         let start = std::time::Instant::now();
-        let max_column_position = self.metadata.read().get_max_column_position();
+        let (max_column_position, has_column_name_ref) = {
+            let metadata = self.metadata.read();
+            (
+                metadata.get_max_column_position(),
+                metadata.has_column_name_ref(),
+            )
+        };
         let table = table_ctx
             .create_stage_table(
                 stage_info,
                 files_info,
                 files_to_copy,
                 max_column_position,
+                has_column_name_ref,
                 on_error_mode,
             )
             .await?;

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -77,6 +77,7 @@ pub struct Metadata {
     table_row_id_index: HashMap<IndexType, Symbol>,
     agg_indices: HashMap<String, Vec<(u64, String, SExpr)>>,
     max_column_position: usize, // for CSV
+    has_column_name_ref: bool,  // for schema inference from stage files
 
     /// Scan id of each scan operator.
     next_scan_id: usize,
@@ -490,12 +491,17 @@ impl Metadata {
         }
     }
 
-    pub fn set_max_column_position(&mut self, max_pos: usize) {
-        self.max_column_position = max_pos
+    pub fn set_stage_column_references(&mut self, max_pos: usize, has_name_ref: bool) {
+        self.max_column_position = max_pos;
+        self.has_column_name_ref = has_name_ref;
     }
 
     pub fn get_max_column_position(&self) -> usize {
         self.max_column_position
+    }
+
+    pub fn has_column_name_ref(&self) -> bool {
+        self.has_column_name_ref
     }
 
     pub fn next_scan_id(&mut self) -> usize {

--- a/src/query/storages/orc/src/table.rs
+++ b/src/query/storages/orc/src/table.rs
@@ -74,6 +74,7 @@ impl OrcTable {
     pub async fn try_create(
         ctx: &dyn TableContext,
         mut stage_table_info: StageTableInfo,
+        has_column_name_ref: bool,
     ) -> Result<Arc<dyn Table>> {
         let stage_info = &stage_table_info.stage_info;
         if stage_table_info.is_variant {
@@ -96,7 +97,13 @@ impl OrcTable {
             };
 
             let Some(first_file) = first_file else {
-                return ctx.get_zero_table().await;
+                return if has_column_name_ref {
+                    Err(ErrorCode::SemanticError(
+                        "no files found. specify a prefix/pattern/files that matches at least one file",
+                    ))
+                } else {
+                    ctx.get_zero_table().await
+                };
             };
 
             let schema_from = first_file.path.clone();

--- a/src/query/storages/parquet/src/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_table/table.rs
@@ -116,6 +116,7 @@ impl ParquetTable {
         settings: Arc<Settings>,
         query_kind: QueryKind,
         fmt: &ParquetFileFormatParams,
+        has_column_name_ref: bool,
     ) -> Result<Arc<dyn Table>> {
         let operator = init_stage_operator(&stage_info)?;
         let first_file = match &files_to_read {
@@ -124,7 +125,13 @@ impl ParquetTable {
         };
 
         let Some(first_file) = first_file else {
-            return ctx.get_zero_table().await;
+            return if has_column_name_ref {
+                Err(ErrorCode::SemanticError(
+                    "no files found. specify a prefix/pattern/files that matches at least one file",
+                ))
+            } else {
+                ctx.get_zero_table().await
+            };
         };
 
         let first_file = first_file.path;

--- a/tests/sqllogictests/suites/stage/empty_stage_select_error.test
+++ b/tests/sqllogictests/suites/stage/empty_stage_select_error.test
@@ -1,0 +1,15 @@
+statement ok
+drop stage if exists empty_stage_select_error;
+
+statement ok
+create stage empty_stage_select_error file_format = (type = parquet);
+
+query error 1065.*no files found\. specify a prefix/pattern/files that matches at least one file
+select a from @empty_stage_select_error;
+
+query ?
+select * from @empty_stage_select_error
+----
+
+statement ok
+drop stage empty_stage_select_error;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Selecting named columns from an empty staged Parquet/ORC location currently falls back to a zero table and reports a misleading column-not-found error, for example `column a doesn't exist`.

This PR distinguishes stage reads that need named columns from reads that do not:

- `select * from @stage` with no matching Parquet/ORC files returns an empty result set.
- `select a from @stage` still fails because schema inference has no file to read, but now returns a clearer error:

`no files found. specify a prefix/pattern/files that matches at least one file`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19846)
<!-- Reviewable:end -->
