### PR TITLE
fix(query): avoid blocking during statistics sender shutdown

### DIFF
--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use arrow_flight::FlightData;
 use arrow_flight::flight_service_client::FlightServiceClient;
@@ -45,6 +46,7 @@ use parking_lot::ReentrantMutex;
 use petgraph::Direction;
 use petgraph::prelude::EdgeRef;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 use tonic::Status;
 
 use super::exchange_params::BroadcastExchangeParams;
@@ -709,7 +711,16 @@ impl DataExchangeManager {
 
     #[fastrace::trace]
     pub fn on_finished_query(&self, query_id: &str, cause: Option<ErrorCode>) {
+        let lock_start = Instant::now();
         let queries_coordinator_guard = self.queries_coordinator.lock();
+        let lock_wait = lock_start.elapsed();
+        if lock_wait > Duration::from_secs(1) {
+            warn!(
+                "Waited {:?} to acquire queries_coordinator lock in on_finished_query, query_id={}",
+                lock_wait, query_id
+            );
+        }
+
         let queries_coordinator = unsafe { &mut *queries_coordinator_guard.deref().get() };
 
         if let Some(mut query_coordinator) = queries_coordinator.remove(query_id) {

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -1264,9 +1264,13 @@ impl QueryCoordinator {
                 let error = executor.execute().await.err();
                 statistics_sender.shutdown(error.clone()).await;
                 let exchange_manager = query_ctx.get_exchange_manager();
-                spawn_blocking(move || {
+                if let Err(cause) = spawn_blocking(move || {
                     exchange_manager.on_finished_query(&query_id, error);
-                });
+                })
+                .await
+                {
+                    warn!("on_finished_query cleanup task failed: {:?}", cause);
+                }
             }
             .in_span(span),
             "Distributed-Executor",

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -1261,7 +1261,7 @@ impl QueryCoordinator {
         GlobalIORuntime::instance().spawn(
             async move {
                 let error = executor.execute().await.err();
-                statistics_sender.shutdown(error.clone());
+                statistics_sender.shutdown(error.clone()).await;
                 query_ctx
                     .get_exchange_manager()
                     .on_finished_query(&query_id, error);

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -576,7 +576,6 @@ impl DataExchangeManager {
         let queries_coordinator_guard = self.queries_coordinator.lock();
         let queries_coordinator = unsafe { &mut *queries_coordinator_guard.deref().get() };
 
-        // TODO: When the query is not executed for a long time after submission, we need to remove it
         match queries_coordinator.get_mut(&fragments.query_id) {
             None => Err(ErrorCode::Internal(format!(
                 "Query {} not found in cluster.",

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -46,7 +46,6 @@ use parking_lot::ReentrantMutex;
 use petgraph::Direction;
 use petgraph::prelude::EdgeRef;
 use tokio::sync::oneshot;
-use tokio::time::Instant;
 use tonic::Status;
 
 use super::exchange_params::BroadcastExchangeParams;

--- a/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/exchange_manager.rs
@@ -29,6 +29,7 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_base::runtime::ExecutorStatsSnapshot;
 use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_base::runtime::QueryPerf;
+use databend_common_base::runtime::spawn_blocking;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -1258,15 +1259,17 @@ impl QueryCoordinator {
         } else {
             Span::noop()
         };
-        GlobalIORuntime::instance().spawn(
+        GlobalIORuntime::instance().spawn_named(
             async move {
                 let error = executor.execute().await.err();
                 statistics_sender.shutdown(error.clone()).await;
-                query_ctx
-                    .get_exchange_manager()
-                    .on_finished_query(&query_id, error);
+                let exchange_manager = query_ctx.get_exchange_manager();
+                spawn_blocking(move || {
+                    exchange_manager.on_finished_query(&query_id, error);
+                });
             }
             .in_span(span),
+            "Distributed-Executor",
         );
 
         Ok(())

--- a/src/query/service/src/servers/flight/v1/exchange/statistics_sender.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/statistics_sender.rs
@@ -154,24 +154,22 @@ impl StatisticsSender {
         }
     }
 
-    pub fn shutdown(&mut self, error: Option<ErrorCode>) {
+    pub async fn shutdown(&mut self, error: Option<ErrorCode>) {
         let shutdown_flag_sender = self.shutdown_flag_sender.clone();
 
         let join_handle = self.join_handle.take();
-        futures::executor::block_on(async move {
-            if let Err(error_code) = shutdown_flag_sender.send(error).await {
-                warn!(
-                    "Cannot send data via flight exchange, cause: {:?}",
-                    error_code
-                );
-            }
+        if let Err(error_code) = shutdown_flag_sender.send(error).await {
+            warn!(
+                "Cannot send data via flight exchange, cause: {:?}",
+                error_code
+            );
+        }
 
-            shutdown_flag_sender.close();
+        shutdown_flag_sender.close();
 
-            if let Some(join_handle) = join_handle {
-                let _ = join_handle.await;
-            }
-        });
+        if let Some(join_handle) = join_handle {
+            let _ = join_handle.await;
+        }
     }
 
     #[async_backtrace::framed]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

[fix(query): avoid blocking during statistics sender shutdown](https://github.com/databendlabs/databend/pull/19887/commits/a7938611da4abe7b718d1aa7c5a93989623e0321)

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19887)
<!-- Reviewable:end -->
