### PR TITLE
fix(query): clarify flight client timeout errors

### DIFF
--- a/src/common/exception/src/exception_into.rs
+++ b/src/common/exception/src/exception_into.rs
@@ -392,7 +392,22 @@ impl From<tonic::Status> for ErrorCode {
                     .set_span(serialized_error.span),
                 }
             }
-            _ => ErrorCode::Unimplemented(status.to_string()),
+            tonic::Code::Cancelled if status.message() == "Timeout expired" => {
+                ErrorCode::CannotConnectNode(format!(
+                    "gRPC request exceeded its timeout and was cancelled: {}",
+                    status
+                ))
+            }
+            tonic::Code::DeadlineExceeded => {
+                ErrorCode::CannotConnectNode(format!("gRPC request deadline exceeded: {}", status))
+            }
+            tonic::Code::Cancelled => {
+                ErrorCode::AbortedQuery(format!("gRPC request was cancelled: {}", status))
+            }
+            tonic::Code::Unavailable => {
+                ErrorCode::CannotConnectNode(format!("gRPC service is unavailable: {}", status))
+            }
+            _ => ErrorCode::UnknownException(format!("gRPC request failed: {}", status)),
         }
     }
 }

--- a/src/query/service/src/servers/flight/flight_client.rs
+++ b/src/query/service/src/servers/flight/flight_client.rs
@@ -32,6 +32,7 @@ use futures_util::future::Either;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::time::Duration;
+use tonic::Code;
 use tonic::Request;
 use tonic::Status;
 use tonic::Streaming;
@@ -100,9 +101,18 @@ impl FlightClient {
             AsciiMetadataValue::from_str(&secret).unwrap(),
         );
 
-        let response = self.inner.do_action(request).await?;
+        let response = self
+            .inner
+            .do_action(request)
+            .await
+            .map_err(|status| flight_client_status_to_error(status, path, timeout))?;
 
-        match response.into_inner().message().await? {
+        match response
+            .into_inner()
+            .message()
+            .await
+            .map_err(|status| flight_client_status_to_error(status, path, timeout))?
+        {
             Some(response) => {
                 let mut deserializer = serde_json::Deserializer::from_slice(&response.body);
                 deserializer.disable_recursion_limit();
@@ -238,6 +248,29 @@ impl FlightClient {
                 Err(status) => Err(status),
             }
         })
+    }
+}
+
+fn flight_client_status_to_error(status: Status, path: &str, timeout: u64) -> ErrorCode {
+    match status.code() {
+        Code::Cancelled if status.message() == "Timeout expired" => {
+            ErrorCode::CannotConnectNode(format!(
+                "Flight action {path:?} exceeded flight_client_timeout ({timeout} seconds). \
+                The remote node did not finish the request before the gRPC deadline; \
+                consider increasing the flight_client_timeout setting if the action can legitimately take longer."
+            ))
+        }
+        Code::DeadlineExceeded => ErrorCode::CannotConnectNode(format!(
+            "Flight action {path:?} timed out after {timeout} seconds: {status}"
+        )),
+        Code::Unavailable => ErrorCode::CannotConnectNode(format!(
+            "Flight action {path:?} failed because the remote node is unavailable: {status}"
+        )),
+        Code::Unknown => {
+            ErrorCode::from(status).add_message(format!("failed to execute flight action {path:?}"))
+        }
+        _ => ErrorCode::from(status)
+            .add_message(format!("failed to execute flight action {path:?} via gRPC")),
     }
 }
 


### PR DESCRIPTION
## Summary
- map non-serialized gRPC timeout/cancel/unavailable statuses to clearer ErrorCode variants instead of Unimplemented(1002)
- add flight action path and flight_client_timeout context when do_action hits the gRPC deadline

## Tests
- cargo check -p databend-common-exception --manifest-path Cargo.toml
- cargo check -p databend-query --manifest-path Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19856)
<!-- Reviewable:end -->
