### PR TITLE
feat(query): add admin API for clustering information

### DIFF
--- a/src/query/service/src/servers/admin/admin_service.rs
+++ b/src/query/service/src/servers/admin/admin_service.rs
@@ -49,7 +49,7 @@ impl AdminService {
         })
     }
 
-    fn build_router(&self) -> impl Endpoint + use<> {
+    pub fn build_router(&self) -> impl Endpoint + use<> {
         #[cfg_attr(not(feature = "memory-profiling"), allow(unused_mut))]
         let mut route = Route::new()
             .at("/v1/health", get(health_handler))
@@ -122,6 +122,10 @@ impl AdminService {
                 .at(
                     "/v1/tenants/:tenant/procedures/:name",
                     get(super::v1::procedures::get_procedure_by_name),
+                )
+                .at(
+                    "/v1/tenants/:tenant/databases/:database/tables/:table/clustering_information",
+                    get(super::v1::clustering_information::clustering_information_handler),
                 )
                 .at(
                     "/v1/tenants/:tenant/databases/:database/tables/:table/stats",

--- a/src/query/service/src/servers/admin/v1/clustering_information.rs
+++ b/src/query/service/src/servers/admin/v1/clustering_information.rs
@@ -1,0 +1,84 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::session_type::SessionType;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_meta_app::tenant::Tenant;
+use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::table_functions::ClusteringInformationResponse;
+use databend_common_storages_fuse::table_functions::get_clustering_information;
+use fastrace::func_name;
+use http::StatusCode;
+use poem::IntoResponse;
+use poem::web::Json;
+use poem::web::Path;
+use poem::web::Query;
+use serde::Deserialize;
+
+use crate::sessions::SessionManager;
+use crate::sessions::TableContext;
+
+#[derive(Debug, Deserialize)]
+pub struct ClusteringInformationQuery {
+    pub cluster_key: Option<String>,
+    pub branch: Option<String>,
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn clustering_information_handler(
+    Path((tenant, database, table)): Path<(String, String, String)>,
+    Query(params): Query<ClusteringInformationQuery>,
+) -> poem::Result<impl IntoResponse> {
+    let tenant = Tenant::new_or_err(tenant, func_name!()).map_err(poem::error::BadRequest)?;
+    let resp = load_clustering_information(&tenant, &database, &table, params)
+        .await
+        .map_err(clustering_information_error)?;
+    Ok(Json(resp))
+}
+
+#[async_backtrace::framed]
+async fn load_clustering_information(
+    tenant: &Tenant,
+    database: &str,
+    table: &str,
+    params: ClusteringInformationQuery,
+) -> Result<ClusteringInformationResponse> {
+    let mut dummy_session = SessionManager::instance()
+        .create_session(SessionType::Dummy)
+        .await?;
+    dummy_session.set_current_tenant(tenant.clone());
+    let session = SessionManager::instance().register_session(dummy_session)?;
+
+    let ctx: Arc<dyn TableContext> = session
+        .create_query_context(&databend_common_version::BUILD_INFO)
+        .await?;
+    let tbl = ctx
+        .get_table_with_branch("default", database, table, params.branch.as_deref())
+        .await?;
+    let tbl = FuseTable::try_from_table(tbl.as_ref())?;
+    get_clustering_information(ctx, tbl, &params.cluster_key).await
+}
+
+fn clustering_information_error(error: ErrorCode) -> poem::Error {
+    let status = match error.name().as_str() {
+        "UnknownDatabase" | "UnknownTable" => StatusCode::NOT_FOUND,
+        "BadArguments" | "StorageUnsupported" | "UnclusteredTable" => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    poem::Error::from_string(error.to_string(), status)
+}

--- a/src/query/service/src/servers/admin/v1/mod.rs
+++ b/src/query/service/src/servers/admin/v1/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod cluster;
+pub mod clustering_information;
 pub mod config;
 pub mod instance_status;
 pub mod procedures;

--- a/src/query/service/tests/it/servers/admin/v1/clustering_information.rs
+++ b/src/query/service/tests/it/servers/admin/v1/clustering_information.rs
@@ -1,0 +1,61 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_query::servers::admin::AdminService;
+use databend_query::test_kits::*;
+use http::Method;
+use http::StatusCode;
+use http::Uri;
+use http::header;
+use poem::Endpoint;
+use poem::Request;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_clustering_information() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    fixture.create_default_table().await?;
+
+    let srv = AdminService::create(&ConfigBuilder::create().with_management_mode().build());
+
+    let uri = format!(
+        "/v1/tenants/{}/databases/{}/tables/{}/clustering_information",
+        fixture.default_tenant().tenant_name(),
+        fixture.default_db_name(),
+        fixture.default_table_name(),
+    );
+    let response = srv
+        .build_router()
+        .get_response(
+            Request::builder()
+                .uri(Uri::from_maybe_shared(uri)?)
+                .header(header::CONTENT_TYPE, "application/json")
+                .method(Method::GET)
+                .finish(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().into_vec().await.unwrap();
+    let resp = serde_json::from_slice::<Value>(&body)?;
+    assert_eq!(resp["cluster_key"], "(id)");
+    assert_eq!(resp["type"], "linear");
+    assert!(resp["timestamp"].as_i64().is_some());
+    assert_eq!(resp["info"]["total_block_count"].as_u64(), Some(0));
+    assert_eq!(resp["info"]["constant_block_count"].as_u64(), Some(0));
+
+    Ok(())
+}

--- a/src/query/service/tests/it/servers/admin/v1/mod.rs
+++ b/src/query/service/tests/it/servers/admin/v1/mod.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 mod cluster;
+mod clustering_information;
 mod config;
 mod status;

--- a/src/query/storages/fuse/src/table_functions/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information.rs
@@ -42,6 +42,7 @@ use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::table::ClusterType;
 use jsonb::Value as JsonbValue;
+use serde::Deserialize;
 use serde::Serialize;
 
 use crate::FuseTable;
@@ -91,6 +92,26 @@ impl TryFrom<(&str, TableArgs)> for ClusteringInformationArgs {
 pub type ClusteringInformationFunc = SimpleArgFuncTemplate<ClusteringInformation>;
 pub struct ClusteringInformation;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClusteringInformationResponse {
+    pub cluster_key: String,
+    #[serde(rename = "type")]
+    pub cluster_type: String,
+    pub timestamp: i64,
+    pub info: serde_json::Value,
+}
+
+#[async_backtrace::framed]
+pub async fn get_clustering_information(
+    ctx: Arc<dyn TableContext>,
+    table: &FuseTable,
+    cluster_key: &Option<String>,
+) -> Result<ClusteringInformationResponse> {
+    ClusteringInformationImpl::new(ctx, table)
+        .get_clustering_info(cluster_key)
+        .await
+}
+
 #[async_trait::async_trait]
 impl SimpleArgFunc for ClusteringInformation {
     type Args = ClusteringInformationArgs;
@@ -115,17 +136,9 @@ impl SimpleArgFunc for ClusteringInformation {
             )
             .await?;
         let tbl = FuseTable::try_from_table(tbl.as_ref())?;
-        ClusteringInformationImpl::new(ctx.clone(), tbl)
-            .get_clustering_info(&args.cluster_key)
-            .await
+        let info = get_clustering_information(ctx.clone(), tbl, &args.cluster_key).await?;
+        build_block(info)
     }
-}
-
-struct ClusteringStatisticsWrapper<T> {
-    cluster_key: String,
-    cluster_type: String,
-    timestamp: i64,
-    info: T,
 }
 
 struct ClusteringInformationImpl<'a> {
@@ -139,7 +152,10 @@ impl<'a> ClusteringInformationImpl<'a> {
     }
 
     #[async_backtrace::framed]
-    async fn get_clustering_info(&self, cluster_key: &Option<String>) -> Result<DataBlock> {
+    async fn get_clustering_info(
+        &self,
+        cluster_key: &Option<String>,
+    ) -> Result<ClusteringInformationResponse> {
         match (self.table.cluster_type(), cluster_key) {
             (Some(ClusterType::Hilbert), None) => self.get_hilbert_clustering_info().await,
             (None, None) => Err(ErrorCode::UnclusteredTable(format!(
@@ -157,7 +173,10 @@ impl<'a> ClusteringInformationImpl<'a> {
     }
 
     #[async_backtrace::framed]
-    async fn get_linear_clustering_info(&self, cluster_key: &Option<String>) -> Result<DataBlock> {
+    async fn get_linear_clustering_info(
+        &self,
+        cluster_key: &Option<String>,
+    ) -> Result<ClusteringInformationResponse> {
         let mut default_cluster_key_id = None;
         let (cluster_key, exprs) = match (self.table.cluster_key_str(), cluster_key) {
             (a, Some(b)) => {
@@ -196,11 +215,11 @@ impl<'a> ClusteringInformationImpl<'a> {
             .map_or(now, |s| s.timestamp.unwrap_or(now))
             .timestamp_micros();
         if snapshot.is_none() {
-            return build_block(ClusteringStatisticsWrapper {
+            return Ok(ClusteringInformationResponse {
                 cluster_key,
                 cluster_type,
                 timestamp,
-                info: LinerClusterStatistics::default(),
+                info: serde_json::to_value(LinerClusterStatistics::default())?,
             });
         }
         let snapshot = snapshot.unwrap();
@@ -323,18 +342,16 @@ impl<'a> ClusteringInformationImpl<'a> {
             average_depth,
             block_depth_histogram,
         };
-        let info = ClusteringStatisticsWrapper {
+        Ok(ClusteringInformationResponse {
             cluster_key,
             cluster_type,
             timestamp,
-            info,
-        };
-
-        build_block(info)
+            info: serde_json::to_value(info)?,
+        })
     }
 
     #[async_backtrace::framed]
-    async fn get_hilbert_clustering_info(&self) -> Result<DataBlock> {
+    async fn get_hilbert_clustering_info(&self) -> Result<ClusteringInformationResponse> {
         let Some((cluster_key_id, cluster_key_str)) = self.table.cluster_key_meta() else {
             unreachable!("Unclustered table {}", self.table.table_info.desc);
         };
@@ -406,14 +423,12 @@ impl<'a> ClusteringInformationImpl<'a> {
             unclustered_block_count,
         };
 
-        let stats = ClusteringStatisticsWrapper {
+        Ok(ClusteringInformationResponse {
             cluster_key: cluster_key_str.to_string(),
             cluster_type: "hilbert".to_string(),
             timestamp,
-            info,
-        };
-
-        build_block(stats)
+            info: serde_json::to_value(info)?,
+        })
     }
 
     fn schema() -> Arc<TableSchema> {
@@ -426,14 +441,14 @@ impl<'a> ClusteringInformationImpl<'a> {
     }
 }
 
-fn build_block<A: Serialize>(info: ClusteringStatisticsWrapper<A>) -> Result<DataBlock> {
+fn build_block(info: ClusteringInformationResponse) -> Result<DataBlock> {
     Ok(DataBlock::new(
         vec![
             BlockEntry::new_const_column_arg::<StringType>(info.cluster_key, 1),
             BlockEntry::new_const_column_arg::<StringType>(info.cluster_type, 1),
             BlockEntry::new_const_column_arg::<TimestampType>(info.timestamp, 1),
             BlockEntry::new_const_column_arg::<VariantType>(
-                JsonbValue::from(serde_json::to_value(&info.info)?).to_vec(),
+                JsonbValue::from(info.info).to_vec(),
                 1,
             ),
         ],

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -34,6 +34,8 @@ mod fuse_virtual_column;
 mod set_cache_capacity;
 
 pub use clustering_information::ClusteringInformationFunc;
+pub use clustering_information::ClusteringInformationResponse;
+pub use clustering_information::get_clustering_information;
 pub use clustering_statistics::ClusteringStatisticsFunc;
 pub use databend_common_catalog::table_args::*;
 use databend_common_catalog::table_function::TableFunction;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  - Add an admin API to fetch table clustering information:
    `/v1/tenants/:tenant/databases/:database/tables/:table/clustering_information`
  - Reuse the existing `clustering_information` table function logic so SQL and admin API return consistent data
  - Add admin API coverage for the new endpoint

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19885)
<!-- Reviewable:end -->
