### PR TITLE
feat(query): support full outer asof join

### DIFF
--- a/src/query/ast/src/ast/query.rs
+++ b/src/query/ast/src/ast/query.rs
@@ -1058,6 +1058,9 @@ impl Display for TableReference {
                     JoinOperator::RightAsof => {
                         write!(f, " ASOF RIGHT JOIN")?;
                     }
+                    JoinOperator::FullAsof => {
+                        write!(f, " ASOF FULL JOIN")?;
+                    }
                     JoinOperator::InnerAny => {
                         write!(f, " INNER ANY JOIN")?;
                     }
@@ -1149,6 +1152,7 @@ pub enum JoinOperator {
     Asof,
     LeftAsof,
     RightAsof,
+    FullAsof,
     // Any
     InnerAny,
     LeftAny,

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -707,6 +707,7 @@ pub fn join_operator(i: Input) -> IResult<JoinOperator> {
         value(JoinOperator::CrossJoin, rule! { CROSS }),
         value(JoinOperator::LeftAsof, rule! { ASOF ~ LEFT }),
         value(JoinOperator::RightAsof, rule! { ASOF ~ RIGHT }),
+        value(JoinOperator::FullAsof, rule! { ASOF ~ FULL ~ OUTER? }),
         value(JoinOperator::Asof, rule! { ASOF }),
     ))
     .parse(i)

--- a/src/query/catalog/src/plan/agg_index.rs
+++ b/src/query/catalog/src/plan/agg_index.rs
@@ -29,7 +29,7 @@ pub struct AggIndexInfo {
     ///
     /// - The first element in the tuple is the expression.
     ///     - The index in the [`RemoteExpr`] is the offset of `schema`.
-    /// - The seoncd element in the tuple is the offset of the output schema of the table scan plan.
+    /// - The second element in the tuple is the offset of the output schema of the table scan plan.
     ///     - If the offset is [None], it means the selection item will be appended to the end of the output block;
     ///     - else the selection item will be placed at the offset.
     ///

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -602,6 +602,7 @@ impl PhysicalPlanBuilder {
             | JoinType::LeftAny
             | JoinType::LeftSingle
             | JoinType::LeftAsof
+            | JoinType::FullAsof
             | JoinType::Full => {
                 let build_schema = build_side.output_schema()?;
                 // Wrap nullable type for columns in build side
@@ -638,7 +639,11 @@ impl PhysicalPlanBuilder {
         probe_side: &PhysicalPlan,
     ) -> Result<DataSchemaRef> {
         match join_type {
-            JoinType::Right | JoinType::RightSingle | JoinType::RightAsof | JoinType::Full => {
+            JoinType::Right
+            | JoinType::RightSingle
+            | JoinType::RightAsof
+            | JoinType::FullAsof
+            | JoinType::Full => {
                 let probe_schema = probe_side.output_schema()?;
                 // Wrap nullable type for columns in probe side
                 let probe_schema = DataSchemaRefExt::create(
@@ -1193,10 +1198,12 @@ impl PhysicalPlanBuilder {
                 ));
                 result
             }
-            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof => unreachable!(
-                "Invalid join type {} during building physical hash join.",
-                join.join_type
-            ),
+            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof | JoinType::FullAsof => {
+                unreachable!(
+                    "Invalid join type {} during building physical hash join.",
+                    join.join_type
+                )
+            }
         };
 
         // Create projections and output schema

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -48,6 +48,7 @@ fn asof_hash_join_type(join_type: JoinType) -> JoinType {
         // to preserve the original SQL null-preserving side.
         JoinType::LeftAsof => JoinType::Right,
         JoinType::RightAsof => JoinType::Left,
+        JoinType::FullAsof => JoinType::Full,
         _ => join_type,
     }
 }

--- a/src/query/service/src/physical_plans/physical_range_join.rs
+++ b/src/query/service/src/physical_plans/physical_range_join.rs
@@ -56,7 +56,8 @@ pub struct RangeJoin {
     pub conditions: Vec<RangeJoinCondition>,
     // The other conditions
     pub other_conditions: Vec<RemoteExpr>,
-    // Now only support inner join, will support left/right join later
+    // Now only support inner join, will support left/right join later.
+    // ASOF outer joins reuse this path after the interval-boundary rewrite.
     pub join_type: JoinType,
     pub range_join_type: RangeJoinType,
     pub output_schema: DataSchemaRef,

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
@@ -180,8 +180,12 @@ impl RangeJoinState {
             blocks
         } else {
             if !self.left_match.read().is_empty() {
-                return Ok(vec![self.fill_outer(task_id, true)?]);
-            } else if !self.right_match.read().is_empty() {
+                let left_fill_end = partition_count + self.left_sorted_blocks.read().len();
+                if task_id < left_fill_end {
+                    return Ok(vec![self.fill_outer(task_id, true)?]);
+                }
+            }
+            if !self.right_match.read().is_empty() {
                 return Ok(vec![self.fill_outer(task_id, false)?]);
             }
             Ok(vec![DataBlock::empty()])

--- a/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
@@ -40,8 +40,12 @@ impl RangeJoinState {
         let partition_count = self.partition_count.load(Ordering::SeqCst) as usize;
         if task_id >= partition_count {
             if !self.left_match.read().is_empty() {
-                return Ok(vec![self.fill_outer(task_id, true)?]);
-            } else if !self.right_match.read().is_empty() {
+                let left_fill_end = partition_count + self.left_sorted_blocks.read().len();
+                if task_id < left_fill_end {
+                    return Ok(vec![self.fill_outer(task_id, true)?]);
+                }
+            }
+            if !self.right_match.read().is_empty() {
                 return Ok(vec![self.fill_outer(task_id, false)?]);
             }
             return Ok(vec![DataBlock::empty()]);

--- a/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
@@ -111,7 +111,10 @@ impl RangeJoinState {
     pub(crate) fn sink_right(&self, block: DataBlock) -> Result<()> {
         // Sink block to right table
         let mut right_table = self.right_table.write();
-        let right_block = if matches!(self.join_type, JoinType::Left | JoinType::LeftAsof) {
+        let right_block = if matches!(
+            self.join_type,
+            JoinType::Left | JoinType::LeftAsof | JoinType::FullAsof
+        ) {
             let rows = block.num_rows();
             let nullable_right_columns = block
                 .take_columns()
@@ -129,7 +132,10 @@ impl RangeJoinState {
     pub(crate) fn sink_left(&self, block: DataBlock) -> Result<()> {
         // Sink block to left table
         let mut left_table = self.left_table.write();
-        let left_block = if matches!(self.join_type, JoinType::Right | JoinType::RightAsof) {
+        let left_block = if matches!(
+            self.join_type,
+            JoinType::Right | JoinType::RightAsof | JoinType::FullAsof
+        ) {
             let rows = block.num_rows();
             let nullable_left_columns = block
                 .take_columns()
@@ -316,7 +322,10 @@ impl RangeJoinState {
         // Add Fill task
         left_offset = 0;
         right_offset = 0;
-        if matches!(self.join_type, JoinType::Left | JoinType::LeftAsof) {
+        if matches!(
+            self.join_type,
+            JoinType::Left | JoinType::LeftAsof | JoinType::FullAsof
+        ) {
             let mut left_match = self.left_match.write();
             for (left_idx, left_block) in left_sorted_blocks.iter().enumerate() {
                 row_offset.push((left_offset, 0));
@@ -325,7 +334,10 @@ impl RangeJoinState {
                 left_match.extend_constant(left_block.num_rows(), false);
             }
         }
-        if matches!(self.join_type, JoinType::Right | JoinType::RightAsof) {
+        if matches!(
+            self.join_type,
+            JoinType::Right | JoinType::RightAsof | JoinType::FullAsof
+        ) {
             let mut right_match = self.right_match.write();
             for (right_idx, right_block) in right_sorted_blocks.iter().enumerate() {
                 row_offset.push((0, right_offset));

--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/push_down_filter_join_test.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/push_down_filter_join_test.rs
@@ -159,6 +159,7 @@ fn sexpr_to_string(s_expr: &SExpr) -> String {
                     JoinType::Asof => "Asof",
                     JoinType::LeftAsof => "LeftAsof",
                     JoinType::RightAsof => "RightAsof",
+                    JoinType::FullAsof => "FullAsof",
                 };
 
                 let conditions: Vec<String> = join

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
@@ -367,7 +367,7 @@ impl Binder {
                     "Join conditions should be empty in cross join",
                 ));
             }
-            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof
+            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof | JoinType::FullAsof
                 if non_equi_conditions.is_empty() =>
             {
                 return Err(ErrorCode::SemanticError("Missing inequality condition!"));
@@ -534,7 +534,9 @@ impl Binder {
                         need_push_down = true;
                         left_push_down.push(predicate.clone());
                     }
-                    JoinType::Full => non_equi_conditions.push(predicate.clone()),
+                    JoinType::Full | JoinType::FullAsof => {
+                        non_equi_conditions.push(predicate.clone())
+                    }
                 },
                 JoinPredicate::Left(_) => {
                     need_push_down = true;
@@ -603,7 +605,10 @@ impl Binder {
                     "cross join should not contain join conditions".to_string(),
                 ));
             }
-            JoinOperator::Asof | JoinOperator::LeftAsof | JoinOperator::RightAsof
+            JoinOperator::Asof
+            | JoinOperator::LeftAsof
+            | JoinOperator::RightAsof
+            | JoinOperator::FullAsof
                 if join_condition == &JoinCondition::None =>
             {
                 return Err(ErrorCode::SemanticError(
@@ -1092,6 +1097,7 @@ fn join_type(join_type: &JoinOperator) -> JoinType {
         JoinOperator::Asof => JoinType::Asof,
         JoinOperator::LeftAsof => JoinType::LeftAsof,
         JoinOperator::RightAsof => JoinType::RightAsof,
+        JoinOperator::FullAsof => JoinType::FullAsof,
         JoinOperator::LeftAny => JoinType::LeftAny,
         JoinOperator::RightAny => JoinType::RightAny,
         JoinOperator::InnerAny => JoinType::InnerAny,

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
@@ -154,7 +154,7 @@ fn try_push_down_filter_join(s_expr: &SExpr, metadata: MetadataRef) -> Result<(b
             JoinPredicate::Left(_) => {
                 if matches!(
                     join.join_type,
-                    JoinType::Right | JoinType::RightSingle | JoinType::Full
+                    JoinType::Right | JoinType::RightSingle | JoinType::Full | JoinType::FullAsof
                 ) {
                     if can_filter_null(
                         &predicate,
@@ -173,7 +173,7 @@ fn try_push_down_filter_join(s_expr: &SExpr, metadata: MetadataRef) -> Result<(b
             JoinPredicate::Right(_) => {
                 if matches!(
                     join.join_type,
-                    JoinType::Left | JoinType::LeftSingle | JoinType::Full
+                    JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::FullAsof
                 ) {
                     if can_filter_null(
                         &predicate,
@@ -213,7 +213,9 @@ fn try_push_down_filter_join(s_expr: &SExpr, metadata: MetadataRef) -> Result<(b
         return Ok((false, s_expr.clone()));
     }
 
-    if !matches!(join.join_type, JoinType::Full) && !join.has_null_equi_condition() {
+    if !matches!(join.join_type, JoinType::Full | JoinType::FullAsof)
+        && !join.has_null_equi_condition()
+    {
         // Infer new predicate and push down filter.
         for equi_condition in join.equi_conditions.iter() {
             let left = equi_condition.left.clone();

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
@@ -136,17 +136,18 @@ fn eliminate_outer_join_type(
     match join_type {
         JoinType::Left | JoinType::LeftSingle if can_filter_right_null => JoinType::Inner,
         JoinType::Right | JoinType::RightSingle if can_filter_left_null => JoinType::Inner,
-        JoinType::Full => {
-            if can_filter_left_null && can_filter_right_null {
-                JoinType::Inner
-            } else if can_filter_left_null {
-                JoinType::Left
-            } else if can_filter_right_null {
-                JoinType::Right
-            } else {
-                join_type
-            }
-        }
+        JoinType::Full => match (can_filter_left_null, can_filter_right_null) {
+            (true, true) => JoinType::Inner,
+            (true, false) => JoinType::Left,
+            (false, true) => JoinType::Right,
+            (false, false) => join_type,
+        },
+        JoinType::FullAsof => match (can_filter_left_null, can_filter_right_null) {
+            (true, true) => JoinType::Asof,
+            (true, false) => JoinType::LeftAsof,
+            (false, true) => JoinType::RightAsof,
+            (false, false) => join_type,
+        },
         _ => join_type,
     }
 }
@@ -157,7 +158,10 @@ pub fn can_filter_null(
     join_type: &JoinType,
     metadata: MetadataRef,
 ) -> Result<bool> {
-    if !matches!(join_type, JoinType::Left | JoinType::Right | JoinType::Full) {
+    if !matches!(
+        join_type,
+        JoinType::Left | JoinType::Right | JoinType::Full | JoinType::FullAsof
+    ) {
         return Ok(true);
     }
 

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -72,6 +72,7 @@ pub enum JoinType {
     Asof,
     LeftAsof,
     RightAsof,
+    FullAsof,
 }
 
 impl JoinType {
@@ -107,6 +108,7 @@ impl JoinType {
                 | JoinType::RightSingle
                 | JoinType::LeftAsof
                 | JoinType::RightAsof
+                | JoinType::FullAsof
         )
     }
 
@@ -124,7 +126,7 @@ impl JoinType {
     pub fn is_asof_join(&self) -> bool {
         matches!(
             self,
-            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof
+            JoinType::Asof | JoinType::LeftAsof | JoinType::RightAsof | JoinType::FullAsof
         )
     }
 
@@ -202,6 +204,9 @@ impl Display for JoinType {
             }
             JoinType::RightAsof => {
                 write!(f, "RIGHT ASOF")
+            }
+            JoinType::FullAsof => {
+                write!(f, "FULL ASOF")
             }
         }
     }
@@ -392,7 +397,7 @@ impl Join {
             JoinType::Right | JoinType::RightAny | JoinType::RightAsof => {
                 f64::max(right_cardinality, inner_join_cardinality)
             }
-            JoinType::Full => {
+            JoinType::Full | JoinType::FullAsof => {
                 f64::max(left_cardinality, inner_join_cardinality)
                     + f64::max(right_cardinality, inner_join_cardinality)
                     - inner_join_cardinality
@@ -610,6 +615,7 @@ impl Operator for Join {
                 | JoinType::Asof
                 | JoinType::LeftAsof
                 | JoinType::RightAsof
+                | JoinType::FullAsof
         ) {
             let settings = ctx.get_settings();
             let left_stat_info = rel_expr.derive_cardinality_child(0)?;
@@ -745,6 +751,7 @@ impl Operator for Join {
                 | JoinType::Asof
                 | JoinType::LeftAsof
                 | JoinType::RightAsof
+                | JoinType::FullAsof
         ) && !settings.get_enforce_shuffle_join()?
         {
             // (Any, Broadcast)

--- a/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
+++ b/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
@@ -83,6 +83,23 @@ order by p.price, t.id
 20 3
 21 NULL
 
+# Full ASOF should preserve unmatched rows from both original sides after
+# ASOF nearest-predecessor matching.
+query II
+select t.id, p.price
+from asof_eq_trades t
+asof full join asof_eq_prices p
+    on t.symbol = p.symbol and t.wh >= p.wh
+order by t.id, p.price
+----
+1 10
+2 20
+3 20
+4 11
+5 NULL
+6 NULL
+NULL 21
+
 statement ok
 drop table asof_eq_trades
 

--- a/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_ints.test
+++ b/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_ints.test
@@ -133,6 +133,50 @@ ORDER BY p.begin ASC, e.value ASC
 NULL	-1
 NULL	9
 
+# FULL ON inequality only
+query II
+SELECT p.begin, e.value
+FROM probe0 p ASOF FULL JOIN events0 e
+ON p.begin >= e.begin
+ORDER BY p.begin ASC, e.value ASC
+----
+0	NULL
+1	0
+2	0
+3	1
+4	1
+5	1
+6	2
+7	2
+8	3
+9	3
+NULL	-1
+NULL	9
+
+# FULL ASOF keeps both sides when an ON predicate is unsatisfiable.
+query II
+SELECT p.begin, e.value
+FROM probe0 p ASOF FULL JOIN events0 e
+ON p.begin >= e.begin AND false
+ORDER BY p.begin ASC, e.value ASC
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	NULL
+8	NULL
+9	NULL
+NULL	-1
+NULL	0
+NULL	1
+NULL	2
+NULL	3
+NULL	9
+
 # LEFT ON inequality only for unsigned integer keys
 query II
 SELECT p.begin, e.value


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Support `ASOF FULL JOIN` / `ASOF FULL OUTER JOIN`.

This extends existing ASOF join support from inner/left/right to full outer semantics:

- preserve unmatched probe-side rows as NULL build-side rows
- preserve build-side rows that are never selected by ASOF nearest matching
- keep equi-key ASOF on the hash join fast path
- support inequality-only ASOF through the range join path

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

```bash
cargo fmt --all --check
cargo check -p databend-query
cargo build --bin=databend-query --bin=databend-sqllogictests
target/debug/databend-sqllogictests --run_file test_asof_join_ints.test
target/debug/databend-sqllogictests --run_file test_asof_join_eq_hash_fast_path.test
```

E2E sqllogictest results with standalone Databend:

- `test_asof_join_ints.test`: MySQL 36 passed, HTTP 36 passed
- `test_asof_join_eq_hash_fast_path.test`: MySQL 18 passed, HTTP 18 passed

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19859)
<!-- Reviewable:end -->
