### PR TITLE
feat(query): add CONV scalar function

### DIFF
--- a/src/query/functions/src/scalars/binary.rs
+++ b/src/query/functions/src/scalars/binary.rs
@@ -220,7 +220,7 @@ pub fn register(registry: &mut FunctionRegistry) {
 
     registry
         .scalar_builder("to_hex")
-        .aliases(&["hex", "hex_encode"])
+        .aliases(&["hex_encode"])
         .function()
         .typed_1_arg::<BinaryType, StringType>()
         .passthrough_nullable()
@@ -228,9 +228,22 @@ pub fn register(registry: &mut FunctionRegistry) {
         .vectorized(vectorize_binary_to_string(
             |col| col.total_bytes_len() * 2,
             |val, output, _| {
-                let extra_len = val.len() * 2;
-                output.row_buffer.resize(extra_len, 0);
-                hex::encode_to_slice(val, &mut output.row_buffer).unwrap();
+                write_hex_lower(val, output);
+                output.commit_row();
+            },
+        ))
+        .register();
+
+    registry
+        .scalar_builder("hex")
+        .function()
+        .typed_1_arg::<BinaryType, StringType>()
+        .passthrough_nullable()
+        .calc_domain(|_, _| FunctionDomain::Full)
+        .vectorized(vectorize_binary_to_string(
+            |col| col.total_bytes_len() * 2,
+            |val, output, _| {
+                write_hex_lower(val, output);
                 output.commit_row();
             },
         ))
@@ -347,6 +360,12 @@ fn eval_unhex(val: Value<StringType>, ctx: &mut EvalContext) -> Value<BinaryType
             output.commit_row();
         },
     )(val, ctx)
+}
+
+pub fn write_hex_lower(bytes: &[u8], output: &mut StringColumnBuilder) {
+    let old_len = output.row_buffer.len();
+    output.row_buffer.resize(old_len + bytes.len() * 2, 0);
+    hex::encode_to_slice(bytes, &mut output.row_buffer[old_len..]).unwrap();
 }
 
 fn eval_from_base64(val: Value<StringType>, ctx: &mut EvalContext) -> Value<BinaryType> {

--- a/src/query/functions/src/scalars/string.rs
+++ b/src/query/functions/src/scalars/string.rs
@@ -32,6 +32,7 @@ use databend_common_expression::vectorize_with_builder_4_arg;
 use databend_functions_scalar_decimal::register_decimal_to_uuid;
 use stringslice::StringSlice;
 
+use crate::scalars::binary::write_hex_lower;
 use crate::srfs;
 
 pub const ALL_STRING_FUNC_NAMES: &[&str] = &[
@@ -60,6 +61,7 @@ pub const ALL_STRING_FUNC_NAMES: &[&str] = &[
     "trim_trailing",
     "trim_both",
     "to_hex",
+    "conv",
     "bin",
     "oct",
     "to_hex",
@@ -668,16 +670,66 @@ pub fn register(registry: &mut FunctionRegistry) {
         .calc_domain(|_, _| FunctionDomain::Full)
         .vectorized(vectorize_with_builder_1_arg::<StringType, StringType>(
             |val, output, _| {
-                let len = val.len() * 2;
-                output.row_buffer.resize(len, 0);
-                hex::encode_to_slice(val, &mut output.row_buffer).unwrap();
+                write_hex_lower(val.as_bytes(), output);
                 output.commit_row();
             },
         ))
         .register();
 
-    // TODO: generalize them to be alias of [CONV](https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html#function_conv)
-    // Tracking issue: https://github.com/datafuselabs/databend/issues/7242
+    registry
+        .scalar_builder("hex")
+        .function()
+        .typed_1_arg::<StringType, StringType>()
+        .passthrough_nullable()
+        .calc_domain(|_, _| FunctionDomain::Full)
+        .vectorized(vectorize_with_builder_1_arg::<StringType, StringType>(
+            |val, output, _| {
+                write_hex_lower(val.as_bytes(), output);
+                output.commit_row();
+            },
+        ))
+        .register();
+
+    registry.register_passthrough_nullable_3_arg::<
+        StringType,
+        NumberType<i64>,
+        NumberType<i64>,
+        StringType,
+        _,
+        _,
+    >(
+        "conv",
+        |_, _, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_3_arg::<
+            StringType,
+            NumberType<i64>,
+            NumberType<i64>,
+            StringType,
+        >(|num, from_base, to_base, output, ctx| {
+            conv(num, from_base, to_base, output, ctx);
+        }),
+    );
+
+    registry.register_passthrough_nullable_3_arg::<
+        NumberType<i64>,
+        NumberType<i64>,
+        NumberType<i64>,
+        StringType,
+        _,
+        _,
+    >(
+        "conv",
+        |_, _, _, _| FunctionDomain::MayThrow,
+        vectorize_with_builder_3_arg::<
+            NumberType<i64>,
+            NumberType<i64>,
+            NumberType<i64>,
+            StringType,
+        >(|num, from_base, to_base, output, ctx| {
+            conv(&num.to_string(), from_base, to_base, output, ctx);
+        }),
+    );
+
     registry
         .scalar_builder("bin")
         .function()
@@ -686,7 +738,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         .calc_domain(|_, _| FunctionDomain::Full)
         .vectorized(vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(
             |val, output, _| {
-                write!(output.row_buffer, "{val:b}").unwrap();
+                write_conv_num(val as u64, 2, output);
                 output.commit_row();
             },
         ))
@@ -700,7 +752,7 @@ pub fn register(registry: &mut FunctionRegistry) {
         .calc_domain(|_, _| FunctionDomain::Full)
         .vectorized(vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(
             |val, output, _| {
-                write!(output.row_buffer, "{val:o}").unwrap();
+                write_conv_num(val as u64, 8, output);
                 output.commit_row();
             },
         ))
@@ -715,6 +767,20 @@ pub fn register(registry: &mut FunctionRegistry) {
         .vectorized(vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(
             |val, output, _| {
                 write!(output.row_buffer, "{val:x}").unwrap();
+                output.commit_row();
+            },
+        ))
+        .register();
+
+    registry
+        .scalar_builder("hex")
+        .function()
+        .typed_1_arg::<NumberType<i64>, StringType>()
+        .passthrough_nullable()
+        .calc_domain(|_, _| FunctionDomain::Full)
+        .vectorized(vectorize_with_builder_1_arg::<NumberType<i64>, StringType>(
+            |val, output, _| {
+                write_conv_num(val as u64, 16, output);
                 output.commit_row();
             },
         ))
@@ -1077,6 +1143,117 @@ fn substr(builder: &mut StringColumnBuilder, str: &str, pos: i64, len: u64) {
 
     builder.put_char_iter(str.chars().skip(start).take(len as usize));
     builder.commit_row();
+}
+
+fn conv(
+    num: &str,
+    from_base: i64,
+    to_base: i64,
+    output: &mut StringColumnBuilder,
+    ctx: &mut databend_common_expression::EvalContext,
+) {
+    let Some(from_base) = validate_conv_base(from_base) else {
+        ctx.set_error(
+            output.len(),
+            format!(
+                "from_base absolute value must be between 2 and 36, but got {}",
+                from_base
+            ),
+        );
+        output.commit_row();
+        return;
+    };
+
+    let signed_to_base = to_base < 0;
+    let Some(to_base) = validate_conv_base(to_base) else {
+        ctx.set_error(
+            output.len(),
+            format!(
+                "to_base absolute value must be between 2 and 36, but got {}",
+                to_base
+            ),
+        );
+        output.commit_row();
+        return;
+    };
+
+    let mut num = parse_conv_num(num, from_base);
+    if signed_to_base {
+        let signed_num = num as i64;
+        if signed_num < 0 {
+            output.put_char('-');
+            num = (signed_num as u64).wrapping_neg();
+        }
+    }
+    write_conv_num(num, to_base, output);
+    output.commit_row();
+}
+
+fn validate_conv_base(base: i64) -> Option<u32> {
+    let base = base.unsigned_abs();
+    if (2..=36).contains(&base) {
+        Some(base as u32)
+    } else {
+        None
+    }
+}
+
+fn parse_conv_num(num: &str, from_base: u32) -> u64 {
+    let num = num.trim_start();
+    let (negative, digits) = if let Some(rest) = num.strip_prefix('-') {
+        (true, rest)
+    } else if let Some(rest) = num.strip_prefix('+') {
+        (false, rest)
+    } else {
+        (false, num)
+    };
+
+    let mut value = 0_u64;
+    for ch in digits.bytes() {
+        let Some(digit) = conv_digit(ch) else {
+            break;
+        };
+        if digit >= from_base {
+            break;
+        }
+
+        value = value
+            .saturating_mul(from_base as u64)
+            .saturating_add(digit as u64);
+    }
+
+    if negative {
+        value.wrapping_neg()
+    } else {
+        value
+    }
+}
+
+fn conv_digit(ch: u8) -> Option<u32> {
+    match ch {
+        b'0'..=b'9' => Some((ch - b'0') as u32),
+        b'a'..=b'z' => Some((ch - b'a' + 10) as u32),
+        b'A'..=b'Z' => Some((ch - b'A' + 10) as u32),
+        _ => None,
+    }
+}
+
+fn write_conv_num(mut num: u64, to_base: u32, output: &mut StringColumnBuilder) {
+    const DIGITS: &[u8; 36] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    if num == 0 {
+        output.put_char('0');
+        return;
+    }
+
+    let mut buf = [0_u8; 64];
+    let mut idx = buf.len();
+    while num > 0 {
+        idx -= 1;
+        buf[idx] = DIGITS[(num % to_base as u64) as usize];
+        num /= to_base as u64;
+    }
+    output.put_slice(&buf[idx..]);
 }
 
 #[inline]

--- a/src/query/functions/tests/it/scalars/binary.rs
+++ b/src/query/functions/tests/it/scalars/binary.rs
@@ -51,6 +51,7 @@ fn test_length(file: &mut impl Write) {
 
 fn test_to_hex(file: &mut impl Write) {
     run_ast(file, "to_hex(to_binary('abc'))", &[]);
+    run_ast(file, "hex(to_binary('abc'))", &[]);
     run_ast(file, "to_hex(to_binary(a))", &[(
         "a",
         StringType::from_data(vec!["abc", "def", "databend"]),

--- a/src/query/functions/tests/it/scalars/string.rs
+++ b/src/query/functions/tests/it/scalars/string.rs
@@ -49,6 +49,7 @@ fn test_string() {
     test_bin(file);
     test_oct(file);
     test_hex(file);
+    test_conv(file);
     test_pad(file);
     test_replace(file);
     test_translate(file);
@@ -498,6 +499,34 @@ fn test_hex(file: &mut impl Write) {
     run_ast(file, "hex(c)", columns);
     run_ast(file, "hex(d)", columns);
     run_ast(file, "hex(e)", columns);
+    run_ast(file, "to_hex(c)", columns);
+    run_ast(file, "to_hex(e)", columns);
+}
+
+fn test_conv(file: &mut impl Write) {
+    run_ast(file, "conv('a', 16, 10)", &[]);
+    run_ast(file, "conv('6E', 18, 8)", &[]);
+    run_ast(file, "conv('zz', 36, 10)", &[]);
+    run_ast(file, "conv('11', 2, 36)", &[]);
+    run_ast(file, "conv(10, 10, 2)", &[]);
+    run_ast(file, "conv(10, 16, 10)", &[]);
+    run_ast(file, "conv(15, 10, 16)", &[]);
+    run_ast(file, "conv(-128, 10, 8)", &[]);
+    run_ast(file, "conv(-17, 10, -18)", &[]);
+    run_ast(file, "conv('FFFFFFFFFFFFFFFF', 16, -10)", &[]);
+    run_ast(file, "conv('11', -2, 10)", &[]);
+
+    let columns = &[
+        ("a", StringType::from_data(vec!["10", "a", "zz"])),
+        (
+            "b",
+            Int64Type::from_data_with_validity(vec![2i64, 16, 36], vec![true, false, true]),
+        ),
+        ("c", Int64Type::from_data(vec![10i64, 10, 16])),
+        ("d", Int64Type::from_data(vec![10i64, 16, -128])),
+    ];
+    run_ast(file, "conv(a, b, c)", columns);
+    run_ast(file, "conv(d, 10, 2)", columns);
 }
 
 fn test_pad(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/binary.txt
+++ b/src/query/functions/tests/it/scalars/testdata/binary.txt
@@ -95,6 +95,15 @@ output domain  : {"616263"..="616263"}
 output         : '616263'
 
 
+ast            : hex(to_binary('abc'))
+raw expr       : hex(to_binary('abc'))
+checked expr   : hex<Binary>(CAST<String>("abc" AS Binary))
+optimized expr : "616263"
+output type    : String
+output domain  : {"616263"..="616263"}
+output         : '616263'
+
+
 ast            : to_hex(to_binary(a))
 raw expr       : to_hex(to_binary(a::String))
 checked expr   : to_hex<Binary>(CAST<String>(a AS Binary))

--- a/src/query/functions/tests/it/scalars/testdata/function_list.txt
+++ b/src/query/functions/tests/it/scalars/testdata/function_list.txt
@@ -31,7 +31,6 @@ diff_dows -> diff_days
 diff_doys -> diff_days
 diff_epochs -> diff_seconds
 diff_isodows -> diff_days
-hex -> to_hex
 hex_decode_binary -> from_hex
 hex_encode -> to_hex
 intdiv -> div
@@ -1355,6 +1354,10 @@ Functions overloads:
 28 contains(Array(Boolean), Boolean) :: Boolean
 29 contains(Array(Boolean) NULL, Boolean NULL) :: Boolean NULL
 30 contains(Array(T0) NULL, T0) :: Boolean
+0 conv(String, Int64, Int64) :: String
+1 conv(String NULL, Int64 NULL, Int64 NULL) :: String NULL
+2 conv(Int64, Int64, Int64) :: String
+3 conv(Int64 NULL, Int64 NULL, Int64 NULL) :: String NULL
 0 convert_timezone(String, Timestamp) :: Timestamp
 1 convert_timezone(String NULL, Timestamp NULL) :: Timestamp NULL
 0 cos(Float64) :: Float64
@@ -2259,6 +2262,12 @@ Functions overloads:
 1 h3_unidirectional_edge_is_valid(UInt64 NULL) :: Boolean NULL
 0 haversine(Float64, Float64, Float64, Float64) :: Float64
 1 haversine(Float64 NULL, Float64 NULL, Float64 NULL, Float64 NULL) :: Float64 NULL
+0 hex(String) :: String
+1 hex(String NULL) :: String NULL
+2 hex(Int64) :: String
+3 hex(Int64 NULL) :: String NULL
+4 hex(Binary) :: String
+5 hex(Binary NULL) :: String NULL
 0 hilbert_range_index FACTORY
 0 humanize_number(Float64) :: String
 1 humanize_number(Float64 NULL) :: String NULL

--- a/src/query/functions/tests/it/scalars/testdata/string.txt
+++ b/src/query/functions/tests/it/scalars/testdata/string.txt
@@ -2326,14 +2326,14 @@ candidate functions:
 
 ast            : hex(a)
 raw expr       : hex(a::Int8)
-checked expr   : to_hex<Int64>(CAST<Int8>(a AS Int64))
+checked expr   : hex<Int64>(CAST<Int8>(a AS Int64))
 evaluation:
 +--------+----------+--------------------+
 |        | a        | Output             |
 +--------+----------+--------------------+
 | Type   | Int8     | String             |
 | Domain | {-1..=3} | {""..}             |
-| Row 0  | -1       | 'ffffffffffffffff' |
+| Row 0  | -1       | 'FFFFFFFFFFFFFFFF' |
 | Row 1  | 2        | '2'                |
 | Row 2  | 3        | '3'                |
 +--------+----------+--------------------+
@@ -2342,13 +2342,13 @@ evaluation (internal):
 | Column | Data                                 |
 +--------+--------------------------------------+
 | a      | Column(Int8([-1, 2, 3]))             |
-| Output | StringColumn[ffffffffffffffff, 2, 3] |
+| Output | StringColumn[FFFFFFFFFFFFFFFF, 2, 3] |
 +--------+--------------------------------------+
 
 
 ast            : hex(a2)
 raw expr       : hex(a2::UInt8 NULL)
-checked expr   : to_hex<Int64 NULL>(CAST<UInt8 NULL>(a2 AS Int64 NULL))
+checked expr   : hex<Int64 NULL>(CAST<UInt8 NULL>(a2 AS Int64 NULL))
 evaluation:
 +--------+------------------+-----------------+
 |        | a2               | Output          |
@@ -2370,7 +2370,7 @@ evaluation (internal):
 
 ast            : hex(b)
 raw expr       : hex(b::Int16)
-checked expr   : to_hex<Int64>(CAST<Int16>(b AS Int64))
+checked expr   : hex<Int64>(CAST<Int16>(b AS Int64))
 evaluation:
 +--------+---------+--------+
 |        | b       | Output |
@@ -2392,6 +2392,64 @@ evaluation (internal):
 
 ast            : hex(c)
 raw expr       : hex(c::UInt32)
+checked expr   : hex<Int64>(CAST<UInt32>(c AS Int64))
+evaluation:
++--------+-----------+--------+
+|        | c         | Output |
++--------+-----------+--------+
+| Type   | UInt32    | String |
+| Domain | {10..=30} | {""..} |
+| Row 0  | 10        | 'A'    |
+| Row 1  | 20        | '14'   |
+| Row 2  | 30        | '1E'   |
++--------+-----------+--------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| c      | Column(UInt32([10, 20, 30])) |
+| Output | StringColumn[A, 14, 1E]      |
++--------+------------------------------+
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | hex(d)
+  | ^^^^^^ no function matches signature `hex(Float64)`, you might need to add explicit type casts.
+
+candidate functions:
+  hex(String) :: String            : unable to unify `Float64` with `String`
+  hex(String NULL) :: String NULL  : unable to unify `Float64` with `String`
+  hex(Int64) :: String             : unable to unify `Float64` with `Int64`
+... and 3 more
+
+
+
+ast            : hex(e)
+raw expr       : hex(e::String)
+checked expr   : hex<String>(e)
+evaluation:
++--------+-----------------+--------------------+
+|        | e               | Output             |
++--------+-----------------+--------------------+
+| Type   | String          | String             |
+| Domain | {"abc"..="def"} | {""..}             |
+| Row 0  | 'abc'           | '616263'           |
+| Row 1  | 'def'           | '646566'           |
+| Row 2  | 'databend'      | '6461746162656e64' |
++--------+-----------------+--------------------+
+evaluation (internal):
++--------+------------------------------------------------+
+| Column | Data                                           |
++--------+------------------------------------------------+
+| e      | Column(StringColumn[abc, def, databend])       |
+| Output | StringColumn[616263, 646566, 6461746162656e64] |
++--------+------------------------------------------------+
+
+
+ast            : to_hex(c)
+raw expr       : to_hex(c::UInt32)
 checked expr   : to_hex<Int64>(CAST<UInt32>(c AS Int64))
 evaluation:
 +--------+-----------+--------+
@@ -2412,22 +2470,8 @@ evaluation (internal):
 +--------+------------------------------+
 
 
-error: 
-  --> SQL:1:1
-  |
-1 | hex(d)
-  | ^^^^^^ no function matches signature `to_hex(Float64)`, you might need to add explicit type casts.
-
-candidate functions:
-  to_hex(String) :: String            : unable to unify `Float64` with `String`
-  to_hex(String NULL) :: String NULL  : unable to unify `Float64` with `String`
-  to_hex(Int64) :: String             : unable to unify `Float64` with `Int64`
-... and 3 more
-
-
-
-ast            : hex(e)
-raw expr       : hex(e::String)
+ast            : to_hex(e)
+raw expr       : to_hex(e::String)
 checked expr   : to_hex<String>(e)
 evaluation:
 +--------+-----------------+--------------------+
@@ -2446,6 +2490,152 @@ evaluation (internal):
 | e      | Column(StringColumn[abc, def, databend])       |
 | Output | StringColumn[616263, 646566, 6461746162656e64] |
 +--------+------------------------------------------------+
+
+
+ast            : conv('a', 16, 10)
+raw expr       : conv('a', 16, 10)
+checked expr   : conv<String, Int64, Int64>("a", CAST<UInt8>(16_u8 AS Int64), CAST<UInt8>(10_u8 AS Int64))
+optimized expr : "10"
+output type    : String
+output domain  : {"10"..="10"}
+output         : '10'
+
+
+ast            : conv('6E', 18, 8)
+raw expr       : conv('6E', 18, 8)
+checked expr   : conv<String, Int64, Int64>("6E", CAST<UInt8>(18_u8 AS Int64), CAST<UInt8>(8_u8 AS Int64))
+optimized expr : "172"
+output type    : String
+output domain  : {"172"..="172"}
+output         : '172'
+
+
+ast            : conv('zz', 36, 10)
+raw expr       : conv('zz', 36, 10)
+checked expr   : conv<String, Int64, Int64>("zz", CAST<UInt8>(36_u8 AS Int64), CAST<UInt8>(10_u8 AS Int64))
+optimized expr : "1295"
+output type    : String
+output domain  : {"1295"..="1295"}
+output         : '1295'
+
+
+ast            : conv('11', 2, 36)
+raw expr       : conv('11', 2, 36)
+checked expr   : conv<String, Int64, Int64>("11", CAST<UInt8>(2_u8 AS Int64), CAST<UInt8>(36_u8 AS Int64))
+optimized expr : "3"
+output type    : String
+output domain  : {"3"..="3"}
+output         : '3'
+
+
+ast            : conv(10, 10, 2)
+raw expr       : conv(10, 10, 2)
+checked expr   : conv<Int64, Int64, Int64>(CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(2_u8 AS Int64))
+optimized expr : "1010"
+output type    : String
+output domain  : {"1010"..="1010"}
+output         : '1010'
+
+
+ast            : conv(10, 16, 10)
+raw expr       : conv(10, 16, 10)
+checked expr   : conv<Int64, Int64, Int64>(CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(16_u8 AS Int64), CAST<UInt8>(10_u8 AS Int64))
+optimized expr : "16"
+output type    : String
+output domain  : {"16"..="16"}
+output         : '16'
+
+
+ast            : conv(15, 10, 16)
+raw expr       : conv(15, 10, 16)
+checked expr   : conv<Int64, Int64, Int64>(CAST<UInt8>(15_u8 AS Int64), CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(16_u8 AS Int64))
+optimized expr : "F"
+output type    : String
+output domain  : {"F"..="F"}
+output         : 'F'
+
+
+ast            : conv(-128, 10, 8)
+raw expr       : conv(-128, 10, 8)
+checked expr   : conv<Int64, Int64, Int64>(CAST<Int8>(-128_i8 AS Int64), CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(8_u8 AS Int64))
+optimized expr : "1777777777777777777600"
+output type    : String
+output domain  : {"1777777777777777777600"..="1777777777777777777600"}
+output         : '1777777777777777777600'
+
+
+ast            : conv(-17, 10, -18)
+raw expr       : conv(-17, 10, -18)
+checked expr   : conv<Int64, Int64, Int64>(CAST<Int8>(-17_i8 AS Int64), CAST<UInt8>(10_u8 AS Int64), CAST<Int8>(-18_i8 AS Int64))
+optimized expr : "-H"
+output type    : String
+output domain  : {"-H"..="-H"}
+output         : '-H'
+
+
+ast            : conv('FFFFFFFFFFFFFFFF', 16, -10)
+raw expr       : conv('FFFFFFFFFFFFFFFF', 16, -10)
+checked expr   : conv<String, Int64, Int64>("FFFFFFFFFFFFFFFF", CAST<UInt8>(16_u8 AS Int64), CAST<Int8>(-10_i8 AS Int64))
+optimized expr : "-1"
+output type    : String
+output domain  : {"-1"..="-1"}
+output         : '-1'
+
+
+ast            : conv('11', -2, 10)
+raw expr       : conv('11', -2, 10)
+checked expr   : conv<String, Int64, Int64>("11", CAST<Int8>(-2_i8 AS Int64), CAST<UInt8>(10_u8 AS Int64))
+optimized expr : "3"
+output type    : String
+output domain  : {"3"..="3"}
+output         : '3'
+
+
+ast            : conv(a, b, c)
+raw expr       : conv(a::String, b::Int64 NULL, c::Int64)
+checked expr   : conv<String NULL, Int64 NULL, Int64 NULL>(CAST<String>(a AS String NULL), b, CAST<Int64>(c AS Int64 NULL))
+evaluation:
++--------+---------------+-------------------+-----------+-------------+
+|        | a             | b                 | c         | Output      |
++--------+---------------+-------------------+-----------+-------------+
+| Type   | String        | Int64 NULL        | Int64     | String NULL |
+| Domain | {"10"..="zz"} | {2..=36} ∪ {NULL} | {10..=16} | Unknown     |
+| Row 0  | '10'          | 2                 | 10        | '2'         |
+| Row 1  | 'a'           | NULL              | 10        | NULL        |
+| Row 2  | 'zz'          | 36                | 16        | '50F'       |
++--------+---------------+-------------------+-----------+-------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------+
+| Column | Data                                                                          |
++--------+-------------------------------------------------------------------------------+
+| a      | Column(StringColumn[10, a, zz])                                               |
+| b      | Column(NullableColumn { column: Int64([2, 16, 36]), validity: [0b_____101] }) |
+| c      | Column(Int64([10, 10, 16]))                                                   |
+| Output | NullableColumn { column: StringColumn[2, 10, 50F], validity: [0b_____101] }   |
++--------+-------------------------------------------------------------------------------+
+
+
+ast            : conv(d, 10, 2)
+raw expr       : conv(d::Int64, 10, 2)
+checked expr   : conv<Int64, Int64, Int64>(d, CAST<UInt8>(10_u8 AS Int64), CAST<UInt8>(2_u8 AS Int64))
+optimized expr : conv<Int64, Int64, Int64>(d, 10_i64, 2_i64)
+evaluation:
++--------+-------------+--------------------------------------------------------------------+
+|        | d           | Output                                                             |
++--------+-------------+--------------------------------------------------------------------+
+| Type   | Int64       | String                                                             |
+| Domain | {-128..=16} | Unknown                                                            |
+| Row 0  | 10          | '1010'                                                             |
+| Row 1  | 16          | '10000'                                                            |
+| Row 2  | -128        | '1111111111111111111111111111111111111111111111111111111110000000' |
++--------+-------------+--------------------------------------------------------------------+
+evaluation (internal):
++--------+---------------------------------------------------------------------------------------------+
+| Column | Data                                                                                        |
++--------+---------------------------------------------------------------------------------------------+
+| d      | Column(Int64([10, 16, -128]))                                                               |
+| Output | StringColumn[1010, 10000, 1111111111111111111111111111111111111111111111111111111110000000] |
++--------+---------------------------------------------------------------------------------------------+
 
 
 ast            : lpad('hi', 2, '?')

--- a/tests/sqllogictests/suites/query/functions/02_0019_function_strings_hex.test
+++ b/tests/sqllogictests/suites/query/functions/02_0019_function_strings_hex.test
@@ -6,7 +6,7 @@ select hex(100)
 query T
 select hex(-100)
 ----
-ffffffffffffff9c
+FFFFFFFFFFFFFF9C
 
 query T
 select hex('abc')

--- a/tests/sqllogictests/suites/query/functions/02_0084_function_strings_conv.test
+++ b/tests/sqllogictests/suites/query/functions/02_0084_function_strings_conv.test
@@ -1,0 +1,54 @@
+query T
+select conv('a', 16, 10)
+----
+10
+
+query T
+select conv('6E', 18, 8)
+----
+172
+
+query T
+select conv('zz', 36, 10)
+----
+1295
+
+query T
+select conv('11', 2, 36)
+----
+3
+
+query T
+select conv(10, 10, 2)
+----
+1010
+
+query T
+select conv(10, 16, 10)
+----
+16
+
+query T
+select conv(15, 10, 16)
+----
+F
+
+query T
+select conv(-128, 10, 8)
+----
+1777777777777777777600
+
+query T
+select conv(-17, 10, -18)
+----
+-H
+
+query T
+select conv('FFFFFFFFFFFFFFFF', 16, -10)
+----
+-1
+
+query T
+select conv('11', -2, 10)
+----
+3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add MySQL-style `conv(num, from_base, to_base)` for string and integer inputs, with bases in `2..=36`.
- Rework numeric `bin`, `oct`, and `hex` around the shared base-conversion implementation: `bin(n) = conv(n, 10, 2)`, `oct(n) = conv(n, 10, 8)`, and `hex(n) = conv(n, 10, 16)`.
- Remove `hex` as a global alias of `to_hex`.
- Keep existing `to_hex` implementations and lower-case output behavior unchanged.

This resolves the old TODO around generalizing `bin` / `oct` / numeric hex into `CONV`.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation run:

- `cargo fmt --all`
- `env REGENERATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::string::test_string`
- `env REGENERATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::binary::test_binary`
- `env REGENERATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::list_all_builtin_functions`
- `env REGENERATE_GOLDENFILES=1 cargo test -p databend-common-functions --test it scalars::check_ambiguity`
- `git diff --check`

Added sqllogictest coverage in `02_0084_function_strings_conv.test` and updated hex behavior coverage in `02_0019_function_strings_hex.test`.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

`hex` was previously an alias of `to_hex`, so `hex(String)` and `hex(Binary)` were accepted. This PR intentionally narrows `hex` to numeric base conversion only; String/Binary hex encoding remains available through `to_hex`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19892)
<!-- Reviewable:end -->
