### PR TITLE
feat(query): add geometry scalar functions

### DIFF
--- a/src/query/functions/src/scalars/geographic/src/geometry.rs
+++ b/src/query/functions/src/scalars/geographic/src/geometry.rs
@@ -59,14 +59,17 @@ use databend_common_io::geometry_type_name;
 use databend_common_io::read_srid;
 use geo::Area;
 use geo::BoundingRect;
+use geo::Buffer;
 use geo::Centroid;
 use geo::Contains;
 use geo::ConvexHull;
 use geo::Coord;
+use geo::Covers;
 use geo::Distance;
 use geo::Euclidean;
 use geo::Geometry;
 use geo::HasDimensions;
+use geo::HausdorffDistance;
 use geo::Haversine;
 use geo::Intersects;
 use geo::Length;
@@ -78,10 +81,13 @@ use geo::Point;
 use geo::Polygon;
 use geo::Rect;
 use geo::Relate;
+use geo::Simplify;
 use geo::ToDegrees;
 use geo::ToRadians;
 use geo::Triangle;
+use geo::Validation;
 use geo::Within;
+use geo::algorithm::buffer::BufferStyle;
 use geo::coord;
 use geo::dimensions::Dimensions;
 use geohash::decode_bbox;
@@ -859,6 +865,204 @@ pub fn register(registry: &mut FunctionRegistry) {
             }
         }),
     );
+
+    registry.register_passthrough_nullable_2_arg::<GeometryType, Float64Type, GeometryType, _, _>(
+        "st_simplify",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<GeometryType, Float64Type, GeometryType>(
+            |ewkb, tolerance, builder, ctx| {
+                let row = builder.len();
+                if let Some(validity) = &ctx.validity {
+                    if !validity.get_bit(row) {
+                        builder.commit_row();
+                        return;
+                    }
+                }
+
+                match ewkb_to_geo(&mut Ewkb(ewkb)).and_then(|(geo, srid)| {
+                    let simplified = match geo {
+                        Geometry::LineString(g) => Geometry::LineString(g.simplify(tolerance.0)),
+                        Geometry::Polygon(g) => Geometry::Polygon(g.simplify(tolerance.0)),
+                        Geometry::MultiLineString(g) => {
+                            Geometry::MultiLineString(g.simplify(tolerance.0))
+                        }
+                        Geometry::MultiPolygon(g) => {
+                            Geometry::MultiPolygon(g.simplify(tolerance.0))
+                        }
+                        Geometry::Point(g) => Geometry::Point(g),
+                        Geometry::MultiPoint(g) => Geometry::MultiPoint(g),
+                        Geometry::GeometryCollection(_) => {
+                            return Err(ErrorCode::GeometryError(
+                                "st_simplify is not supported for GeometryCollection".to_string(),
+                            ));
+                        }
+                        other_geo => other_geo,
+                    };
+                    geo_to_ewkb(simplified, srid)
+                }) {
+                    Ok(data) => builder.put_slice(data.as_slice()),
+                    Err(e) => ctx.set_error(row, e.to_string()),
+                }
+                builder.commit_row();
+            },
+        ),
+    );
+
+    geometry_unary_fn::<BooleanType>("st_isvalid", registry, |geo, _| Ok(geo.is_valid()));
+    geometry_unary_fn::<Float64Type>("st_perimeter", registry, |geo, _| {
+        fn polygon_perimeter(p: &Polygon<f64>) -> f64 {
+            let mut len = 0f64;
+            for line in p.exterior().lines() {
+                len += Euclidean.length(&line);
+            }
+            for ring in p.interiors() {
+                for line in ring.lines() {
+                    len += Euclidean.length(&line);
+                }
+            }
+            len
+        }
+        let perimeter = match geo {
+            Geometry::Polygon(ref p) => polygon_perimeter(p),
+            Geometry::MultiPolygon(ref mp) => mp.iter().map(polygon_perimeter).sum(),
+            _ => 0f64,
+        };
+        let perimeter = (perimeter * 1_000_000_000_f64).round() / 1_000_000_000_f64;
+        Ok(perimeter.into())
+    });
+    geometry_binary_fn::<BooleanType>("st_covers", registry, |l, r, _| Ok(l.covers(&r)));
+    geometry_binary_fn::<BooleanType>("st_coveredby", registry, |l, r, _| {
+        Ok(l.relate(&r).is_coveredby())
+    });
+
+    geometry_binary_combine_fn::<Float64Type>("st_azimuth", registry, |l, r, _| match (l, r) {
+        (Geometry::Point(p1), Geometry::Point(p2)) => {
+            if p1 == p2 {
+                Ok(None)
+            } else {
+                let azimuth = f64::atan2(p2.x() - p1.x(), p2.y() - p1.y());
+                let azimuth = if azimuth < 0.0 {
+                    azimuth + 2.0 * std::f64::consts::PI
+                } else {
+                    azimuth
+                };
+                let azimuth = (azimuth * 1_000_000_000_f64).round() / 1_000_000_000_f64;
+                Ok(Some(azimuth.into()))
+            }
+        }
+        _ => Err(ErrorCode::GeometryError(
+            "st_azimuth only accepts Point geometries".to_string(),
+        )),
+    });
+
+    geometry_binary_fn::<Float64Type>("st_hausdorffdistance", registry, |l, r, _| {
+        let distance = l.hausdorff_distance(&r);
+        let distance = (distance * 1_000_000_000_f64).round() / 1_000_000_000_f64;
+        Ok(distance.into())
+    });
+
+    geometry_unary_fn::<GeometryType>("st_makepolygonoriented", registry, |geo, srid| match geo {
+        Geometry::LineString(line_string) => {
+            let points = line_string.into_points();
+            if points.len() < 4 {
+                Err(ErrorCode::GeometryError(format!(
+                    "Input lines must have at least 4 points, but got {}",
+                    points.len()
+                )))
+            } else if points.last() != points.first() {
+                Err(ErrorCode::GeometryError(
+                    "The first point and last point are not equal".to_string(),
+                ))
+            } else {
+                let polygon = Polygon::new(LineString::from(points), vec![]);
+                let geo: Geometry = polygon.into();
+                if !geo.is_valid() {
+                    return Err(ErrorCode::GeometryError(
+                        "Input line does not form a valid polygon".to_string(),
+                    ));
+                }
+                geo_to_ewkb(geo, srid)
+            }
+        }
+        _ => Err(ErrorCode::GeometryError(format!(
+            "Type {} is not supported as argument to st_makepolygonoriented",
+            geometry_type_name(&geo)
+        ))),
+    });
+
+    registry.register_combine_nullable_2_arg::<GeometryType, Float64Type, GeometryType, _, _>(
+        "st_buffer",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<GeometryType, Float64Type, NullableType<GeometryType>>(
+            |ewkb, distance, builder, ctx| {
+                let row = builder.len();
+                if let Some(validity) = &ctx.validity {
+                    if !validity.get_bit(row) {
+                        builder.push_null();
+                        return;
+                    }
+                }
+
+                match ewkb_to_geo(&mut Ewkb(ewkb)) {
+                    Ok((geo, srid)) => {
+                        if matches!(geo, Geometry::GeometryCollection(_)) {
+                            ctx.set_error(
+                                row,
+                                "ST_BUFFER is not supported for GeometryCollection".to_string(),
+                            );
+                            builder.push_null();
+                            return;
+                        }
+
+                        let effective = match &geo {
+                            Geometry::Point(_)
+                            | Geometry::MultiPoint(_)
+                            | Geometry::Line(_)
+                            | Geometry::LineString(_)
+                            | Geometry::MultiLineString(_) => distance.0.abs(),
+                            _ => distance.0,
+                        };
+
+                        if effective == 0.0 {
+                            let wrapped = match geo {
+                                Geometry::Polygon(p) => Some(MultiPolygon::new(vec![p])),
+                                Geometry::MultiPolygon(mp) => Some(mp),
+                                _ => None,
+                            };
+                            match wrapped {
+                                Some(mp) => match geo_to_ewkb(Geometry::MultiPolygon(mp), srid) {
+                                    Ok(data) => builder.push(data.as_slice()),
+                                    Err(e) => {
+                                        ctx.set_error(row, e.to_string());
+                                        builder.push_null();
+                                    }
+                                },
+                                None => builder.push_null(),
+                            }
+                            return;
+                        }
+
+                        let buffered = geo.buffer_with_style(BufferStyle::new(effective));
+                        if buffered.0.is_empty() {
+                            builder.push_null();
+                            return;
+                        }
+                        match geo_to_ewkb(Geometry::MultiPolygon(buffered), srid) {
+                            Ok(data) => builder.push(data.as_slice()),
+                            Err(e) => {
+                                ctx.set_error(row, e.to_string());
+                                builder.push_null();
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        ctx.set_error(row, e.to_string());
+                        builder.push_null();
+                    }
+                }
+            },
+        ),
+    )
 }
 
 fn st_transform_impl(

--- a/src/query/functions/tests/it/scalars/geometry.rs
+++ b/src/query/functions/tests/it/scalars/geometry.rs
@@ -74,6 +74,15 @@ fn test_geometry() {
     test_st_area(file);
     test_st_convexhull(file);
     test_st_hilbert(file);
+    test_st_simplify(file);
+    test_st_isvalid(file);
+    test_st_covers(file);
+    test_st_coveredby(file);
+    test_st_perimeter(file);
+    test_st_azimuth(file);
+    test_st_hausdorffdistance(file);
+    test_st_makepolygonoriented(file);
+    test_st_buffer(file);
 }
 
 fn test_haversine(file: &mut impl Write) {
@@ -1009,6 +1018,114 @@ fn test_st_hilbert(file: &mut impl Write) {
     run_ast(
         file,
         "ST_HILBERT(TO_GEOMETRY('POINT(0.75 0.75)'), [0, 0, 1, 1])",
+        &[],
+    );
+}
+
+fn test_st_simplify(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 1, 2 1)'), 0.5))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))'), 0.6))",
+        &[],
+    );
+}
+
+fn test_st_isvalid(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))'))",
+        &[],
+    );
+}
+
+fn test_st_covers(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(1 1)'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(5 5)'))",
+        &[],
+    );
+}
+
+fn test_st_coveredby(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_COVEREDBY(TO_GEOMETRY('POINT(1 1)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_COVEREDBY(TO_GEOMETRY('POINT(5 5)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))",
+        &[],
+    );
+}
+
+fn test_st_perimeter(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_PERIMETER(TO_GEOMETRY('POLYGON((0 0, 0 3, 4 3, 4 0, 0 0))'))",
+        &[],
+    );
+    run_ast(file, "ST_PERIMETER(TO_GEOMETRY('POINT(1 1)'))", &[]);
+}
+
+fn test_st_azimuth(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 0)'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 1)'))",
+        &[],
+    );
+}
+
+fn test_st_hausdorffdistance(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_HAUSDORFFDISTANCE(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(0 1)'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_HAUSDORFFDISTANCE(TO_GEOMETRY('LINESTRING(0 0, 1 0)'), TO_GEOMETRY('LINESTRING(0 1, 1 1)'))",
+        &[],
+    );
+}
+
+fn test_st_makepolygonoriented(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_ASWKT(ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 2, 0 2, 0 0)')))",
+        &[],
+    );
+}
+
+fn test_st_buffer(file: &mut impl Write) {
+    run_ast(
+        file,
+        "ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 1) IS NOT NULL",
+        &[],
+    );
+    run_ast(
+        file,
+        "ST_ASWKT(ST_BUFFER(TO_GEOMETRY('POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))'), 0))",
         &[],
     );
 }

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -3879,12 +3879,20 @@ Functions overloads:
 1 st_aswkt(Geometry NULL) :: String NULL
 2 st_aswkt(Geography) :: String
 3 st_aswkt(Geography NULL) :: String NULL
+0 st_azimuth(Geometry, Geometry) :: Float64 NULL
+1 st_azimuth(Geometry NULL, Geometry NULL) :: Float64 NULL
+0 st_buffer(Geometry, Float64) :: Geometry NULL
+1 st_buffer(Geometry NULL, Float64 NULL) :: Geometry NULL
 0 st_centroid(Geometry) :: Geometry NULL
 1 st_centroid(Geometry NULL) :: Geometry NULL
 0 st_contains(Geometry, Geometry) :: Boolean
 1 st_contains(Geometry NULL, Geometry NULL) :: Boolean NULL
 0 st_convexhull(Geometry) :: Geometry
 1 st_convexhull(Geometry NULL) :: Geometry NULL
+0 st_coveredby(Geometry, Geometry) :: Boolean
+1 st_coveredby(Geometry NULL, Geometry NULL) :: Boolean NULL
+0 st_covers(Geometry, Geometry) :: Boolean
+1 st_covers(Geometry NULL, Geometry NULL) :: Boolean NULL
 0 st_difference(Geometry, Geometry) :: Geometry NULL
 1 st_difference(Geometry NULL, Geometry NULL) :: Geometry NULL
 0 st_dimension(Geometry) :: Int32 NULL
@@ -3941,6 +3949,8 @@ Functions overloads:
 1 st_geomfromgeohash(String NULL) :: Geometry NULL
 0 st_geompointfromgeohash(String) :: Geometry
 1 st_geompointfromgeohash(String NULL) :: Geometry NULL
+0 st_hausdorffdistance(Geometry, Geometry) :: Float64
+1 st_hausdorffdistance(Geometry NULL, Geometry NULL) :: Float64 NULL
 0 st_hilbert(Geometry) :: UInt64 NULL
 1 st_hilbert(Geometry NULL) :: UInt64 NULL
 2 st_hilbert(Geometry, Array(Float64)) :: UInt64 NULL
@@ -3953,6 +3963,8 @@ Functions overloads:
 1 st_intersection(Geometry NULL, Geometry NULL) :: Geometry NULL
 0 st_intersects(Geometry, Geometry) :: Boolean
 1 st_intersects(Geometry NULL, Geometry NULL) :: Boolean NULL
+0 st_isvalid(Geometry) :: Boolean
+1 st_isvalid(Geometry NULL) :: Boolean NULL
 0 st_length(Geometry) :: Float64
 1 st_length(Geometry NULL) :: Float64 NULL
 2 st_length(Geography) :: Float64
@@ -3969,16 +3981,22 @@ Functions overloads:
 1 st_makepolygon(Geometry NULL) :: Geometry NULL
 2 st_makepolygon(Geography) :: Geography
 3 st_makepolygon(Geography NULL) :: Geography NULL
+0 st_makepolygonoriented(Geometry) :: Geometry
+1 st_makepolygonoriented(Geometry NULL) :: Geometry NULL
 0 st_npoints(Geometry) :: UInt32
 1 st_npoints(Geometry NULL) :: UInt32 NULL
 2 st_npoints(Geography) :: UInt32
 3 st_npoints(Geography NULL) :: UInt32 NULL
+0 st_perimeter(Geometry) :: Float64
+1 st_perimeter(Geometry NULL) :: Float64 NULL
 0 st_pointn(Geometry, Int32) :: Geometry NULL
 1 st_pointn(Geometry NULL, Int32 NULL) :: Geometry NULL
 2 st_pointn(Geography, Int32) :: Geography NULL
 3 st_pointn(Geography NULL, Int32 NULL) :: Geography NULL
 0 st_setsrid(Geometry, Int32) :: Geometry
 1 st_setsrid(Geometry NULL, Int32 NULL) :: Geometry NULL
+0 st_simplify(Geometry, Float64) :: Geometry
+1 st_simplify(Geometry NULL, Float64 NULL) :: Geometry NULL
 0 st_srid(Geometry) :: Int32
 1 st_srid(Geometry NULL) :: Int32 NULL
 2 st_srid(Geography) :: Int32

--- a/src/query/functions/tests/it/scalars/testdata/geometry.txt
+++ b/src/query/functions/tests/it/scalars/testdata/geometry.txt
@@ -1802,3 +1802,156 @@ output domain  : {2326440618..=2326440618}
 output         : 2326440618
 
 
+ast            : ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 1, 2 1)'), 0.5))
+raw expr       : ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 1, 2 1)'), 0.5))
+checked expr   : st_aswkt<Geometry>(st_simplify<Geometry, Float64>(CAST<String>("LINESTRING(0 0, 1 0, 1 1, 2 1)" AS Geometry), CAST<Decimal(1, 1)>(0.5_d64(1,1) AS Float64)))
+optimized expr : "LINESTRING(0 0,2 1)"
+output type    : String
+output domain  : {"LINESTRING(0 0,2 1)"..="LINESTRING(0 0,2 1)"}
+output         : 'LINESTRING(0 0,2 1)'
+
+
+ast            : ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))'), 0.6))
+raw expr       : ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))'), 0.6))
+checked expr   : st_aswkt<Geometry>(st_simplify<Geometry, Float64>(CAST<String>("POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))" AS Geometry), CAST<Decimal(1, 1)>(0.6_d64(1,1) AS Float64)))
+optimized expr : "POLYGON((0 0,1 0,1 1,0 1,0 0))"
+output type    : String
+output domain  : {"POLYGON((0 0,1 0,1 1,0 1,0 0))"..="POLYGON((0 0,1 0,1 1,0 1,0 0))"}
+output         : 'POLYGON((0 0,1 0,1 1,0 1,0 0))'
+
+
+ast            : ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'))
+raw expr       : ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'))
+checked expr   : st_isvalid<Geometry>(CAST<String>("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))" AS Geometry))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))'))
+raw expr       : ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))'))
+checked expr   : st_isvalid<Geometry>(CAST<String>("POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))" AS Geometry))
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
+
+
+ast            : ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(1 1)'))
+raw expr       : ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(1 1)'))
+checked expr   : st_covers<Geometry, Geometry>(CAST<String>("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))" AS Geometry), CAST<String>("POINT(1 1)" AS Geometry))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(5 5)'))
+raw expr       : ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(5 5)'))
+checked expr   : st_covers<Geometry, Geometry>(CAST<String>("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))" AS Geometry), CAST<String>("POINT(5 5)" AS Geometry))
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
+
+
+ast            : ST_COVEREDBY(TO_GEOMETRY('POINT(1 1)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))
+raw expr       : ST_COVEREDBY(TO_GEOMETRY('POINT(1 1)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))
+checked expr   : st_coveredby<Geometry, Geometry>(CAST<String>("POINT(1 1)" AS Geometry), CAST<String>("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))" AS Geometry))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : ST_COVEREDBY(TO_GEOMETRY('POINT(5 5)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))
+raw expr       : ST_COVEREDBY(TO_GEOMETRY('POINT(5 5)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'))
+checked expr   : st_coveredby<Geometry, Geometry>(CAST<String>("POINT(5 5)" AS Geometry), CAST<String>("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))" AS Geometry))
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
+
+
+ast            : ST_PERIMETER(TO_GEOMETRY('POLYGON((0 0, 0 3, 4 3, 4 0, 0 0))'))
+raw expr       : ST_PERIMETER(TO_GEOMETRY('POLYGON((0 0, 0 3, 4 3, 4 0, 0 0))'))
+checked expr   : st_perimeter<Geometry>(CAST<String>("POLYGON((0 0, 0 3, 4 3, 4 0, 0 0))" AS Geometry))
+optimized expr : 14_f64
+output type    : Float64
+output domain  : {14..=14}
+output         : 14
+
+
+ast            : ST_PERIMETER(TO_GEOMETRY('POINT(1 1)'))
+raw expr       : ST_PERIMETER(TO_GEOMETRY('POINT(1 1)'))
+checked expr   : st_perimeter<Geometry>(CAST<String>("POINT(1 1)" AS Geometry))
+optimized expr : 0_f64
+output type    : Float64
+output domain  : {0..=0}
+output         : 0
+
+
+ast            : ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 0)'))
+raw expr       : ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 0)'))
+checked expr   : st_azimuth<Geometry, Geometry>(CAST<String>("POINT(0 0)" AS Geometry), CAST<String>("POINT(1 0)" AS Geometry))
+optimized expr : 1.570796327_f64
+output type    : Float64 NULL
+output domain  : {1.570796327..=1.570796327}
+output         : 1.570796327
+
+
+ast            : ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 1)'))
+raw expr       : ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 1)'))
+checked expr   : st_azimuth<Geometry, Geometry>(CAST<String>("POINT(0 0)" AS Geometry), CAST<String>("POINT(1 1)" AS Geometry))
+optimized expr : 0.785398163_f64
+output type    : Float64 NULL
+output domain  : {0.785398163..=0.785398163}
+output         : 0.785398163
+
+
+ast            : ST_HAUSDORFFDISTANCE(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(0 1)'))
+raw expr       : ST_HAUSDORFFDISTANCE(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(0 1)'))
+checked expr   : st_hausdorffdistance<Geometry, Geometry>(CAST<String>("POINT(0 0)" AS Geometry), CAST<String>("POINT(0 1)" AS Geometry))
+optimized expr : 1_f64
+output type    : Float64
+output domain  : {1..=1}
+output         : 1
+
+
+ast            : ST_HAUSDORFFDISTANCE(TO_GEOMETRY('LINESTRING(0 0, 1 0)'), TO_GEOMETRY('LINESTRING(0 1, 1 1)'))
+raw expr       : ST_HAUSDORFFDISTANCE(TO_GEOMETRY('LINESTRING(0 0, 1 0)'), TO_GEOMETRY('LINESTRING(0 1, 1 1)'))
+checked expr   : st_hausdorffdistance<Geometry, Geometry>(CAST<String>("LINESTRING(0 0, 1 0)" AS Geometry), CAST<String>("LINESTRING(0 1, 1 1)" AS Geometry))
+optimized expr : 1_f64
+output type    : Float64
+output domain  : {1..=1}
+output         : 1
+
+
+ast            : ST_ASWKT(ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 2, 0 2, 0 0)')))
+raw expr       : ST_ASWKT(ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 2, 0 2, 0 0)')))
+checked expr   : st_aswkt<Geometry>(st_makepolygonoriented<Geometry>(CAST<String>("LINESTRING(0 0, 1 0, 1 2, 0 2, 0 0)" AS Geometry)))
+optimized expr : "POLYGON((0 0,1 0,1 2,0 2,0 0))"
+output type    : String
+output domain  : {"POLYGON((0 0,1 0,1 2,0 2,0 0))"..="POLYGON((0 0,1 0,1 2,0 2,0 0))"}
+output         : 'POLYGON((0 0,1 0,1 2,0 2,0 0))'
+
+
+ast            : ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 1) IS NOT NULL
+raw expr       : is_not_null(ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 1))
+checked expr   : is_not_null<T0=Geometry><T0 NULL>(st_buffer<Geometry, Float64>(CAST<String>("POINT(0 0)" AS Geometry), CAST<UInt8>(1_u8 AS Float64)))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : ST_ASWKT(ST_BUFFER(TO_GEOMETRY('POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))'), 0))
+raw expr       : ST_ASWKT(ST_BUFFER(TO_GEOMETRY('POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))'), 0))
+checked expr   : st_aswkt<Geometry NULL>(st_buffer<Geometry, Float64>(CAST<String>("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))" AS Geometry), CAST<UInt8>(0_u8 AS Float64)))
+optimized expr : "MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)))"
+output type    : String NULL
+output domain  : {"MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)))"..="MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)))"}
+output         : 'MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)))'
+
+

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -879,29 +879,35 @@ impl<'a> TypeChecker<'a> {
                             .scalar;
                         new_params.push(constant);
                     }
+
                     let in_window = self.in_window_function;
                     self.in_window_function = self.in_window_function || window.is_some();
                     let in_aggregate_function = self.in_aggregate_function;
-                    let (new_agg_func, data_type) = self.resolve_aggregate_function(
+                    let agg_result = self.resolve_aggregate_function(
                         *span, func_name, expr, *distinct, new_params, &args, order_by,
-                    )?;
+                    );
                     self.in_window_function = in_window;
                     self.in_aggregate_function = in_aggregate_function;
-                    if let Some(window) = window {
-                        // aggregate window function
-                        let display_name = format!("{:#}", expr);
-                        if window.ignore_nulls.is_some() {
-                            return Err(ErrorCode::SemanticError(format!(
-                                "window function {func_name} not support IGNORE/RESPECT NULLS option"
-                            ))
-                                .set_span(*span));
+                    match agg_result {
+                        Ok((new_agg_func, data_type)) => {
+                            if let Some(window) = window {
+                                // aggregate window function
+                                let display_name = format!("{:#}", expr);
+                                if window.ignore_nulls.is_some() {
+                                    return Err(ErrorCode::SemanticError(format!(
+                                        "window function {func_name} not support IGNORE/RESPECT NULLS option"
+                                    ))
+                                        .set_span(*span));
+                                }
+                                // general window function
+                                let func = WindowFuncType::Aggregate(new_agg_func);
+                                self.resolve_window(*span, display_name, &window.window, func)
+                            } else {
+                                // aggregate function
+                                Ok(Box::new((new_agg_func.into(), data_type)))
+                            }
                         }
-                        // general window function
-                        let func = WindowFuncType::Aggregate(new_agg_func);
-                        self.resolve_window(*span, display_name, &window.window, func)
-                    } else {
-                        // aggregate function
-                        Ok(Box::new((new_agg_func.into(), data_type)))
+                        Err(e) => Err(e),
                     }
                 } else if GENERAL_LAMBDA_FUNCTIONS.contains(&uni_case_func_name) {
                     if lambda.is_none() {

--- a/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
+++ b/tests/sqllogictests/suites/query/functions/02_0060_function_geometry.test
@@ -857,3 +857,402 @@ DROP TABLE collect_test;
 
 statement ok
 DROP TABLE IF EXISTS t1;
+
+## ST_SIMPLIFY
+
+query T
+SELECT ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(1100 1100, 2500 2100, 3100 3100, 4900 1100, 3100 1900)'), 500));
+----
+LINESTRING(1100 1100,3100 3100,4900 1100,3100 1900)
+
+query T
+SELECT ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 1, 2 1)'), 0.5));
+----
+LINESTRING(0 0,2 1)
+
+query T
+SELECT ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 1, 2 1)'), 1.5));
+----
+LINESTRING(0 0,2 1)
+
+query T
+SELECT ST_ASWKT(ST_SIMPLIFY(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))'), 0.6));
+----
+POLYGON((0 0,1 0,1 1,0 1,0 0))
+
+statement error
+SELECT ST_SIMPLIFY(TO_GEOMETRY('GEOMETRYCOLLECTION(POINT(0 0))'), 1);
+
+## ST_ISVALID
+
+query B
+SELECT ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'));
+----
+1
+
+query B
+SELECT ST_ISVALID(TO_GEOMETRY('POINT(1 2)'));
+----
+1
+
+query B
+SELECT ST_ISVALID(TO_GEOMETRY('LINESTRING(0 0, 1 1, 2 2)'));
+----
+1
+
+query B
+SELECT ST_ISVALID(TO_GEOMETRY('POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))'));
+----
+0
+
+## ST_COVERS
+
+query BBBB
+SELECT ST_COVERS(poly, poly_inside),
+       ST_COVERS(poly, poly),
+       ST_COVERS(poly, line_on_boundary),
+       ST_COVERS(poly, line_inside)
+FROM (SELECT TO_GEOMETRY('POLYGON((-2 0, 0 2, 2 0, -2 0))') AS poly,
+             TO_GEOMETRY('POLYGON((-1 0, 0 1, 1 0, -1 0))') AS poly_inside,
+             TO_GEOMETRY('LINESTRING(-1 1, 0 2, 1 1)') AS line_on_boundary,
+             TO_GEOMETRY('LINESTRING(-2 0, 0 0, 0 1)') AS line_inside);
+----
+1 1 1 1
+
+query B
+SELECT ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(1 1)'));
+----
+1
+
+query B
+SELECT ST_COVERS(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POINT(5 5)'));
+----
+0
+
+## ST_COVEREDBY
+
+query B
+SELECT ST_COVEREDBY(TO_GEOMETRY('POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'));
+----
+1
+
+query B
+SELECT ST_COVEREDBY(TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'), TO_GEOMETRY('POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))'));
+----
+0
+
+query B
+SELECT ST_COVEREDBY(TO_GEOMETRY('POINT(1 1)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'));
+----
+1
+
+query B
+SELECT ST_COVEREDBY(TO_GEOMETRY('POINT(5 5)'), TO_GEOMETRY('POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))'));
+----
+0
+
+## ST_PERIMETER
+
+query R
+SELECT ST_PERIMETER(TO_GEOMETRY('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'));
+----
+4.0
+
+query R
+SELECT ST_PERIMETER(TO_GEOMETRY('POINT(1 1)'));
+----
+0.0
+
+query R
+SELECT ST_PERIMETER(TO_GEOMETRY('LINESTRING(0 0, 1 1)'));
+----
+0.0
+
+query R
+SELECT ST_PERIMETER(TO_GEOMETRY('POLYGON((0 0, 0 3, 4 3, 4 0, 0 0))'));
+----
+14.0
+
+## ST_AZIMUTH
+
+query R
+SELECT ST_AZIMUTH(TO_GEOMETRY('POINT(0 1)'), TO_GEOMETRY('POINT(0 0)'));
+----
+3.141592654
+
+query R
+SELECT ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 0)'));
+----
+1.570796327
+
+query R
+SELECT ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(0 1)'));
+----
+0.0
+
+query R
+SELECT ST_AZIMUTH(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(1 1)'));
+----
+0.785398163
+
+statement error
+SELECT ST_AZIMUTH(TO_GEOMETRY('LINESTRING(0 0, 1 1)'), TO_GEOMETRY('POINT(0 0)'));
+
+## ST_HAUSDORFFDISTANCE
+
+query R
+SELECT ST_HAUSDORFFDISTANCE(TO_GEOMETRY('POINT(0 0)'), TO_GEOMETRY('POINT(0 1)'));
+----
+1.0
+
+query R
+SELECT ST_HAUSDORFFDISTANCE(TO_GEOMETRY('LINESTRING(0 0, 1 0)'), TO_GEOMETRY('LINESTRING(0 1, 1 1)'));
+----
+1.0
+
+query R
+SELECT ST_HAUSDORFFDISTANCE(TO_GEOMETRY('LINESTRING(0 0, 1 0, 2 0)'), TO_GEOMETRY('LINESTRING(0 1, 1 1, 2 1)'));
+----
+1.0
+
+query R
+SELECT ST_HAUSDORFFDISTANCE(TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'), TO_GEOMETRY('POLYGON((2 0, 3 0, 3 1, 2 1, 2 0))'));
+----
+2.0
+
+## ST_MAKEPOLYGONORIENTED
+
+query T
+SELECT ST_ASWKT(ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 0, 1 2, 0 2, 0 0)')));
+----
+POLYGON((0 0,1 0,1 2,0 2,0 0))
+
+query T
+SELECT ST_ASWKT(ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 0 2, 1 2, 1 0, 0 0)')));
+----
+POLYGON((0 0,0 2,1 2,1 0,0 0))
+
+statement error
+SELECT ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 0, 0 1)'));
+
+statement error
+SELECT ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('POINT(0 0)'));
+
+statement error
+SELECT ST_MAKEPOLYGONORIENTED(TO_GEOMETRY('LINESTRING(0 0, 1 1, 1 0, 0 1, 0 0)'));
+
+## ST_BUFFER
+
+# Point: positive and negative distance return equivalent shape
+query B
+SELECT ST_EQUALS(
+  ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 1),
+  ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), -1)
+);
+----
+1
+
+# Point: zero distance returns NULL
+query T
+SELECT ST_ASWKT(ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 0));
+----
+NULL
+
+# Point buffer area close to pi * r^2 (32-gon approximation, expect ~0.6% error)
+query B
+SELECT ABS(ST_AREA(ST_BUFFER(TO_GEOMETRY('POINT(0 0)'), 1)) - 3.14159) < 0.05;
+----
+1
+
+# LineString: negative distance equals positive distance (Snowflake alignment)
+query B
+SELECT ST_EQUALS(
+  ST_BUFFER(TO_GEOMETRY('LINESTRING(0 0, 2 0)'), 0.5),
+  ST_BUFFER(TO_GEOMETRY('LINESTRING(0 0, 2 0)'), -0.5)
+);
+----
+1
+
+# LineString: zero distance returns NULL
+query T
+SELECT ST_ASWKT(ST_BUFFER(TO_GEOMETRY('LINESTRING(0 0, 2 0)'), 0));
+----
+NULL
+
+# Polygon: positive distance inflates
+query B
+SELECT ST_AREA(ST_BUFFER(
+  TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'),
+  0.5
+)) > ST_AREA(TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'));
+----
+1
+
+# Polygon: negative distance deflates
+query B
+SELECT ST_AREA(ST_BUFFER(
+  TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'),
+  -0.5
+)) < ST_AREA(TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'));
+----
+1
+
+# Polygon: zero distance returns original polygon wrapped as MultiPolygon
+query B
+SELECT ST_EQUALS(
+  ST_BUFFER(TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'), 0),
+  TO_GEOMETRY('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))')
+);
+----
+1
+
+# Polygon: negative distance shrinking past zero area returns NULL
+query T
+SELECT ST_ASWKT(ST_BUFFER(
+  TO_GEOMETRY('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'),
+  -1
+));
+----
+NULL
+
+# MultiPoint: abs(distance)
+query B
+SELECT ST_EQUALS(
+  ST_BUFFER(TO_GEOMETRY('MULTIPOINT(0 0, 2 0)'), 0.5),
+  ST_BUFFER(TO_GEOMETRY('MULTIPOINT(0 0, 2 0)'), -0.5)
+);
+----
+1
+
+# MultiLineString: abs(distance)
+query B
+SELECT ST_EQUALS(
+  ST_BUFFER(TO_GEOMETRY('MULTILINESTRING((0 0, 2 0), (0 2, 2 2))'), 0.5),
+  ST_BUFFER(TO_GEOMETRY('MULTILINESTRING((0 0, 2 0), (0 2, 2 2))'), -0.5)
+);
+----
+1
+
+# GeometryCollection: unsupported
+statement error
+SELECT ST_BUFFER(
+  TO_GEOMETRY('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(2 0, 4 0))'),
+  0.5
+);
+
+# SRID preservation
+query I
+SELECT ST_SRID(ST_BUFFER(ST_GEOMETRYFROMWKT('POINT(0 0)', 4326), 1));
+----
+4326
+
+## Column-level (batch) tests
+
+statement ok
+CREATE OR REPLACE TABLE geom_batch (id INT, g GEOMETRY);
+
+statement ok
+INSERT INTO geom_batch VALUES
+    (1, 'POINT(0 0)'),
+    (2, 'LINESTRING(0 0, 1 0, 1 1, 2 1)'),
+    (3, 'POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'),
+    (4, 'POLYGON((0 0, 1 0, 1 1, 0.5 0.5, 0 1, 0 0))'),
+    (5, 'MULTIPOINT(0 0, 2 0, 4 0)');
+
+# ST_ISVALID on a column
+query IB
+SELECT id, ST_ISVALID(g) FROM geom_batch ORDER BY id;
+----
+1 1
+2 1
+3 1
+4 1
+5 1
+
+# ST_PERIMETER on a column
+query IR
+SELECT id, ST_PERIMETER(g) FROM geom_batch ORDER BY id;
+----
+1 0.0
+2 0.0
+3 16.0
+4 4.414213562
+5 0.0
+
+# ST_SIMPLIFY on a column (tolerance 0.5)
+query IT
+SELECT id, ST_ASWKT(ST_SIMPLIFY(g, 0.5)) FROM geom_batch WHERE id IN (2, 4) ORDER BY id;
+----
+2 LINESTRING(0 0,2 1)
+4 POLYGON((0 0,1 0,1 1,0 1,0 0))
+
+# ST_BUFFER on a column: positive distance always produces non-null MultiPolygon
+query IB
+SELECT id, ST_BUFFER(g, 0.5) IS NOT NULL FROM geom_batch ORDER BY id;
+----
+1 1
+2 1
+3 1
+4 1
+5 1
+
+# ST_BUFFER on a column: negative distance
+# Points/Lines use abs(distance); polygons shrink
+query IB
+SELECT id, ST_BUFFER(g, -0.5) IS NOT NULL FROM geom_batch WHERE id IN (1, 2, 3, 5) ORDER BY id;
+----
+1 1
+2 1
+3 1
+5 1
+
+# ST_MAKEPOLYGONORIENTED on a column
+statement ok
+CREATE OR REPLACE TABLE ring_batch (id INT, g GEOMETRY);
+
+statement ok
+INSERT INTO ring_batch VALUES
+    (1, 'LINESTRING(0 0, 1 0, 1 1, 0 1, 0 0)'),
+    (2, 'LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)'),
+    (3, 'LINESTRING(0 0, 2 0, 2 2, 0 2, 0 0)');
+
+query IT
+SELECT id, ST_ASWKT(ST_MAKEPOLYGONORIENTED(g)) FROM ring_batch ORDER BY id;
+----
+1 POLYGON((0 0,1 0,1 1,0 1,0 0))
+2 POLYGON((0 0,0 1,1 1,1 0,0 0))
+3 POLYGON((0 0,2 0,2 2,0 2,0 0))
+
+statement ok
+CREATE OR REPLACE TABLE pair_batch (id INT, g1 GEOMETRY, g2 GEOMETRY);
+
+statement ok
+INSERT INTO pair_batch VALUES
+    (1, 'POINT(0 0)', 'POINT(1 1)'),
+    (2, 'LINESTRING(0 0, 1 1)', 'LINESTRING(2 2, 3 3)'),
+    (3, 'POINT(5 5)', 'LINESTRING(6 6, 7 7)');
+
+# ST_COVERS / ST_COVEREDBY on columns
+query IBB
+SELECT id, ST_COVERS(g1, g2), ST_COVEREDBY(g2, g1) FROM pair_batch ORDER BY id;
+----
+1 0 0
+2 0 0
+3 0 0
+
+# ST_HAUSDORFFDISTANCE on columns
+query IR
+SELECT id, ST_HAUSDORFFDISTANCE(g1, g2) FROM pair_batch ORDER BY id;
+----
+1 1.414213562
+2 2.828427125
+3 2.828427125
+
+statement ok
+DROP TABLE geom_batch;
+
+statement ok
+DROP TABLE ring_batch;
+
+statement ok
+DROP TABLE pair_batch;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  Add geometry scalar functions, including
  ST_SIMPLIFY, ST_ISVALID, ST_COVERS, ST_COVEREDBY, ST_PERIMETER,
  ST_AZIMUTH, ST_HAUSDORFFDISTANCE, ST_MAKEPOLYGONORIENTED and ST_BUFFER.


- fixes: #19821

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19847)
<!-- Reviewable:end -->
