### PR TITLE
feat(query): support ASOF JOIN USING

### DIFF
--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
@@ -46,6 +46,7 @@ use crate::planner::semantic::NameResolutionContext;
 use crate::plans::BoundColumnRef;
 use crate::plans::EvalScalar;
 use crate::plans::Filter;
+use crate::plans::FunctionCall;
 use crate::plans::HashJoinBuildCacheInfo;
 use crate::plans::Join;
 use crate::plans::JoinEquiCondition;
@@ -60,6 +61,8 @@ pub struct JoinConditions {
     pub(crate) non_equi_conditions: Vec<ScalarExpr>,
     pub(crate) other_conditions: Vec<ScalarExpr>,
 }
+
+const ASOF_USING_RANGE_FUNC: &str = "gte";
 
 impl Binder {
     pub(crate) fn bind_join(
@@ -732,6 +735,7 @@ impl<'a> JoinConditionResolver<'a> {
                     using_columns,
                     left_join_conditions,
                     right_join_conditions,
+                    non_equi_conditions,
                     join_op,
                 )?;
             }
@@ -746,6 +750,7 @@ impl<'a> JoinConditionResolver<'a> {
                     using_columns,
                     left_join_conditions,
                     right_join_conditions,
+                    non_equi_conditions,
                     join_op,
                 )?
             }
@@ -907,6 +912,7 @@ impl<'a> JoinConditionResolver<'a> {
         using_columns: Vec<(Span, String)>,
         left_join_conditions: &mut Vec<ScalarExpr>,
         right_join_conditions: &mut Vec<ScalarExpr>,
+        non_equi_conditions: &mut Vec<ScalarExpr>,
         join_op: &JoinOperator,
     ) -> Result<()> {
         bind_join_columns(
@@ -915,7 +921,18 @@ impl<'a> JoinConditionResolver<'a> {
             self.join_context,
         );
         let left_columns_len = self.left_column_bindings.len();
-        for (span, join_key) in using_columns.iter() {
+        let asof_range_column = if matches!(
+            join_op,
+            JoinOperator::Asof
+                | JoinOperator::LeftAsof
+                | JoinOperator::RightAsof
+                | JoinOperator::FullAsof
+        ) {
+            using_columns.len().checked_sub(1)
+        } else {
+            None
+        };
+        for (index, (span, join_key)) in using_columns.iter().enumerate() {
             let join_key_name = join_key.as_str();
             let left_scalar = if let Some(col_binding) = self.join_context.columns
                 [0..left_columns_len]
@@ -950,7 +967,8 @@ impl<'a> JoinConditionResolver<'a> {
                 ))
                 .set_span(*span));
             };
-            let idx = !matches!(join_op, JoinOperator::RightOuter) as usize;
+            let idx =
+                !matches!(join_op, JoinOperator::RightOuter | JoinOperator::RightAsof) as usize;
             if let Some(col_binding) = self
                 .join_context
                 .columns
@@ -961,16 +979,25 @@ impl<'a> JoinConditionResolver<'a> {
                 })
                 .nth(idx)
             {
-                // Always make the second using column in the join_context invisible in unqualified wildcard.
+                // Make the duplicate USING column invisible in unqualified wildcard.
                 col_binding.visibility = Visibility::UnqualifiedWildcardInVisible;
             }
 
-            self.add_equi_conditions(
-                left_scalar,
-                right_scalar,
-                left_join_conditions,
-                right_join_conditions,
-            )?;
+            if Some(index) == asof_range_column {
+                non_equi_conditions.push(ScalarExpr::FunctionCall(FunctionCall {
+                    span: *span,
+                    func_name: ASOF_USING_RANGE_FUNC.to_string(),
+                    params: vec![],
+                    arguments: vec![left_scalar, right_scalar],
+                }));
+            } else {
+                self.add_equi_conditions(
+                    left_scalar,
+                    right_scalar,
+                    left_join_conditions,
+                    right_join_conditions,
+                )?;
+            }
         }
         Ok(())
     }

--- a/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
+++ b/tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test
@@ -52,6 +52,20 @@ order by t.id
 3 20
 4 11
 
+# ASOF USING treats the final USING column as the range key and the
+# preceding USING columns as equality keys.
+query I?II
+select *
+from asof_eq_trades t
+asof join asof_eq_prices p
+    using (symbol, wh)
+order by id
+----
+1 2020-01-01 00:00:01.000000 1 10
+2 2020-01-01 00:00:03.000000 2 20
+3 2020-01-01 00:00:05.000000 2 20
+4 2020-01-01 00:00:06.000000 1 11
+
 # Left ASOF should preserve unmatched rows as NULL while keeping the same
 # nearest-predecessor semantics for matched rows.
 query II
@@ -59,6 +73,20 @@ select t.id, p.price
 from asof_eq_trades t
 asof left join asof_eq_prices p
     on t.symbol = p.symbol and t.wh >= p.wh
+order by t.id
+----
+1 10
+2 20
+3 20
+4 11
+5 NULL
+6 NULL
+
+query II
+select t.id, p.price
+from asof_eq_trades t
+asof left join asof_eq_prices p
+    using (symbol, wh)
 order by t.id
 ----
 1 10
@@ -90,6 +118,34 @@ select t.id, p.price
 from asof_eq_trades t
 asof full join asof_eq_prices p
     on t.symbol = p.symbol and t.wh >= p.wh
+order by t.id, p.price
+----
+1 10
+2 20
+3 20
+4 11
+5 NULL
+6 NULL
+NULL 21
+
+query II
+select p.price, t.id
+from asof_eq_trades t
+asof right join asof_eq_prices p
+    using (symbol, wh)
+order by p.price, t.id
+----
+10 1
+11 4
+20 2
+20 3
+21 NULL
+
+query II
+select t.id, p.price
+from asof_eq_trades t
+asof full join asof_eq_prices p
+    using (symbol, wh)
 order by t.id, p.price
 ----
 1 10


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Support `ASOF JOIN ... USING (...)` in the query binder
- Treat the final `USING` column as the ASOF range key and preceding columns as equality keys
- Keep duplicate `USING` columns hidden from unqualified wildcard output, including right ASOF joins

Related to #15423

## Changes

This enables SQL like:

```sql
SELECT *
FROM trades t
ASOF JOIN prices p
USING (symbol, wh);
```

The binder rewrites the final `USING` column into the default ASOF range predicate (`left >= right`) while preserving the existing `USING` equality behavior for earlier keys.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Commands run:

```shell
cargo fmt --check
git diff --check
cargo test -p databend-common-sql --lib bind_asof_join
target/debug/databend-sqllogictests --run 'tests/sqllogictests/suites/duckdb/join/asof/test_asof_join_eq_hash_fast_path.test'
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19862)
<!-- Reviewable:end -->
