### PR TITLE
ci: stabilize admin status test

### DIFF
--- a/src/query/service/tests/it/servers/admin/v1/status.rs
+++ b/src/query/service/tests/it/servers/admin/v1/status.rs
@@ -101,9 +101,8 @@ async fn test_status() -> anyhow::Result<()> {
                 status.inflight_queries_count,
                 status.running_queries_count,
                 status.last_query_started_at.is_some(),
-                status.last_query_finished_at.is_some(),
             ),
-            (1, 1, true, false),
+            (1, 1, true),
             "running"
         );
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Stabilize `test_status` by avoiding an over-specific assertion on `last_query_finished_at` while the test is observing the running state.

`/v1/status` combines dynamically scanned running session state with the global last-finished timestamp. On slower CI scheduling, the `select sleep(3) from numbers(1)` pipeline can finish before the status request is handled, while the stream still retains the query context and keeps the query counted as running. In that valid timing window, `last_query_finished_at` can already be present.

This keeps the running-state checks focused on the values that must hold: inflight count, running count, and started timestamp.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

`cargo nextest run -p databend-query test_status --no-fail-fast`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Test stabilization

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19849)
<!-- Reviewable:end -->
