### PR TITLE
feat(query): support ISO 8601 interval durations

### DIFF
--- a/src/common/io/src/interval.rs
+++ b/src/common/io/src/interval.rs
@@ -17,6 +17,8 @@ use std::fmt::Formatter;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use jiff::Span;
+use jiff::fmt::temporal::SpanParser;
 
 pub trait BufferReadIntervalExt {
     fn read_interval_text(&mut self) -> Result<Interval>;
@@ -156,16 +158,23 @@ impl Interval {
         if len == 0 {
             return Err(ErrorCode::BadArguments("Empty string".to_string()));
         }
-        match str[pos] {
-            b'@' => {
-                pos += 1;
-            }
-            b'P' | b'p' => {
-                return Err(ErrorCode::BadArguments(
-                    "Posix intervals not supported yet".to_string(),
-                ));
+        if str[pos] == b'@' {
+            pos += 1;
+        }
+
+        let mut iso_pos = pos;
+        while iso_pos < len && matches!(str[iso_pos], b' ' | b'\t' | b'\n') {
+            iso_pos += 1;
+        }
+        let iso_start = iso_pos;
+        match str.get(iso_pos) {
+            Some(b'-') | Some(b'+') => {
+                iso_pos += 1;
             }
             _ => {}
+        }
+        if iso_pos < len && matches!(str[iso_pos], b'P' | b'p') {
+            return parse_iso8601_duration(&str[iso_start..]);
         }
 
         while pos < len {
@@ -339,6 +348,97 @@ fn parse_time_part_with_micros(bytes: &[u8]) -> Result<(i64, i64, usize)> {
     }
 
     Ok((number, fraction, pos))
+}
+
+fn parse_iso8601_duration(bytes: &[u8]) -> Result<Interval> {
+    SpanParser::new()
+        .parse_span(bytes)
+        .map_err(|e| ErrorCode::BadArguments(format!("Invalid ISO 8601 duration: {}", e)))
+        .and_then(span_to_interval)
+}
+
+fn add_months(result: &mut Interval, months: i64) -> Result<()> {
+    result.months = result
+        .months
+        .checked_add(
+            months
+                .try_into()
+                .map_err(|_| ErrorCode::BadArguments("Overflow".to_string()))?,
+        )
+        .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?;
+    Ok(())
+}
+
+fn add_days(result: &mut Interval, days: i64) -> Result<()> {
+    result.days = result
+        .days
+        .checked_add(
+            days.try_into()
+                .map_err(|_| ErrorCode::BadArguments("Overflow".to_string()))?,
+        )
+        .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?;
+    Ok(())
+}
+
+fn add_micros(result: &mut Interval, micros: i64) -> Result<()> {
+    result.micros = result
+        .micros
+        .checked_add(micros)
+        .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?;
+    Ok(())
+}
+
+fn span_to_interval(span: Span) -> Result<Interval> {
+    let mut result = Interval::default();
+    add_months(
+        &mut result,
+        i64::from(span.get_years())
+            .checked_mul(MONTHS_PER_YEAR as i64)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_months(&mut result, i64::from(span.get_months()))?;
+    add_days(
+        &mut result,
+        i64::from(span.get_weeks())
+            .checked_mul(DAYS_PER_WEEK as i64)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_days(&mut result, i64::from(span.get_days()))?;
+    add_micros(
+        &mut result,
+        i64::from(span.get_hours())
+            .checked_mul(MICROS_PER_HOUR)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_micros(
+        &mut result,
+        span.get_minutes()
+            .checked_mul(MICROS_PER_MINUTE)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_micros(
+        &mut result,
+        span.get_seconds()
+            .checked_mul(MICROS_PER_SEC)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_micros(
+        &mut result,
+        span.get_milliseconds()
+            .checked_mul(MICROS_PER_MSEC)
+            .ok_or(ErrorCode::BadArguments("Overflow".to_string()))?,
+    )?;
+    add_micros(&mut result, span.get_microseconds())?;
+
+    let nanoseconds = span.get_nanoseconds();
+    if nanoseconds % 1_000 != 0 {
+        return Err(ErrorCode::BadArguments(
+            "ISO 8601 durations with sub-microsecond precision are not supported".to_string(),
+        ));
+    }
+    add_micros(&mut result, nanoseconds / 1_000)?;
+
+    Ok(result)
 }
 
 fn parse_identifier(s: &[u8]) -> (String, usize) {

--- a/src/common/io/tests/it/interval.rs
+++ b/src/common/io/tests/it/interval.rs
@@ -67,11 +67,72 @@ fn test_interval_from_string() {
             days: -1,
             micros: -5025000000,
         }),
+        ("P1Y2M3DT4H5M6S", Interval {
+            months: 14,
+            days: 3,
+            micros: 14_706_000_000,
+        }),
+        ("p1y2m3dt4h5m6s", Interval {
+            months: 14,
+            days: 3,
+            micros: 14_706_000_000,
+        }),
+        ("P3W", Interval {
+            months: 0,
+            days: 21,
+            micros: 0,
+        }),
+        ("PT0.123456S", Interval {
+            months: 0,
+            days: 0,
+            micros: 123_456,
+        }),
+        ("PT1.5M", Interval {
+            months: 0,
+            days: 0,
+            micros: 90_000_000,
+        }),
+        ("+P2D", Interval {
+            months: 0,
+            days: 2,
+            micros: 0,
+        }),
+        ("@ P1Y", Interval {
+            months: 12,
+            days: 0,
+            micros: 0,
+        }),
+        ("PT0.123456000S", Interval {
+            months: 0,
+            days: 0,
+            micros: 123_456,
+        }),
+        ("-P1DT2H", Interval {
+            months: 0,
+            days: -1,
+            micros: -7_200_000_000,
+        }),
     ];
 
     for (input, expected) in tests {
         let interval = Interval::from_string(input).unwrap();
         assert_eq!(interval, expected);
+    }
+
+    for input in [
+        "P",
+        "PT",
+        "P0.5D",
+        "P1.5Y",
+        "P1.5M",
+        "P1D2Y",
+        "PT1H2Y",
+        "PT0.123456789S",
+    ] {
+        assert!(
+            Interval::from_string(input).is_err(),
+            "{input} should be rejected"
+        );
     }
 }
 

--- a/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
+++ b/tests/sqllogictests/suites/query/functions/02_0079_function_interval.test
@@ -58,6 +58,40 @@ select to_interval('1 month 1 hour 1 microsecond ago');
 
 skipif mysql
 query ?
+select to_interval('P1Y2M3DT4H5M6S');
+----
+1 year 2 months 3 days 4:05:06
+
+skipif mysql
+query ?
+select interval 'P3W';
+----
+21 days
+
+skipif mysql
+query ?
+select to_interval('PT0.123456S');
+----
+0:00:00.123456
+
+skipif mysql
+query ?
+select to_interval('+P2D');
+----
+2 days
+
+skipif mysql
+query ?
+select to_interval('-P1DT2H');
+----
+-1 day -2:00:00
+
+skipif mysql
+statement error 1006
+select to_interval('PT0.123456789S');
+
+skipif mysql
+query ?
 select to_interval('1 month 1 hour 1 microsecond ago');
 ----
 -1 month -1:00:00.000001


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #19139
- Add ISO 8601 duration parsing for Databend INTERVAL values using jiff's temporal SpanParser.
- Convert parsed spans into Databend's months/days/microseconds interval representation with checked arithmetic.
- Reject sub-microsecond ISO 8601 durations that cannot be represented losslessly.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Ran:

- cargo test -p databend-common-io interval --test it
- cargo clippy -p databend-common-io --test it -- -D warnings
- cargo build -p databend-binaries --bin databend-query
- target/debug/databend-sqllogictests --handlers http --run_dir functions --run_file 02_0079_function_interval.test --enable_sandbox

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19877)
<!-- Reviewable:end -->
