### PR TITLE
fix(query): validate security policy metadata in planner cache

### DIFF
--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -727,7 +727,7 @@ impl TableContextAuthorization for CtxDelegation {
     }
 
     fn get_current_role(&self) -> Option<RoleInfo> {
-        todo!()
+        None
     }
 
     fn get_secondary_roles(&self) -> Option<Vec<String>> {

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -249,35 +249,22 @@ impl Planner {
         let settings = self.ctx.get_settings();
         // Step 3: Bind AST with catalog, and generate a pure logical SExpr
         let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
-        let mut enable_planner_cache = self.ctx.get_settings().get_enable_planner_cache()?;
-        let plan_cache_context = if enable_planner_cache {
-            if matches!(stmt, Statement::Query(_)) {
-                let cache_ctx = self.build_plan_cache_context(name_resolution_ctx.clone(), stmt);
-                if cache_ctx.is_cacheable() {
-                    Some(cache_ctx)
-                } else {
-                    enable_planner_cache = false;
-                    None
-                }
-            } else {
-                enable_planner_cache = false;
-                None
-            }
-        } else {
-            None
-        };
-        let planner_cache_key = if let Some(cache_ctx) = &plan_cache_context {
-            Some(self.planner_cache_key_for_stmt(stmt, cache_ctx)?)
-        } else {
-            None
-        };
+        let enable_planner_cache = self.ctx.get_settings().get_enable_planner_cache()?
+            && matches!(stmt, Statement::Query(_));
 
-        if enable_planner_cache {
-            let plan = self.get_cache(
-                planner_cache_key.as_ref().unwrap(),
-                plan_cache_context.as_ref().unwrap(),
-            );
-            if let Some(plan) = plan {
+        let plan_cache_context = enable_planner_cache
+            .then(|| self.build_plan_cache_context(name_resolution_ctx.clone(), stmt))
+            .filter(|ctx| ctx.is_cacheable());
+
+        let planner_cache_key = plan_cache_context
+            .as_ref()
+            .map(|ctx| self.planner_cache_key_for_stmt(stmt, ctx))
+            .transpose()?;
+
+        if let Some((cache_key, cache_ctx)) =
+            planner_cache_key.as_ref().zip(plan_cache_context.as_ref())
+        {
+            if let Some(plan) = self.get_cache(cache_key, cache_ctx) {
                 info!(
                     "Logical plan retrieved from cache, elapsed: {:?}",
                     start.elapsed()
@@ -332,8 +319,8 @@ impl Planner {
 
         let optimized_plan = optimize(opt_ctx, plan).await?;
 
-        if enable_planner_cache {
-            self.set_cache(planner_cache_key.clone().unwrap(), optimized_plan.clone());
+        if let Some(cache_key) = planner_cache_key {
+            self.set_cache(cache_key, optimized_plan.clone());
         }
 
         info!(

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -250,17 +250,32 @@ impl Planner {
         // Step 3: Bind AST with catalog, and generate a pure logical SExpr
         let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
         let mut enable_planner_cache = self.ctx.get_settings().get_enable_planner_cache()?;
-        let planner_cache_key = if enable_planner_cache {
-            Some(Self::planner_cache_key(&stmt.to_string()))
+        let plan_cache_context = if enable_planner_cache {
+            if matches!(stmt, Statement::Query(_)) {
+                let cache_ctx = self.build_plan_cache_context(name_resolution_ctx.clone(), stmt);
+                if cache_ctx.is_cacheable() {
+                    Some(cache_ctx)
+                } else {
+                    enable_planner_cache = false;
+                    None
+                }
+            } else {
+                enable_planner_cache = false;
+                None
+            }
+        } else {
+            None
+        };
+        let planner_cache_key = if let Some(cache_ctx) = &plan_cache_context {
+            Some(self.planner_cache_key_for_stmt(stmt, cache_ctx)?)
         } else {
             None
         };
 
         if enable_planner_cache {
-            let (c, plan) = self.get_cache(
-                name_resolution_ctx.clone(),
+            let plan = self.get_cache(
                 planner_cache_key.as_ref().unwrap(),
-                stmt,
+                plan_cache_context.as_ref().unwrap(),
             );
             if let Some(plan) = plan {
                 info!(
@@ -271,7 +286,6 @@ impl Planner {
                 self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
                 return Ok(plan.plan);
             }
-            enable_planner_cache = c;
         }
 
         let metadata = Arc::new(RwLock::new(Metadata::default()));

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -22,9 +23,12 @@ use databend_common_ast::ast::IdentifierType;
 use databend_common_ast::ast::Statement;
 use databend_common_ast::ast::TableReference;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_functions::is_cacheable_function;
+use databend_common_meta_app::schema::SecurityPolicyColumnMap;
+use databend_common_meta_app::schema::TableMeta;
 use databend_common_settings::ChangeValue;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheValue;
@@ -58,38 +62,84 @@ impl From<PlanCacheItem> for CacheValue<PlanCacheItem> {
 }
 
 impl Planner {
-    pub fn planner_cache_key(format_sql: &str) -> String {
+    pub(crate) fn planner_cache_key(format_sql: &str) -> String {
         // use sha2 to encode the sql
         format!("{:x}", Sha256::digest(format_sql))
     }
 
-    pub fn get_cache(
+    pub(crate) fn build_plan_cache_context(
         &self,
         name_resolution_ctx: NameResolutionContext,
-        key: &str,
         stmt: &Statement,
-    ) -> (bool, Option<PlanCacheItem>) {
-        if !matches!(stmt, Statement::Query(_)) {
-            return (false, None);
-        }
-
+    ) -> PlanCacheContext {
         let mut visitor = TableRefVisitor {
             ctx: self.ctx.clone(),
-            schema_snapshots: vec![],
+            table_snapshots: vec![],
             name_resolution_ctx,
             cache_miss: false,
+            has_security_policy: false,
         };
         stmt.drive(&mut visitor);
 
-        if visitor.schema_snapshots.is_empty() || visitor.cache_miss {
-            return (false, None);
+        PlanCacheContext {
+            table_snapshots: visitor.table_snapshots,
+            cache_miss: visitor.cache_miss,
+            has_security_policy: visitor.has_security_policy,
         }
+    }
+
+    pub(crate) fn planner_cache_key_for_stmt(
+        &self,
+        stmt: &Statement,
+        cache_ctx: &PlanCacheContext,
+    ) -> databend_common_exception::Result<String> {
+        if cache_ctx.has_security_policy {
+            let user = self
+                .ctx
+                .get_current_user()?
+                .identity()
+                .display()
+                .to_string();
+            let role = self
+                .ctx
+                .get_current_role()
+                .map(|r| r.name)
+                .unwrap_or_default();
+            let mut secondary_roles = self.ctx.get_secondary_roles();
+            if let Some(roles) = &mut secondary_roles {
+                roles.sort();
+            }
+            let secondary_roles_key = match secondary_roles {
+                None => "ALL".to_string(),
+                Some(roles) if roles.is_empty() => "NONE".to_string(),
+                Some(roles) => format!("SOME:{}", roles.join(",")),
+            };
+            return Ok(Self::planner_cache_key(&format!(
+                "secure\0{}\0{}\0{}\0{}\0{}",
+                self.ctx.get_tenant().tenant_name(),
+                user,
+                role,
+                secondary_roles_key,
+                stmt
+            )));
+        }
+
+        Ok(Self::planner_cache_key(&stmt.to_string()))
+    }
+
+    pub(crate) fn get_cache(
+        &self,
+        key: &str,
+        cache_ctx: &PlanCacheContext,
+    ) -> Option<PlanCacheItem> {
+        debug_assert!(!cache_ctx.table_snapshots.is_empty());
+        debug_assert!(!cache_ctx.cache_miss);
 
         let cache = LazyLock::force(&PLAN_CACHE);
         if let Some(plan_item) = cache.get(key) {
             let settings = self.ctx.get_settings();
             if settings.changes().len() != plan_item.setting_changes.len() {
-                return (true, None);
+                return None;
             }
 
             let setting_changes = settings
@@ -102,31 +152,33 @@ impl Planner {
             if setting_changes != plan_item.setting_changes
                 || self.ctx.get_all_variables() != plan_item.variables
             {
-                return (true, None);
+                return None;
             }
 
             if let Plan::Query { metadata, .. } = &plan_item.plan {
                 let metadata = metadata.read();
-                if visitor.schema_snapshots.iter().all(|ss| {
+                if cache_ctx.table_snapshots.iter().all(|ss| {
                     metadata.tables().iter().any(|table| {
                         let tbl = table.table();
-                        if tbl.is_temp() || tbl.schema().ne(&ss.0) {
+                        if tbl.is_temp() || tbl.schema().ne(&ss.schema) {
                             return false;
                         }
                         let snapshot = tbl.options().get(OPT_KEY_SNAPSHOT_LOCATION);
-                        snapshot == Some(&ss.1)
+                        if snapshot != Some(&ss.snapshot_location) {
+                            return false;
+                        }
+                        SecurityPolicySnapshot::from(&tbl.get_table_info().meta)
+                            == ss.security_policy
                     })
                 }) {
-                    return (!visitor.cache_miss, Some(plan_item.as_ref().clone()));
+                    return Some(plan_item.as_ref().clone());
                 }
             }
-            (!visitor.cache_miss, None)
-        } else {
-            (!visitor.cache_miss, None)
         }
+        None
     }
 
-    pub fn set_cache(&self, key: String, plan: Plan) {
+    pub(crate) fn set_cache(&self, key: String, plan: Plan) {
         let setting_changes = self
             .ctx
             .get_settings()
@@ -152,9 +204,51 @@ impl Planner {
 #[visitor(TableReference(enter), FunctionCall(enter))]
 struct TableRefVisitor {
     ctx: Arc<dyn TableContext>,
-    schema_snapshots: Vec<(TableSchemaRef, String)>,
+    table_snapshots: Vec<TableSnapshot>,
     name_resolution_ctx: NameResolutionContext,
     cache_miss: bool,
+    has_security_policy: bool,
+}
+
+pub(crate) struct PlanCacheContext {
+    table_snapshots: Vec<TableSnapshot>,
+    cache_miss: bool,
+    has_security_policy: bool,
+}
+
+impl PlanCacheContext {
+    pub(crate) fn is_cacheable(&self) -> bool {
+        !self.cache_miss && !self.table_snapshots.is_empty()
+    }
+}
+
+#[derive(Clone)]
+struct TableSnapshot {
+    schema: TableSchemaRef,
+    snapshot_location: String,
+    security_policy: SecurityPolicySnapshot,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SecurityPolicySnapshot {
+    column_mask_policy_columns_ids: BTreeMap<ColumnId, SecurityPolicyColumnMap>,
+    row_access_policy_columns_ids: Option<SecurityPolicyColumnMap>,
+}
+
+impl SecurityPolicySnapshot {
+    fn has_policy(&self) -> bool {
+        !self.column_mask_policy_columns_ids.is_empty()
+            || self.row_access_policy_columns_ids.is_some()
+    }
+}
+
+impl From<&TableMeta> for SecurityPolicySnapshot {
+    fn from(meta: &TableMeta) -> Self {
+        Self {
+            column_mask_policy_columns_ids: meta.column_mask_policy_columns_ids.clone(),
+            row_access_policy_columns_ids: meta.row_access_policy_columns_ids.clone(),
+        }
+    }
 }
 
 impl TableRefVisitor {
@@ -224,7 +318,16 @@ impl TableRefVisitor {
                     {
                         let snapshot = table_meta.options().get(OPT_KEY_SNAPSHOT_LOCATION).cloned();
                         if let Some(sn) = snapshot {
-                            self.schema_snapshots.push((table_meta.schema(), sn));
+                            let table_info = table_meta.get_table_info();
+                            let security_policy = SecurityPolicySnapshot::from(&table_info.meta);
+                            if security_policy.has_policy() {
+                                self.has_security_policy = true;
+                            }
+                            self.table_snapshots.push(TableSnapshot {
+                                schema: table_meta.schema(),
+                                snapshot_location: sn,
+                                security_policy,
+                            });
                             return;
                         }
                     }

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -304,11 +304,12 @@ impl TableRefVisitor {
             databend_common_base::runtime::block_on(async move {
                 if let Ok(table_meta) = self
                     .ctx
-                    .get_table_with_branch(
+                    .resolve_data_source(
                         &catalog_name,
                         &database_name,
                         &table_name,
                         branch.as_deref(),
+                        None,
                     )
                     .await
                 {

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0004_ddl_security_policy.test
@@ -16,9 +16,6 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
-set global enable_planner_cache = 0;
-
-statement ok
 drop table if exists rap_multi_test;
 
 statement ok
@@ -1164,6 +1161,3 @@ DROP ROLE rap_role_7_day;
 
 statement ok
 DROP ROLE rap_role_1_day;
-
-statement ok
-unset global enable_planner_cache;

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
@@ -19,7 +19,7 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
-set enable_planner_cache = 0;
+set enable_planner_cache = 1;
 
 statement ok
 drop table if exists rap_cache_test;

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0012_row_policy_dml_coverage.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0012_row_policy_dml_coverage.test
@@ -16,9 +16,6 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
-set enable_planner_cache = 0;
-
-statement ok
 drop table if exists rap_dml_test;
 
 statement ok

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0014_row_policy_select_subquery_coverage.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0014_row_policy_select_subquery_coverage.test
@@ -16,7 +16,7 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
-set enable_planner_cache = 0;
+set enable_planner_cache = 1;
 
 statement ok
 drop table if exists rap_select_subquery_test;

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0015_row_policy_column_order.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0015_row_policy_column_order.test
@@ -20,7 +20,7 @@ statement ok
 set global enable_experimental_row_access_policy = 1;
 
 statement ok
-set enable_planner_cache = 0;
+set enable_planner_cache = 1;
 
 statement ok
 drop table if exists rap_order_test;

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0016_policy_planner_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0016_policy_planner_cache.test
@@ -1,0 +1,177 @@
+## Copyright 2026 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+SET GLOBAL enable_experimental_row_access_policy = 1
+
+statement ok
+SET enable_experimental_row_access_policy = 1
+
+statement ok
+SET enable_planner_cache = 1
+
+statement ok
+SET enable_query_result_cache = 0
+
+statement ok
+DROP TABLE IF EXISTS pc_rap_add_test
+
+statement ok
+DROP ROW ACCESS POLICY IF EXISTS pc_rap_add_policy
+
+statement ok
+CREATE TABLE pc_rap_add_test(id INT, region STRING)
+
+statement ok
+INSERT INTO pc_rap_add_test VALUES (1, 'EMEA'), (2, 'APAC')
+
+query I
+SELECT id FROM pc_rap_add_test ORDER BY id
+----
+1
+2
+
+query I
+SELECT id FROM pc_rap_add_test ORDER BY id
+----
+1
+2
+
+statement ok
+CREATE ROW ACCESS POLICY pc_rap_add_policy AS (region STRING) RETURNS BOOLEAN -> region = 'APAC'
+
+statement ok
+ALTER TABLE pc_rap_add_test ADD ROW ACCESS POLICY pc_rap_add_policy ON (region)
+
+query I
+SELECT id FROM pc_rap_add_test ORDER BY id
+----
+2
+
+query I
+SELECT id FROM pc_rap_add_test ORDER BY id
+----
+2
+
+statement ok
+DROP TABLE IF EXISTS pc_rap_add_test
+
+statement ok
+DROP ROW ACCESS POLICY IF EXISTS pc_rap_add_policy
+
+statement ok
+DROP TABLE IF EXISTS pc_rap_drop_test
+
+statement ok
+DROP ROW ACCESS POLICY IF EXISTS pc_rap_drop_policy
+
+statement ok
+CREATE TABLE pc_rap_drop_test(id INT, region STRING)
+
+statement ok
+INSERT INTO pc_rap_drop_test VALUES (1, 'EMEA'), (2, 'APAC')
+
+statement ok
+CREATE ROW ACCESS POLICY pc_rap_drop_policy AS (region STRING) RETURNS BOOLEAN -> region = 'APAC'
+
+statement ok
+ALTER TABLE pc_rap_drop_test ADD ROW ACCESS POLICY pc_rap_drop_policy ON (region)
+
+query I
+SELECT id FROM pc_rap_drop_test ORDER BY id
+----
+2
+
+query I
+SELECT id FROM pc_rap_drop_test ORDER BY id
+----
+2
+
+statement ok
+ALTER TABLE pc_rap_drop_test DROP ROW ACCESS POLICY pc_rap_drop_policy
+
+query I
+SELECT id FROM pc_rap_drop_test ORDER BY id
+----
+1
+2
+
+query I
+SELECT id FROM pc_rap_drop_test ORDER BY id
+----
+1
+2
+
+statement ok
+DROP TABLE IF EXISTS pc_rap_drop_test
+
+statement ok
+DROP ROW ACCESS POLICY IF EXISTS pc_rap_drop_policy
+
+statement ok
+DROP TABLE IF EXISTS pc_mask_toggle_test
+
+statement ok
+DROP MASKING POLICY IF EXISTS pc_mask_toggle_policy
+
+statement ok
+CREATE TABLE pc_mask_toggle_test(id INT, secret STRING)
+
+statement ok
+INSERT INTO pc_mask_toggle_test VALUES (1, 'plain')
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 plain
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 plain
+
+statement ok
+CREATE MASKING POLICY pc_mask_toggle_policy AS (val STRING) RETURNS STRING -> 'MASKED'
+
+statement ok
+ALTER TABLE pc_mask_toggle_test MODIFY COLUMN secret SET MASKING POLICY pc_mask_toggle_policy
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 MASKED
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 MASKED
+
+statement ok
+ALTER TABLE pc_mask_toggle_test MODIFY COLUMN secret UNSET MASKING POLICY
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 plain
+
+query IT
+SELECT id, secret FROM pc_mask_toggle_test ORDER BY id
+----
+1 plain
+
+statement ok
+DROP TABLE IF EXISTS pc_mask_toggle_test
+
+statement ok
+DROP MASKING POLICY IF EXISTS pc_mask_toggle_policy

--- a/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.result
+++ b/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.result
@@ -1,0 +1,56 @@
+#### Test: Data masking WHERE security and constant folding
+#### setup: create table, roles, users, masking policy
+>>>> DROP TABLE IF EXISTS default.mask_test
+>>>> DROP MASKING POLICY IF EXISTS mask_variant_sensitive
+>>>> DROP USER IF EXISTS mask_admin_user
+>>>> DROP USER IF EXISTS mask_reader_user
+>>>> DROP ROLE IF EXISTS mask_admin
+>>>> DROP ROLE IF EXISTS mask_reader
+>>>> CREATE ROLE mask_admin
+>>>> CREATE ROLE mask_reader
+>>>> CREATE USER mask_admin_user IDENTIFIED BY '123' WITH DEFAULT_ROLE='mask_admin'
+>>>> CREATE USER mask_reader_user IDENTIFIED BY '123' WITH DEFAULT_ROLE='mask_reader'
+>>>> GRANT ROLE mask_admin TO mask_admin_user
+>>>> GRANT ROLE mask_reader TO mask_reader_user
+>>>> CREATE TABLE default.mask_test(id INT, data VARIANT)
+>>>> INSERT INTO default.mask_test VALUES (1, '{"name":"alice","content":"secret","age":30}'), (2, '{"name":"bob","content":"private","age":25}')
+2
+>>>> CREATE MASKING POLICY mask_variant_sensitive AS (val VARIANT) RETURNS VARIANT -> CASE WHEN current_role() IN ('mask_admin', 'account_admin') THEN val ELSE object_delete(val, 'content') END
+>>>> ALTER TABLE default.mask_test MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive
+>>>> GRANT SELECT ON default.mask_test TO ROLE mask_admin
+>>>> GRANT SELECT ON default.mask_test TO ROLE mask_reader
+#### === Constant folding verification ===
+#### test 1: admin EXPLAIN shows no IF, no object_delete (folded to column ref)
+0
+0
+#### test 2: reader EXPLAIN shows no IF, has object_delete (folded to else branch)
+0
+1
+#### === Data correctness ===
+#### test 3: admin sees full data
+{"age":30,"content":"secret","name":"alice"}
+{"age":25,"content":"private","name":"bob"}
+#### test 4: reader sees masked data (no content field)
+{"age":30,"name":"alice"}
+{"age":25,"name":"bob"}
+#### === WHERE security: masked column cannot be exploited ===
+#### test 5: WHERE IS NOT NULL on masked field returns 0 rows
+#### test 6: WHERE equality on masked field returns 0 rows
+#### test 7: WHERE via CAST LIKE cannot detect hidden field
+#### === Access bypass prevention ===
+#### test 8: subfield access returns NULL
+NULL
+NULL
+#### test 9: json_object_keys does not leak hidden field
+["age","name"]
+#### test 10: CAST does not bypass masking
+{"age":30,"name":"alice"}
+{"age":25,"name":"bob"}
+#### cleanup
+>>>> ALTER TABLE default.mask_test MODIFY COLUMN data UNSET MASKING POLICY
+>>>> DROP TABLE IF EXISTS default.mask_test
+>>>> DROP MASKING POLICY IF EXISTS mask_variant_sensitive
+>>>> DROP USER IF EXISTS mask_admin_user
+>>>> DROP USER IF EXISTS mask_reader_user
+>>>> DROP ROLE IF EXISTS mask_admin
+>>>> DROP ROLE IF EXISTS mask_reader

--- a/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.sh
+++ b/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+comment "Test: Data masking WHERE security and constant folding"
+
+comment "setup: create table, roles, users, masking policy"
+stmt "DROP TABLE IF EXISTS default.mask_test"
+stmt "DROP MASKING POLICY IF EXISTS mask_variant_sensitive"
+stmt "DROP USER IF EXISTS mask_admin_user"
+stmt "DROP USER IF EXISTS mask_reader_user"
+stmt "DROP ROLE IF EXISTS mask_admin"
+stmt "DROP ROLE IF EXISTS mask_reader"
+
+stmt "CREATE ROLE mask_admin"
+stmt "CREATE ROLE mask_reader"
+stmt "CREATE USER mask_admin_user IDENTIFIED BY '123' WITH DEFAULT_ROLE='mask_admin'"
+stmt "CREATE USER mask_reader_user IDENTIFIED BY '123' WITH DEFAULT_ROLE='mask_reader'"
+stmt "GRANT ROLE mask_admin TO mask_admin_user"
+stmt "GRANT ROLE mask_reader TO mask_reader_user"
+
+stmt "CREATE TABLE default.mask_test(id INT, data VARIANT)"
+stmt "INSERT INTO default.mask_test VALUES (1, '{\"name\":\"alice\",\"content\":\"secret\",\"age\":30}'), (2, '{\"name\":\"bob\",\"content\":\"private\",\"age\":25}')"
+
+stmt "CREATE MASKING POLICY mask_variant_sensitive AS (val VARIANT) RETURNS VARIANT -> CASE WHEN current_role() IN ('mask_admin', 'account_admin') THEN val ELSE object_delete(val, 'content') END"
+stmt "ALTER TABLE default.mask_test MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive"
+
+stmt "GRANT SELECT ON default.mask_test TO ROLE mask_admin"
+stmt "GRANT SELECT ON default.mask_test TO ROLE mask_reader"
+
+ADMIN_CONNECT="bendsql_query_http_user_connect mask_admin_user 123 --quote-style=never"
+READER_CONNECT="bendsql_query_http_user_connect mask_reader_user 123 --quote-style=never"
+
+comment "=== Constant folding verification ==="
+
+comment "test 1: admin EXPLAIN shows no IF, no object_delete (folded to column ref)"
+echo "EXPLAIN SELECT data FROM default.mask_test WHERE id = 1;" | $ADMIN_CONNECT | grep -c "if("
+echo "EXPLAIN SELECT data FROM default.mask_test WHERE id = 1;" | $ADMIN_CONNECT | grep -c "object_delete"
+
+comment "test 2: reader EXPLAIN shows no IF, has object_delete (folded to else branch)"
+echo "EXPLAIN SELECT data FROM default.mask_test WHERE id = 1;" | $READER_CONNECT | grep -c "if("
+echo "EXPLAIN SELECT data FROM default.mask_test WHERE id = 1;" | $READER_CONNECT | grep -c "object_delete"
+
+comment "=== Data correctness ==="
+
+comment "test 3: admin sees full data"
+echo "SELECT data FROM default.mask_test ORDER BY id;" | $ADMIN_CONNECT
+
+comment "test 4: reader sees masked data (no content field)"
+echo "SELECT data FROM default.mask_test ORDER BY id;" | $READER_CONNECT
+
+comment "=== WHERE security: masked column cannot be exploited ==="
+
+comment "test 5: WHERE IS NOT NULL on masked field returns 0 rows"
+echo "SELECT id FROM default.mask_test WHERE data['content'] IS NOT NULL;" | $READER_CONNECT
+
+comment "test 6: WHERE equality on masked field returns 0 rows"
+echo "SELECT id FROM default.mask_test WHERE data['content'] = 'secret';" | $READER_CONNECT
+
+comment "test 7: WHERE via CAST LIKE cannot detect hidden field"
+echo "SELECT id FROM default.mask_test WHERE data::STRING LIKE '%content%';" | $READER_CONNECT
+
+comment "=== Access bypass prevention ==="
+
+comment "test 8: subfield access returns NULL"
+echo "SELECT data['content'] AS c FROM default.mask_test ORDER BY id;" | $READER_CONNECT
+
+comment "test 9: json_object_keys does not leak hidden field"
+echo "SELECT json_object_keys(data) AS keys FROM default.mask_test WHERE id = 1;" | $READER_CONNECT
+
+comment "test 10: CAST does not bypass masking"
+echo "SELECT data::STRING AS s FROM default.mask_test ORDER BY id;" | $READER_CONNECT
+
+comment "cleanup"
+stmt "ALTER TABLE default.mask_test MODIFY COLUMN data UNSET MASKING POLICY"
+stmt "DROP TABLE IF EXISTS default.mask_test"
+stmt "DROP MASKING POLICY IF EXISTS mask_variant_sensitive"
+stmt "DROP USER IF EXISTS mask_admin_user"
+stmt "DROP USER IF EXISTS mask_reader_user"
+stmt "DROP ROLE IF EXISTS mask_admin"
+stmt "DROP ROLE IF EXISTS mask_reader"

--- a/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.result
+++ b/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.result
@@ -1,0 +1,11 @@
+#### Test: planner cache secure policy key includes current user
+#### setup
+#### user a populates a plan with unmasked policy body
+ok
+#### user a can reuse its own secure plan
+ok
+#### same role user b must not reuse user a's secure plan
+ok
+#### user b can reuse its own secure plan
+ok
+#### cleanup

--- a/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.sh
+++ b/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+TABLE_NAME="pc_current_user_mask_test"
+POLICY_NAME="pc_current_user_mask_policy"
+ROLE_NAME="pc_same_role"
+USER_A="pc_user_a"
+USER_B="pc_user_b"
+PASSWORD="123"
+
+quiet_root_sql() {
+	echo "$1" | $BENDSQL_CLIENT_OUTPUT_NULL
+}
+
+cleanup() {
+	quiet_root_sql "DROP TABLE IF EXISTS ${TABLE_NAME}" || true
+	quiet_root_sql "DROP MASKING POLICY IF EXISTS ${POLICY_NAME}" || true
+	quiet_root_sql "DROP USER IF EXISTS ${USER_A}" || true
+	quiet_root_sql "DROP USER IF EXISTS ${USER_B}" || true
+	quiet_root_sql "DROP ROLE IF EXISTS ${ROLE_NAME}" || true
+}
+
+run_user_query() {
+	local user="$1"
+	local sql="$2"
+	bendsql_query_http_user_connect "${user}" "${PASSWORD}" -A --quote-style=never <<<"${sql}"
+}
+
+expect_user_query() {
+	local user="$1"
+	local sql="$2"
+	local expected="$3"
+	local actual
+
+	actual=$(run_user_query "${user}" "${sql}")
+	if [[ "${actual}" != "${expected}" ]]; then
+		echo "unexpected result for ${user}"
+		echo "expected: ${expected}"
+		echo "actual: ${actual}"
+		exit 1
+	fi
+	echo "ok"
+}
+
+comment "Test: planner cache secure policy key includes current user"
+comment "setup"
+cleanup
+
+quiet_root_sql "CREATE ROLE ${ROLE_NAME}"
+quiet_root_sql "CREATE USER ${USER_A} IDENTIFIED BY '${PASSWORD}' WITH DEFAULT_ROLE='${ROLE_NAME}'"
+quiet_root_sql "CREATE USER ${USER_B} IDENTIFIED BY '${PASSWORD}' WITH DEFAULT_ROLE='${ROLE_NAME}'"
+quiet_root_sql "GRANT ROLE ${ROLE_NAME} TO ${USER_A}"
+quiet_root_sql "GRANT ROLE ${ROLE_NAME} TO ${USER_B}"
+quiet_root_sql "CREATE TABLE ${TABLE_NAME}(id INT, secret STRING)"
+quiet_root_sql "INSERT INTO ${TABLE_NAME} VALUES (1, 'visible_to_a')"
+quiet_root_sql "GRANT SELECT ON default.${TABLE_NAME} TO ROLE ${ROLE_NAME}"
+quiet_root_sql "CREATE MASKING POLICY ${POLICY_NAME} AS (val STRING) RETURNS STRING -> CASE WHEN current_user() = '''${USER_A}''@''%''' THEN val ELSE 'MASKED' END"
+quiet_root_sql "ALTER TABLE ${TABLE_NAME} MODIFY COLUMN secret SET MASKING POLICY ${POLICY_NAME}"
+
+SQL="SET enable_planner_cache = 1; SET enable_query_result_cache = 0; SELECT secret FROM ${TABLE_NAME} ORDER BY id;"
+
+comment "user a populates a plan with unmasked policy body"
+expect_user_query "${USER_A}" "${SQL}" "visible_to_a"
+
+comment "user a can reuse its own secure plan"
+expect_user_query "${USER_A}" "${SQL}" "visible_to_a"
+
+comment "same role user b must not reuse user a's secure plan"
+expect_user_query "${USER_B}" "${SQL}" "MASKED"
+
+comment "user b can reuse its own secure plan"
+expect_user_query "${USER_B}" "${SQL}" "MASKED"
+
+comment "cleanup"
+cleanup


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Planner cache used to validate cached plans only by table schema and snapshot. This could reuse a stale plan after row access policy or masking policy metadata changed on a table.

This change records security policy metadata in the planner cache context and compares it on cache lookup. Normal table queries keep the SQL-only cache key. Queries involving security policies use a secure key that also includes tenant, current user, current role, and secondary roles, avoiding cross-user reuse when policy bodies depend on session context such as current_user().

Also enable planner cache in security policy regression suites and add targeted coverage for RAP attach/detach, masking policy set/unset, and same-role different-user masking policy plans.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19897)
<!-- Reviewable:end -->
