### PR TITLE
feat(query): support variant array concat

### DIFF
--- a/src/query/functions/src/scalars/variant.rs
+++ b/src/query/functions/src/scalars/variant.rs
@@ -2166,6 +2166,44 @@ pub fn register(registry: &mut FunctionRegistry) {
         ),
     );
 
+    registry.register_passthrough_nullable_2_arg::<VariantType, VariantType, VariantType, _, _>(
+        "array_concat",
+        |_, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_2_arg::<VariantType, VariantType, VariantType>(
+            |left, right, output, ctx| {
+                if let Some(validity) = &ctx.validity
+                    && !validity.get_bit(output.len())
+                {
+                    output.commit_row();
+                    return;
+                }
+
+                let left_val = RawJsonb::new(left);
+                let right_val = RawJsonb::new(right);
+                let build_array = || {
+                    let mut new_vals = left_val
+                        .array_values()
+                        .map(|vals_opt| vals_opt.unwrap_or(vec![left_val.to_owned()]))?;
+                    let mut right_vals = right_val
+                        .array_values()
+                        .map(|vals_opt| vals_opt.unwrap_or(vec![right_val.to_owned()]))?;
+                    new_vals.append(&mut right_vals);
+                    OwnedJsonb::build_array(new_vals.iter().map(|v| v.as_raw()))
+                };
+
+                match build_array() {
+                    Ok(owned_jsonb) => {
+                        output.put_slice(owned_jsonb.as_ref());
+                    }
+                    Err(err) => {
+                        ctx.set_error(output.len(), err.to_string());
+                    }
+                }
+                output.commit_row();
+            },
+        ),
+    );
+
     registry.register_passthrough_nullable_1_arg::<VariantType, VariantType, _>(
         "array_remove_first",
         |_, _| FunctionDomain::MayThrow,

--- a/src/query/functions/tests/it/scalars/testdata/array.txt
+++ b/src/query/functions/tests/it/scalars/testdata/array.txt
@@ -798,10 +798,10 @@ error:
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no function matches signature `array_concat(Array(Boolean), Array(UInt8))`, you might need to add explicit type casts.
 
 candidate functions:
+  array_concat(Variant, Variant) :: Variant                                      : unable to unify `Array(Boolean)` with `Variant`
+  array_concat(Variant NULL, Variant NULL) :: Variant NULL                       : unable to unify `Array(Boolean)` with `Variant`
   array_concat(Array(Nothing), Array(Nothing)) :: Array(Nothing)                 : unable to unify `Array(Boolean)` with `Array(Nothing)`
-  array_concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing) NULL  : unable to unify `Array(Boolean)` with `Array(Nothing)`
-  array_concat(Array(T0), Array(T0)) :: Array(T0)                                : unable to find a common super type for `Boolean` and `UInt8`
-... and 1 more
+... and 3 more
 
 
 

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -184,10 +184,12 @@ Functions overloads:
 3 array_compact(Array(Nothing) NULL) :: Array(Nothing) NULL
 4 array_compact(Array(T0)) :: Array(T0)
 5 array_compact(Array(T0) NULL) :: Array(T0) NULL
-0 array_concat(Array(Nothing), Array(Nothing)) :: Array(Nothing)
-1 array_concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing) NULL
-2 array_concat(Array(T0), Array(T0)) :: Array(T0)
-3 array_concat(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
+0 array_concat(Variant, Variant) :: Variant
+1 array_concat(Variant NULL, Variant NULL) :: Variant NULL
+2 array_concat(Array(Nothing), Array(Nothing)) :: Array(Nothing)
+3 array_concat(Array(Nothing) NULL, Array(Nothing) NULL) :: Array(Nothing) NULL
+4 array_concat(Array(T0), Array(T0)) :: Array(T0)
+5 array_concat(Array(T0) NULL, Array(T0) NULL) :: Array(T0) NULL
 0 array_construct FACTORY
 0 array_count FACTORY
 0 array_distinct(Variant) :: Variant

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -6899,6 +6899,74 @@ evaluation (internal):
 +--------+-----------------------------------------------------------------------------------------------------+
 
 
+ast            : array_concat(parse_json('[1, 2]'), parse_json('[3, 4]'))
+raw expr       : array_concat(parse_json('[1, 2]'), parse_json('[3, 4]'))
+checked expr   : array_concat<Variant, Variant>(CAST<String>("[1, 2]" AS Variant), CAST<String>("[3, 4]" AS Variant))
+optimized expr : 0x80000004200000022000000220000002200000025001500250035004
+output type    : Variant
+output domain  : Undefined
+output         : '[1,2,3,4]'
+
+
+ast            : array_concat(parse_json('[1, "a"]'), parse_json('[true, null]'))
+raw expr       : array_concat(parse_json('[1, "a"]'), parse_json('[true, null]'))
+checked expr   : array_concat<Variant, Variant>(CAST<String>("[1, \"a\"]" AS Variant), CAST<String>("[true, null]" AS Variant))
+optimized expr : 0x8000000420000002100000014000000000000000500161
+output type    : Variant
+output domain  : Undefined
+output         : '[1,"a",true,null]'
+
+
+ast            : array_concat(parse_json('1'), parse_json('[2, 3]'))
+raw expr       : array_concat(parse_json('1'), parse_json('[2, 3]'))
+checked expr   : array_concat<Variant, Variant>(CAST<String>("1" AS Variant), CAST<String>("[2, 3]" AS Variant))
+optimized expr : 0x80000003200000022000000220000002500150025003
+output type    : Variant
+output domain  : Undefined
+output         : '[1,2,3]'
+
+
+ast            : array_concat(parse_json('[1, 2]'), parse_json('3'))
+raw expr       : array_concat(parse_json('[1, 2]'), parse_json('3'))
+checked expr   : array_concat<Variant, Variant>(CAST<String>("[1, 2]" AS Variant), CAST<String>("3" AS Variant))
+optimized expr : 0x80000003200000022000000220000002500150025003
+output type    : Variant
+output domain  : Undefined
+output         : '[1,2,3]'
+
+
+ast            : array_concat(null, parse_json('[1]'))
+raw expr       : array_concat(NULL, parse_json('[1]'))
+checked expr   : array_concat<Variant NULL, Variant NULL>(CAST<NULL>(NULL AS Variant NULL), CAST<Variant>(CAST<String>("[1]" AS Variant) AS Variant NULL))
+optimized expr : NULL
+output type    : Variant NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : array_concat(parse_json(c1), parse_json(c2))
+raw expr       : array_concat(parse_json(c1::String), parse_json(c2::String))
+checked expr   : array_concat<Variant, Variant>(CAST<String>(c1 AS Variant), CAST<String>(c2 AS Variant))
+evaluation:
++--------+----------------------+--------------------------------+-----------------+
+|        | c1                   | c2                             | Output          |
++--------+----------------------+--------------------------------+-----------------+
+| Type   | String               | String                         | Variant         |
+| Domain | {"[\"a\"]"..="true"} | {"[\"b\", \"c\"]"..="[false]"} | Unknown         |
+| Row 0  | '[1, 2]'             | '[3, 4]'                       | '[1,2,3,4]'     |
+| Row 1  | '["a"]'              | '["b", "c"]'                   | '["a","b","c"]' |
+| Row 2  | 'true'               | '[false]'                      | '[true,false]'  |
++--------+----------------------+--------------------------------+-----------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                                                        |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| c1     | Column(StringColumn[[1, 2], ["a"], true])                                                                                                   |
+| c2     | Column(StringColumn[[3, 4], ["b", "c"], [false]])                                                                                           |
+| Output | Variant([0x80000004200000022000000220000002200000025001500250035004, 0x80000003100000011000000110000001616263, 0x800000024000000030000000]) |
++--------+---------------------------------------------------------------------------------------------------------------------------------------------+
+
+
 ast            : array_remove_first(parse_json('[1, 2, 3]'))
 raw expr       : array_remove_first(parse_json('[1, 2, 3]'))
 checked expr   : array_remove_first<Variant>(CAST<String>("[1, 2, 3]" AS Variant))

--- a/src/query/functions/tests/it/scalars/testdata/variant.txt
+++ b/src/query/functions/tests/it/scalars/testdata/variant.txt
@@ -7217,6 +7217,15 @@ output domain  : {TRUE}
 output         : true
 
 
+ast            : array_contains(parse_json('[1, 2, 3]'), 3)
+raw expr       : array_contains(parse_json('[1, 2, 3]'), 3)
+checked expr   : contains<T0=UInt8><Variant, T0>(CAST<String>("[1, 2, 3]" AS Variant), 3_u8)
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
 ast            : contains(parse_json('[]'), 1)
 raw expr       : contains(parse_json('[]'), 1)
 checked expr   : contains<T0=UInt8><Variant, T0>(CAST<String>("[]" AS Variant), 1_u8)
@@ -7283,6 +7292,73 @@ evaluation (internal):
 | c2     | Column(StringColumn[a, b, c])               |
 | Output | Boolean([0b_____001])                       |
 +--------+---------------------------------------------+
+
+
+ast            : array_approx_count_distinct(parse_json('[1, 2, 2, 3, null]'))
+raw expr       : array_approx_count_distinct(parse_json('[1, 2, 2, 3, null]'))
+checked expr   : array_approx_count_distinct<Variant>(CAST<String>("[1, 2, 2, 3, null]" AS Variant))
+optimized expr : 4_u64
+output type    : UInt64
+output domain  : {4..=4}
+output         : 4
+
+
+ast            : array_approx_count_distinct(parse_json('["a", "b", "a", null]'))
+raw expr       : array_approx_count_distinct(parse_json('["a", "b", "a", null]'))
+checked expr   : array_approx_count_distinct<Variant>(CAST<String>("[\"a\", \"b\", \"a\", null]" AS Variant))
+optimized expr : 3_u64
+output type    : UInt64
+output domain  : {3..=3}
+output         : 3
+
+
+ast            : array_approx_count_distinct(parse_json('[]'))
+raw expr       : array_approx_count_distinct(parse_json('[]'))
+checked expr   : array_approx_count_distinct<Variant>(CAST<String>("[]" AS Variant))
+optimized expr : 0_u64
+output type    : UInt64
+output domain  : {0..=0}
+output         : 0
+
+
+ast            : array_approx_count_distinct(parse_json('1'))
+raw expr       : array_approx_count_distinct(parse_json('1'))
+checked expr   : array_approx_count_distinct<Variant>(CAST<String>("1" AS Variant))
+optimized expr : 1_u64
+output type    : UInt64
+output domain  : {1..=1}
+output         : 1
+
+
+ast            : array_approx_count_distinct(try_cast(NULL AS Variant))
+raw expr       : array_approx_count_distinct(TRY_CAST(NULL AS Variant))
+checked expr   : array_approx_count_distinct<Variant NULL>(TRY_CAST<NULL>(NULL AS Variant NULL))
+optimized expr : NULL
+output type    : UInt64 NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : array_approx_count_distinct(parse_json(c1))
+raw expr       : array_approx_count_distinct(parse_json(c1::String))
+checked expr   : array_approx_count_distinct<Variant>(CAST<String>(c1 AS Variant))
+evaluation:
++--------+----------------------------------+---------+
+|        | c1                               | Output  |
++--------+----------------------------------+---------+
+| Type   | String                           | UInt64  |
+| Domain | {"[\"a\", \"b\", \"a\"]"..="[]"} | Unknown |
+| Row 0  | '[1, 1, 2, null]'                | 3       |
+| Row 1  | '["a", "b", "a"]'                | 2       |
+| Row 2  | '[]'                             | 0       |
++--------+----------------------------------+---------+
+evaluation (internal):
++--------+------------------------------------------------------------+
+| Column | Data                                                       |
++--------+------------------------------------------------------------+
+| c1     | Column(StringColumn[[1, 1, 2, null], ["a", "b", "a"], []]) |
+| Output | UInt64([3, 2, 0])                                          |
++--------+------------------------------------------------------------+
 
 
 ast            : slice(parse_json('[]'), 1)

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -85,6 +85,7 @@ fn test_variant() {
     test_array_reverse(file);
     test_array_unique(file);
     test_array_contains(file);
+    test_array_approx_count_distinct(file);
     test_array_slice(file);
 }
 
@@ -2592,6 +2593,7 @@ fn test_array_unique(file: &mut impl Write) {
 fn test_array_contains(file: &mut impl Write) {
     // Test with simple arrays
     run_ast(file, "contains(parse_json('[1, 2, 3]'), 3)", &[]);
+    run_ast(file, "array_contains(parse_json('[1, 2, 3]'), 3)", &[]);
     run_ast(file, "contains(parse_json('[]'), 1)", &[]);
     run_ast(file, "contains(parse_json('[1, 2, 3]'), null)", &[]);
 
@@ -2612,6 +2614,30 @@ fn test_array_contains(file: &mut impl Write) {
         ),
         ("c2", StringType::from_data(vec!["a", "b", "c"])),
     ]);
+}
+
+fn test_array_approx_count_distinct(file: &mut impl Write) {
+    run_ast(
+        file,
+        "array_approx_count_distinct(parse_json('[1, 2, 2, 3, null]'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "array_approx_count_distinct(parse_json('[\"a\", \"b\", \"a\", null]'))",
+        &[],
+    );
+    run_ast(file, "array_approx_count_distinct(parse_json('[]'))", &[]);
+    run_ast(file, "array_approx_count_distinct(parse_json('1'))", &[]);
+    run_ast(
+        file,
+        "array_approx_count_distinct(try_cast(NULL AS Variant))",
+        &[],
+    );
+    run_ast(file, "array_approx_count_distinct(parse_json(c1))", &[(
+        "c1",
+        StringType::from_data(vec!["[1, 1, 2, null]", "[\"a\", \"b\", \"a\"]", "[]"]),
+    )]);
 }
 
 fn test_array_slice(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/variant.rs
+++ b/src/query/functions/tests/it/scalars/variant.rs
@@ -79,6 +79,7 @@ fn test_variant() {
     test_array_flatten(file);
     test_array_indexof(file);
     test_array_remove(file);
+    test_array_concat(file);
     test_array_remove_first(file);
     test_array_remove_last(file);
     test_array_reverse(file);
@@ -2466,6 +2467,40 @@ fn test_array_remove(file: &mut impl Write) {
             StringType::from_data(vec!["[1, 2, 3]", "[\"a\", \"b\"]", "null"]),
         ),
         ("c2", StringType::from_data(vec!["a", "b", "c"])),
+    ]);
+}
+
+fn test_array_concat(file: &mut impl Write) {
+    run_ast(
+        file,
+        "array_concat(parse_json('[1, 2]'), parse_json('[3, 4]'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "array_concat(parse_json('[1, \"a\"]'), parse_json('[true, null]'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "array_concat(parse_json('1'), parse_json('[2, 3]'))",
+        &[],
+    );
+    run_ast(
+        file,
+        "array_concat(parse_json('[1, 2]'), parse_json('3'))",
+        &[],
+    );
+    run_ast(file, "array_concat(null, parse_json('[1]'))", &[]);
+    run_ast(file, "array_concat(parse_json(c1), parse_json(c2))", &[
+        (
+            "c1",
+            StringType::from_data(vec!["[1, 2]", "[\"a\"]", "true"]),
+        ),
+        (
+            "c2",
+            StringType::from_data(vec!["[3, 4]", "[\"b\", \"c\"]", "[false]"]),
+        ),
     ]);
 }
 

--- a/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
+++ b/tests/sqllogictests/suites/query/functions/02_0065_function_json.test
@@ -1594,6 +1594,21 @@ SELECT array_contains(parse_json('1'), 1), array_contains(parse_json('1'), 4)
 1 0
 
 query ?
+SELECT array_concat(parse_json('[1,2]'), parse_json('[3,4]'))
+----
+[1,2,3,4]
+
+query ?
+SELECT array_concat(parse_json('[1, "a"]'), parse_json('[true, null]'))
+----
+[1,"a",true,null]
+
+query ??
+SELECT array_concat(parse_json('1'), parse_json('[2,3]')), array_concat(parse_json('[1,2]'), parse_json('3'))
+----
+[1,2,3] [1,2,3]
+
+query ?
 SELECT array_flatten(parse_json('[[1,2],[3,4]]'))
 ----
 [1,2,3,4]
@@ -1695,4 +1710,3 @@ query I
 SELECT array_unique(parse_json('["a", "b", "a", null, "c"]'))
 ----
 4
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add `array_concat(Variant, Variant)` support for Variant arrays and scalar Variant values
- Add regression coverage for Variant `array_contains` alias resolution
- Add regression coverage for Variant `array_approx_count_distinct`

Closes #18011 partially. Numeric/statistical Variant array aggregates are intentionally left out because they require implicit numeric conversion semantics.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation run:

```bash
cargo test -p databend-common-functions --test it test_variant
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19869)
<!-- Reviewable:end -->
