### PR TITLE
feat(query): support ndjson copy schema evolution

### DIFF
--- a/src/query/ast/src/ast/statements/copy.rs
+++ b/src/query/ast/src/ast/statements/copy.rs
@@ -88,6 +88,7 @@ impl CopyIntoTableStmt {
             CopyIntoTableOption::ColumnMatchMode(v) => {
                 self.options.column_match_mode = Some(ColumnMatchMode::from_str(&v)?)
             }
+            CopyIntoTableOption::SchemaEvolution(v) => self.options.schema_evolution = Some(v),
         }
         Ok(())
     }
@@ -146,11 +147,21 @@ pub struct CopyIntoTableOptions {
     pub disable_variant_check: bool,
     pub return_failed_only: bool,
     pub column_match_mode: Option<ColumnMatchMode>,
+    pub schema_evolution: Option<CopySchemaEvolutionOptions>,
 
     // not used for now
     pub size_limit: usize,
     pub split_size: usize,
     pub validation_mode: String,
+}
+
+#[derive(
+    serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Drive, DriveMut, Eq,
+)]
+pub struct CopySchemaEvolutionOptions {
+    pub sample_files: Option<usize>,
+    pub sample_records_per_file: Option<usize>,
+    pub sample_total_records: Option<usize>,
 }
 
 impl CopyIntoTableOptions {
@@ -238,7 +249,29 @@ impl Display for CopyIntoTableOptions {
         if let Some(mode) = &self.column_match_mode {
             write!(f, " COLUMN_MATCH_MODE = {}", mode)?;
         }
+        if let Some(schema_evolution) = &self.schema_evolution {
+            write!(f, " SCHEMA_EVOLUTION = ({schema_evolution})")?;
+        }
         Ok(())
+    }
+}
+
+impl Display for CopySchemaEvolutionOptions {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut opts = BTreeMap::new();
+        if let Some(sample_files) = self.sample_files {
+            opts.insert("sample_files", sample_files.to_string());
+        }
+        if let Some(sample_records_per_file) = self.sample_records_per_file {
+            opts.insert(
+                "sample_records_per_file",
+                sample_records_per_file.to_string(),
+            );
+        }
+        if let Some(sample_total_records) = self.sample_total_records {
+            opts.insert("sample_total_records", sample_total_records.to_string());
+        }
+        write_comma_separated_map(f, &opts)
     }
 }
 
@@ -677,6 +710,7 @@ pub enum CopyIntoTableOption {
     ReturnFailedOnly(bool),
     OnError(String),
     ColumnMatchMode(String),
+    SchemaEvolution(CopySchemaEvolutionOptions),
 }
 
 pub enum CopyIntoLocationOption {

--- a/src/query/ast/src/parser/copy.rs
+++ b/src/query/ast/src/parser/copy.rs
@@ -24,6 +24,8 @@ use crate::ast::CopyIntoLocationStmt;
 use crate::ast::CopyIntoTableOption;
 use crate::ast::CopyIntoTableSource;
 use crate::ast::CopyIntoTableStmt;
+use crate::ast::CopySchemaEvolutionOptions;
+use crate::ast::Identifier;
 use crate::ast::LiteralStringOrVariable;
 use crate::ast::Statement;
 use crate::ast::Statement::CopyIntoLocation;
@@ -220,6 +222,49 @@ fn copy_into_table_option(i: Input) -> IResult<CopyIntoTableOption> {
             rule! { RETURN_FAILED_ONLY ~ "=" ~ #literal_bool },
             |(_, _, return_failed_only)| CopyIntoTableOption::ReturnFailedOnly(return_failed_only),
         ),
+        map_res(
+            rule! { SCHEMA_EVOLUTION ~ "=" ~ "(" ~ #comma_separated_list0(schema_evolution_option) ~ ")" },
+            |(_, _, _, opts, _)| {
+                let mut schema_evolution = CopySchemaEvolutionOptions::default();
+                for (key, value) in opts {
+                    let target = match key.name.to_lowercase().as_str() {
+                        "sample_files" => &mut schema_evolution.sample_files,
+                        "sample_records_per_file" => {
+                            &mut schema_evolution.sample_records_per_file
+                        }
+                        "sample_total_records" => &mut schema_evolution.sample_total_records,
+                        _ => {
+                            return Err(nom::Err::Failure(ErrorKind::other(format!(
+                                "Unknown schema evolution option {}",
+                                key.name
+                            ))));
+                        }
+                    };
+                    if let Some(value) = value {
+                        if value == 0 {
+                            return Err(nom::Err::Failure(ErrorKind::other(format!(
+                                "Schema evolution option {} must be greater than 0",
+                                key.name
+                            ))));
+                        }
+                        *target = Some(value as usize);
+                    } else {
+                        *target = None;
+                    }
+                }
+                Ok(CopyIntoTableOption::SchemaEvolution(schema_evolution))
+            },
+        ),
+    ))
+    .parse(i)
+}
+
+fn schema_evolution_option(i: Input) -> IResult<(Identifier, Option<u64>)> {
+    alt((
+        map(rule! { #ident ~ "=" ~ AUTO }, |(key, _, _)| (key, None)),
+        map(rule! { #ident ~ "=" ~ #literal_u64 }, |(key, _, value)| {
+            (key, Some(value))
+        }),
     ))
     .parse(i)
 }

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -1194,6 +1194,8 @@ pub enum TokenKind {
     SATURDAY,
     #[token("SCHEMA", ignore(ascii_case))]
     SCHEMA,
+    #[token("SCHEMA_EVOLUTION", ignore(ascii_case))]
+    SCHEMA_EVOLUTION,
     #[token("SCHEMAS", ignore(ascii_case))]
     SCHEMAS,
     #[token("SECOND", ignore(ascii_case))]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -607,6 +607,16 @@ SELECT * from s;"#,
         r#"
             COPY INTO mytable
                 FROM @my_stage
+                FILE_FORMAT = (type = NDJSON)
+                SCHEMA_EVOLUTION = (
+                    sample_files = 64,
+                    sample_records_per_file = AUTO,
+                    sample_total_records = 10000
+                );
+        "#,
+        r#"
+            COPY INTO mytable
+                FROM @my_stage
                 FILE_FORMAT = (
                     type = CSV,
                     field_delimiter = ',',

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -474,7 +474,7 @@ error:
   --> SQL:1:38
   |
 1 | COPY INTO mytable FROM 's3://bucket' CONECTION= ();
-  |                                      ^^^^^^^^^ unexpected `CONECTION`, expecting `CONNECTION`, `ON_ERROR`, `COLUMN_MATCH_MODE`, `RETURN_FAILED_ONLY`, `FORMAT`, `FORCE`, `PATTERN`, `FILES`, `PURGE`, `SIZE_LIMIT`, `FILE_FORMAT`, `MAX_FILES`, `DISABLE_VARIANT_CHECK`, `SPLIT_SIZE`, or `;`
+  |                                      ^^^^^^^^^ unexpected `CONECTION`, expecting `CONNECTION`, `ON_ERROR`, `SCHEMA_EVOLUTION`, `COLUMN_MATCH_MODE`, `RETURN_FAILED_ONLY`, `FORMAT`, `FORCE`, `PATTERN`, `FILES`, `PURGE`, `SIZE_LIMIT`, `FILE_FORMAT`, `MAX_FILES`, `DISABLE_VARIANT_CHECK`, `SPLIT_SIZE`, or `;`
 
 
 ---------- Input ----------
@@ -484,7 +484,7 @@ error:
   --> SQL:1:33
   |
 1 | COPY INTO mytable FROM @mystage CONNECTION = ();
-  |                                 ^^^^^^^^^^ unexpected `CONNECTION`. it's reserved keyword, you may avoid using it, expecting `ON_ERROR`, `COLUMN_MATCH_MODE`, `RETURN_FAILED_ONLY`, `FORMAT`, `FORCE`, `FILES`, `PURGE`, `SIZE_LIMIT`, `FILE_FORMAT`, `DISABLE_VARIANT_CHECK`, `PATTERN`, `MAX_FILES`, `SPLIT_SIZE`, or `;`
+  |                                 ^^^^^^^^^^ unexpected `CONNECTION`. it's reserved keyword, you may avoid using it, expecting `ON_ERROR`, `SCHEMA_EVOLUTION`, `COLUMN_MATCH_MODE`, `RETURN_FAILED_ONLY`, `FORMAT`, `FORCE`, `FILES`, `PURGE`, `SIZE_LIMIT`, `FILE_FORMAT`, `DISABLE_VARIANT_CHECK`, `PATTERN`, `MAX_FILES`, `SPLIT_SIZE`, or `;`
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -21719,6 +21719,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22059,6 +22060,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -22129,6 +22131,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -22198,6 +22201,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22276,6 +22280,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22354,6 +22359,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22436,6 +22442,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22518,6 +22525,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -22954,6 +22962,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -23011,6 +23020,77 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
+            size_limit: 0,
+            split_size: 0,
+            validation_mode: "",
+        },
+    },
+)
+
+
+---------- Input ----------
+COPY INTO mytable
+    FROM @my_stage
+    FILE_FORMAT = (type = NDJSON)
+    SCHEMA_EVOLUTION = (
+        sample_files = 64,
+        sample_records_per_file = AUTO,
+        sample_total_records = 10000
+    );
+---------- Output ---------
+COPY INTO mytable FROM '@my_stage' FILE_FORMAT = (type = NDJSON)  PURGE = false FORCE = false DISABLE_VARIANT_CHECK = false ON_ERROR = abort RETURN_FAILED_ONLY = false SCHEMA_EVOLUTION = (sample_files = 64, sample_total_records = 10000)
+---------- AST ------------
+CopyIntoTable(
+    CopyIntoTableStmt {
+        with: None,
+        src: Location(
+            Stage(
+                "my_stage",
+            ),
+        ),
+        catalog: None,
+        database: None,
+        table: Identifier {
+            span: Some(
+                10..17,
+            ),
+            name: "mytable",
+            quote: None,
+            ident_type: None,
+        },
+        dst_columns: None,
+        hints: None,
+        file_format: FileFormatOptions {
+            options: {
+                "type": Keyword(
+                    "NDJSON",
+                ),
+            },
+        },
+        files: None,
+        pattern: None,
+        options: CopyIntoTableOptions {
+            on_error: AbortNum(
+                1,
+            ),
+            max_files: 0,
+            force: false,
+            purge: false,
+            disable_variant_check: false,
+            return_failed_only: false,
+            column_match_mode: None,
+            schema_evolution: Some(
+                CopySchemaEvolutionOptions {
+                    sample_files: Some(
+                        64,
+                    ),
+                    sample_records_per_file: None,
+                    sample_total_records: Some(
+                        10000,
+                    ),
+                },
+            ),
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -23084,6 +23164,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -23444,6 +23525,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -23513,6 +23595,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -23582,6 +23665,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -23651,6 +23735,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -23729,6 +23814,7 @@ CopyIntoTable(
             disable_variant_check: true,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 10,
             split_size: 0,
             validation_mode: "",
@@ -23801,6 +23887,7 @@ CopyIntoTable(
             disable_variant_check: false,
             return_failed_only: false,
             column_match_mode: None,
+            schema_evolution: None,
             size_limit: 0,
             split_size: 0,
             validation_mode: "",
@@ -30634,6 +30721,7 @@ CreatePipe(
                 disable_variant_check: false,
                 return_failed_only: false,
                 column_match_mode: None,
+                schema_evolution: None,
                 size_limit: 0,
                 split_size: 0,
                 validation_mode: "",
@@ -30697,6 +30785,7 @@ CreatePipe(
                 disable_variant_check: false,
                 return_failed_only: false,
                 column_match_mode: None,
+                schema_evolution: None,
                 size_limit: 0,
                 split_size: 0,
                 validation_mode: "",

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -15,13 +15,19 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use arrow_schema::Field;
 use databend_common_ast::Span;
 use databend_common_ast::ast::ColumnMatchMode;
+use databend_common_ast::ast::CopySchemaEvolutionOptions;
+use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::lock::LockTableOption;
 use databend_common_catalog::plan::StageTableInfo;
 use databend_common_catalog::table::TableExt;
+use databend_common_compress::CompressAlgorithm;
+use databend_common_compress::DecompressDecoder;
+use databend_common_compress::DecompressState;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
@@ -33,11 +39,13 @@ use databend_common_expression::Scalar;
 use databend_common_expression::SendableDataBlockStream;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::StringType;
 use databend_common_meta_app::principal::FileFormatParams;
+use databend_common_meta_app::principal::StageFileCompression;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
 use databend_common_pipeline::core::Pipeline;
@@ -79,6 +87,105 @@ use crate::sessions::TableContextTableManagement;
 use crate::sql::plans::CopyIntoTablePlan;
 use crate::sql::plans::Plan;
 use crate::stream::DataBlockStream;
+use crate::table_functions::infer_schema::InferSchemaSeparator;
+use crate::table_functions::infer_schema::merge_schema;
+
+const NDJSON_SCHEMA_EVOLUTION_AUTO_SAMPLE_FILES: usize = 64;
+const NDJSON_SCHEMA_EVOLUTION_AUTO_RECORDS_PER_FILE: usize = 1000;
+const NDJSON_SCHEMA_EVOLUTION_AUTO_TOTAL_RECORDS: usize = 10000;
+const NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE: usize = 32 * 1024 * 1024;
+const NDJSON_SCHEMA_EVOLUTION_COMPRESSED_READ_CHUNK_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct NdJsonSchemaEvolutionOptions {
+    sample_files: usize,
+    sample_records_per_file: usize,
+    sample_total_records: usize,
+}
+
+struct NdJsonSampleBytes {
+    data: Vec<u8>,
+    is_truncated: bool,
+}
+
+impl NdJsonSchemaEvolutionOptions {
+    fn resolve(
+        options: Option<&CopySchemaEvolutionOptions>,
+        total_files: usize,
+        max_threads: usize,
+    ) -> Self {
+        let auto_sample_files = total_files
+            .min(max_threads.max(1) * 4)
+            .clamp(1, NDJSON_SCHEMA_EVOLUTION_AUTO_SAMPLE_FILES);
+        Self {
+            sample_files: options
+                .and_then(|v| v.sample_files)
+                .unwrap_or(auto_sample_files)
+                .min(total_files)
+                .max(1),
+            sample_records_per_file: options
+                .and_then(|v| v.sample_records_per_file)
+                .unwrap_or(NDJSON_SCHEMA_EVOLUTION_AUTO_RECORDS_PER_FILE),
+            sample_total_records: options
+                .and_then(|v| v.sample_total_records)
+                .unwrap_or(NDJSON_SCHEMA_EVOLUTION_AUTO_TOTAL_RECORDS),
+        }
+    }
+}
+
+fn normalize_schema_field_name(name: &str, case_sensitive: bool) -> String {
+    if case_sensitive {
+        name.to_string()
+    } else {
+        name.to_lowercase()
+    }
+}
+
+fn trim_ndjson_sample_bytes<'a>(
+    bytes: &'a [u8],
+    is_truncated: bool,
+    path: &str,
+) -> Result<&'a [u8]> {
+    if bytes.is_empty() || matches!(bytes.last(), Some(b'\n' | b'\r')) {
+        return Ok(bytes);
+    }
+    match bytes.iter().rposition(|b| *b == b'\n') {
+        Some(pos) => Ok(&bytes[..=pos]),
+        None if is_truncated => Err(ErrorCode::BadBytes(format!(
+            "insufficient NDJSON sample data for file '{path}': the sampled prefix does not contain a complete JSON record. Please adjust SCHEMA_EVOLUTION sample options such as SAMPLE_FILES, SAMPLE_RECORDS_PER_FILE, or SAMPLE_TOTAL_RECORDS",
+        ))),
+        None => Ok(bytes),
+    }
+}
+
+fn compression_algo_from_path(
+    compression: StageFileCompression,
+    path: &str,
+) -> Result<Option<CompressAlgorithm>> {
+    let algo = match compression {
+        StageFileCompression::Auto => CompressAlgorithm::from_path(path),
+        StageFileCompression::Gzip => Some(CompressAlgorithm::Gzip),
+        StageFileCompression::Bz2 => Some(CompressAlgorithm::Bz2),
+        StageFileCompression::Brotli => Some(CompressAlgorithm::Brotli),
+        StageFileCompression::Zstd => Some(CompressAlgorithm::Zstd),
+        StageFileCompression::Deflate => Some(CompressAlgorithm::Zlib),
+        StageFileCompression::RawDeflate => Some(CompressAlgorithm::Deflate),
+        StageFileCompression::Xz => Some(CompressAlgorithm::Xz),
+        StageFileCompression::Lzo => {
+            return Err(ErrorCode::Unimplemented(
+                "compress type lzo is unimplemented for copy into",
+            ));
+        }
+        StageFileCompression::Snappy => {
+            return Err(ErrorCode::Unimplemented(
+                "compress type snappy is unimplemented for copy into",
+            ));
+        }
+        StageFileCompression::None => None,
+        StageFileCompression::Zip => Some(CompressAlgorithm::Zip),
+    };
+    Ok(algo)
+}
 
 pub struct CopyIntoTableInterpreter {
     ctx: Arc<QueryContext>,
@@ -153,6 +260,10 @@ impl CopyIntoTableInterpreter {
         } else {
             let mut stage_table_info = plan.stage_table_info.clone();
             if plan.enable_schema_evolution {
+                stage_table_info
+                    .copy_into_table_options
+                    .schema_evolution
+                    .get_or_insert_default();
                 new_schema = Self::infer_schema(&mut stage_table_info, self.ctx.clone())
                     .await
                     .map_err(|e| e.with_context("infer_schema"))?;
@@ -320,9 +431,341 @@ impl CopyIntoTableInterpreter {
                     return Ok(Some(schema));
                 }
             }
+            FileFormatParams::NdJson(_) => {
+                let settings = ctx.get_settings();
+                let max_threads = settings.get_max_threads()? as usize;
+                let max_memory_usage = settings.get_max_memory_usage()?;
+                let files = stage_table_info.files_to_copy.as_ref().expect(
+                    "StageTableForCopy::do_read_partitions must be called with files_to_copy set",
+                );
+                let mut files = files
+                    .iter()
+                    .filter(|f| f.size > 0)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                files.sort_by(|a, b| a.path.cmp(&b.path));
+                if files.is_empty() {
+                    return Ok(None);
+                }
+
+                let options = NdJsonSchemaEvolutionOptions::resolve(
+                    stage_table_info
+                        .copy_into_table_options
+                        .schema_evolution
+                        .as_ref(),
+                    files.len(),
+                    max_threads,
+                );
+                let sampled_files = Self::sample_ndjson_files(&files, options.sample_files);
+                if sampled_files.is_empty() || options.sample_total_records == 0 {
+                    return Ok(None);
+                }
+
+                ctx.set_status_info("[COPY] Infer NDJSON schema");
+                let start = Instant::now();
+                let operator = init_stage_operator(&stage_table_info.stage_info)?;
+                let compression = stage_table_info.stage_info.file_format_params.compression();
+                let mut remaining_records = options.sample_total_records;
+                let mut tasks = Vec::with_capacity(sampled_files.len());
+                for file in sampled_files {
+                    let max_records = remaining_records.min(options.sample_records_per_file);
+                    if max_records == 0 {
+                        break;
+                    }
+                    remaining_records -= max_records;
+                    let operator = operator.clone();
+                    let path = file.path.clone();
+                    let file_size = file.size;
+                    tasks.push(async move {
+                        let sample = Self::read_ndjson_sample_bytes(
+                            operator,
+                            &path,
+                            file_size,
+                            compression,
+                            max_memory_usage,
+                        )
+                        .await?;
+                        let bytes =
+                            trim_ndjson_sample_bytes(&sample.data, sample.is_truncated, &path)?;
+                        if bytes.is_empty() {
+                            return Ok(None);
+                        }
+                        let schema =
+                            InferSchemaSeparator::infer_ndjson_schema(bytes, Some(max_records))?;
+                        Ok::<_, ErrorCode>(Some((path, max_records, schema)))
+                    });
+                }
+
+                let concurrency = max_threads.max(1).min(tasks.len().max(1));
+                let results = execute_futures_in_parallel(
+                    tasks,
+                    concurrency,
+                    concurrency,
+                    "infer-ndjson-schema-worker".to_owned(),
+                )
+                .await?;
+
+                let mut inferred_schema: Option<TableSchema> = None;
+                let mut sampled_records_limit = 0usize;
+                let mut sampled_file_count = 0usize;
+                for result in results {
+                    let Some((_path, max_records, schema)) = result? else {
+                        continue;
+                    };
+                    sampled_records_limit += max_records;
+                    sampled_file_count += 1;
+                    inferred_schema = Some(match inferred_schema {
+                        None => schema,
+                        Some(existing) => merge_schema(existing, schema),
+                    });
+                }
+
+                let Some(inferred_schema) = inferred_schema else {
+                    return Ok(None);
+                };
+
+                let case_sensitive = stage_table_info.copy_into_table_options.column_match_mode
+                    == Some(ColumnMatchMode::CaseSensitive);
+                let mut new_schema = stage_table_info.schema.as_ref().to_owned();
+                let old_fields: HashMap<String, TableDataType> = stage_table_info
+                    .schema
+                    .fields
+                    .iter()
+                    .map(|f| {
+                        (
+                            normalize_schema_field_name(f.name(), case_sensitive),
+                            f.data_type.clone(),
+                        )
+                    })
+                    .collect::<_>();
+                let mut new_fields: HashMap<String, TableField> = HashMap::new();
+                for field in inferred_schema.fields().iter() {
+                    let name = normalize_schema_field_name(field.name(), case_sensitive);
+                    if old_fields.contains_key(&name) {
+                        continue;
+                    }
+                    if let Some(existing) = new_fields.get_mut(&name) {
+                        let merged = merge_schema(
+                            TableSchema::new(vec![existing.clone()]),
+                            TableSchema::new(vec![field.clone()]),
+                        );
+                        *existing = merged.fields()[0].clone();
+                    } else {
+                        new_fields.insert(name, field.clone());
+                    }
+                }
+
+                if new_fields.is_empty() {
+                    return Ok(None);
+                }
+
+                let new_fields = new_fields.into_iter().sorted_by(|a, b| a.0.cmp(&b.0));
+                let new_fields_count = new_fields.len();
+                for (_, mut field) in new_fields {
+                    field.data_type = field.data_type.wrap_nullable();
+                    if let Some(exprs) = &mut stage_table_info.default_exprs {
+                        exprs.push(RemoteDefaultExpr::RemoteExpr(RemoteExpr::Constant {
+                            scalar: Scalar::Null,
+                            data_type: DataType::Null,
+                            span: Span::default(),
+                        }))
+                    }
+                    new_schema.add_column(&field, new_schema.num_fields())?;
+                }
+
+                info!(
+                    "Infer NDJSON schema for COPY: total_files={}, sampled_files={}, sample_records_per_file={}, sample_total_records={}, sampled_records_limit={}, new_columns={}, elapsed={:?}",
+                    files.len(),
+                    sampled_file_count,
+                    options.sample_records_per_file,
+                    options.sample_total_records,
+                    sampled_records_limit,
+                    new_fields_count,
+                    start.elapsed(),
+                );
+
+                let schema = Arc::new(new_schema);
+                stage_table_info.schema = schema.clone();
+                return Ok(Some(schema));
+            }
             _ => {}
         }
         Ok(None)
+    }
+
+    fn sample_ndjson_files(files: &[StageFileInfo], sample_files: usize) -> Vec<StageFileInfo> {
+        if files.len() <= sample_files {
+            return files.to_vec();
+        }
+        if sample_files == 1 {
+            return vec![files[files.len() / 2].clone()];
+        }
+
+        let mut sampled = BTreeMap::new();
+        let last = files.len() - 1;
+        for i in 0..sample_files {
+            let index = i * last / (sample_files - 1);
+            sampled.insert(index, files[index].clone());
+        }
+        sampled.into_values().collect()
+    }
+
+    async fn read_ndjson_sample_bytes(
+        operator: opendal::Operator,
+        path: &str,
+        file_size: u64,
+        compression: StageFileCompression,
+        max_memory_usage: u64,
+    ) -> Result<NdJsonSampleBytes> {
+        let algo = compression_algo_from_path(compression, path)?;
+        let sample = match algo {
+            None => {
+                let read_size = file_size.min(NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE as u64);
+                let data = operator
+                    .read_with(path)
+                    .range(0..read_size)
+                    .await?
+                    .to_bytes()
+                    .to_vec();
+                NdJsonSampleBytes {
+                    data,
+                    is_truncated: read_size < file_size,
+                }
+            }
+            Some(algo) => {
+                if algo == CompressAlgorithm::Zip {
+                    Self::check_zip_ndjson_sample_size(path, file_size)?;
+                    let compressed = operator.read(path).await?.to_bytes().to_vec();
+                    let data = Self::read_zip_ndjson_sample_bytes(
+                        &compressed,
+                        path,
+                        file_size,
+                        max_memory_usage as usize,
+                    )?;
+                    let is_truncated = data.len() > NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE;
+                    NdJsonSampleBytes { data, is_truncated }
+                } else {
+                    Self::read_compressed_ndjson_sample_bytes(operator, path, file_size, algo)
+                        .await?
+                }
+            }
+        };
+        Ok(NdJsonSampleBytes {
+            is_truncated: sample.is_truncated
+                || sample.data.len() > NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE,
+            data: sample
+                .data
+                .into_iter()
+                .take(NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE)
+                .collect(),
+        })
+    }
+
+    fn check_zip_ndjson_sample_size(path: &str, file_size: u64) -> Result<()> {
+        if file_size > NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE as u64 {
+            return Err(ErrorCode::BadBytes(format!(
+                "zip file {path} is too large for bounded NDJSON schema evolution sampling, compressed_size = {file_size}, maximum allowed = {}",
+                NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE,
+            )));
+        }
+        Ok(())
+    }
+
+    fn read_zip_ndjson_sample_bytes(
+        compressed: &[u8],
+        path: &str,
+        file_size: u64,
+        max_memory_usage: usize,
+    ) -> Result<Vec<u8>> {
+        Self::check_zip_ndjson_sample_size(path, file_size)?;
+        DecompressDecoder::decompress_all_zip(compressed, path, max_memory_usage)
+    }
+
+    async fn read_compressed_ndjson_sample_bytes(
+        operator: opendal::Operator,
+        path: &str,
+        file_size: u64,
+        algo: CompressAlgorithm,
+    ) -> Result<NdJsonSampleBytes> {
+        let reader = operator.reader(path).await?;
+        let mut decoder = DecompressDecoder::new(algo);
+        let mut output = Vec::with_capacity(NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE);
+        let compressed_read_limit =
+            file_size.min(NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE as u64);
+        let mut offset = 0_u64;
+
+        while offset < compressed_read_limit
+            && output.len() < NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE
+            && !matches!(decoder.state(), DecompressState::Done)
+        {
+            let end = (offset + NDJSON_SCHEMA_EVOLUTION_COMPRESSED_READ_CHUNK_BYTES as u64)
+                .min(compressed_read_limit);
+            let chunk = reader.read(offset..end).await?.to_vec();
+            if chunk.is_empty() {
+                return Err(ErrorCode::BadBytes(format!(
+                    "Unexpected EOF {path} expect {file_size} bytes, read only {offset} bytes.",
+                )));
+            }
+            offset += chunk.len() as u64;
+            decoder.fill(&chunk);
+            Self::drain_ndjson_decompressor_sample(&mut decoder, &mut output, false)?;
+        }
+
+        if offset == file_size
+            && output.len() < NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE
+            && !matches!(decoder.state(), DecompressState::Done)
+        {
+            if matches!(decoder.state(), DecompressState::Reading) {
+                decoder.fill(&[]);
+            }
+            Self::drain_ndjson_decompressor_sample(&mut decoder, &mut output, true)?;
+            if !matches!(decoder.state(), DecompressState::Done) {
+                return Err(ErrorCode::BadBytes(format!(
+                    "decompressor state is {:?} after decompressing all data from {}",
+                    decoder.state(),
+                    path,
+                )));
+            }
+        }
+
+        Ok(NdJsonSampleBytes {
+            is_truncated: offset < file_size || !matches!(decoder.state(), DecompressState::Done),
+            data: output,
+        })
+    }
+
+    fn drain_ndjson_decompressor_sample(
+        decoder: &mut DecompressDecoder,
+        output: &mut Vec<u8>,
+        finish: bool,
+    ) -> Result<()> {
+        while output.len() < NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE {
+            match decoder.state() {
+                DecompressState::Decoding => {
+                    let remaining = NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE - output.len();
+                    let mut buf = vec![0_u8; remaining.min(4096)];
+                    let written = decoder.decode(&mut buf).map_err(|e| {
+                        ErrorCode::InvalidCompressionData(format!("compression data invalid: {e}"))
+                    })?;
+                    buf.truncate(written);
+                    output.extend_from_slice(&buf);
+                }
+                DecompressState::Flushing => {
+                    let remaining = NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE - output.len();
+                    let mut buf = vec![0_u8; remaining.min(4096)];
+                    let written = decoder.finish(&mut buf).map_err(|e| {
+                        ErrorCode::InvalidCompressionData(format!("compression data invalid: {e}"))
+                    })?;
+                    buf.truncate(written);
+                    output.extend_from_slice(&buf);
+                }
+                DecompressState::Reading if finish => {
+                    decoder.fill(&[]);
+                }
+                DecompressState::Reading | DecompressState::Done => break,
+            }
+        }
+        Ok(())
     }
 
     fn get_copy_into_table_result(&self) -> Result<Vec<DataBlock>> {
@@ -599,5 +1042,157 @@ impl Interpreter for CopyIntoTableInterpreter {
         };
 
         Ok(Box::pin(DataBlockStream::create(None, blocks)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_ast::ast::CopySchemaEvolutionOptions;
+    use databend_common_compress::CompressCodec;
+    use databend_common_storage::StageFileStatus;
+
+    use super::*;
+
+    fn stage_file(path: &str) -> StageFileInfo {
+        StageFileInfo {
+            path: path.to_string(),
+            size: 1,
+            md5: None,
+            last_modified: None,
+            etag: None,
+            status: StageFileStatus::NeedCopy,
+            creator: None,
+        }
+    }
+
+    #[test]
+    fn test_ndjson_schema_evolution_auto_options() {
+        let options = NdJsonSchemaEvolutionOptions::resolve(None, 100, 8);
+        assert_eq!(options.sample_files, 32);
+        assert_eq!(
+            options.sample_records_per_file,
+            NDJSON_SCHEMA_EVOLUTION_AUTO_RECORDS_PER_FILE
+        );
+        assert_eq!(
+            options.sample_total_records,
+            NDJSON_SCHEMA_EVOLUTION_AUTO_TOTAL_RECORDS
+        );
+
+        let explicit = CopySchemaEvolutionOptions {
+            sample_files: Some(3),
+            sample_records_per_file: Some(10),
+            sample_total_records: Some(20),
+        };
+        let options = NdJsonSchemaEvolutionOptions::resolve(Some(&explicit), 100, 8);
+        assert_eq!(options.sample_files, 3);
+        assert_eq!(options.sample_records_per_file, 10);
+        assert_eq!(options.sample_total_records, 20);
+    }
+
+    #[test]
+    fn test_sample_ndjson_files_evenly() {
+        let files = ["a", "b", "c", "d", "e"]
+            .into_iter()
+            .map(stage_file)
+            .collect::<Vec<_>>();
+        let sampled = CopyIntoTableInterpreter::sample_ndjson_files(&files, 3);
+        let paths = sampled.iter().map(|f| f.path.as_str()).collect::<Vec<_>>();
+        assert_eq!(paths, vec!["a", "c", "e"]);
+
+        let sampled = CopyIntoTableInterpreter::sample_ndjson_files(&files, 1);
+        let paths = sampled.iter().map(|f| f.path.as_str()).collect::<Vec<_>>();
+        assert_eq!(paths, vec!["c"]);
+    }
+
+    #[test]
+    fn test_trim_ndjson_sample_bytes() -> Result<()> {
+        assert_eq!(
+            trim_ndjson_sample_bytes(b"{\"a\":1}\n{\"b\"", true, "sample.ndjson")?,
+            b"{\"a\":1}\n"
+        );
+        assert_eq!(
+            trim_ndjson_sample_bytes(b"{\"a\":1}\n", true, "sample.ndjson")?,
+            b"{\"a\":1}\n"
+        );
+        assert_eq!(
+            trim_ndjson_sample_bytes(b"{\"a\":1}", false, "sample.ndjson")?,
+            b"{\"a\":1}"
+        );
+        let err = trim_ndjson_sample_bytes(b"{\"a\":1", true, "sample.ndjson").unwrap_err();
+        assert!(err.message().contains("insufficient NDJSON sample data"));
+        assert!(err.message().contains("sample.ndjson"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_drain_compressed_ndjson_prefix_does_not_require_eof() -> Result<()> {
+        let content = vec![b'a'; 1024 * 1024];
+        let mut encoder = CompressCodec::from(CompressAlgorithm::Gzip);
+        let compressed = encoder.compress_all(&content)?;
+        let mut decoder = DecompressDecoder::new(CompressAlgorithm::Gzip);
+        let mut output = Vec::new();
+
+        decoder.fill(&compressed[..compressed.len() / 2]);
+        CopyIntoTableInterpreter::drain_ndjson_decompressor_sample(
+            &mut decoder,
+            &mut output,
+            false,
+        )?;
+
+        assert!(!matches!(decoder.state(), DecompressState::Done));
+        assert!(output.len() < content.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_drain_compressed_ndjson_sample_caps_decompressed_bytes() -> Result<()> {
+        let content = vec![b'a'; NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE + 1024];
+        let mut encoder = CompressCodec::from(CompressAlgorithm::Gzip);
+        let compressed = encoder.compress_all(&content)?;
+        assert!(compressed.len() < NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE);
+
+        let mut decoder = DecompressDecoder::new(CompressAlgorithm::Gzip);
+        let mut sample = Vec::new();
+        decoder.fill(&compressed);
+        CopyIntoTableInterpreter::drain_ndjson_decompressor_sample(
+            &mut decoder,
+            &mut sample,
+            false,
+        )?;
+
+        assert_eq!(sample.len(), NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE);
+        assert!(sample.iter().all(|v| *v == b'a'));
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_small_zip_ndjson_sample() -> Result<()> {
+        let content = b"{\"a\":1}\n{\"a\":2}\n";
+        let compressed = CompressCodec::compress_all_zip(content, "data.ndjson")?;
+        let path = "/compressed/small.ndjson.zip";
+
+        let sample = CopyIntoTableInterpreter::read_zip_ndjson_sample_bytes(
+            &compressed,
+            path,
+            compressed.len() as u64,
+            0,
+        )?;
+
+        assert_eq!(sample, content);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_large_zip_ndjson_sample_rejects_unbounded_read() -> Result<()> {
+        let err = CopyIntoTableInterpreter::read_zip_ndjson_sample_bytes(
+            &[],
+            "/compressed/large.ndjson.zip",
+            NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE as u64 + 1,
+            0,
+        )
+        .unwrap_err();
+
+        assert!(err.message().contains("bounded NDJSON schema evolution"));
+        Ok(())
     }
 }

--- a/src/query/service/src/table_functions/infer_schema/mod.rs
+++ b/src/query/service/src/table_functions/infer_schema/mod.rs
@@ -19,3 +19,5 @@ mod separator;
 mod table_args;
 
 pub use infer_schema_table::InferSchemaTable;
+pub(crate) use merge::merge_schema;
+pub(crate) use separator::InferSchemaSeparator;

--- a/src/query/service/src/table_functions/infer_schema/separator.rs
+++ b/src/query/service/src/table_functions/infer_schema/separator.rs
@@ -137,6 +137,30 @@ impl InferSchemaSeparator {
         }
     }
 
+    pub(crate) fn infer_ndjson_schema(
+        file_bytes: &[u8],
+        max_records: Option<usize>,
+    ) -> Result<TableSchema> {
+        TableSchema::try_from(&Self::infer_ndjson_arrow_schema(file_bytes, max_records)?)
+    }
+
+    fn infer_ndjson_arrow_schema(
+        file_bytes: &[u8],
+        max_records: Option<usize>,
+    ) -> std::result::Result<Schema, ArrowError> {
+        let mut records = ValueIter::new(Cursor::new(file_bytes), max_records);
+        if let Some(max_record) = max_records {
+            let mut tmp: Vec<std::result::Result<_, ArrowError>> = Vec::with_capacity(max_record);
+
+            for result in records {
+                tmp.push(Ok(result?));
+            }
+            infer_json_schema_from_iterator(tmp.into_iter())
+        } else {
+            infer_json_schema_from_iterator(&mut records)
+        }
+    }
+
     fn infer_tsv_schema(
         bytes: &[u8],
         params: &TextFileFormatParams,
@@ -438,29 +462,33 @@ impl AccumulatingTransform for InferSchemaSeparator {
             return Ok(vec![DataBlock::empty()]);
         }
         let file_bytes = bytes.as_slice();
-        let result = match &self.file_format_params {
+        enum InferError {
+            Incomplete,
+            Arrow(ArrowError),
+            Error(ErrorCode),
+        }
+
+        let result: std::result::Result<TableSchema, InferError> = match &self.file_format_params {
             FileFormatParams::Csv(params) => {
                 Self::infer_csv_schema(file_bytes, params, batch.is_eof, self.max_records)
+                    .map_err(|err| match err {
+                        Some(err) => InferError::Arrow(err),
+                        None => InferError::Incomplete,
+                    })
+                    .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
             }
             FileFormatParams::Text(params) => {
                 Self::infer_tsv_schema(file_bytes, params, batch.is_eof, self.max_records)
+                    .map_err(|err| match err {
+                        Some(err) => InferError::Arrow(err),
+                        None => InferError::Incomplete,
+                    })
+                    .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
             }
             FileFormatParams::NdJson(_) => {
-                let mut records = ValueIter::new(Cursor::new(file_bytes), self.max_records);
-                let fn_ndjson = |max_records| -> std::result::Result<Schema, Option<ArrowError>> {
-                    if let Some(max_record) = max_records {
-                        let mut tmp: Vec<std::result::Result<_, ArrowError>> =
-                            Vec::with_capacity(max_record);
-
-                        for result in records {
-                            tmp.push(Ok(result.map_err(|_| None)?));
-                        }
-                        infer_json_schema_from_iterator(tmp.into_iter()).map_err(Some)
-                    } else {
-                        infer_json_schema_from_iterator(&mut records).map_err(Some)
-                    }
-                };
-                fn_ndjson(self.max_records)
+                Self::infer_ndjson_arrow_schema(file_bytes, self.max_records)
+                    .map_err(InferError::Arrow)
+                    .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
             }
             _ => {
                 return Err(ErrorCode::BadArguments(
@@ -468,25 +496,31 @@ impl AccumulatingTransform for InferSchemaSeparator {
                 ));
             }
         };
-        let arrow_schema = match result {
+        let table_schema = match result {
             Ok(schema) => schema,
-            Err(None) => return Ok(vec![DataBlock::empty()]),
-            Err(Some(err)) => {
-                if matches!(err, ArrowError::CsvError(_))
-                    && self.max_records.is_some()
+            Err(InferError::Incomplete) => return Ok(vec![DataBlock::empty()]),
+            Err(InferError::Arrow(err)) => {
+                if self.max_records.is_some()
                     && !batch.is_eof
+                    && (matches!(err, ArrowError::CsvError(_))
+                        || is_ndjson_incomplete_parse_error(
+                            &err,
+                            file_bytes,
+                            &self.file_format_params,
+                        ))
                 {
                     return Ok(vec![DataBlock::empty()]);
                 }
                 return Err(err.into());
             }
+            Err(InferError::Error(err)) => return Err(err),
         };
         self.files.remove(&batch.path);
         self.filenames.push(batch.path);
 
         let merge_schema = match self.schemas.take() {
-            None => TableSchema::try_from(&arrow_schema)?,
-            Some(schema) => merge_schema(schema, TableSchema::try_from(&arrow_schema)?),
+            None => table_schema,
+            Some(schema) => merge_schema(schema, table_schema),
         };
         self.schemas = Some(merge_schema);
 
@@ -547,9 +581,20 @@ fn trim_ascii_space(data: &[u8]) -> &[u8] {
     data.trim_ascii()
 }
 
+fn is_ndjson_incomplete_parse_error(
+    err: &ArrowError,
+    file_bytes: &[u8],
+    file_format_params: &FileFormatParams,
+) -> bool {
+    matches!(file_format_params, FileFormatParams::NdJson(_))
+        && matches!(err, ArrowError::JsonError(_))
+        && !matches!(file_bytes.last(), Some(b'\n' | b'\r'))
+}
+
 #[cfg(test)]
 mod tests {
     use databend_common_meta_app::principal::CsvFileFormatParams;
+    use databend_common_meta_app::principal::NdJsonFileFormatParams;
     use databend_common_meta_app::principal::TextFileFormatParams;
 
     use super::*;
@@ -642,6 +687,33 @@ mod tests {
         let schema =
             InferSchemaSeparator::infer_tsv_schema(b"1\ntext\n", &params, true, None).unwrap();
         assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_infer_ndjson_incomplete_parse_error_waits_for_next_batch() -> Result<()> {
+        let mut separator = InferSchemaSeparator::create(
+            FileFormatParams::NdJson(NdJsonFileFormatParams::default()),
+            Some(2),
+            1,
+        );
+        let output = separator.transform(DataBlock::empty_with_meta(Box::new(BytesBatch {
+            data: b"{\"a\":1}\n{\"a\"".to_vec(),
+            path: "sample.ndjson".to_string(),
+            offset: 0,
+            is_eof: false,
+        })))?;
+        assert_eq!(output.len(), 1);
+        assert!(output[0].is_empty());
+
+        let output = separator.transform(DataBlock::empty_with_meta(Box::new(BytesBatch {
+            data: b":2}\n".to_vec(),
+            path: "sample.ndjson".to_string(),
+            offset: 13,
+            is_eof: true,
+        })))?;
+        assert_eq!(output.len(), 1);
+        assert!(!output[0].is_empty());
+        Ok(())
     }
 
     #[test]

--- a/src/query/service/src/table_functions/mod.rs
+++ b/src/query/service/src/table_functions/mod.rs
@@ -17,7 +17,7 @@ mod billing_usage_daily;
 mod copy_history;
 mod fuse_vacuum2;
 #[cfg(feature = "storage-stage")]
-mod infer_schema;
+pub(crate) mod infer_schema;
 mod inspect_parquet;
 mod list_stage;
 mod numbers;

--- a/src/query/storages/stage/src/read/load_context.rs
+++ b/src/query/storages/stage/src/read/load_context.rs
@@ -42,6 +42,7 @@ pub struct LoadContext {
     pub stage_root: String,
 
     pub is_select: bool,
+    pub schema_evolution: bool,
     pub settings: InputFormatSettings,
     pub block_compact_thresholds: BlockThresholds,
 
@@ -62,7 +63,7 @@ impl LoadContext {
         settings.disable_variant_check = stage_table_info
             .copy_into_table_options
             .disable_variant_check;
-        Self::try_create(
+        let mut load_context = Self::try_create(
             ctx,
             stage_table_info.schema.clone(),
             is_select,
@@ -73,7 +74,12 @@ impl LoadContext {
             internal_columns,
             stage_table_info.stage_root.clone(),
             stage_table_info.copy_into_table_options.on_error.clone(),
-        )
+        )?;
+        load_context.schema_evolution = stage_table_info
+            .copy_into_table_options
+            .schema_evolution
+            .is_some();
+        Ok(load_context)
     }
     pub fn try_create(
         ctx: Arc<dyn TableContext>,
@@ -114,6 +120,7 @@ impl LoadContext {
             pos_projection,
             stage_root,
             is_select,
+            schema_evolution: false,
             settings,
             error_handler: Arc::new(ErrorHandler {
                 on_error_mode,

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use bstr::ByteSlice;
@@ -32,16 +34,24 @@ pub struct NdJsonDecoder {
     pub load_context: Arc<LoadContext>,
     pub fmt: NdJsonInputFormat,
     pub field_decoder: FieldJsonAstDecoder,
+    pub schema_field_names: HashSet<String>,
 }
 
 impl NdJsonDecoder {
     pub fn create(fmt: NdJsonInputFormat, load_context: Arc<LoadContext>) -> Self {
         let field_decoder =
             FieldJsonAstDecoder::create(&load_context.settings, load_context.is_select);
+        let schema_field_names = load_context
+            .schema
+            .fields()
+            .iter()
+            .map(|field| normalize_field_name(field.name(), field_decoder.ident_case_sensitive))
+            .collect();
         Self {
             load_context,
             fmt,
             field_decoder,
+            schema_field_names,
         }
     }
     fn read_row(
@@ -55,7 +65,7 @@ impl NdJsonDecoder {
         // in an IoRead adapter that reads byte-by-byte and disables serde_json's
         // slice fast path. Benchmarks on ~890 MiB of real NDJSON show a 2.5x
         // speedup from this change alone.
-        let mut json: serde_json::Value =
+        let json: serde_json::Value =
             serde_json::from_slice(buf).map_err(|e| map_json_error(e, buf, file_full_path))?;
         // todo: this is temporary
         if self.field_decoder.is_select {
@@ -66,13 +76,10 @@ impl NdJsonDecoder {
                     message: e.to_string(),
                 })?;
         } else {
-            // if it's not case_sensitive, we convert to lowercase
-            if !self.field_decoder.ident_case_sensitive {
-                if let serde_json::Value::Object(x) = json {
-                    let y = x.into_iter().map(|(k, v)| (k.to_lowercase(), v)).collect();
-                    json = serde_json::Value::Object(y);
-                }
-            }
+            let object_keys = json.as_object().map(|object| object.len()).unwrap_or(0);
+            let object_values =
+                object_values_by_key(&json, self.field_decoder.ident_case_sensitive);
+            let mut used_keys = 0;
 
             for ((column_index, field), column) in self
                 .load_context
@@ -82,12 +89,17 @@ impl NdJsonDecoder {
                 .enumerate()
                 .zip(columns.iter_mut())
             {
-                let field_name = if self.field_decoder.ident_case_sensitive {
-                    field.name().to_owned()
-                } else {
-                    field.name().to_lowercase()
-                };
-                let value = json.get(field_name);
+                let field_name =
+                    normalize_field_name(field.name(), self.field_decoder.ident_case_sensitive);
+                let value = get_object_value(
+                    &json,
+                    object_values.as_ref(),
+                    &field_name,
+                    self.field_decoder.ident_case_sensitive,
+                );
+                if value.is_some() {
+                    used_keys += 1;
+                }
                 match value {
                     None => match self.fmt.params.missing_field_as {
                         NullAs::Error => {
@@ -152,9 +164,86 @@ impl NdJsonDecoder {
                     }
                 }
             }
+
+            if self.load_context.schema_evolution && object_keys != used_keys {
+                let extra_columns = extra_object_keys(
+                    &json,
+                    &self.schema_field_names,
+                    self.field_decoder.ident_case_sensitive,
+                );
+                if !extra_columns.is_empty() {
+                    return Err(FileParseError::InvalidRow {
+                        format: "NDJSON".to_string(),
+                        message: format!(
+                            "schema evolution sample did not include all columns for File '{}'. Extra columns: {}. Please adjust SCHEMA_EVOLUTION sample options such as SAMPLE_FILES, SAMPLE_RECORDS_PER_FILE, or SAMPLE_TOTAL_RECORDS",
+                            file_full_path,
+                            extra_columns.join(", "),
+                        ),
+                    });
+                }
+            }
         }
         Ok(())
     }
+}
+
+fn normalize_field_name(name: &str, case_sensitive: bool) -> String {
+    if case_sensitive {
+        name.to_string()
+    } else {
+        name.to_lowercase()
+    }
+}
+
+fn get_object_value<'a>(
+    json: &'a serde_json::Value,
+    object_values: Option<&HashMap<String, &'a serde_json::Value>>,
+    field_name: &str,
+    case_sensitive: bool,
+) -> Option<&'a serde_json::Value> {
+    let serde_json::Value::Object(object) = json else {
+        return None;
+    };
+    if case_sensitive {
+        object.get(field_name)
+    } else {
+        object_values.and_then(|values| values.get(field_name).copied())
+    }
+}
+
+fn object_values_by_key(
+    json: &serde_json::Value,
+    case_sensitive: bool,
+) -> Option<HashMap<String, &serde_json::Value>> {
+    if case_sensitive {
+        return None;
+    }
+    let serde_json::Value::Object(object) = json else {
+        return None;
+    };
+    Some(
+        object
+            .iter()
+            .map(|(key, value)| (key.to_lowercase(), value))
+            .collect(),
+    )
+}
+
+fn extra_object_keys(
+    json: &serde_json::Value,
+    schema_field_names: &HashSet<String>,
+    case_sensitive: bool,
+) -> Vec<String> {
+    let serde_json::Value::Object(object) = json else {
+        return vec![];
+    };
+    let mut extra_columns = object
+        .keys()
+        .filter(|key| !schema_field_names.contains(&normalize_field_name(key, case_sensitive)))
+        .cloned()
+        .collect::<Vec<_>>();
+    extra_columns.sort();
+    extra_columns
 }
 
 impl RowDecoder for NdJsonDecoder {
@@ -218,8 +307,13 @@ fn map_json_error(err: serde_json::Error, data: &[u8], file_full_path: &str) -> 
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use super::FileParseError;
+    use super::extra_object_keys;
+    use super::get_object_value;
     use super::map_json_error;
+    use super::object_values_by_key;
 
     fn decode_err(data: &str) -> String {
         serde_json::from_slice::<serde_json::Value>(data.as_bytes())
@@ -249,5 +343,20 @@ mod test {
             decode_err("{\"k\"-}").as_str(),
             "expected `:` at line 1, position 4 of size 6 for File 'mock_file', next byte is '-'"
         );
+    }
+
+    #[test]
+    fn test_ndjson_extra_object_keys_case_insensitive() {
+        let json: serde_json::Value = serde_json::from_str(r#"{"A":1,"B":2,"D":3}"#).unwrap();
+        let schema_field_names = HashSet::from(["a".to_string(), "b".to_string()]);
+        let object_values = object_values_by_key(&json, false);
+
+        assert_eq!(
+            get_object_value(&json, object_values.as_ref(), "a", false),
+            Some(&serde_json::Value::Number(1.into()))
+        );
+        assert_eq!(extra_object_keys(&json, &schema_field_names, false), vec![
+            "D".to_string()
+        ]);
     }
 }

--- a/tests/sqllogictests/suites/stage/formats/ndjson/schema_evolution.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/schema_evolution.test
@@ -1,0 +1,100 @@
+statement ok
+drop table if exists t_ndjson_schema_evolution
+
+statement ok
+drop stage if exists s_ndjson_schema_evolution
+
+statement ok
+create table t_ndjson_schema_evolution(a int)
+
+statement ok
+create stage s_ndjson_schema_evolution
+
+statement ok
+copy into @s_ndjson_schema_evolution from (select 1 as a, 2 as b, 3 as c) file_format=(type=ndjson)
+
+statement ok
+copy into @s_ndjson_schema_evolution from (select 4 as a, 6 as c) file_format=(type=ndjson)
+
+statement ok
+copy into t_ndjson_schema_evolution from @s_ndjson_schema_evolution/ file_format=(type=ndjson missing_field_as=field_default)
+
+query ?
+select * from t_ndjson_schema_evolution order by a;
+----
+1
+4
+
+statement ok
+truncate table t_ndjson_schema_evolution
+
+statement ok
+alter table t_ndjson_schema_evolution set options(enable_schema_evolution = true)
+
+statement ok
+copy into t_ndjson_schema_evolution
+from @s_ndjson_schema_evolution/
+file_format=(type=ndjson missing_field_as=field_default)
+force=true
+schema_evolution=(
+  sample_files=auto,
+  sample_records_per_file=auto,
+  sample_total_records=auto
+)
+
+query ???
+select * from t_ndjson_schema_evolution order by a;
+----
+1 2 3
+4 NULL 6
+
+query ?????
+desc t_ndjson_schema_evolution;
+----
+a INT YES NULL (empty)
+b BIGINT YES NULL (empty)
+c BIGINT YES NULL (empty)
+
+statement ok
+truncate table t_ndjson_schema_evolution
+
+statement ok
+copy into @s_ndjson_schema_evolution from (select 7 as a, 'new' as d) file_format=(type=ndjson)
+
+statement error 1046.*schema evolution sample did not include all columns.*Extra columns: d.*SAMPLE_FILES.*SAMPLE_RECORDS_PER_FILE.*SAMPLE_TOTAL_RECORDS
+copy into t_ndjson_schema_evolution
+from @s_ndjson_schema_evolution/
+file_format=(type=ndjson missing_field_as=field_default)
+force=true
+schema_evolution=(
+  sample_files=1,
+  sample_records_per_file=1,
+  sample_total_records=1
+)
+
+statement ok
+truncate table t_ndjson_schema_evolution
+
+statement ok
+copy into t_ndjson_schema_evolution
+from @s_ndjson_schema_evolution/
+file_format=(type=ndjson missing_field_as=field_default)
+force=true
+schema_evolution=(
+  sample_files=3,
+  sample_records_per_file=1,
+  sample_total_records=3
+)
+
+query ????
+select a, b, c, d from t_ndjson_schema_evolution order by a;
+----
+1 2 3 NULL
+4 NULL 6 NULL
+7 NULL NULL new
+
+statement ok
+drop table t_ndjson_schema_evolution
+
+statement ok
+drop stage s_ndjson_schema_evolution


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add schema evolution support for NDJSON `COPY INTO`. When table schema evolution is enabled, COPY can sample NDJSON files, infer fields that do not exist in the target table, and append those fields as nullable columns with NULL defaults before loading the data.

New COPY syntax:

```sql
COPY INTO <table>
FROM @<stage>/<path>
FILE_FORMAT = (TYPE = NDJSON ...)
SCHEMA_EVOLUTION = (
  SAMPLE_FILES = AUTO | <positive integer>,
  SAMPLE_RECORDS_PER_FILE = AUTO | <positive integer>,
  SAMPLE_TOTAL_RECORDS = AUTO | <positive integer>
);
```

`AUTO` lets the engine choose bounded defaults. The current internal defaults sample up to 64 files, 1000 records per file, and 10000 records total, with the actual file count also bounded by `max_threads` and the staged file set.

Example:

```sql
CREATE TABLE events(id INT);
ALTER TABLE events SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);

COPY INTO events
FROM @events_stage/
FILE_FORMAT = (TYPE = NDJSON MISSING_FIELD_AS = FIELD_DEFAULT)
SCHEMA_EVOLUTION = (
  SAMPLE_FILES = AUTO,
  SAMPLE_RECORDS_PER_FILE = AUTO,
  SAMPLE_TOTAL_RECORDS = AUTO
);
```

If staged NDJSON contains `{"id":1,"city":"SF","score":9}`, COPY can evolve the target table to include nullable `city` and `score` columns before loading rows.

Implementation notes:

- Adds parser/AST support for `SCHEMA_EVOLUTION = (...)` on `COPY INTO <table>` and supports `AUTO` for each sampling option.
- Uses an async NDJSON schema inference path in `CopyIntoTableInterpreter`; sampled files are sorted and sampled evenly, then inferred schemas are merged and appended to the table schema.
- Keeps sampling bounded for compressed NDJSON by incrementally reading/decompressing compressed prefixes instead of reading full compressed objects; ZIP is rejected when the compressed object exceeds the sampling cap.
- During NDJSON loading with schema evolution enabled, each JSON object is checked for keys not consumed by the current schema. If a row contains extra keys, COPY fails with the file path and extra columns, indicating the schema sample missed columns and the sampling options should be adjusted.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_


## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19900)
<!-- Reviewable:end -->
