### PR TITLE
docs: clarify PR title format

### DIFF
--- a/agents/commit-and-pr.md
+++ b/agents/commit-and-pr.md
@@ -7,6 +7,8 @@
 - Include formatting and linting updates in the same patch when they belong to the change.
 
 ## Pull Requests
+- Allowed PR title types are `rfc`, `feat`, `fix`, `refactor`, `ci`, `docs`, and `chore`; prefer `ci` for test-only or CI-only changes.
+- Optional PR title scopes may contain only lowercase letters, digits, and hyphens, such as `query` or `admin-status`.
 - Outline motivation, implementation notes, and validation commands.
 - Link issues or RFCs when relevant.
 - Follow `PULL_REQUEST_TEMPLATE.md`, including checkboxes, verification, and screenshots when needed.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Clarify the semantic PR title format enforced by the PR Assistant workflow so future PRs avoid unsupported title types such as `test(...)`.

This documents the allowed title types, optional scope format, and recommended alternatives for test stabilization changes.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Documentation-only change; validated against the PR title checker regex.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19850)
<!-- Reviewable:end -->
