### PR TITLE
feat(query): add is_role_in_session funciton

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check/sugar.rs
+++ b/src/query/sql/src/planner/semantic/type_check/sugar.rs
@@ -54,6 +54,7 @@ impl<'a> TypeChecker<'a> {
             Ascii::new("current_role"),
             Ascii::new("current_secondary_roles"),
             Ascii::new("current_available_roles"),
+            Ascii::new("is_role_in_session"),
             Ascii::new("connection_id"),
             Ascii::new("client_session_id"),
             Ascii::new("timezone"),
@@ -180,6 +181,49 @@ impl<'a> TypeChecker<'a> {
                         e
                     )))),
                 }
+            }
+            ("is_role_in_session", &[role]) => {
+                let effective_roles = match self.ctx.get_all_effective_roles().await {
+                    Ok(roles) => roles,
+                    Err(err) => return Some(Err(err)),
+                };
+                let (role_expr, _) = match self.resolve(role) {
+                    Ok(res) => *res,
+                    Err(err) => return Some(Err(err)),
+                };
+
+                let mut predicate_levels =
+                    Vec::with_capacity(effective_roles.len().max(1).ilog2() as usize + 1);
+                for effective_role in effective_roles {
+                    let role_literal = ScalarExpr::ConstantExpr(ConstantExpr {
+                        span,
+                        value: Scalar::String(effective_role.name),
+                    });
+                    let predicate =
+                        match self.resolve_scalar_function_call(span, "eq", vec![], vec![
+                            role_expr.clone(),
+                            role_literal,
+                        ]) {
+                            Ok(res) => {
+                                let (predicate, _) = *res;
+                                predicate
+                            }
+                            Err(err) => return Some(Err(err)),
+                        };
+                    if let Err(err) = self.merge_or_level(span, &mut predicate_levels, predicate) {
+                        return Some(Err(err));
+                    }
+                }
+
+                let predicate = match self.fold_or_levels(span, predicate_levels) {
+                    Ok(Some(predicate)) => predicate,
+                    Ok(None) => ScalarExpr::ConstantExpr(ConstantExpr {
+                        span,
+                        value: Scalar::Boolean(false),
+                    }),
+                    Err(err) => return Some(Err(err)),
+                };
+                Some(self.resolve_scalar_function_call(span, "is_true", vec![], vec![predicate]))
             }
             ("connection_id", &[]) => Some(self.resolve(&Expr::Literal {
                 span,

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
@@ -1063,5 +1063,107 @@ DROP TABLE employees;
 statement ok
 DROP MASKING POLICY mask_ssn_conditional;
 
+## row access policy with active role hierarchy
+statement ok
+SET ROLE account_admin;
+
+statement ok
+SET SECONDARY ROLES ALL;
+
+statement ok
+DROP TABLE IF EXISTS rap_time_range_test;
+
+statement ok
+DROP ROW ACCESS POLICY IF EXISTS rap_time_range;
+
+statement ok
+DROP ROLE IF EXISTS rap_role_7_day;
+
+statement ok
+DROP ROLE IF EXISTS rap_role_1_day;
+
+statement ok
+CREATE ROLE rap_role_7_day;
+
+statement ok
+CREATE ROLE rap_role_1_day;
+
+statement ok
+CREATE ROW ACCESS POLICY rap_time_range AS (start_time TIMESTAMP) RETURNS boolean ->
+  CASE
+    WHEN IS_ROLE_IN_SESSION('rap_role_7_day') THEN
+      start_time BETWEEN to_timestamp('2024-01-08 00:00:00') AND to_timestamp('2024-01-15 00:00:00')
+    WHEN IS_ROLE_IN_SESSION('rap_role_1_day') THEN
+      start_time BETWEEN to_timestamp('2024-01-14 00:00:00') AND to_timestamp('2024-01-15 00:00:00')
+    ELSE false
+  END;
+
+statement ok
+CREATE TABLE rap_time_range_test(id INT, start_time TIMESTAMP);
+
+statement ok
+INSERT INTO rap_time_range_test VALUES
+  (1, to_timestamp('2024-01-07 00:00:00')),
+  (2, to_timestamp('2024-01-09 00:00:00')),
+  (3, to_timestamp('2024-01-14 12:00:00')),
+  (4, to_timestamp('2024-01-15 00:00:00')),
+  (5, to_timestamp('2024-01-16 00:00:00'));
+
+statement ok
+ALTER TABLE rap_time_range_test ADD ROW ACCESS POLICY rap_time_range ON (start_time);
+
+statement ok
+SET ROLE rap_role_1_day;
+
+statement ok
+SET SECONDARY ROLES NONE;
+
+query I
+SELECT id FROM rap_time_range_test ORDER BY id;
+----
+3
+4
+
+statement ok
+SET SECONDARY ROLES rap_role_7_day;
+
+query I
+SELECT id FROM rap_time_range_test ORDER BY id;
+----
+2
+3
+4
+
+statement ok
+SET ROLE rap_role_7_day;
+
+statement ok
+SET SECONDARY ROLES NONE;
+
+query I
+SELECT id FROM rap_time_range_test ORDER BY id;
+----
+2
+3
+4
+
+statement ok
+SET ROLE account_admin;
+
+statement ok
+SET SECONDARY ROLES ALL;
+
+statement ok
+DROP TABLE rap_time_range_test;
+
+statement ok
+DROP ROW ACCESS POLICY rap_time_range;
+
+statement ok
+DROP ROLE rap_role_7_day;
+
+statement ok
+DROP ROLE rap_role_1_day;
+
 statement ok
 unset global enable_planner_cache;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add `IS_ROLE_IN_SESSION(role)` as a SQL sugar function so row access and masking policy expressions can check whether a role is active in the current session.

The function is rewritten during semantic type checking against the session's effective roles. Effective roles follow the existing secondary-role semantics:

- `SET SECONDARY ROLES ALL` checks all roles available to the current user.
- `SET SECONDARY ROLES NONE` checks only the current role and its related roles.
- `SET SECONDARY ROLES role_name` checks the current role plus the specified secondary role and their related roles.

This enables policies to express role-dependent access using active role hierarchy instead of checking only `CURRENT_ROLE()`.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19867)
<!-- Reviewable:end -->
