### PR TITLE
fix(query): reject negative factorial inputs

### DIFF
--- a/src/query/functions/src/scalars/mathematics/src/math.rs
+++ b/src/query/functions/src/scalars/mathematics/src/math.rs
@@ -415,9 +415,19 @@ pub fn register(registry: &mut FunctionRegistry) {
                     |_, _| FunctionDomain::MayThrow,
                     vectorize_with_builder_1_arg::<NumberType<NUM_TYPE>, NumberType<i64>>(
                         |val, output, ctx| {
-                            let n: i64 = AsPrimitive::<i64>::as_(val);
-                            if n > MAX_FACTORIAL_NUMBER {
+                            let max = AsPrimitive::<NUM_TYPE>::as_(MAX_FACTORIAL_NUMBER);
+                            if val > max {
                                 ctx.set_error(output.len(), format!("factorial number is out of range, max is: {}", MAX_FACTORIAL_NUMBER));
+                                output.push(0);
+                                return;
+                            }
+
+                            let n = AsPrimitive::<i64>::as_(val);
+                            if n < 0 {
+                                ctx.set_error(
+                                    output.len(),
+                                    "factorial number is out of range, min is: 0".to_string(),
+                                );
                                 output.push(0);
                             } else {
                                 output.push(factorial(n));
@@ -530,5 +540,5 @@ type Log10Function = GenericLogFunction<TenBase>;
 type Log2Function = GenericLogFunction<TwoBase>;
 
 fn factorial(n: i64) -> i64 {
-    if n <= 0 { 1 } else { n * factorial(n - 1) }
+    if n == 0 { 1 } else { n * factorial(n - 1) }
 }

--- a/src/query/functions/tests/it/scalars/math.rs
+++ b/src/query/functions/tests/it/scalars/math.rs
@@ -129,7 +129,12 @@ fn test_cbrt(file: &mut impl Write) {
 
 fn test_factorial(file: &mut impl Write) {
     run_ast(file, "factorial(5)", &[]);
+    run_ast(file, "factorial(-1)", &[]);
     run_ast(file, "factorial(30)", &[]);
+    run_ast(file, "factorial(u)", &[(
+        "u",
+        UInt64Type::from_data(vec![u64::MAX]),
+    )]);
     run_ast(file, "factorial(a)", &[(
         "a",
         Int64Type::from_data(vec![3, 12, 16]),

--- a/src/query/functions/tests/it/scalars/testdata/math.txt
+++ b/src/query/functions/tests/it/scalars/testdata/math.txt
@@ -573,8 +573,24 @@ output         : 120
 error: 
   --> SQL:1:1
   |
+1 | factorial(-1)
+  | ^^^^^^^^^^^^^ factorial number is out of range, min is: 0 while evaluating function `factorial(-1)` in expr `factorial(-1)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
 1 | factorial(30)
   | ^^^^^^^^^^^^^ factorial number is out of range, max is: 20 while evaluating function `factorial(30)` in expr `factorial(30)`
+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | factorial(u)
+  | ^^^^^^^^^^^^ factorial number is out of range, max is: 20 while evaluating function `factorial(18446744073709551615)` in expr `factorial(u)`
 
 
 

--- a/tests/sqllogictests/suites/query/functions/02_0014_function_maths.test
+++ b/tests/sqllogictests/suites/query/functions/02_0014_function_maths.test
@@ -330,7 +330,15 @@ SELECT factorial(5)
 120
 
 statement error 1006
+SELECT factorial(-1)
+
+
+statement error 1006
 SELECT factorial(30)
+
+
+statement error 1006
+SELECT factorial(18446744073709551615::UInt64)
 
 
 statement error 1006


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Reject negative inputs to `factorial` instead of returning `1`
- Check the max factorial bound before converting integer inputs to `i64`, so large `UInt64` values report the max-range error correctly
- Add function golden coverage and sqllogictest coverage for `factorial(-1)` and large `UInt64` input

## Changes

`factorial(-1)` previously reached the recursive helper base case and returned `1`. This PR adds an explicit `n < 0` error path before evaluating the factorial helper, and tightens the helper base case to `n == 0`.

The bound check now compares the original integer input against `20` before casting to `i64`. This avoids lossy `UInt64` conversions for values above `i64::MAX`.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation run:

- `cargo fmt --all --check`
- `env UPDATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::math::test_math`
- `cargo test -p databend-common-functions --test it scalars::math::test_math`

Not run locally:

- Full sqllogictest runner; requires a Databend test service.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19891)
<!-- Reviewable:end -->
