### PR TITLE
fix(query): load ndjson row into single variant column

### DIFF
--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use bstr::ByteSlice;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
+use databend_common_expression::TableDataType;
 use databend_common_formats::FieldJsonAstDecoder;
 use databend_common_meta_app::principal::NullAs;
 use databend_common_storage::FileParseError;
@@ -57,8 +58,7 @@ impl NdJsonDecoder {
         // speedup from this change alone.
         let mut json: serde_json::Value =
             serde_json::from_slice(buf).map_err(|e| map_json_error(e, buf, file_full_path))?;
-        // todo: this is temporary
-        if self.field_decoder.is_select {
+        if self.field_decoder.is_select || self.should_read_whole_row(&json) {
             self.field_decoder
                 .read_field(&mut columns[0], &json)
                 .map_err(|e| FileParseError::InvalidRow {
@@ -154,6 +154,34 @@ impl NdJsonDecoder {
             }
         }
         Ok(())
+    }
+
+    fn should_read_whole_row(&self, json: &serde_json::Value) -> bool {
+        let fields = self.load_context.schema.fields();
+        if fields.len() != 1
+            || !matches!(
+                fields[0].data_type.remove_nullable(),
+                TableDataType::Variant
+            )
+        {
+            return false;
+        }
+
+        let field_name = if self.field_decoder.ident_case_sensitive {
+            fields[0].name().to_owned()
+        } else {
+            fields[0].name().to_lowercase()
+        };
+
+        match json {
+            serde_json::Value::Object(obj) if self.field_decoder.ident_case_sensitive => {
+                !obj.contains_key(&field_name)
+            }
+            serde_json::Value::Object(obj) => {
+                !obj.keys().any(|key| key.to_lowercase() == field_name)
+            }
+            _ => true,
+        }
     }
 }
 

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_select.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_select.test
@@ -3,6 +3,12 @@ statement ok
 drop table if exists v
 
 statement ok
+drop table if exists v_whole_row
+
+statement ok
+drop table if exists v_score
+
+statement ok
 create table v (a variant)
 
 query ?
@@ -47,6 +53,34 @@ select $1 from v order by $1
 2
 3
 4
+
+statement ok
+create table v_whole_row (v variant)
+
+query TIITI
+copy into v_whole_row from @data/ndjson/json_sample.ndjson file_format = (type = ndjson) force=true
+----
+ndjson/json_sample.ndjson 4 0 NULL NULL
+
+query III
+select count(), min(json_path_query(v, '$.b')::int), max(json_path_query(v, '$.b')::int) from v_whole_row
+----
+4 1 4
+
+statement ok
+create table v_score (score variant)
+
+query TIITI
+copy into v_score from @data/ndjson/numbers.ndjson file_format = (type = ndjson) force=true
+----
+ndjson/numbers.ndjson 3 0 NULL NULL
+
+query T
+select score from v_score order by score
+----
+-1e+77
+1e+38
+null
 
 # ndjson only supports $1
 query error column position 2 doesn't exist


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #18834.

When copying NDJSON into a table with a single VARIANT column, load the whole JSON row if the row does not contain a field matching the target column name. This preserves the existing key-based behavior when a matching field exists, while allowing raw NDJSON objects to be loaded directly into a single VARIANT column.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p databend-common-storages-stage`
- `cargo build -p databend-binaries --bin databend-query -p databend-sqllogictests --bin databend-sqllogictests`
- `target/debug/databend-sqllogictests --handlers http --run_file ndjson_select.test`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19886)
<!-- Reviewable:end -->
