### PR TITLE
fix(query): isolate auto materialized CTE names

### DIFF
--- a/src/query/service/src/physical_plans/format/common.rs
+++ b/src/query/service/src/physical_plans/format/common.rs
@@ -38,6 +38,21 @@ pub struct FormatContext<'a> {
     pub runtime_filter_reports: HashMap<IndexType, Vec<RuntimeFilterReport>>,
 }
 
+pub fn display_materialized_cte_name(name: &str) -> &str {
+    let Some(rest) = name.strip_prefix("__materialized_cte_") else {
+        return name;
+    };
+    let Some((id, display_name)) = rest.split_once('_') else {
+        return name;
+    };
+
+    if !display_name.is_empty() && id.chars().all(|c| c.is_ascii_digit()) {
+        display_name
+    } else {
+        name
+    }
+}
+
 pub fn pretty_display_agg_desc(desc: &AggregateFunctionDesc, metadata: &Metadata) -> String {
     format!(
         "{}({})",

--- a/src/query/service/src/physical_plans/format/format_cte_consumer.rs
+++ b/src/query/service/src/physical_plans/format/format_cte_consumer.rs
@@ -20,6 +20,7 @@ use crate::physical_plans::MaterializeCTERef;
 use crate::physical_plans::PhysicalPlanMeta;
 use crate::physical_plans::format::FormatContext;
 use crate::physical_plans::format::PhysicalFormat;
+use crate::physical_plans::format::display_materialized_cte_name;
 use crate::physical_plans::format::format_output_columns;
 use crate::physical_plans::format::plan_stats_info_to_format_tree;
 
@@ -43,7 +44,7 @@ impl<'a> PhysicalFormat for MaterializeCTERefFormatter<'a> {
         let mut children = Vec::new();
         children.push(FormatTreeNode::new(format!(
             "cte_name: {}",
-            self.inner.cte_name.clone()
+            display_materialized_cte_name(&self.inner.cte_name)
         )));
         children.push(FormatTreeNode::new(format!(
             "cte_schema: [{}]",
@@ -64,7 +65,10 @@ impl<'a> PhysicalFormat for MaterializeCTERefFormatter<'a> {
     #[recursive::recursive]
     fn format_join(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
         let children = vec![
-            FormatTreeNode::new(format!("cte_name: {}", self.inner.cte_name)),
+            FormatTreeNode::new(format!(
+                "cte_name: {}",
+                display_materialized_cte_name(&self.inner.cte_name)
+            )),
             FormatTreeNode::new(format!(
                 "cte_schema: [{}]",
                 format_output_columns(self.inner.cte_schema.clone(), ctx.metadata, false)

--- a/src/query/service/src/physical_plans/format/format_materialized_cte.rs
+++ b/src/query/service/src/physical_plans/format/format_materialized_cte.rs
@@ -20,6 +20,7 @@ use crate::physical_plans::MaterializedCTE;
 use crate::physical_plans::PhysicalPlanMeta;
 use crate::physical_plans::format::FormatContext;
 use crate::physical_plans::format::PhysicalFormat;
+use crate::physical_plans::format::display_materialized_cte_name;
 
 pub struct MaterializedCTEFormatter<'a> {
     inner: &'a MaterializedCTE,
@@ -42,7 +43,10 @@ impl<'a> PhysicalFormat for MaterializedCTEFormatter<'a> {
         let input_payload = input_formatter.dispatch(ctx)?;
 
         Ok(FormatTreeNode::with_children(
-            format!("MaterializedCTE: {}", self.inner.cte_name),
+            format!(
+                "MaterializedCTE: {}",
+                display_materialized_cte_name(&self.inner.cte_name)
+            ),
             vec![input_payload],
         ))
     }
@@ -51,7 +55,10 @@ impl<'a> PhysicalFormat for MaterializedCTEFormatter<'a> {
     fn format_join(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
         let input = self.inner.input.formatter()?.format_join(ctx)?;
         let children = vec![
-            FormatTreeNode::new(format!("cte_name: {}", self.inner.cte_name)),
+            FormatTreeNode::new(format!(
+                "cte_name: {}",
+                display_materialized_cte_name(&self.inner.cte_name)
+            )),
             FormatTreeNode::new(format!("ref_count: {}", self.inner.ref_count)),
             input,
         ];

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -248,6 +248,7 @@ pub struct CteInfo {
 
 #[derive(Clone, Debug)]
 pub struct MaterializedCTEInfo {
+    pub cte_name: String,
     pub bound_s_expr: SExpr,
     pub bound_context: BindContext,
 }

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_cte.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_cte.rs
@@ -55,7 +55,11 @@ impl Binder {
                     &bind_context.cte_context.cte_map,
                     &cte.query,
                 )?;
+                // The physical CTE registry is query-global, while CTE aliases are scoped.
+                // Give each materialized producer a unique execution name.
+                let materialized_cte_id = self.metadata.write().allocate_materialized_cte_id();
                 let materialized_cte_info = MaterializedCTEInfo {
+                    cte_name: format!("__materialized_cte_{materialized_cte_id}_{cte_name}"),
                     bound_s_expr: s_expr,
                     bound_context: cte_bind_context,
                 };
@@ -167,7 +171,11 @@ impl Binder {
 
         let s_expr = SExpr::create_leaf(Arc::new(RelOperator::MaterializedCTERef(
             MaterializedCTERef {
-                cte_name: table_name.to_string(),
+                cte_name: cte_info
+                    .materialized_cte_info
+                    .as_ref()
+                    .map(|info| info.cte_name.clone())
+                    .unwrap_or_else(|| table_name.to_string()),
                 output_columns,
                 def: s_expr,
                 column_mapping,
@@ -218,7 +226,8 @@ impl Binder {
             if let Some(materialized_cte_info) = &cte_info.materialized_cte_info {
                 let s_expr = materialized_cte_info.bound_s_expr.clone();
 
-                let materialized_cte = MaterializedCTE::new(cte_name, None);
+                let materialized_cte =
+                    MaterializedCTE::new(materialized_cte_info.cte_name.clone(), None);
                 let materialized_cte = SExpr::create_unary(materialized_cte, s_expr);
                 let sequence = Sequence {};
                 current_expr = SExpr::create_binary(sequence, materialized_cte, current_expr);

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -84,6 +84,7 @@ pub struct Metadata {
     base_column_scan_id: HashMap<Symbol, usize>,
     next_runtime_filter_id: usize,
     next_logical_recursive_cte_id: u32,
+    next_materialized_cte_id: usize,
 }
 
 impl Metadata {
@@ -220,6 +221,12 @@ impl Metadata {
         let logical_recursive_cte_id = self.next_logical_recursive_cte_id;
         self.next_logical_recursive_cte_id += 1;
         logical_recursive_cte_id
+    }
+
+    pub fn allocate_materialized_cte_id(&mut self) -> usize {
+        let materialized_cte_id = self.next_materialized_cte_id;
+        self.next_materialized_cte_id += 1;
+        materialized_cte_id
     }
 
     pub fn columns_by_table_index(&self, index: IndexType) -> Vec<ColumnEntry> {

--- a/tests/sqllogictests/suites/query/cte/auto_materialized_cte_unique_name.test
+++ b/tests/sqllogictests/suites/query/cte/auto_materialized_cte_unique_name.test
@@ -1,0 +1,53 @@
+statement ok
+SET enable_auto_materialize_cte = 1
+
+statement ok
+DROP DATABASE IF EXISTS auto_m_cte_unique
+
+statement ok
+CREATE DATABASE auto_m_cte_unique
+
+statement ok
+CREATE TABLE auto_m_cte_unique.t(id INT NULL, k INT NULL) ENGINE = FUSE
+
+statement ok
+CREATE VIEW auto_m_cte_unique.v_base AS
+SELECT * FROM (
+    WITH c AS (
+        SELECT id, k FROM auto_m_cte_unique.t
+    ),
+    d AS (
+        SELECT id, k FROM auto_m_cte_unique.c
+        UNION ALL
+        SELECT id, k FROM auto_m_cte_unique.c
+    )
+    SELECT id, k FROM auto_m_cte_unique.d
+) v(id, k)
+
+statement ok
+CREATE VIEW auto_m_cte_unique.v_wrap AS
+SELECT * FROM auto_m_cte_unique.v_base
+
+query I
+WITH a AS (
+    SELECT id, COUNT(*) AS c
+    FROM auto_m_cte_unique.v_wrap
+    GROUP BY id
+),
+b AS (
+    SELECT id, COUNT(*) AS c
+    FROM auto_m_cte_unique.v_wrap
+    WHERE k IS NOT NULL
+    GROUP BY id
+),
+u AS (
+    SELECT id, c FROM a
+    UNION ALL
+    SELECT id, c FROM b
+)
+SELECT COUNT(*) FROM u
+----
+0
+
+statement ok
+DROP DATABASE auto_m_cte_unique


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Assign a query-local unique execution name to each auto materialized CTE producer.
- Keep materialized CTE refs and producers keyed by the same internal name to avoid scoped alias collisions after view expansion.
- Preserve user-facing CTE names in EXPLAIN output and add a regression sqllogictest.

## Changes

When the same view containing auto materialized CTEs is expanded multiple times, different scoped CTEs can share the same alias, such as `c` or `metric_event`. The physical CTE required-column registry is query-global, so those aliases could collide and mix required columns from different CTE instances.

This change stores a unique internal materialized CTE name in `MaterializedCTEInfo`, uses it for producer/ref execution keys, and maps that internal name back to the original alias for explain formatting.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation commands:

```bash
cargo build --bin=databend-query --bin=databend-sqllogictests
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy target/debug/databend-sqllogictests --handlers mysql --run 'tests/sqllogictests/suites/query/cte/auto_materialized_cte_unique_name.test'
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy target/debug/databend-sqllogictests --handlers mysql --run 'tests/sqllogictests/suites/mode/standalone/explain/cte_prune_columns.test'
```

Also manually verified the reported query with `enable_auto_materialize_cte=1`; it returns `0` instead of `Unable to get field named ...`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19853)
<!-- Reviewable:end -->
