### PR TITLE
fix(query): handle sub_bitmap offset beyond cardinality

### DIFF
--- a/src/query/functions/src/scalars/bitmap.rs
+++ b/src/query/functions/src/scalars/bitmap.rs
@@ -346,13 +346,18 @@ pub fn register(registry: &mut FunctionRegistry) {
                     Ok(rb) => {
                         let subset_start = offset;
                         let subset_length = length;
-                        if subset_start >= b.len() as u64 {
+                        let bitmap_len = rb.len();
+                        if subset_start >= bitmap_len {
                             let rb = HybridBitmap::new();
                             rb.serialize_into(&mut builder.data).unwrap();
                         } else {
-                            let adjusted_length = (subset_start + subset_length).min(b.len() as u64) - subset_start;
-                            let subset_bitmap = &rb.into_iter().collect::<Vec<_>>()[subset_start as usize..(subset_start + adjusted_length) as usize];
-                            let rb = HybridBitmap::from_iter(subset_bitmap.iter());
+                            let subset_end = subset_start.saturating_add(subset_length).min(bitmap_len);
+                            let subset_bitmap = (0_u64..)
+                                .zip(rb)
+                                .skip_while(|(index, _)| *index < subset_start)
+                                .take_while(|(index, _)| *index < subset_end)
+                                .map(|(_, value)| value);
+                            let rb = HybridBitmap::from_iter(subset_bitmap);
                             rb.serialize_into(&mut builder.data).unwrap();
                         }
                     }

--- a/src/query/functions/tests/it/scalars/bitmap.rs
+++ b/src/query/functions/tests/it/scalars/bitmap.rs
@@ -99,6 +99,7 @@ fn test_bitmap_min(file: &mut impl Write) {
 
 fn test_sub_bitmap(file: &mut impl Write) {
     run_ast(file, "sub_bitmap(build_bitmap([1, 2, 3, 4, 5]), 1, 3)", &[]);
+    run_ast(file, "sub_bitmap(build_bitmap([1]), 2, 1)", &[]);
 }
 
 fn test_bitmap_subset_limit(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/bitmap.txt
+++ b/src/query/functions/tests/it/scalars/testdata/bitmap.txt
@@ -146,6 +146,15 @@ output domain  : Undefined
 output         : '2,3,4'
 
 
+ast            : sub_bitmap(build_bitmap([1]), 2, 1)
+raw expr       : sub_bitmap(build_bitmap(array(1)), 2, 1)
+checked expr   : sub_bitmap<Bitmap, UInt64, UInt64>(build_bitmap<Array(UInt8 NULL)>(CAST<Array(UInt8)>(array<T0=UInt8><T0>(1_u8) AS Array(UInt8 NULL))), CAST<UInt8>(2_u8 AS UInt64), CAST<UInt8>(1_u8 AS UInt64))
+optimized expr : HybridBitmap<[]>
+output type    : Bitmap
+output domain  : Undefined
+output         : ''
+
+
 ast            : bitmap_subset_limit(build_bitmap([3,5,7]), 4, 2)
 raw expr       : bitmap_subset_limit(build_bitmap(array(3, 5, 7)), 4, 2)
 checked expr   : bitmap_subset_limit<Bitmap, UInt64, UInt64>(build_bitmap<Array(UInt8 NULL)>(CAST<Array(UInt8)>(array<T0=UInt8><T0, T0, T0>(3_u8, 5_u8, 7_u8) AS Array(UInt8 NULL))), CAST<UInt8>(4_u8 AS UInt64), CAST<UInt8>(2_u8 AS UInt64))

--- a/tests/sqllogictests/suites/query/functions/02_0064_function_bitmap.test
+++ b/tests/sqllogictests/suites/query/functions/02_0064_function_bitmap.test
@@ -73,6 +73,11 @@ SELECT sub_bitmap(build_bitmap([1, 2, 3, 4, 5]), 1, 3)::String;
 2,3,4
 
 query T
+SELECT sub_bitmap(build_bitmap([1]), 2, 1)::String;
+----
+(empty)
+
+query T
 SELECT bitmap_subset_limit(build_bitmap([3,5,7]), 4, 2)::String;
 ----
 5,7
@@ -86,4 +91,3 @@ query T
 SELECT bitmap_to_array(build_bitmap([1, 2, 3, 100, 10000]));
 ----
 [1,2,3,100,10000]
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix `sub_bitmap` to compare offsets against bitmap cardinality instead of serialized byte length.
- Return an empty bitmap when `offset` is beyond the number of bitmap elements, for example `sub_bitmap(build_bitmap([1]), 2, 1)`.
- Add scalar golden coverage and sqllogictest regression coverage for the out-of-range offset case.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all`
- `cargo test -p databend-common-functions --test it scalars::bitmap::test_bitmap`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19894)
<!-- Reviewable:end -->
