### PR TITLE
feat(storage): add Vortex columnar file format support for Fuse engine

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -14,6 +14,7 @@ Nd = "Nd"
 typ = "typ"
 aranges = "aranges"
 pendings = "pendings"
+writeable = "writeable"
 
 [default.extend-identifiers]
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -14,7 +14,6 @@ Nd = "Nd"
 typ = "typ"
 aranges = "aranges"
 pendings = "pendings"
-writeable = "writeable"
 
 [default.extend-identifiers]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "arrow-udf-runtime"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=955f84470ff596640364fe6561d183979a4ab11f#955f84470ff596640364fe6561d183979a4ab11f"
+source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=ddde517521a6bc27a7db1e3a59c69f7279b2289f#ddde517521a6bc27a7db1e3a59c69f7279b2289f"
 dependencies = [
  "anyhow",
  "arrow-array 58.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,11 +369,32 @@ dependencies = [
  "arrow-ipc 56.2.0",
  "arrow-json 56.2.0",
  "arrow-ord 56.2.0",
- "arrow-pyarrow",
  "arrow-row 56.2.0",
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "arrow-string 56.2.0",
+]
+
+[[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-csv 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-json 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-pyarrow",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-string 58.1.0",
 ]
 
 [[package]]
@@ -402,6 +423,20 @@ dependencies = [
  "arrow-schema 56.2.0",
  "chrono",
  "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "num-traits",
 ]
 
 [[package]]
@@ -439,6 +474,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "chrono-tz 0.10.3",
+ "half",
+ "hashbrown 0.16.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-buffer"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +512,18 @@ dependencies = [
  "bytes",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -503,6 +569,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
 name = "arrow-csv"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +622,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
 name = "arrow-data"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +661,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-flight"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,9 +695,37 @@ dependencies = [
  "futures",
  "once_cell",
  "paste",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "tonic 0.13.1",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302b2e036335f3f04d65dad3f74ff1f2aae6dc671d6aa04dc6b61193761e16fb"
+dependencies = [
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-string 58.1.0",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "once_cell",
+ "paste",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -609,7 +753,22 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.11.3",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "flatbuffers",
+ "lz4_flex 0.13.0",
  "zstd 0.13.3",
 ]
 
@@ -658,6 +817,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "half",
+ "indexmap 2.12.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
 name = "arrow-ord"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,14 +867,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-pyarrow"
-version = "56.2.0"
+name = "arrow-ord"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d924b32e96f8bb74d94cd82bd97b313c432fcb0ea331689ef9e7c6b8be4b258"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+]
+
+[[package]]
+name = "arrow-pyarrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63351dc11981a316c828a6032a5021345bba882f68bc4a36c36825a50725089"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "pyo3",
 ]
 
@@ -722,6 +918,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "half",
+]
+
+[[package]]
 name = "arrow-schema"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,9 +945,16 @@ name = "arrow-schema"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
  "bitflags 2.9.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -767,6 +983,20 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -804,16 +1034,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "arrow-udf-runtime"
 version = "0.8.0"
-source = "git+https://github.com/datafuse-extras/arrow-udf.git?rev=2480dccf1#2480dccf1bad1a88d39a7c084ed7d54685e93735"
+source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=a0a2bb369cdd96dea3da3d61e190db4c79119da4#a0a2bb369cdd96dea3da3d61e190db4c79119da4"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-trait",
  "atomic-time",
  "base64 0.22.1",
@@ -1654,8 +1901,8 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 name = "bendpy"
 version = "0.1.0"
 dependencies = [
- "arrow 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-schema 58.1.0",
  "ctor",
  "databend-common-base",
  "databend-common-catalog",
@@ -1743,7 +1990,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2014,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -3496,7 +3743,7 @@ name = "databend-common-catalog"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-schema 56.2.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "chrono",
@@ -3526,13 +3773,12 @@ dependencies = [
  "log",
  "maplit",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rand 0.8.5",
  "roaring 0.10.12",
  "serde",
  "serde_json",
  "sha2",
- "thrift",
  "tokio",
  "typetag",
  "uuid",
@@ -3549,13 +3795,14 @@ dependencies = [
  "databend-common-exception",
  "hyper-util",
  "lenient_semver",
- "prost",
- "prost-build",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
  "semver",
  "serde",
  "tokio",
- "tonic 0.13.1",
- "tonic-build",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower 0.5.2",
 ]
 
@@ -3563,9 +3810,9 @@ dependencies = [
 name = "databend-common-column"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "borsh",
  "bytemuck",
  "databend-common-base",
@@ -3641,8 +3888,8 @@ name = "databend-common-exception"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-flight",
- "arrow-schema 56.2.0",
+ "arrow-flight 58.1.0",
+ "arrow-schema 58.1.0",
  "backtrace",
  "bincode 2.0.1",
  "cidr",
@@ -3656,9 +3903,9 @@ dependencies = [
  "object",
  "once_cell",
  "opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "paste",
- "prost",
+ "prost 0.14.3",
  "redis",
  "reqwest",
  "rustc-demangle",
@@ -3668,7 +3915,7 @@ dependencies = [
  "tantivy",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.13.1",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -3676,14 +3923,14 @@ name = "databend-common-expression"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-flight",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-flight 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-backtrace",
  "base64 0.22.1",
  "borsh",
@@ -3735,7 +3982,7 @@ dependencies = [
  "serde_json",
  "strength_reduce",
  "terminal_size",
- "tonic 0.13.1",
+ "tonic 0.14.5",
  "typetag",
  "unicode-segmentation",
 ]
@@ -3861,7 +4108,7 @@ dependencies = [
  "semver",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.13.1",
+ "tonic 0.14.5",
  "tower-service",
 ]
 
@@ -3968,7 +4215,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
- "prost",
+ "prost 0.14.3",
  "seq-marked",
  "serde",
  "serde_json",
@@ -3997,7 +4244,7 @@ dependencies = [
  "log",
  "logcall",
  "maplit",
- "prost",
+ "prost 0.14.3",
  "rand 0.8.5",
  "seq-marked",
  "serde",
@@ -4005,6 +4252,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.13.1",
+ "tonic 0.14.5",
  "uuid",
  "zstd 0.12.4",
 ]
@@ -4033,7 +4281,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "paste",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "sha1",
@@ -4071,7 +4319,7 @@ dependencies = [
  "futures",
  "mlua",
  "openraft",
- "prost",
+ "prost 0.14.3",
  "reqwest",
  "serde",
  "serde_json",
@@ -4094,7 +4342,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-client 260205.5.0",
  "openraft",
- "prost",
+ "prost 0.14.3",
  "regex",
  "serde",
  "serde_json",
@@ -4153,7 +4401,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic 0.13.1",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -4208,7 +4456,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot 0.12.3",
- "petgraph",
+ "petgraph 0.6.5",
  "serde",
  "tokio",
  "typetag",
@@ -4219,9 +4467,9 @@ name = "databend-common-pipeline-transforms"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-channel",
  "async-trait",
@@ -4273,7 +4521,7 @@ dependencies = [
  "maplit",
  "num",
  "pretty_assertions",
- "prost",
+ "prost 0.14.3",
  "thiserror 1.0.69",
 ]
 
@@ -4284,11 +4532,12 @@ dependencies = [
  "lenient_semver",
  "num-derive",
  "num-traits",
- "prost",
- "prost-build",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
  "semver",
- "tonic 0.13.1",
- "tonic-build",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -4444,7 +4693,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
- "arrow-schema 56.2.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "base64 0.22.1",
  "borsh",
@@ -4464,7 +4713,7 @@ dependencies = [
  "log",
  "lru",
  "opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "prometheus-client 0.22.3",
  "regex",
  "reqwest",
@@ -4479,7 +4728,7 @@ dependencies = [
 name = "databend-common-storages-basic"
 version = "0.1.0"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "async-backtrace",
  "async-trait",
  "databend-common-base",
@@ -4497,7 +4746,7 @@ dependencies = [
  "log",
  "opendal",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4510,7 +4759,7 @@ dependencies = [
 name = "databend-common-storages-delta"
 version = "0.1.0"
 dependencies = [
- "arrow-schema 56.2.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "databend-common-base",
@@ -4528,7 +4777,7 @@ dependencies = [
  "fastrace",
  "itertools 0.13.0",
  "object_store_opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "serde",
  "serde_json",
  "tokio",
@@ -4557,10 +4806,10 @@ name = "databend-common-storages-fuse"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.12",
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-channel",
  "async-trait",
@@ -4612,7 +4861,7 @@ dependencies = [
  "match-template",
  "opendal",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "paste",
  "rand 0.8.5",
  "roaring 0.10.12",
@@ -4658,7 +4907,7 @@ dependencies = [
  "hive_metastore",
  "log",
  "opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "recursive",
  "serde",
  "tokio",
@@ -4670,8 +4919,8 @@ dependencies = [
 name = "databend-common-storages-iceberg"
 version = "0.1.0"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "chrono",
@@ -4700,7 +4949,7 @@ dependencies = [
  "iceberg-catalog-rest",
  "iceberg-catalog-s3tables",
  "log",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "serde",
  "serde_json",
  "typetag",
@@ -4722,8 +4971,8 @@ dependencies = [
 name = "databend-common-storages-orc"
 version = "0.1.0"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "bytes",
@@ -4754,10 +5003,10 @@ dependencies = [
 name = "databend-common-storages-parquet"
 version = "0.1.0"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "bytes",
@@ -4781,10 +5030,9 @@ dependencies = [
  "jiff",
  "log",
  "opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rand 0.8.5",
  "serde",
- "thrift",
  "tokio",
  "typetag",
 ]
@@ -4794,8 +5042,8 @@ name = "databend-common-storages-stage"
 version = "0.1.0"
 dependencies = [
  "apache-avro 0.17.0",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "async-backtrace",
  "async-trait",
  "bstr",
@@ -4837,7 +5085,7 @@ dependencies = [
  "object_store_opendal",
  "opendal",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "serde",
  "serde_json",
  "simdutf8",
@@ -4934,8 +5182,8 @@ name = "databend-common-tracing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "async-channel",
  "backtrace",
  "concurrent-queue",
@@ -4955,12 +5203,12 @@ dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry-otlp 0.29.0",
  "opentelemetry_sdk 0.29.0",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "serde",
  "serde_json",
  "tokio",
  "toml 0.8.22",
- "tonic 0.13.1",
+ "tonic 0.14.5",
  "uuid",
 ]
 
@@ -5315,7 +5563,7 @@ source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0
 dependencies = [
  "anyerror",
  "anyhow",
- "arrow-flight",
+ "arrow-flight 56.2.0",
  "async-trait",
  "backon",
  "base2histogram",
@@ -5343,7 +5591,7 @@ dependencies = [
  "openraft",
  "peel-off",
  "prometheus-client 0.22.3",
- "prost",
+ "prost 0.13.5",
  "raft-log",
  "rustls 0.23.36",
  "seq-marked",
@@ -5465,7 +5713,7 @@ version = "260205.5.0"
 source = "git+https://github.com/databendlabs/databend-meta?tag=v260205.5.0#b0c74ad6d4e3c2e2f8801fdb193704dc5c682d56"
 dependencies = [
  "anyerror",
- "arrow-flight",
+ "arrow-flight 56.2.0",
  "async-backtrace",
  "chrono",
  "databend-base",
@@ -5483,7 +5731,7 @@ dependencies = [
  "logcall",
  "once_cell",
  "parking_lot 0.12.3",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5497,7 +5745,7 @@ version = "260312.7.0"
 source = "git+https://github.com/databendlabs/databend-meta?tag=v260312.7.0#d2a0e8316f0537be1ba6aa59f87f3ac052ade57d"
 dependencies = [
  "anyerror",
- "arrow-flight",
+ "arrow-flight 56.2.0",
  "async-backtrace",
  "async-trait",
  "chrono",
@@ -5517,7 +5765,7 @@ dependencies = [
  "logcall",
  "once_cell",
  "parking_lot 0.12.3",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5674,13 +5922,13 @@ dependencies = [
  "num-derive",
  "num-traits",
  "openraft",
- "prost",
- "prost-build",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
  "serde",
  "serde_json",
  "state-machine-api",
  "tonic 0.13.1",
- "tonic-build",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -5817,15 +6065,15 @@ dependencies = [
  "num_cpus",
  "openraft",
  "pretty_assertions",
- "prost",
- "prost-build",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
  "rotbl",
  "serde",
  "serde_json",
  "state-machine-api",
  "thiserror 1.0.69",
  "tonic 0.13.1",
- "tonic-build",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -5847,7 +6095,7 @@ dependencies = [
  "num_cpus",
  "openraft",
  "pretty_assertions",
- "prost",
+ "prost 0.13.5",
  "rotbl",
  "serde",
  "serde_json",
@@ -5884,13 +6132,16 @@ name = "databend-query"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-flight",
- "arrow-ipc 56.2.0",
- "arrow-json 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-csv 58.1.0",
+ "arrow-flight 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-json 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-udf-runtime",
  "async-backtrace",
  "async-channel",
  "async-compat",
@@ -6013,14 +6264,14 @@ dependencies = [
  "opentelemetry_sdk 0.29.0",
  "p256",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
- "petgraph",
+ "parquet 58.1.0",
+ "petgraph 0.6.5",
  "pin-project-lite",
  "poem",
  "pretty_assertions",
  "prometheus-client 0.22.3",
  "proptest",
- "prost",
+ "prost 0.14.3",
  "rand 0.8.5",
  "recursive",
  "redis",
@@ -6043,7 +6294,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.13.1",
+ "toml 0.8.22",
+ "tonic 0.14.5",
  "tower 0.5.2",
  "typetag",
  "unicase",
@@ -6181,13 +6433,13 @@ dependencies = [
 name = "databend-storages-common-blocks"
 version = "0.1.0"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array 58.1.0",
  "bytes",
  "databend-common-exception",
  "databend-common-expression",
  "databend-storages-common-table-meta",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "tokio",
 ]
 
@@ -6195,7 +6447,7 @@ dependencies = [
 name = "databend-storages-common-cache"
 version = "0.1.0"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "async-backtrace",
  "async-trait",
  "bytes",
@@ -6216,7 +6468,7 @@ dependencies = [
  "log",
  "mockall",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rayon",
  "rustix 0.38.44",
  "siphasher 0.3.11",
@@ -6229,8 +6481,8 @@ version = "0.1.0"
 dependencies = [
  "anyerror",
  "anyhow",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "base64 0.22.1",
  "bincode 2.0.1",
  "bitvec",
@@ -6262,7 +6514,7 @@ dependencies = [
  "num_cpus",
  "ordered-float 5.1.0",
  "parking_lot 0.12.3",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rand 0.8.5",
  "rayon",
  "roaring 0.10.12",
@@ -6294,7 +6546,7 @@ dependencies = [
  "futures",
  "log",
  "opendal",
- "parquet 56.2.0",
+ "parquet 58.1.0",
 ]
 
 [[package]]
@@ -6333,7 +6585,7 @@ dependencies = [
 name = "databend-storages-common-stage"
 version = "0.1.0"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array 58.1.0",
  "databend-common-ast",
  "databend-common-catalog",
  "databend-common-exception",
@@ -6349,7 +6601,7 @@ dependencies = [
 name = "databend-storages-common-table-meta"
 version = "0.1.0"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "bincode 1.3.3",
  "bytes",
  "chrono",
@@ -6366,7 +6618,7 @@ dependencies = [
  "databend-common-storage",
  "enum-as-inner",
  "log",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -7442,6 +7694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7657,10 +7915,9 @@ dependencies = [
 [[package]]
 name = "fsst"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7cb31412f3f09e2e0487281b2920fd4c19aba352c3db6e93e7d63d8f2081eb"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow-array 56.2.0",
+ "arrow-array 58.1.0",
  "rand 0.9.2",
 ]
 
@@ -9773,7 +10030,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -9788,19 +10045,19 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=6ccaa60e#6ccaa60e3da324b570a1288cd9b5977c70981930"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0",
  "array-init",
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-string 58.1.0",
  "as-any",
  "async-trait",
  "backon",
@@ -9820,7 +10077,7 @@ dependencies = [
  "once_cell",
  "opendal",
  "ordered-float 4.6.0",
- "parquet 56.2.0",
+ "parquet 58.1.0",
  "rand 0.8.5",
  "reqsign",
  "reqwest",
@@ -9843,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=6ccaa60e#6ccaa60e3da324b570a1288cd9b5977c70981930"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9858,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-hms"
 version = "0.8.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=6ccaa60e#6ccaa60e3da324b570a1288cd9b5977c70981930"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9880,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=6ccaa60e#6ccaa60e3da324b570a1288cd9b5977c70981930"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9900,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.8.0"
-source = "git+https://github.com/databendlabs/iceberg-rust?rev=6ccaa60e#6ccaa60e3da324b570a1288cd9b5977c70981930"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10122,12 +10379,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inferno"
@@ -10604,15 +10855,14 @@ dependencies = [
 [[package]]
 name = "lance-arrow"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53669b967e3800e3ef80b6d32451ca1f4a98adab5a0ea180b57451b45ef4f7e"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytes",
  "getrandom 0.2.16",
  "half",
@@ -10624,8 +10874,7 @@ dependencies = [
 [[package]]
 name = "lance-bitpacking"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab4c7e3d69d4318e4078c38f3bba4e24d70eed8dad01ef2646a3639da59cdcf"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
  "arrayref",
  "paste",
@@ -10635,12 +10884,11 @@ dependencies = [
 [[package]]
 name = "lance-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc4d37a02c3212343e87008e9140ce8d28c370b45c31ca9cadcb3528b588162"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "byteorder",
  "bytes",
@@ -10655,7 +10903,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rand 0.9.2",
  "roaring 0.10.12",
  "serde_json",
@@ -10671,16 +10919,15 @@ dependencies = [
 [[package]]
 name = "lance-encoding"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226f5cc09ff8f52f7648ac3aeb0193c9a041f881108de6f7a928cf23a802165d"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -10695,9 +10942,9 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "protobuf-src",
  "rand 0.9.2",
  "snafu",
@@ -10711,15 +10958,14 @@ dependencies = [
 [[package]]
 name = "lance-file"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc5f0bfc5fb352cd1f127968dc3118320fa5c339bc1d41667a75db0dc44e185"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "byteorder",
@@ -10734,9 +10980,9 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "protobuf-src",
  "snafu",
  "tokio",
@@ -10746,17 +10992,16 @@ dependencies = [
 [[package]]
 name = "lance-io"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dda9825d75111d83a3bd63fcbd6dbaa1f0ae9aa8b791dfb32fb5d521055c6b"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow 56.2.0",
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "byteorder",
@@ -10771,7 +11016,7 @@ dependencies = [
  "object_store",
  "path_abs",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rand 0.9.2",
  "serde",
  "shellexpand 3.1.2",
@@ -10784,10 +11029,9 @@ dependencies = [
 [[package]]
 name = "lance-namespace"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f89added88947b232179e39c400dd6091498be7cfe29cefd464c0bf31d6f3ad"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "async-trait",
  "bytes",
  "lance-core",
@@ -10811,14 +11055,13 @@ dependencies = [
 [[package]]
 name = "lance-table"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee04ca678959cd94f11fe4c4229eebcce636f0ea1094d2c81a0ee5e0458c1a2"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
 dependencies = [
- "arrow 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "byteorder",
  "bytes",
@@ -10831,9 +11074,9 @@ dependencies = [
  "lance-io",
  "log",
  "object_store",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.13.5",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "protobuf-src",
  "rand 0.9.2",
  "rangemap",
@@ -11005,7 +11248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -11272,6 +11515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash 2.1.0",
+]
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11354,11 +11606,11 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -11950,12 +12202,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12240,7 +12491,7 @@ dependencies = [
  "moka",
  "percent-encoding",
  "prometheus-client 0.23.1",
- "prost",
+ "prost 0.13.5",
  "quick-xml 0.38.4",
  "reqsign",
  "reqwest",
@@ -12447,7 +12698,7 @@ dependencies = [
  "opentelemetry-http 0.28.0",
  "opentelemetry-proto 0.28.0",
  "opentelemetry_sdk 0.28.0",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "serde_json",
  "thiserror 2.0.18",
@@ -12468,7 +12719,7 @@ dependencies = [
  "opentelemetry-http 0.29.0",
  "opentelemetry-proto 0.29.0",
  "opentelemetry_sdk 0.29.0",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
@@ -12486,7 +12737,7 @@ dependencies = [
  "hex",
  "opentelemetry 0.28.0",
  "opentelemetry_sdk 0.28.0",
- "prost",
+ "prost 0.13.5",
  "serde",
  "tonic 0.12.3",
 ]
@@ -12499,7 +12750,7 @@ checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry_sdk 0.29.0",
- "prost",
+ "prost 0.13.5",
  "tonic 0.12.3",
 ]
 
@@ -12547,9 +12798,9 @@ dependencies = [
 [[package]]
 name = "orc-rust"
 version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/orc-rust?rev=fc812ad7010#fc812ad7010c5ab9753a0d93a31dbeed0bcbf3b7"
+source = "git+https://github.com/SkyFan2002/orc-rust.git?rev=6b32f1adec3e3850fbb303c97f16681e175d54bb#6b32f1adec3e3850fbb303c97f16681e175d54bb"
 dependencies = [
- "arrow 56.2.0",
+ "arrow 58.1.0",
  "async-trait",
  "bytemuck",
  "bytes",
@@ -12559,10 +12810,10 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
- "lz4_flex",
+ "lz4_flex 0.11.3",
  "lzokay-native",
  "num",
- "prost",
+ "prost 0.13.5",
  "snafu",
  "snap",
  "tokio",
@@ -12613,12 +12864,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "ownedbytes"
@@ -12734,7 +12979,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.15.3",
- "lz4_flex",
+ "lz4_flex 0.11.3",
  "num",
  "num-bigint",
  "object_store",
@@ -12750,18 +12995,17 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "56.2.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "base64 0.22.1",
  "brotli 8.0.1",
  "bytes",
@@ -12770,9 +13014,10 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.0",
- "lz4_flex",
- "num",
+ "lz4_flex 0.13.0",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -12932,10 +13177,21 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.12.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.3",
+ "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -13561,7 +13817,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -13570,15 +13836,36 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.5",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.106",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.106",
  "tempfile",
@@ -13591,7 +13878,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -13603,7 +13903,16 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -13797,6 +14106,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.9.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13809,37 +14138,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
- "once_cell",
  "python3-dll-a",
- "target-lexicon 0.13.2",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -13847,9 +14172,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -13859,9 +14184,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -14293,30 +14618,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -15665,7 +15981,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -16553,7 +16869,7 @@ dependencies = [
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
+ "lz4_flex 0.11.3",
  "measure_time",
  "memmap2",
  "once_cell",
@@ -16693,9 +17009,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
@@ -17194,7 +17510,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.9",
  "tokio",
  "tokio-stream",
@@ -17223,9 +17539,40 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-native-certs 0.8.1",
  "socket2 0.5.9",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum 0.8.7",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs 0.8.1",
+ "socket2 0.6.1",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-stream",
@@ -17243,10 +17590,49 @@ checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost 0.14.3",
+ "tonic 0.14.5",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "quote",
+ "syn 2.0.106",
+ "tempfile",
+ "tonic-build 0.14.5",
 ]
 
 [[package]]
@@ -17255,8 +17641,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9687bd5bfeafebdded2356950f278bba8226f0b32109537c4253406e09aafe1"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic 0.13.1",
@@ -17399,14 +17785,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -18566,7 +18952,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "arrow-udf-runtime"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=ddde517521a6bc27a7db1e3a59c69f7279b2289f#ddde517521a6bc27a7db1e3a59c69f7279b2289f"
+source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=4865bcc06b0da73391c279b3a5a962ef92a3162e#4865bcc06b0da73391c279b3a5a962ef92a3162e"
 dependencies = [
  "anyhow",
  "arrow-array 58.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,12 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,12 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apache-avro"
@@ -356,23 +347,23 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
- "arrow-arith 56.2.0",
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-csv 56.2.0",
- "arrow-data 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-json 56.2.0",
- "arrow-ord 56.2.0",
- "arrow-row 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
- "arrow-string 56.2.0",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-csv 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-json 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "arrow-string 57.3.0",
 ]
 
 [[package]]
@@ -427,6 +418,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
@@ -467,10 +472,28 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
  "chrono-tz 0.10.3",
  "half",
- "hashbrown 0.16.0",
- "num",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -486,7 +509,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.10.3",
  "half",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -512,6 +535,18 @@ dependencies = [
  "bytes",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -561,10 +596,31 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "chrono",
- "comfy-table",
  "half",
  "lexical-core",
  "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
  "ryu",
 ]
 
@@ -608,13 +664,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -658,6 +714,19 @@ dependencies = [
  "arrow-schema 56.2.0",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+dependencies = [
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -753,7 +822,21 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers",
- "lz4_flex 0.11.3",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "flatbuffers",
+ "lz4_flex 0.12.1",
 ]
 
 [[package]]
@@ -785,7 +868,7 @@ dependencies = [
  "arrow-schema 55.1.0",
  "chrono",
  "half",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "lexical-core",
  "memchr",
  "num",
@@ -796,22 +879,24 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "56.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
- "arrow-array 56.2.0",
- "arrow-buffer 56.2.0",
- "arrow-cast 56.2.0",
- "arrow-data 56.2.0",
- "arrow-schema 56.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "half",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
@@ -829,7 +914,7 @@ dependencies = [
  "arrow-schema 58.1.0",
  "chrono",
  "half",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -864,6 +949,19 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
 ]
 
 [[package]]
@@ -919,6 +1017,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
@@ -945,6 +1056,12 @@ name = "arrow-schema"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 
 [[package]]
 name = "arrow-schema"
@@ -983,6 +1100,20 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -1035,6 +1166,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "arrow-string"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
@@ -1053,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "arrow-udf-runtime"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=4865bcc06b0da73391c279b3a5a962ef92a3162e#4865bcc06b0da73391c279b3a5a962ef92a3162e"
+source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=ec0c74d1bb53d68243c2bb23ebaa9392223e094c#ec0c74d1bb53d68243c2bb23ebaa9392223e094c"
 dependencies = [
  "anyhow",
  "arrow-array 58.1.0",
@@ -1990,7 +2138,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2350,9 +2498,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -2596,17 +2744,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3585,7 +3732,7 @@ dependencies = [
  "http 1.3.1",
  "log",
  "logforth",
- "opendal",
+ "opendal 0.54.1",
  "tokio",
  "toml 0.8.22",
 ]
@@ -3609,7 +3756,7 @@ dependencies = [
  "databend-storages-common-table-meta",
  "limits-rs",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "serde",
  "serde_json",
  "serfig",
@@ -3902,7 +4049,7 @@ dependencies = [
  "libc",
  "object",
  "once_cell",
- "opendal",
+ "opendal 0.54.1",
  "parquet 58.1.0",
  "paste",
  "prost 0.14.3",
@@ -4294,7 +4441,7 @@ name = "databend-common-meta-app-storage"
 version = "0.1.0"
 dependencies = [
  "databend-common-exception",
- "opendal",
+ "opendal 0.54.1",
  "serde",
  "tokio",
 ]
@@ -4432,7 +4579,7 @@ dependencies = [
  "lz4",
  "match-template",
  "num",
- "opendal",
+ "opendal 0.54.1",
  "rand 0.8.5",
  "ringbuffer",
  "roaring 0.10.12",
@@ -4633,13 +4780,13 @@ dependencies = [
  "fastrace",
  "globiter",
  "goldenfile",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "jsonb",
  "log",
  "num-derive",
  "num-traits",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "prqlc",
  "recursive",
@@ -4712,7 +4859,7 @@ dependencies = [
  "iceberg",
  "log",
  "lru",
- "opendal",
+ "opendal 0.54.1",
  "parquet 58.1.0",
  "prometheus-client 0.22.3",
  "regex",
@@ -4744,7 +4891,7 @@ dependencies = [
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "parquet 58.1.0",
  "serde",
@@ -4854,12 +5001,12 @@ dependencies = [
  "futures-util",
  "geo",
  "geo-index",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "jsonb",
  "log",
  "match-template",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "parquet 58.1.0",
  "paste",
@@ -4906,7 +5053,7 @@ dependencies = [
  "futures",
  "hive_metastore",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "parquet 58.1.0",
  "recursive",
  "serde",
@@ -4992,7 +5139,7 @@ dependencies = [
  "futures-util",
  "jiff",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "orc-rust",
  "serde",
  "serde_json",
@@ -5029,7 +5176,7 @@ dependencies = [
  "futures",
  "jiff",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "parquet 58.1.0",
  "rand 0.8.5",
  "serde",
@@ -5083,7 +5230,7 @@ dependencies = [
  "num-traits",
  "object_store",
  "object_store_opendal",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "parquet 58.1.0",
  "serde",
@@ -5149,7 +5296,7 @@ dependencies = [
  "jsonb",
  "log",
  "once_cell",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "regex",
  "serde",
@@ -5199,7 +5346,7 @@ dependencies = [
  "libc",
  "log",
  "logforth",
- "opendal",
+ "opendal 0.54.1",
  "opentelemetry 0.29.1",
  "opentelemetry-otlp 0.29.0",
  "opentelemetry_sdk 0.29.0",
@@ -5378,7 +5525,7 @@ dependencies = [
  "jsonb",
  "jwt-simple",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "serde",
  "tempfile",
  "tokio",
@@ -6256,7 +6403,7 @@ dependencies = [
  "md-5",
  "mysql_async",
  "num_cpus",
- "opendal",
+ "opendal 0.54.1",
  "opensrv-mysql",
  "opentelemetry 0.29.1",
  "opentelemetry_sdk 0.29.0",
@@ -6542,7 +6689,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "parquet 58.1.0",
 ]
 
@@ -6572,7 +6719,7 @@ dependencies = [
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
- "opendal",
+ "opendal 0.54.1",
  "parking_lot 0.12.3",
  "serde",
  "uuid",
@@ -6639,22 +6786,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "50.3.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
+checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
  "ahash 0.8.12",
- "arrow 56.2.0",
- "arrow-ipc 56.2.0",
- "base64 0.22.1",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "chrono",
  "half",
- "hashbrown 0.14.5",
- "indexmap 2.12.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "libc",
  "log",
  "paste",
- "sqlparser 0.58.0",
  "tokio",
  "web-time",
 ]
@@ -6729,7 +6874,7 @@ dependencies = [
  "chrono",
  "delta_kernel_derive",
  "futures",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "object_store",
  "parquet 55.1.0",
@@ -6792,7 +6937,7 @@ dependencies = [
  "either",
  "futures",
  "humantime",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "maplit",
  "num-bigint",
@@ -7763,6 +7908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7911,8 +8062,8 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow-array 58.1.0",
  "rand 0.9.2",
@@ -8319,7 +8470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -9322,7 +9473,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -9341,7 +9492,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -9369,13 +9520,14 @@ checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -9433,14 +9585,25 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -10027,7 +10190,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -10042,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=edb4e4f8158821d274850d19d2c7d0030e16e142#edb4e4f8158821d274850d19d2c7d0030e16e142"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0",
@@ -10072,7 +10235,7 @@ dependencies = [
  "murmur3",
  "num-bigint",
  "once_cell",
- "opendal",
+ "opendal 0.55.0",
  "ordered-float 4.6.0",
  "parquet 58.1.0",
  "rand 0.8.5",
@@ -10097,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=edb4e4f8158821d274850d19d2c7d0030e16e142#edb4e4f8158821d274850d19d2c7d0030e16e142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10112,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-hms"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=edb4e4f8158821d274850d19d2c7d0030e16e142#edb4e4f8158821d274850d19d2c7d0030e16e142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10134,7 +10297,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=edb4e4f8158821d274850d19d2c7d0030e16e142#edb4e4f8158821d274850d19d2c7d0030e16e142"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10154,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=db28794b73307c6c588c717131526533b0e11070#db28794b73307c6c588c717131526533b0e11070"
+source = "git+https://github.com/SkyFan2002/iceberg-rust.git?rev=edb4e4f8158821d274850d19d2c7d0030e16e142#edb4e4f8158821d274850d19d2c7d0030e16e142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10367,12 +10530,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -10384,7 +10547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.12",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -10484,6 +10647,17 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-uring"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipconfig"
@@ -10618,9 +10792,9 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
  "hifijson",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "jaq-core",
  "jaq-std",
  "serde_json",
@@ -10817,7 +10991,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -10851,16 +11025,19 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow-array 58.1.0",
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
  "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
  "arrow-schema 58.1.0",
  "arrow-select 58.1.0",
  "bytes",
+ "futures",
  "getrandom 0.2.16",
  "half",
  "jsonb",
@@ -10870,8 +11047,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrayref",
  "paste",
@@ -10880,8 +11057,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow-array 58.1.0",
  "arrow-buffer 58.1.0",
@@ -10892,6 +11069,7 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
+ "itertools 0.13.0",
  "lance-arrow",
  "libc",
  "log",
@@ -10900,11 +11078,11 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost 0.13.5",
+ "prost 0.14.3",
  "rand 0.9.2",
- "roaring 0.10.12",
+ "roaring 0.11.3",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -10915,8 +11093,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow-arith 58.1.0",
  "arrow-array 58.1.0",
@@ -10939,12 +11117,12 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "protobuf-src",
  "rand 0.9.2",
- "snafu",
+ "snafu 0.9.0",
  "strum 0.26.3",
  "tokio",
  "tracing",
@@ -10954,8 +11132,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow-arith 58.1.0",
  "arrow-array 58.1.0",
@@ -10977,19 +11155,19 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "protobuf-src",
- "snafu",
+ "snafu 0.9.0",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "lance-io"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow 58.1.0",
  "arrow-arith 58.1.0",
@@ -11006,18 +11184,22 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
+ "http 1.3.1",
+ "io-uring",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
+ "libc",
  "log",
+ "moka",
  "object_store",
  "path_abs",
  "pin-project",
- "prost 0.13.5",
+ "prost 0.14.3",
  "rand 0.9.2",
  "serde",
- "shellexpand 3.1.2",
- "snafu",
+ "snafu 0.9.0",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -11025,22 +11207,23 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
  "bytes",
  "lance-core",
  "lance-namespace-reqwest-client",
- "snafu",
+ "serde",
+ "snafu 0.9.0",
 ]
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
+checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
 dependencies = [
  "reqwest",
  "serde",
@@ -11051,8 +11234,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "1.0.4"
-source = "git+https://github.com/SkyFan2002/lance.git?rev=d47ca5a1ed3fa80534a902a678961beca8e2e279#d47ca5a1ed3fa80534a902a678961beca8e2e279"
+version = "5.1.0-beta.3"
+source = "git+https://github.com/SkyFan2002/lance.git?rev=983238285f482cc6d229483d15d6dde8f3bc3e96#983238285f482cc6d229483d15d6dde8f3bc3e96"
 dependencies = [
  "arrow 58.1.0",
  "arrow-array 58.1.0",
@@ -11071,17 +11254,17 @@ dependencies = [
  "lance-io",
  "log",
  "object_store",
- "prost 0.13.5",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "protobuf-src",
  "rand 0.9.2",
  "rangemap",
- "roaring 0.10.12",
+ "roaring 0.11.3",
  "semver",
  "serde",
  "serde_json",
- "snafu",
+ "snafu 0.9.0",
  "tokio",
  "tracing",
  "url",
@@ -11245,7 +11428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -11509,6 +11692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash 1.6.3",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash 2.1.0",
 ]
 
 [[package]]
@@ -12384,7 +12576,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.15.3",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "memchr",
  "ruzstd",
 ]
@@ -12437,7 +12629,7 @@ dependencies = [
  "bytes",
  "futures",
  "object_store",
- "opendal",
+ "opendal 0.54.1",
  "pin-project",
  "tokio",
 ]
@@ -12496,6 +12688,35 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "opendal"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+dependencies = [
+ "anyhow",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "jiff",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
  "uuid",
 ]
 
@@ -12795,7 +13016,7 @@ dependencies = [
 [[package]]
 name = "orc-rust"
 version = "0.6.0"
-source = "git+https://github.com/SkyFan2002/orc-rust.git?rev=6b32f1adec3e3850fbb303c97f16681e175d54bb#6b32f1adec3e3850fbb303c97f16681e175d54bb"
+source = "git+https://github.com/SkyFan2002/orc-rust.git?rev=3fba34ccde628b4063d7f892d15866f89236064c#3fba34ccde628b4063d7f892d15866f89236064c"
 dependencies = [
  "arrow 58.1.0",
  "async-trait",
@@ -12811,7 +13032,7 @@ dependencies = [
  "lzokay-native",
  "num",
  "prost 0.13.5",
- "snafu",
+ "snafu 0.8.5",
  "snap",
  "tokio",
  "zstd 0.13.3",
@@ -13010,7 +13231,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "lz4_flex 0.13.0",
  "num-bigint",
  "num-integer",
@@ -13175,7 +13396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
 ]
@@ -13188,7 +13409,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.3",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -13833,8 +14054,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -13853,8 +14074,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -13875,7 +14096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -13888,7 +14109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -13945,7 +14166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -14857,7 +15078,7 @@ checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
  "bytes",
  "hashbrown 0.15.3",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -14996,7 +15217,7 @@ dependencies = [
  "convert_case 0.6.0",
  "fnv",
  "ident_case",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "proc-macro-crate 1.3.1",
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -15511,7 +15732,7 @@ version = "0.1.0"
 source = "git+https://github.com/datafuse-extras/serde-bridge?rev=4f0e99a#4f0e99abc82de8a82046415c90f01f9739bad630"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -15587,7 +15808,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -15665,7 +15886,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -15691,7 +15912,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -15704,7 +15925,7 @@ version = "0.1.0"
 source = "git+https://github.com/datafuse-extras/serfig?rev=610ac6d#610ac6dfa251206d3667d169b772de7b0f05d151"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde-bridge",
@@ -15770,15 +15991,6 @@ name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -15969,7 +16181,16 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
- "snafu-derive",
+ "snafu-derive 0.8.5",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
+dependencies = [
+ "snafu-derive 0.9.0",
 ]
 
 [[package]]
@@ -15978,7 +16199,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -16166,27 +16399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlparser"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
-dependencies = [
- "log",
- "sqlparser_derive",
-]
-
-[[package]]
-name = "sqlparser_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "sqlx"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16217,7 +16429,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.3",
  "hashlink 0.10.0",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -17411,7 +17623,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -17444,7 +17656,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.9",
@@ -17457,7 +17669,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.9",
@@ -17673,7 +17885,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -18488,7 +18700,7 @@ dependencies = [
  "ahash 0.8.12",
  "bitflags 2.9.0",
  "hashbrown 0.14.5",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -18500,7 +18712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
  "bitflags 2.9.0",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -18532,7 +18744,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli 0.31.1",
  "hashbrown 0.14.5",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "ittapi",
  "libc",
  "libm",
@@ -18658,7 +18870,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.31.1",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -18754,7 +18966,7 @@ checksum = "bf3963c9c29df91564d8bd181eb00d0dbaeafa1b2a01e15952bb7391166b704e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "wit-parser",
 ]
 
@@ -18904,7 +19116,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "shellexpand 2.1.2",
+ "shellexpand",
  "syn 2.0.106",
  "witx",
 ]
@@ -18949,7 +19161,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19537,7 +19749,7 @@ checksum = "ca004bb251010fe956f4a5b9d4bf86b4e415064160dd6669569939e8cbf2504f"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -19781,7 +19993,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.3",
  "hmac",
- "indexmap 2.12.0",
+ "indexmap 2.14.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "arrow-udf-runtime"
 version = "0.8.0"
-source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=a0a2bb369cdd96dea3da3d61e190db4c79119da4#a0a2bb369cdd96dea3da3d61e190db4c79119da4"
+source = "git+https://github.com/SkyFan2002/arrow-udf.git?rev=955f84470ff596640364fe6561d183979a4ab11f#955f84470ff596640364fe6561d183979a4ab11f"
 dependencies = [
  "anyhow",
  "arrow-array 58.1.0",
@@ -6140,8 +6140,6 @@ dependencies = [
  "arrow-ipc 58.1.0",
  "arrow-json 58.1.0",
  "arrow-schema 58.1.0",
- "arrow-select 58.1.0",
- "arrow-udf-runtime",
  "async-backtrace",
  "async-channel",
  "async-compat",
@@ -6294,7 +6292,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.8.22",
  "tonic 0.14.5",
  "tower 0.5.2",
  "typetag",
@@ -6310,10 +6307,10 @@ name = "databend-query-script-udf-support"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array 56.2.0",
- "arrow-ipc 56.2.0",
- "arrow-schema 56.2.0",
- "arrow-select 56.2.0",
+ "arrow-array 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "arrow-udf-runtime",
  "databend-common-base",
  "databend-common-cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -292,9 +292,18 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arcref"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f6098a1e8ab66ff91324cce8fea6643101882cf7d09c85acdb1485ecf61e29"
 
 [[package]]
 name = "ariadne"
@@ -1278,7 +1287,7 @@ source = "git+https://github.com/datafuse-extras/async-backtrace.git?rev=dea4553
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1353,6 +1362,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,13 +1416,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.0.7",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "git+https://github.com/datafuse-extras/async-recursion.git?rev=a353334#a353334ceb408c80a802634ff0cfeeb7a50d0ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.7",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1392,7 +1491,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1409,7 +1508,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2072,6 +2171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2249,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2152,6 +2257,15 @@ name = "binstring"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a3c2603413428303761fae99d4b6d936404208221a44eba47d7c1e6dd03a3"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -2334,7 +2448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2357,7 +2471,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2487,7 +2601,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2732,15 +2846,26 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -2910,7 +3035,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3117,6 +3242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_for"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c50fcfdf972929aff202c16b80086aa3cfc6a3a820af714096c58c7c1d0582"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,6 +3371,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3558,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3578,6 +3718,18 @@ checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
  "nix 0.30.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "custom-labels"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4121f4f539659ad975da5bc6702b7d7d6de59ff1bbaec328dfe7dd5058052ef2"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3611,7 +3763,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3625,7 +3777,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3636,7 +3788,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3647,7 +3799,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3811,7 +3963,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4175,7 +4327,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.106",
+ "syn 2.0.117",
  "trybuild",
 ]
 
@@ -4993,6 +5145,7 @@ dependencies = [
  "databend-storages-common-pruner",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
+ "databend-storages-vortex",
  "divan",
  "enum-as-inner",
  "enum_dispatch",
@@ -6282,7 +6435,6 @@ dependencies = [
  "arrow-array 58.1.0",
  "arrow-buffer 58.1.0",
  "arrow-cast 58.1.0",
- "arrow-csv 58.1.0",
  "arrow-flight 58.1.0",
  "arrow-ipc 58.1.0",
  "arrow-json 58.1.0",
@@ -6773,6 +6925,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "databend-storages-vortex"
+version = "0.1.0"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "bytes",
+ "databend-common-exception",
+ "futures",
+ "opendal 0.54.1",
+ "thiserror 1.0.69",
+ "tokio",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-file",
+ "vortex-io",
+ "vortex-session",
+]
+
+[[package]]
 name = "databend_educe"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6781,7 +6955,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6900,7 +7074,7 @@ checksum = "f7b49a2e67ebafbe644e36f251ee985f237bfb39e4ef1e312eb5876535bc449e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6973,7 +7147,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7027,7 +7201,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7048,7 +7222,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7058,7 +7232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7088,7 +7262,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -7102,7 +7276,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.106",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -7198,7 +7372,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7229,7 +7403,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7297,6 +7471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtype_dispatch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7351,7 +7531,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7429,7 +7609,27 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7449,7 +7649,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7461,7 +7661,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7482,7 +7682,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7554,7 +7754,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7642,6 +7842,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ext-trait"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5"
+dependencies = [
+ "ext-trait-proc_macros",
+]
+
+[[package]]
+name = "ext-trait-proc_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "extension-traits"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537"
+dependencies = [
+ "ext-trait",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7705,6 +7934,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastlanes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cb755aee48ff7b0907995d2949c68c8c17900970076dff6a808e18e592d71"
+dependencies = [
+ "arrayref",
+ "const_for",
+ "num-traits",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
 name = "fastrace"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7728,7 +7970,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7978,7 +8220,7 @@ checksum = "e99b8b3c28ae0e84b604c75f721c21dc77afb3706076af5e8216d15fd1deaae3"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7990,7 +8232,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8002,7 +8244,7 @@ dependencies = [
  "frunk_core",
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8070,6 +8312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsst-rs"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf53d7c403a2b76873d4d66ba7d79c54bde2784cdaba6083f223d6e33270708"
+dependencies = [
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8109,7 +8360,7 @@ checksum = "f664c1c2186b81f798ac765d661fb8cefd74fdb398fd23c76c3fb3c1aec760e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8162,7 +8413,10 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
+ "fastrand",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -8174,7 +8428,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8442,9 +8696,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -9604,6 +9872,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -9953,6 +10226,15 @@ name = "human_format"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -10491,7 +10773,7 @@ dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "zstd 0.13.3",
 ]
 
@@ -10678,16 +10960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10850,9 +11122,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb",
@@ -10866,20 +11138,20 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -10902,10 +11174,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -10983,6 +11257,16 @@ dependencies = [
  "once_cell",
  "sha2",
  "signature",
+]
+
+[[package]]
+name = "kanal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3953adf0cd667798b396c2fa13552d6d9b3269d7dd1154c4c416442d1ff574"
+dependencies = [
+ "futures-core",
+ "lock_api",
 ]
 
 [[package]]
@@ -11272,6 +11556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasso"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
+dependencies = [
+ "dashmap 6.1.0",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11291,6 +11585,31 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lending-iterator"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc07588c853b50689205fb5c00498aa681d89828e0ce8cbd965ebc7a5d8ae260"
+dependencies = [
+ "extension-traits",
+ "lending-iterator-proc_macros",
+ "macro_rules_attribute",
+ "never-say-never",
+ "nougat",
+ "polonius-the-crab",
+]
+
+[[package]]
+name = "lending-iterator-proc_macros"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "lenient_semver"
@@ -11560,7 +11879,7 @@ dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11753,6 +12072,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
 name = "map-api"
 version = "0.4.2"
 source = "git+https://github.com/databendlabs/map-api?tag=v0.4.2#0fee58dfa938b7234723dd3d383f71e559c202b4"
@@ -11832,7 +12167,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12096,7 +12431,7 @@ checksum = "b40e46c845ac234bcba19db7ab252bc2778cbadd516a466d2f12b1580852d136"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12124,6 +12459,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "target-features",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12140,7 +12497,7 @@ checksum = "0ac7d860b767c6398e88fe93db73ce53eb496057aa6895ffa4d60cb02e1d1c6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12174,7 +12531,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "termcolor",
  "thiserror 1.0.69",
 ]
@@ -12287,6 +12644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12352,7 +12715,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12378,6 +12741,27 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nougat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510"
+dependencies = [
+ "macro_rules_attribute",
+ "nougat-proc_macros",
+]
+
+[[package]]
+name = "nougat-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12464,7 +12848,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12546,7 +12930,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12641,6 +13025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "critical-section",
+ "parking_lot_core 0.9.10",
  "portable-atomic",
 ]
 
@@ -12649,6 +13034,12 @@ name = "oneshot"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+
+[[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "opaque-debug"
@@ -12752,7 +13143,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12816,7 +13207,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13268,7 +13659,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "structmeta",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13315,6 +13706,18 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pco"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553ccdc7f6999785559af4998c79712a5ab820e26b68bad9146609c19587ec82"
+dependencies = [
+ "better_io",
+ "dtype_dispatch",
+ "half",
+ "rand_xoshiro",
 ]
 
 [[package]]
@@ -13528,7 +13931,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13647,7 +14050,21 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.1",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13657,13 +14074,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "polonius-the-crab"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -13775,7 +14198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.5.1",
 ]
 
 [[package]]
@@ -13795,7 +14218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13895,7 +14318,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13997,7 +14420,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14064,7 +14487,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.106",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -14085,7 +14508,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.106",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -14099,7 +14522,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14112,7 +14535,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14310,7 +14733,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14397,7 +14820,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14410,7 +14833,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14525,9 +14948,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -14537,6 +14960,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -14590,6 +15019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14627,6 +15067,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -14675,7 +15121,7 @@ checksum = "f5135143cb48d14289139e4615bffec0d59b4cbfd4ea2398a3770bd2abfc4aa2"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14734,7 +15180,7 @@ version = "0.1.1"
 source = "git+https://github.com/datafuse-extras/recursive.git?rev=16e433a#16e433ab3f291512b437206f7ce7b8d078e84195"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14818,7 +15264,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15107,7 +15553,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15223,7 +15669,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15781,7 +16227,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15824,7 +16270,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15903,7 +16349,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -15940,7 +16386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -15967,7 +16413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -16133,13 +16579,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.9"
+name = "sketches-ddsketch"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sled"
@@ -16176,6 +16625,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "snafu"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16202,7 +16668,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16214,7 +16680,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16455,7 +16921,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16478,7 +16944,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.106",
+ "syn 2.0.117",
  "tempfile",
  "tokio",
  "url",
@@ -16706,7 +17172,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16717,7 +17183,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16767,7 +17233,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16779,7 +17245,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -16948,9 +17414,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16985,7 +17451,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17082,14 +17548,14 @@ dependencies = [
  "measure_time",
  "memmap2",
  "once_cell",
- "oneshot",
+ "oneshot 0.1.11",
  "rayon",
  "regex",
  "rust-stemmers",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "sketches-ddsketch",
+ "sketches-ddsketch 0.3.0",
  "smallvec",
  "tantivy-bitpacker",
  "tantivy-columnar",
@@ -17211,6 +17677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17276,6 +17748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "termtree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
+
+[[package]]
 name = "test-harness"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17283,7 +17761,7 @@ checksum = "ae861f7d521762a2e5524ceeb3a518fab2c06c25e217a1d7270b8c5e158c141b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17350,7 +17828,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17361,7 +17839,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17510,7 +17988,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17802,7 +18280,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17814,7 +18292,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -17839,7 +18317,7 @@ dependencies = [
  "prost-build 0.14.3",
  "prost-types 0.14.3",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build 0.14.5",
 ]
@@ -17898,20 +18376,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -17946,7 +18424,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18097,7 +18575,7 @@ checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18108,7 +18586,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18144,7 +18622,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18319,14 +18797,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
- "rand 0.9.2",
- "serde",
+ "rand 0.10.1",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -18508,6 +18986,517 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-alp"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8e1da51ef4feaca010bf0929fef08056af3c94fc57beb52db2a00c1a9774d0"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "prost 0.14.3",
+ "rustc-hash 2.1.1",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-fastlanes",
+ "vortex-mask",
+ "vortex-session",
+ "vortex-utils",
+]
+
+[[package]]
+name = "vortex-array"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6a482bfd544b6d6d13fabdd0fbf7129a6d940c52ada53b37d932a070daedb"
+dependencies = [
+ "arc-swap",
+ "arcref",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-string 58.1.0",
+ "async-lock",
+ "bytes",
+ "cfg-if",
+ "enum-iterator",
+ "flatbuffers",
+ "futures",
+ "half",
+ "humansize",
+ "inventory",
+ "itertools 0.14.0",
+ "jiff",
+ "multiversion",
+ "num-traits",
+ "num_enum",
+ "parking_lot 0.12.3",
+ "paste",
+ "pin-project-lite",
+ "prost 0.14.3",
+ "rand 0.10.1",
+ "rustc-hash 2.1.1",
+ "serde",
+ "simdutf8",
+ "static_assertions",
+ "termtree 1.0.0",
+ "tracing",
+ "uuid",
+ "vortex-array-macros",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-flatbuffers",
+ "vortex-mask",
+ "vortex-proto",
+ "vortex-session",
+ "vortex-utils",
+]
+
+[[package]]
+name = "vortex-array-macros"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b969a03f7691c9c2b36312351f42b79edae328bcd8b05d374e46bd3bd307a335"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "vortex-btrblocks"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86548e6548a15ebb243d280c0a7a5cd67bef8631033b48b999f6a5900cc11ae8"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "rand 0.10.1",
+ "rustc-hash 2.1.1",
+ "tracing",
+ "vortex-alp",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-compressor",
+ "vortex-datetime-parts",
+ "vortex-decimal-byte-parts",
+ "vortex-error",
+ "vortex-fastlanes",
+ "vortex-fsst",
+ "vortex-mask",
+ "vortex-runend",
+ "vortex-sequence",
+ "vortex-sparse",
+ "vortex-utils",
+ "vortex-zigzag",
+]
+
+[[package]]
+name = "vortex-buffer"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49a17335dad8b0bc63dd27edef05ed86f97df505f620148e2add41f9c114ddf"
+dependencies = [
+ "arrow-buffer 58.1.0",
+ "bitvec",
+ "bytes",
+ "itertools 0.14.0",
+ "serde",
+ "simdutf8",
+ "vortex-error",
+]
+
+[[package]]
+name = "vortex-bytebool"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72051360c3d36cdcb40f5d4549f861122723c1da5d0a02c9438991ff201fff0a"
+dependencies = [
+ "num-traits",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-compressor"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8ba49c94482fa38b5597ebde66b8d22d7d594117c3111c075e344354ad6b45"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "parking_lot 0.12.3",
+ "rand 0.10.1",
+ "rustc-hash 2.1.1",
+ "tracing",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-utils",
+]
+
+[[package]]
+name = "vortex-datetime-parts"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13deb6bd4f182518759026bacdae3657c0641038e0e998c89840517967d50754"
+dependencies = [
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-decimal-byte-parts"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f20d82dea087ae870dfd9f34acb1b6ec2211a218f261aada73311f41714a5"
+dependencies = [
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-error"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e062cda75c2c6fbe4c124c0745c5e5f4c427b710e4eab8e262f7f021a3d9c"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "flatbuffers",
+ "jiff",
+ "prost 0.14.3",
+ "tokio",
+]
+
+[[package]]
+name = "vortex-fastlanes"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e69f7e4e7582d76a32c87e91707bc067a66f0e874c71346c386448580e5c9"
+dependencies = [
+ "fastlanes",
+ "itertools 0.14.0",
+ "lending-iterator",
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-file"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ced672b8f0597928c252d0ba9854ab43524bbaee596298f78f98fe02090860"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "flatbuffers",
+ "futures",
+ "itertools 0.14.0",
+ "kanal",
+ "moka",
+ "oneshot 0.2.1",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "vortex-alp",
+ "vortex-array",
+ "vortex-btrblocks",
+ "vortex-buffer",
+ "vortex-bytebool",
+ "vortex-datetime-parts",
+ "vortex-decimal-byte-parts",
+ "vortex-error",
+ "vortex-fastlanes",
+ "vortex-flatbuffers",
+ "vortex-fsst",
+ "vortex-io",
+ "vortex-layout",
+ "vortex-mask",
+ "vortex-metrics",
+ "vortex-pco",
+ "vortex-runend",
+ "vortex-scan",
+ "vortex-sequence",
+ "vortex-session",
+ "vortex-sparse",
+ "vortex-utils",
+ "vortex-zigzag",
+]
+
+[[package]]
+name = "vortex-flatbuffers"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e60db2af40dd63c1f0c52b20fdb4d2c45d711e237a62b4f2773452f09aa4c1"
+dependencies = [
+ "flatbuffers",
+ "vortex-buffer",
+ "vortex-error",
+]
+
+[[package]]
+name = "vortex-fsst"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f283cdd8646f708f3f18c844f5c10f065d6c32635028ef89f2c3f706c3b0c3fa"
+dependencies = [
+ "fsst-rs",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-io"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a3c96d35ec9d5b04b7de75eae140c60be2b93583eb74625e650c8b5a6d129c"
+dependencies = [
+ "async-fs",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "custom-labels",
+ "futures",
+ "glob",
+ "kanal",
+ "oneshot 0.2.1",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "smol",
+ "tokio",
+ "tracing",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-metrics",
+ "vortex-session",
+ "vortex-utils",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "vortex-layout"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0be2721a10c0be5cc23b305b94dbe376635d3566c973ecda130b99169946592"
+dependencies = [
+ "arcref",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
+ "async-stream",
+ "async-trait",
+ "bit-vec",
+ "flatbuffers",
+ "futures",
+ "itertools 0.14.0",
+ "kanal",
+ "moka",
+ "once_cell",
+ "oneshot 0.2.1",
+ "parking_lot 0.12.3",
+ "paste",
+ "pin-project-lite",
+ "prost 0.14.3",
+ "rustc-hash 2.1.1",
+ "sketches-ddsketch 0.4.0",
+ "termtree 1.0.0",
+ "tokio",
+ "tracing",
+ "vortex-array",
+ "vortex-btrblocks",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-flatbuffers",
+ "vortex-io",
+ "vortex-mask",
+ "vortex-metrics",
+ "vortex-runend",
+ "vortex-scan",
+ "vortex-sequence",
+ "vortex-session",
+ "vortex-utils",
+]
+
+[[package]]
+name = "vortex-mask"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40763e543b1152ece372db3df790bb234ed87679aa658bc0faa62c8c5f4fb8c7"
+dependencies = [
+ "itertools 0.14.0",
+ "serde",
+ "vortex-buffer",
+ "vortex-error",
+]
+
+[[package]]
+name = "vortex-metrics"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90b2fab74847f9458d23809d6f9989533c0b1e108c8f137e429f3b72b64c3db"
+dependencies = [
+ "parking_lot 0.12.3",
+ "sketches-ddsketch 0.4.0",
+]
+
+[[package]]
+name = "vortex-pco"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40c959c9bdd123bbf91e069969a5d1ab4c5df95da4c5c72035c067561e826f6"
+dependencies = [
+ "pco",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-proto"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00cc10e60073a8c7035f364b0245a612281767b614a82eea7a91101154d06904"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+]
+
+[[package]]
+name = "vortex-runend"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab758ef0a632235a9c2b0d84936a196fdbe4c977b76ae26bf61551ea06bb978f"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-scan"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2de638d954c096a74cc1d65f8d8eaec87d65f3f1b5b2107b7f4b9ce04e8736"
+dependencies = [
+ "async-trait",
+ "futures",
+ "roaring 0.11.3",
+ "tracing",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-sequence"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3def30531a2ab05a75c4e9b56ed62f129067f46b809be39664d797648d4cf1e"
+dependencies = [
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-proto",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-session"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66a1a9174743e63eeb2183d0108faecad1035bae1c83c6cc71d761b2065f6c7"
+dependencies = [
+ "dashmap 6.1.0",
+ "lasso",
+ "parking_lot 0.12.3",
+ "vortex-error",
+ "vortex-utils",
+]
+
+[[package]]
+name = "vortex-sparse"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac2008140172a9899d209449de0e36345f6d28368e76f3340424435c5857806"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "prost 0.14.3",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+]
+
+[[package]]
+name = "vortex-utils"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdd36eb4a0bf533757b998033771a1bfa5bf08e3fe24ea75ad9d10c8f5519d1"
+dependencies = [
+ "dashmap 6.1.0",
+ "hashbrown 0.17.0",
+ "vortex-error",
+]
+
+[[package]]
+name = "vortex-zigzag"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5bb91a5c03e2537f0d3da80baa39b176cdfe7166855414862b3b4fa7d9a3df"
+dependencies = [
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-session",
+ "zigzag",
+]
+
+[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18573,6 +19562,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18589,48 +19596,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -18638,22 +19629,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -18676,6 +19667,28 @@ checksum = "d4349d0943718e6e434b51b9639e876293093dca4b96384fb136ab5bd5ce6660"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.230.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -18712,6 +19725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
  "bitflags 2.9.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.0",
+ "hashbrown 0.15.3",
  "indexmap 2.14.0",
  "semver",
 ]
@@ -18822,10 +19847,10 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.219.2",
 ]
 
 [[package]]
@@ -18938,7 +19963,7 @@ checksum = "df09be00c38f49172ca9936998938476e3f2df782673a39ae2ef9fb0838341b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18967,7 +19992,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser",
+ "wit-parser 0.219.2",
 ]
 
 [[package]]
@@ -19015,9 +20040,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -19117,7 +20142,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.106",
+ "syn 2.0.117",
  "witx",
 ]
 
@@ -19129,7 +20154,7 @@ checksum = "9b8eb1a5783540696c59cefbfc9e52570c2d5e62bd47bdf0bdcef29231879db2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "wiggle-generate",
 ]
 
@@ -19271,7 +20296,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19282,7 +20307,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19293,7 +20318,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19304,7 +20329,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19733,12 +20758,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.0",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -19757,6 +20858,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.219.2",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -19874,7 +20993,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -19901,7 +21020,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19921,7 +21040,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -19942,7 +21061,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -19975,7 +21094,16 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zigzag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5107,6 +5107,7 @@ dependencies = [
  "ahash 0.8.12",
  "arrow 58.1.0",
  "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
  "arrow-ipc 58.1.0",
  "arrow-schema 58.1.0",
  "async-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,18 +180,18 @@ anyerror = { version = "=0.1.13" }
 anyhow = { version = "1.0.65" }
 apache-avro = { version = "0.17.0", features = ["snappy", "zstandard", "xz", "snappy", "bzip"] }
 approx = "0.5.1"
-arrow = { version = "56" }
-arrow-array = { version = "56" }
-arrow-buffer = { version = "56" }
-arrow-cast = { version = "56", features = ["prettyprint"] }
-arrow-csv = { version = "56" }
-arrow-data = { version = "56" }
-arrow-flight = { version = "56", features = ["flight-sql-experimental", "tls-ring"] }
-arrow-ipc = { version = "56", features = ["lz4", "zstd"] }
-arrow-json = { version = "56" }
-arrow-ord = { version = "56" }
-arrow-schema = { version = "56", features = ["serde"] }
-arrow-select = { version = "56" }
+arrow = { version = "58.1.0" }
+arrow-array = { version = "58.1.0" }
+arrow-buffer = { version = "58.1.0" }
+arrow-cast = { version = "58.1.0", features = ["prettyprint"] }
+arrow-csv = { version = "58.1.0" }
+arrow-data = { version = "58.1.0" }
+arrow-flight = { version = "58.1.0", features = ["flight-sql-experimental", "tls-ring"] }
+arrow-ipc = { version = "58.1.0", features = ["lz4", "zstd"] }
+arrow-json = { version = "58.1.0" }
+arrow-ord = { version = "58.1.0" }
+arrow-schema = { version = "58.1.0", features = ["serde"] }
+arrow-select = { version = "58.1.0" }
 arrow-udf-runtime = { version = "0.8.0", default-features = false, features = ["javascript", "wasm"] }
 async-backtrace = "0.2"
 async-channel = "2.3.1"
@@ -298,13 +298,13 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 ## in branch dev
-iceberg = { version = "0.8.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "6ccaa60e", features = [
+iceberg = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070", features = [
     "storage-all",
 ] }
-iceberg-catalog-glue = { version = "0.8.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "6ccaa60e" }
-iceberg-catalog-hms = { version = "0.8.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "6ccaa60e" }
-iceberg-catalog-rest = { version = "0.8.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "6ccaa60e" }
-iceberg-catalog-s3tables = { version = "0.8.0", git = "https://github.com/databendlabs/iceberg-rust", rev = "6ccaa60e" }
+iceberg-catalog-glue = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
+iceberg-catalog-hms = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
+iceberg-catalog-rest = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
+iceberg-catalog-s3tables = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
 
 # Explicitly specify compatible AWS SDK versions
 aws-config = "1.5.18"
@@ -389,7 +389,7 @@ orc-rust = "0.6.0"
 ordered-float = { version = "5.1.0", default-features = false }
 p256 = "0.13"
 parking_lot = "0.12.1"
-parquet = { version = "56", features = ["async"] }
+parquet = { version = "58.1.0", features = ["async"] }
 passwords = { version = "3.1.16" }
 paste = "1.0.15"
 percent-encoding = "2.3.1"
@@ -406,8 +406,8 @@ pretty_assertions = "1.3.0"
 procfs = { version = "0.17.0" }
 proj4rs = { version = "0.1.10", features = ["geo-types", "crs-definitions"] }
 proptest = { version = "1", default-features = false, features = ["std"] }
-prost = { version = "0.13" }
-prost-build = { version = "0.13" }
+prost = { version = "0.14.3" }
+prost-build = { version = "0.14.3" }
 prqlc = "0.11.3"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 rand_distr = "0.4.3"
@@ -489,9 +489,11 @@ tokio = { version = "1.35.0", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.13" }
 toml = { version = "0.8", features = ["parse"] }
-tonic = { version = "0.13", features = ["transport", "codegen", "tls-native-roots"] }
-tonic-build = { version = "0.13" }
-tonic-reflection = { version = "0.13" }
+tonic = { version = "0.14.5", features = ["transport", "codegen", "tls-native-roots"] }
+tonic-build = { version = "0.14.5" }
+tonic-prost = { version = "0.14.5" }
+tonic-prost-build = { version = "0.14.5" }
+tonic-reflection = { version = "0.14.5" }
 tower = { version = "0.5.1", features = ["util"] }
 tower-service = "0.3.3"
 twox-hash = "1.6.3"
@@ -616,7 +618,7 @@ overflow-checks = true
 rpath = true
 
 [patch.crates-io]
-arrow-udf-runtime = { git = "https://github.com/datafuse-extras/arrow-udf.git", rev = "2480dccf1" }
+arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "a0a2bb369cdd96dea3da3d61e190db4c79119da4" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
@@ -630,7 +632,14 @@ deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
 openraft-rt = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
-orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc812ad7010" }
+# Keep ORC on a local patch while the upstream crate has not caught up with Arrow 58 yet.
+lance-arrow = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+lance-core = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+lance-encoding = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+lance-file = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+lance-io = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+lance-table = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
+orc-rust = { git = "https://github.com/SkyFan2002/orc-rust.git", rev = "6b32f1adec3e3850fbb303c97f16681e175d54bb" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.3.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,7 +618,7 @@ overflow-checks = true
 rpath = true
 
 [patch.crates-io]
-arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "a0a2bb369cdd96dea3da3d61e190db4c79119da4" }
+arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "955f84470ff596640364fe6561d183979a4ab11f" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,7 +618,7 @@ overflow-checks = true
 rpath = true
 
 [patch.crates-io]
-arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "955f84470ff596640364fe6561d183979a4ab11f" }
+arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "ddde517521a6bc27a7db1e3a59c69f7279b2289f" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,7 +618,7 @@ overflow-checks = true
 rpath = true
 
 [patch.crates-io]
-arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "ddde517521a6bc27a7db1e3a59c69f7279b2289f" }
+arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "4865bcc06b0da73391c279b3a5a962ef92a3162e" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,13 +298,13 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 ## in branch dev
-iceberg = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070", features = [
+iceberg = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "edb4e4f8158821d274850d19d2c7d0030e16e142", features = [
     "storage-all",
 ] }
-iceberg-catalog-glue = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
-iceberg-catalog-hms = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
-iceberg-catalog-rest = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
-iceberg-catalog-s3tables = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "db28794b73307c6c588c717131526533b0e11070" }
+iceberg-catalog-glue = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "edb4e4f8158821d274850d19d2c7d0030e16e142" }
+iceberg-catalog-hms = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "edb4e4f8158821d274850d19d2c7d0030e16e142" }
+iceberg-catalog-rest = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "edb4e4f8158821d274850d19d2c7d0030e16e142" }
+iceberg-catalog-s3tables = { version = "0.8.0", git = "https://github.com/SkyFan2002/iceberg-rust.git", rev = "edb4e4f8158821d274850d19d2c7d0030e16e142" }
 
 # Explicitly specify compatible AWS SDK versions
 aws-config = "1.5.18"
@@ -324,11 +324,11 @@ jaq-std = "2.1.2"
 jiff = { version = "0.2.16", features = ["serde", "tzdb-bundle-always"] }
 jsonb = "0.5.6"
 jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
-lance-core = "1.0.4"
-lance-encoding = { version = "1.0.4", features = ["protoc"] }
-lance-file = "1.0.4"
-lance-io = { version = "1.0.4", default-features = false }
-lance-table = "1.0.4"
+lance-core = "5.1.0-beta.3"
+lance-encoding = { version = "5.1.0-beta.3", features = ["protoc"] }
+lance-file = "5.1.0-beta.3"
+lance-io = { version = "5.1.0-beta.3", default-features = false }
+lance-table = "5.1.0-beta.3"
 lenient_semver = "0.4.2"
 levenshtein_automata = "0.2.1"
 lexical-core = "1"
@@ -618,7 +618,7 @@ overflow-checks = true
 rpath = true
 
 [patch.crates-io]
-arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "4865bcc06b0da73391c279b3a5a962ef92a3162e" }
+arrow-udf-runtime = { git = "https://github.com/SkyFan2002/arrow-udf.git", rev = "ec0c74d1bb53d68243c2bb23ebaa9392223e094c" }
 async-backtrace = { git = "https://github.com/datafuse-extras/async-backtrace.git", rev = "dea4553" }
 async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.git", rev = "a353334" }
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
@@ -633,13 +633,13 @@ map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
 openraft = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
 openraft-rt = { git = "https://github.com/databendlabs/openraft", tag = "v0.10.0-alpha.17" }
 # Keep ORC on a local patch while the upstream crate has not caught up with Arrow 58 yet.
-lance-arrow = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-lance-core = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-lance-encoding = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-lance-file = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-lance-io = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-lance-table = { git = "https://github.com/SkyFan2002/lance.git", rev = "d47ca5a1ed3fa80534a902a678961beca8e2e279" }
-orc-rust = { git = "https://github.com/SkyFan2002/orc-rust.git", rev = "6b32f1adec3e3850fbb303c97f16681e175d54bb" }
+lance-arrow = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+lance-core = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+lance-encoding = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+lance-file = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+lance-io = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+lance-table = { git = "https://github.com/SkyFan2002/lance.git", rev = "983238285f482cc6d229483d15d6dde8f3bc3e96" }
+orc-rust = { git = "https://github.com/SkyFan2002/orc-rust.git", rev = "3fba34ccde628b4063d7f892d15866f89236064c" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.3.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "src/meta/store",
     "src/meta/ver",
     "src/query/codegen",
+    "src/query/storages/vortex",
     "src/tests/sqlsmith",
     "tests/sqllogictests",
 ]
@@ -120,6 +121,7 @@ databend-common-storages-parquet = { path = "src/query/storages/parquet" }
 databend-common-storages-stage = { path = "src/query/storages/stage" }
 databend-common-storages-stream = { path = "src/query/storages/stream" }
 databend-common-storages-system = { path = "src/query/storages/system" }
+databend-storages-vortex = { path = "src/query/storages/vortex" }
 databend-common-telemetry = { path = "src/common/telemetry" }
 databend-common-timezone = { path = "src/common/timezone" }
 databend-common-tracing = { path = "src/common/tracing" }

--- a/src/bendpy/Cargo.toml
+++ b/src/bendpy/Cargo.toml
@@ -7,7 +7,7 @@ publish = { workspace = true }
 edition = { workspace = true }
 
 [build-dependencies]
-pyo3-build-config = "0.25"
+pyo3-build-config = "0.28"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -32,7 +32,7 @@ databend-query = { workspace = true, features = [
     "simd",
     "disable_initial_exec_tls",
 ] }
-pyo3 = { version = "0.25", features = ["generate-import-lib", "abi3-py312"] }
+pyo3 = { version = "0.28", features = ["generate-import-lib", "abi3-py312"] }
 serde_json = { workspace = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/src/bendpy/src/context.rs
+++ b/src/bendpy/src/context.rs
@@ -96,7 +96,12 @@ fn build_position_select(col_names: &[String]) -> PyResult<String> {
         .join(", "))
 }
 
-#[pyclass(name = "SessionContext", module = "databend", subclass)]
+#[pyclass(
+    name = "SessionContext",
+    module = "databend",
+    subclass,
+    skip_from_py_object
+)]
 #[derive(Clone)]
 pub(crate) struct PySessionContext {
     pub(crate) session: Arc<Session>,

--- a/src/bendpy/src/dataframe.rs
+++ b/src/bendpy/src/dataframe.rs
@@ -23,14 +23,14 @@ use databend_query::interpreters::InterpreterFactory;
 use databend_query::sessions::QueryContext;
 use databend_query::sql::plans::Plan;
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
+use pyo3::types::PyAny;
 use tokio_stream::StreamExt;
 
 use crate::datablock::PyDataBlocks;
 use crate::schema::PySchema;
 use crate::utils::wait_for_future;
 
-#[pyclass(name = "BoxSize", module = "databend", subclass)]
+#[pyclass(name = "BoxSize", module = "databend", subclass, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub(crate) struct PyBoxSize {
     pub(crate) bs_max_display_rows: usize,
@@ -38,7 +38,7 @@ pub(crate) struct PyBoxSize {
     pub(crate) bs_max_col_width: usize,
 }
 
-#[pyclass(name = "DataFrame", module = "databend", subclass)]
+#[pyclass(name = "DataFrame", module = "databend", subclass, skip_from_py_object)]
 #[derive(Clone)]
 pub(crate) struct PyDataFrame {
     ctx: Arc<QueryContext>,
@@ -119,7 +119,7 @@ impl PyDataFrame {
         }
     }
 
-    pub fn to_py_arrow(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    pub fn to_py_arrow(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         let blocks = wait_for_future(py, self.df_collect());
         let blocks = blocks.map_err(|err| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("DataFrame collect error: {:?}", err))
@@ -132,50 +132,38 @@ impl PyDataFrame {
                     .to_record_batch_with_dataschema(self.df.schema().as_ref())
                     .unwrap()
                     .to_pyarrow(py)
+                    .map(Bound::unbind)
             })
             .collect()
     }
 
     /// Convert to Arrow Table
     /// Collect the batches and pass to Arrow Table
-    pub fn to_arrow_table(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_arrow_table(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let batches = self.to_py_arrow(py)?.into_pyobject(py)?;
         let schema = ArrowSchema::from(self.df.schema().as_ref());
         let schema = PyArrowType(schema);
         let schema = schema.into_pyobject(py)?;
 
-        Python::with_gil(|py| {
-            // Instantiate pyarrow Table object and use its from_batches method
-            let table_class = py.import("pyarrow")?.getattr("Table")?;
-            let args = PyTuple::new(py, &[batches, schema])?;
-            let table: PyObject = table_class.call_method1("from_batches", args)?.into();
-            Ok(table)
-        })
+        let table_class = py.import("pyarrow")?.getattr("Table")?;
+        Ok(table_class
+            .call_method1("from_batches", (batches, schema))?
+            .unbind())
     }
 
     /// Convert to pandas dataframe with pyarrow
     /// Collect the batches, pass to Arrow Table & then convert to Pandas DataFrame
-    fn to_pandas(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pandas(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let table = self.to_arrow_table(py)?;
-
-        Python::with_gil(|py| {
-            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
-            let result = table.call_method0(py, "to_pandas")?;
-            Ok(result)
-        })
+        table.call_method0(py, "to_pandas")
     }
 
     /// Convert to polars dataframe with pyarrow
     /// Collect the batches, pass to Arrow Table & then convert to polars DataFrame
-    fn to_polars(&self, py: Python) -> PyResult<PyObject> {
+    fn to_polars(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let table = self.to_arrow_table(py)?;
-
-        Python::with_gil(|py| {
-            let dataframe = py.import("polars")?.getattr("DataFrame")?;
-            let args = PyTuple::new(py, &[table])?;
-            let result: PyObject = dataframe.call1(args)?.into();
-            Ok(result)
-        })
+        let dataframe = py.import("polars")?.getattr("DataFrame")?;
+        Ok(dataframe.call1((table,))?.unbind())
     }
 }
 

--- a/src/bendpy/src/utils.rs
+++ b/src/bendpy/src/utils.rs
@@ -30,5 +30,5 @@ where
     F: Future + Send,
     F::Output: Send,
 {
-    py.allow_threads(|| RUNTIME.block_on(f))
+    py.detach(|| RUNTIME.block_on(f))
 }

--- a/src/common/cloud_control/Cargo.toml
+++ b/src/common/cloud_control/Cargo.toml
@@ -16,17 +16,21 @@ hyper-util = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 
 [build-dependencies]
 lenient_semver = { workspace = true }
 prost-build = { workspace = true }
 semver = { workspace = true }
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["tonic-prost"]
 
 [lints]
 workspace = true

--- a/src/common/cloud_control/build.rs
+++ b/src/common/cloud_control/build.rs
@@ -80,5 +80,5 @@ fn build_proto() -> Result<()> {
         config.protoc_arg("--experimental_allow_proto3_optional");
     }
 
-    tonic_build::configure().compile_protos_with_config(config, &proto_defs, &[proto_path])
+    tonic_prost_build::configure().compile_with_config(config, &proto_defs, &[proto_path])
 }

--- a/src/common/cloud_control/src/task_utils.rs
+++ b/src/common/cloud_control/src/task_utils.rs
@@ -17,6 +17,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use chrono::DateTime;
+use chrono::FixedOffset;
 use chrono::Utc;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -165,7 +166,7 @@ impl TryFrom<crate::pb::Task> for Task {
                             value.next_scheduled_at
                         ))
                     })
-                    .map(|d| d.with_timezone(&Utc))
+                    .map(|d: DateTime<FixedOffset>| d.with_timezone(&Utc))
             })
             .transpose()?;
 
@@ -180,7 +181,7 @@ impl TryFrom<crate::pb::Task> for Task {
                             value.last_suspended_at
                         ))
                     })
-                    .map(|d| d.with_timezone(&Utc))
+                    .map(|d: DateTime<FixedOffset>| d.with_timezone(&Utc))
             })
             .transpose()?;
         let schedule = match value.schedule_options {

--- a/src/common/column/src/binview/mod.rs
+++ b/src/common/column/src/binview/mod.rs
@@ -658,7 +658,7 @@ impl From<Utf8ViewColumn> for ArrayData {
                 column
                     .buffers
                     .iter()
-                    .map(|x| x.clone().into())
+                    .map(|buffer| arrow_buffer::Buffer::from(buffer.clone()))
                     .collect::<Vec<_>>(),
             );
         unsafe { builder.build_unchecked() }
@@ -674,7 +674,7 @@ impl From<BinaryViewColumn> for ArrayData {
                 column
                     .buffers
                     .iter()
-                    .map(|x| x.clone().into())
+                    .map(|buffer| arrow_buffer::Buffer::from(buffer.clone()))
                     .collect::<Vec<_>>(),
             );
         unsafe { builder.build_unchecked() }
@@ -686,8 +686,8 @@ impl From<ArrayData> for Utf8ViewColumn {
         let views = data.buffers()[0].clone();
         let buffers = data.buffers()[1..]
             .iter()
-            .map(|x| x.clone().into())
-            .collect();
+            .map(|buffer| crate::buffer::Buffer::from(buffer.clone()))
+            .collect::<Arc<[crate::buffer::Buffer<u8>]>>();
 
         unsafe { Utf8ViewColumn::new_unchecked_unknown_md(views.into(), buffers, None) }
     }

--- a/src/common/column/src/bitmap/mutable.rs
+++ b/src/common/column/src/bitmap/mutable.rs
@@ -19,8 +19,6 @@ use std::iter::TrustedLen;
 use std::ops::Range;
 use std::sync::Arc;
 
-use databend_common_base::vec_ext::VecExt;
-
 use super::Bitmap;
 use super::utils::BitChunk;
 use super::utils::BitChunksExactMut;
@@ -267,14 +265,12 @@ impl MutableBitmap {
     /// The caller must ensure that the [`MutableBitmap`] has sufficient capacity.
     #[inline]
     pub unsafe fn push_unchecked(&mut self, value: bool) {
-        unsafe {
-            if self.length.is_multiple_of(8) {
-                self.buffer.push_unchecked(0);
-            }
-            let byte = self.buffer.as_mut_slice().last_mut().unwrap();
-            *byte = set(*byte, self.length % 8, value);
-            self.length += 1;
+        if self.length.is_multiple_of(8) {
+            self.buffer.push(0);
         }
+        let byte = self.buffer.as_mut_slice().last_mut().unwrap();
+        *byte = set(*byte, self.length % 8, value);
+        self.length += 1;
     }
 
     /// Returns the number of unset bits on this [`MutableBitmap`].
@@ -525,20 +521,20 @@ unsafe fn extend_aligned_trusted_iter_unchecked(
         // chunks of 64 bits
         for _ in 0..chunks {
             let chunk = get_chunk_unchecked(&mut iterator);
-            buffer.extend_from_slice_unchecked(&chunk.to_le_bytes());
+            buffer.extend_from_slice(&chunk.to_le_bytes());
         }
 
         // remaining complete bytes
         for _ in 0..(remainder / 8) {
             let byte = get_byte_unchecked(8, &mut iterator);
-            buffer.push_unchecked(byte)
+            buffer.push(byte)
         }
 
         // remaining bits
         let remainder = remainder % 8;
         if remainder > 0 {
             let byte = get_byte_unchecked(remainder, &mut iterator);
-            buffer.push_unchecked(byte)
+            buffer.push(byte)
         }
         additional_bits
     }
@@ -744,7 +740,7 @@ impl MutableBitmap {
             }
 
             // SAFETY: Already allocated sufficient capacity
-            unsafe { buffer.extend_from_slice_unchecked(&packed.to_le_bytes()) }
+            buffer.extend_from_slice(&packed.to_le_bytes())
         }
 
         if remainder != 0 {
@@ -755,7 +751,7 @@ impl MutableBitmap {
             }
 
             // SAFETY: Already allocated sufficient capacity
-            unsafe { buffer.extend_from_slice_unchecked(&packed.to_le_bytes()) }
+            buffer.extend_from_slice(&packed.to_le_bytes())
         }
 
         buffer.truncate(len.div_ceil(8));

--- a/src/common/column/src/types/native.rs
+++ b/src/common/column/src/types/native.rs
@@ -142,11 +142,11 @@ impl NativeType for F32 {
     }
     #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self(f32::from_le_bytes(bytes))
+        OrderedFloat(f32::from_le_bytes(bytes))
     }
     #[inline]
     fn from_be_bytes(bytes: Self::Bytes) -> Self {
-        Self(f32::from_be_bytes(bytes))
+        OrderedFloat(f32::from_be_bytes(bytes))
     }
 }
 
@@ -164,11 +164,11 @@ impl NativeType for F64 {
     }
     #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self(f64::from_le_bytes(bytes))
+        OrderedFloat(f64::from_le_bytes(bytes))
     }
     #[inline]
     fn from_be_bytes(bytes: Self::Bytes) -> Self {
-        Self(f64::from_be_bytes(bytes))
+        OrderedFloat(f64::from_be_bytes(bytes))
     }
 }
 

--- a/src/common/storage/src/parquet.rs
+++ b/src/common/storage/src/parquet.rs
@@ -25,6 +25,7 @@ use parquet::arrow::parquet_to_arrow_schema;
 use parquet::errors::ParquetError;
 // FIXME(xuanwo): refactor code here.
 use parquet::file::metadata::FileMetaData;
+use parquet::file::metadata::FooterTail;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::metadata::ParquetMetaDataReader;
 
@@ -108,12 +109,8 @@ pub async fn read_metadata_async(
 
     let map_err =
         |e: ParquetError| ErrorCode::BadBytes(format!("Invalid Parquet file '{path}': {e}",));
-    let footer_tail = ParquetMetaDataReader::decode_footer_tail(
-        &buffer[(buffer_len - FOOTER_SIZE as usize)..]
-            .try_into()
-            .unwrap(),
-    )
-    .map_err(map_err)?;
+    let footer_tail =
+        FooterTail::try_from(&buffer[(buffer_len - FOOTER_SIZE as usize)..]).map_err(map_err)?;
     let metadata_len = footer_tail.metadata_length() as u64;
     check_meta_size(file_size, metadata_len, path)?;
 

--- a/src/common/tracing/src/init.rs
+++ b/src/common/tracing/src/init.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::Ordering;
 
 use databend_common_base::base::GlobalInstance;
 use databend_common_base::runtime::Thread;
+use fastrace::collector::SpanContext;
 use fastrace::prelude::*;
 use log::LevelFilter;
 use logforth::filter::EnvFilter;

--- a/src/meta/api/Cargo.toml
+++ b/src/meta/api/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+tonic_013 = { package = "tonic", version = "0.13.1" }
 uuid = { workspace = true }
 zstd = { workspace = true }
 

--- a/src/meta/api/src/error/app_error.rs
+++ b/src/meta/api/src/error/app_error.rs
@@ -25,7 +25,7 @@ use databend_meta_client::types::MetaAPIError;
 use databend_meta_client::types::MetaClientError;
 use databend_meta_client::types::MetaError;
 use databend_meta_client::types::MetaNetworkError;
-use tonic::Status;
+use tonic_013::Status;
 
 use super::txn_error::MetaTxnError;
 

--- a/src/meta/api/src/kv/pb_api/codec.rs
+++ b/src/meta/api/src/kv/pb_api/codec.rs
@@ -26,6 +26,11 @@ use crate::kv_pb_api::errors::PbApiReadError;
 use crate::kv_pb_api::errors::PbDecodeError;
 use crate::kv_pb_api::errors::PbEncodeError;
 
+#[allow(deprecated)]
+fn prost_decode_error(message: impl Into<String>) -> prost::DecodeError {
+    prost::DecodeError::new(message.into())
+}
+
 /// Encode a `FromToProto` value to protobuf bytes, with transparent zstd compression.
 ///
 /// Delegates to [`compress::GLOBAL_ENCODER`].
@@ -36,7 +41,7 @@ pub fn encode_pb<T: FromToProto>(value: &T) -> Result<Vec<u8>, PbEncodeError> {
 /// Decode protobuf bytes (possibly zstd-compressed) to a `FromToProto` value.
 pub fn decode_pb<T: FromToProto>(buf: &[u8]) -> Result<T, PbDecodeError> {
     let buf = compress::decode_value(buf)
-        .map_err(|e| PbDecodeError::from(prost::DecodeError::new(e.to_string())))?;
+        .map_err(|e| PbDecodeError::from(prost_decode_error(e.to_string())))?;
     let p: T::PB = prost::Message::decode(buf.as_ref()).map_err(PbDecodeError::from)?;
     T::from_pb(p).map_err(PbDecodeError::from)
 }

--- a/src/meta/api/src/kv/pb_api/errors/decode_error.rs
+++ b/src/meta/api/src/kv/pb_api/errors/decode_error.rs
@@ -74,18 +74,24 @@ impl PbDecodeError {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
+fn prost_decode_error(message: impl Into<String>) -> prost::DecodeError {
+    prost::DecodeError::new(message.into())
+}
+
+#[cfg(test)]
 mod tests {
     use crate::kv_pb_api::errors::PbDecodeError;
 
     #[test]
     fn test_error_message() {
-        let e = PbDecodeError::from(prost::DecodeError::new("decode error"));
+        let e = PbDecodeError::from(super::prost_decode_error("decode error"));
         assert_eq!(
             "PbDecodeError: failed to decode Protobuf message: decode error",
             e.to_string()
         );
 
-        let e = PbDecodeError::from(prost::DecodeError::new("decode error")).with_context("ctx");
+        let e = PbDecodeError::from(super::prost_decode_error("decode error")).with_context("ctx");
         assert_eq!(
             "PbDecodeError: failed to decode Protobuf message: decode error; when:(ctx)",
             e.to_string()

--- a/src/meta/app/src/data_id.rs
+++ b/src/meta/app/src/data_id.rs
@@ -152,6 +152,11 @@ mod prost_message_impl {
     use crate::data_id::DataId;
     use crate::tenant_key::resource::TenantResource;
 
+    #[allow(deprecated)]
+    fn decode_error(message: impl Into<String>) -> DecodeError {
+        DecodeError::new(message.into())
+    }
+
     impl<R> prost::Message for DataId<R>
     where R: TenantResource + Sync + Send
     {
@@ -165,7 +170,7 @@ mod prost_message_impl {
             let mut b = [0; 64];
             let len = buf.remaining();
             if len > b.len() {
-                return Err(DecodeError::new(format!(
+                return Err(decode_error(format!(
                     "buffer(len={}) is too large, max={}",
                     len,
                     b.len()
@@ -174,7 +179,7 @@ mod prost_message_impl {
 
             buf.copy_to_slice(&mut b[..len]);
             let id: u64 = serde_json::from_slice(&b[..len])
-                .map_err(|e| DecodeError::new(format!("failed to decode u64 as json: {}", e)))?;
+                .map_err(|e| decode_error(format!("failed to decode u64 as json: {}", e)))?;
             Ok(DataId::new(id))
         }
 

--- a/src/meta/app/src/primitive.rs
+++ b/src/meta/app/src/primitive.rs
@@ -122,6 +122,11 @@ mod prost_message_impl {
 
     use crate::primitive::Id;
 
+    #[allow(deprecated)]
+    fn decode_error(message: impl Into<String>) -> DecodeError {
+        DecodeError::new(message.into())
+    }
+
     impl<T> prost::Message for Id<T>
     where
         T: fmt::Debug + Send + Sync,
@@ -137,7 +142,7 @@ mod prost_message_impl {
             let mut b = [0; 64];
             let len = buf.remaining();
             if len > b.len() {
-                return Err(DecodeError::new(format!(
+                return Err(decode_error(format!(
                     "buffer(len={}) is too large, max={}",
                     len,
                     b.len()
@@ -146,7 +151,7 @@ mod prost_message_impl {
 
             buf.copy_to_slice(&mut b[..len]);
             let id: u64 = serde_json::from_slice(&b[..len])
-                .map_err(|e| DecodeError::new(format!("failed to decode u64 as json: {}", e)))?;
+                .map_err(|e| decode_error(format!("failed to decode u64 as json: {}", e)))?;
             Ok(Id::from(id))
         }
 

--- a/src/meta/plugins/cache/Cargo.toml
+++ b/src/meta/plugins/cache/Cargo.toml
@@ -24,7 +24,7 @@ databend-meta-runtime = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 sub-cache = { workspace = true }
-tonic = { workspace = true }
+tonic_013 = { package = "tonic", version = "0.13.1" }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/meta/plugins/cache/src/meta_client_source.rs
+++ b/src/meta/plugins/cache/src/meta_client_source.rs
@@ -32,7 +32,7 @@ use sub_cache::errors::Unsupported;
 use sub_cache::event_stream::Change;
 use sub_cache::event_stream::Event;
 use sub_cache::event_stream::EventStream;
-use tonic::Status;
+use tonic_013::Status;
 
 pub struct MetaClientSource {
     pub(crate) client: Arc<ClientHandle<DatabendRuntime>>,

--- a/src/meta/plugins/semaphore/Cargo.toml
+++ b/src/meta/plugins/semaphore/Cargo.toml
@@ -21,7 +21,7 @@ log = { workspace = true }
 seq-marked = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true }
+tonic_013 = { package = "tonic", version = "0.13.1" }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/meta/plugins/semaphore/src/errors/connection_closed.rs
+++ b/src/meta/plugins/semaphore/src/errors/connection_closed.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 use std::io;
 
-use tonic::Status;
+use tonic_013::Status;
 
 use crate::errors::either::Either;
 

--- a/src/meta/plugins/semaphore/src/errors/processor_error.rs
+++ b/src/meta/plugins/semaphore/src/errors/processor_error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tonic::Status;
+use tonic_013::Status;
 
 use crate::errors::AcquirerClosed;
 use crate::errors::ConnectionClosed;

--- a/src/meta/plugins/semaphore/src/meta_event_subscriber/subscriber.rs
+++ b/src/meta/plugins/semaphore/src/meta_event_subscriber/subscriber.rs
@@ -28,7 +28,7 @@ use futures::TryStreamExt;
 use log::error;
 use log::info;
 use log::warn;
-use tonic::Status;
+use tonic_013::Status;
 
 use crate::errors::ConnectionClosed;
 use crate::errors::ProcessorError;
@@ -88,7 +88,7 @@ impl MetaEventSubscriber {
     pub(crate) async fn new_watch_stream(
         &self,
         ctx: impl fmt::Display,
-    ) -> Result<tonic::Streaming<WatchResponse>, ConnectionClosed> {
+    ) -> Result<tonic_013::Streaming<WatchResponse>, ConnectionClosed> {
         let watch =
             WatchRequest::new(self.left.clone(), Some(self.right.clone())).with_initial_flush(true);
 

--- a/src/meta/protos/Cargo.toml
+++ b/src/meta/protos/Cargo.toml
@@ -11,15 +11,16 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 
 [build-dependencies]
 lenient_semver = { workspace = true }
 prost-build = { workspace = true }
 semver = { workspace = true }
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [package.metadata.cargo-machete]
-ignored = ["num-derive", "num-traits"]
+ignored = ["num-derive", "num-traits", "tonic-prost"]
 
 [lints]
 workspace = true

--- a/src/meta/protos/build.rs
+++ b/src/meta/protos/build.rs
@@ -81,7 +81,7 @@ fn build_proto() -> Result<()> {
         config.protoc_arg("--experimental_allow_proto3_optional");
     }
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .type_attribute("IntervalKind", "#[derive(num_derive::FromPrimitive)]")
         .type_attribute(
             "StageFileFormatType",
@@ -92,5 +92,5 @@ fn build_proto() -> Result<()> {
             "#[derive(num_derive::FromPrimitive)]",
         )
         .type_attribute("StageType", "#[derive(num_derive::FromPrimitive)]")
-        .compile_protos_with_config(config, &proto_defs, &[proto_path])
+        .compile_with_config(config, &proto_defs, &[proto_path])
 }

--- a/src/meta/runtime/Cargo.toml
+++ b/src/meta/runtime/Cargo.toml
@@ -16,7 +16,7 @@ databend-meta = { workspace = true }
 databend-meta-client = { workspace = true }
 fastrace = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true }
+tonic_013 = { package = "tonic", version = "0.13.1", features = ["transport", "tls-native-roots"] }
 
 [lints]
 workspace = true

--- a/src/meta/runtime/src/client_bridge.rs
+++ b/src/meta/runtime/src/client_bridge.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 
 use databend_meta::runtime_api as server_rt;
 use databend_meta_client::runtime_api as client_rt;
+use tonic_013::Request;
 
 use crate::DatabendMetrics;
 use crate::DatabendRuntime;
@@ -126,17 +127,17 @@ impl client_rt::SpawnApi for DatabendRuntime {
         <Self as server_rt::SpawnApi>::unlimited_future(fut)
     }
 
-    fn prepare_request<T>(request: tonic::Request<T>) -> tonic::Request<T> {
+    fn prepare_request<T>(request: Request<T>) -> Request<T> {
         <DatabendRuntime as server_rt::SpawnApi>::prepare_request(request)
     }
 
     fn trace_request<'a, T, F, Fut, R>(
         name: &'static str,
-        request: tonic::Request<T>,
+        request: Request<T>,
         f: F,
     ) -> client_rt::BoxFuture<'a, R>
     where
-        F: FnOnce(tonic::Request<T>) -> Fut,
+        F: FnOnce(Request<T>) -> Fut,
         Fut: Future<Output = R> + Send + 'a,
         R: Send + 'a,
     {

--- a/src/meta/runtime/src/lib.rs
+++ b/src/meta/runtime/src/lib.rs
@@ -214,6 +214,7 @@ impl SpawnApi for DatabendRuntime {
 
             if let Some(timeout) = timeout {
                 endpoint = endpoint.timeout(timeout);
+                endpoint = endpoint.connect_timeout(timeout);
             }
 
             endpoint

--- a/src/meta/runtime/src/lib.rs
+++ b/src/meta/runtime/src/lib.rs
@@ -25,13 +25,11 @@ mod metrics;
 
 use std::future::Future;
 use std::net::IpAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use databend_common_base::runtime;
-use databend_common_grpc::ConnectionFactory;
-use databend_common_grpc::GrpcConnectionError;
-use databend_common_grpc::RpcClientTlsConfig;
 use databend_meta::runtime_api::BoxFuture;
 use databend_meta::runtime_api::Channel;
 use databend_meta::runtime_api::ChannelError;
@@ -40,24 +38,13 @@ use databend_meta::runtime_api::RuntimeApi;
 use databend_meta::runtime_api::SpawnApi;
 use databend_meta::runtime_api::TlsConfig;
 use databend_meta::runtime_api::TrackingData;
+use fastrace::collector::SpanContext;
 pub use metrics::DatabendMetrics;
+use tonic_013::transport::Certificate;
+use tonic_013::transport::ClientTlsConfig;
+use tonic_013::transport::Endpoint;
 
-fn convert_grpc_error(e: GrpcConnectionError) -> ChannelError {
-    match e {
-        GrpcConnectionError::InvalidUri { uri, source } => ChannelError::InvalidUri {
-            uri,
-            message: source.to_string(),
-        },
-        GrpcConnectionError::TLSConfigError { action, source } => ChannelError::TlsConfig {
-            action,
-            message: source.to_string(),
-        },
-        GrpcConnectionError::CannotConnect { uri, source } => ChannelError::CannotConnect {
-            uri,
-            message: source.to_string(),
-        },
-    }
-}
+const HEADER_TRACE_PARENT: &str = "traceparent";
 
 /// Runtime adapter that wraps `databend_common_base::Runtime`.
 ///
@@ -130,16 +117,23 @@ impl SpawnApi for DatabendRuntime {
         Box::pin(runtime::UnlimitedFuture::create(fut))
     }
 
-    fn prepare_request<T>(request: tonic::Request<T>) -> tonic::Request<T> {
-        use std::str::FromStr;
+    fn prepare_request<T>(request: tonic_013::Request<T>) -> tonic_013::Request<T> {
+        let mut req = request;
 
-        // Inject tracing span context
-        let mut req = databend_common_tracing::inject_span_to_tonic_request(request);
+        if let Some(current) = SpanContext::current_local_parent() {
+            let key = tonic_013::metadata::MetadataKey::from_bytes(HEADER_TRACE_PARENT.as_bytes())
+                .unwrap();
+            let val = tonic_013::metadata::AsciiMetadataValue::try_from(
+                &current.encode_w3c_traceparent(),
+            )
+            .unwrap();
+            req.metadata_mut().insert(key, val);
+        }
 
         // Inject query ID if available
         if let Some(query_id) = runtime::ThreadTracker::query_id() {
-            let key = tonic::metadata::AsciiMetadataKey::from_str("QueryID");
-            let value = tonic::metadata::AsciiMetadataValue::from_str(query_id);
+            let key = tonic_013::metadata::AsciiMetadataKey::from_str("QueryID");
+            let value = tonic_013::metadata::AsciiMetadataValue::from_str(query_id);
 
             if let Some((key, value)) = key.ok().zip(value.ok()) {
                 req.metadata_mut().insert(key, value);
@@ -151,17 +145,26 @@ impl SpawnApi for DatabendRuntime {
 
     fn trace_request<'a, T, F, Fut, R>(
         name: &'static str,
-        request: tonic::Request<T>,
+        request: tonic_013::Request<T>,
         f: F,
     ) -> BoxFuture<'a, R>
     where
-        F: FnOnce(tonic::Request<T>) -> Fut,
+        F: FnOnce(tonic_013::Request<T>) -> Fut,
         Fut: Future<Output = R> + Send + 'a,
         R: Send + 'a,
     {
         use fastrace::prelude::*;
 
-        let span = databend_common_tracing::start_trace_for_remote_request(name, &request);
+        let span_context = request
+            .metadata()
+            .get(HEADER_TRACE_PARENT)
+            .and_then(|traceparent| traceparent.to_str().ok())
+            .and_then(SpanContext::decode_w3c_traceparent);
+        let span = if let Some(span_context) = span_context {
+            Span::root(name, span_context)
+        } else {
+            Span::noop()
+        };
         Box::pin(f(request).in_span(span))
     }
 
@@ -177,26 +180,63 @@ impl SpawnApi for DatabendRuntime {
         tls_config: Option<TlsConfig>,
     ) -> BoxFuture<'static, Result<Channel, ChannelError>> {
         Box::pin(async move {
-            let grpc_tls = tls_config.map(|c| RpcClientTlsConfig {
-                rpc_tls_server_root_ca_cert: c.root_ca_cert_path,
-                domain_name: c.domain_name,
-            });
+            let uri = format!(
+                "{}://{}",
+                if tls_config.is_some() {
+                    "https"
+                } else {
+                    "http"
+                },
+                addr
+            );
+            let mut endpoint =
+                Endpoint::from_shared(uri.clone()).map_err(|e| ChannelError::InvalidUri {
+                    uri: uri.clone(),
+                    message: e.to_string(),
+                })?;
 
-            ConnectionFactory::create_rpc_channel(&addr, timeout, grpc_tls, None)
+            if let Some(tls) = tls_config {
+                let cert =
+                    std::fs::read(&tls.root_ca_cert_path).map_err(|e| ChannelError::TlsConfig {
+                        action: "loading".to_string(),
+                        message: e.to_string(),
+                    })?;
+                let tls = ClientTlsConfig::new()
+                    .domain_name(tls.domain_name)
+                    .ca_certificate(Certificate::from_pem(cert));
+                endpoint = endpoint
+                    .tls_config(tls)
+                    .map_err(|e| ChannelError::TlsConfig {
+                        action: "building".to_string(),
+                        message: e.to_string(),
+                    })?;
+            }
+
+            if let Some(timeout) = timeout {
+                endpoint = endpoint.timeout(timeout);
+            }
+
+            endpoint
+                .connect()
                 .await
-                .map_err(convert_grpc_error)
+                .map_err(|e| ChannelError::CannotConnect {
+                    uri,
+                    message: e.to_string(),
+                })
         })
     }
 
     fn resolve(hostname: &str) -> BoxFuture<'static, std::io::Result<Vec<IpAddr>>> {
         let hostname = hostname.to_string();
         Box::pin(async move {
-            let resolver = databend_common_grpc::DNSResolver::instance()
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
-            resolver
+            let resolver: Arc<databend_common_grpc::DNSResolver> =
+                databend_common_grpc::DNSResolver::instance()
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+            let addrs: Vec<IpAddr> = resolver
                 .resolve(&hostname)
                 .await
-                .map_err(|e| std::io::Error::other(e.to_string()))
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            Ok(addrs)
         })
     }
 

--- a/src/query/catalog/Cargo.toml
+++ b/src/query/catalog/Cargo.toml
@@ -40,7 +40,6 @@ roaring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-thrift = { workspace = true }
 tokio = { workspace = true }
 typetag = { workspace = true }
 uuid = { workspace = true }

--- a/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
@@ -110,6 +110,7 @@ mod tests {
     use parquet::basic::Repetition;
     use parquet::basic::Type as PhysicalType;
     use parquet::errors::ParquetError;
+    use parquet::schema::printer::print_schema;
     use parquet::schema::types::SchemaDescPtr;
     use parquet::schema::types::SchemaDescriptor;
     use parquet::schema::types::Type;
@@ -188,6 +189,12 @@ mod tests {
         };
         let s = serde_json::to_string(&info).unwrap();
         let info = serde_json::from_str::<ParquetTableInfo>(&s).unwrap();
-        assert_eq!(info.schema_descr, schema_descr)
+
+        let mut original = Vec::new();
+        print_schema(&mut original, schema_descr.root_schema());
+        let mut roundtrip = Vec::new();
+        print_schema(&mut roundtrip, info.schema_descr.root_schema());
+
+        assert_eq!(original, roundtrip)
     }
 }

--- a/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
@@ -26,18 +26,11 @@ use databend_common_storage::StageFileInfo;
 use databend_common_storage::StageFilesInfo;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use parquet::file::metadata::ParquetMetaData;
-use parquet::format::SchemaElement;
-use parquet::schema::types;
+use parquet::schema::parser::parse_message_type;
+use parquet::schema::printer::print_schema;
 use parquet::schema::types::SchemaDescPtr;
 use parquet::schema::types::SchemaDescriptor;
-use parquet::thrift::TSerializable;
 use serde::Deserialize;
-use thrift::protocol::TCompactInputProtocol;
-use thrift::protocol::TCompactOutputProtocol;
-use thrift::protocol::TInputProtocol;
-use thrift::protocol::TListIdentifier;
-use thrift::protocol::TOutputProtocol;
-use thrift::protocol::TType;
 
 use crate::plan::datasource::datasource_info::parquet_read_options::ParquetReadOptions;
 
@@ -93,37 +86,18 @@ impl ParquetTableInfo {
 fn deser_schema_desc<'de, D>(deserializer: D) -> Result<SchemaDescPtr, D::Error>
 where D: serde::Deserializer<'de> {
     let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-    let cursor = Cursor::new(bytes);
-    let mut i_prot = TCompactInputProtocol::new(cursor);
-    let list_ident = i_prot.read_list_begin().unwrap();
-    let mut schema_elements: Vec<SchemaElement> = Vec::with_capacity(list_ident.size as usize);
-    for _ in 0..list_ident.size {
-        let list_elem = SchemaElement::read_from_in_protocol(&mut i_prot).unwrap();
-        schema_elements.push(list_elem);
-    }
-    i_prot.read_list_end().unwrap();
-    let schema = types::from_thrift(&schema_elements).unwrap();
-    Ok(Arc::new(SchemaDescriptor::new(schema)))
+    let schema_string =
+        String::from_utf8(bytes).map_err(|e| serde::de::Error::custom(e.to_string()))?;
+    let schema =
+        parse_message_type(&schema_string).map_err(|e| serde::de::Error::custom(e.to_string()))?;
+    Ok(Arc::new(SchemaDescriptor::new(Arc::new(schema))))
 }
 
 fn ser_schema_desc<S>(schema: &SchemaDescPtr, serializer: S) -> Result<S::Ok, S::Error>
 where S: serde::Serializer {
-    let mut transport = Vec::<u8>::new();
-    let mut o_prot = TCompactOutputProtocol::new(&mut transport);
-    let schema_elements = types::to_thrift(schema.root_schema()).map_err(|e| {
-        serde::ser::Error::custom(format!("Failed to convert schema to thrift: {:?}", e))
-    })?;
-    o_prot
-        .write_list_begin(&TListIdentifier::new(
-            TType::Struct,
-            schema_elements.len() as i32,
-        ))
-        .unwrap();
-    for e in schema_elements {
-        e.write_to_out_protocol(&mut o_prot).unwrap();
-    }
-    o_prot.write_list_end().unwrap();
-    serializer.serialize_bytes(&transport)
+    let mut out = Cursor::new(Vec::<u8>::new());
+    print_schema(&mut out, schema.root_schema());
+    serializer.serialize_bytes(out.get_ref())
 }
 
 #[cfg(test)]

--- a/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/parquet.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::io::Cursor;
 use std::sync::Arc;
 
 use arrow_schema::Schema as ArrowSchema;
@@ -25,12 +24,14 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_storage::StageFileInfo;
 use databend_common_storage::StageFilesInfo;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
+use parquet::arrow::ArrowSchemaConverter;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::parser::parse_message_type;
 use parquet::schema::printer::print_schema;
 use parquet::schema::types::SchemaDescPtr;
 use parquet::schema::types::SchemaDescriptor;
 use serde::Deserialize;
+use serde::Serialize;
 
 use crate::plan::datasource::datasource_info::parquet_read_options::ParquetReadOptions;
 
@@ -49,7 +50,7 @@ pub struct FullParquetMeta {
     pub row_group_level_stats: Option<Vec<HashMap<ColumnId, ColumnStatistics>>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ParquetTableInfo {
     pub read_options: ParquetReadOptions,
     pub stage_info: StageInfo,
@@ -57,19 +58,14 @@ pub struct ParquetTableInfo {
 
     pub table_info: TableInfo,
     pub arrow_schema: ArrowSchema,
-    #[serde(deserialize_with = "deser_schema_desc")]
-    #[serde(serialize_with = "ser_schema_desc")]
     pub schema_descr: SchemaDescPtr,
     pub files_to_read: Option<Vec<StageFileInfo>>,
     pub schema_from: String,
     pub compression_ratio: f64,
     pub leaf_fields: Arc<Vec<TableField>>,
 
-    #[serde(skip)]
     pub need_stats_provider: bool,
-    #[serde(skip)]
     pub max_threads: usize,
-    #[serde(skip)]
     pub max_memory_usage: u64,
 }
 
@@ -83,21 +79,82 @@ impl ParquetTableInfo {
     }
 }
 
-fn deser_schema_desc<'de, D>(deserializer: D) -> Result<SchemaDescPtr, D::Error>
-where D: serde::Deserializer<'de> {
-    let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-    let schema_string =
-        String::from_utf8(bytes).map_err(|e| serde::de::Error::custom(e.to_string()))?;
-    let schema =
-        parse_message_type(&schema_string).map_err(|e| serde::de::Error::custom(e.to_string()))?;
+#[derive(Serialize, Deserialize)]
+struct ParquetTableInfoSerde {
+    read_options: ParquetReadOptions,
+    stage_info: StageInfo,
+    files_info: StageFilesInfo,
+    table_info: TableInfo,
+    arrow_schema: ArrowSchema,
+    schema_descr_bytes: Vec<u8>,
+    schema_descr_root: String,
+    files_to_read: Option<Vec<StageFileInfo>>,
+    schema_from: String,
+    compression_ratio: f64,
+    leaf_fields: Arc<Vec<TableField>>,
+}
+
+impl Serialize for ParquetTableInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        ParquetTableInfoSerde {
+            read_options: self.read_options,
+            stage_info: self.stage_info.clone(),
+            files_info: self.files_info.clone(),
+            table_info: self.table_info.clone(),
+            arrow_schema: self.arrow_schema.clone(),
+            schema_descr_bytes: schema_to_bytes(&self.schema_descr),
+            schema_descr_root: self.schema_descr.root_schema().name().to_string(),
+            files_to_read: self.files_to_read.clone(),
+            schema_from: self.schema_from.clone(),
+            compression_ratio: self.compression_ratio,
+            leaf_fields: self.leaf_fields.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ParquetTableInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        let helper = ParquetTableInfoSerde::deserialize(deserializer)?;
+        let schema_descr = schema_from_bytes(&helper.schema_descr_bytes).or_else(|_| {
+            ArrowSchemaConverter::new()
+                .schema_root(&helper.schema_descr_root)
+                .convert(&helper.arrow_schema)
+                .map(Arc::new)
+        });
+        let schema_descr = schema_descr.map_err(|e| serde::de::Error::custom(e.to_string()))?;
+
+        Ok(Self {
+            read_options: helper.read_options,
+            stage_info: helper.stage_info,
+            files_info: helper.files_info,
+            table_info: helper.table_info,
+            arrow_schema: helper.arrow_schema,
+            schema_descr,
+            files_to_read: helper.files_to_read,
+            schema_from: helper.schema_from,
+            compression_ratio: helper.compression_ratio,
+            leaf_fields: helper.leaf_fields,
+            need_stats_provider: false,
+            max_threads: 0,
+            max_memory_usage: 0,
+        })
+    }
+}
+
+fn schema_from_bytes(bytes: &[u8]) -> parquet::errors::Result<SchemaDescPtr> {
+    let schema_string = String::from_utf8(bytes.to_vec())
+        .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
+    let schema = parse_message_type(&schema_string)?;
     Ok(Arc::new(SchemaDescriptor::new(Arc::new(schema))))
 }
 
-fn ser_schema_desc<S>(schema: &SchemaDescPtr, serializer: S) -> Result<S::Ok, S::Error>
-where S: serde::Serializer {
-    let mut out = Cursor::new(Vec::<u8>::new());
+fn schema_to_bytes(schema: &SchemaDescPtr) -> Vec<u8> {
+    let mut out = Vec::new();
     print_schema(&mut out, schema.root_schema());
-    serializer.serialize_bytes(out.get_ref())
+    out
 }
 
 #[cfg(test)]
@@ -106,10 +163,12 @@ mod tests {
 
     use arrow_schema::Schema as ArrowSchema;
     use databend_common_storage::StageFilesInfo;
+    use parquet::arrow::parquet_to_arrow_schema;
     use parquet::basic::ConvertedType;
     use parquet::basic::Repetition;
     use parquet::basic::Type as PhysicalType;
     use parquet::errors::ParquetError;
+    use parquet::schema::parser::parse_message_type;
     use parquet::schema::printer::print_schema;
     use parquet::schema::types::SchemaDescPtr;
     use parquet::schema::types::SchemaDescriptor;
@@ -162,6 +221,17 @@ mod tests {
         Ok(Arc::new(SchemaDescriptor::new(Arc::new(schema))))
     }
 
+    fn make_arrow_compatible_desc() -> Result<SchemaDescPtr, ParquetError> {
+        let schema = parse_message_type(
+            "
+            message stage_file {
+              OPTIONAL INT64 number (UINT_64);
+            }
+            ",
+        )?;
+        Ok(Arc::new(SchemaDescriptor::new(Arc::new(schema))))
+    }
+
     #[test]
     fn test_serde() {
         let schema_descr = make_desc().unwrap();
@@ -195,6 +265,54 @@ mod tests {
         let mut roundtrip = Vec::new();
         print_schema(&mut roundtrip, info.schema_descr.root_schema());
 
+        assert_eq!(
+            schema_descr.root_schema().name(),
+            info.schema_descr.root_schema().name()
+        );
         assert_eq!(original, roundtrip)
+    }
+
+    #[test]
+    fn test_serde_falls_back_to_arrow_schema() {
+        let schema_descr = make_arrow_compatible_desc().unwrap();
+        let arrow_schema = parquet_to_arrow_schema(&schema_descr, None).unwrap();
+        let info = ParquetTableInfo {
+            schema_descr: schema_descr.clone(),
+            read_options: Default::default(),
+            stage_info: Default::default(),
+            files_info: StageFilesInfo {
+                path: "".to_string(),
+                files: None,
+                pattern: None,
+            },
+            table_info: Default::default(),
+            leaf_fields: Arc::new(vec![]),
+            arrow_schema,
+            files_to_read: None,
+            schema_from: "".to_string(),
+            compression_ratio: 0.0,
+            need_stats_provider: false,
+            max_threads: 1,
+            max_memory_usage: 10000,
+        };
+
+        let mut json = serde_json::to_value(&info).unwrap();
+        json["schema_descr_bytes"] = serde_json::json!(Vec::<u8>::from("invalid schema"));
+
+        let info = serde_json::from_value::<ParquetTableInfo>(json).unwrap();
+
+        assert_eq!(
+            schema_descr.root_schema().name(),
+            info.schema_descr.root_schema().name()
+        );
+        assert_eq!(schema_descr.num_columns(), info.schema_descr.num_columns());
+        assert_eq!(
+            schema_descr.column(0).name(),
+            info.schema_descr.column(0).name()
+        );
+        assert_eq!(
+            schema_descr.column(0).physical_type(),
+            info.schema_descr.column(0).physical_type()
+        );
     }
 }

--- a/src/query/service/src/physical_plans/physical_compact_source.rs
+++ b/src/query/service/src/physical_plans/physical_compact_source.rs
@@ -89,6 +89,15 @@ impl IPhysicalPlan for CompactSource {
             .build_table_by_table_info(&self.table_info, None)?;
         let table = FuseTable::try_from_table(table.as_ref())?;
 
+        if matches!(
+            table.get_storage_format(),
+            databend_common_storages_fuse::FuseStorageFormat::Vortex
+        ) {
+            return Err(databend_common_exception::ErrorCode::Unimplemented(
+                "Compact is not yet supported for Vortex storage format tables",
+            ));
+        }
+
         if self.parts.is_empty() {
             return builder.main_pipeline.add_source(EmptySource::create, 1);
         }

--- a/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/serde/exchange_serializer.rs
@@ -21,6 +21,7 @@ use arrow_array::RecordBatchOptions;
 use arrow_flight::FlightData;
 use arrow_flight::SchemaAsIpc;
 use arrow_ipc::CompressionType;
+use arrow_ipc::writer::CompressionContext;
 use arrow_ipc::writer::DictionaryTracker;
 use arrow_ipc::writer::IpcDataGenerator;
 use arrow_ipc::writer::IpcWriteOptions;
@@ -240,10 +241,15 @@ pub fn batches_to_flight_data_with_options(
 
     let data_gen = IpcDataGenerator::default();
     let mut dictionary_tracker = DictionaryTracker::new(false);
+    let mut compression_context = CompressionContext::default();
 
     for batch in batches.iter() {
-        let (encoded_dictionaries, encoded_batch) =
-            data_gen.encoded_batch(batch, &mut dictionary_tracker, options)?;
+        let (encoded_dictionaries, encoded_batch) = data_gen.encode(
+            batch,
+            &mut dictionary_tracker,
+            options,
+            &mut compression_context,
+        )?;
 
         dictionaries.extend(encoded_dictionaries.into_iter().map(Into::into));
         flight_data.push(encoded_batch.into());

--- a/src/query/service/src/servers/flight/v1/network/outbound_channel.rs
+++ b/src/query/service/src/servers/flight/v1/network/outbound_channel.rs
@@ -21,6 +21,7 @@ use arrow_array::RecordBatchOptions;
 use arrow_flight::FlightData;
 use arrow_flight::FlightDescriptor;
 use arrow_ipc::CompressionType;
+use arrow_ipc::writer::CompressionContext;
 use arrow_ipc::writer::DictionaryTracker;
 use arrow_ipc::writer::IpcDataGenerator;
 use arrow_ipc::writer::IpcWriteOptions;
@@ -69,8 +70,13 @@ fn encode_batch(
 ) -> Result<(Vec<FlightData>, FlightData)> {
     let data_gen = IpcDataGenerator::default();
     let mut dictionary_tracker = DictionaryTracker::new(false);
-    let (encoded_dictionaries, encoded_batch) =
-        data_gen.encoded_batch(batch, &mut dictionary_tracker, ipc_options)?;
+    let mut compression_context = CompressionContext::default();
+    let (encoded_dictionaries, encoded_batch) = data_gen.encode(
+        batch,
+        &mut dictionary_tracker,
+        ipc_options,
+        &mut compression_context,
+    )?;
     let dictionaries: Vec<FlightData> = encoded_dictionaries.into_iter().map(Into::into).collect();
     let batch_data: FlightData = encoded_batch.into();
     Ok((dictionaries, batch_data))

--- a/src/query/service/src/servers/flight_sql/flight_sql_service/query.rs
+++ b/src/query/service/src/servers/flight_sql/flight_sql_service/query.rs
@@ -114,9 +114,15 @@ impl FlightSqlServiceImpl {
             .to_record_batch_with_dataschema(data_schema)
             .map_err(|e| ErrorCode::Internal(format!("{e:?}")))?;
         let mut dictionary_tracker = writer::DictionaryTracker::new(false);
+        let mut compression_context = writer::CompressionContext::default();
 
         let (_encoded_dictionaries, encoded_batch) = data_gen
-            .encoded_batch(&batch, &mut dictionary_tracker, options)
+            .encode(
+                &batch,
+                &mut dictionary_tracker,
+                options,
+                &mut compression_context,
+            )
             .map_err(|e| ErrorCode::Internal(format!("{e:?}")))?;
 
         Ok(encoded_batch.into())

--- a/src/query/service/src/spillers/row_group_encoder.rs
+++ b/src/query/service/src/spillers/row_group_encoder.rs
@@ -40,8 +40,8 @@ use parquet::arrow::FieldLevels;
 use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::arrow::arrow_writer::ArrowColumnWriter;
+use parquet::arrow::arrow_writer::ArrowRowGroupWriterFactory;
 use parquet::arrow::arrow_writer::compute_leaves;
-use parquet::arrow::arrow_writer::get_column_writers;
 use parquet::arrow::parquet_to_arrow_field_levels;
 use parquet::errors;
 use parquet::file::metadata::RowGroupMetaData;
@@ -86,7 +86,7 @@ impl Properties {
     }
 
     pub fn new_encoder(&self) -> RowGroupEncoder {
-        RowGroupEncoder::new(&self.writer_props, self.schema.clone(), &self.parquet)
+        RowGroupEncoder::new(&self.writer_props, self.schema.clone(), &self.parquet, 0)
     }
 }
 
@@ -97,8 +97,19 @@ pub struct RowGroupEncoder {
 }
 
 impl RowGroupEncoder {
-    fn new(props: &WriterPropertiesPtr, schema: Arc<Schema>, parquet: &SchemaDescriptor) -> Self {
-        let writers = get_column_writers(parquet, props, &schema).unwrap();
+    fn new(
+        props: &WriterPropertiesPtr,
+        schema: Arc<Schema>,
+        parquet: &SchemaDescriptor,
+        row_group_index: usize,
+    ) -> Self {
+        let file_writer =
+            SerializedFileWriter::new(Vec::new(), parquet.root_schema_ptr(), props.clone())
+                .unwrap();
+        let row_group_factory = ArrowRowGroupWriterFactory::new(&file_writer, schema.clone());
+        let writers = row_group_factory
+            .create_column_writers(row_group_index)
+            .unwrap();
         Self {
             schema,
             props: props.clone(),
@@ -204,6 +215,7 @@ impl<W: Write + Send> FileWriter<W> {
             self.writer.properties(),
             self.schema.clone(),
             self.writer.schema_descr(),
+            self.row_groups.len(),
         )
     }
 
@@ -235,12 +247,13 @@ impl<W: Write + Send> FileWriter<W> {
         let file_metadata = writer.finish()?;
         let tp = writer.schema_descr().root_schema_ptr();
         let schema_descr = Arc::new(SchemaDescriptor::new(tp));
+        let file_metadata = file_metadata.file_metadata();
 
         let metadata = parquet::file::metadata::FileMetaData::new(
-            file_metadata.version,
-            file_metadata.num_rows,
-            file_metadata.created_by.clone(),
-            file_metadata.key_value_metadata.clone(),
+            file_metadata.version(),
+            file_metadata.num_rows(),
+            file_metadata.created_by().map(ToString::to_string),
+            file_metadata.key_value_metadata().cloned(),
             schema_descr,
             None,
         );

--- a/src/query/service/src/spillers/serialize.rs
+++ b/src/query/service/src/spillers/serialize.rs
@@ -38,10 +38,10 @@ use opendal::Buffer;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use parquet::basic::Compression;
+use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::EnabledStatistics;
 use parquet::file::properties::WriterProperties;
 use parquet::file::reader::ChunkReader;
-use parquet::format::FileMetaData;
 
 #[derive(Debug, Clone)]
 pub enum Layout {
@@ -171,7 +171,7 @@ fn bare_blocks_from_parquet<R: ChunkReader + 'static>(data: R) -> Result<DataBlo
 fn bare_blocks_to_parquet<W: Write + Send>(
     blocks: Vec<DataBlock>,
     write_buffer: W,
-) -> Result<FileMetaData> {
+) -> Result<ParquetMetaData> {
     assert!(!blocks.is_empty());
 
     let data_schema = blocks.first().unwrap().infer_schema();

--- a/src/query/service/src/test_kits/block_writer.rs
+++ b/src/query/service/src/test_kits/block_writer.rs
@@ -41,7 +41,7 @@ use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::meta::encode_column_hll;
 use databend_storages_common_table_meta::table::TableCompression;
 use opendal::Operator;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 use uuid::Uuid;
 
 use super::old_version_generator;
@@ -75,7 +75,7 @@ impl<'a> BlockWriter<'a> {
         block: DataBlock,
         col_stats: StatisticsOfColumns,
         cluster_stats: Option<ClusterStatistics>,
-    ) -> Result<(BlockMeta, Option<FileMetaData>, RawBlockHLL)> {
+    ) -> Result<(BlockMeta, Option<ParquetMetaData>, RawBlockHLL)> {
         let (location, block_id) = if !self.is_greater_than_v5 {
             let location_generator = old_version_generator::TableMetaLocationGenerator::with_prefix(
                 self.location_generator.prefix().to_string(),
@@ -140,7 +140,7 @@ impl<'a> BlockWriter<'a> {
         schema: TableSchemaRef,
         block: &DataBlock,
         block_id: Uuid,
-    ) -> Result<(u64, Option<Location>, Option<FileMetaData>)> {
+    ) -> Result<(u64, Option<Location>, Option<ParquetMetaData>)> {
         let location = self
             .location_generator
             .block_bloom_index_location(&block_id);

--- a/src/query/service/tests/it/parquet_rs/data.rs
+++ b/src/query/service/tests/it/parquet_rs/data.rs
@@ -348,7 +348,7 @@ pub async fn make_test_file_rg(scenario: Scenario) -> (NamedTempFile, SchemaRef)
         .expect("tempfile creation");
 
     let props = WriterProperties::builder()
-        .set_max_row_group_size(5)
+        .set_max_row_group_row_count(Some(5))
         .build();
 
     let batches = create_data_batch(scenario);

--- a/src/query/service/tests/it/parquet_rs/prune_pages.rs
+++ b/src/query/service/tests/it/parquet_rs/prune_pages.rs
@@ -22,6 +22,7 @@ use parquet::arrow::arrow_reader::ArrowReaderMetadata;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
+use parquet::file::metadata::PageIndexPolicy;
 
 use crate::parquet_rs::data::Scenario;
 use crate::parquet_rs::data::make_test_file_page;
@@ -41,7 +42,7 @@ async fn test_batch(batches: &[(Scenario, &str, RowSelection)]) {
         let metadata = ArrowReaderMetadata::load(
             file.as_file(),
             ArrowReaderOptions::new()
-                .with_page_index(true)
+                .with_page_index_policy(PageIndexPolicy::from(true))
                 .with_skip_arrow_metadata(true),
         )
         .unwrap();

--- a/src/query/service/tests/it/servers/flight_sql/flight_sql_handler.rs
+++ b/src/query/service/tests/it/servers/flight_sql/flight_sql_handler.rs
@@ -19,9 +19,9 @@ use std::io::Write;
 
 use arrow_array::RecordBatch;
 use arrow_cast::pretty::pretty_format_batches;
+use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use arrow_flight::sql::client::FlightSqlServiceClient;
-use arrow_schema::ArrowError;
 use databend_common_base::runtime::Runtime;
 use databend_common_config::InnerConfig;
 use databend_common_config::UserAuthConfig;
@@ -66,7 +66,7 @@ async fn client_with_uds(path: String) -> FlightSqlServiceClient<Channel> {
 async fn run_query(
     client: &mut FlightSqlServiceClient<Channel>,
     sql: &str,
-) -> std::result::Result<String, ArrowError> {
+) -> std::result::Result<String, FlightError> {
     let mut stmt = client.prepare(sql.to_string(), None).await?;
     let res = if stmt.dataset_schema()?.fields.is_empty() {
         let affected_rows = client.execute_update(sql.to_string(), None).await?;
@@ -76,7 +76,9 @@ async fn run_query(
         let ticket = flight_info.endpoint[0].ticket.as_ref().unwrap().clone();
         let flight_data = client.do_get(ticket).await?;
         let batches: Vec<RecordBatch> = flight_data.try_collect().await.unwrap();
-        pretty_format_batches(batches.as_slice())?.to_string()
+        pretty_format_batches(batches.as_slice())
+            .map_err(FlightError::from)?
+            .to_string()
     };
     Ok(res)
 }

--- a/src/query/service/tests/it/storages/fuse/bloom_index_meta_size.rs
+++ b/src/query/service/tests/it/storages/fuse/bloom_index_meta_size.rs
@@ -35,6 +35,7 @@ use databend_query::test_kits::*;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheValue;
 use databend_storages_common_cache::InMemoryLruCache;
+use databend_storages_common_cache::ParquetMetaData;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
@@ -46,7 +47,6 @@ use databend_storages_common_table_meta::meta::SingleColumnMeta;
 use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::Versioned;
 use opendal::Operator;
-use parquet::format::FileMetaData;
 use sysinfo::System;
 use sysinfo::get_current_pid;
 use uuid::Uuid;
@@ -384,7 +384,7 @@ where T: Clone + Into<CacheValue<T>> {
 }
 
 #[allow(dead_code)]
-async fn setup() -> databend_common_exception::Result<FileMetaData> {
+async fn setup() -> databend_common_exception::Result<ParquetMetaData> {
     let fields = (0..23)
         .map(|_| TableField::new("id", TableDataType::Number(NumberDataType::Int32)))
         .collect::<Vec<_>>();

--- a/src/query/storages/common/blocks/src/parquet_rs.rs
+++ b/src/query/storages/common/blocks/src/parquet_rs.rs
@@ -26,10 +26,10 @@ use databend_storages_common_table_meta::table::TableCompression;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Encoding;
 use parquet::file::metadata::KeyValue;
+use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::EnabledStatistics;
 use parquet::file::properties::WriterProperties;
 use parquet::file::properties::WriterVersion;
-use parquet::format::FileMetaData;
 use parquet::schema::types::ColumnPath;
 
 /// Disable dictionary encoding once the NDV-to-row ratio is greater than this threshold.
@@ -50,7 +50,7 @@ pub fn blocks_to_parquet(
     compression: TableCompression,
     enable_dictionary: bool,
     metadata: Option<Vec<KeyValue>>,
-) -> Result<FileMetaData> {
+) -> Result<ParquetMetaData> {
     blocks_to_parquet_with_stats(
         table_schema,
         blocks,
@@ -80,7 +80,7 @@ pub fn blocks_to_parquet_with_stats(
     enable_dictionary: bool,
     metadata: Option<Vec<KeyValue>>,
     column_stats: Option<&StatisticsOfColumns>,
-) -> Result<FileMetaData> {
+) -> Result<ParquetMetaData> {
     assert!(!blocks.is_empty());
 
     // Writer properties cannot be tweaked after ArrowWriter creation, so we mirror the behavior of
@@ -178,7 +178,7 @@ pub fn build_parquet_writer_properties(
     let mut builder = WriterProperties::builder()
         .set_compression(compression.into())
         // use `usize::MAX` to effectively limit the number of row groups to 1
-        .set_max_row_group_size(usize::MAX)
+        .set_max_row_group_row_count(Some(usize::MAX))
         .set_encoding(Encoding::PLAIN)
         .set_statistics_enabled(EnabledStatistics::None)
         .set_bloom_filter_enabled(false)

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -76,11 +76,12 @@ use databend_storages_common_table_meta::meta::SingleColumnMeta;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::Versioned;
 use jsonb::RawJsonb;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::eliminate_cast::is_injective_cast;
+use super::index_common::index_columns_from_parquet_meta;
 use crate::Index;
 use crate::eliminate_cast::cast_const;
 use crate::filters::BinaryFuse32Builder;
@@ -158,44 +159,13 @@ impl TryFrom<Bytes> for BloomIndexMeta {
     }
 }
 
-impl TryFrom<FileMetaData> for BloomIndexMeta {
+impl TryFrom<ParquetMetaData> for BloomIndexMeta {
     type Error = ErrorCode;
 
-    fn try_from(mut meta: FileMetaData) -> std::result::Result<Self, Self::Error> {
-        let rg = meta.row_groups.remove(0);
-        let mut col_metas = Vec::with_capacity(rg.columns.len());
-        for x in &rg.columns {
-            match &x.meta_data {
-                Some(chunk_meta) => {
-                    let col_start =
-                        if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                            dict_page_offset
-                        } else {
-                            chunk_meta.data_page_offset
-                        };
-                    let col_len = chunk_meta.total_compressed_size;
-                    assert!(
-                        col_start >= 0 && col_len >= 0,
-                        "column start and length should not be negative"
-                    );
-                    let num_values = chunk_meta.num_values as u64;
-                    let res = SingleColumnMeta {
-                        offset: col_start as u64,
-                        len: col_len as u64,
-                        num_values,
-                    };
-                    let column_name = chunk_meta.path_in_schema[0].to_owned();
-                    col_metas.push((column_name, res));
-                }
-                None => {
-                    panic!(
-                        "expecting chunk meta data while converting ThriftFileMetaData to BloomIndexMeta"
-                    )
-                }
-            }
-        }
-        col_metas.shrink_to_fit();
-        Ok(Self { columns: col_metas })
+    fn try_from(meta: ParquetMetaData) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            columns: index_columns_from_parquet_meta(&meta),
+        })
     }
 }
 

--- a/src/query/storages/common/index/src/index_common.rs
+++ b/src/query/storages/common/index/src/index_common.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 use bytes::Bytes;
 use databend_common_exception::ErrorCode;
 use databend_storages_common_table_meta::meta::SingleColumnMeta;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct IndexMeta {
@@ -114,56 +114,48 @@ macro_rules! impl_bincode_codec_for_file {
 impl_bincode_codec_for_meta!(IndexMeta, "index");
 impl_bincode_codec_for_file!(IndexFile, "index");
 
-impl TryFrom<FileMetaData> for IndexMeta {
+pub(crate) fn index_columns_from_parquet_meta(
+    meta: &ParquetMetaData,
+) -> Vec<(String, SingleColumnMeta)> {
+    let row_group = &meta.row_groups()[0];
+    let mut col_metas = Vec::with_capacity(row_group.columns().len());
+    for chunk_meta in row_group.columns() {
+        let (offset, len) = chunk_meta.byte_range();
+        let num_values = chunk_meta.num_values() as u64;
+        let column_name = chunk_meta.column_path().parts()[0].to_owned();
+        col_metas.push((column_name, SingleColumnMeta {
+            offset,
+            len,
+            num_values,
+        }));
+    }
+    col_metas.shrink_to_fit();
+    col_metas
+}
+
+pub(crate) fn user_metadata_from_parquet_meta(meta: &ParquetMetaData) -> BTreeMap<String, String> {
+    let mut metadata = BTreeMap::new();
+    if let Some(key_value_metadata) = meta.file_metadata().key_value_metadata() {
+        for key_value in key_value_metadata {
+            let Some(value) = &key_value.value else {
+                continue;
+            };
+            if key_value.key == "ARROW:schema" {
+                continue;
+            }
+            metadata.insert(key_value.key.clone(), value.clone());
+        }
+    }
+    metadata
+}
+
+impl TryFrom<ParquetMetaData> for IndexMeta {
     type Error = ErrorCode;
 
-    fn try_from(mut meta: FileMetaData) -> std::result::Result<Self, Self::Error> {
-        let rg = meta.row_groups.remove(0);
-        let mut col_metas = Vec::with_capacity(rg.columns.len());
-        for x in &rg.columns {
-            match &x.meta_data {
-                Some(chunk_meta) => {
-                    let col_start =
-                        if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                            dict_page_offset
-                        } else {
-                            chunk_meta.data_page_offset
-                        };
-                    let col_len = chunk_meta.total_compressed_size;
-                    assert!(
-                        col_start >= 0 && col_len >= 0,
-                        "column start and length should not be negative"
-                    );
-                    let num_values = chunk_meta.num_values as u64;
-                    let res = SingleColumnMeta {
-                        offset: col_start as u64,
-                        len: col_len as u64,
-                        num_values,
-                    };
-                    let column_name = chunk_meta.path_in_schema[0].to_owned();
-                    col_metas.push((column_name, res));
-                }
-                None => {
-                    panic!(
-                        "expecting chunk meta data while converting ThriftFileMetaData to IndexMeta"
-                    )
-                }
-            }
-        }
-        col_metas.shrink_to_fit();
-        let mut metadata = BTreeMap::new();
-        if let Some(key_value_metadata) = meta.key_value_metadata {
-            for key_value in &key_value_metadata {
-                if key_value.key == "ARROW:schema" || key_value.value.is_none() {
-                    continue;
-                }
-                metadata.insert(key_value.key.clone(), key_value.value.clone().unwrap());
-            }
-        }
-
+    fn try_from(meta: ParquetMetaData) -> std::result::Result<Self, Self::Error> {
         Ok(IndexMeta {
-            columns: col_metas,
-            metadata,
+            columns: index_columns_from_parquet_meta(&meta),
+            metadata: user_metadata_from_parquet_meta(&meta),
         })
     }
 }

--- a/src/query/storages/common/index/src/inverted_index.rs
+++ b/src/query/storages/common/index/src/inverted_index.rs
@@ -65,7 +65,7 @@ use levenshtein_automata::DFA;
 use levenshtein_automata::Distance;
 use levenshtein_automata::LevenshteinAutomatonBuilder;
 use log::warn;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 use roaring::RoaringTreemap;
 use tantivy::Directory;
 use tantivy::Term;
@@ -1242,47 +1242,13 @@ pub struct InvertedIndexMeta {
     pub columns: Vec<(String, SingleColumnMeta)>,
 }
 
-impl TryFrom<FileMetaData> for InvertedIndexMeta {
+impl TryFrom<ParquetMetaData> for InvertedIndexMeta {
     type Error = ErrorCode;
 
-    fn try_from(mut meta: FileMetaData) -> std::result::Result<Self, Self::Error> {
-        let rg = meta.row_groups.remove(0);
-        let mut col_metas = Vec::with_capacity(rg.columns.len());
-        for x in &rg.columns {
-            match &x.meta_data {
-                Some(chunk_meta) => {
-                    let col_start =
-                        if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                            dict_page_offset
-                        } else {
-                            chunk_meta.data_page_offset
-                        };
-                    let col_len = chunk_meta.total_compressed_size;
-                    assert!(
-                        col_start >= 0 && col_len >= 0,
-                        "column start and length should not be negative"
-                    );
-                    let num_values = chunk_meta.num_values as u64;
-                    let res = SingleColumnMeta {
-                        offset: col_start as u64,
-                        len: col_len as u64,
-                        num_values,
-                    };
-                    let column_name = chunk_meta.path_in_schema[0].to_owned();
-                    col_metas.push((column_name, res));
-                }
-                None => {
-                    panic!(
-                        "expecting chunk meta data while converting ThriftFileMetaData to InvertedIndexMeta"
-                    )
-                }
-            }
-        }
-        col_metas.shrink_to_fit();
-
+    fn try_from(meta: ParquetMetaData) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
             version: 3,
-            columns: col_metas,
+            columns: super::index_common::index_columns_from_parquet_meta(&meta),
         })
     }
 }

--- a/src/query/storages/common/index/src/virtual_column.rs
+++ b/src/query/storages/common/index/src/virtual_column.rs
@@ -23,7 +23,7 @@ use databend_common_exception::Result;
 use databend_common_expression::DataSchema;
 use databend_common_expression::types::DataType;
 use databend_storages_common_table_meta::meta::SingleColumnMeta;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 
 pub const VIRTUAL_COLUMN_STRING_TABLE_KEY: &str = "virtual_column_string_table";
 pub const VIRTUAL_COLUMN_NODES_KEY: &str = "virtual_column_nodes";
@@ -97,16 +97,20 @@ impl TryFrom<Bytes> for VirtualColumnFileMeta {
 // - VIRTUAL_COLUMN_NODES_KEY: the trie encoded by string table ids and leaf indices.
 // - VIRTUAL_COLUMN_SHARED_COLUMN_IDS_KEY: mapping of source_column_id -> (key_id, value_id).
 // Column offsets/lengths/num_values and shared map columns are derived from parquet metadata.
-impl TryFrom<FileMetaData> for VirtualColumnFileMeta {
+impl TryFrom<ParquetMetaData> for VirtualColumnFileMeta {
     type Error = ErrorCode;
 
-    fn try_from(mut meta: FileMetaData) -> std::result::Result<Self, Self::Error> {
+    fn try_from(meta: ParquetMetaData) -> std::result::Result<Self, Self::Error> {
         let mut arrow_schema = None;
         let mut string_table = None;
         let mut virtual_column_nodes = None;
         let mut shared_column_ids = None;
 
-        let key_value_metadata = meta.key_value_metadata.unwrap_or_default();
+        let key_value_metadata = meta
+            .file_metadata()
+            .key_value_metadata()
+            .cloned()
+            .unwrap_or_default();
         for key_value in &key_value_metadata {
             if key_value.key == "ARROW:schema" {
                 let encoded_meta = key_value.value.as_ref().unwrap();
@@ -135,31 +139,17 @@ impl TryFrom<FileMetaData> for VirtualColumnFileMeta {
         })?;
         let shared_column_ids = shared_column_ids.unwrap_or_default();
 
-        let rg = meta.row_groups.remove(0);
-        let mut column_metas = Vec::with_capacity(rg.columns.len());
-        for (column_idx, column) in rg.columns.iter().enumerate() {
-            let chunk_meta = column.meta_data.as_ref().ok_or_else(|| {
-                ErrorCode::Internal(
-                    "expecting chunk meta data while converting ThriftFileMetaData to VirtualColumnFileMeta",
-                )
-            })?;
-            let col_start = if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                dict_page_offset
-            } else {
-                chunk_meta.data_page_offset
-            };
-            let col_len = chunk_meta.total_compressed_size;
-            assert!(
-                col_start >= 0 && col_len >= 0,
-                "column start and length should not be negative"
-            );
-            let num_values = chunk_meta.num_values as u64;
+        let row_group = &meta.row_groups()[0];
+        let mut column_metas = Vec::with_capacity(row_group.columns().len());
+        for (column_idx, chunk_meta) in row_group.columns().iter().enumerate() {
+            let (offset, len) = chunk_meta.byte_range();
+            let num_values = chunk_meta.num_values() as u64;
             let res = SingleColumnMeta {
-                offset: col_start as u64,
-                len: col_len as u64,
+                offset,
+                len,
                 num_values,
             };
-            let data_type = data_type_from_path(&data_schema, &chunk_meta.path_in_schema)?;
+            let data_type = data_type_from_path(&data_schema, chunk_meta.column_path().parts())?;
             let column_id = column_idx as u32;
             column_metas.push(VirtualColumnIdWithMeta {
                 column_id,

--- a/src/query/storages/common/table_meta/src/meta/column_oriented_segment/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/column_oriented_segment/segment.rs
@@ -270,7 +270,7 @@ impl AbstractSegment for ColumnOrientedSegment {
             // TODO(Sky): Construct the optimal props, enabling compression, encoding, etc., if performance is better.
             let props = Some(
                 WriterProperties::builder()
-                    .set_max_row_group_size(usize::MAX)
+                    .set_max_row_group_row_count(Some(usize::MAX))
                     .build(),
             );
             let arrow_schema = Arc::new(Schema::from(&self.segment_schema));

--- a/src/query/storages/common/table_meta/src/meta/current/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/current/mod.rs
@@ -26,6 +26,7 @@ pub use v2::SpatialStatistics;
 pub use v2::Statistics;
 pub use v2::VirtualBlockMeta;
 pub use v2::VirtualColumnMeta;
+pub use v2::VortexColumnMeta;
 pub use v4::CompactSegmentInfo;
 pub use v4::RawBlockMeta;
 pub use v4::SegmentInfo;

--- a/src/query/storages/common/table_meta/src/meta/v2/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/mod.rs
@@ -26,6 +26,7 @@ pub use segment::ExtendedBlockMeta;
 pub use segment::SegmentInfo;
 pub use segment::VirtualBlockMeta;
 pub use segment::VirtualColumnMeta;
+pub use segment::VortexColumnMeta;
 pub use segment_statistics::SegmentStatistics;
 pub use snapshot::TableSnapshot;
 pub use statistics::AdditionalStatsMeta;

--- a/src/query/storages/common/table_meta/src/meta/v2/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/segment.rs
@@ -328,12 +328,28 @@ impl SegmentInfo {
     }
 }
 
+/// Column-level metadata for a Vortex-format block.
+///
+/// Unlike Parquet and Native formats where each column has its own byte range,
+/// a Vortex file stores all columns together in a single file. Column offsets are
+/// encoded in the Vortex file footer (Layout flatbuffer) and resolved at read time
+/// by the Vortex reader. We only need to track the row count here; the file-level
+/// location is stored in BlockMeta.location.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct VortexColumnMeta {
+    /// Total number of rows in this column (== block row count).
+    pub num_values: u64,
+}
+
 #[derive(
     serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, EnumAsInner, FrozenAPI,
 )]
 pub enum ColumnMeta {
     Parquet(v0::ColumnMeta),
     Native(NativeColumnMeta),
+    /// Vortex format: column layout is encoded in the file footer; only row count
+    /// is stored here. The file path comes from BlockMeta.location.
+    Vortex(VortexColumnMeta),
 }
 
 impl ColumnMeta {
@@ -341,6 +357,7 @@ impl ColumnMeta {
         match self {
             ColumnMeta::Parquet(v) => v.num_values as usize,
             ColumnMeta::Native(v) => v.pages.iter().map(|page| page.num_values as usize).sum(),
+            ColumnMeta::Vortex(v) => v.num_values as usize,
         }
     }
 
@@ -348,6 +365,10 @@ impl ColumnMeta {
         match self {
             ColumnMeta::Parquet(v) => (v.offset, v.len),
             ColumnMeta::Native(v) => (v.offset, v.pages.iter().map(|page| page.length).sum()),
+            // Vortex files are read as a whole; offset/length are not meaningful
+            // at the column level. Return (0, 0) — callers must use the file path
+            // from BlockMeta.location and let the Vortex reader handle IO.
+            ColumnMeta::Vortex(_) => (0, 0),
         }
     }
 
@@ -364,6 +385,7 @@ impl ColumnMeta {
                     .sum(),
                 None => v.pages.iter().map(|page| page.num_values).sum(),
             },
+            ColumnMeta::Vortex(v) => v.num_values,
         }
     }
 
@@ -380,6 +402,9 @@ impl ColumnMeta {
                     .sum(),
                 None => v.pages.iter().map(|page| page.length).sum(),
             },
+            // File size is tracked at block level (BlockMeta.file_size); return 0
+            // here to avoid double-counting in callers that sum column bytes.
+            ColumnMeta::Vortex(_) => 0,
         }
     }
 }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -38,6 +38,7 @@ databend-storages-common-io = { workspace = true }
 databend-storages-common-pruner = { workspace = true }
 databend-storages-common-session = { workspace = true }
 databend-storages-common-table-meta = { workspace = true }
+databend-storages-vortex = { workspace = true }
 
 ahash = { workspace = true }
 arrow = { workspace = true }

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -43,6 +43,7 @@ databend-storages-vortex = { workspace = true }
 ahash = { workspace = true }
 arrow = { workspace = true }
 arrow-array = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-ipc = { workspace = true }
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -354,6 +354,7 @@ impl FuseTable {
         match self.storage_format {
             FuseStorageFormat::Parquet => None,
             FuseStorageFormat::Native => Some(self.get_write_settings().max_page_size),
+            FuseStorageFormat::Vortex => None,
         }
     }
 

--- a/src/query/storages/fuse/src/fuse_type.rs
+++ b/src/query/storages/fuse/src/fuse_type.rs
@@ -47,6 +47,11 @@ impl FuseTableType {
 pub enum FuseStorageFormat {
     Parquet,
     Native,
+    /// Vortex columnar file format (https://github.com/vortex-data/vortex).
+    /// Provides faster scans and random access vs Parquet via modern compression
+    /// algorithms (ALP, FastLanes, FSST). Column statistics are stored externally
+    /// in Fuse's BlockMeta, not inside the Vortex file.
+    Vortex,
 }
 
 impl Display for FuseStorageFormat {
@@ -54,6 +59,7 @@ impl Display for FuseStorageFormat {
         match self {
             FuseStorageFormat::Parquet => write!(f, "Parquet"),
             FuseStorageFormat::Native => write!(f, "Native"),
+            FuseStorageFormat::Vortex => write!(f, "Vortex"),
         }
     }
 }
@@ -65,6 +71,7 @@ impl FromStr for FuseStorageFormat {
         match s.to_lowercase().as_str() {
             "" | "parquet" => Ok(FuseStorageFormat::Parquet),
             "native" => Ok(FuseStorageFormat::Native),
+            "vortex" => Ok(FuseStorageFormat::Vortex),
             other => Err(ErrorCode::UnknownFormat(format!(
                 "unknown fuse storage_format {}",
                 other

--- a/src/query/storages/fuse/src/io/locations.rs
+++ b/src/query/storages/fuse/src/io/locations.rs
@@ -150,13 +150,27 @@ impl TableMetaLocationGenerator {
         &self,
         table_meta_timestamps: TableMetaTimestamps,
     ) -> (Location, Uuid) {
+        self.gen_block_location_with_format(table_meta_timestamps, &crate::FuseStorageFormat::Parquet)
+    }
+
+    pub fn gen_block_location_with_format(
+        &self,
+        table_meta_timestamps: TableMetaTimestamps,
+        storage_format: &crate::FuseStorageFormat,
+    ) -> (Location, Uuid) {
         let part_uuid = uuid_from_date_time(table_meta_timestamps.segment_block_timestamp);
+        let ext = match storage_format {
+            crate::FuseStorageFormat::Parquet => "parquet",
+            crate::FuseStorageFormat::Native => "parquet", // native uses parquet extension by convention
+            crate::FuseStorageFormat::Vortex => "vortex",
+        };
         let location_path = format!(
-            "{}{}{}_v{}.parquet",
+            "{}{}{}_v{}.{}",
             self.block_location_prefix(),
             VACUUM2_OBJECT_KEY_PREFIX,
             part_uuid.as_simple(),
             DataBlock::VERSION,
+            ext,
         );
 
         ((location_path, DataBlock::VERSION), part_uuid)

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -36,6 +36,7 @@ pub use read::TableSnapshotReader;
 pub use read::VirtualBlockReadResult;
 pub use read::VirtualColumnReader;
 pub use read::build_columns_meta;
+pub(crate) use read::read_vortex_block;
 pub use segments::SegmentsIO;
 pub use segments::SerializedSegment;
 pub use snapshots::SnapshotLiteExtended;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_deserialize.rs
@@ -32,6 +32,7 @@ use crate::BlockReadResult;
 use crate::FuseBlockPartInfo;
 use crate::FuseStorageFormat;
 use crate::io::read::block::block_reader_merge_io::DataItem;
+use crate::io::read::block::vortex_reader::read_vortex_block;
 
 pub enum DeserializedArray<'a> {
     Cached(&'a Arc<SizedColumnArray>),
@@ -85,6 +86,11 @@ impl BlockReader {
             FuseStorageFormat::Native => {
                 self.deserialize_native_chunks(block_path, num_rows, column_metas, column_chunks)
             }
+            // Vortex blocks are read as a whole file via read_by_meta / read_vortex_block;
+            // this path should not be reached for Vortex format.
+            FuseStorageFormat::Vortex => Err(databend_common_exception::ErrorCode::StorageOther(
+                "deserialize_chunks called for Vortex format; use read_by_meta instead".to_string(),
+            )),
         }
     }
 
@@ -96,6 +102,18 @@ impl BlockReader {
         meta: &BlockMeta,
         storage_format: &FuseStorageFormat,
     ) -> Result<DataBlock> {
+        // Vortex files are read as a whole — bypass the merge-IO path entirely.
+        if matches!(storage_format, FuseStorageFormat::Vortex) {
+            return read_vortex_block(
+                self.operator.clone(),
+                &meta.location.0,
+                &self.projected_schema,
+                &self.project_indices,
+                meta.row_count as usize,
+            )
+            .await;
+        }
+
         // Get the merged IO read result.
         let merge_io_read_result = self
             .read_columns_data_by_merge_io(settings, &meta.location.0, &meta.col_metas, &None)
@@ -130,6 +148,11 @@ impl BlockReader {
                 &meta.col_metas,
                 column_chunks,
             ),
+            // Vortex blocks must be read via read_by_meta which bypasses merge-IO.
+            FuseStorageFormat::Vortex => Err(databend_common_exception::ErrorCode::StorageOther(
+                "deserialize_chunks_with_meta called for Vortex format; use read_by_meta instead"
+                    .to_string(),
+            )),
         }
     }
 }

--- a/src/query/storages/fuse/src/io/read/block/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/mod.rs
@@ -20,6 +20,7 @@ mod block_reader_native;
 mod block_reader_native_deserialize;
 mod block_reader_parquet_deserialize;
 pub mod parquet;
+pub(crate) mod vortex_reader;
 
 pub use block_reader::BlockReadContext;
 pub use block_reader::BlockReader;

--- a/src/query/storages/fuse/src/io/read/block/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/mod.rs
@@ -30,3 +30,4 @@ pub use block_reader_native::NativeReaderExt;
 pub use block_reader_native::NativeSourceData;
 pub use parquet::RowSelection;
 pub use parquet::column_chunks_to_record_batch;
+pub(crate) use vortex_reader::read_vortex_block;

--- a/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
@@ -159,6 +159,7 @@ mod tests {
     use std::sync::Arc;
 
     use opendal::Buffer;
+    use parquet::arrow::arrow_reader::RowGroups;
     use parquet::basic::Compression;
     use parquet::basic::Repetition;
     use parquet::basic::Type as PhysicalType;

--- a/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
@@ -25,6 +25,9 @@ use parquet::column::page::PageIterator;
 use parquet::column::page::PageReader;
 use parquet::errors::Result as ParquetResult;
 use parquet::file::metadata::ColumnChunkMetaData;
+use parquet::file::metadata::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::metadata::RowGroupMetaData;
 use parquet::file::serialized_reader::SerializedPageReader;
 use parquet::schema::types::SchemaDescriptor;
 
@@ -65,10 +68,20 @@ impl<'a> RowGroupImplBuilder<'a> {
     }
 
     pub fn build(self) -> RowGroupImpl {
+        let schema_descriptor = Arc::new(self.schema_descriptor.clone());
+        let row_group = RowGroupMetaData::builder(schema_descriptor.clone())
+            .set_num_rows(self.num_rows as i64)
+            .set_column_metadata(self.column_chunk_metadatas.values().cloned().collect())
+            .build()
+            .unwrap();
         RowGroupImpl {
             num_rows: self.num_rows,
             column_chunks: self.column_chunks,
             column_chunk_metadatas: self.column_chunk_metadatas,
+            parquet_meta: ParquetMetaData::new(
+                FileMetaData::new(0, self.num_rows as i64, None, None, schema_descriptor, None),
+                vec![row_group],
+            ),
         }
     }
 }
@@ -78,6 +91,7 @@ pub struct RowGroupImpl {
     num_rows: usize,
     column_chunks: HashMap<usize, Buffer>,
     column_chunk_metadatas: HashMap<usize, ColumnChunkMetaData>,
+    parquet_meta: ParquetMetaData,
 }
 
 impl RowGroups for RowGroupImpl {
@@ -100,6 +114,14 @@ impl RowGroups for RowGroupImpl {
         Ok(Box::new(PageIteratorImpl {
             reader: Some(Ok(page_reader)),
         }))
+    }
+
+    fn row_groups(&self) -> Box<dyn Iterator<Item = &RowGroupMetaData> + '_> {
+        Box::new(self.parquet_meta.row_groups().iter())
+    }
+
+    fn metadata(&self) -> &databend_storages_common_cache::ParquetMetaData {
+        &self.parquet_meta
     }
 }
 

--- a/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/adapter.rs
@@ -69,9 +69,24 @@ impl<'a> RowGroupImplBuilder<'a> {
 
     pub fn build(self) -> RowGroupImpl {
         let schema_descriptor = Arc::new(self.schema_descriptor.clone());
+        let column_metadata = (0..schema_descriptor.num_columns())
+            .map(|dfs_id| {
+                self.column_chunk_metadatas
+                    .get(&dfs_id)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        ColumnChunkMetaData::builder(self.schema_descriptor.column(dfs_id))
+                            .set_compression(self.compression)
+                            .set_data_page_offset(0)
+                            .set_total_compressed_size(0)
+                            .build()
+                            .unwrap()
+                    })
+            })
+            .collect();
         let row_group = RowGroupMetaData::builder(schema_descriptor.clone())
             .set_num_rows(self.num_rows as i64)
-            .set_column_metadata(self.column_chunk_metadatas.values().cloned().collect())
+            .set_column_metadata(column_metadata)
             .build()
             .unwrap();
         RowGroupImpl {
@@ -138,3 +153,60 @@ impl Iterator for PageIteratorImpl {
 }
 
 impl PageIterator for PageIteratorImpl {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use opendal::Buffer;
+    use parquet::basic::Compression;
+    use parquet::basic::Repetition;
+    use parquet::basic::Type as PhysicalType;
+    use parquet::schema::types::SchemaDescriptor;
+    use parquet::schema::types::Type;
+
+    use super::RowGroupImplBuilder;
+
+    fn test_schema() -> SchemaDescriptor {
+        let fields = vec![
+            Arc::new(
+                Type::primitive_type_builder("c0", PhysicalType::INT32)
+                    .with_repetition(Repetition::OPTIONAL)
+                    .build()
+                    .unwrap(),
+            ),
+            Arc::new(
+                Type::primitive_type_builder("c1", PhysicalType::INT32)
+                    .with_repetition(Repetition::OPTIONAL)
+                    .build()
+                    .unwrap(),
+            ),
+            Arc::new(
+                Type::primitive_type_builder("c2", PhysicalType::INT32)
+                    .with_repetition(Repetition::OPTIONAL)
+                    .build()
+                    .unwrap(),
+            ),
+        ];
+        let schema = Type::group_type_builder("schema")
+            .with_fields(fields)
+            .build()
+            .unwrap();
+        SchemaDescriptor::new(Arc::new(schema))
+    }
+
+    #[test]
+    fn test_build_sparse_projection_row_group_metadata() {
+        let schema = test_schema();
+        let mut builder = RowGroupImplBuilder::new(1, &schema, Compression::UNCOMPRESSED);
+        builder.add_column_chunk(2, Buffer::from(vec![1_u8, 2, 3, 4]));
+
+        let row_group = builder.build();
+        let metadata = row_group.row_groups().next().unwrap();
+
+        assert_eq!(metadata.columns().len(), schema.num_columns());
+        assert_eq!(metadata.column(2).compressed_size(), 4);
+        assert_eq!(metadata.column(0).compressed_size(), 0);
+        assert_eq!(metadata.column(1).compressed_size(), 0);
+    }
+}

--- a/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
@@ -62,6 +62,7 @@ pub fn column_chunks_to_record_batch(
             DataItem::ColumnArray(_) => {}
         }
     }
+    projection_mask.sort_unstable();
     let row_group = Box::new(builder.build());
     let field_levels = parquet_to_arrow_field_levels(
         &parquet_schema,

--- a/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
@@ -75,7 +75,11 @@ pub fn column_chunks_to_record_batch(
         num_rows,
         selection,
     )?;
-    let record = record_reader.next().unwrap()?;
+    // When num_rows == 0 the reader produces no batches; return an empty RecordBatch.
+    let record = match record_reader.next() {
+        Some(r) => r?,
+        None => RecordBatch::new_empty(std::sync::Arc::new(arrow_schema)),
+    };
     assert!(record_reader.next().is_none());
     Ok(record)
 }

--- a/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
@@ -1,0 +1,90 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read a Vortex-format block file and return a Databend DataBlock.
+//!
+//! Flow:
+//!   opendal::Operator + path
+//!     → databend-storages-vortex::read_vortex_file (arrow 58 + vortex)
+//!       → Arrow IPC bytes (arrow 58, stable binary format)
+//!         → RecordBatch (arrow 56, Databend side)
+//!           → DataBlock
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arrow_ipc::reader::StreamReader;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_expression::DataField;
+use databend_common_expression::FieldIndex;
+use databend_common_expression::TableSchemaRef;
+use databend_common_expression::ColumnId;
+use databend_common_expression::types::DataType;
+use arrow_schema::Field;
+use databend_storages_vortex::read_vortex_file as vortex_read;
+use opendal::Operator;
+
+/// Read a Vortex block file and return a DataBlock with the projected columns.
+///
+/// # Arguments
+/// * `operator`        - opendal Operator for the storage backend.
+/// * `path`            - Path to the `.vortex` file.
+/// * `projected_schema`- The projected table schema (only requested columns).
+/// * `project_indices` - Map from field index → (column_id, arrow Field, DataType).
+/// * `num_rows`        - Expected row count (from BlockMeta).
+pub async fn read_vortex_block(
+    operator: Operator,
+    path: &str,
+    projected_schema: &TableSchemaRef,
+    project_indices: &Arc<BTreeMap<FieldIndex, (ColumnId, Field, DataType)>>,
+    num_rows: usize,
+) -> Result<DataBlock> {
+    // Build the column projection list (indices into the Vortex file's schema).
+    // Vortex uses 0-based column indices matching the schema order.
+    let projected_cols: Vec<usize> = project_indices.keys().copied().collect();
+    let projected_cols = if projected_cols.is_empty() {
+        None
+    } else {
+        Some(projected_cols)
+    };
+
+    // Read the Vortex file → Arrow IPC bytes (arrow 58 inside vortex crate).
+    let ipc_bytes = vortex_read(operator, path, projected_cols)
+        .await
+        .map_err(|e| ErrorCode::StorageOther(format!("Vortex read error: {e}")))?;
+
+    if ipc_bytes.is_empty() {
+        // Empty file — return an empty block with the right schema.
+        return Ok(DataBlock::new(vec![], num_rows));
+    }
+
+    // Deserialize Arrow IPC bytes → RecordBatch (arrow 56, Databend side).
+    let cursor = Cursor::new(&ipc_bytes);
+    let mut reader = StreamReader::try_new(cursor, None)
+        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC stream read error: {e}")))?;
+
+    let batch = reader
+        .next()
+        .ok_or_else(|| {
+            ErrorCode::StorageOther("Vortex: IPC stream contained no batches".to_string())
+        })?
+        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
+
+    // Convert RecordBatch → DataBlock using the projected schema.
+    let data_schema = projected_schema.as_ref().into();
+    DataBlock::from_record_batch(&data_schema, &batch)
+}

--- a/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
@@ -17,9 +17,9 @@
 //! Flow:
 //!   opendal::Operator + path
 //!     → databend-storages-vortex::read_vortex_file (arrow 58 + vortex)
-//!       → Arrow IPC bytes (stable binary format)
-//!         → RecordBatch(es) (arrow 58, Databend side)
-//!           → DataBlock(s) → concatenated DataBlock
+//!       → Arrow IPC bytes (arrow 58, stable binary format)
+//!         → RecordBatch (arrow 56, Databend side)
+//!           → DataBlock
 
 use std::collections::BTreeMap;
 use std::io::Cursor;
@@ -31,7 +31,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
-use databend_common_expression::DataField;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::DataType;
@@ -41,11 +40,11 @@ use opendal::Operator;
 /// Read a Vortex block file and return a DataBlock with the projected columns.
 ///
 /// # Arguments
-/// * `operator`        - opendal Operator for the storage backend.
-/// * `path`            - Path to the `.vortex` file.
-/// * `projected_schema`- The projected table schema (only requested columns).
-/// * `project_indices` - Map from field index → (column_id, arrow Field, DataType).
-/// * `num_rows`        - Expected row count (from BlockMeta).
+/// * `operator`         - opendal Operator for the storage backend.
+/// * `path`             - Path to the `.vortex` file.
+/// * `projected_schema` - The projected table schema (only requested columns).
+/// * `project_indices`  - Map from field index → (column_id, arrow Field, DataType).
+/// * `num_rows`         - Expected row count (from BlockMeta).
 pub async fn read_vortex_block(
     operator: Operator,
     path: &str,
@@ -53,15 +52,20 @@ pub async fn read_vortex_block(
     project_indices: &Arc<BTreeMap<FieldIndex, (ColumnId, Field, DataType)>>,
     num_rows: usize,
 ) -> Result<DataBlock> {
-    // Build the column projection list (0-based indices into the Vortex file's schema).
-    let projected_cols: Vec<usize> = project_indices.keys().copied().collect();
-    let projected_cols = if projected_cols.is_empty() {
+    // Build the column projection list as column names (matching the Vortex file schema).
+    // Vortex projection uses field names, which match the TableSchema field names.
+    let projected_cols: Option<Vec<String>> = if project_indices.is_empty() {
         None
     } else {
-        Some(projected_cols)
+        Some(
+            project_indices
+                .values()
+                .map(|(_, field, _)| field.name().to_string())
+                .collect(),
+        )
     };
 
-    // Read the Vortex file → Arrow IPC bytes.
+    // Read the Vortex file → Arrow IPC bytes (arrow 58 inside vortex crate).
     let ipc_bytes = vortex_read(operator, path, projected_cols)
         .await
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex read error: {e}")))?;
@@ -70,25 +74,19 @@ pub async fn read_vortex_block(
         return Ok(DataBlock::new(vec![], num_rows));
     }
 
-    // Deserialize Arrow IPC bytes → RecordBatches.
-    // A Vortex file may have multiple chunks, each becoming one IPC batch.
+    // Deserialize Arrow IPC bytes → RecordBatch (arrow 56, Databend side).
     let cursor = Cursor::new(&ipc_bytes);
-    let reader = StreamReader::try_new(cursor, None)
+    let mut reader = StreamReader::try_new(cursor, None)
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC stream read error: {e}")))?;
 
+    let batch = reader
+        .next()
+        .ok_or_else(|| {
+            ErrorCode::StorageOther("Vortex: IPC stream contained no batches".to_string())
+        })?
+        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
+
+    // Convert RecordBatch → DataBlock using the projected schema.
     let data_schema = projected_schema.as_ref().into();
-    let mut blocks: Vec<DataBlock> = Vec::new();
-
-    for batch_result in reader {
-        let batch = batch_result
-            .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
-        let block = DataBlock::from_record_batch(&data_schema, &batch)?;
-        blocks.push(block);
-    }
-
-    match blocks.len() {
-        0 => Ok(DataBlock::new(vec![], num_rows)),
-        1 => Ok(blocks.remove(0)),
-        _ => DataBlock::concat(&blocks),
-    }
+    DataBlock::from_record_batch(&data_schema, &batch)
 }

--- a/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
@@ -16,9 +16,9 @@
 //!
 //! Flow:
 //!   opendal::Operator + path
-//!     → databend-storages-vortex::read_vortex_file (arrow 58 + vortex)
-//!       → Arrow IPC bytes (arrow 58, stable binary format)
-//!         → RecordBatch (arrow 56, Databend side)
+//!     → databend-storages-vortex::read_vortex_file (vortex + arrow 58)
+//!       → Arrow IPC bytes (stable binary format)
+//!         → RecordBatch (arrow 58, Databend side)
 //!           → DataBlock
 
 use std::collections::BTreeMap;
@@ -40,11 +40,11 @@ use opendal::Operator;
 /// Read a Vortex block file and return a DataBlock with the projected columns.
 ///
 /// # Arguments
-/// * `operator`         - opendal Operator for the storage backend.
-/// * `path`             - Path to the `.vortex` file.
-/// * `projected_schema` - The projected table schema (only requested columns).
-/// * `project_indices`  - Map from field index → (column_id, arrow Field, DataType).
-/// * `num_rows`         - Expected row count (from BlockMeta).
+/// * `operator`        - opendal Operator for the storage backend.
+/// * `path`            - Path to the `.vortex` file.
+/// * `projected_schema`- The projected table schema (only requested columns).
+/// * `project_indices` - Map from field index → (column_id, arrow Field, DataType).
+/// * `num_rows`        - Expected row count (from BlockMeta).
 pub async fn read_vortex_block(
     operator: Operator,
     path: &str,
@@ -52,21 +52,22 @@ pub async fn read_vortex_block(
     project_indices: &Arc<BTreeMap<FieldIndex, (ColumnId, Field, DataType)>>,
     num_rows: usize,
 ) -> Result<DataBlock> {
-    // Build the column projection list as column names (matching the Vortex file schema).
-    // Vortex projection uses field names, which match the TableSchema field names.
-    let projected_cols: Option<Vec<String>> = if project_indices.is_empty() {
+    // Build the column projection list from the projected schema field names.
+    // Vortex uses field names for projection (not positional indices).
+    let projected_names: Option<Vec<String>> = if project_indices.is_empty() {
         None
     } else {
         Some(
-            project_indices
-                .values()
-                .map(|(_, field, _)| field.name().to_string())
+            projected_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().to_string())
                 .collect(),
         )
     };
 
-    // Read the Vortex file → Arrow IPC bytes (arrow 58 inside vortex crate).
-    let ipc_bytes = vortex_read(operator, path, projected_cols)
+    // Read the Vortex file → Arrow IPC bytes.
+    let ipc_bytes = vortex_read(operator, path, projected_names)
         .await
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex read error: {e}")))?;
 
@@ -74,19 +75,25 @@ pub async fn read_vortex_block(
         return Ok(DataBlock::new(vec![], num_rows));
     }
 
-    // Deserialize Arrow IPC bytes → RecordBatch (arrow 56, Databend side).
+    // Deserialize Arrow IPC bytes → RecordBatches.
+    // A Vortex file may have multiple chunks, each becoming one IPC batch.
     let cursor = Cursor::new(&ipc_bytes);
-    let mut reader = StreamReader::try_new(cursor, None)
+    let reader = StreamReader::try_new(cursor, None)
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC stream read error: {e}")))?;
 
-    let batch = reader
-        .next()
-        .ok_or_else(|| {
-            ErrorCode::StorageOther("Vortex: IPC stream contained no batches".to_string())
-        })?
-        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
-
-    // Convert RecordBatch → DataBlock using the projected schema.
     let data_schema = projected_schema.as_ref().into();
-    DataBlock::from_record_batch(&data_schema, &batch)
+    let mut blocks: Vec<DataBlock> = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result
+            .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
+        let block = DataBlock::from_record_batch(&data_schema, &batch)?;
+        blocks.push(block);
+    }
+
+    match blocks.len() {
+        0 => Ok(DataBlock::new(vec![], num_rows)),
+        1 => Ok(blocks.remove(0)),
+        _ => DataBlock::concat(&blocks),
+    }
 }

--- a/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
@@ -17,24 +17,24 @@
 //! Flow:
 //!   opendal::Operator + path
 //!     → databend-storages-vortex::read_vortex_file (arrow 58 + vortex)
-//!       → Arrow IPC bytes (arrow 58, stable binary format)
-//!         → RecordBatch (arrow 56, Databend side)
-//!           → DataBlock
+//!       → Arrow IPC bytes (stable binary format)
+//!         → RecordBatch(es) (arrow 58, Databend side)
+//!           → DataBlock(s) → concatenated DataBlock
 
 use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::sync::Arc;
 
 use arrow_ipc::reader::StreamReader;
+use arrow_schema::Field;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ColumnId;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
 use databend_common_expression::FieldIndex;
 use databend_common_expression::TableSchemaRef;
-use databend_common_expression::ColumnId;
 use databend_common_expression::types::DataType;
-use arrow_schema::Field;
 use databend_storages_vortex::read_vortex_file as vortex_read;
 use opendal::Operator;
 
@@ -53,8 +53,7 @@ pub async fn read_vortex_block(
     project_indices: &Arc<BTreeMap<FieldIndex, (ColumnId, Field, DataType)>>,
     num_rows: usize,
 ) -> Result<DataBlock> {
-    // Build the column projection list (indices into the Vortex file's schema).
-    // Vortex uses 0-based column indices matching the schema order.
+    // Build the column projection list (0-based indices into the Vortex file's schema).
     let projected_cols: Vec<usize> = project_indices.keys().copied().collect();
     let projected_cols = if projected_cols.is_empty() {
         None
@@ -62,29 +61,34 @@ pub async fn read_vortex_block(
         Some(projected_cols)
     };
 
-    // Read the Vortex file → Arrow IPC bytes (arrow 58 inside vortex crate).
+    // Read the Vortex file → Arrow IPC bytes.
     let ipc_bytes = vortex_read(operator, path, projected_cols)
         .await
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex read error: {e}")))?;
 
     if ipc_bytes.is_empty() {
-        // Empty file — return an empty block with the right schema.
         return Ok(DataBlock::new(vec![], num_rows));
     }
 
-    // Deserialize Arrow IPC bytes → RecordBatch (arrow 56, Databend side).
+    // Deserialize Arrow IPC bytes → RecordBatches.
+    // A Vortex file may have multiple chunks, each becoming one IPC batch.
     let cursor = Cursor::new(&ipc_bytes);
-    let mut reader = StreamReader::try_new(cursor, None)
+    let reader = StreamReader::try_new(cursor, None)
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC stream read error: {e}")))?;
 
-    let batch = reader
-        .next()
-        .ok_or_else(|| {
-            ErrorCode::StorageOther("Vortex: IPC stream contained no batches".to_string())
-        })?
-        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
-
-    // Convert RecordBatch → DataBlock using the projected schema.
     let data_schema = projected_schema.as_ref().into();
-    DataBlock::from_record_batch(&data_schema, &batch)
+    let mut blocks: Vec<DataBlock> = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result
+            .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
+        let block = DataBlock::from_record_batch(&data_schema, &batch)?;
+        blocks.push(block);
+    }
+
+    match blocks.len() {
+        0 => Ok(DataBlock::new(vec![], num_rows)),
+        1 => Ok(blocks.remove(0)),
+        _ => DataBlock::concat(&blocks),
+    }
 }

--- a/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
+++ b/src/query/storages/fuse/src/io/read/block/vortex_reader.rs
@@ -20,13 +20,22 @@
 //!       → Arrow IPC bytes (stable binary format)
 //!         → RecordBatch (arrow 58, Databend side)
 //!           → DataBlock
+//!
+//! Type fixup: Vortex stores Boolean columns as Int8 internally. When reading
+//! back via Arrow IPC, Boolean columns may arrive as Int8. We cast them back
+//! to Boolean using the projected_schema as the source of truth.
 
 use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::sync::Arc;
 
+use arrow_array::RecordBatch;
+use arrow_array::cast::AsArray;
+use arrow_cast::cast;
 use arrow_ipc::reader::StreamReader;
+use arrow_schema::DataType as ArrowDataType;
 use arrow_schema::Field;
+use arrow_schema::Schema as ArrowSchema;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
@@ -81,12 +90,20 @@ pub async fn read_vortex_block(
     let reader = StreamReader::try_new(cursor, None)
         .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC stream read error: {e}")))?;
 
+    // Build the expected Arrow schema from projected_schema so we can cast
+    // columns that Vortex may have changed type on (e.g. Boolean → Int8).
+    let expected_arrow_schema: ArrowSchema = projected_schema.as_ref().into();
+
     let data_schema = projected_schema.as_ref().into();
     let mut blocks: Vec<DataBlock> = Vec::new();
 
     for batch_result in reader {
         let batch = batch_result
             .map_err(|e| ErrorCode::StorageOther(format!("Vortex: IPC batch read error: {e}")))?;
+
+        // Cast any columns whose type doesn't match the expected schema.
+        let batch = cast_batch_to_schema(batch, &expected_arrow_schema)?;
+
         let block = DataBlock::from_record_batch(&data_schema, &batch)?;
         blocks.push(block);
     }
@@ -96,4 +113,50 @@ pub async fn read_vortex_block(
         1 => Ok(blocks.remove(0)),
         _ => DataBlock::concat(&blocks),
     }
+}
+
+/// Cast columns in `batch` to match `expected_schema` where types differ.
+///
+/// Vortex may store Boolean as Int8 internally. This function casts such
+/// columns back to their expected Arrow type using arrow_cast::cast.
+fn cast_batch_to_schema(batch: RecordBatch, expected: &ArrowSchema) -> Result<RecordBatch> {
+    // Fast path: if schemas already match, return as-is.
+    if batch.schema().fields().len() == expected.fields().len()
+        && batch
+            .schema()
+            .fields()
+            .iter()
+            .zip(expected.fields().iter())
+            .all(|(a, b)| a.data_type() == b.data_type())
+    {
+        return Ok(batch);
+    }
+
+    let mut new_columns = Vec::with_capacity(batch.num_columns());
+    let mut new_fields = Vec::with_capacity(batch.num_columns());
+
+    for (i, col) in batch.columns().iter().enumerate() {
+        let expected_field = &expected.fields()[i];
+        let expected_type = expected_field.data_type();
+
+        let new_col = if col.data_type() != expected_type {
+            cast(col.as_ref(), expected_type).map_err(|e| {
+                ErrorCode::StorageOther(format!(
+                    "Vortex: failed to cast column '{}' from {:?} to {:?}: {e}",
+                    expected_field.name(),
+                    col.data_type(),
+                    expected_type,
+                ))
+            })?
+        } else {
+            col.clone()
+        };
+
+        new_fields.push(expected_field.clone());
+        new_columns.push(new_col);
+    }
+
+    let new_schema = Arc::new(ArrowSchema::new(new_fields));
+    RecordBatch::try_new(new_schema, new_columns)
+        .map_err(|e| ErrorCode::StorageOther(format!("Vortex: failed to rebuild RecordBatch: {e}")))
 }

--- a/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
+++ b/src/query/storages/fuse/src/io/read/bloom/block_filter_reader.rs
@@ -40,10 +40,8 @@ use databend_storages_common_table_meta::meta::SingleColumnMeta;
 use futures_util::future::try_join_all;
 use opendal::Operator;
 use parquet::arrow::ArrowSchemaConverter;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaDataReader;
 use parquet::schema::types::SchemaDescPtr;
-use parquet::thrift::TSerializable;
-use thrift::protocol::TCompactInputProtocol;
 
 use crate::index::filters::BlockBloomFilterIndexVersion;
 use crate::index::filters::BlockFilter;
@@ -280,10 +278,9 @@ fn load_index_meta_from_bytes(data: &Bytes) -> Result<BloomIndexMeta> {
     }
 
     let remaining = data.len() - footer_len as usize;
-    let mut prot = TCompactInputProtocol::new(&data[remaining..]);
-    let thrift_meta = FileMetaData::read_from_in_protocol(&mut prot)
+    let parquet_meta = ParquetMetaDataReader::decode_metadata(&data[remaining..])
         .map_err(|err| ErrorCode::StorageOther(format!("read bloom index meta failed, {err}")))?;
-    BloomIndexMeta::try_from(thrift_meta)
+    BloomIndexMeta::try_from(parquet_meta)
 }
 
 #[async_trait::async_trait]

--- a/src/query/storages/fuse/src/io/read/meta/meta_readers.rs
+++ b/src/query/storages/fuse/src/io/read/meta/meta_readers.rs
@@ -44,8 +44,8 @@ use futures::AsyncSeek;
 use futures_util::AsyncSeekExt;
 use opendal::Buffer;
 use opendal::Operator;
-use parquet::format::FileMetaData;
-use parquet::thrift::TSerializable;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::metadata::ParquetMetaDataReader;
 
 pub use self::thrift_file_meta_read::read_thrift_file_metadata;
 
@@ -362,7 +362,6 @@ pub async fn bytes_reader(op: &Operator, path: &str, len_hint: Option<u64>) -> R
 
 mod thrift_file_meta_read {
     use parquet::errors::ParquetError;
-    use thrift::protocol::TCompactInputProtocol;
 
     use super::*;
 
@@ -395,7 +394,7 @@ mod thrift_file_meta_read {
         op: Operator,
         path: &str,
         len_hint: Option<u64>,
-    ) -> Result<FileMetaData> {
+    ) -> Result<ParquetMetaData> {
         let file_size = if let Some(len) = len_hint {
             len
         } else {
@@ -443,11 +442,8 @@ mod thrift_file_meta_read {
         if (footer_len as usize) < buffer.len() {
             // the whole metadata is in the bytes we already read
             let remaining = buffer.len() - footer_len as usize;
-
-            let mut prot = TCompactInputProtocol::new(&buffer[remaining..]);
-            let meta = FileMetaData::read_from_in_protocol(&mut prot)
-                .map_err(|err| ErrorCode::ParquetFileInvalid(err.to_string()))?;
-            Ok(meta)
+            ParquetMetaDataReader::decode_metadata(&buffer[remaining..])
+                .map_err(|err| ErrorCode::ParquetFileInvalid(err.to_string()))
         } else {
             // the end of file read by default is not long enough, read again including the metadata.
             let buffer = op
@@ -455,11 +451,9 @@ mod thrift_file_meta_read {
                 .range(file_size - footer_len..file_size)
                 .await
                 .map_err(|err| ErrorCode::ParquetFileInvalid(err.to_string()))?;
-
-            let mut prot = TCompactInputProtocol::new(buffer.reader());
-            let meta = FileMetaData::read_from_in_protocol(&mut prot)
-                .map_err(|err| ErrorCode::ParquetFileInvalid(err.to_string()))?;
-            Ok(meta)
+            let buffer = buffer.to_vec();
+            ParquetMetaDataReader::decode_metadata(&buffer)
+                .map_err(|err| ErrorCode::ParquetFileInvalid(err.to_string()))
         }
     }
 }

--- a/src/query/storages/fuse/src/io/read/mod.rs
+++ b/src/query/storages/fuse/src/io/read/mod.rs
@@ -35,6 +35,7 @@ pub use block::NativeReaderExt;
 pub use block::NativeSourceData;
 pub use block::RowSelection;
 pub use block::column_chunks_to_record_batch;
+pub(crate) use block::read_vortex_block;
 pub use bloom::BloomBlockFilterReader;
 pub use inverted_index::InvertedIndexReader;
 pub use meta::CompactSegmentInfoReader;

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -49,8 +49,6 @@ use databend_common_metrics::storage::metrics_inc_block_write_nums;
 use databend_common_native::write::NativeWriter;
 use databend_storages_common_blocks::blocks_to_parquet_with_stats;
 use databend_storages_common_index::NgramArgs;
-use databend_storages_common_table_meta::meta::VortexColumnMeta;
-use databend_storages_vortex::write_vortex_file;
 use databend_storages_common_table_meta::meta::BlockHLLState;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
@@ -58,8 +56,10 @@ use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::ExtendedBlockMeta;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
+use databend_storages_common_table_meta::meta::VortexColumnMeta;
 use databend_storages_common_table_meta::meta::encode_column_hll;
 use databend_storages_common_table_meta::table::TableCompression;
+use databend_storages_vortex::write_vortex_file;
 use opendal::Operator;
 
 use crate::FuseStorageFormat;
@@ -149,9 +149,7 @@ pub fn serialize_block_with_column_stats(
 
             Ok(metas)
         }
-        FuseStorageFormat::Vortex => {
-            serialize_block_vortex(&schema, block, buf)
-        }
+        FuseStorageFormat::Vortex => serialize_block_vortex(&schema, block, buf),
     }
 }
 
@@ -174,8 +172,9 @@ fn serialize_block_vortex(
     block: DataBlock,
     buf: &mut Vec<u8>,
 ) -> Result<HashMap<ColumnId, ColumnMeta>> {
-    use arrow_ipc::writer::StreamWriter;
     use std::sync::Arc as StdArc;
+
+    use arrow_ipc::writer::StreamWriter;
 
     let row_count = block.num_rows() as u64;
     let leaf_column_ids = schema.to_leaf_column_ids();
@@ -282,9 +281,10 @@ impl BlockBuilder {
     where F: Fn(DataBlock, &ClusterStatsGenerator) -> Result<(Option<ClusterStatistics>, DataBlock)>
     {
         let (cluster_stats, data_block) = f(data_block, &self.cluster_stats_gen)?;
-        let (block_location, block_id) = self
-            .meta_locations
-            .gen_block_location(self.table_meta_timestamps);
+        let (block_location, block_id) = self.meta_locations.gen_block_location_with_format(
+            self.table_meta_timestamps,
+            &self.write_settings.storage_format,
+        );
 
         let bloom_index_location = self.meta_locations.block_bloom_index_location(&block_id);
         let bloom_index_state = BloomIndexState::from_data_block(

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -49,6 +49,8 @@ use databend_common_metrics::storage::metrics_inc_block_write_nums;
 use databend_common_native::write::NativeWriter;
 use databend_storages_common_blocks::blocks_to_parquet_with_stats;
 use databend_storages_common_index::NgramArgs;
+use databend_storages_common_table_meta::meta::VortexColumnMeta;
+use databend_storages_vortex::write_vortex_file;
 use databend_storages_common_table_meta::meta::BlockHLLState;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
@@ -147,7 +149,86 @@ pub fn serialize_block_with_column_stats(
 
             Ok(metas)
         }
+        FuseStorageFormat::Vortex => {
+            serialize_block_vortex(&schema, block, buf)
+        }
     }
+}
+
+/// Serialize a DataBlock into a Vortex file.
+///
+/// The strategy is:
+/// 1. Convert DataBlock → RecordBatch (arrow 56) → Arrow IPC bytes
+/// 2. Pass IPC bytes to `databend-storages-vortex` crate (arrow 58 + vortex)
+/// 3. That crate deserializes IPC with arrow 58, converts to Vortex arrays,
+///    compresses, and writes a .vortex file into `buf`.
+///
+/// Column statistics are NOT written into the Vortex file — they are stored
+/// externally in Fuse's BlockMeta.col_stats (computed by gen_columns_statistics).
+/// This keeps the Vortex file as a pure data container.
+///
+/// Returns a ColumnMeta::Vortex entry per leaf column (all sharing the same
+/// row count; the file path comes from BlockMeta.location).
+fn serialize_block_vortex(
+    schema: &TableSchemaRef,
+    block: DataBlock,
+    buf: &mut Vec<u8>,
+) -> Result<HashMap<ColumnId, ColumnMeta>> {
+    use arrow_ipc::writer::StreamWriter;
+    use std::sync::Arc as StdArc;
+
+    let row_count = block.num_rows() as u64;
+    let leaf_column_ids = schema.to_leaf_column_ids();
+
+    // Step 1: DataBlock → RecordBatch (arrow 56)
+    let record_batch = block.to_record_batch(schema.as_ref())?;
+
+    // Step 2: RecordBatch → Arrow IPC stream bytes (arrow 56)
+    // These bytes are the stable binary bridge to the vortex crate (arrow 58).
+    let mut ipc_buf = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut ipc_buf, record_batch.schema_ref().as_ref())
+            .map_err(|e| {
+                databend_common_exception::ErrorCode::StorageOther(format!(
+                    "Vortex: failed to create Arrow IPC writer: {e}"
+                ))
+            })?;
+        writer.write(&record_batch).map_err(|e| {
+            databend_common_exception::ErrorCode::StorageOther(format!(
+                "Vortex: failed to write Arrow IPC batch: {e}"
+            ))
+        })?;
+        writer.finish().map_err(|e| {
+            databend_common_exception::ErrorCode::StorageOther(format!(
+                "Vortex: failed to finish Arrow IPC stream: {e}"
+            ))
+        })?;
+    }
+
+    // Step 3: IPC bytes → Vortex file (via databend-storages-vortex, arrow 58)
+    // This runs synchronously by blocking on the async write_vortex_file.
+    let rt = tokio::runtime::Handle::current();
+    let _row_count_written = rt.block_on(write_vortex_file(&ipc_buf, buf)).map_err(|e| {
+        databend_common_exception::ErrorCode::StorageOther(format!(
+            "Vortex: failed to write vortex file: {e}"
+        ))
+    })?;
+
+    // Step 4: Build ColumnMeta::Vortex for each leaf column.
+    // All columns share the same row count; the file path is in BlockMeta.location.
+    let metas = leaf_column_ids
+        .iter()
+        .map(|col_id| {
+            (
+                *col_id,
+                ColumnMeta::Vortex(VortexColumnMeta {
+                    num_values: row_count,
+                }),
+            )
+        })
+        .collect();
+
+    Ok(metas)
 }
 
 /// Take ownership here to avoid extra copy.

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -203,16 +203,12 @@ fn serialize_block_vortex(
     }
 
     // Step 3: IPC bytes → Vortex file (via databend-storages-vortex, arrow 58).
-    // serialize_block is called from a sync context inside a Tokio runtime, so we
-    // use block_in_place to safely run the async write without blocking the executor.
-    let _row_count_written = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(write_vortex_file(&ipc_buf, buf))
-    })
-    .map_err(|e| {
-        databend_common_exception::ErrorCode::StorageOther(format!(
-            "Vortex: failed to write vortex file: {e}"
-        ))
-    })?;
+    // write_vortex_file is synchronous and creates its own private Tokio
+    // current-thread runtime internally, so it is safe to call from any thread.
+    let _row_count_written = write_vortex_file(&ipc_buf, buf)
+        .map_err(|e| databend_common_exception::ErrorCode::StorageOther(
+            format!("Vortex: failed to write vortex file: {e}")
+        ))?;
 
     // Step 4: Build ColumnMeta::Vortex for each leaf column.
     // All columns share the same row count; the file path is in BlockMeta.location.

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -172,8 +172,6 @@ fn serialize_block_vortex(
     block: DataBlock,
     buf: &mut Vec<u8>,
 ) -> Result<HashMap<ColumnId, ColumnMeta>> {
-    use std::sync::Arc as StdArc;
-
     use arrow_ipc::writer::StreamWriter;
 
     let row_count = block.num_rows() as u64;
@@ -204,10 +202,13 @@ fn serialize_block_vortex(
         })?;
     }
 
-    // Step 3: IPC bytes → Vortex file (via databend-storages-vortex, arrow 58)
-    // This runs synchronously by blocking on the async write_vortex_file.
-    let rt = tokio::runtime::Handle::current();
-    let _row_count_written = rt.block_on(write_vortex_file(&ipc_buf, buf)).map_err(|e| {
+    // Step 3: IPC bytes → Vortex file (via databend-storages-vortex, arrow 58).
+    // serialize_block is called from a sync context inside a Tokio runtime, so we
+    // use block_in_place to safely run the async write without blocking the executor.
+    let _row_count_written = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(write_vortex_file(&ipc_buf, buf))
+    })
+    .map_err(|e| {
         databend_common_exception::ErrorCode::StorageOther(format!(
             "Vortex: failed to write vortex file: {e}"
         ))

--- a/src/query/storages/fuse/src/io/write/stream/block_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/block_builder.rs
@@ -55,7 +55,7 @@ use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::table::TableCompression;
 use parquet::arrow::ArrowWriter;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 
 use crate::FuseStorageFormat;
 use crate::FuseTable;
@@ -126,7 +126,7 @@ impl ArrowParquetWriter {
         Ok(())
     }
 
-    fn finish(&mut self) -> Result<FileMetaData> {
+    fn finish(&mut self) -> Result<ParquetMetaData> {
         let Initialized(writer) = self else {
             unreachable!("ArrowParquetWriter::finish called before initialization");
         };

--- a/src/query/storages/fuse/src/io/write/stream/block_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/block_builder.rs
@@ -303,6 +303,15 @@ impl StreamBlockBuilder {
                 )?;
                 BlockWriterImpl::Native(writer)
             }
+            FuseStorageFormat::Vortex => {
+                // Vortex format does not support streaming writes; use the batch
+                // write path (BlockBuilder::build) instead.
+                return Err(databend_common_exception::ErrorCode::StorageOther(
+                    "Vortex format does not support streaming block writes; \
+                     use the batch write path instead"
+                        .to_string(),
+                ));
+            }
         };
 
         let inverted_index_writers = properties
@@ -409,7 +418,10 @@ impl StreamBlockBuilder {
         let (block_location, block_id) = self
             .properties
             .meta_locations
-            .gen_block_location(self.properties.table_meta_timestamps);
+            .gen_block_location_with_format(
+                self.properties.table_meta_timestamps,
+                &self.properties.write_settings.storage_format,
+            );
 
         let bloom_index_location = self
             .properties

--- a/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
+++ b/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
@@ -74,7 +74,7 @@ use jsonb::Value as JsonbValue;
 use jsonb::keypath::KeyPath as JsonbKeyPath;
 use jsonb::keypath::KeyPaths as JsonbKeyPaths;
 use parquet::file::metadata::KeyValue;
-use parquet::format::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 use siphasher::sip128::Hasher128;
 use siphasher::sip128::SipHasher24;
 
@@ -797,67 +797,46 @@ impl VirtualColumnBuilder {
 
     fn file_meta_to_virtual_column_metas(
         &self,
-        file_meta: FileMetaData,
+        file_meta: ParquetMetaData,
         mut virtual_column_names: HashMap<String, (u32, String, VariantDataType)>,
         mut columns_statistics: StatisticsOfColumns,
     ) -> Result<Vec<DraftVirtualColumnMeta>> {
-        let num_row_groups = file_meta.row_groups.len();
+        let num_row_groups = file_meta.row_groups().len();
         if num_row_groups != 1 {
             return Err(ErrorCode::ParquetFileInvalid(format!(
                 "invalid parquet file, expects only one row group, but got {}",
                 num_row_groups
             )));
         }
-        let row_group = &file_meta.row_groups[0];
+        let row_group = &file_meta.row_groups()[0];
 
         let mut draft_virtual_column_metas = Vec::with_capacity(virtual_column_names.len());
-        for (i, col_chunk) in row_group.columns.iter().enumerate() {
+        for (i, chunk_meta) in row_group.columns().iter().enumerate() {
             let tmp_column_id = i as u32;
-            match &col_chunk.meta_data {
-                Some(chunk_meta) => {
-                    let Some((source_column_id, key_name, variant_type)) =
-                        virtual_column_names.remove(&chunk_meta.path_in_schema[0])
-                    else {
-                        continue;
-                    };
+            let Some((source_column_id, key_name, variant_type)) =
+                virtual_column_names.remove(&chunk_meta.column_path().parts()[0])
+            else {
+                continue;
+            };
 
-                    let col_start =
-                        if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                            dict_page_offset
-                        } else {
-                            chunk_meta.data_page_offset
-                        };
-                    let col_len = chunk_meta.total_compressed_size;
-                    assert!(
-                        col_start >= 0 && col_len >= 0,
-                        "column start and length should not be negative"
-                    );
-                    let num_values = chunk_meta.num_values as u64;
+            let (offset, len) = chunk_meta.byte_range();
+            let variant_type_code = VirtualColumnMeta::data_type_code(&variant_type);
+            let column_stat = columns_statistics.remove(&tmp_column_id);
+            let virtual_column_meta = VirtualColumnMeta {
+                offset,
+                len,
+                num_values: chunk_meta.num_values() as u64,
+                data_type: variant_type_code,
+                column_stat,
+            };
 
-                    let variant_type_code = VirtualColumnMeta::data_type_code(&variant_type);
-                    let column_stat = columns_statistics.remove(&tmp_column_id);
-                    let virtual_column_meta = VirtualColumnMeta {
-                        offset: col_start as u64,
-                        len: col_len as u64,
-                        num_values,
-                        data_type: variant_type_code,
-                        column_stat,
-                    };
-
-                    let draft_virtual_column_meta = DraftVirtualColumnMeta {
-                        source_column_id,
-                        name: key_name,
-                        data_type: variant_type,
-                        column_meta: virtual_column_meta,
-                    };
-                    draft_virtual_column_metas.push(draft_virtual_column_meta);
-                }
-                None => {
-                    return Err(ErrorCode::ParquetFileInvalid(format!(
-                        "invalid parquet file, meta data of column is empty",
-                    )));
-                }
-            }
+            let draft_virtual_column_meta = DraftVirtualColumnMeta {
+                source_column_id,
+                name: key_name,
+                data_type: variant_type,
+                column_meta: virtual_column_meta,
+            };
+            draft_virtual_column_metas.push(draft_virtual_column_meta);
         }
         Ok(draft_virtual_column_metas)
     }

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -138,6 +138,8 @@ impl CompactTransform {
         storage_format: FuseStorageFormat,
         stream_ctx: Option<StreamContext>,
     ) -> Self {
+        // Note: Vortex format compact is not yet supported. The caller
+        // (compact.rs) should check storage_format before creating this transform.
         Self {
             scan_progress: ctx.get_scan_progress(),
             block_reader,

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -102,6 +102,12 @@ impl MutationSource {
         operators: Vec<BlockOperator>,
         storage_format: FuseStorageFormat,
     ) -> Result<ProcessorPtr> {
+        if matches!(storage_format, FuseStorageFormat::Vortex) {
+            return Err(databend_common_exception::ErrorCode::Unimplemented(
+                "DML operations (UPDATE/DELETE/MERGE) are not yet supported for \
+                 Vortex storage format tables",
+            ));
+        }
         Ok(ProcessorPtr::create(Box::new(MutationSource {
             state: State::ReadData(None),
             output,

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -70,7 +70,7 @@ pub fn row_fetch_processor(
 
     match &fuse_table.storage_format {
         FuseStorageFormat::Native => unreachable!(),
-        FuseStorageFormat::Parquet => {
+        FuseStorageFormat::Parquet | FuseStorageFormat::Vortex => {
             let read_settings = ReadSettings::from_ctx(&ctx)?;
             let block_threshold = BlockThreshold {
                 max_rows: ctx.get_settings().get_max_block_size()? as usize,

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -121,6 +121,7 @@ pub fn build_fuse_source_pipeline(
         block_format,
         index_reader.clone(),
         virtual_reader.clone(),
+        block_reader.clone(),
     )?;
 
     pipeline.add_transform(|input, output| {

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -108,6 +108,10 @@ pub fn build_fuse_source_pipeline(
     let block_format = match storage_format {
         FuseStorageFormat::Native => FuseNativeBlockFormat::create(),
         FuseStorageFormat::Parquet => FuseParquetBlockFormat::create(),
+        // Vortex files are read as a whole via read_by_meta (in block_reader_deserialize.rs).
+        // The merge-IO path is never reached for Vortex, so we reuse the Parquet block format
+        // as a placeholder to satisfy the type system.
+        FuseStorageFormat::Vortex => FuseParquetBlockFormat::create(),
     };
 
     let read_block_context = ReadBlockContext::create(
@@ -158,7 +162,7 @@ pub fn build_fuse_source_pipeline(
                 )
             })?;
         }
-        FuseStorageFormat::Parquet => {
+        FuseStorageFormat::Parquet | FuseStorageFormat::Vortex => {
             pipeline.add_transform(|transform_input, transform_output| {
                 DeserializeDataTransform::create(
                     ctx.clone(),

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -63,6 +63,9 @@ pub struct DeserializeDataTransform {
     output_schema: DataSchema,
     parts: Vec<PartInfoPtr>,
     chunks: Vec<ParquetDataSource>,
+    /// Vortex blocks are fully deserialized during async IO; they still need
+    /// filter/prewhere applied and block-meta attached before output.
+    vortex_queue: Vec<(PartInfoPtr, DataBlock)>,
 
     index_reader: Arc<Option<AggIndexReader>>,
     virtual_reader: Arc<Option<VirtualColumnReader>>,
@@ -124,6 +127,7 @@ impl DeserializeDataTransform {
             output_schema,
             parts: vec![],
             chunks: vec![],
+            vortex_queue: vec![],
             index_reader,
             virtual_reader,
             base_block_ids: plan.base_block_ids.clone(),
@@ -160,7 +164,7 @@ impl Processor for DeserializeDataTransform {
             return Ok(Event::NeedConsume);
         }
 
-        if !self.chunks.is_empty() {
+        if !self.chunks.is_empty() || !self.vortex_queue.is_empty() {
             if !self.input.has_data() {
                 self.input.set_need_data();
             }
@@ -175,11 +179,23 @@ impl Processor for DeserializeDataTransform {
                     DataSourceWithMeta::<ReadDataSource>::downcast_from(source_meta)
                 {
                     self.parts = source_meta.meta;
-                    self.chunks = source_meta
-                        .data
-                        .into_iter()
-                        .map(ReadDataSource::into_parquet)
-                        .collect::<Result<Vec<_>>>()?;
+                    let mut parquet_parts: Vec<PartInfoPtr> = Vec::new();
+                    let mut parquet_chunks: Vec<ParquetDataSource> = Vec::new();
+
+                    for (part, source) in self.parts.drain(..).zip(source_meta.data.into_iter()) {
+                        match source {
+                            ReadDataSource::Vortex(block) => {
+                                self.vortex_queue.push((part, block));
+                            }
+                            other => {
+                                parquet_parts.push(part);
+                                parquet_chunks.push(other.into_parquet()?);
+                            }
+                        }
+                    }
+
+                    self.parts = parquet_parts;
+                    self.chunks = parquet_chunks;
                     return Ok(Event::Sync);
                 }
             }
@@ -197,6 +213,64 @@ impl Processor for DeserializeDataTransform {
     }
 
     fn process(&mut self) -> Result<()> {
+        // Process one Vortex block from the queue first.
+        // Vortex blocks are already deserialized; we only need to apply filter/prewhere
+        // and attach block metadata before pushing to output.
+        if let Some((part, mut block)) = self.vortex_queue.pop() {
+            let fuse_part = FuseBlockPartInfo::from_part(&part)?;
+            let num_rows = block.num_rows();
+
+            // Apply prewhere filter for Vortex blocks.
+            //
+            // ReadState::filter uses column indices from prewhere_schema (which only
+            // contains prewhere columns), but the Vortex DataBlock has columns ordered
+            // by src_schema (all projected columns).  We must re-project the filter
+            // expression against src_schema before evaluating it.
+            if let Some(prewhere_info) = &self.prewhere_info {
+                let filter_expr = prewhere_info
+                    .filter
+                    .as_expr(&databend_common_functions::BUILTIN_FUNCTIONS)
+                    .project_column_ref(|name| {
+                        Ok(self.src_schema.column_with_name(name).unwrap().0)
+                    })?;
+                let func_ctx = self.ctx.get_function_context()?;
+                let evaluator = databend_common_expression::Evaluator::new(
+                    &block,
+                    &func_ctx,
+                    &databend_common_functions::BUILTIN_FUNCTIONS,
+                );
+                let filter_result = evaluator
+                    .run(&filter_expr)?
+                    .try_downcast::<databend_common_expression::types::BooleanType>()
+                    .unwrap();
+                let bitmap = databend_common_expression::filter_helper::FilterHelpers::filter_to_bitmap(
+                    filter_result,
+                    num_rows,
+                );
+                block = block.filter_with_bitmap(&bitmap.into())?;
+            }
+
+            let progress_values = ProgressValues {
+                rows: block.num_rows(),
+                bytes: block.memory_size(),
+            };
+            self.scan_progress.incr(&progress_values);
+            Profile::record_usize_profile(ProfileStatisticsName::ScanBytes, block.memory_size());
+
+            block = block.resort(&self.src_schema, &self.output_schema)?;
+            block = add_data_block_meta(
+                block,
+                fuse_part,
+                None,
+                self.base_block_ids.clone(),
+                self.block_reader.update_stream_columns(),
+                self.block_reader.query_internal_columns(),
+                self.need_reserve_block_info,
+            )?;
+            self.output_data = Some(block);
+            return Ok(());
+        }
+
         let part = self.parts.pop();
         let chunks = self.chunks.pop();
         if let Some((part, read_res)) = part.zip(chunks) {

--- a/src/query/storages/fuse/src/operations/read/read_block_context.rs
+++ b/src/query/storages/fuse/src/operations/read/read_block_context.rs
@@ -29,9 +29,11 @@ use crate::FuseBlockPartInfo;
 use crate::FuseStorageFormat;
 use crate::io::AggIndexReader;
 use crate::io::BlockReadContext;
+use crate::io::BlockReader;
 use crate::io::TableMetaLocationGenerator;
 use crate::io::VirtualBlockReadResult;
 use crate::io::VirtualColumnReader;
+use crate::io::read_vortex_block;
 
 pub struct ReadBlockContext {
     read_settings: ReadSettings,
@@ -40,6 +42,8 @@ pub struct ReadBlockContext {
     block_format: Arc<dyn FuseBlockFormat>,
     index_reader: Arc<Option<AggIndexReader>>,
     virtual_reader: Arc<Option<VirtualColumnReader>>,
+    /// Used for Vortex format: reads the whole file and deserializes it directly.
+    block_reader: Arc<BlockReader>,
 }
 
 impl ReadBlockContext {
@@ -50,6 +54,7 @@ impl ReadBlockContext {
         block_format: Arc<dyn FuseBlockFormat>,
         index_reader: Arc<Option<AggIndexReader>>,
         virtual_reader: Arc<Option<VirtualColumnReader>>,
+        block_reader: Arc<BlockReader>,
     ) -> Result<Arc<Self>> {
         Ok(Arc::new(Self {
             read_settings: ReadSettings::from_ctx(&ctx)?,
@@ -58,6 +63,7 @@ impl ReadBlockContext {
             block_format,
             index_reader,
             virtual_reader,
+            block_reader,
         }))
     }
 
@@ -69,6 +75,26 @@ impl ReadBlockContext {
     #[async_backtrace::framed]
     pub async fn read_data(&self, part: PartInfoPtr) -> Result<ReadDataSource> {
         let fuse_part = FuseBlockPartInfo::from_part(&part)?;
+
+        // Vortex files are self-contained: read and deserialize the whole file here,
+        // bypassing the merge-IO path entirely.
+        if matches!(self.storage_format, FuseStorageFormat::Vortex) {
+            let block = read_vortex_block(
+                self.block_read_ctx.operator().clone(),
+                &fuse_part.location,
+                &self.block_reader.projected_schema,
+                &self.block_reader.project_indices,
+                fuse_part.nums_rows,
+            )
+            .await?;
+            debug!(
+                "[VORTEX] read_vortex_block: path={} rows={} cols={}",
+                fuse_part.location,
+                block.num_rows(),
+                block.num_columns()
+            );
+            return Ok(ReadDataSource::Vortex(block));
+        }
 
         if let Some(data_source) = self.read_agg_index_data(fuse_part).await? {
             return Ok(data_source);

--- a/src/query/storages/fuse/src/operations/read/read_data_source.rs
+++ b/src/query/storages/fuse/src/operations/read/read_data_source.rs
@@ -15,6 +15,7 @@
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfo;
+use databend_common_expression::DataBlock;
 
 use super::native_data_source::NativeDataSource;
 use super::parquet_data_source::ParquetDataSource;
@@ -23,14 +24,17 @@ use crate::operations::read::data_source_with_meta::DataSourceWithMeta;
 pub enum ReadDataSource {
     Native(Box<NativeDataSource>),
     Parquet(Box<ParquetDataSource>),
+    /// Vortex blocks are read and fully deserialized during the async IO phase.
+    /// The deserializer just passes the DataBlock through.
+    Vortex(DataBlock),
 }
 
 impl ReadDataSource {
     pub fn into_native(self) -> Result<NativeDataSource> {
         match self {
             ReadDataSource::Native(data) => Ok(*data),
-            ReadDataSource::Parquet(_) => Err(ErrorCode::Internal(
-                "NativeDeserializeDataTransform got parquet data source",
+            _ => Err(ErrorCode::Internal(
+                "NativeDeserializeDataTransform got non-native data source",
             )),
         }
     }
@@ -38,8 +42,17 @@ impl ReadDataSource {
     pub fn into_parquet(self) -> Result<ParquetDataSource> {
         match self {
             ReadDataSource::Parquet(data) => Ok(*data),
-            ReadDataSource::Native(_) => Err(ErrorCode::Internal(
-                "DeserializeDataTransform got native data source",
+            _ => Err(ErrorCode::Internal(
+                "DeserializeDataTransform got non-parquet data source",
+            )),
+        }
+    }
+
+    pub fn into_vortex(self) -> Result<DataBlock> {
+        match self {
+            ReadDataSource::Vortex(block) => Ok(block),
+            _ => Err(ErrorCode::Internal(
+                "VortexDeserializeDataTransform got non-vortex data source",
             )),
         }
     }

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -55,6 +55,7 @@ use log::warn;
 use opendal::Operator;
 use tokio::sync::Semaphore;
 
+use crate::FuseStorageFormat;
 use crate::FuseTable;
 use crate::io::BlockBuilder;
 use crate::io::BlockReader;
@@ -636,6 +637,14 @@ impl AggregationContext {
     }
 
     async fn read_block(&self, reader: &BlockReader, block_meta: &BlockMeta) -> Result<DataBlock> {
+        let storage_format = self.write_settings.storage_format;
+
+        // Vortex files are read as a whole; bypass merge-IO.
+        if matches!(storage_format, FuseStorageFormat::Vortex) {
+            let read_settings = &self.read_settings;
+            return reader.read_by_meta(read_settings, block_meta, &storage_format).await;
+        }
+
         let merged_io_read_result = reader
             .read_columns_data_by_merge_io(
                 &self.read_settings,
@@ -647,7 +656,6 @@ impl AggregationContext {
 
         // deserialize block data
         // cpu intensive task, send them to dedicated thread pool
-        let storage_format = self.write_settings.storage_format;
         let block_meta_ptr = block_meta.clone();
         let reader = reader.clone();
         GlobalIORuntime::instance()

--- a/src/query/storages/fuse/src/operations/util.rs
+++ b/src/query/storages/fuse/src/operations/util.rs
@@ -71,11 +71,11 @@ pub fn set_backoff(
 }
 
 pub fn column_parquet_metas(
-    file_meta: &parquet::format::FileMetaData,
+    file_meta: &parquet::file::metadata::ParquetMetaData,
     schema: &TableSchemaRef,
 ) -> Result<HashMap<ColumnId, ColumnMeta>> {
     // currently we use one group only
-    let num_row_groups = file_meta.row_groups.len();
+    let num_row_groups = file_meta.row_groups().len();
     if num_row_groups != 1 {
         return Err(ErrorCode::ParquetFileInvalid(format!(
             "invalid parquet file, expects only one row group, but got {}",
@@ -84,40 +84,20 @@ pub fn column_parquet_metas(
     }
     // use `to_leaf_column_ids` instead of `to_column_ids` to handle nested type column ids.
     let column_ids = schema.to_leaf_column_ids();
-    let row_group = &file_meta.row_groups[0];
+    let row_group = &file_meta.row_groups()[0];
     // Make sure that schema and row_group has the same number column, or else it is a panic error.
-    assert_eq!(column_ids.len(), row_group.columns.len());
-    let mut col_metas = HashMap::with_capacity(row_group.columns.len());
-    for (idx, col_chunk) in row_group.columns.iter().enumerate() {
-        match &col_chunk.meta_data {
-            Some(chunk_meta) => {
-                let col_start = if let Some(dict_page_offset) = chunk_meta.dictionary_page_offset {
-                    dict_page_offset
-                } else {
-                    chunk_meta.data_page_offset
-                };
-                let col_len = chunk_meta.total_compressed_size;
-                assert!(
-                    col_start >= 0 && col_len >= 0,
-                    "column start and length should not be negative"
-                );
-                let num_values = chunk_meta.num_values as u64;
-                let res = SingleColumnMeta {
-                    offset: col_start as u64,
-                    len: col_len as u64,
-                    num_values,
-                };
-                // use column id as key instead of index
-                let column_id = column_ids[idx];
-                col_metas.insert(column_id, ColumnMeta::Parquet(res));
-            }
-            None => {
-                return Err(ErrorCode::ParquetFileInvalid(format!(
-                    "invalid parquet file, meta data of column idx {} is empty",
-                    idx
-                )));
-            }
-        }
+    assert_eq!(column_ids.len(), row_group.columns().len());
+    let mut col_metas = HashMap::with_capacity(row_group.columns().len());
+    for (idx, chunk_meta) in row_group.columns().iter().enumerate() {
+        let (offset, len) = chunk_meta.byte_range();
+        let res = SingleColumnMeta {
+            offset,
+            len,
+            num_values: chunk_meta.num_values() as u64,
+        };
+        // use column id as key instead of index
+        let column_id = column_ids[idx];
+        col_metas.insert(column_id, ColumnMeta::Parquet(res));
     }
     Ok(col_metas)
 }

--- a/src/query/storages/fuse/src/operations/util.rs
+++ b/src/query/storages/fuse/src/operations/util.rs
@@ -119,6 +119,11 @@ pub async fn read_block(
     block_meta: &BlockMeta,
     read_settings: &ReadSettings,
 ) -> Result<DataBlock> {
+    // Vortex files are read as a whole via read_by_meta; bypass merge-IO.
+    if matches!(storage_format, FuseStorageFormat::Vortex) {
+        return reader.read_by_meta(read_settings, block_meta, &storage_format).await;
+    }
+
     let merged_io_read_result = reader
         .read_columns_data_by_merge_io(
             read_settings,

--- a/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 // Copyright 2021 Datafuse Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +62,7 @@ use futures::stream::TryStreamExt;
 use opendal::Operator;
 use parquet::basic::Compression as ParquetCompression;
 use parquet::basic::Encoding as ParquetEncoding;
-use parquet::format::Type as ParquetPhysicalType;
+use parquet::basic::Type as ParquetPhysicalType;
 
 use crate::BlockReadResult;
 use crate::FuseStorageFormat;
@@ -392,15 +394,15 @@ impl<'a> FuseEncodingImpl<'a> {
         column_name_filter: Arc<Option<String>>,
     ) -> Result<Vec<EncodingRow>> {
         let file_meta = read_thrift_file_metadata(operator, &location, Some(file_size)).await?;
-        if file_meta.row_groups.len() != 1 {
+        if file_meta.row_groups().len() != 1 {
             return Err(ErrorCode::ParquetFileInvalid(format!(
                 "invalid parquet file {}, expects one row group but got {}",
                 location,
-                file_meta.row_groups.len()
+                file_meta.row_groups().len()
             )));
         }
-        let row_group = &file_meta.row_groups[0];
-        let columns = &row_group.columns;
+        let row_group = &file_meta.row_groups()[0];
+        let columns = row_group.columns();
         let mut block_rows = Vec::new();
 
         for field in fields.iter() {
@@ -418,23 +420,15 @@ impl<'a> FuseEncodingImpl<'a> {
                 // Missing column caused by schema evolutions
                 continue;
             };
-            let chunk_meta = column_chunk.meta_data.as_ref().ok_or_else(|| {
+            let compressed_size = u64::try_from(column_chunk.compressed_size()).map_err(|_| {
                 ErrorCode::ParquetFileInvalid(format!(
-                    "invalid parquet file {}, meta data of column {} is empty",
-                    location, column_id
+                    "invalid parquet file {}, compressed size overflow for column {}",
+                    location,
+                    field.name()
                 ))
             })?;
-
-            let compressed_size =
-                u64::try_from(chunk_meta.total_compressed_size).map_err(|_| {
-                    ErrorCode::ParquetFileInvalid(format!(
-                        "invalid parquet file {}, compressed size overflow for column {}",
-                        location,
-                        field.name()
-                    ))
-                })?;
             let uncompressed_size =
-                u64::try_from(chunk_meta.total_uncompressed_size).map_err(|_| {
+                u64::try_from(column_chunk.uncompressed_size()).map_err(|_| {
                     ErrorCode::ParquetFileInvalid(format!(
                         "invalid parquet file {}, uncompressed size overflow for column {}",
                         location,
@@ -442,7 +436,7 @@ impl<'a> FuseEncodingImpl<'a> {
                     ))
                 })?;
 
-            let physical_type = parquet_physical_type_to_string(chunk_meta.type_);
+            let physical_type = parquet_physical_type_to_string(column_chunk.column_type());
             block_rows.push(EncodingRow {
                 table_name: table_name.as_str().to_string(),
                 storage_format,
@@ -452,8 +446,8 @@ impl<'a> FuseEncodingImpl<'a> {
                 validity_size: None,
                 compressed_size,
                 uncompressed_size,
-                level_one: parquet_encodings_to_string(&chunk_meta.encodings),
-                level_two: Some(parquet_codec_to_string(chunk_meta.codec)),
+                level_one: parquet_encodings_to_string(column_chunk.encodings()),
+                level_two: Some(parquet_codec_to_string(column_chunk.compression())),
             });
         }
 
@@ -634,45 +628,41 @@ fn native_level_two_encoding(page_body: &PageBody) -> Option<String> {
     }
 }
 
-fn parquet_encodings_to_string(encodings: &[parquet::format::Encoding]) -> String {
+fn parquet_encodings_to_string(encodings: impl Iterator<Item = ParquetEncoding>) -> String {
+    let encodings = encodings
+        .map(parquet_encoding_to_string)
+        .collect::<Vec<_>>();
     if encodings.is_empty() {
         "unknown".to_string()
     } else {
-        encodings
-            .iter()
-            .map(|encoding| parquet_encoding_to_string(*encoding))
-            .collect::<Vec<_>>()
-            .join(",")
+        encodings.join(",")
     }
 }
 
-fn parquet_encoding_to_string(encoding: parquet::format::Encoding) -> &'static str {
-    match ParquetEncoding::try_from(encoding) {
-        Ok(ParquetEncoding::PLAIN) => "plain",
-        Ok(ParquetEncoding::PLAIN_DICTIONARY) => "plain_dictionary",
-        Ok(ParquetEncoding::RLE) => "rle",
-        #[allow(deprecated)]
-        Ok(ParquetEncoding::BIT_PACKED) => "bit_packed",
-        Ok(ParquetEncoding::DELTA_BINARY_PACKED) => "delta_binary_packed",
-        Ok(ParquetEncoding::DELTA_LENGTH_BYTE_ARRAY) => "delta_length_byte_array",
-        Ok(ParquetEncoding::DELTA_BYTE_ARRAY) => "delta_byte_array",
-        Ok(ParquetEncoding::RLE_DICTIONARY) => "rle_dictionary",
-        Ok(ParquetEncoding::BYTE_STREAM_SPLIT) => "byte_stream_split",
-        Err(_) => "unknown",
+fn parquet_encoding_to_string(encoding: ParquetEncoding) -> &'static str {
+    match encoding {
+        ParquetEncoding::PLAIN => "plain",
+        ParquetEncoding::PLAIN_DICTIONARY => "plain_dictionary",
+        ParquetEncoding::RLE => "rle",
+        ParquetEncoding::BIT_PACKED => "bit_packed",
+        ParquetEncoding::DELTA_BINARY_PACKED => "delta_binary_packed",
+        ParquetEncoding::DELTA_LENGTH_BYTE_ARRAY => "delta_length_byte_array",
+        ParquetEncoding::DELTA_BYTE_ARRAY => "delta_byte_array",
+        ParquetEncoding::RLE_DICTIONARY => "rle_dictionary",
+        ParquetEncoding::BYTE_STREAM_SPLIT => "byte_stream_split",
     }
 }
 
-fn parquet_codec_to_string(codec: parquet::format::CompressionCodec) -> String {
-    match ParquetCompression::try_from(codec) {
-        Ok(ParquetCompression::UNCOMPRESSED) => "uncompressed".to_string(),
-        Ok(ParquetCompression::SNAPPY) => "snappy".to_string(),
-        Ok(ParquetCompression::GZIP(_)) => "gzip".to_string(),
-        Ok(ParquetCompression::LZO) => "lzo".to_string(),
-        Ok(ParquetCompression::BROTLI(_)) => "brotli".to_string(),
-        Ok(ParquetCompression::LZ4) => "lz4".to_string(),
-        Ok(ParquetCompression::ZSTD(_)) => "zstd".to_string(),
-        Ok(ParquetCompression::LZ4_RAW) => "lz4_raw".to_string(),
-        Err(_) => format!("compression_codec({})", codec.0),
+fn parquet_codec_to_string(codec: ParquetCompression) -> String {
+    match codec {
+        ParquetCompression::UNCOMPRESSED => "uncompressed".to_string(),
+        ParquetCompression::SNAPPY => "snappy".to_string(),
+        ParquetCompression::GZIP(_) => "gzip".to_string(),
+        ParquetCompression::LZO => "lzo".to_string(),
+        ParquetCompression::BROTLI(_) => "brotli".to_string(),
+        ParquetCompression::LZ4 => "lz4".to_string(),
+        ParquetCompression::ZSTD(_) => "zstd".to_string(),
+        ParquetCompression::LZ4_RAW => "lz4_raw".to_string(),
     }
 }
 
@@ -686,7 +676,6 @@ fn parquet_physical_type_to_string(ty: ParquetPhysicalType) -> &'static str {
         ParquetPhysicalType::DOUBLE => "DOUBLE",
         ParquetPhysicalType::BYTE_ARRAY => "BYTE_ARRAY",
         ParquetPhysicalType::FIXED_LEN_BYTE_ARRAY => "FIXED_LEN_BYTE_ARRAY",
-        parquet::format::Type(_) => "UNKNOWN",
     }
 }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_encoding.rs
@@ -244,6 +244,11 @@ impl<'a> FuseEncodingImpl<'a> {
                     )
                     .await?;
                 }
+                FuseStorageFormat::Vortex => {
+                    // fuse_encoding is not yet implemented for Vortex format.
+                    // Vortex encoding information is stored in the file footer,
+                    // not in per-column metadata. Return empty rows for now.
+                }
             }
         }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_page.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_page.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 // Copyright 2021 Datafuse Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -41,8 +41,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::DataSchema;
-use databend_common_expression::FieldIndex;
-use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_meta_app::schema::CatalogInfo;
@@ -490,64 +488,34 @@ impl IcebergTable {
                 .map(|v| v.name.clone())
                 .collect()),
             Projection::InnerColumns(path_indices) => {
-                let fields = schema.fields();
-                let mut names = Vec::with_capacity(path_indices.len());
+                // Iceberg scan.select() only accepts direct children of the table schema.
+                // Keep nested projection pruning in Databend's read path and only push down
+                // the required top-level columns to the Iceberg scan planner.
+                let mut top_level_indices = Vec::with_capacity(path_indices.len());
                 for path in path_indices.values() {
-                    names.push(Self::inner_column_path_to_name(fields, path)?);
+                    let index = *path.first().ok_or_else(|| {
+                        ErrorCode::BadArguments("Inner column path should not be empty".to_string())
+                    })?;
+                    top_level_indices.push(index);
                 }
-                Ok(names)
+                top_level_indices.sort_unstable();
+                top_level_indices.dedup();
+                top_level_indices
+                    .into_iter()
+                    .map(|index| {
+                        schema
+                            .fields()
+                            .get(index)
+                            .map(|field| field.name().clone())
+                            .ok_or_else(|| {
+                                ErrorCode::BadArguments(format!(
+                                    "Inner column projection root {index} is out of range"
+                                ))
+                            })
+                    })
+                    .collect()
             }
         }
-    }
-
-    fn inner_column_path_to_name(fields: &[TableField], path: &[FieldIndex]) -> Result<String> {
-        if path.is_empty() {
-            return Err(ErrorCode::BadArguments(
-                "Inner column path should not be empty".to_string(),
-            ));
-        }
-
-        let field = fields.get(path[0]).ok_or_else(|| {
-            ErrorCode::BadArguments(format!("Inner column path {:?} is out of range", path))
-        })?;
-        let mut name_parts = Vec::with_capacity(path.len());
-        name_parts.push(field.name().clone());
-
-        let mut current_type = field.data_type().remove_nullable();
-        for index in path.iter().skip(1) {
-            match &current_type {
-                TableDataType::Tuple {
-                    fields_name,
-                    fields_type,
-                } => {
-                    let inner_name = fields_name.get(*index).ok_or_else(|| {
-                        ErrorCode::BadArguments(format!(
-                            "Inner column path {:?} is out of range for {}",
-                            path,
-                            name_parts.join(".")
-                        ))
-                    })?;
-                    name_parts.push(inner_name.clone());
-                    let inner_type = fields_type.get(*index).ok_or_else(|| {
-                        ErrorCode::BadArguments(format!(
-                            "Inner column path {:?} is out of range for {}",
-                            path,
-                            name_parts.join(".")
-                        ))
-                    })?;
-                    current_type = inner_type.remove_nullable();
-                }
-                _ => {
-                    return Err(ErrorCode::BadArguments(format!(
-                        "Inner column path {:?} is invalid for non-tuple field {}",
-                        path,
-                        name_parts.join(".")
-                    )));
-                }
-            }
-        }
-
-        Ok(name_parts.join("."))
     }
 
     fn convert_orc_schema(schema: &Schema) -> Schema {

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -591,7 +591,8 @@ impl IcebergTable {
                         .map(|(i, field)| (i, visit_field(field)))
                         .unzip();
                     arrow_schema::DataType::Union(
-                        arrow_schema::UnionFields::new(ids, fields),
+                        arrow_schema::UnionFields::try_new(ids, fields)
+                            .expect("existing union fields should remain valid"),
                         *mode,
                     )
                 }

--- a/src/query/storages/parquet/Cargo.toml
+++ b/src/query/storages/parquet/Cargo.toml
@@ -38,7 +38,6 @@ opendal = { workspace = true }
 parquet = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-thrift = { workspace = true }
 typetag = { workspace = true }
 
 [dev-dependencies]

--- a/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/row_group_reader.rs
@@ -53,7 +53,7 @@ use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::metadata::RowGroupMetaData;
-use parquet::format::PageLocation;
+use parquet::file::page_index::offset_index::PageLocation;
 use parquet::schema::types::SchemaDescPtr;
 
 use crate::DeleteType;

--- a/src/query/storages/parquet/src/parquet_reader/row_group.rs
+++ b/src/query/storages/parquet/src/parquet_reader/row_group.rs
@@ -31,11 +31,13 @@ use parquet::arrow::arrow_reader::RowSelection;
 use parquet::column::page::PageIterator;
 use parquet::column::page::PageReader;
 use parquet::errors::ParquetError;
+use parquet::file::metadata::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
 use parquet::file::metadata::RowGroupMetaData;
+use parquet::file::page_index::offset_index::PageLocation;
 use parquet::file::reader::ChunkReader;
 use parquet::file::reader::Length;
 use parquet::file::serialized_reader::SerializedPageReader;
-use parquet::format::PageLocation;
 
 use crate::read_settings::ReadSettings;
 
@@ -181,15 +183,29 @@ pub async fn get_ranges(
 
 pub struct RowGroupCore<T> {
     metadata: T,
+    parquet_meta: ParquetMetaData,
     page_locations: Option<Vec<Vec<PageLocation>>>,
     column_chunks: Vec<Option<Arc<ColumnChunkData>>>,
 }
 
 impl<T: AsMetaRef> RowGroupCore<T> {
     pub fn new(meta: T, page_locations: Option<Vec<Vec<PageLocation>>>) -> RowGroupCore<T> {
+        let row_group_meta = meta.meta().clone();
+        let parquet_meta = ParquetMetaData::new(
+            FileMetaData::new(
+                0,
+                row_group_meta.num_rows(),
+                None,
+                None,
+                row_group_meta.schema_descr_ptr(),
+                None,
+            ),
+            vec![row_group_meta],
+        );
         RowGroupCore {
             column_chunks: vec![None; meta.meta().num_columns()],
             metadata: meta,
+            parquet_meta,
             page_locations,
         }
     }
@@ -374,6 +390,14 @@ impl<T: AsMetaRef> RowGroups for RowGroupCore<T> {
             }
         }
     }
+
+    fn row_groups(&self) -> Box<dyn Iterator<Item = &RowGroupMetaData> + '_> {
+        Box::new(self.parquet_meta.row_groups().iter())
+    }
+
+    fn metadata(&self) -> &databend_storages_common_cache::ParquetMetaData {
+        &self.parquet_meta
+    }
 }
 
 pub trait AsMetaRef {
@@ -434,6 +458,14 @@ impl RowGroups for InMemoryRowGroup<'_> {
 
     fn column_chunks(&self, i: usize) -> parquet::errors::Result<Box<dyn PageIterator>> {
         self.core.column_chunks(i)
+    }
+
+    fn row_groups(&self) -> Box<dyn Iterator<Item = &RowGroupMetaData> + '_> {
+        self.core.row_groups()
+    }
+
+    fn metadata(&self) -> &databend_storages_common_cache::ParquetMetaData {
+        self.core.metadata()
     }
 }
 

--- a/src/query/storages/parquet/src/partition.rs
+++ b/src/query/storages/parquet/src/partition.rs
@@ -15,7 +15,7 @@
 use databend_common_expression::Scalar;
 use parquet::arrow::arrow_reader::RowSelector;
 use parquet::file::metadata::RowGroupMetaData;
-use parquet::format::PageLocation;
+use parquet::file::page_index::offset_index::PageLocation;
 
 use crate::row_group_serde::deserialize_row_group_meta;
 use crate::row_group_serde::serialize_row_group_meta;

--- a/src/query/storages/parquet/src/pruning.rs
+++ b/src/query/storages/parquet/src/pruning.rs
@@ -29,7 +29,7 @@ use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::arrow::arrow_reader::RowSelector;
 use parquet::file::metadata::ParquetMetaData;
-use parquet::format::PageLocation;
+use parquet::file::page_index::offset_index::PageLocation;
 
 use super::statistics::collect_row_group_stats;
 use crate::statistics::convert_index_to_column_statistics;

--- a/src/query/storages/parquet/src/row_group_serde.rs
+++ b/src/query/storages/parquet/src/row_group_serde.rs
@@ -12,78 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Cursor;
-use std::sync::Arc;
-
 use databend_common_exception::ErrorCode;
+use parquet::file::metadata::FileMetaData;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::metadata::ParquetMetaDataReader;
+use parquet::file::metadata::ParquetMetaDataWriter;
 use parquet::file::metadata::RowGroupMetaData;
-use parquet::format::RowGroup;
-use parquet::format::SchemaElement;
-use parquet::schema::types::SchemaDescriptor;
-use parquet::schema::types::from_thrift;
-use parquet::schema::types::to_thrift;
-use parquet::thrift::TSerializable;
 use serde::Deserialize;
-use thrift::protocol::TCompactInputProtocol;
-use thrift::protocol::TCompactOutputProtocol;
-use thrift::protocol::TInputProtocol;
-use thrift::protocol::TListIdentifier;
-use thrift::protocol::TOutputProtocol;
-use thrift::protocol::TType;
+
+fn wrap_in_parquet_meta(row_group: &RowGroupMetaData) -> ParquetMetaData {
+    let file_meta = FileMetaData::new(
+        0,
+        row_group.num_rows(),
+        None,
+        None,
+        row_group.schema_descr_ptr(),
+        None,
+    );
+    ParquetMetaData::new(file_meta, vec![row_group.clone()])
+}
 
 pub fn serialize_row_group_meta_to_bytes(meta: &RowGroupMetaData) -> Result<Vec<u8>, ErrorCode> {
-    let mut transport = Vec::<u8>::new();
-    let mut o_prot = TCompactOutputProtocol::new(&mut transport);
-
-    let schema = meta.schema_descr();
-    let schema_elements = to_thrift(schema.root_schema())
-        .map_err(|e| wrap_error(e, " (while converting schema to thrift)"))?;
-    o_prot
-        .write_list_begin(&TListIdentifier::new(
-            TType::Struct,
-            schema_elements.len() as i32,
-        ))
-        .map_err(|e| wrap_error(e, " (while writing schema list header)"))?;
-    for element in schema_elements {
-        element
-            .write_to_out_protocol(&mut o_prot)
-            .map_err(|e| wrap_error(e, " (while writing schema element)"))?;
-    }
-    o_prot
-        .write_list_end()
-        .map_err(|e| wrap_error(e, " (while finishing schema list)"))?;
-
-    let rg = meta.to_thrift();
-    rg.write_to_out_protocol(&mut o_prot)
-        .map_err(|e| wrap_error(e, " (while writing row group meta)"))?;
-
-    Ok(transport)
+    let parquet_meta = wrap_in_parquet_meta(meta);
+    let mut buffer = Vec::new();
+    ParquetMetaDataWriter::new(&mut buffer, &parquet_meta)
+        .finish()
+        .map_err(ErrorCode::from_std_error)?;
+    Ok(buffer)
 }
 
 pub fn deserialize_row_group_meta_from_bytes(bytes: &[u8]) -> Result<RowGroupMetaData, ErrorCode> {
-    let cursor = Cursor::new(bytes);
-    let mut i_prot = TCompactInputProtocol::new(cursor);
-
-    let list_ident = i_prot
-        .read_list_begin()
-        .map_err(|e| wrap_error(e, " (while reading schema list header)"))?;
-    let mut schema_elements: Vec<SchemaElement> = Vec::with_capacity(list_ident.size as usize);
-    for _ in 0..list_ident.size {
-        let element = SchemaElement::read_from_in_protocol(&mut i_prot)
-            .map_err(|e| wrap_error(e, " (while reading schema element)"))?;
-        schema_elements.push(element);
-    }
-    i_prot
-        .read_list_end()
-        .map_err(|e| wrap_error(e, " (while finishing schema list)"))?;
-    let schema = from_thrift(&schema_elements)
-        .map_err(|e| wrap_error(e, " (while converting thrift schema)"))?;
-    let schema = Arc::new(SchemaDescriptor::new(schema));
-
-    let rg = RowGroup::read_from_in_protocol(&mut i_prot)
-        .map_err(|e| wrap_error(e, " (while reading row group meta)"))?;
-    RowGroupMetaData::from_thrift(schema, rg)
-        .map_err(|e| wrap_error(e, " (while constructing row group meta)"))
+    let parquet_meta =
+        ParquetMetaDataReader::decode_metadata(bytes).map_err(ErrorCode::from_std_error)?;
+    parquet_meta
+        .row_groups()
+        .first()
+        .cloned()
+        .ok_or_else(|| ErrorCode::ParquetFileInvalid("serialized row group metadata is empty"))
 }
 
 pub fn serialize_row_group_meta<S>(
@@ -103,9 +68,4 @@ where D: serde::Deserializer<'de> {
     let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
     deserialize_row_group_meta_from_bytes(&bytes)
         .map_err(|e| serde::de::Error::custom(e.to_string()))
-}
-
-fn wrap_error<E>(err: E, context: &'static str) -> ErrorCode
-where E: std::error::Error + Send + Sync + 'static {
-    ErrorCode::from_std_error(err).add_message_back(context)
 }

--- a/src/query/storages/parquet/src/statistics/page.rs
+++ b/src/query/storages/parquet/src/statistics/page.rs
@@ -20,123 +20,88 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::i256;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use parquet::data_type::AsBytes;
-use parquet::data_type::ByteArray;
 use parquet::data_type::FixedLenByteArray;
 use parquet::data_type::Int96;
-use parquet::file::page_index::index::Index;
-use parquet::file::page_index::index::PageIndex;
+use parquet::file::page_index::column_index::ByteArrayColumnIndex;
+use parquet::file::page_index::column_index::ColumnIndexMetaData;
+use parquet::file::page_index::column_index::PrimitiveColumnIndex;
 
 use super::utils::decode_decimal128_from_bytes;
 use super::utils::decode_decimal256_from_bytes;
 
 pub fn convert_index_to_column_statistics(
-    index: &Index,
+    index: &ColumnIndexMetaData,
     num_pagas: usize,
     typ: &TableDataType,
 ) -> Vec<Option<ColumnStatistics>> {
     match index {
-        Index::NONE => vec![None; num_pagas],
-        Index::BOOLEAN(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_bool(index, typ))
-                .collect()
-        }
-        Index::INT32(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_int32(index, typ))
-                .collect()
-        }
-        Index::INT64(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_int64(index, typ))
-                .collect()
-        }
-        Index::INT96(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_int96(index, typ))
-                .collect()
-        }
-        Index::FLOAT(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_float(index, typ))
-                .collect()
-        }
-        Index::DOUBLE(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_double(index, typ))
-                .collect()
-        }
-        Index::BYTE_ARRAY(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_byte_array(index, typ))
-                .collect()
-        }
-        Index::FIXED_LEN_BYTE_ARRAY(index) => {
-            assert_eq!(num_pagas, index.indexes.len());
-            index
-                .indexes
-                .iter()
-                .map(|index| convert_page_index_fixed_len_byte_array(index, typ))
-                .collect()
-        }
+        ColumnIndexMetaData::NONE => vec![None; num_pagas],
+        ColumnIndexMetaData::BOOLEAN(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_bool(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::INT32(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_int32(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::INT64(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_int64(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::INT96(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_int96(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::FLOAT(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_float(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::DOUBLE(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_double(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::BYTE_ARRAY(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_byte_array(index, i, typ))
+            .collect(),
+        ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(index) => (0..index.num_pages() as usize)
+            .map(|i| convert_page_index_fixed_len_byte_array(index, i, typ))
+            .collect(),
     }
 }
 
 fn convert_page_index_int32(
-    index: &PageIndex<i32>,
+    index: &PrimitiveColumnIndex<i32>,
+    idx: usize,
     typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (index.min, index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => {
             let (max, min) = match typ {
                 TableDataType::Number(NumberDataType::Int8) => {
-                    (Scalar::from(max as i8), Scalar::from(min as i8))
+                    (Scalar::from(*max as i8), Scalar::from(*min as i8))
                 }
                 TableDataType::Number(NumberDataType::Int16) => {
-                    (Scalar::from(max as i16), Scalar::from(min as i16))
+                    (Scalar::from(*max as i16), Scalar::from(*min as i16))
                 }
                 TableDataType::Number(NumberDataType::Int32) => {
-                    (Scalar::from(max), Scalar::from(min))
+                    (Scalar::from(*max), Scalar::from(*min))
                 }
                 TableDataType::Number(NumberDataType::UInt8) => {
-                    (Scalar::from(max as u8), Scalar::from(min as u8))
+                    (Scalar::from(*max as u8), Scalar::from(*min as u8))
                 }
                 TableDataType::Number(NumberDataType::UInt16) => {
-                    (Scalar::from(max as u16), Scalar::from(min as u16))
+                    (Scalar::from(*max as u16), Scalar::from(*min as u16))
                 }
                 TableDataType::Number(NumberDataType::UInt32) => {
-                    (Scalar::from(max as u32), Scalar::from(min as u32))
+                    (Scalar::from(*max as u32), Scalar::from(*min as u32))
                 }
-                TableDataType::Date => (Scalar::Date(max), Scalar::Date(min)),
+                TableDataType::Date => (Scalar::Date(*max), Scalar::Date(*min)),
                 TableDataType::Decimal(decimal) => match decimal {
                     DecimalDataType::Decimal128(size) => (
-                        Scalar::Decimal(DecimalScalar::Decimal128(i128::from(max), *size)),
-                        Scalar::Decimal(DecimalScalar::Decimal128(i128::from(min), *size)),
+                        Scalar::Decimal(DecimalScalar::Decimal128(i128::from(*max), *size)),
+                        Scalar::Decimal(DecimalScalar::Decimal128(i128::from(*min), *size)),
                     ),
                     DecimalDataType::Decimal256(size) => (
-                        Scalar::Decimal(DecimalScalar::Decimal256(i256::from(max), *size)),
-                        Scalar::Decimal(DecimalScalar::Decimal256(i256::from(min), *size)),
+                        Scalar::Decimal(DecimalScalar::Decimal256(i256::from(*max), *size)),
+                        Scalar::Decimal(DecimalScalar::Decimal256(i256::from(*min), *size)),
                     ),
                     _ => unreachable!(),
                 },
@@ -149,26 +114,31 @@ fn convert_page_index_int32(
 }
 
 fn convert_page_index_int64(
-    index: &PageIndex<i64>,
+    index: &PrimitiveColumnIndex<i64>,
+    idx: usize,
     typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (index.min, index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => {
             let (max, min) = match typ {
                 TableDataType::Number(NumberDataType::UInt64) => {
-                    (Scalar::from(max as u64), Scalar::from(min as u64))
+                    (Scalar::from(*max as u64), Scalar::from(*min as u64))
                 }
                 TableDataType::Number(NumberDataType::Int64) => {
-                    (Scalar::from(max), Scalar::from(min))
+                    (Scalar::from(*max), Scalar::from(*min))
                 }
-                TableDataType::Timestamp => (Scalar::Timestamp(max), Scalar::Timestamp(min)),
+                TableDataType::Timestamp => (Scalar::Timestamp(*max), Scalar::Timestamp(*min)),
                 TableDataType::Decimal(DecimalDataType::Decimal128(size)) => (
-                    Scalar::Decimal(DecimalScalar::Decimal128(i128::from(max), *size)),
-                    Scalar::Decimal(DecimalScalar::Decimal128(i128::from(min), *size)),
+                    Scalar::Decimal(DecimalScalar::Decimal128(i128::from(*max), *size)),
+                    Scalar::Decimal(DecimalScalar::Decimal128(i128::from(*min), *size)),
                 ),
                 TableDataType::Decimal(DecimalDataType::Decimal256(size)) => (
-                    Scalar::Decimal(DecimalScalar::Decimal256(i256::from(max), *size)),
-                    Scalar::Decimal(DecimalScalar::Decimal256(i256::from(min), *size)),
+                    Scalar::Decimal(DecimalScalar::Decimal256(i256::from(*max), *size)),
+                    Scalar::Decimal(DecimalScalar::Decimal256(i256::from(*min), *size)),
                 ),
                 _ => unreachable!(),
             };
@@ -179,10 +149,15 @@ fn convert_page_index_int64(
 }
 
 fn convert_page_index_int96(
-    index: &PageIndex<Int96>,
+    index: &PrimitiveColumnIndex<Int96>,
+    idx: usize,
     _typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (&index.min, &index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => Some(ColumnStatistics::new(
             Scalar::Timestamp(min.to_micros()),
             Scalar::Timestamp(max.to_micros()),
@@ -195,13 +170,18 @@ fn convert_page_index_int96(
 }
 
 fn convert_page_index_float(
-    index: &PageIndex<f32>,
+    index: &PrimitiveColumnIndex<f32>,
+    idx: usize,
     _typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (index.min, index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => Some(ColumnStatistics::new(
-            Scalar::from(min),
-            Scalar::from(max),
+            Scalar::from(*min),
+            Scalar::from(*max),
             null_count as u64,
             0,
             None,
@@ -211,13 +191,18 @@ fn convert_page_index_float(
 }
 
 fn convert_page_index_bool(
-    index: &PageIndex<bool>,
+    index: &PrimitiveColumnIndex<bool>,
+    idx: usize,
     _typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (index.min, index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => Some(ColumnStatistics::new(
-            Scalar::Boolean(min),
-            Scalar::Boolean(max),
+            Scalar::Boolean(*min),
+            Scalar::Boolean(*max),
             null_count as u64,
             0,
             None,
@@ -227,13 +212,18 @@ fn convert_page_index_bool(
 }
 
 fn convert_page_index_double(
-    index: &PageIndex<f64>,
+    index: &PrimitiveColumnIndex<f64>,
+    idx: usize,
     _typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (index.min, index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => Some(ColumnStatistics::new(
-            Scalar::from(min),
-            Scalar::from(max),
+            Scalar::from(*min),
+            Scalar::from(*max),
             null_count as u64,
             0,
             None,
@@ -243,10 +233,15 @@ fn convert_page_index_double(
 }
 
 fn convert_page_index_byte_array(
-    index: &PageIndex<ByteArray>,
+    index: &ByteArrayColumnIndex,
+    idx: usize,
     _typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (&index.min, &index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => Some(ColumnStatistics::new(
             Scalar::String(String::from_utf8(min.as_bytes().to_vec()).ok()?),
             Scalar::String(String::from_utf8(max.as_bytes().to_vec()).ok()?),
@@ -259,19 +254,24 @@ fn convert_page_index_byte_array(
 }
 
 fn convert_page_index_fixed_len_byte_array(
-    index: &PageIndex<FixedLenByteArray>,
+    index: &ByteArrayColumnIndex,
+    idx: usize,
     typ: &TableDataType,
 ) -> Option<ColumnStatistics> {
-    match (&index.min, &index.max, index.null_count) {
+    match (
+        index.min_value(idx),
+        index.max_value(idx),
+        index.null_count(idx),
+    ) {
         (Some(min), Some(max), Some(null_count)) => {
             let (max, min) = match typ {
                 TableDataType::Decimal(DecimalDataType::Decimal128(size)) => (
-                    decode_decimal128_from_bytes(max, *size),
-                    decode_decimal128_from_bytes(min, *size),
+                    decode_decimal128_from_bytes(&FixedLenByteArray::from(max.to_vec()), *size),
+                    decode_decimal128_from_bytes(&FixedLenByteArray::from(min.to_vec()), *size),
                 ),
                 TableDataType::Decimal(DecimalDataType::Decimal256(size)) => (
-                    decode_decimal256_from_bytes(max, *size),
-                    decode_decimal256_from_bytes(min, *size),
+                    decode_decimal256_from_bytes(&FixedLenByteArray::from(max.to_vec()), *size),
+                    decode_decimal256_from_bytes(&FixedLenByteArray::from(min.to_vec()), *size),
                 ),
                 _ => unreachable!(),
             };

--- a/src/query/storages/stage/src/append/lance_dataset/committer_processor.rs
+++ b/src/query/storages/stage/src/append/lance_dataset/committer_processor.rs
@@ -37,6 +37,7 @@ use lance_io::object_store::ObjectStoreParams;
 use lance_io::object_store::ObjectStoreRegistry;
 use lance_io::object_writer::ObjectWriter;
 use lance_io::traits::WriteExt;
+use lance_io::traits::Writer;
 use lance_table::format::DataStorageFormat;
 use lance_table::format::Fragment;
 use lance_table::format::Manifest;

--- a/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
+++ b/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
@@ -326,6 +326,7 @@ impl FragmentWriterParams {
         data_accessor: Operator,
         dataset_path: &str,
     ) -> Result<ObjectStoreParams> {
+        let scheme = data_accessor.info().scheme().to_string();
         let object_store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(data_accessor));
 
         let mut root = PathBuf::from("/");
@@ -333,9 +334,10 @@ impl FragmentWriterParams {
         if !normalized.is_empty() {
             root.push(normalized);
         }
-        let base_url = Url::from_directory_path(root).map_err(|_| {
-            ErrorCode::Internal("invalid base url for lance object store".to_string())
+        let mut base_url = Url::parse(&format!("{scheme}:///")).map_err(|err| {
+            ErrorCode::Internal(format!("invalid lance object store scheme '{scheme}': {err}"))
         })?;
+        base_url.set_path(root.to_string_lossy().as_ref());
 
         #[allow(deprecated)]
         let store_params = ObjectStoreParams {
@@ -696,6 +698,11 @@ mod tests {
 
     use arrow_array::StringViewArray;
     use arrow_schema::Field;
+    use lance_io::object_store::ObjectStore as LanceObjectStore;
+    use lance_io::object_store::ObjectStoreRegistry;
+    use object_store::path::Path;
+    use opendal::Operator;
+    use opendal::services::Memory;
 
     use super::*;
 
@@ -748,5 +755,29 @@ mod tests {
         assert!(strings.is_null(1));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_build_store_params_preserves_accessor_scheme() {
+        let accessor = Operator::new(Memory::default()).unwrap().finish();
+        let params = FragmentWriterParams::build_store_params(accessor, "tmp").unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let (store, base_path) = runtime
+            .block_on(async {
+                LanceObjectStore::from_uri_and_params(
+                    Arc::new(ObjectStoreRegistry::default()),
+                    "tmp",
+                    &params,
+                )
+                .await
+            })
+            .unwrap();
+
+        assert!(!store.is_local());
+        assert_eq!(base_path, Path::parse("/tmp").unwrap());
     }
 }

--- a/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
+++ b/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
@@ -335,7 +335,9 @@ impl FragmentWriterParams {
             root.push(normalized);
         }
         let mut base_url = Url::parse(&format!("{scheme}:///")).map_err(|err| {
-            ErrorCode::Internal(format!("invalid lance object store scheme '{scheme}': {err}"))
+            ErrorCode::Internal(format!(
+                "invalid lance object store scheme '{scheme}': {err}"
+            ))
         })?;
         base_url.set_path(root.to_string_lossy().as_ref());
 

--- a/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
+++ b/src/query/storages/stage/src/append/lance_dataset/writer_processor.rs
@@ -97,7 +97,11 @@ pub(crate) fn lance_compatible_arrow_schema(schema: &ArrowSchema) -> ArrowSchema
                     .iter()
                     .map(|(i, field)| (i, visit_field(field)))
                     .unzip();
-                ArrowDataType::Union(arrow_schema::UnionFields::new(ids, fields), *mode)
+                ArrowDataType::Union(
+                    arrow_schema::UnionFields::try_new(ids, fields)
+                        .expect("existing union fields should remain valid"),
+                    *mode,
+                )
             }
             ArrowDataType::Dictionary(key, value) => {
                 ArrowDataType::Dictionary(Box::new(visit_type(key)), Box::new(visit_type(value)))

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -93,7 +93,7 @@ fn create_writer(
         .set_writer_version(WriterVersion::PARQUET_2_0)
         .set_compression(compression)
         .set_created_by(create_by)
-        .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
+        .set_max_row_group_row_count(Some(MAX_ROW_GROUP_SIZE))
         .set_statistics_enabled(EnabledStatistics::Chunk)
         .set_dictionary_enabled(true)
         .set_bloom_filter_enabled(false);

--- a/src/query/storages/vortex/Cargo.toml
+++ b/src/query/storages/vortex/Cargo.toml
@@ -7,9 +7,10 @@ publish = { workspace = true }
 edition = { workspace = true }
 
 # This crate bridges Databend's Fuse storage engine with the Vortex columnar file
-# format. Arrow 58 is now the workspace-wide version so we use workspace deps
-# directly. object_store is pinned to 0.13 (required by vortex-io) which differs
-# from the 0.12 used elsewhere; object_store_opendal 0.56 bridges the two.
+# format. Arrow 58 is the workspace-wide version so we use workspace deps directly.
+#
+# IO bridge: we implement VortexReadAt directly on top of opendal::Operator,
+# bypassing the object_store version conflict (workspace uses 0.12, vortex needs 0.13).
 
 [dependencies]
 databend-common-exception = { workspace = true }
@@ -21,17 +22,14 @@ arrow-ipc = { workspace = true }
 arrow-select = { workspace = true }
 
 # Vortex 0.70 — pinned, file format is stable from 0.36+
+# No object_store feature — we implement VortexReadAt directly via opendal
 vortex-array = { version = "=0.70.0", features = ["serde"] }
 vortex-file = { version = "=0.70.0", features = ["tokio"] }
-vortex-io = { version = "=0.70.0", features = ["object_store", "tokio"] }
+vortex-io = { version = "=0.70.0", features = ["tokio"] }
 vortex-session = { version = "=0.70.0" }
-vortex-compressor = { version = "=0.70.0" }
 vortex-error = { version = "=0.70.0" }
+vortex-buffer = { version = "=0.70.0" }
 
-# object_store 0.13 required by vortex-io (workspace uses 0.12)
-# object_store_opendal 0.56 wraps opendal::Operator as an ObjectStore
-object_store = "0.13"
-object_store_opendal = "0.56"
 opendal = { workspace = true }
 
 futures = { workspace = true }

--- a/src/query/storages/vortex/Cargo.toml
+++ b/src/query/storages/vortex/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "databend-storages-vortex"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+edition = { workspace = true }
+
+# This crate bridges Databend's Fuse storage engine with the Vortex columnar file
+# format. Arrow 58 is now the workspace-wide version so we use workspace deps
+# directly. object_store is pinned to 0.13 (required by vortex-io) which differs
+# from the 0.12 used elsewhere; object_store_opendal 0.56 bridges the two.
+
+[dependencies]
+databend-common-exception = { workspace = true }
+
+# Arrow — use workspace version (58.1.0)
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+arrow-ipc = { workspace = true }
+arrow-select = { workspace = true }
+
+# Vortex 0.70 — pinned, file format is stable from 0.36+
+vortex-array = { version = "=0.70.0", features = ["serde"] }
+vortex-file = { version = "=0.70.0", features = ["tokio"] }
+vortex-io = { version = "=0.70.0", features = ["object_store", "tokio"] }
+vortex-session = { version = "=0.70.0" }
+vortex-compressor = { version = "=0.70.0" }
+vortex-error = { version = "=0.70.0" }
+
+# object_store 0.13 required by vortex-io (workspace uses 0.12)
+# object_store_opendal 0.56 wraps opendal::Operator as an ObjectStore
+object_store = "0.13"
+object_store_opendal = "0.56"
+opendal = { workspace = true }
+
+futures = { workspace = true }
+tokio = { workspace = true }
+bytes = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/query/storages/vortex/src/error.rs
+++ b/src/query/storages/vortex/src/error.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use arrow_schema::ArrowError;
 use databend_common_exception::ErrorCode;
 use vortex_error::VortexError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum VortexStorageError {
     #[error("Arrow IPC error: {0}")]
-    ArrowIpc(String),
+    ArrowIpc(#[from] ArrowError),
 
     #[error("Vortex error: {0}")]
     Vortex(#[from] VortexError),
@@ -26,23 +27,8 @@ pub enum VortexStorageError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("Object store error: {0}")]
-    ObjectStore(#[from] object_store::Error),
-
     #[error("{0}")]
     Other(String),
-}
-
-impl From<arrow_ipc::reader::ArrowError> for VortexStorageError {
-    fn from(e: arrow_ipc::reader::ArrowError) -> Self {
-        VortexStorageError::ArrowIpc(e.to_string())
-    }
-}
-
-impl From<arrow_ipc::writer::ArrowError> for VortexStorageError {
-    fn from(e: arrow_ipc::writer::ArrowError) -> Self {
-        VortexStorageError::ArrowIpc(e.to_string())
-    }
 }
 
 impl From<VortexStorageError> for ErrorCode {

--- a/src/query/storages/vortex/src/error.rs
+++ b/src/query/storages/vortex/src/error.rs
@@ -1,0 +1,59 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::ErrorCode;
+use vortex_error::VortexError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum VortexStorageError {
+    #[error("Arrow IPC error: {0}")]
+    ArrowIpc(String),
+
+    #[error("Vortex error: {0}")]
+    Vortex(#[from] VortexError),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Object store error: {0}")]
+    ObjectStore(#[from] object_store::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<arrow_ipc::reader::ArrowError> for VortexStorageError {
+    fn from(e: arrow_ipc::reader::ArrowError) -> Self {
+        VortexStorageError::ArrowIpc(e.to_string())
+    }
+}
+
+impl From<arrow_ipc::writer::ArrowError> for VortexStorageError {
+    fn from(e: arrow_ipc::writer::ArrowError) -> Self {
+        VortexStorageError::ArrowIpc(e.to_string())
+    }
+}
+
+impl From<VortexStorageError> for ErrorCode {
+    fn from(e: VortexStorageError) -> Self {
+        ErrorCode::StorageOther(e.to_string())
+    }
+}
+
+pub type VortexResult<T> = std::result::Result<T, VortexStorageError>;
+
+/// Convert a VortexResult into a Databend Result.
+pub fn into_databend_result<T>(r: VortexResult<T>) -> databend_common_exception::Result<T> {
+    r.map_err(ErrorCode::from)
+}

--- a/src/query/storages/vortex/src/io.rs
+++ b/src/query/storages/vortex/src/io.rs
@@ -1,0 +1,50 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! IO bridge: opendal::Operator → object_store::ObjectStore → VortexReadAt
+//!
+//! object_store_opendal provides OpendalStore which implements ObjectStore on top of
+//! opendal::Operator. vortex-io's ObjectStoreReadAt then wraps that into VortexReadAt.
+//! This gives us a zero-copy path from Databend's opendal-based storage to Vortex's IO layer.
+
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use object_store::path::Path as ObjectPath;
+use object_store_opendal::OpendalStore;
+use opendal::Operator;
+use vortex_io::object_store::ObjectStoreReadAt;
+use vortex_io::runtime::Handle;
+
+/// Build a VortexReadAt from a Databend opendal Operator and a file path.
+///
+/// The chain is:
+///   opendal::Operator
+///     → object_store_opendal::OpendalStore (implements ObjectStore)
+///       → vortex_io::ObjectStoreReadAt (implements VortexReadAt)
+pub fn make_vortex_reader(
+    operator: Operator,
+    path: &str,
+    handle: Handle,
+) -> ObjectStoreReadAt {
+    let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
+    let object_path = ObjectPath::from(path);
+    ObjectStoreReadAt::new(store, object_path, handle)
+}
+
+/// Build a VortexWrite sink backed by an in-memory Vec<u8>.
+/// The caller is responsible for extracting the bytes after writing.
+pub fn make_memory_writer() -> Vec<u8> {
+    Vec::new()
+}

--- a/src/query/storages/vortex/src/io.rs
+++ b/src/query/storages/vortex/src/io.rs
@@ -12,35 +12,78 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! IO bridge: opendal::Operator → object_store::ObjectStore → VortexReadAt
+//! IO bridge: opendal::Operator → VortexReadAt
 //!
-//! object_store_opendal provides OpendalStore which implements ObjectStore on top of
-//! opendal::Operator. vortex-io's ObjectStoreReadAt then wraps that into VortexReadAt.
-//! This gives us a zero-copy path from Databend's opendal-based storage to Vortex's IO layer.
+//! We implement VortexReadAt directly on top of opendal::Operator, bypassing
+//! the object_store version conflict (workspace uses 0.12, vortex-io needs 0.13).
 
 use std::sync::Arc;
 
-use object_store::ObjectStore;
-use object_store::path::Path as ObjectPath;
-use object_store_opendal::OpendalStore;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use opendal::Operator;
-use vortex_io::object_store::ObjectStoreReadAt;
-use vortex_io::runtime::Handle;
+use vortex_array::buffer::BufferHandle;
+use vortex_buffer::Alignment;
+use vortex_buffer::ByteBuffer;
+use vortex_error::VortexResult;
 
-/// Build a VortexReadAt from a Databend opendal Operator and a file path.
-///
-/// The chain is:
-///   opendal::Operator
-///     → object_store_opendal::OpendalStore (implements ObjectStore)
-///       → vortex_io::ObjectStoreReadAt (implements VortexReadAt)
-pub fn make_vortex_reader(operator: Operator, path: &str, handle: Handle) -> ObjectStoreReadAt {
-    let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
-    let object_path = ObjectPath::from(path);
-    ObjectStoreReadAt::new(store, object_path, handle)
+use vortex_io::VortexReadAt;
+
+/// Wraps an opendal Operator as a VortexReadAt source.
+#[derive(Clone)]
+pub struct OpendalVortexReader {
+    operator: Operator,
+    path: Arc<String>,
 }
 
-/// Build a VortexWrite sink backed by an in-memory Vec<u8>.
-/// The caller is responsible for extracting the bytes after writing.
-pub fn make_memory_writer() -> Vec<u8> {
-    Vec::new()
+impl OpendalVortexReader {
+    pub fn new(operator: Operator, path: impl Into<String>) -> Self {
+        Self {
+            operator,
+            path: Arc::new(path.into()),
+        }
+    }
+}
+
+impl VortexReadAt for OpendalVortexReader {
+    fn read_at(
+        &self,
+        offset: u64,
+        length: usize,
+        _alignment: Alignment,
+    ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+        let operator = self.operator.clone();
+        let path = self.path.clone();
+
+        async move {
+            let end = offset + length as u64;
+            let buf = operator
+                .read_with(&*path)
+                .range(offset..end)
+                .await
+                .map_err(|e| vortex_error::vortex_err!("opendal read_at error: {e}"))?;
+
+            let byte_buf = ByteBuffer::from(buf.to_bytes());
+            Ok(BufferHandle::new_host(byte_buf))
+        }
+        .boxed()
+    }
+
+    fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
+        let operator = self.operator.clone();
+        let path = self.path.clone();
+
+        async move {
+            let meta = operator
+                .stat(&*path)
+                .await
+                .map_err(|e| vortex_error::vortex_err!("opendal stat error: {e}"))?;
+            Ok(meta.content_length())
+        }
+        .boxed()
+    }
+
+    fn concurrency(&self) -> usize {
+        64
+    }
 }

--- a/src/query/storages/vortex/src/io.rs
+++ b/src/query/storages/vortex/src/io.rs
@@ -33,11 +33,7 @@ use vortex_io::runtime::Handle;
 ///   opendal::Operator
 ///     → object_store_opendal::OpendalStore (implements ObjectStore)
 ///       → vortex_io::ObjectStoreReadAt (implements VortexReadAt)
-pub fn make_vortex_reader(
-    operator: Operator,
-    path: &str,
-    handle: Handle,
-) -> ObjectStoreReadAt {
+pub fn make_vortex_reader(operator: Operator, path: &str, handle: Handle) -> ObjectStoreReadAt {
     let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
     let object_path = ObjectPath::from(path);
     ObjectStoreReadAt::new(store, object_path, handle)

--- a/src/query/storages/vortex/src/lib.rs
+++ b/src/query/storages/vortex/src/lib.rs
@@ -1,0 +1,42 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Vortex storage format integration for Databend Fuse engine.
+//!
+//! This crate bridges Databend's storage layer with the Vortex columnar file format.
+//! It intentionally uses arrow 58 (required by vortex) which differs from the arrow 56
+//! used by the rest of Databend. The public interface is purely byte-based so both
+//! arrow versions can coexist in the same workspace without type conflicts.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Databend (arrow 56)          │  This crate (arrow 58 + vortex)
+//!                              │
+//! DataBlock ──IPC bytes──────► │ ──► RecordBatch(58) ──► VortexArray ──► .vortex file
+//!                              │
+//! DataBlock ◄──IPC bytes────── │ ◄── RecordBatch(58) ◄── VortexArray ◄── .vortex file
+//! ```
+//!
+//! The IPC byte stream is the stable binary protocol shared between arrow 56 and 58.
+
+mod error;
+mod io;
+mod reader;
+mod schema;
+mod writer;
+
+pub use error::VortexStorageError;
+pub use reader::read_vortex_file;
+pub use writer::write_vortex_file;

--- a/src/query/storages/vortex/src/lib.rs
+++ b/src/query/storages/vortex/src/lib.rs
@@ -14,22 +14,33 @@
 
 //! Vortex storage format integration for Databend Fuse engine.
 //!
-//! This crate bridges Databend's storage layer with the Vortex columnar file format.
-//! It intentionally uses arrow 58 (required by vortex) which differs from the arrow 56
-//! used by the rest of Databend. The public interface is purely byte-based so both
-//! arrow versions can coexist in the same workspace without type conflicts.
+//! This crate bridges Databend's Fuse storage engine with the Vortex columnar
+//! file format (https://github.com/vortex-data/vortex).
 //!
 //! # Architecture
 //!
 //! ```text
-//! Databend (arrow 56)          │  This crate (arrow 58 + vortex)
-//!                              │
-//! DataBlock ──IPC bytes──────► │ ──► RecordBatch(58) ──► VortexArray ──► .vortex file
-//!                              │
-//! DataBlock ◄──IPC bytes────── │ ◄── RecordBatch(58) ◄── VortexArray ◄── .vortex file
+//! Databend Fuse                    databend-storages-vortex
+//!
+//! DataBlock ──to_record_batch()──► RecordBatch
+//!           ──Arrow IPC bytes───► ──► VortexArray ──► .vortex file (object storage)
+//!
+//! DataBlock ◄──from_record_batch() ◄── RecordBatch
+//!           ◄──Arrow IPC bytes──── ◄── VortexArray ◄── .vortex file (object storage)
 //! ```
 //!
-//! The IPC byte stream is the stable binary protocol shared between arrow 56 and 58.
+//! # IO
+//!
+//! The IO bridge is implemented directly on top of `opendal::Operator` via
+//! `OpendalVortexReader` (implements `VortexReadAt`), bypassing the
+//! `object_store` version conflict between the workspace (0.12) and vortex-io (0.13).
+//!
+//! # Statistics
+//!
+//! Column statistics (min/max/null_count) are stored externally in Fuse's
+//! `BlockMeta.col_stats` — NOT inside the Vortex file. The Vortex file is a
+//! pure data container. This keeps the pruning logic entirely in Fuse's
+//! existing metadata layer.
 
 mod error;
 mod io;

--- a/src/query/storages/vortex/src/reader.rs
+++ b/src/query/storages/vortex/src/reader.rs
@@ -14,12 +14,10 @@
 
 //! Read a Vortex file and return Arrow IPC bytes.
 //!
-//! The caller passes an opendal Operator and a path. We open the Vortex file via
-//! object_store_opendal, scan the requested columns, convert to RecordBatches,
-//! serialize to Arrow IPC bytes, and return those bytes to the caller.
-//!
-//! Statistics-based pruning is handled entirely by Fuse's BlockMeta — we never
-//! read per-column statistics from the Vortex file itself.
+//! The caller (Databend fuse, using arrow 56) passes an opendal Operator and a path.
+//! We open the Vortex file via object_store_opendal, scan the requested columns,
+//! convert to RecordBatches (arrow 58), serialize to Arrow IPC bytes, and return
+//! those bytes to the caller. The caller then deserializes with arrow 56.
 
 use std::sync::Arc;
 
@@ -28,11 +26,9 @@ use futures::TryStreamExt;
 use object_store::ObjectStore;
 use object_store_opendal::OpendalStore;
 use opendal::Operator;
-use vortex_array::ExecutionCtx;
-use vortex_array::arrow::ArrowArrayExecutor;
+use vortex_array::arrow::IntoArrowArray;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_file::OpenOptionsSessionExt;
-use vortex_file::VortexOpenOptions;
 use vortex_file::register_default_encodings;
 use vortex_session::VortexSession;
 
@@ -45,10 +41,10 @@ use crate::schema::record_batches_to_ipc_bytes;
 /// # Arguments
 /// * `operator`       - Databend opendal Operator for the storage backend.
 /// * `path`           - Path to the `.vortex` file within the operator's namespace.
-/// * `projected_cols` - Optional column indices (0-based) to project. `None` reads all columns.
+/// * `projected_cols` - Optional list of column indices to project. `None` reads all columns.
 ///
 /// # Returns
-/// Arrow IPC stream bytes, readable by Databend's arrow IPC reader.
+/// Arrow IPC stream bytes (arrow 58 format, readable by arrow 56 on the Databend side).
 pub async fn read_vortex_file(
     operator: Operator,
     path: &str,
@@ -61,17 +57,20 @@ pub async fn read_vortex_file(
     // 2. Wrap opendal Operator as an object_store ObjectStore
     let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
 
-    // 3. Open the Vortex file via object_store integration.
-    //    open_object_store reads only the footer (O(1) IO), not the data.
-    let vortex_file = VortexOpenOptions::new(session.clone())
+    // 3. Open the Vortex file via object_store (reads only the footer — O(1) IO)
+    let vortex_file = session
+        .open_options()
         .open_object_store(&store, path)
         .await
         .map_err(VortexStorageError::Vortex)?;
 
-    // 4. Build the scan with optional column projection
-    let mut scan_builder = vortex_file.scan();
-    if let Some(indices) = projected_cols {
-        scan_builder = scan_builder.with_indices(indices);
+    // 4. Build the scan, optionally applying column projection
+    let mut scan_builder = vortex_file
+        .scan()
+        .map_err(VortexStorageError::Vortex)?;
+
+    if let Some(cols) = projected_cols {
+        scan_builder = scan_builder.with_indices(cols);
     }
 
     // 5. Execute the scan → stream of Vortex arrays
@@ -80,32 +79,22 @@ pub async fn read_vortex_file(
         .await
         .map_err(VortexStorageError::Vortex)?;
 
-    // 6. Derive the Arrow schema from the Vortex DType
-    let dtype = array_stream.dtype().clone();
-    let arrow_schema = dtype
-        .to_arrow_schema()
-        .map_err(VortexStorageError::Vortex)?;
-
-    // 7. Collect all arrays from the stream
-    let arrays: Vec<_> = array_stream
+    // 6. Convert each Vortex array chunk → RecordBatch (arrow 58)
+    let batches: Vec<RecordBatch> = array_stream
         .map_err(VortexStorageError::Vortex)
+        .and_then(|array| async move {
+            array
+                .into_arrow_record_batch()
+                .map_err(VortexStorageError::Vortex)
+        })
         .try_collect()
         .await?;
 
-    if arrays.is_empty() {
+    if batches.is_empty() {
         return Ok(Vec::new());
     }
 
-    // 8. Convert each Vortex array → RecordBatch via ArrowArrayExecutor
-    let mut ctx = ExecutionCtx::new(session);
-    let mut batches: Vec<RecordBatch> = Vec::with_capacity(arrays.len());
-    for array in arrays {
-        let batch = array
-            .execute_record_batch(&arrow_schema, &mut ctx)
-            .map_err(VortexStorageError::Vortex)?;
-        batches.push(batch);
-    }
-
-    // 9. Serialize RecordBatches → Arrow IPC bytes
-    record_batches_to_ipc_bytes(&arrow_schema, &batches)
+    // 7. Serialize RecordBatches → Arrow IPC bytes (readable by arrow 56)
+    let schema = batches[0].schema();
+    record_batches_to_ipc_bytes(&schema, &batches)
 }

--- a/src/query/storages/vortex/src/reader.rs
+++ b/src/query/storages/vortex/src/reader.rs
@@ -13,107 +13,98 @@
 // limitations under the License.
 
 //! Read a Vortex file and return Arrow IPC bytes.
-//!
-//! The caller (Databend fuse, using arrow 56) passes an opendal Operator and a path.
-//! We open the Vortex file via object_store_opendal, scan the requested columns,
-//! convert to RecordBatches (arrow 58), serialize to Arrow IPC bytes, and return
-//! those bytes to the caller. The caller then deserializes with arrow 56.
 
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
-use arrow_array::cast::AsArray;
 use futures::TryStreamExt;
-use object_store::ObjectStore;
-use object_store_opendal::OpendalStore;
 use opendal::Operator;
 use vortex_array::ArrayRef;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
-use vortex_array::dtype::Field;
-use vortex_array::expr::Expression;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrow::ArrowArrayExecutor;
+use vortex_array::expr::root;
 use vortex_array::expr::select;
-use vortex_array::stream::ArrayStreamExt;
+use vortex_array::stream::ArrayStream;
 use vortex_file::OpenOptionsSessionExt;
 use vortex_file::register_default_encodings;
 use vortex_session::VortexSession;
 
 use crate::error::VortexResult;
 use crate::error::VortexStorageError;
+use crate::io::OpendalVortexReader;
 use crate::schema::record_batches_to_ipc_bytes;
 
 /// Read a Vortex file and return Arrow IPC stream bytes.
 ///
 /// # Arguments
-/// * `operator`       - Databend opendal Operator for the storage backend.
-/// * `path`           - Path to the `.vortex` file within the operator's namespace.
-/// * `projected_cols` - Optional list of column names to project. `None` reads all columns.
-///
-/// # Returns
-/// Arrow IPC stream bytes (arrow 58 format, readable by arrow 56 on the Databend side).
+/// * `operator`        - Databend opendal Operator for the storage backend.
+/// * `path`            - Path to the `.vortex` file.
+/// * `projected_names` - Optional column names to project. `None` reads all columns.
 pub async fn read_vortex_file(
     operator: Operator,
     path: &str,
-    projected_cols: Option<Vec<String>>,
+    projected_names: Option<Vec<String>>,
 ) -> VortexResult<Vec<u8>> {
-    // 1. Build a VortexSession with default encodings
+    // 1. Build session with default encodings
     let session = VortexSession::empty();
     register_default_encodings(&session);
 
-    // 2. Wrap opendal Operator as an object_store ObjectStore
-    let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
+    // 2. Build VortexReadAt from opendal Operator
+    let reader = Arc::new(OpendalVortexReader::new(operator, path));
 
-    // 3. Open the Vortex file via object_store (reads only the footer — O(1) IO)
+    // 3. Open the Vortex file (reads only the footer — O(1) IO)
     let vortex_file = session
         .open_options()
-        .open_object_store(&store, path)
+        .open(reader)
         .await
         .map_err(VortexStorageError::Vortex)?;
 
-    // 4. Build the scan with optional column projection
-    let mut scan_builder = vortex_file.scan().map_err(VortexStorageError::Vortex)?;
+    // 4. Build scan with optional column projection via select() expression
+    let scan_builder = vortex_file
+        .scan()
+        .map_err(VortexStorageError::Vortex)?;
 
-    if let Some(cols) = projected_cols {
-        let projection = build_projection_expr(&cols);
-        scan_builder = scan_builder.with_projection(projection);
-    }
+    let scan_builder = if let Some(names) = projected_names {
+        // select(field_names, root()) projects the named columns
+        let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        scan_builder.with_projection(select(name_refs, root()))
+    } else {
+        scan_builder
+    };
 
     // 5. Execute the scan → ArrayStream
     let array_stream = scan_builder
         .into_array_stream()
         .map_err(VortexStorageError::Vortex)?;
 
-    // 6. Convert each Vortex array chunk → RecordBatch (arrow 58).
-    // We use execute_arrow(None, ctx) which picks the preferred Arrow representation
-    // for each column, then wrap the resulting StructArray as a RecordBatch.
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let batches: Vec<RecordBatch> = array_stream
+    // 6. Derive Arrow schema from Vortex DType
+    let dtype = array_stream.dtype().clone();
+    let arrow_schema = Arc::new(
+        dtype
+            .to_arrow_schema()
+            .map_err(VortexStorageError::Vortex)?,
+    );
+
+    // 7. Collect all arrays
+    let arrays: Vec<ArrayRef> = array_stream
         .map_err(VortexStorageError::Vortex)
-        .and_then(|array: ArrayRef| {
-            // execute_arrow with None picks the preferred (cheapest) Arrow type per column.
-            let result = array
-                .execute_arrow(None, &mut ctx)
-                .map_err(VortexStorageError::Vortex)
-                .map(|arrow_array| RecordBatch::from(arrow_array.as_struct()));
-            async move { result }
-        })
         .try_collect()
         .await?;
 
-    if batches.is_empty() {
+    if arrays.is_empty() {
         return Ok(Vec::new());
     }
 
-    // 7. Serialize RecordBatches → Arrow IPC bytes (readable by arrow 56)
-    let schema = batches[0].schema();
-    record_batches_to_ipc_bytes(&schema, &batches)
-}
+    // 8. Convert Vortex arrays → RecordBatches
+    let mut ctx = ExecutionCtx::new(session);
+    let mut batches: Vec<RecordBatch> = Vec::with_capacity(arrays.len());
+    for array in arrays {
+        let batch: RecordBatch = array
+            .execute_record_batch(&arrow_schema, &mut ctx)
+            .map_err(VortexStorageError::Vortex)?;
+        batches.push(batch);
+    }
 
-/// Build a Vortex projection expression from a list of column names.
-fn build_projection_expr(cols: &[String]) -> Expression {
-    let fields: Vec<Field> = cols
-        .iter()
-        .map(|name| Field::Name(name.as_str().into()))
-        .collect();
-    select(fields)
+    // 9. Serialize to Arrow IPC bytes
+    record_batches_to_ipc_bytes(&arrow_schema, &batches)
 }

--- a/src/query/storages/vortex/src/reader.rs
+++ b/src/query/storages/vortex/src/reader.rs
@@ -22,11 +22,14 @@ use opendal::Operator;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::arrow::ArrowArrayExecutor;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::StructFields;
 use vortex_array::expr::root;
 use vortex_array::expr::select;
-use vortex_array::stream::ArrayStream;
 use vortex_file::OpenOptionsSessionExt;
 use vortex_file::register_default_encodings;
+use vortex_io::session::RuntimeSessionExt;
 use vortex_session::VortexSession;
 
 use crate::error::VortexResult;
@@ -45,8 +48,11 @@ pub async fn read_vortex_file(
     path: &str,
     projected_names: Option<Vec<String>>,
 ) -> VortexResult<Vec<u8>> {
-    // 1. Build session with default encodings
-    let session = VortexSession::empty();
+    // 1. Build session with default encodings and Tokio runtime handle.
+    //    with_tokio() registers TokioRuntime::current() so that ScanBuilder's
+    //    spawn_blocking calls are driven by the ambient Tokio multi-thread runtime
+    //    rather than an undriven smol executor.
+    let session = VortexSession::empty().with_tokio();
     register_default_encodings(&session);
 
     // 2. Build VortexReadAt from opendal Operator
@@ -59,7 +65,38 @@ pub async fn read_vortex_file(
         .await
         .map_err(VortexStorageError::Vortex)?;
 
-    // 4. Build scan with optional column projection via select() expression
+    // 4. Derive Arrow schema from the file's original DType (written at ingest time).
+    //    We must NOT use array_stream.dtype() because Vortex compression can change
+    //    the physical dtype (e.g. bool → constant/bitpacked int).  The file footer
+    //    always preserves the logical schema.
+    let arrow_schema = Arc::new({
+        let file_dtype = match &projected_names {
+            Some(names) => {
+                // Build a projected dtype that only includes the requested fields.
+                let fields = vortex_file
+                    .dtype()
+                    .as_struct_fields_opt()
+                    .ok_or_else(|| {
+                        VortexStorageError::Other(
+                            "Vortex file dtype is not a struct".into(),
+                        )
+                    })?;
+                // project() takes a &[FieldName] where FieldName wraps Arc<str>
+                let field_names: Vec<vortex_array::dtype::FieldName> =
+                    names.iter().map(|n| vortex_array::dtype::FieldName::from(n.as_str())).collect();
+                let projected = fields
+                    .project(field_names.as_slice())
+                    .map_err(VortexStorageError::Vortex)?;
+                DType::Struct(projected, Nullability::NonNullable)
+            }
+            None => vortex_file.dtype().clone(),
+        };
+        file_dtype
+            .to_arrow_schema()
+            .map_err(VortexStorageError::Vortex)?
+    });
+
+    // 5. Build scan with optional column projection via select() expression
     let scan_builder = vortex_file
         .scan()
         .map_err(VortexStorageError::Vortex)?;
@@ -72,18 +109,10 @@ pub async fn read_vortex_file(
         scan_builder
     };
 
-    // 5. Execute the scan → ArrayStream
+    // 6. Execute the scan → ArrayStream
     let array_stream = scan_builder
         .into_array_stream()
         .map_err(VortexStorageError::Vortex)?;
-
-    // 6. Derive Arrow schema from Vortex DType
-    let dtype = array_stream.dtype().clone();
-    let arrow_schema = Arc::new(
-        dtype
-            .to_arrow_schema()
-            .map_err(VortexStorageError::Vortex)?,
-    );
 
     // 7. Collect all arrays
     let arrays: Vec<ArrayRef> = array_stream
@@ -95,7 +124,9 @@ pub async fn read_vortex_file(
         return Ok(Vec::new());
     }
 
-    // 8. Convert Vortex arrays → RecordBatches
+    // 8. Convert Vortex arrays → RecordBatches using the logical Arrow schema.
+    //    execute_record_batch casts the physical (compressed) representation back
+    //    to the logical Arrow types declared in arrow_schema.
     let mut ctx = ExecutionCtx::new(session);
     let mut batches: Vec<RecordBatch> = Vec::with_capacity(arrays.len());
     for array in arrays {

--- a/src/query/storages/vortex/src/reader.rs
+++ b/src/query/storages/vortex/src/reader.rs
@@ -1,0 +1,111 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read a Vortex file and return Arrow IPC bytes.
+//!
+//! The caller passes an opendal Operator and a path. We open the Vortex file via
+//! object_store_opendal, scan the requested columns, convert to RecordBatches,
+//! serialize to Arrow IPC bytes, and return those bytes to the caller.
+//!
+//! Statistics-based pruning is handled entirely by Fuse's BlockMeta — we never
+//! read per-column statistics from the Vortex file itself.
+
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use futures::TryStreamExt;
+use object_store::ObjectStore;
+use object_store_opendal::OpendalStore;
+use opendal::Operator;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrow::ArrowArrayExecutor;
+use vortex_array::stream::ArrayStreamExt;
+use vortex_file::OpenOptionsSessionExt;
+use vortex_file::VortexOpenOptions;
+use vortex_file::register_default_encodings;
+use vortex_session::VortexSession;
+
+use crate::error::VortexResult;
+use crate::error::VortexStorageError;
+use crate::schema::record_batches_to_ipc_bytes;
+
+/// Read a Vortex file and return Arrow IPC stream bytes.
+///
+/// # Arguments
+/// * `operator`       - Databend opendal Operator for the storage backend.
+/// * `path`           - Path to the `.vortex` file within the operator's namespace.
+/// * `projected_cols` - Optional column indices (0-based) to project. `None` reads all columns.
+///
+/// # Returns
+/// Arrow IPC stream bytes, readable by Databend's arrow IPC reader.
+pub async fn read_vortex_file(
+    operator: Operator,
+    path: &str,
+    projected_cols: Option<Vec<usize>>,
+) -> VortexResult<Vec<u8>> {
+    // 1. Build a VortexSession with default encodings
+    let session = VortexSession::empty();
+    register_default_encodings(&session);
+
+    // 2. Wrap opendal Operator as an object_store ObjectStore
+    let store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(operator));
+
+    // 3. Open the Vortex file via object_store integration.
+    //    open_object_store reads only the footer (O(1) IO), not the data.
+    let vortex_file = VortexOpenOptions::new(session.clone())
+        .open_object_store(&store, path)
+        .await
+        .map_err(VortexStorageError::Vortex)?;
+
+    // 4. Build the scan with optional column projection
+    let mut scan_builder = vortex_file.scan();
+    if let Some(indices) = projected_cols {
+        scan_builder = scan_builder.with_indices(indices);
+    }
+
+    // 5. Execute the scan → stream of Vortex arrays
+    let array_stream = scan_builder
+        .execute()
+        .await
+        .map_err(VortexStorageError::Vortex)?;
+
+    // 6. Derive the Arrow schema from the Vortex DType
+    let dtype = array_stream.dtype().clone();
+    let arrow_schema = dtype
+        .to_arrow_schema()
+        .map_err(VortexStorageError::Vortex)?;
+
+    // 7. Collect all arrays from the stream
+    let arrays: Vec<_> = array_stream
+        .map_err(VortexStorageError::Vortex)
+        .try_collect()
+        .await?;
+
+    if arrays.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 8. Convert each Vortex array → RecordBatch via ArrowArrayExecutor
+    let mut ctx = ExecutionCtx::new(session);
+    let mut batches: Vec<RecordBatch> = Vec::with_capacity(arrays.len());
+    for array in arrays {
+        let batch = array
+            .execute_record_batch(&arrow_schema, &mut ctx)
+            .map_err(VortexStorageError::Vortex)?;
+        batches.push(batch);
+    }
+
+    // 9. Serialize RecordBatches → Arrow IPC bytes
+    record_batches_to_ipc_bytes(&arrow_schema, &batches)
+}

--- a/src/query/storages/vortex/src/reader.rs
+++ b/src/query/storages/vortex/src/reader.rs
@@ -22,11 +22,17 @@
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
+use arrow_array::cast::AsArray;
 use futures::TryStreamExt;
 use object_store::ObjectStore;
 use object_store_opendal::OpendalStore;
 use opendal::Operator;
-use vortex_array::arrow::IntoArrowArray;
+use vortex_array::ArrayRef;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::dtype::Field;
+use vortex_array::expr::Expression;
+use vortex_array::expr::select;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_file::OpenOptionsSessionExt;
 use vortex_file::register_default_encodings;
@@ -41,14 +47,14 @@ use crate::schema::record_batches_to_ipc_bytes;
 /// # Arguments
 /// * `operator`       - Databend opendal Operator for the storage backend.
 /// * `path`           - Path to the `.vortex` file within the operator's namespace.
-/// * `projected_cols` - Optional list of column indices to project. `None` reads all columns.
+/// * `projected_cols` - Optional list of column names to project. `None` reads all columns.
 ///
 /// # Returns
 /// Arrow IPC stream bytes (arrow 58 format, readable by arrow 56 on the Databend side).
 pub async fn read_vortex_file(
     operator: Operator,
     path: &str,
-    projected_cols: Option<Vec<usize>>,
+    projected_cols: Option<Vec<String>>,
 ) -> VortexResult<Vec<u8>> {
     // 1. Build a VortexSession with default encodings
     let session = VortexSession::empty();
@@ -64,28 +70,32 @@ pub async fn read_vortex_file(
         .await
         .map_err(VortexStorageError::Vortex)?;
 
-    // 4. Build the scan, optionally applying column projection
-    let mut scan_builder = vortex_file
-        .scan()
-        .map_err(VortexStorageError::Vortex)?;
+    // 4. Build the scan with optional column projection
+    let mut scan_builder = vortex_file.scan().map_err(VortexStorageError::Vortex)?;
 
     if let Some(cols) = projected_cols {
-        scan_builder = scan_builder.with_indices(cols);
+        let projection = build_projection_expr(&cols);
+        scan_builder = scan_builder.with_projection(projection);
     }
 
-    // 5. Execute the scan → stream of Vortex arrays
+    // 5. Execute the scan → ArrayStream
     let array_stream = scan_builder
-        .execute()
-        .await
+        .into_array_stream()
         .map_err(VortexStorageError::Vortex)?;
 
-    // 6. Convert each Vortex array chunk → RecordBatch (arrow 58)
+    // 6. Convert each Vortex array chunk → RecordBatch (arrow 58).
+    // We use execute_arrow(None, ctx) which picks the preferred Arrow representation
+    // for each column, then wrap the resulting StructArray as a RecordBatch.
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let batches: Vec<RecordBatch> = array_stream
         .map_err(VortexStorageError::Vortex)
-        .and_then(|array| async move {
-            array
-                .into_arrow_record_batch()
+        .and_then(|array: ArrayRef| {
+            // execute_arrow with None picks the preferred (cheapest) Arrow type per column.
+            let result = array
+                .execute_arrow(None, &mut ctx)
                 .map_err(VortexStorageError::Vortex)
+                .map(|arrow_array| RecordBatch::from(arrow_array.as_struct()));
+            async move { result }
         })
         .try_collect()
         .await?;
@@ -97,4 +107,13 @@ pub async fn read_vortex_file(
     // 7. Serialize RecordBatches → Arrow IPC bytes (readable by arrow 56)
     let schema = batches[0].schema();
     record_batches_to_ipc_bytes(&schema, &batches)
+}
+
+/// Build a Vortex projection expression from a list of column names.
+fn build_projection_expr(cols: &[String]) -> Expression {
+    let fields: Vec<Field> = cols
+        .iter()
+        .map(|name| Field::Name(name.as_str().into()))
+        .collect();
+    select(fields)
 }

--- a/src/query/storages/vortex/src/schema.rs
+++ b/src/query/storages/vortex/src/schema.rs
@@ -38,8 +38,8 @@ pub fn ipc_bytes_to_record_batches(ipc_bytes: &[u8]) -> VortexResult<Vec<RecordB
 
     let mut batches = Vec::new();
     for batch in reader {
-        let batch = batch
-            .map_err(|e| VortexStorageError::Other(format!("IPC batch read error: {e}")))?;
+        let batch =
+            batch.map_err(|e| VortexStorageError::Other(format!("IPC batch read error: {e}")))?;
         batches.push(batch);
     }
     Ok(batches)

--- a/src/query/storages/vortex/src/schema.rs
+++ b/src/query/storages/vortex/src/schema.rs
@@ -1,0 +1,68 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Schema and data conversion via Arrow IPC.
+//!
+//! Databend uses arrow 56; Vortex requires arrow 58. We bridge the gap using the
+//! Arrow IPC binary format, which is stable across minor versions. The caller
+//! serializes a RecordBatch with arrow 56 into IPC bytes, passes those bytes here,
+//! and we deserialize with arrow 58 before handing off to Vortex.
+
+use arrow_array::RecordBatch;
+use arrow_ipc::reader::StreamReader;
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::Schema;
+
+use crate::error::VortexResult;
+use crate::error::VortexStorageError;
+
+/// Deserialize Arrow IPC stream bytes (written by arrow 56) into a list of
+/// RecordBatches using arrow 58.
+///
+/// The IPC stream format is stable across arrow versions so this is safe.
+pub fn ipc_bytes_to_record_batches(ipc_bytes: &[u8]) -> VortexResult<Vec<RecordBatch>> {
+    let cursor = std::io::Cursor::new(ipc_bytes);
+    let reader = StreamReader::try_new(cursor, None)
+        .map_err(|e| VortexStorageError::Other(format!("IPC stream read error: {e}")))?;
+
+    let mut batches = Vec::new();
+    for batch in reader {
+        let batch = batch
+            .map_err(|e| VortexStorageError::Other(format!("IPC batch read error: {e}")))?;
+        batches.push(batch);
+    }
+    Ok(batches)
+}
+
+/// Serialize a list of RecordBatches (arrow 58) into Arrow IPC stream bytes.
+/// These bytes can be deserialized by arrow 56 on the Databend side.
+pub fn record_batches_to_ipc_bytes(
+    schema: &Schema,
+    batches: &[RecordBatch],
+) -> VortexResult<Vec<u8>> {
+    let mut buf = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buf, schema)
+            .map_err(|e| VortexStorageError::Other(format!("IPC stream write error: {e}")))?;
+        for batch in batches {
+            writer
+                .write(batch)
+                .map_err(|e| VortexStorageError::Other(format!("IPC batch write error: {e}")))?;
+        }
+        writer
+            .finish()
+            .map_err(|e| VortexStorageError::Other(format!("IPC stream finish error: {e}")))?;
+    }
+    Ok(buf)
+}

--- a/src/query/storages/vortex/src/writer.rs
+++ b/src/query/storages/vortex/src/writer.rs
@@ -22,12 +22,10 @@
 //! in Fuse's BlockMeta.col_stats. This keeps the Vortex file as a pure data container.
 
 use arrow_array::RecordBatch;
-use futures::TryStreamExt;
 use futures::stream;
 use vortex_array::ArrayRef;
 use vortex_array::arrow::FromArrowArray;
 use vortex_array::stream::ArrayStreamExt;
-use vortex_file::VortexWriteOptions;
 use vortex_file::WriteOptionsSessionExt;
 use vortex_file::register_default_encodings;
 use vortex_session::VortexSession;
@@ -58,16 +56,18 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
     register_default_encodings(&session);
 
     // 3. Convert RecordBatches → Vortex Arrays
+    // ArrayRef::from_arrow(RecordBatch, nullable) converts a RecordBatch to a StructArray.
     let arrays: Vec<ArrayRef> = batches
         .into_iter()
-        .map(record_batch_to_vortex)
+        .map(|batch| ArrayRef::from_arrow(batch, false).map_err(VortexStorageError::Vortex))
         .collect::<VortexResult<_>>()?;
 
     // 4. Build an ArrayStream from the arrays
     let dtype = arrays[0].dtype().clone();
     let array_stream = stream::iter(arrays.into_iter().map(Ok)).into_array_stream(dtype);
 
-    // 5. Write to the output buffer using the session's write options
+    // 5. Write to the output buffer using the session's write options.
+    // write() takes ownership of the sink and stream, compresses, and writes the .vortex file.
     session
         .write_options()
         .write(out, array_stream)
@@ -75,12 +75,4 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
         .map_err(VortexStorageError::Vortex)?;
 
     Ok(row_count)
-}
-
-/// Convert a single RecordBatch (arrow 58) into a Vortex ArrayRef.
-fn record_batch_to_vortex(batch: RecordBatch) -> VortexResult<ArrayRef> {
-    // vortex_array::arrow::FromArrowArray provides conversion from Arrow arrays.
-    // A RecordBatch maps to a StructArray in Vortex.
-    ArrayRef::from_arrow_record_batch(&batch)
-        .map_err(VortexStorageError::Vortex)
 }

--- a/src/query/storages/vortex/src/writer.rs
+++ b/src/query/storages/vortex/src/writer.rs
@@ -14,18 +14,21 @@
 
 //! Write a Vortex file from Arrow IPC bytes.
 //!
-//! The caller (Databend fuse) serializes its DataBlock into Arrow IPC bytes and
-//! passes them here. We deserialize, convert to Vortex arrays, compress, and write
-//! a self-contained .vortex file into the output buffer.
+//! The caller (Databend fuse, using arrow 56) serializes its DataBlock into Arrow IPC
+//! bytes and passes them here. We deserialize with arrow 58, convert to a Vortex
+//! ArrayStream, compress, and write a Vortex file into the output buffer.
 //!
-//! Column statistics are NOT written into the Vortex file — Fuse's own BlockMeta
-//! already carries that information in the segment metadata.
+//! Column statistics are NOT written into the Vortex file — they are stored externally
+//! in Fuse's BlockMeta.col_stats. This keeps the Vortex file as a pure data container.
 
 use arrow_array::RecordBatch;
+use futures::TryStreamExt;
+use futures::stream;
 use vortex_array::ArrayRef;
 use vortex_array::arrow::FromArrowArray;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_file::VortexWriteOptions;
+use vortex_file::WriteOptionsSessionExt;
 use vortex_file::register_default_encodings;
 use vortex_session::VortexSession;
 
@@ -36,13 +39,13 @@ use crate::schema::ipc_bytes_to_record_batches;
 /// Write Arrow IPC bytes as a Vortex file into `out`.
 ///
 /// # Arguments
-/// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend.
+/// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend (arrow 56).
 /// * `out`       - Output buffer; will contain a complete `.vortex` file on success.
 ///
 /// # Returns
 /// Number of rows written.
 pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
-    // 1. Deserialize IPC bytes → RecordBatches
+    // 1. Deserialize IPC bytes → RecordBatches (arrow 58)
     let batches = ipc_bytes_to_record_batches(ipc_bytes)?;
     if batches.is_empty() {
         return Ok(0);
@@ -50,30 +53,23 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
 
     let row_count: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
 
-    // 2. Build a VortexSession with default encodings (ALP, FastLanes, FSST, ZigZag, etc.)
+    // 2. Build a VortexSession with default encodings (ALP, FastLanes, FSST, etc.)
     let session = VortexSession::empty();
     register_default_encodings(&session);
 
-    // 3. Convert RecordBatches → Vortex Arrays via FromArrowArray
+    // 3. Convert RecordBatches → Vortex Arrays
     let arrays: Vec<ArrayRef> = batches
         .into_iter()
         .map(record_batch_to_vortex)
         .collect::<VortexResult<_>>()?;
 
-    // 4. Capture the dtype from the first array (all batches share the same schema)
+    // 4. Build an ArrayStream from the arrays
     let dtype = arrays[0].dtype().clone();
+    let array_stream = stream::iter(arrays.into_iter().map(Ok)).into_array_stream(dtype);
 
-    // 5. Build an ArrayStream from the arrays
-    let array_stream = futures::stream::iter(
-        arrays
-            .into_iter()
-            .map(Ok::<_, vortex_error::VortexError>),
-    )
-    .into_array_stream(dtype);
-
-    // 6. Write to the output buffer.
-    //    Statistics are excluded — Fuse BlockMeta owns that data.
-    VortexWriteOptions::new(session)
+    // 5. Write to the output buffer using the session's write options
+    session
+        .write_options()
         .write(out, array_stream)
         .await
         .map_err(VortexStorageError::Vortex)?;
@@ -81,8 +77,10 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
     Ok(row_count)
 }
 
-/// Convert a single RecordBatch into a Vortex ArrayRef via FromArrowArray.
+/// Convert a single RecordBatch (arrow 58) into a Vortex ArrayRef.
 fn record_batch_to_vortex(batch: RecordBatch) -> VortexResult<ArrayRef> {
-    // FromArrowArray<RecordBatch> is implemented for ArrayRef (owned conversion).
-    ArrayRef::from_arrow(batch, true).map_err(VortexStorageError::Vortex)
+    // vortex_array::arrow::FromArrowArray provides conversion from Arrow arrays.
+    // A RecordBatch maps to a StructArray in Vortex.
+    ArrayRef::from_arrow_record_batch(&batch)
+        .map_err(VortexStorageError::Vortex)
 }

--- a/src/query/storages/vortex/src/writer.rs
+++ b/src/query/storages/vortex/src/writer.rs
@@ -1,0 +1,88 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Write a Vortex file from Arrow IPC bytes.
+//!
+//! The caller (Databend fuse) serializes its DataBlock into Arrow IPC bytes and
+//! passes them here. We deserialize, convert to Vortex arrays, compress, and write
+//! a self-contained .vortex file into the output buffer.
+//!
+//! Column statistics are NOT written into the Vortex file — Fuse's own BlockMeta
+//! already carries that information in the segment metadata.
+
+use arrow_array::RecordBatch;
+use vortex_array::ArrayRef;
+use vortex_array::arrow::FromArrowArray;
+use vortex_array::stream::ArrayStreamExt;
+use vortex_file::VortexWriteOptions;
+use vortex_file::register_default_encodings;
+use vortex_session::VortexSession;
+
+use crate::error::VortexResult;
+use crate::error::VortexStorageError;
+use crate::schema::ipc_bytes_to_record_batches;
+
+/// Write Arrow IPC bytes as a Vortex file into `out`.
+///
+/// # Arguments
+/// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend.
+/// * `out`       - Output buffer; will contain a complete `.vortex` file on success.
+///
+/// # Returns
+/// Number of rows written.
+pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
+    // 1. Deserialize IPC bytes → RecordBatches
+    let batches = ipc_bytes_to_record_batches(ipc_bytes)?;
+    if batches.is_empty() {
+        return Ok(0);
+    }
+
+    let row_count: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+
+    // 2. Build a VortexSession with default encodings (ALP, FastLanes, FSST, ZigZag, etc.)
+    let session = VortexSession::empty();
+    register_default_encodings(&session);
+
+    // 3. Convert RecordBatches → Vortex Arrays via FromArrowArray
+    let arrays: Vec<ArrayRef> = batches
+        .into_iter()
+        .map(record_batch_to_vortex)
+        .collect::<VortexResult<_>>()?;
+
+    // 4. Capture the dtype from the first array (all batches share the same schema)
+    let dtype = arrays[0].dtype().clone();
+
+    // 5. Build an ArrayStream from the arrays
+    let array_stream = futures::stream::iter(
+        arrays
+            .into_iter()
+            .map(Ok::<_, vortex_error::VortexError>),
+    )
+    .into_array_stream(dtype);
+
+    // 6. Write to the output buffer.
+    //    Statistics are excluded — Fuse BlockMeta owns that data.
+    VortexWriteOptions::new(session)
+        .write(out, array_stream)
+        .await
+        .map_err(VortexStorageError::Vortex)?;
+
+    Ok(row_count)
+}
+
+/// Convert a single RecordBatch into a Vortex ArrayRef via FromArrowArray.
+fn record_batch_to_vortex(batch: RecordBatch) -> VortexResult<ArrayRef> {
+    // FromArrowArray<RecordBatch> is implemented for ArrayRef (owned conversion).
+    ArrayRef::from_arrow(batch, true).map_err(VortexStorageError::Vortex)
+}

--- a/src/query/storages/vortex/src/writer.rs
+++ b/src/query/storages/vortex/src/writer.rs
@@ -14,19 +14,17 @@
 
 //! Write a Vortex file from Arrow IPC bytes.
 //!
-//! The caller (Databend fuse, using arrow 56) serializes its DataBlock into Arrow IPC
-//! bytes and passes them here. We deserialize with arrow 58, convert to a Vortex
-//! ArrayStream, compress, and write a Vortex file into the output buffer.
+//! The caller serializes its DataBlock into Arrow IPC bytes and passes them here.
+//! We deserialize, convert to Vortex arrays, and write a self-contained .vortex file.
 //!
-//! Column statistics are NOT written into the Vortex file — they are stored externally
-//! in Fuse's BlockMeta.col_stats. This keeps the Vortex file as a pure data container.
+//! Column statistics are NOT written into the Vortex file — Fuse's own BlockMeta
+//! already carries that information in the segment metadata.
 
 use arrow_array::RecordBatch;
-use futures::stream;
 use vortex_array::ArrayRef;
 use vortex_array::arrow::FromArrowArray;
-use vortex_array::stream::ArrayStreamExt;
-use vortex_file::WriteOptionsSessionExt;
+use vortex_array::stream::ArrayStreamAdapter;
+use vortex_file::VortexWriteOptions;
 use vortex_file::register_default_encodings;
 use vortex_session::VortexSession;
 
@@ -37,13 +35,13 @@ use crate::schema::ipc_bytes_to_record_batches;
 /// Write Arrow IPC bytes as a Vortex file into `out`.
 ///
 /// # Arguments
-/// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend (arrow 56).
+/// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend.
 /// * `out`       - Output buffer; will contain a complete `.vortex` file on success.
 ///
 /// # Returns
 /// Number of rows written.
 pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
-    // 1. Deserialize IPC bytes → RecordBatches (arrow 58)
+    // 1. Deserialize IPC bytes → RecordBatches
     let batches = ipc_bytes_to_record_batches(ipc_bytes)?;
     if batches.is_empty() {
         return Ok(0);
@@ -51,28 +49,38 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
 
     let row_count: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
 
-    // 2. Build a VortexSession with default encodings (ALP, FastLanes, FSST, etc.)
+    // 2. Build a VortexSession with default encodings (ALP, FastLanes, FSST, ZigZag, etc.)
     let session = VortexSession::empty();
     register_default_encodings(&session);
 
-    // 3. Convert RecordBatches → Vortex Arrays
-    // ArrayRef::from_arrow(RecordBatch, nullable) converts a RecordBatch to a StructArray.
+    // 3. Convert RecordBatches → Vortex Arrays via FromArrowArray
     let arrays: Vec<ArrayRef> = batches
         .into_iter()
-        .map(|batch| ArrayRef::from_arrow(batch, false).map_err(VortexStorageError::Vortex))
+        .map(record_batch_to_vortex)
         .collect::<VortexResult<_>>()?;
 
-    // 4. Build an ArrayStream from the arrays
+    // 4. Capture the dtype from the first array (all batches share the same schema)
     let dtype = arrays[0].dtype().clone();
-    let array_stream = stream::iter(arrays.into_iter().map(Ok)).into_array_stream(dtype);
 
-    // 5. Write to the output buffer using the session's write options.
-    // write() takes ownership of the sink and stream, compresses, and writes the .vortex file.
-    session
-        .write_options()
+    // 5. Build an ArrayStream from the arrays using ArrayStreamAdapter
+    let stream = futures::stream::iter(
+        arrays
+            .into_iter()
+            .map(Ok::<ArrayRef, vortex_error::VortexError>),
+    );
+    let array_stream = ArrayStreamAdapter::new(dtype, stream);
+
+    // 6. Write to the output buffer.
+    //    Statistics are excluded — Fuse BlockMeta owns that data.
+    VortexWriteOptions::new(session)
         .write(out, array_stream)
         .await
         .map_err(VortexStorageError::Vortex)?;
 
     Ok(row_count)
+}
+
+/// Convert a single RecordBatch into a Vortex ArrayRef via FromArrowArray.
+fn record_batch_to_vortex(batch: RecordBatch) -> VortexResult<ArrayRef> {
+    ArrayRef::from_arrow(batch, true).map_err(VortexStorageError::Vortex)
 }

--- a/src/query/storages/vortex/src/writer.rs
+++ b/src/query/storages/vortex/src/writer.rs
@@ -23,6 +23,8 @@
 use arrow_array::RecordBatch;
 use vortex_array::ArrayRef;
 use vortex_array::arrow::FromArrowArray;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
 use vortex_array::stream::ArrayStreamAdapter;
 use vortex_file::VortexWriteOptions;
 use vortex_file::register_default_encodings;
@@ -32,7 +34,13 @@ use crate::error::VortexResult;
 use crate::error::VortexStorageError;
 use crate::schema::ipc_bytes_to_record_batches;
 
-/// Write Arrow IPC bytes as a Vortex file into `out`.
+/// Write Arrow IPC bytes as a Vortex file into `out` (synchronous entry point).
+///
+/// This function is safe to call from any thread context — it creates its own
+/// single-threaded Tokio runtime internally so it does not depend on an ambient
+/// Tokio reactor.  Vortex's write path is async-only, so we need a runtime, but
+/// we deliberately avoid `block_in_place` / `Handle::current()` because Databend's
+/// pipeline executor threads are plain OS threads, not Tokio worker threads.
 ///
 /// # Arguments
 /// * `ipc_bytes` - Arrow IPC stream bytes produced by Databend.
@@ -40,7 +48,22 @@ use crate::schema::ipc_bytes_to_record_batches;
 ///
 /// # Returns
 /// Number of rows written.
-pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
+pub fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
+    // Build a private single-threaded runtime for this write.
+    // This is cheap (no thread pool) and avoids any dependency on an ambient Tokio context.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            VortexStorageError::Other(format!("Vortex: failed to build Tokio runtime: {e}"))
+        })?;
+
+    rt.block_on(write_vortex_file_async(ipc_bytes, out))
+}
+
+/// Async implementation — called from within the private runtime created by
+/// `write_vortex_file`.
+async fn write_vortex_file_async(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexResult<u64> {
     // 1. Deserialize IPC bytes → RecordBatches
     let batches = ipc_bytes_to_record_batches(ipc_bytes)?;
     if batches.is_empty() {
@@ -59,8 +82,11 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
         .map(record_batch_to_vortex)
         .collect::<VortexResult<_>>()?;
 
-    // 4. Capture the dtype from the first array (all batches share the same schema)
-    let dtype = arrays[0].dtype().clone();
+    // 4. Capture the dtype from the first array (all batches share the same schema).
+    //    Vortex's FileStatsAccumulator requires the top-level struct to be NonNullable.
+    //    Arrow RecordBatch → StructArray conversion may produce a nullable struct dtype,
+    //    so we force NonNullable here.
+    let dtype = force_nonnullable_struct(arrays[0].dtype().clone());
 
     // 5. Build an ArrayStream from the arrays using ArrayStreamAdapter
     let stream = futures::stream::iter(
@@ -81,6 +107,23 @@ pub async fn write_vortex_file(ipc_bytes: &[u8], out: &mut Vec<u8>) -> VortexRes
 }
 
 /// Convert a single RecordBatch into a Vortex ArrayRef via FromArrowArray.
+///
+/// The second argument is `nullable` for the top-level struct array.
+/// Vortex's FileStatsAccumulator requires the top-level struct to be NonNullable,
+/// so we always pass `false` here regardless of the individual column nullability.
 fn record_batch_to_vortex(batch: RecordBatch) -> VortexResult<ArrayRef> {
-    ArrayRef::from_arrow(batch, true).map_err(VortexStorageError::Vortex)
+    ArrayRef::from_arrow(batch, false).map_err(VortexStorageError::Vortex)
+}
+
+/// Force the top-level DType to be NonNullable if it is a Struct.
+///
+/// Vortex's FileStatsAccumulator panics when the top-level struct dtype is
+/// Nullable (even if no actual null values are present).  Arrow's
+/// RecordBatch → StructArray conversion can produce a nullable struct dtype,
+/// so we patch it here before passing it to the writer.
+fn force_nonnullable_struct(dtype: DType) -> DType {
+    match dtype {
+        DType::Struct(fields, _) => DType::Struct(fields, Nullability::NonNullable),
+        other => other,
+    }
 }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0027_func_fuse_encoding.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0027_func_fuse_encoding.test
@@ -81,12 +81,12 @@ query TTTTIIITT
 select * exclude(block_location) from fuse_encoding('db_09_0027', 't_parquet') order by column_name;
 ----
 t_parquet Parquet c1 INT NULL (INT32) NULL 57 48 plain,rle,rle_dictionary zstd
-t_parquet Parquet c2 INT NULL (INT32) NULL 202 429 plain,rle zstd
+t_parquet Parquet c2 INT NULL (INT32) NULL 203 429 plain,rle zstd
 
 query TTTTIIITT
 select * exclude(block_location) from fuse_encoding('db_09_0027', 't_parquet', 'c2');
 ----
-t_parquet Parquet c2 INT NULL (INT32) NULL 202 429 plain,rle zstd
+t_parquet Parquet c2 INT NULL (INT32) NULL 203 429 plain,rle zstd
 
 statement ok
 DROP DATABASE db_09_0027

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0050_vortex_storage_format.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0050_vortex_storage_format.test
@@ -1,0 +1,171 @@
+## Tests for Vortex storage format (STORAGE_FORMAT = 'vortex')
+## Vortex is a next-generation columnar file format providing faster scans
+## and random access vs Parquet via modern compression algorithms.
+## Column statistics are stored in Fuse BlockMeta (not inside the Vortex file).
+
+statement ok
+USE default
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_basic
+
+## Basic create and insert
+statement ok
+CREATE TABLE t_vortex_basic (
+    id      INT NOT NULL,
+    name    VARCHAR NOT NULL,
+    score   DOUBLE NOT NULL,
+    active  BOOLEAN NOT NULL
+) ENGINE = fuse STORAGE_FORMAT = 'vortex'
+
+statement ok
+INSERT INTO t_vortex_basic VALUES
+    (1, 'alice', 95.5, true),
+    (2, 'bob',   82.0, false),
+    (3, 'carol', 91.3, true)
+
+query ITRI
+SELECT id, name, score, active FROM t_vortex_basic ORDER BY id
+----
+1 alice 95.5 1
+2 bob 82.0 0
+3 carol 91.3 1
+
+## Column projection
+query IT
+SELECT id, name FROM t_vortex_basic ORDER BY id
+----
+1 alice
+2 bob
+3 carol
+
+## Filter pushdown
+query I
+SELECT id FROM t_vortex_basic WHERE active = true ORDER BY id
+----
+1
+3
+
+## Aggregation
+query R
+SELECT AVG(score) FROM t_vortex_basic
+----
+89.6
+
+query I
+SELECT COUNT(*) FROM t_vortex_basic
+----
+3
+
+## Multiple inserts (multiple blocks)
+statement ok
+INSERT INTO t_vortex_basic VALUES
+    (4, 'dave',  78.5, true),
+    (5, 'eve',   88.0, false)
+
+query I
+SELECT COUNT(*) FROM t_vortex_basic
+----
+5
+
+query ITRI
+SELECT id, name, score, active FROM t_vortex_basic ORDER BY id
+----
+1 alice 95.5 1
+2 bob 82.0 0
+3 carol 91.3 1
+4 dave 78.5 1
+5 eve 88.0 0
+
+## Verify storage format is recorded correctly
+query T
+SELECT engine_full FROM system.tables
+WHERE database = 'default' AND name = 't_vortex_basic'
+----
+FUSE STORAGE_FORMAT='vortex'
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_basic
+
+## Numeric types
+statement ok
+DROP TABLE IF EXISTS t_vortex_types
+
+statement ok
+CREATE TABLE t_vortex_types (
+    a  TINYINT,
+    b  SMALLINT,
+    c  INT,
+    d  BIGINT,
+    e  FLOAT,
+    f  DOUBLE
+) ENGINE = fuse STORAGE_FORMAT = 'vortex'
+
+statement ok
+INSERT INTO t_vortex_types VALUES (1, 100, 10000, 1000000, 1.5, 2.5)
+
+query IIIIRR
+SELECT a, b, c, d, e, f FROM t_vortex_types
+----
+1 100 10000 1000000 1.5 2.5
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_types
+
+## String and nullable types
+statement ok
+DROP TABLE IF EXISTS t_vortex_nullable
+
+statement ok
+CREATE TABLE t_vortex_nullable (
+    id   INT NOT NULL,
+    val  VARCHAR
+) ENGINE = fuse STORAGE_FORMAT = 'vortex'
+
+statement ok
+INSERT INTO t_vortex_nullable VALUES (1, 'hello'), (2, NULL), (3, 'world')
+
+query IT
+SELECT id, val FROM t_vortex_nullable ORDER BY id
+----
+1 hello
+2 NULL
+3 world
+
+query I
+SELECT COUNT(*) FROM t_vortex_nullable WHERE val IS NULL
+----
+1
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_nullable
+
+## CTAS (CREATE TABLE AS SELECT) from a Parquet table into Vortex
+statement ok
+DROP TABLE IF EXISTS t_vortex_src
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_ctas
+
+statement ok
+CREATE TABLE t_vortex_src (id INT, val VARCHAR) ENGINE = fuse
+
+statement ok
+INSERT INTO t_vortex_src VALUES (1, 'a'), (2, 'b'), (3, 'c')
+
+statement ok
+CREATE TABLE t_vortex_ctas ENGINE = fuse STORAGE_FORMAT = 'vortex'
+AS SELECT * FROM t_vortex_src
+
+query IT
+SELECT id, val FROM t_vortex_ctas ORDER BY id
+----
+1 a
+2 b
+3 c
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_src
+
+statement ok
+DROP TABLE IF EXISTS t_vortex_ctas

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -159,7 +159,7 @@ EvalScalar
                     ├── scan id: 0
                     ├── output columns: [number (#0), money (#2)]
                     ├── read rows: 3000
-                    ├── read size: 10.51 KiB
+                    ├── read size: <slt:ignore>
                     ├── partitions total: 2
                     ├── partitions scanned: 2
                     ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -205,7 +205,7 @@ EvalScalar
             ├── scan id: 0
             ├── output columns: [number (#0), money (#2)]
             ├── read rows: 3000
-            ├── read size: 10.51 KiB
+            ├── read size: <slt:ignore>
             ├── partitions total: 2
             ├── partitions scanned: 2
             ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -85,7 +85,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
         ├── push downs: [filters: [is_true(t.number (#0) > 10)], limit: NONE]
         └── estimated rows: 2983.50
 
@@ -109,7 +109,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3000.00
 
@@ -162,7 +162,7 @@ EvalScalar
                     ├── read size: 10.51 KiB
                     ├── partitions total: 2
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 3000.00
 
@@ -208,7 +208,7 @@ EvalScalar
             ├── read size: 10.51 KiB
             ├── partitions total: 2
             ├── partitions scanned: 2
-            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 3000.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -85,7 +85,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
+        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_true(t.number (#0) > 10)], limit: NONE]
         └── estimated rows: 2983.50
 
@@ -109,7 +109,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
+        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3000.00
 
@@ -162,7 +162,7 @@ EvalScalar
                     ├── read size: 10.51 KiB
                     ├── partitions total: 2
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
+                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 3000.00
 
@@ -208,7 +208,7 @@ EvalScalar
             ├── read size: 10.51 KiB
             ├── partitions total: 2
             ├── partitions scanned: 2
-            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: 1 ms>, blocks: <range pruning: 2 to 2 cost: 1 ms>]
+            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 3000.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
@@ -64,7 +64,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -80,10 +80,10 @@ HashJoin
     ├── scan id: 0
     ├── output columns: [number (#0)]
     ├── read rows: 100000
-    ├── read size: 167.25 KiB
+    ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -132,7 +132,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -149,10 +149,10 @@ HashJoin
     ├── scan id: 0
     ├── output columns: [number (#0)]
     ├── read rows: 100000
-    ├── read size: 167.25 KiB
+    ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -211,7 +211,7 @@ HashJoin
 │       ├── read size: <slt:ignore>
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -231,7 +231,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
@@ -64,7 +64,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -83,7 +83,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -132,7 +132,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -152,7 +152,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -211,7 +211,7 @@ HashJoin
 │       ├── read size: <slt:ignore>
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 2 to 1 cost: 1 ms>]
+│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -231,7 +231,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 99 to 99 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -65,7 +65,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -76,7 +76,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     ├── push downs: [filters: [is_true(t2.a (#2) > 1)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -104,7 +104,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 2.00
     └── Limit
@@ -120,7 +120,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 2.00
 
@@ -148,7 +148,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     │       ├── push downs: [filters: [], limit: 4]
     │       └── estimated rows: 2.00
     └── Limit
@@ -164,7 +164,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
             ├── push downs: [filters: [], limit: 4]
             └── estimated rows: 2.00
 
@@ -192,7 +192,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     │       ├── push downs: [filters: [], limit: 1]
     │       └── estimated rows: 2.00
     └── Limit
@@ -208,7 +208,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 2.00
 
@@ -227,7 +227,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -238,7 +238,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     ├── push downs: [filters: [is_true(t2.b (#3) > 2)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -277,10 +277,10 @@ UnionAll
     ├── scan id: 1
     ├── output columns: [b (#1)]
     ├── read rows: 10000
-    ├── read size: 10.59 KiB
+    ├── read size: 10.60 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10000.00
 
@@ -296,10 +296,10 @@ UnionAll
 │   ├── scan id: 0
 │   ├── output columns: [a (#0)]
 │   ├── read rows: 10000
-│   ├── read size: 10.59 KiB
+│   ├── read size: 10.60 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10000.00
 └── EmptyResultScan

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -65,7 +65,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -76,7 +76,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.a (#2) > 1)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -104,7 +104,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 2.00
     └── Limit
@@ -120,7 +120,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 2.00
 
@@ -148,7 +148,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 4]
     │       └── estimated rows: 2.00
     └── Limit
@@ -164,7 +164,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 4]
             └── estimated rows: 2.00
 
@@ -192,7 +192,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 1]
     │       └── estimated rows: 2.00
     └── Limit
@@ -208,7 +208,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 2.00
 
@@ -227,7 +227,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -238,7 +238,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.b (#3) > 2)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -280,7 +280,7 @@ UnionAll
     ├── read size: 10.60 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10000.00
 
@@ -299,7 +299,7 @@ UnionAll
 │   ├── read size: 10.60 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10000.00
 └── EmptyResultScan


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Adds support for the [Vortex](https://github.com/vortex-data/vortex) columnar file format as a new `STORAGE_FORMAT = 'vortex'` option for Fuse engine tables.

This PR depends on #19684 (arrow-rs upgrade to 58.1.0) and is intended to be merged on top of that PR once it lands.

### Architecture

A new isolated crate `databend-storages-vortex` bridges Databend's Fuse storage engine with Vortex 0.70:

```
Write: DataBlock → RecordBatch → Arrow IPC bytes → VortexArray → .vortex file
Read:  .vortex file → VortexArray → RecordBatch → Arrow IPC bytes → DataBlock
```

**IO bridge**: `OpendalVortexReader` implements `VortexReadAt` directly on top of `opendal::Operator`, bypassing the `object_store` version conflict (workspace 0.12 vs vortex-io 0.13).

**Statistics**: Column stats (min/max/null_count) are stored externally in Fuse's `BlockMeta.col_stats` — NOT inside the Vortex file. The Vortex file is a pure data container.

### Changes

- New crate `databend-storages-vortex` (writer, reader, IO bridge, IPC schema utils)
- `FuseStorageFormat::Vortex` variant + `FromStr`/`Display` support
- `ColumnMeta::Vortex(VortexColumnMeta)` — stores only `num_values`; column layout is in the Vortex file footer
- `gen_block_location_with_format` — Vortex files use `.vortex` extension
- Write path: `serialize_block_vortex` in `block_writer.rs` (batch only)
- Read path: `read_vortex_block` via `vortex_reader.rs`, bypasses merge-IO entirely
- All `FuseStorageFormat` match expressions updated with Vortex branches

### Known Limitations (follow-up PRs)

| Feature | Status |
|---------|--------|
| SELECT / INSERT / CTAS | ✅ |
| UPDATE / DELETE / MERGE | ❌ Returns Unimplemented error |
| COMPACT | ❌ Returns Unimplemented error |
| Streaming writes | ❌ Returns error (batch write path only) |
| fuse_encoding() | ❌ Returns empty result |

## Tests

- [x] Logic Test — `tests/sqllogictests/suites/base/09_fuse_engine/09_0050_vortex_storage_format.test`
- [ ] No Unit Test — Vortex format requires a running storage backend to exercise the read/write roundtrip

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19863)
<!-- Reviewable:end -->
