### PR TITLE
fix(query): account for NaN in inverse trig domains

### DIFF
--- a/src/query/functions/src/scalars/mathematics/src/math.rs
+++ b/src/query/functions/src/scalars/mathematics/src/math.rs
@@ -81,12 +81,36 @@ pub fn register(registry: &mut FunctionRegistry) {
         |f: F64, _| OrderedFloat(1.0f64) / f.tan(),
     );
 
+    fn unit_domain_bounds(domain: &SimpleDomain<F64>) -> Option<(F64, F64)> {
+        let min = Ord::max(domain.min, OrderedFloat(-1.0));
+        let max = Ord::min(domain.max, OrderedFloat(1.0));
+
+        if min <= max { Some((min, max)) } else { None }
+    }
+
+    fn has_unit_domain_overflow(domain: &SimpleDomain<F64>) -> bool {
+        domain.min < OrderedFloat(-1.0) || domain.max > OrderedFloat(1.0)
+    }
+
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _>(
         "acos",
-        |_, _| {
+        |_, domain| {
+            let Some((input_min, input_max)) = unit_domain_bounds(domain) else {
+                return FunctionDomain::Domain(SimpleDomain {
+                    min: OrderedFloat(f64::NAN),
+                    max: OrderedFloat(f64::NAN),
+                });
+            };
+
+            let max = if has_unit_domain_overflow(domain) {
+                OrderedFloat(f64::NAN)
+            } else {
+                input_min.acos()
+            };
+
             FunctionDomain::Domain(SimpleDomain {
-                min: OrderedFloat(0.0),
-                max: OrderedFloat(PI),
+                min: input_max.acos(),
+                max,
             })
         },
         |f: F64, _| f.acos(),
@@ -94,10 +118,23 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry.register_1_arg::<NumberType<F64>, NumberType<F64>, _>(
         "asin",
-        |_, _| {
+        |_, domain| {
+            let Some((min, max)) = unit_domain_bounds(domain) else {
+                return FunctionDomain::Domain(SimpleDomain {
+                    min: OrderedFloat(f64::NAN),
+                    max: OrderedFloat(f64::NAN),
+                });
+            };
+
+            let max = if has_unit_domain_overflow(domain) {
+                OrderedFloat(f64::NAN)
+            } else {
+                max.asin()
+            };
+
             FunctionDomain::Domain(SimpleDomain {
-                min: OrderedFloat(0.0),
-                max: OrderedFloat(2.0 * PI),
+                min: min.asin(),
+                max,
             })
         },
         |f: F64, _| f.asin(),

--- a/src/query/functions/tests/it/scalars/math.rs
+++ b/src/query/functions/tests/it/scalars/math.rs
@@ -66,7 +66,19 @@ fn test_trigonometric(file: &mut impl Write) {
     run_ast(file, "atan(0.5)", &[]);
     run_ast(file, "cot(-1.0)", &[]);
     run_ast(file, "asin(1)", &[]);
+    run_ast(file, "asin(a)", &[(
+        "a",
+        Float64Type::from_data(vec![-1.0f64, -0.5, 0.5]),
+    )]);
+    run_ast(file, "asin(a) > 2", &[(
+        "a",
+        Float64Type::from_data(vec![0.5f64, 1.1]),
+    )]);
     run_ast(file, "acos(0)", &[]);
+    run_ast(file, "acos(a) > 4", &[(
+        "a",
+        Float64Type::from_data(vec![0.5f64, 1.1]),
+    )]);
     run_ast(file, "atan(null)", &[]);
     run_ast(file, "atan2(a, 4)", &[(
         "a",

--- a/src/query/functions/tests/it/scalars/testdata/math.txt
+++ b/src/query/functions/tests/it/scalars/testdata/math.txt
@@ -159,6 +159,50 @@ output domain  : {1.5707963267..=1.5707963267}
 output         : 1.5707963267
 
 
+ast            : asin(a)
+raw expr       : asin(a::Float64)
+checked expr   : asin<Float64>(a)
+evaluation:
++--------+------------+--------------------------------+
+|        | a          | Output                         |
++--------+------------+--------------------------------+
+| Type   | Float64    | Float64                        |
+| Domain | {-1..=0.5} | {-1.5707963267..=0.5235987755} |
+| Row 0  | -1         | -1.5707963267                  |
+| Row 1  | -0.5       | -0.5235987755                  |
+| Row 2  | 0.5        | 0.5235987755                   |
++--------+------------+--------------------------------+
+evaluation (internal):
++--------+-------------------------------------------------------+
+| Column | Data                                                  |
++--------+-------------------------------------------------------+
+| a      | Column(Float64([-1, -0.5, 0.5]))                      |
+| Output | Float64([-1.5707963267, -0.5235987755, 0.5235987755]) |
++--------+-------------------------------------------------------+
+
+
+ast            : asin(a) > 2
+raw expr       : gt(asin(a::Float64), 2)
+checked expr   : gt<Float64, Float64>(asin<Float64>(a), CAST<UInt8>(2_u8 AS Float64))
+optimized expr : gt<Float64, Float64>(asin<Float64>(a), 2_f64)
+evaluation:
++--------+-------------+---------------+
+|        | a           | Output        |
++--------+-------------+---------------+
+| Type   | Float64     | Boolean       |
+| Domain | {0.5..=1.1} | {FALSE, TRUE} |
+| Row 0  | 0.5         | false         |
+| Row 1  | 1.1         | true          |
++--------+-------------+---------------+
+evaluation (internal):
++--------+-----------------------------+
+| Column | Data                        |
++--------+-----------------------------+
+| a      | Column(Float64([0.5, 1.1])) |
+| Output | Boolean([0b______10])       |
++--------+-----------------------------+
+
+
 ast            : acos(0)
 raw expr       : acos(0)
 checked expr   : acos<Float64>(CAST<UInt8>(0_u8 AS Float64))
@@ -166,6 +210,28 @@ optimized expr : 1.5707963267_f64
 output type    : Float64
 output domain  : {1.5707963267..=1.5707963267}
 output         : 1.5707963267
+
+
+ast            : acos(a) > 4
+raw expr       : gt(acos(a::Float64), 4)
+checked expr   : gt<Float64, Float64>(acos<Float64>(a), CAST<UInt8>(4_u8 AS Float64))
+optimized expr : gt<Float64, Float64>(acos<Float64>(a), 4_f64)
+evaluation:
++--------+-------------+---------------+
+|        | a           | Output        |
++--------+-------------+---------------+
+| Type   | Float64     | Boolean       |
+| Domain | {0.5..=1.1} | {FALSE, TRUE} |
+| Row 0  | 0.5         | false         |
+| Row 1  | 1.1         | true          |
++--------+-------------+---------------+
+evaluation (internal):
++--------+-----------------------------+
+| Column | Data                        |
++--------+-----------------------------+
+| a      | Column(Float64([0.5, 1.1])) |
+| Output | Boolean([0b______10])       |
++--------+-----------------------------+
 
 
 ast            : atan(null)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Correct `asin` and `acos` domain inference for inputs outside `[-1, 1]`.
- Preserve finite inverse-trig ranges for valid input domains while including `NaN` when the input domain may produce it.
- Add golden coverage to ensure comparisons like `asin(a) > 2` are not folded away when out-of-domain inputs can produce `NaN`.

## Changes

`OrderedFloat(NaN)` sorts above finite values in this codebase, so `asin(1.1) > 2` and `acos(1.1) > 4` evaluate to true. Advertising only finite upper bounds for these functions can make comparison domain logic incorrectly fold those predicates to false.

This PR computes the finite output range from the intersection of the input domain with `[-1, 1]`, and uses `NaN` as the output upper bound whenever the input domain may include out-of-domain or NaN values.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Ran:

```shell
env REGENERATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it test_math
cargo test -p databend-common-functions --test it test_math
git diff --check
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19890)
<!-- Reviewable:end -->
