### PR TITLE
fix(stage): estimate parquet stage rows

### DIFF
--- a/src/common/storage/src/stage.rs
+++ b/src/common/storage/src/stage.rs
@@ -83,6 +83,12 @@ impl StageFileInfo {
                 .unwrap_or(format!("{}/{last_modified}/{}", self.path, self.size))
         }
     }
+
+    pub fn object_identity_key(&self) -> Option<String> {
+        // Do not fall back to path/last_modified/size for cache keys that
+        // must not survive object replacement.
+        self.md5.clone().or_else(|| self.etag.clone())
+    }
 }
 
 pub fn init_stage_operator(stage_info: &StageInfo) -> Result<Operator> {

--- a/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
@@ -71,6 +71,8 @@ pub struct ParquetTableInfo {
     pub schema_from: String,
     pub compression_ratio: f64,
     pub leaf_fields: Arc<Vec<TableField>>,
+    pub first_file: StageFileInfo,
+    pub first_file_num_rows: u64,
 
     #[serde(skip)]
     pub need_stats_provider: bool,
@@ -131,6 +133,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::Schema as ArrowSchema;
+    use databend_common_storage::StageFileInfo;
     use databend_common_storage::StageFilesInfo;
     use parquet::basic::ConvertedType;
     use parquet::basic::Repetition;
@@ -206,6 +209,16 @@ mod tests {
                 metadata: Default::default(),
             },
             files_to_read: None,
+            first_file: StageFileInfo {
+                path: "".to_string(),
+                size: 0,
+                md5: None,
+                last_modified: None,
+                etag: None,
+                status: databend_common_storage::StageFileStatus::NeedCopy,
+                creator: None,
+            },
+            first_file_num_rows: 0,
             schema_from: "".to_string(),
             compression_ratio: 0.0,
             need_stats_provider: false,

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -48,10 +48,11 @@ use databend_common_storage::StageFileInfo;
 use databend_common_storage::init_stage_operator;
 use databend_common_storage::parquet::infer_schema_with_extension;
 use databend_common_storages_fuse::FuseTable;
-use databend_common_storages_parquet::read_metas_in_parallel_for_copy;
+use databend_common_storages_parquet::stream_metas_in_parallel_for_copy;
 use databend_query_storage_stage_support::StageTable;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotAccessor;
+use futures::TryStreamExt;
 use itertools::Itertools;
 use log::debug;
 use log::info;
@@ -246,12 +247,13 @@ impl CopyIntoTableInterpreter {
                     .map(|f| (f.path.clone(), f.size))
                     .collect::<Vec<_>>();
                 ctx.set_status_info("[TABLE-SCAN] Infer Parquet Schemas");
-                let metas = read_metas_in_parallel_for_copy(
+                let metas = stream_metas_in_parallel_for_copy(
                     &operator,
-                    &file_infos,
+                    file_infos,
                     max_threads,
                     max_memory_usage,
                 )
+                .try_collect::<Vec<_>>()
                 .await?;
 
                 let case_sensitive = stage_table_info.copy_into_table_options.column_match_mode

--- a/src/query/service/tests/it/parquet_rs/cache.rs
+++ b/src/query/service/tests/it/parquet_rs/cache.rs
@@ -1,0 +1,258 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_catalog::plan::ParquetReadOptions;
+use databend_common_catalog::query_kind::QueryKind;
+use databend_common_catalog::table_context::TableContextSettings;
+use databend_common_meta_app::principal::FileFormatParams;
+use databend_common_meta_app::principal::ParquetFileFormatParams;
+use databend_common_meta_app::principal::StageInfo;
+use databend_common_meta_app::storage::StorageFsConfig;
+use databend_common_meta_app::storage::StorageParams;
+use databend_common_storage::StageFileInfo;
+use databend_common_storage::StageFileStatus;
+use databend_common_storage::StageFilesInfo;
+use databend_common_storages_parquet::ParquetTable;
+use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CacheManager;
+use futures::TryStreamExt;
+use tempfile::TempDir;
+use tokio::fs;
+
+use super::data::Scenario;
+use super::data::make_test_file_rg;
+use super::utils::create_parquet_test_fixture;
+
+const PARQUET_META_CACHE: &str = "memory_cache_parquet_meta_data";
+
+fn reset_parquet_meta_cache() -> databend_common_exception::Result<()> {
+    let cache_manager = CacheManager::instance();
+    cache_manager.set_cache_capacity(PARQUET_META_CACHE, 128)?;
+    if let Some(cache) = cache_manager.get_parquet_meta_data_cache() {
+        cache.clear();
+    }
+    Ok(())
+}
+
+fn parquet_meta_cache_len() -> usize {
+    CacheManager::instance()
+        .get_parquet_meta_data_cache()
+        .map(|cache| cache.len())
+        .unwrap_or_default()
+}
+
+async fn copy_parquet_to_stage_root(
+    file_names: &[&str],
+) -> anyhow::Result<(TempDir, Vec<(String, u64)>)> {
+    let (file, _) = make_test_file_rg(Scenario::Int32).await;
+    let stage_root = tempfile::tempdir()?;
+    let mut files = Vec::with_capacity(file_names.len());
+    for file_name in file_names {
+        let stage_path = stage_root.path().join(file_name);
+        fs::copy(file.path(), &stage_path).await?;
+        let size = fs::metadata(&stage_path).await?.len();
+        files.push((file_name.to_string(), size));
+    }
+    Ok((stage_root, files))
+}
+
+fn fs_stage_info(stage_root: &TempDir) -> StageInfo {
+    let mut stage_info = StageInfo::new_external_stage(
+        StorageParams::Fs(StorageFsConfig {
+            root: stage_root.path().display().to_string(),
+        }),
+        true,
+    );
+    stage_info.file_format_params = FileFormatParams::Parquet(ParquetFileFormatParams::default());
+    stage_info
+}
+
+fn stage_file(path: String, size: u64, md5: Option<String>) -> StageFileInfo {
+    StageFileInfo {
+        path,
+        size,
+        md5,
+        last_modified: None,
+        etag: None,
+        status: StageFileStatus::NeedCopy,
+        creator: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_parquet_metadata_cache_boundaries() -> anyhow::Result<()> {
+    let fixture = create_parquet_test_fixture().await;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_setting(
+        "enable_stage_parquet_table_statistics".to_string(),
+        "0".to_string(),
+    )?;
+
+    reset_parquet_meta_cache()?;
+    let (stage_root, files) =
+        copy_parquet_to_stage_root(&["first.parquet", "second.parquet"]).await?;
+    let (first_file_name, first_file_size) = files[0].clone();
+    let (second_file_name, second_file_size) = files[1].clone();
+    let stage_info = fs_stage_info(&stage_root);
+    let files_info = StageFilesInfo {
+        path: first_file_name.clone(),
+        files: None,
+        pattern: None,
+    };
+
+    // ParquetTable schema inference should not populate the metadata cache if
+    // the stage file only has the weak path/mtime/size fallback identity.
+    let weak_table = ParquetTable::create(
+        ctx.as_ref(),
+        stage_info.clone(),
+        files_info.clone(),
+        ParquetReadOptions::default(),
+        Some(vec![
+            stage_file(first_file_name.clone(), first_file_size, None),
+            stage_file(second_file_name.clone(), second_file_size, None),
+        ]),
+        ctx.get_settings(),
+        QueryKind::Query,
+        &ParquetFileFormatParams::default(),
+    )
+    .await?;
+    assert_eq!(0, parquet_meta_cache_len());
+
+    // The single-file ParquetTable path can answer from the footer already
+    // read during schema inference, without enabling extra planning-time
+    // footer scans or populating cache when only weak identity is available.
+    let weak_single_table = ParquetTable::create(
+        ctx.as_ref(),
+        stage_info.clone(),
+        files_info.clone(),
+        ParquetReadOptions::default(),
+        Some(vec![stage_file(
+            first_file_name.clone(),
+            first_file_size,
+            None,
+        )]),
+        ctx.get_settings(),
+        QueryKind::Query,
+        &ParquetFileFormatParams::default(),
+    )
+    .await?;
+    reset_parquet_meta_cache()?;
+    let weak_single_statistics = weak_single_table
+        .table_statistics(ctx.clone(), false, None)
+        .await?
+        .unwrap();
+    assert_eq!(Some(20), weak_single_statistics.num_rows);
+    assert_eq!(0, parquet_meta_cache_len());
+
+    // With a strong object identity, ParquetTable can cache the already-read
+    // first footer so ParquetSource can reuse it later.
+    let strong_file = stage_file(
+        first_file_name.clone(),
+        first_file_size,
+        Some("first-md5".to_string()),
+    );
+    let _ = ParquetTable::create(
+        ctx.as_ref(),
+        stage_info.clone(),
+        files_info.clone(),
+        ParquetReadOptions::default(),
+        Some(vec![strong_file]),
+        ctx.get_settings(),
+        QueryKind::Query,
+        &ParquetFileFormatParams::default(),
+    )
+    .await?;
+    assert_eq!(1, parquet_meta_cache_len());
+
+    reset_parquet_meta_cache()?;
+    let disabled_statistics = weak_table
+        .table_statistics(ctx.clone(), false, None)
+        .await?;
+    assert!(disabled_statistics.is_none());
+    assert_eq!(0, parquet_meta_cache_len());
+
+    ctx.get_settings().set_setting(
+        "enable_stage_parquet_table_statistics".to_string(),
+        "1".to_string(),
+    )?;
+
+    // ParquetTable table_statistics reads full footers when gated, but still
+    // avoids cache population if only weak fallback identity is available.
+    reset_parquet_meta_cache()?;
+    let weak_statistics = weak_table
+        .table_statistics(ctx.clone(), false, None)
+        .await?
+        .unwrap();
+    assert_eq!(Some(40), weak_statistics.num_rows);
+    assert_eq!(0, parquet_meta_cache_len());
+
+    // With strong object identities, ParquetTable table_statistics populates
+    // the metadata cache while collecting exact row counts.
+    reset_parquet_meta_cache()?;
+    let strong_table = ParquetTable::create(
+        ctx.as_ref(),
+        stage_info,
+        files_info,
+        ParquetReadOptions::default(),
+        Some(vec![
+            stage_file(
+                first_file_name.clone(),
+                first_file_size,
+                Some("first-md5".to_string()),
+            ),
+            stage_file(
+                second_file_name,
+                second_file_size,
+                Some("second-md5".to_string()),
+            ),
+        ]),
+        ctx.get_settings(),
+        QueryKind::Query,
+        &ParquetFileFormatParams::default(),
+    )
+    .await?;
+    reset_parquet_meta_cache()?;
+    let strong_statistics = strong_table
+        .table_statistics(ctx.clone(), false, None)
+        .await?
+        .unwrap();
+    assert_eq!(Some(40), strong_statistics.num_rows);
+    assert_eq!(2, parquet_meta_cache_len());
+
+    // ParquetSource small-file path reads the whole file and should not touch
+    // the parquet metadata cache.
+    reset_parquet_meta_cache()?;
+    let (file, _) = make_test_file_rg(Scenario::Int32).await;
+    let file_path = file.path().to_string_lossy();
+    let stream = fixture
+        .execute_query(&format!(
+            "select /*+ set_var(parquet_fast_read_bytes=104857600) */ sum(i) from 'fs://{file_path}'"
+        ))
+        .await?;
+    stream.try_collect::<Vec<_>>().await?;
+    assert_eq!(0, parquet_meta_cache_len());
+
+    // For a normal ParquetSource File part, source execution reads the footer
+    // through read_metadata_async_cached and should populate the cache.
+    reset_parquet_meta_cache()?;
+    let stream = fixture
+        .execute_query(&format!(
+            "select /*+ set_var(parquet_fast_read_bytes=0) */ sum(i) from 'fs://{file_path}'"
+        ))
+        .await?;
+    stream.try_collect::<Vec<_>>().await?;
+    assert_eq!(1, parquet_meta_cache_len());
+
+    Ok(())
+}

--- a/src/query/service/tests/it/parquet_rs/mod.rs
+++ b/src/query/service/tests/it/parquet_rs/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cache;
 mod data;
 mod prune_pages;
 mod prune_row_groups;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -828,6 +828,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(1024 * 1024..=u64::MAX)),
                 }),
+                ("enable_stage_parquet_table_statistics", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Enable exact table statistics for parquet stage scans by reading parquet footer metadata. Disabled by default to avoid planning-time object-store IO.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 // enterprise license related settings
                 ("enterprise_license", DefaultSettingValue {
                     value: UserSettingValue::String("".to_owned()),

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -623,6 +623,10 @@ impl Settings {
         self.try_get_u64("parquet_rowgroup_hint_bytes")
     }
 
+    pub fn get_enable_stage_parquet_table_statistics(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_stage_parquet_table_statistics")? != 0)
+    }
+
     pub fn get_enable_table_lock(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_table_lock")? != 0)
     }

--- a/src/query/storages/parquet/src/copy_into_table/table.rs
+++ b/src/query/storages/parquet/src/copy_into_table/table.rs
@@ -32,12 +32,13 @@ use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_storage::FileStatus;
 use databend_common_storage::init_stage_operator;
+use futures::TryStreamExt;
 use parquet::file::metadata::FileMetaData;
 
 use crate::ParquetPart;
 use crate::copy_into_table::reader::RowGroupReaderForCopy;
 use crate::copy_into_table::source::ParquetCopySource;
-use crate::meta::read_metas_in_parallel_for_copy;
+use crate::meta::stream_metas_in_parallel_for_copy;
 use crate::partition::ParquetRowGroupPart;
 
 pub struct ParquetTableForCopy {}
@@ -67,7 +68,8 @@ impl ParquetTableForCopy {
             let max_memory_usage = settings.get_max_memory_usage()?;
 
             let operator = init_stage_operator(&stage_table_info.stage_info)?;
-            read_metas_in_parallel_for_copy(&operator, &file_infos, max_threads, max_memory_usage)
+            stream_metas_in_parallel_for_copy(&operator, file_infos, max_threads, max_memory_usage)
+                .try_collect::<Vec<_>>()
                 .await?
         };
 

--- a/src/query/storages/parquet/src/lib.rs
+++ b/src/query/storages/parquet/src/lib.rs
@@ -49,7 +49,8 @@ mod parquet_variant_table;
 mod schema;
 
 pub use copy_into_table::ParquetTableForCopy;
-pub use meta::read_metas_in_parallel_for_copy;
+pub use meta::stream_basic_metas_in_parallel_with_cache;
+pub use meta::stream_metas_in_parallel_for_copy;
 pub use parquet_part::DeleteTask;
 pub use parquet_part::DeleteType;
 pub use parquet_part::ParquetFilePart;

--- a/src/query/storages/parquet/src/meta.rs
+++ b/src/query/storages/parquet/src/meta.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
 use std::intrinsics::unlikely;
 use std::sync::Arc;
 
 use databend_common_base::runtime::GLOBAL_MEM_STAT;
-use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::plan::FullParquetMeta;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -26,12 +26,21 @@ use databend_storages_common_cache::CacheManager;
 use databend_storages_common_cache::InMemoryCacheReader;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_cache::Loader;
+use futures::Stream;
+use futures::StreamExt;
 use opendal::Operator;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::SchemaDescPtr;
 use parquet::schema::types::SchemaDescriptor;
 
 use crate::statistics::collect_row_group_stats;
+
+#[derive(Clone)]
+struct BasicMetaFileInfo {
+    location: String,
+    size: u64,
+    dedup_key: Option<String>,
+}
 
 pub async fn read_metadata_async_cached(
     path: &str,
@@ -51,60 +60,29 @@ pub async fn read_metadata_async_cached(
     reader.read(&load_params).await
 }
 
-#[async_backtrace::framed]
-pub async fn read_metas_in_parallel(
+pub fn stream_metas_in_parallel(
     op: &Operator,
-    file_infos: &[(String, u64, String)],
+    file_infos: Vec<(String, u64, String)>,
     expected: (SchemaDescPtr, String),
     leaf_fields: Arc<Vec<TableField>>,
     num_threads: usize,
     max_memory_usage: u64,
     enable_cache: bool,
-) -> Result<Vec<Arc<FullParquetMeta>>> {
-    if file_infos.is_empty() {
-        return Ok(vec![]);
-    }
-    let num_files = file_infos.len();
-
-    let mut tasks = Vec::with_capacity(num_threads);
-    // Equally distribute the tasks
-    for i in 0..num_threads {
-        let begin = num_files * i / num_threads;
-        let end = num_files * (i + 1) / num_threads;
-        if begin == end {
-            continue;
-        }
-
-        let file_infos = file_infos[begin..end].to_vec();
-        let op = op.clone();
+) -> impl Stream<Item = Result<Arc<FullParquetMeta>>> + Send + 'static {
+    stream_metas_in_parallel_with(file_infos, op, num_threads, move |file_info, op| {
         let (expected_schema, schema_from) = expected.clone();
         let leaf_fields = leaf_fields.clone();
 
-        tasks.push(read_parquet_metas_batch(
-            file_infos,
+        read_parquet_meta(
+            file_info,
             op,
             expected_schema,
             leaf_fields,
             schema_from,
             max_memory_usage,
             enable_cache,
-        ));
-    }
-
-    let metas = execute_futures_in_parallel(
-        tasks,
-        num_threads,
-        num_threads * 2,
-        "read-parquet-metas-worker".to_owned(),
-    )
-    .await?
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-
-    Ok(metas)
+        )
+    })
 }
 
 pub(crate) fn check_parquet_schema(
@@ -125,51 +103,103 @@ pub(crate) fn check_parquet_schema(
     Ok(())
 }
 
-#[async_backtrace::framed]
-pub async fn read_metas_in_parallel_for_copy(
+pub fn stream_metas_in_parallel_for_copy(
     op: &Operator,
-    file_infos: &[(String, u64)],
+    file_infos: Vec<(String, u64)>,
     num_threads: usize,
     max_memory_usage: u64,
-) -> Result<Vec<Arc<FullParquetMeta>>> {
-    if file_infos.is_empty() {
-        return Ok(vec![]);
-    }
-    let num_files = file_infos.len();
-
-    let mut tasks = Vec::with_capacity(num_threads);
-    // Equally distribute the tasks
-    for i in 0..num_threads {
-        let begin = num_files * i / num_threads;
-        let end = num_files * (i + 1) / num_threads;
-        if begin == end {
-            continue;
-        }
-
-        let file_infos = file_infos[begin..end].to_vec();
-        let op = op.clone();
-
-        tasks.push(read_parquet_metas_batch_for_copy(
-            file_infos,
+) -> impl Stream<Item = Result<Arc<FullParquetMeta>>> + Send + 'static {
+    stream_metas_in_parallel_with(file_infos, op, num_threads, move |file_info, op| {
+        let (location, size) = file_info;
+        read_basic_parquet_meta(
+            BasicMetaFileInfo {
+                location,
+                size,
+                // Keep COPY metadata reads uncached. Some object stores may not
+                // provide a strong object identity, and COPY correctness should
+                // not depend on fallback cache keys.
+                dedup_key: None,
+            },
             op,
             max_memory_usage,
-        ));
-    }
+        )
+    })
+}
 
-    let metas = execute_futures_in_parallel(
-        tasks,
-        num_threads,
-        num_threads * 2,
-        "read-parquet-metas-worker".to_owned(),
+pub fn stream_basic_metas_in_parallel_with_cache(
+    op: &Operator,
+    file_infos: Vec<(String, u64, Option<String>)>,
+    num_threads: usize,
+    max_memory_usage: u64,
+) -> impl Stream<Item = Result<Arc<FullParquetMeta>>> + Send + 'static {
+    stream_metas_in_parallel_with(file_infos, op, num_threads, move |file_info, op| {
+        let (location, size, dedup_key) = file_info;
+        read_basic_parquet_meta(
+            BasicMetaFileInfo {
+                location,
+                size,
+                dedup_key,
+            },
+            op,
+            max_memory_usage,
+        )
+    })
+}
+
+fn stream_metas_in_parallel_with<T, F, Fut>(
+    file_infos: Vec<T>,
+    op: &Operator,
+    num_threads: usize,
+    read_meta: F,
+) -> impl Stream<Item = Result<Arc<FullParquetMeta>>> + Send + 'static
+where
+    T: Send + 'static,
+    F: Fn(T, Operator) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<Arc<FullParquetMeta>>>> + Send + 'static,
+{
+    let op = op.clone();
+    futures::stream::iter(file_infos)
+        .map(move |file_info| {
+            let read_meta = read_meta.clone();
+            let op = op.clone();
+            async move { read_meta(file_info, op).await }
+        })
+        .buffer_unordered(num_threads.max(1))
+        .filter_map(|meta| async move { meta.transpose() })
+}
+
+async fn read_parquet_meta(
+    file_info: (String, u64, String),
+    op: Operator,
+    expect: SchemaDescPtr,
+    leaf_fields: Arc<Vec<TableField>>,
+    schema_from: String,
+    max_memory_usage: u64,
+    enable_cache: bool,
+) -> Result<Option<Arc<FullParquetMeta>>> {
+    let (location, size, dedup_key) = file_info;
+    let meta = load_and_check_parquet_meta(
+        &location,
+        size,
+        op,
+        &expect,
+        &schema_from,
+        enable_cache,
+        &dedup_key,
     )
-    .await?
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-
-    Ok(metas)
+    .await?;
+    check_memory_usage(max_memory_usage)?;
+    if unlikely(meta.file_metadata().num_rows() == 0) {
+        // Don't collect empty files
+        return Ok(None);
+    }
+    let stats = collect_row_group_stats(meta.row_groups(), &leaf_fields, None);
+    Ok(Some(Arc::new(FullParquetMeta {
+        location,
+        size,
+        meta,
+        row_group_level_stats: stats,
+    })))
 }
 
 /// Load parquet meta and check if the schema is matched.
@@ -197,65 +227,36 @@ async fn load_and_check_parquet_meta(
     Ok(metadata)
 }
 
-pub async fn read_parquet_metas_batch(
-    file_infos: Vec<(String, u64, String)>,
+async fn read_basic_parquet_meta(
+    file_info: BasicMetaFileInfo,
     op: Operator,
-    expect: SchemaDescPtr,
-    leaf_fields: Arc<Vec<TableField>>,
-    schema_from: String,
     max_memory_usage: u64,
-    enable_cache: bool,
-) -> Result<Vec<Arc<FullParquetMeta>>> {
-    let mut metas = Vec::with_capacity(file_infos.len());
-    for (location, size, dedup_key) in file_infos {
-        let meta = load_and_check_parquet_meta(
-            &location,
-            size,
-            op.clone(),
-            &expect,
-            &schema_from,
-            enable_cache,
-            &dedup_key,
-        )
-        .await?;
-        if unlikely(meta.file_metadata().num_rows() == 0) {
-            // Don't collect empty files
-            continue;
-        }
-        let stats = collect_row_group_stats(meta.row_groups(), &leaf_fields, None);
-        metas.push(Arc::new(FullParquetMeta {
-            location,
-            size,
-            meta,
-            row_group_level_stats: stats,
-        }));
-    }
-
+) -> Result<Option<Arc<FullParquetMeta>>> {
+    let meta = load_basic_parquet_meta_data(&file_info, &op).await?;
     check_memory_usage(max_memory_usage)?;
-    Ok(metas)
+    if unlikely(meta.file_metadata().num_rows() == 0) {
+        // Don't collect empty files
+        return Ok(None);
+    }
+    Ok(Some(Arc::new(FullParquetMeta {
+        location: file_info.location,
+        size: file_info.size,
+        meta,
+        row_group_level_stats: None,
+    })))
 }
 
-pub async fn read_parquet_metas_batch_for_copy(
-    file_infos: Vec<(String, u64)>,
-    op: Operator,
-    max_memory_usage: u64,
-) -> Result<Vec<Arc<FullParquetMeta>>> {
-    let mut metas = Vec::with_capacity(file_infos.len());
-    for (location, size) in file_infos {
-        let meta = Arc::new(read_metadata_async(&location, &op, Some(size)).await?);
-        if unlikely(meta.file_metadata().num_rows() == 0) {
-            // Don't collect empty files
-            continue;
-        }
-        metas.push(Arc::new(FullParquetMeta {
-            location,
-            size,
-            meta,
-            row_group_level_stats: None,
-        }));
+async fn load_basic_parquet_meta_data(
+    file_info: &BasicMetaFileInfo,
+    op: &Operator,
+) -> Result<Arc<ParquetMetaData>> {
+    if let Some(dedup_key) = &file_info.dedup_key {
+        read_metadata_async_cached(&file_info.location, op, Some(file_info.size), dedup_key).await
+    } else {
+        Ok(Arc::new(
+            read_metadata_async(&file_info.location, op, Some(file_info.size)).await?,
+        ))
     }
-    check_memory_usage(max_memory_usage)?;
-    Ok(metas)
 }
 
 // TODO(parquet): how to limit the memory when running this method is to be determined.

--- a/src/query/storages/parquet/src/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_table/table.rs
@@ -52,12 +52,16 @@ use databend_common_storage::init_stage_operator;
 use databend_common_storage::parquet::infer_schema_with_extension;
 use databend_common_storage::read_metadata_async;
 use databend_storages_common_table_meta::table::ChangeType;
+use futures::StreamExt;
+use futures::TryStreamExt;
 use log::info;
 use opendal::Operator;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::SchemaDescPtr;
 
-use crate::meta::read_metas_in_parallel;
+use crate::meta::read_metadata_async_cached;
+use crate::meta::stream_basic_metas_in_parallel_with_cache;
+use crate::meta::stream_metas_in_parallel;
 use crate::parquet_table::stats::create_stats_provider;
 use crate::schema::arrow_to_table_schema;
 
@@ -72,6 +76,8 @@ pub struct ParquetTable {
     pub(super) arrow_schema: ArrowSchema,
     pub(super) schema_descr: SchemaDescPtr,
     pub(super) files_to_read: Option<Vec<StageFileInfo>>,
+    pub(super) first_file: StageFileInfo,
+    pub(super) first_file_num_rows: u64,
     pub(super) schema_from: String,
     pub(super) compression_ratio: f64,
     /// Leaf fields of the schema.
@@ -82,6 +88,13 @@ pub struct ParquetTable {
     pub(super) need_stats_provider: bool,
     pub(super) max_threads: usize,
     pub(super) max_memory_usage: u64,
+}
+
+struct PreparedParquetMeta {
+    arrow_schema: ArrowSchema,
+    schema_descr: SchemaDescPtr,
+    compression_ratio: f64,
+    num_rows: u64,
 }
 
 impl ParquetTable {
@@ -96,6 +109,8 @@ impl ParquetTable {
             stage_info: info.stage_info.clone(),
             files_info: info.files_info.clone(),
             files_to_read: info.files_to_read.clone(),
+            first_file: info.first_file.clone(),
+            first_file_num_rows: info.first_file_num_rows,
             schema_descr: info.schema_descr.clone(),
             schema_from: info.schema_from.clone(),
             leaf_fields: info.leaf_fields.clone(),
@@ -127,11 +142,9 @@ impl ParquetTable {
             return ctx.get_zero_table().await;
         };
 
-        let first_file = first_file.path;
-
-        let (arrow_schema, schema_descr, compression_ratio) =
-            Self::prepare_metas(&first_file, operator.clone()).await?;
-        let schema = arrow_to_table_schema(&arrow_schema, true, fmt.use_logic_type)?.into();
+        let prepared_meta = Self::prepare_metas(&first_file, operator.clone()).await?;
+        let schema =
+            arrow_to_table_schema(&prepared_meta.arrow_schema, true, fmt.use_logic_type)?.into();
         let table_info = create_parquet_table_info(schema, &stage_info)?;
         let leaf_fields = Arc::new(table_info.schema().leaf_fields());
 
@@ -153,16 +166,18 @@ impl ParquetTable {
 
         Ok(Arc::new(ParquetTable {
             table_info,
-            arrow_schema,
+            arrow_schema: prepared_meta.arrow_schema,
             operator,
             read_options,
-            schema_descr,
+            schema_descr: prepared_meta.schema_descr,
             leaf_fields,
             stage_info,
             files_info,
             files_to_read,
-            compression_ratio,
-            schema_from: first_file,
+            first_file: first_file.clone(),
+            first_file_num_rows: prepared_meta.num_rows,
+            compression_ratio: prepared_meta.compression_ratio,
+            schema_from: first_file.path,
             need_stats_provider,
             max_threads,
             max_memory_usage,
@@ -171,20 +186,32 @@ impl ParquetTable {
 
     #[async_backtrace::framed]
     async fn prepare_metas(
-        path: &str,
+        first_file: &StageFileInfo,
         operator: Operator,
-    ) -> Result<(ArrowSchema, SchemaDescPtr, f64)> {
+    ) -> Result<PreparedParquetMeta> {
         // Infer schema from the first parquet file.
         // Assume all parquet files have the same schema.
         // If not, throw error during reading.
-        let stat = operator.stat(path).await?;
+        let stat = operator.stat(&first_file.path).await?;
         let size = stat.content_length();
-        info!("infer schema from file {}, with stat {:?}", path, stat);
-        let first_meta = read_metadata_async(path, &operator, Some(size)).await?;
+        info!(
+            "infer schema from file {}, with stat {:?}",
+            first_file.path, stat
+        );
+        let first_meta = if let Some(cache_key) = first_file.object_identity_key() {
+            read_metadata_async_cached(&first_file.path, &operator, Some(size), &cache_key).await?
+        } else {
+            Arc::new(read_metadata_async(&first_file.path, &operator, Some(size)).await?)
+        };
         let arrow_schema = infer_schema_with_extension(first_meta.file_metadata())?;
         let compression_ratio = get_compression_ratio(&first_meta);
         let schema_descr = first_meta.file_metadata().schema_descr_ptr();
-        Ok((arrow_schema, schema_descr, compression_ratio))
+        Ok(PreparedParquetMeta {
+            arrow_schema,
+            schema_descr,
+            compression_ratio,
+            num_rows: first_meta.file_metadata().num_rows() as u64,
+        })
     }
 }
 
@@ -228,6 +255,8 @@ impl Table for ParquetTable {
             leaf_fields: self.leaf_fields.clone(),
             files_info: self.files_info.clone(),
             files_to_read: self.files_to_read.clone(),
+            first_file: self.first_file.clone(),
+            first_file_num_rows: self.first_file_num_rows,
             schema_from: self.schema_from.clone(),
             compression_ratio: self.compression_ratio,
             need_stats_provider: self.need_stats_provider,
@@ -311,15 +340,16 @@ impl Table for ParquetTable {
         let num_columns = self.leaf_fields.len();
         let now = Instant::now();
         log::info!("begin read {} parquet file metas", file_locations.len());
-        let metas = read_metas_in_parallel(
+        let metas = stream_metas_in_parallel(
             &self.operator,
-            &file_locations, // The first file is already read.
+            file_locations.clone(), // The first file is already read.
             (self.schema_descr.clone(), self.schema_from.clone()),
             self.leaf_fields.clone(),
             self.max_threads,
             self.max_memory_usage,
             true,
         )
+        .try_collect::<Vec<_>>()
         .await?;
         let elapsed = now.elapsed();
         log::info!(
@@ -337,10 +367,82 @@ impl Table for ParquetTable {
         _require_fresh: bool,
         _change_type: Option<ChangeType>,
     ) -> Result<Option<TableStatistics>> {
-        let col_stats = self.column_statistics_provider(ctx).await?;
-        let num_rows = col_stats.num_rows();
+        let settings = ctx.get_settings();
+        let enable_parquet_table_statistics =
+            settings.get_enable_stage_parquet_table_statistics()?;
+        let files: Vec<StageFileInfo> = match &self.files_to_read {
+            Some(files) => files.iter().filter(|f| f.size > 0).cloned().collect(),
+            None => {
+                if self.files_info.files.is_none()
+                    && self.files_info.pattern.is_none()
+                    && self.first_file.path == self.files_info.path
+                {
+                    return Ok(Some(TableStatistics {
+                        num_rows: Some(self.first_file_num_rows),
+                        data_size_compressed: Some(self.first_file.size),
+                        ..Default::default()
+                    }));
+                }
+
+                if !enable_parquet_table_statistics {
+                    return Ok(None);
+                }
+
+                let thread_num = settings.get_max_threads()? as usize;
+                self.files_info
+                    .list(&self.operator, thread_num, None)
+                    .await?
+                    .into_iter()
+                    .filter(|f| f.size > 0)
+                    .collect()
+            }
+        };
+
+        if files.is_empty() {
+            return Ok(Some(TableStatistics {
+                num_rows: Some(0),
+                data_size_compressed: Some(0),
+                ..Default::default()
+            }));
+        }
+
+        if files.len() == 1
+            && files[0].path == self.first_file.path
+            && files[0].size == self.first_file.size
+        {
+            return Ok(Some(TableStatistics {
+                num_rows: Some(self.first_file_num_rows),
+                data_size_compressed: Some(self.first_file.size),
+                ..Default::default()
+            }));
+        }
+
+        if !enable_parquet_table_statistics {
+            return Ok(None);
+        }
+
+        let data_size_compressed = files.iter().map(|f| f.size).sum();
+        let file_infos = files
+            .iter()
+            .map(|file| (file.path.clone(), file.size, file.object_identity_key()))
+            .collect::<Vec<_>>();
+        let max_threads = settings.get_max_threads()? as usize;
+        let max_memory_usage = settings.get_max_memory_usage()?;
+        let mut metas = stream_basic_metas_in_parallel_with_cache(
+            &self.operator,
+            file_infos,
+            max_threads,
+            max_memory_usage,
+        )
+        .boxed();
+        let mut num_rows = 0;
+        while let Some(meta) = metas.try_next().await? {
+            num_rows += meta.meta.file_metadata().num_rows() as u64;
+        }
+
         Ok(Some(TableStatistics {
-            num_rows,
+            num_rows: Some(num_rows),
+            data_size_compressed: Some(data_size_compressed),
             ..Default::default()
         }))
     }

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -25,6 +25,7 @@ use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::StageTableInfo;
 use databend_common_catalog::table::DistributionLevel;
 use databend_common_catalog::table::Table;
+use databend_common_catalog::table::TableStatistics;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -41,7 +42,9 @@ use databend_common_storage::init_stage_operator;
 use databend_common_storages_orc::OrcTableForCopy;
 use databend_common_storages_parquet::ParquetTableForCopy;
 use databend_common_storages_parquet::ParquetVariantTable;
+use databend_common_storages_parquet::read_metas_in_parallel_for_copy;
 use databend_storages_common_stage::SingleFilePartition;
+use databend_storages_common_table_meta::table::ChangeType;
 use opendal::Operator;
 
 use crate::read::avro::AvroReadPipelineBuilder;
@@ -132,6 +135,53 @@ impl StageTable {
             Partitions::create(PartitionsShuffleKind::Seq, partitions),
         ))
     }
+
+    #[async_backtrace::framed]
+    async fn parquet_table_statistics(
+        &self,
+        ctx: Arc<dyn TableContext>,
+    ) -> Result<Option<TableStatistics>> {
+        let stage_table_info = &self.table_info;
+        let thread_num = ctx.get_settings().get_max_threads()? as usize;
+
+        let files = if let Some(files) = &stage_table_info.files_to_copy {
+            files.clone()
+        } else {
+            StageTable::list_files(stage_table_info, thread_num, None).await?
+        };
+        let file_infos = files
+            .iter()
+            .filter(|file| file.size > 0)
+            .map(|file| (file.path.clone(), file.size))
+            .collect::<Vec<_>>();
+        let data_size_compressed = file_infos.iter().map(|(_, size)| *size).sum::<u64>();
+
+        if file_infos.is_empty() {
+            return Ok(Some(TableStatistics {
+                num_rows: Some(0),
+                data_size_compressed: Some(0),
+                ..Default::default()
+            }));
+        }
+
+        let settings = ctx.get_settings();
+        let max_threads = settings.get_max_threads()? as usize;
+        let max_memory_usage = settings.get_max_memory_usage()?;
+        let operator = init_stage_operator(&stage_table_info.stage_info)?;
+        let metas =
+            read_metas_in_parallel_for_copy(&operator, &file_infos, max_threads, max_memory_usage)
+                .await?;
+        let num_rows = metas
+            .iter()
+            .map(|meta| meta.meta.file_metadata().num_rows() as u64)
+            .sum();
+
+        Ok(Some(TableStatistics {
+            num_rows: Some(num_rows),
+            data_size_compressed: Some(data_size_compressed),
+            ..Default::default()
+        }))
+    }
 }
 
 #[async_trait::async_trait]
@@ -194,6 +244,19 @@ impl Table for StageTable {
 
     fn distribution_level(&self) -> DistributionLevel {
         DistributionLevel::Cluster
+    }
+
+    #[async_backtrace::framed]
+    async fn table_statistics(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _require_fresh: bool,
+        _change_type: Option<ChangeType>,
+    ) -> Result<Option<TableStatistics>> {
+        match self.table_info.stage_info.file_format_params {
+            FileFormatParams::Parquet(_) => self.parquet_table_statistics(ctx).await,
+            _ => Ok(None),
+        }
     }
 
     fn read_data(

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -42,9 +42,11 @@ use databend_common_storage::init_stage_operator;
 use databend_common_storages_orc::OrcTableForCopy;
 use databend_common_storages_parquet::ParquetTableForCopy;
 use databend_common_storages_parquet::ParquetVariantTable;
-use databend_common_storages_parquet::read_metas_in_parallel_for_copy;
+use databend_common_storages_parquet::stream_basic_metas_in_parallel_with_cache;
 use databend_storages_common_stage::SingleFilePartition;
 use databend_storages_common_table_meta::table::ChangeType;
+use futures::StreamExt;
+use futures::TryStreamExt;
 use opendal::Operator;
 
 use crate::read::avro::AvroReadPipelineBuilder;
@@ -142,6 +144,24 @@ impl StageTable {
         ctx: Arc<dyn TableContext>,
     ) -> Result<Option<TableStatistics>> {
         let stage_table_info = &self.table_info;
+        if let Some(metas) = &stage_table_info.parquet_metas {
+            let num_rows = metas
+                .iter()
+                .map(|meta| meta.meta.file_metadata().num_rows() as u64)
+                .sum();
+            let data_size_compressed = metas.iter().map(|meta| meta.size).sum();
+            return Ok(Some(TableStatistics {
+                num_rows: Some(num_rows),
+                data_size_compressed: Some(data_size_compressed),
+                ..Default::default()
+            }));
+        }
+
+        let settings = ctx.get_settings();
+        if !settings.get_enable_stage_parquet_table_statistics()? {
+            return Ok(None);
+        }
+
         let thread_num = ctx.get_settings().get_max_threads()? as usize;
 
         let files = if let Some(files) = &stage_table_info.files_to_copy {
@@ -152,9 +172,9 @@ impl StageTable {
         let file_infos = files
             .iter()
             .filter(|file| file.size > 0)
-            .map(|file| (file.path.clone(), file.size))
+            .map(|file| (file.path.clone(), file.size, file.object_identity_key()))
             .collect::<Vec<_>>();
-        let data_size_compressed = file_infos.iter().map(|(_, size)| *size).sum::<u64>();
+        let data_size_compressed = file_infos.iter().map(|(_, size, _)| *size).sum::<u64>();
 
         if file_infos.is_empty() {
             return Ok(Some(TableStatistics {
@@ -164,17 +184,20 @@ impl StageTable {
             }));
         }
 
-        let settings = ctx.get_settings();
         let max_threads = settings.get_max_threads()? as usize;
         let max_memory_usage = settings.get_max_memory_usage()?;
         let operator = init_stage_operator(&stage_table_info.stage_info)?;
-        let metas =
-            read_metas_in_parallel_for_copy(&operator, &file_infos, max_threads, max_memory_usage)
-                .await?;
-        let num_rows = metas
-            .iter()
-            .map(|meta| meta.meta.file_metadata().num_rows() as u64)
-            .sum();
+        let mut metas = stream_basic_metas_in_parallel_with_cache(
+            &operator,
+            file_infos,
+            max_threads,
+            max_memory_usage,
+        )
+        .boxed();
+        let mut num_rows = 0;
+        while let Some(meta) = metas.try_next().await? {
+            num_rows += meta.meta.file_metadata().num_rows() as u64;
+        }
 
         Ok(Some(TableStatistics {
             num_rows: Some(num_rows),

--- a/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
@@ -59,12 +59,54 @@ select $1, metadata$file_row_number as r, metadata$filename as f from @data/parq
 {"c2":228,"c4":"248","c5":258,"c6":268} 8 parquet/diff_schema/f2.parquet
 {"c2":229,"c4":"249","c5":259,"c6":269} 9 parquet/diff_schema/f2.parquet
 
+query T
+explain select $1 from @data/parquet/diff_schema/(pattern=>'.*[.]parquet');
+----
+TableScan
+├── table: default.system.stage
+├── scan id: 0
+├── output columns: [_$1 (#0)]
+├── read rows: 2
+├── read size: 10.93 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 20.00
+
 query ?
 select $1 from @data/parquet/tuple.parquet;
 ----
 {"id":1,"t":{"A":1,"B":"a"}}
 {"id":2,"t":{"A":3,"B":"b"}}
 {"id":3,"t":{"A":3,"B":"c"}}
+
+query T
+explain select $1 from @data/parquet/tuple.parquet;
+----
+TableScan
+├── table: default.system.stage
+├── scan id: 0
+├── output columns: [_$1 (#0)]
+├── read rows: 1
+├── read size: 1.98 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 3.00
+
+query T
+explain select $1 from @data/parquet/ (files=>('tuple.parquet', 'complex.parquet'));
+----
+TableScan
+├── table: default.system.stage
+├── scan id: 0
+├── output columns: [_$1 (#0)]
+├── read rows: 2
+├── read size: 92.57 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 13.00
 
 query ?
 select $1 from @data/parquet/alltypes_plain.parquet;

--- a/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/parquet_to_variant.test
@@ -60,7 +60,7 @@ select $1, metadata$file_row_number as r, metadata$filename as f from @data/parq
 {"c2":229,"c4":"249","c5":259,"c6":269} 9 parquet/diff_schema/f2.parquet
 
 query T
-explain select $1 from @data/parquet/diff_schema/(pattern=>'.*[.]parquet');
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ $1 from @data/parquet/diff_schema/(pattern=>'.*[.]parquet');
 ----
 TableScan
 ├── table: default.system.stage
@@ -81,7 +81,7 @@ select $1 from @data/parquet/tuple.parquet;
 {"id":3,"t":{"A":3,"B":"c"}}
 
 query T
-explain select $1 from @data/parquet/tuple.parquet;
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ $1 from @data/parquet/tuple.parquet;
 ----
 TableScan
 ├── table: default.system.stage
@@ -95,12 +95,54 @@ TableScan
 └── estimated rows: 3.00
 
 query T
-explain select $1 from @data/parquet/ (files=>('tuple.parquet', 'complex.parquet'));
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ * from @data/parquet/tuple.parquet;
+----
+TableScan
+├── table: default.system.read_parquet(data)
+├── scan id: 0
+├── output columns: [id (#0), t (#1)]
+├── read rows: 1
+├── read size: 1.98 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 3.00
+
+query T
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ id from @data/parquet/tuple.parquet;
+----
+TableScan
+├── table: default.system.read_parquet(data)
+├── scan id: 0
+├── output columns: [id (#0)]
+├── read rows: 1
+├── read size: 1.98 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 3.00
+
+query T
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ $1 from @data/parquet/ (files=>('tuple.parquet', 'complex.parquet'));
 ----
 TableScan
 ├── table: default.system.stage
 ├── scan id: 0
 ├── output columns: [_$1 (#0)]
+├── read rows: 2
+├── read size: 92.57 KiB
+├── partitions total: 1
+├── partitions scanned: 1
+├── push downs: [filters: [], limit: NONE]
+└── estimated rows: 13.00
+
+query T
+explain select /*+ set_var(enable_stage_parquet_table_statistics=1) set_var(parquet_fast_read_bytes=1048576) */ * from @data/parquet/ (files=>('tuple.parquet', 'complex.parquet'));
+----
+TableScan
+├── table: default.system.read_parquet(data)
+├── scan id: 0
+├── output columns: [id (#0), t (#1)]
 ├── read rows: 2
 ├── read size: 92.57 KiB
 ├── partitions total: 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #9884

This PR adds parquet-specific row count statistics for stage-backed parquet scans while keeping the expensive full-footer path gated.

- Adds `enable_stage_parquet_table_statistics` to control whether stage table planning may read parquet footer metadata from all selected files to compute exact row counts.
- Keeps the default planning path cheap: when the setting is disabled, multi-file parquet stage scans do not perform full metadata reads just to populate optimizer statistics.
- Reuses parquet footer metadata that is already read for schema inference/table construction without requiring the setting. In particular, single-file parquet scans, including transform-style `COPY INTO <table> FROM (SELECT ... FROM @stage/...)` after file filtering leaves one file, can report row count from the already-read first footer without an extra footer read.
- Caches parquet metadata only when the file has a strong object identity (`etag`/`content_md5`), avoiding cache pollution or stale reuse for weak size/path-only identities.
- Covers both `ParquetTable` statistics and `ParquetSource` execution cache behavior explicitly, including cache/no-cache boundaries.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Commands run:

```bash
cargo fmt --check
git diff --check
CARGO_BUILD_JOBS=1 cargo check -p databend-common-catalog --lib --tests
CARGO_BUILD_JOBS=1 cargo check -p databend-query --test it
target/debug/databend-sqllogictests --run_file parquet_to_variant.test
```

CI check:

```bash
linux / check passed on head 2cd3f4a0dfd6180bdaaa117d0ba7fd50c6d16a5d
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19848)
<!-- Reviewable:end -->