### PR TITLE
fix(storage): prune integer columns with string literals

### DIFF
--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -24,7 +24,9 @@ use databend_common_expression::Scalar;
 use databend_common_expression::expr::*;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
 use databend_common_expression::visit_expr;
+use databend_common_expression::with_integer_mapped_type;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
 pub(super) fn is_injective_cast(src: &DataType, dest: &DataType) -> bool {
@@ -76,6 +78,9 @@ impl ExprVisitor<String> for RewriteVisitor<'_> {
                     if self.check_no_throw(cast) =>
                 {
                     self.try_rewrite(call.span, cast, constant.clone())?
+                }
+                [Expr::ColumnRef(column), expr] | [expr, Expr::ColumnRef(column)] => {
+                    self.try_rewrite_integer_column_string_constant(call.span, column, expr)?
                 }
                 _ => None,
             };
@@ -136,6 +141,68 @@ impl RewriteVisitor<'_> {
         }
     }
 
+    fn try_rewrite_integer_column_string_constant(
+        &self,
+        span: Span,
+        column: &ColumnRef<String>,
+        expr: &Expr<String>,
+    ) -> RewriteResult {
+        let Some(constant) = self.constant_from_expr(expr) else {
+            return Ok(None);
+        };
+        let Some(scalar) = cast_integer_string_constant(
+            self.func_ctx,
+            &column.data_type,
+            &constant.data_type,
+            &constant.scalar,
+        ) else {
+            return Ok(None);
+        };
+        let constant = Constant {
+            span: None,
+            scalar,
+            data_type: column.data_type.clone(),
+        };
+
+        let Ok(func_expr) = check_function(
+            span,
+            "eq",
+            &[],
+            &[column.clone().into(), constant.into()],
+            self.fn_registry,
+        ) else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            ConstantFolder::fold_with_domain(
+                &func_expr,
+                &self.input_domains,
+                self.func_ctx,
+                self.fn_registry,
+            )
+            .0,
+        ))
+    }
+
+    fn constant_from_expr(&self, expr: &Expr<String>) -> Option<Constant> {
+        match expr {
+            Expr::Constant(constant) => Some(constant.clone()),
+            Expr::Cast(cast) if !cast.is_try => {
+                let Expr::Constant(constant) = cast.expr.as_ref() else {
+                    return None;
+                };
+                let scalar = cast_const(self.func_ctx, cast.dest_type.clone(), constant.clone())?;
+                Some(Constant {
+                    span: None,
+                    scalar,
+                    data_type: cast.dest_type.clone(),
+                })
+            }
+            _ => None,
+        }
+    }
+
     fn check_no_throw(&self, cast: &Cast<String>) -> bool {
         if cast.is_try {
             return false;
@@ -173,6 +240,42 @@ pub(super) fn cast_const(
     };
 
     domain.as_singleton()
+}
+
+fn cast_integer_string_constant(
+    func_ctx: &FunctionContext,
+    column_type: &DataType,
+    scalar_type: &DataType,
+    scalar: &Scalar,
+) -> Option<Scalar> {
+    if scalar.is_null() || scalar_type.remove_nullable() != DataType::String {
+        return None;
+    }
+
+    let DataType::Number(num_ty) = column_type.remove_nullable() else {
+        return None;
+    };
+    if !num_ty.is_integer() || !string_scalar_parses_as_integer_type(scalar, &num_ty) {
+        return None;
+    }
+
+    let scalar = cast_const(func_ctx, column_type.clone(), Constant {
+        span: None,
+        scalar: scalar.clone(),
+        data_type: scalar_type.clone(),
+    })?;
+    (!scalar.is_null()).then_some(scalar)
+}
+
+fn string_scalar_parses_as_integer_type(scalar: &Scalar, num_ty: &NumberDataType) -> bool {
+    let Some(value) = scalar.as_string() else {
+        return false;
+    };
+
+    with_integer_mapped_type!(|NUM_TYPE| match num_ty {
+        NumberDataType::NUM_TYPE => value.parse::<NUM_TYPE>().is_ok(),
+        _ => false,
+    })
 }
 
 pub fn eliminate_cast(

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -94,6 +94,42 @@ fn test_range_index() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_range_index_prunes_integer_column_eq_numeric_string_literal() {
+    fn n(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let func_ctx = FunctionContext::default();
+    let schema = Arc::new(TableSchema::new(vec![TableField::new(
+        "a",
+        TableDataType::Number(NumberDataType::Int32),
+    )]));
+    let stats = create_stats(&[("a", n(-2), n(3))], &schema);
+    let expr = parse_expr("a = '4'", &[("a", Int32Type::data_type())]);
+    let index = RangeIndex::try_create(func_ctx, &expr, schema, Default::default()).unwrap();
+
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
+}
+
+#[test]
+fn test_range_index_prunes_nullable_integer_column_eq_numeric_string_literal() {
+    fn n(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let func_ctx = FunctionContext::default();
+    let schema = Arc::new(TableSchema::new(vec![TableField::new(
+        "a",
+        TableDataType::Nullable(Box::new(TableDataType::Number(NumberDataType::Int32))),
+    )]));
+    let stats = create_stats(&[("a", n(-2), n(3))], &schema);
+    let expr = parse_expr("a = '4'", &[("a", Int32Type::data_type().wrap_nullable())]);
+    let index = RangeIndex::try_create(func_ctx, &expr, schema, Default::default()).unwrap();
+
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
+}
+
+#[test]
 fn test_range_index_dates() -> anyhow::Result<()> {
     let mut mint = Mint::new("tests/it/testdata");
     let file = &mut mint.new_goldenfile("test_range_index_dates.txt").unwrap();

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -48,6 +48,31 @@ EvalScalar
     ├── push downs: [filters: [is_true(range_t.i (#1) > 20)], limit: NONE]
     └── estimated rows: 0.00
 
+statement ok
+create or replace table range_pruner_trust_loan_daily(contract_no varchar, notify_date int)
+
+statement ok
+insert into range_pruner_trust_loan_daily values ('20240508003088208902099794704998', 20240512)
+
+query T
+explain select 1 from range_pruner_trust_loan_daily where notify_date = '20240513' and contract_no = '20240508003088208902099794704998'
+----
+EvalScalar
+├── output columns: [1 (#2)]
+├── expressions: [1]
+├── estimated rows: 0.00
+└── TableScan
+    ├── table: default.default.range_pruner_trust_loan_daily
+    ├── scan id: 0
+    ├── output columns: []
+    ├── read rows: 0
+    ├── read size: 0
+    ├── partitions total: 1
+    ├── partitions scanned: 0
+    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: 1 ms>]
+    ├── push downs: [filters: [range_pruner_trust_loan_daily.notify_date (#1) = '20240513' and range_pruner_trust_loan_daily.contract_no (#0) = '20240508003088208902099794704998'], limit: NONE]
+    └── estimated rows: 0.00
+
 query T
 explain select number from numbers(10) where number > 5 and try_cast(get(try_parse_json(number::String),'xx') as varchar) < '10' and 1 = 0;
 ----
@@ -61,3 +86,6 @@ EmptyResultScan
 
 statement ok
 drop table range_t
+
+statement ok
+drop table range_pruner_trust_loan_daily


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Numeric string predicates on integer columns, such as `notify_date = '20240513'`, were not normalized for range pruning. This made segment/block range pruning much less selective and left more work for later pruning stages.

This PR rewrites integer-column equality predicates with numeric string constants into typed constants for range pruning, while keeping the original pushdown filter unchanged.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Validation

- `cargo test -p databend-storages-common-index --lib --test it`
- `cargo clippy -p databend-storages-common-index --lib --tests -- -D warnings`
- `target/debug/databend-sqllogictests --handlers mysql --run 'tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test'`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19852)
<!-- Reviewable:end -->
