### PR TITLE
fix(query): use session function context in range join

### DIFF
--- a/src/query/service/src/physical_plans/physical_range_join.rs
+++ b/src/query/service/src/physical_plans/physical_range_join.rs
@@ -45,6 +45,7 @@ use crate::pipelines::PipelineBuilder;
 use crate::pipelines::processors::transforms::range_join::RangeJoinState;
 use crate::pipelines::processors::transforms::range_join::TransformRangeJoinLeft;
 use crate::pipelines::processors::transforms::range_join::TransformRangeJoinRight;
+use crate::sessions::TableContextSettings;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RangeJoin {
@@ -141,7 +142,12 @@ impl IPhysicalPlan for RangeJoin {
     }
 
     fn build_pipeline2(&self, builder: &mut PipelineBuilder) -> Result<()> {
-        let state = Arc::new(RangeJoinState::new(builder.ctx.clone(), self));
+        let function_context = builder.ctx.get_function_context()?;
+        let state = Arc::new(RangeJoinState::new(
+            builder.ctx.clone(),
+            self,
+            function_context,
+        ));
         self.build_right(state.clone(), builder)?;
         self.build_left(state, builder)
     }

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_state.rs
@@ -399,7 +399,7 @@ impl RangeJoinState {
             ));
         }
         for filter in self.other_conditions.iter() {
-            left_result_block = filter_block(left_result_block, filter)?;
+            left_result_block = filter_block(left_result_block, filter, &self.function_context)?;
         }
         if !left_match.is_empty() || !right_match.is_empty() {
             let column = &left_result_block

--- a/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_util.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/ie_join_util.rs
@@ -27,14 +27,16 @@ use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_sql::executor::cast_expr_to_non_null_boolean;
 
-pub fn filter_block(block: DataBlock, filter: &RemoteExpr) -> Result<DataBlock> {
+pub fn filter_block(
+    block: DataBlock,
+    filter: &RemoteExpr,
+    func_ctx: &FunctionContext,
+) -> Result<DataBlock> {
     let filter = filter.as_expr(&BUILTIN_FUNCTIONS);
     let other_predicate = cast_expr_to_non_null_boolean(filter)?;
     assert_eq!(other_predicate.data_type(), &DataType::Boolean);
 
-    let func_ctx = FunctionContext::default();
-
-    let evaluator = Evaluator::new(&block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let evaluator = Evaluator::new(&block, func_ctx, &BUILTIN_FUNCTIONS);
     let predicate = evaluator
         .run(&other_predicate)?
         .try_downcast::<BooleanType>()

--- a/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/merge_join_state.rs
@@ -175,7 +175,8 @@ impl RangeJoinState {
                         ));
                     }
                     for filter in self.other_conditions.iter() {
-                        left_result_block = filter_block(left_result_block, filter)?;
+                        left_result_block =
+                            filter_block(left_result_block, filter, &self.function_context)?;
                     }
                     if track_left_outer && !left_result_block.is_empty() {
                         if let Some(left_match_index) = left_match_index {

--- a/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/range_join/range_join_state.rs
@@ -44,6 +44,7 @@ use crate::sessions::TableContextSettings;
 
 pub struct RangeJoinState {
     pub(crate) ctx: Arc<QueryContext>,
+    pub(crate) function_context: FunctionContext,
     // The origin data for left/right table
     pub(crate) left_table: RwLock<Vec<DataBlock>>,
     pub(crate) right_table: RwLock<Vec<DataBlock>>,
@@ -76,7 +77,11 @@ pub struct RangeJoinState {
 }
 
 impl RangeJoinState {
-    pub fn new(ctx: Arc<QueryContext>, range_join: &RangeJoin) -> Self {
+    pub fn new(
+        ctx: Arc<QueryContext>,
+        range_join: &RangeJoin,
+        function_context: FunctionContext,
+    ) -> Self {
         let ie_join_state = if matches!(range_join.range_join_type, RangeJoinType::IEJoin) {
             Some(IEJoinState::new(range_join))
         } else {
@@ -84,6 +89,7 @@ impl RangeJoinState {
         };
         Self {
             ctx,
+            function_context,
             left_table: RwLock::new(vec![]),
             right_table: RwLock::new(vec![]),
             right_sorted_blocks: Default::default(),
@@ -252,8 +258,8 @@ impl RangeJoinState {
             let mut columns = Vec::with_capacity(3);
             // Append join keys columns
             for condition in self.conditions.iter() {
-                let func_ctx = FunctionContext::default();
-                let evaluator = Evaluator::new(left_block, &func_ctx, &BUILTIN_FUNCTIONS);
+                let evaluator =
+                    Evaluator::new(left_block, &self.function_context, &BUILTIN_FUNCTIONS);
                 let expr = condition.left_expr.as_expr(&BUILTIN_FUNCTIONS);
                 let column = evaluator
                     .run(&expr)?
@@ -282,8 +288,8 @@ impl RangeJoinState {
             let mut columns = Vec::with_capacity(3);
             // Append join keys columns
             for condition in self.conditions.iter() {
-                let func_ctx = FunctionContext::default();
-                let evaluator = Evaluator::new(right_block, &func_ctx, &BUILTIN_FUNCTIONS);
+                let evaluator =
+                    Evaluator::new(right_block, &self.function_context, &BUILTIN_FUNCTIONS);
                 let expr = condition.right_expr.as_expr(&BUILTIN_FUNCTIONS);
                 let column = evaluator
                     .run(&expr)?
@@ -382,6 +388,7 @@ mod tests {
 
         let state = RangeJoinState {
             ctx,
+            function_context: FunctionContext::default(),
             left_table: RwLock::new(vec![left_block]),
             right_table: RwLock::new(vec![]),
             right_sorted_blocks: Default::default(),

--- a/tests/sqllogictests/suites/query/rangejoin.test
+++ b/tests/sqllogictests/suites/query/rangejoin.test
@@ -74,6 +74,44 @@ WHERE east.dur < west.time AND east.dur + west.time < east.rev order by 1, 2;
 ----
 
 statement ok
+create table range_join_context_t1(c1 string, c2 string);
+
+statement ok
+insert into range_join_context_t1 values('2000-01-01', '1-1'), ('2020-01-01', '1-2');
+
+statement ok
+create table range_join_context_t2(c1 int, c2 string);
+
+statement ok
+insert into range_join_context_t2 values(1, '2-1'), (1, '2-2');
+
+query I
+select count(*)
+from (
+  select date_sub(year, t2.c1, today()) as d1, t1.c1 as d2
+  from range_join_context_t1 t1 cross join range_join_context_t2 t2
+)
+where d1 >= d2;
+----
+4
+
+query I
+select count(*)
+from (
+  select date_sub(year, t2.c1, today()) as d1, t1.c1 as d2
+  from range_join_context_t1 t1 cross join range_join_context_t2 t2
+)
+where d1 <= d2;
+----
+0
+
+statement ok
+drop table range_join_context_t1;
+
+statement ok
+drop table range_join_context_t2;
+
+statement ok
 drop table east;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fixes: #19896

RangeJoin builds its comparison key blocks during execution by evaluating the range condition expressions on the buffered left/right blocks. That path used `FunctionContext::default()`, so context-sensitive expressions such as `today()` could be evaluated with a different `now`/timezone context from the rest of the query.

This made `CROSS JOIN + WHERE` queries optimized into `MergeJoin` compare keys computed under the wrong context, while the output `EvalScalar` still used the real query context. In the reported case, `date_sub(year, t2.c1, today()) >= t1.c1` was therefore evaluated inconsistently and returned the opposite result.

This PR captures the session `FunctionContext` when building the RangeJoin pipeline and reuses it for:

- range join key evaluation on both sides
- `other_conditions` filtering in MergeJoin and IEJoin

It also adds a sqllogictest regression covering `today()` in a MergeJoin range condition for both `>=` and `<=`.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Ran:

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/home/kould/RustroverProjects/databend/target cargo check -p databend-query`
- `CARGO_TARGET_DIR=/home/kould/RustroverProjects/databend/target cargo build --bin databend-query --bin databend-sqllogictests`
- `/home/kould/RustroverProjects/databend/target/debug/databend-sqllogictests --run_file rangejoin.test`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19901)
<!-- Reviewable:end -->
