### PR TITLE
fix(storage): retry binary fuse32 with expanded capacity

### DIFF
--- a/src/query/storages/common/index/src/filters/xor8/binary_fuse32_filter.rs
+++ b/src/query/storages/common/index/src/filters/xor8/binary_fuse32_filter.rs
@@ -36,11 +36,85 @@ pub struct BinaryFuse32Builder {
     digests: HashSet<u64>,
 }
 
+// Databend-specific retry policy. The upstream xorf constructor does not expose
+// capacity controls, so Databend uses these values only after the default xorf
+// build path fails.
+const BINARY_FUSE32_EXPANSION_FACTORS: &[f64] = &[1.25, 1.5, 2.0];
+const BINARY_FUSE32_EXPANDED_MAX_ITER: usize = 128;
+
+// Copied from xorf 0.12.0's binary-fuse implementation.
+const BINARY_FUSE32_ARITY: u32 = 3;
+const BINARY_FUSE32_MAX_SEGMENT_LENGTH: u32 = 262_144;
+
+// Databend-specific wrapper for selecting the normal xorf build path, expanded
+// capacity retries, and test-only failure injection.
+#[derive(Clone, Copy)]
+pub(super) struct BinaryFuse32BuildPolicy {
+    expansion_factors: &'static [f64],
+    expanded_max_iter: usize,
+    #[cfg(test)]
+    skip_default: bool,
+    #[cfg(test)]
+    force_expanded_failure: bool,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct BinaryFuse32Filter {
     pub descriptor: [u8; BinaryFuse32::DESCRIPTOR_LEN],
     pub fingerprints: Vec<u32>,
     pub len: usize,
+}
+
+struct BinaryFuse32BuildParts {
+    descriptor: [u8; BinaryFuse32::DESCRIPTOR_LEN],
+    fingerprints: Vec<u32>,
+    report: BinaryFuse32ExpandedBuildReport,
+}
+
+struct BinaryFuse32BuildOutcome {
+    filter: BinaryFuse32Filter,
+    report: BinaryFuse32BuildReport,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BinaryFuse32BuildReport {
+    method: BinaryFuse32BuildMethod,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum BinaryFuse32BuildMethod {
+    Default,
+    Expanded(BinaryFuse32ExpandedBuildReport),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BinaryFuse32ExpandedBuildReport {
+    capacity_factor_multiplier: f64,
+    max_iter: usize,
+    iterations: usize,
+    fingerprint_count: usize,
+    segment_length: u32,
+    segment_count_length: u32,
+}
+
+impl BinaryFuse32BuildOutcome {
+    fn log_final_if_needed(&self, distinct_digests: usize) {
+        match self.report.method {
+            BinaryFuse32BuildMethod::Default => {}
+            BinaryFuse32BuildMethod::Expanded(report) => {
+                log::info!(
+                    "binary fuse32 filter built with expanded capacity; final_filter=binary_fuse32 distinct_digests={} capacity_factor_multiplier={:.2} max_iter={} iterations={} fingerprint_count={} segment_length={} segment_count_length={}",
+                    distinct_digests,
+                    report.capacity_factor_multiplier,
+                    report.max_iter,
+                    report.iterations,
+                    report.fingerprint_count,
+                    report.segment_length,
+                    report.segment_count_length
+                );
+            }
+        }
+    }
 }
 
 #[derive(thiserror::Error, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -61,6 +135,114 @@ pub struct BinaryFuse32BuildingError {
 impl BinaryFuse32Builder {
     pub fn create() -> Self {
         Self::default()
+    }
+
+    pub(super) fn take_digests(&mut self) -> Vec<u64> {
+        std::mem::take(&mut self.digests).into_iter().collect()
+    }
+
+    pub(super) fn build_from_digests(
+        digests: &[u64],
+    ) -> Result<BinaryFuse32Filter, BinaryFuse32BuildingError> {
+        Self::build_from_digests_with_policy(digests, BinaryFuse32BuildPolicy::default())
+    }
+
+    pub(super) fn build_from_digests_with_policy(
+        digests: &[u64],
+        policy: BinaryFuse32BuildPolicy,
+    ) -> Result<BinaryFuse32Filter, BinaryFuse32BuildingError> {
+        Self::build_from_digests_with_policy_and_report(digests, policy)
+            .map(|outcome| outcome.filter)
+    }
+
+    fn build_from_digests_with_policy_and_report(
+        digests: &[u64],
+        policy: BinaryFuse32BuildPolicy,
+    ) -> Result<BinaryFuse32BuildOutcome, BinaryFuse32BuildingError> {
+        let len = digests.len();
+        let mut last_error = None;
+
+        // External crate path: keep the default xorf constructor unchanged.
+        if policy.should_try_default() {
+            match BinaryFuse32::try_from(digests) {
+                Ok(filter) => {
+                    let mut descriptor = [0; BinaryFuse32::DESCRIPTOR_LEN];
+                    filter.dma_copy_descriptor_to(&mut descriptor);
+                    return Ok(BinaryFuse32BuildOutcome {
+                        filter: BinaryFuse32Filter {
+                            descriptor,
+                            fingerprints: filter.fingerprints.into_vec(),
+                            len,
+                        },
+                        report: BinaryFuse32BuildReport {
+                            method: BinaryFuse32BuildMethod::Default,
+                        },
+                    });
+                }
+                Err(err) => {
+                    let err = err.to_string();
+                    log::info!(
+                        "binary fuse32 default build failed for {} distinct digests, retrying with expanded capacity; expansion_factors={:?}; error={}",
+                        len,
+                        policy.expansion_factors,
+                        err
+                    );
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        // Databend-specific retry path: use the local xorf-derived constructor
+        // with additional capacity before giving up.
+        for factor in policy.expansion_factors {
+            if policy.should_force_expanded_failure() {
+                let err = "forced binary fuse32 expanded build failure".to_string();
+                log::info!(
+                    "binary fuse32 expanded capacity build failed; distinct_digests={} capacity_factor_multiplier={:.2} max_iter={} error={}",
+                    len,
+                    factor,
+                    policy.expanded_max_iter,
+                    err
+                );
+                last_error = Some(err);
+                continue;
+            }
+
+            match build_binary_fuse32_with_capacity_factor(
+                digests,
+                *factor,
+                policy.expanded_max_iter,
+            ) {
+                Ok(parts) => {
+                    let outcome = BinaryFuse32BuildOutcome {
+                        filter: BinaryFuse32Filter {
+                            descriptor: parts.descriptor,
+                            fingerprints: parts.fingerprints,
+                            len,
+                        },
+                        report: BinaryFuse32BuildReport {
+                            method: BinaryFuse32BuildMethod::Expanded(parts.report),
+                        },
+                    };
+                    outcome.log_final_if_needed(len);
+                    return Ok(outcome);
+                }
+                Err(err) => {
+                    log::info!(
+                        "binary fuse32 expanded capacity build failed; distinct_digests={} capacity_factor_multiplier={:.2} max_iter={} error={}",
+                        len,
+                        factor,
+                        policy.expanded_max_iter,
+                        err
+                    );
+                    last_error = Some(err.to_string());
+                }
+            }
+        }
+
+        Err(BinaryFuse32BuildingError::new(last_error.unwrap_or_else(
+            || "Failed to construct binary fuse filter.".to_string(),
+        )))
     }
 }
 
@@ -106,21 +288,389 @@ impl FilterBuilder for BinaryFuse32Builder {
     }
 
     fn build(&mut self) -> Result<Self::Filter, Self::Error> {
-        let digests = std::mem::take(&mut self.digests);
-        let len = digests.len();
-        let digests = digests.into_iter().collect::<Vec<_>>();
-        let filter =
-            BinaryFuse32::try_from(digests.as_slice()).map_err(BinaryFuse32BuildingError::new)?;
-
-        let mut descriptor = [0; BinaryFuse32::DESCRIPTOR_LEN];
-        filter.dma_copy_descriptor_to(&mut descriptor);
-
-        Ok(BinaryFuse32Filter {
-            descriptor,
-            fingerprints: filter.fingerprints.into_vec(),
-            len,
-        })
+        let digests = self.take_digests();
+        Self::build_from_digests(digests.as_slice())
     }
+}
+
+impl Default for BinaryFuse32BuildPolicy {
+    fn default() -> Self {
+        Self {
+            expansion_factors: BINARY_FUSE32_EXPANSION_FACTORS,
+            expanded_max_iter: BINARY_FUSE32_EXPANDED_MAX_ITER,
+            #[cfg(test)]
+            skip_default: false,
+            #[cfg(test)]
+            force_expanded_failure: false,
+        }
+    }
+}
+
+impl BinaryFuse32BuildPolicy {
+    #[cfg(test)]
+    pub(super) fn for_test(skip_default: bool, force_expanded_failure: bool) -> Self {
+        Self {
+            expansion_factors: &[1.25],
+            expanded_max_iter: BINARY_FUSE32_EXPANDED_MAX_ITER,
+            skip_default,
+            force_expanded_failure,
+        }
+    }
+
+    fn should_try_default(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.skip_default
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    }
+
+    fn should_force_expanded_failure(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.force_expanded_failure
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    }
+}
+
+// Copied/adapted from xorf 0.12.0's binary-fuse constructor
+// (MIT, Copyright (c) 2019 hafiz).
+//
+// Databend modifications:
+// - capacity_factor_multiplier lets retry callers allocate more buckets than upstream xorf.
+// - max_iter is caller-controlled because this path runs after xorf's default 1000 attempts.
+// - the return type is BinaryFuse32BuildParts so Databend can keep its existing filter format.
+fn build_binary_fuse32_with_capacity_factor(
+    keys: &[u64],
+    capacity_factor_multiplier: f64,
+    max_iter: usize,
+) -> Result<BinaryFuse32BuildParts, &'static str> {
+    let size = keys.len();
+    let segment_length = binary_fuse32_segment_length(BINARY_FUSE32_ARITY, size as u32)
+        .min(BINARY_FUSE32_MAX_SEGMENT_LENGTH);
+    let segment_length_mask = segment_length - 1;
+
+    // Databend-specific capacity expansion: upstream xorf uses only
+    // binary_fuse32_size_factor(...); retries multiply it to reduce graph load.
+    let size_factor = binary_fuse32_size_factor(BINARY_FUSE32_ARITY, size as u32)
+        * capacity_factor_multiplier.max(1.0);
+    let capacity = if size > 1 {
+        (size as f64 * size_factor).round() as u32
+    } else {
+        0
+    };
+    let init_segment_count = capacity.div_ceil(segment_length);
+    let (fp_array_len, segment_count) = {
+        let array_len = init_segment_count * segment_length;
+        let proposed = array_len.div_ceil(segment_length);
+        let segment_count = if proposed < BINARY_FUSE32_ARITY {
+            1
+        } else {
+            proposed - (BINARY_FUSE32_ARITY - 1)
+        };
+        let array_len = (segment_count + BINARY_FUSE32_ARITY - 1) * segment_length;
+        (array_len as usize, segment_count)
+    };
+    let segment_count_length = segment_count * segment_length;
+
+    let mut fingerprints = random_u32_vec(fp_array_len);
+    let capacity = fingerprints.len();
+    let mut alone = vec![0_u32; capacity];
+    let mut t2count = vec![0_u8; capacity];
+    let mut t2hash = vec![0_u64; capacity];
+    let mut reverse_h = vec![0_u8; size];
+    let mut reverse_order = vec![0_u64; size + 1];
+    reverse_order[size] = 1;
+
+    let mut block_bits = 1_u32;
+    while (1_u32 << block_bits) < segment_count {
+        block_bits += 1;
+    }
+    let start_pos_len = 1_usize << block_bits;
+    let mut start_pos = vec![0_usize; start_pos_len];
+    let mut h012 = [0_u32; 6];
+
+    let mut rng = 1;
+    let mut seed = splitmix64(&mut rng);
+    let mut ultimate_size = 0;
+    let mut iterations = 0;
+    let mut done = false;
+
+    for iter in 0..max_iter {
+        for (i, pos) in start_pos.iter_mut().enumerate() {
+            *pos = (((i as u64) * (size as u64)) >> block_bits) as usize;
+        }
+        for key in keys {
+            let hash = mix(*key, seed);
+            let mut segment_index = hash >> (64 - block_bits);
+            while reverse_order[start_pos[segment_index as usize]] != 0 {
+                segment_index += 1;
+                segment_index &= (1_u64 << block_bits) - 1;
+            }
+            reverse_order[start_pos[segment_index as usize]] = hash;
+            start_pos[segment_index as usize] += 1;
+        }
+
+        let mut error = false;
+        let mut duplicates = 0;
+        for hash in reverse_order.iter().take(size).copied() {
+            let (index1, index2, index3) = hash_of_hash(
+                hash,
+                segment_length,
+                segment_length_mask,
+                segment_count_length,
+            );
+            let (index1, index2, index3) = (index1 as usize, index2 as usize, index3 as usize);
+
+            t2count[index1] = t2count[index1].wrapping_add(4);
+            t2hash[index1] ^= hash;
+            t2count[index2] = t2count[index2].wrapping_add(4);
+            t2count[index2] ^= 1;
+            t2hash[index2] ^= hash;
+            t2count[index3] = t2count[index3].wrapping_add(4);
+            t2count[index3] ^= 2;
+            t2hash[index3] ^= hash;
+
+            if t2hash[index1] & t2hash[index2] & t2hash[index3] == 0
+                && (((t2hash[index1] == 0) && (t2count[index1] == 8))
+                    || ((t2hash[index2] == 0) && (t2count[index2] == 8))
+                    || ((t2hash[index3] == 0) && (t2count[index3] == 8)))
+            {
+                duplicates += 1;
+                t2count[index1] = t2count[index1].wrapping_sub(4);
+                t2hash[index1] ^= hash;
+                t2count[index2] = t2count[index2].wrapping_sub(4);
+                t2count[index2] ^= 1;
+                t2hash[index2] ^= hash;
+                t2count[index3] = t2count[index3].wrapping_sub(4);
+                t2count[index3] ^= 2;
+                t2hash[index3] ^= hash;
+            }
+            error = t2count[index1] < 4 || t2count[index2] < 4 || t2count[index3] < 4;
+        }
+        if error {
+            reset_binary_fuse32_build_state(&mut reverse_order, &mut t2count, &mut t2hash, size);
+            seed = splitmix64(&mut rng);
+            continue;
+        }
+
+        let mut qsize = 0;
+        for (i, count) in t2count.iter().enumerate().take(capacity) {
+            alone[qsize] = i as u32;
+            if (count >> 2) == 1 {
+                qsize += 1;
+            }
+        }
+
+        let mut stack_size = 0;
+        while qsize > 0 {
+            qsize -= 1;
+            let index = alone[qsize] as usize;
+            if (t2count[index] >> 2) == 1 {
+                let hash = t2hash[index];
+                let found = t2count[index] & 3;
+                reverse_h[stack_size] = found;
+                reverse_order[stack_size] = hash;
+                stack_size += 1;
+
+                let (index1, index2, index3) = hash_of_hash(
+                    hash,
+                    segment_length,
+                    segment_length_mask,
+                    segment_count_length,
+                );
+                h012[1] = index2;
+                h012[2] = index3;
+                h012[3] = index1;
+                h012[4] = h012[1];
+
+                let other_index1 = h012[(found + 1) as usize] as usize;
+                alone[qsize] = other_index1 as u32;
+                if (t2count[other_index1] >> 2) == 2 {
+                    qsize += 1;
+                }
+                t2count[other_index1] = t2count[other_index1].wrapping_sub(4);
+                t2count[other_index1] ^= mod3(found + 1);
+                t2hash[other_index1] ^= hash;
+
+                let other_index2 = h012[(found + 2) as usize] as usize;
+                alone[qsize] = other_index2 as u32;
+                if (t2count[other_index2] >> 2) == 2 {
+                    qsize += 1;
+                }
+                t2count[other_index2] = t2count[other_index2].wrapping_sub(4);
+                t2count[other_index2] ^= mod3(found + 2);
+                t2hash[other_index2] ^= hash;
+            }
+        }
+
+        if stack_size + duplicates == size {
+            ultimate_size = stack_size;
+            iterations = iter + 1;
+            done = true;
+            break;
+        }
+
+        reset_binary_fuse32_build_state(&mut reverse_order, &mut t2count, &mut t2hash, size);
+        seed = splitmix64(&mut rng);
+    }
+
+    if !done {
+        return Err("Failed to construct binary fuse filter.");
+    }
+
+    for i in (0..ultimate_size).rev() {
+        let hash = reverse_order[i];
+        let xor2 = fingerprint(hash);
+        let (index1, index2, index3) = hash_of_hash(
+            hash,
+            segment_length,
+            segment_length_mask,
+            segment_count_length,
+        );
+        let found = reverse_h[i] as usize;
+        h012[0] = index1;
+        h012[1] = index2;
+        h012[2] = index3;
+        h012[3] = h012[0];
+        h012[4] = h012[1];
+        fingerprints[h012[found] as usize] =
+            xor2 ^ fingerprints[h012[found + 1] as usize] ^ fingerprints[h012[found + 2] as usize];
+    }
+
+    Ok(BinaryFuse32BuildParts {
+        descriptor: serialize_binary_fuse32_descriptor(
+            seed,
+            segment_length,
+            segment_length_mask,
+            segment_count_length,
+        ),
+        report: BinaryFuse32ExpandedBuildReport {
+            capacity_factor_multiplier: capacity_factor_multiplier.max(1.0),
+            max_iter,
+            iterations,
+            fingerprint_count: fingerprints.len(),
+            segment_length,
+            segment_count_length,
+        },
+        fingerprints,
+    })
+}
+
+fn reset_binary_fuse32_build_state(
+    reverse_order: &mut [u64],
+    t2count: &mut [u8],
+    t2hash: &mut [u64],
+    size: usize,
+) {
+    for value in reverse_order.iter_mut().take(size) {
+        *value = 0;
+    }
+    t2count.fill(0);
+    t2hash.fill(0);
+}
+
+// Copied from xorf 0.12.0 prelude::bfuse::segment_length.
+fn binary_fuse32_segment_length(arity: u32, size: u32) -> u32 {
+    if size == 0 {
+        return 4;
+    }
+
+    match arity {
+        3 => 1 << ((size as f64).ln() / 3.33_f64.ln() + 2.25).floor() as u32,
+        4 => 1 << ((size as f64).ln() / 2.91_f64.ln() - 0.5).floor() as u32,
+        _ => 65_536,
+    }
+}
+
+// Copied from xorf 0.12.0 prelude::bfuse::size_factor.
+fn binary_fuse32_size_factor(arity: u32, size: u32) -> f64 {
+    match arity {
+        3 => 1.125_f64.max(0.875 + 0.25 * 1_000_000_f64.ln() / (size as f64).ln()),
+        4 => 1.075_f64.max(0.77 + 0.305 * 600_000_f64.ln() / (size as f64).ln()),
+        _ => 2.0,
+    }
+}
+
+// Copied from xorf 0.12.0 prelude::bfuse::hash_of_hash.
+const fn hash_of_hash(
+    hash: u64,
+    segment_length: u32,
+    segment_length_mask: u32,
+    segment_count_length: u32,
+) -> (u32, u32, u32) {
+    let hi = ((hash as u128 * segment_count_length as u128) >> 64) as u64;
+    let h0 = hi as u32;
+    let mut h1 = h0 + segment_length;
+    let mut h2 = h1 + segment_length;
+    h1 ^= ((hash >> 18) as u32) & segment_length_mask;
+    h2 ^= (hash as u32) & segment_length_mask;
+    (h0, h1, h2)
+}
+
+// Copied from xorf 0.12.0 prelude::mix.
+const fn mix(key: u64, seed: u64) -> u64 {
+    murmur3_mix64(key.overflowing_add(seed).0)
+}
+
+// Copied from xorf 0.12.0 murmur3::mix64.
+const fn murmur3_mix64(mut k: u64) -> u64 {
+    k ^= k >> 33;
+    k = k.overflowing_mul(0xff51_afd7_ed55_8ccd).0;
+    k ^= k >> 33;
+    k = k.overflowing_mul(0xc4ce_b9fe_1a85_ec53).0;
+    k ^= k >> 33;
+    k
+}
+
+// Copied from xorf 0.12.0 splitmix64::splitmix64.
+const fn splitmix64(seed: &mut u64) -> u64 {
+    *seed = (*seed).overflowing_add(0x9e37_79b9_7f4a_7c15).0;
+    let mut z = *seed;
+    z = (z ^ (z >> 30)).overflowing_mul(0xbf58_476d_1ce4_e5b9).0;
+    z = (z ^ (z >> 27)).overflowing_mul(0x94d0_49bb_1331_11eb).0;
+    z ^ (z >> 31)
+}
+
+// Copied from xorf 0.12.0 fingerprint! macro for u32 fingerprints.
+const fn fingerprint(hash: u64) -> u32 {
+    (hash ^ (hash >> 32)) as u32
+}
+
+// Copied from xorf 0.12.0 prelude::bfuse::mod3.
+const fn mod3(x: u8) -> u8 {
+    if x > 2 { x - 3 } else { x }
+}
+
+// Copied behavior from xorf 0.12.0 make_fp_block! with the default
+// uniform-random feature enabled.
+fn random_u32_vec(len: usize) -> Vec<u32> {
+    use rand::Rng;
+
+    let mut rng = rand::thread_rng();
+    (0..len).map(|_| rng.r#gen()).collect()
+}
+
+// Copied from xorf 0.12.0 prelude::bfuse::serialize_bfuse_descriptor.
+fn serialize_binary_fuse32_descriptor(
+    seed: u64,
+    segment_length: u32,
+    segment_length_mask: u32,
+    segment_count_length: u32,
+) -> [u8; BinaryFuse32::DESCRIPTOR_LEN] {
+    let mut descriptor = [0; BinaryFuse32::DESCRIPTOR_LEN];
+    descriptor[0..8].copy_from_slice(&seed.to_le_bytes());
+    descriptor[8..12].copy_from_slice(&segment_length.to_le_bytes());
+    descriptor[12..16].copy_from_slice(&segment_length_mask.to_le_bytes());
+    descriptor[16..20].copy_from_slice(&segment_count_length.to_le_bytes());
+    descriptor
 }
 
 impl BinaryFuse32Filter {
@@ -243,5 +793,184 @@ impl From<BinaryFuse32CodecError> for ErrorCode {
 impl From<BinaryFuse32BuildingError> for ErrorCode {
     fn from(value: BinaryFuse32BuildingError) -> Self {
         ErrorCode::Internal(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filters::Filter;
+
+    #[test]
+    fn test_binary_fuse32_expanded_capacity_recovers_default_capacity_failure() -> anyhow::Result<()>
+    {
+        let digests = vec![
+            12100706573412259482,
+            17858013903799158384,
+            10152736786087156494,
+            12170187926617211409,
+            5284553034609843520,
+            3211710694437752088,
+            15694839755804416522,
+            6391141964374214533,
+            17626201369861675860,
+            7626797314791856264,
+            8567517852399908291,
+            6444936252164222020,
+            9673155920647281941,
+            15894702437242958609,
+            90128777876498152,
+            14490824520645362361,
+            14163394562527960091,
+            6708180727249648600,
+            14372662790589329629,
+            14618819062068333240,
+            9620166075153112809,
+            12994877493529946390,
+            16040861691064476301,
+            8245063073441705875,
+            2179470377530870222,
+            16066067840546653594,
+            4265101728311556601,
+            11360246383933319891,
+            10356058033158317956,
+            3785617108824048717,
+            1247669162467556207,
+            10022990056860465042,
+            1110477748206289262,
+            678962376812795467,
+            17831833484229510073,
+            12161966210082697389,
+            4819526261903045160,
+            14885564733575625995,
+            14924878448938284390,
+            15064984116938632310,
+            10127765685281267631,
+            6092469470155110584,
+            7681863527100079009,
+            11015870799992868554,
+            7134618193083055412,
+            16467668817819039376,
+            9928519277040420462,
+            6893434167711646496,
+            15572473738468915916,
+            11315772967394156742,
+            15268015117525993607,
+            14575715293971198500,
+            11495411569663237476,
+            12444118524173595866,
+            14601166832861057032,
+            17642275503075678808,
+            11185851304602332536,
+            709252799161131540,
+            16995486786927067363,
+            274162950980966,
+            7040072277512602530,
+            5934435424632034030,
+            17643569146426879563,
+            5046090017088365665,
+            16014883091215448974,
+            883819158922431235,
+            10196270488149429808,
+            16910334359241066592,
+            13490698011305250417,
+            9517203424476796989,
+            6863696478851308562,
+            14417947448345495252,
+            1571779993856074856,
+            13278998155001809952,
+            13361374239916316824,
+            3837283065186354764,
+            6680095640535184930,
+            15588342311100669528,
+            15924741661086806326,
+            684459667952103007,
+            16868037927113757844,
+            6685867604996884404,
+            13507247350073953511,
+            3158590621289567134,
+            2808056756228423657,
+            8361707712099200938,
+            10784383143483211449,
+            477119357624403010,
+            1911009254525574630,
+            13632728370555614054,
+            11342636802715993318,
+            9862827257094527411,
+            13299353238451455087,
+            2581568334556385261,
+            11414734225507378062,
+            15307696201761468920,
+            248366729594843930,
+            11179289291902106648,
+            6994260465887223064,
+            14502631462809994788,
+            18247160397703506436,
+            17057838425721492455,
+            14520256392420020792,
+            15085264981589126584,
+            10293093893062252943,
+            13161074059329979574,
+            14038977343094598345,
+            14850852512134113083,
+            10330068343636960212,
+            4729983124433325678,
+            17652684372743698114,
+            15535070370897330016,
+            3825171570508255433,
+            8969825465492377628,
+            16167872397109883820,
+            1603489173358878440,
+            7945632331782402465,
+            6971186796201247995,
+            1820773671547830035,
+            8295330553601476933,
+            17796666516457908256,
+            6108601816583581531,
+            10407093527012674639,
+            6552574783561857517,
+            9601667971705774556,
+            85163704654460877,
+            15480882177410309130,
+            16770848825996339221,
+        ];
+
+        assert!(
+            build_binary_fuse32_with_capacity_factor(digests.as_slice(), 1.0, 1).is_err(),
+            "sample should fail with default capacity in a single construction attempt"
+        );
+
+        let outcome = BinaryFuse32Builder::build_from_digests_with_policy_and_report(
+            digests.as_slice(),
+            BinaryFuse32BuildPolicy::for_test(true, false),
+        )?;
+        let filter = outcome.filter;
+
+        match outcome.report.method {
+            BinaryFuse32BuildMethod::Expanded(report) => {
+                assert_eq!(report.capacity_factor_multiplier, 1.25);
+                assert_eq!(report.max_iter, BINARY_FUSE32_EXPANDED_MAX_ITER);
+                assert_eq!(report.fingerprint_count, filter.fingerprints.len());
+            }
+            BinaryFuse32BuildMethod::Default => {
+                panic!("expected expanded capacity build report")
+            }
+        }
+
+        assert_eq!(filter.len(), Some(digests.len()));
+        for digest in digests {
+            assert!(
+                filter.contains_digest(digest),
+                "digest {} not present",
+                digest
+            );
+        }
+
+        let bytes = filter.to_bytes()?;
+        let (decoded, len) = BinaryFuse32Filter::from_bytes(&bytes)?;
+        assert_eq!(len, bytes.len());
+        assert_eq!(decoded, filter);
+
+        Ok(())
     }
 }

--- a/src/query/storages/common/index/src/filters/xor8/mod.rs
+++ b/src/query/storages/common/index/src/filters/xor8/mod.rs
@@ -132,6 +132,40 @@ impl Filter for FilterImpl {
     }
 }
 
+impl FilterImplBuilder {
+    fn build_with_binary_fuse32_policy(
+        &mut self,
+        policy: binary_fuse32_filter::BinaryFuse32BuildPolicy,
+    ) -> Result<FilterImpl, ErrorCode> {
+        match self {
+            FilterImplBuilder::Xor(filter) => Ok(FilterImpl::Xor(filter.build()?)),
+            FilterImplBuilder::BinaryFuse32(filter) => {
+                let digests = filter.take_digests();
+                match BinaryFuse32Builder::build_from_digests_with_policy(
+                    digests.as_slice(),
+                    policy,
+                ) {
+                    Ok(filter) => Ok(FilterImpl::BinaryFuse32(filter)),
+                    Err(err) => {
+                        // Databend-specific fallback: xorf binary-fuse construction is allowed
+                        // to fail, but bloom index generation should not fail the block write.
+                        let mut fallback = Xor8Builder::create();
+                        fallback.add_digests(digests.iter());
+                        let filter = fallback.build()?;
+                        log::warn!(
+                            "failed to build binary fuse32 filter; final_filter=xor8 distinct_digests={} error={}",
+                            digests.len(),
+                            err
+                        );
+                        Ok(FilterImpl::Xor(filter))
+                    }
+                }
+            }
+            FilterImplBuilder::Ngram(filter) => Ok(FilterImpl::Ngram(filter.build()?)),
+        }
+    }
+}
+
 impl FilterBuilder for FilterImplBuilder {
     type Filter = FilterImpl;
     type Error = ErrorCode;
@@ -161,12 +195,42 @@ impl FilterBuilder for FilterImplBuilder {
     }
 
     fn build(&mut self) -> Result<Self::Filter, Self::Error> {
-        match self {
-            FilterImplBuilder::Xor(filter) => Ok(FilterImpl::Xor(filter.build()?)),
-            FilterImplBuilder::BinaryFuse32(filter) => {
-                Ok(FilterImpl::BinaryFuse32(filter.build()?))
+        self.build_with_binary_fuse32_policy(
+            binary_fuse32_filter::BinaryFuse32BuildPolicy::default(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filters::Filter;
+    use crate::filters::FilterBuilder;
+
+    #[test]
+    fn test_binary_fuse32_filter_impl_falls_back_to_xor8() -> anyhow::Result<()> {
+        let digests = vec![3_u64, 5, 8, 13, 21];
+        let mut builder = FilterImplBuilder::BinaryFuse32(BinaryFuse32Builder::create());
+        builder.add_digests(digests.iter());
+
+        let filter = builder.build_with_binary_fuse32_policy(
+            binary_fuse32_filter::BinaryFuse32BuildPolicy::for_test(true, true),
+        )?;
+
+        match filter {
+            FilterImpl::Xor(filter) => {
+                assert_eq!(filter.len(), Some(digests.len()));
+                for digest in digests {
+                    assert!(
+                        filter.contains_digest(digest),
+                        "digest {} not present",
+                        digest
+                    );
+                }
             }
-            FilterImplBuilder::Ngram(filter) => Ok(FilterImpl::Ngram(filter.build()?)),
+            _ => panic!("expected xor8 fallback"),
         }
+
+        Ok(())
     }
 }

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
@@ -248,3 +248,173 @@ drop table if exists test_a;
 
 statement ok
 drop table if exists test_b;
+
+# Runtime-filter bloom index comparison on the same UInt64 data layout:
+# xor8 keeps all probe blocks, while binary_fuse32 prunes most probe blocks.
+
+statement ok
+set max_threads = 1;
+
+statement ok
+set inlist_runtime_filter_threshold = 3001;
+
+statement ok
+set inlist_runtime_bloom_prune_threshold = 3001;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+drop table if exists rf_build_3k;
+
+statement ok
+drop table if exists rf_probe_3k_xor8;
+
+statement ok
+drop table if exists rf_probe_3k_fuse32;
+
+statement ok
+create or replace table rf_build_3k(number UInt64 not null) row_per_block = 1000 as
+select (number % 1000) * 100 + (number DIV 1000) as number from numbers(3000);
+
+statement ok
+create or replace table rf_probe_3k_xor8(number UInt64 not null) bloom_index_columns = 'number' bloom_index_type = 'xor8' row_per_block = 1000 as
+select (number % 1000) * 100 + (number DIV 1000) as number from numbers(100000);
+
+statement ok
+create or replace table rf_probe_3k_fuse32(number UInt64 not null) bloom_index_columns = 'number' bloom_index_type = 'binary_fuse32' row_per_block = 1000 as
+select (number % 1000) * 100 + (number DIV 1000) as number from numbers(100000);
+
+query I
+select count() from rf_probe_3k_xor8 where number in (select number from rf_build_3k);
+----
+3000
+
+query I
+select count() from rf_probe_3k_fuse32 where number in (select number from rf_build_3k);
+----
+3000
+
+query T
+explain analyze select * from rf_probe_3k_xor8 where number in (select number from rf_build_3k);
+----
+HashJoin
+├── cpu time: <slt:ignore>
+├── wait time: <slt:ignore>
+├── output rows: <slt:ignore>
+├── output bytes: <slt:ignore>
+├── output columns: [rf_probe_3k_xor8.number (#0)]
+├── join type: LEFT SEMI
+├── build keys: [subquery_1 (#1)]
+├── probe keys: [rf_probe_3k_xor8.number (#0)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:subquery_1 (#1), probe targets:[rf_probe_3k_xor8.number (#0)@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: <slt:ignore>
+├── TableScan(Build)
+│   ├── cpu time: <slt:ignore>
+│   ├── wait time: <slt:ignore>
+│   ├── output rows: <slt:ignore>
+│   ├── output bytes: <slt:ignore>
+│   ├── bytes scanned: <slt:ignore>
+│   ├── read from remote: <slt:ignore>
+│   ├── runtime filter bloom time: <slt:ignore>
+│   ├── runtime filter inlist/min-max time: <slt:ignore>
+│   ├── table: default.default.rf_build_3k
+│   ├── scan id: 1
+│   ├── output columns: [number (#1)]
+│   ├── read rows: 3000
+│   ├── read size: <slt:ignore>
+│   ├── partitions total: 3
+│   ├── partitions scanned: 3
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 3000.00
+└── TableScan(Probe)
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    ├── output rows: <slt:ignore>
+    ├── output bytes: <slt:ignore>
+    ├── bytes scanned: <slt:ignore>
+    ├── read from remote: <slt:ignore>
+    ├── runtime filter bloom time: <slt:ignore>
+    ├── runtime filter inlist/min-max time: <slt:ignore>
+    ├── table: default.default.rf_probe_3k_xor8
+    ├── scan id: 0
+    ├── output columns: [number (#0)]
+    ├── read rows: 100000
+    ├── read size: 167.25 KiB
+    ├── partitions total: 99
+    ├── partitions scanned: 99
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 100000.00
+
+query T
+explain analyze select * from rf_probe_3k_fuse32 where number in (select number from rf_build_3k);
+----
+HashJoin
+├── cpu time: <slt:ignore>
+├── wait time: <slt:ignore>
+├── output rows: <slt:ignore>
+├── output bytes: <slt:ignore>
+├── output columns: [rf_probe_3k_fuse32.number (#0)]
+├── join type: LEFT SEMI
+├── build keys: [subquery_1 (#1)]
+├── probe keys: [rf_probe_3k_fuse32.number (#0)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:subquery_1 (#1), probe targets:[rf_probe_3k_fuse32.number (#0)@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: <slt:ignore>
+├── TableScan(Build)
+│   ├── cpu time: <slt:ignore>
+│   ├── wait time: <slt:ignore>
+│   ├── output rows: <slt:ignore>
+│   ├── output bytes: <slt:ignore>
+│   ├── bytes scanned: <slt:ignore>
+│   ├── read from remote: <slt:ignore>
+│   ├── runtime filter bloom time: <slt:ignore>
+│   ├── runtime filter inlist/min-max time: <slt:ignore>
+│   ├── table: default.default.rf_build_3k
+│   ├── scan id: 1
+│   ├── output columns: [number (#1)]
+│   ├── read rows: 3000
+│   ├── read size: <slt:ignore>
+│   ├── partitions total: 3
+│   ├── partitions scanned: 3
+│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 3000.00
+└── TableScan(Probe)
+    ├── cpu time: <slt:ignore>
+    ├── wait time: <slt:ignore>
+    ├── output rows: <slt:ignore>
+    ├── output bytes: <slt:ignore>
+    ├── bytes scanned: <slt:ignore>
+    ├── read from remote: <slt:ignore>
+    ├── parts pruned by runtime filter: 96
+    ├── runtime filter bloom time: <slt:ignore>
+    ├── runtime filter inlist/min-max time: <slt:ignore>
+    ├── table: default.default.rf_probe_3k_fuse32
+    ├── scan id: 0
+    ├── output columns: [number (#0)]
+    ├── read rows: 100000
+    ├── read size: 167.25 KiB
+    ├── partitions total: 99
+    ├── partitions scanned: 99
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 100000.00
+
+statement ok
+drop table if exists rf_build_3k;
+
+statement ok
+drop table if exists rf_probe_3k_xor8;
+
+statement ok
+drop table if exists rf_probe_3k_fuse32;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Retry binary fuse32 construction with expanded capacity factors after the default xorf constructor fails
- Fall back to xor8 if all binary fuse32 attempts still fail, so a single abnormal block does not fail writes
- Add logs for abnormal build paths so the final filter choice is visible without logging default successful builds
- Add regression coverage for expanded-capacity recovery and xor8 fallback

## Changes

This keeps the normal binary fuse32 path on `xorf::BinaryFuse32::try_from` first. If that path fails, Databend retries with a local xorf-derived constructor using larger capacity factors (`1.25`, `1.5`, `2.0`) and a bounded iteration count per factor.

The local constructor code is annotated to distinguish xorf 0.12.0 copied/adapted logic from Databend-specific retry policy changes.

Default binary fuse32 success is not logged. Logs are emitted only when the default build fails and enters expanded-capacity retry, when expanded-capacity retry succeeds with `final_filter=binary_fuse32`, and when fallback succeeds with `final_filter=xor8`.

## Implementation

1. Added `BinaryFuse32BuildPolicy` for the default build, expanded-capacity retries, and test-only failure injection.
2. Added a local binary fuse32 construction path that accepts a capacity multiplier while preserving the existing serialized filter format.
3. Updated `FilterImplBuilder` to fall back to xor8 with a warning when binary fuse32 construction cannot be recovered.
4. Added build report metadata used by logs and tests to identify the selected build path.
5. Added tests for an input where default-capacity construction fails but expanded capacity succeeds, plus a forced fallback test.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validated with:

- `cargo fmt --package databend-storages-common-index`
- `cargo test -p databend-storages-common-index binary_fuse32 -- --nocapture`
- `cargo test -p databend-storages-common-index --lib --tests`
- `cargo clippy -p databend-storages-common-index --lib --tests -- -D warnings`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19884)
<!-- Reviewable:end -->