### PR TITLE
feat(parquet): initial support prune parts at runtime when do topk query

### DIFF
--- a/src/common/base/src/runtime/profile/profiles.rs
+++ b/src/common/base/src/runtime/profile/profiles.rs
@@ -63,6 +63,7 @@ pub enum ProfileStatisticsName {
     RuntimeFilterInlistMinMaxTime,
     RuntimeFilterSpatialTime,
     RuntimeFilterBuildTime,
+    ProgressiveTopKPruneParts,
     MemoryUsage,
     ExternalServerRetryCount,
     ExternalServerRequestCount,
@@ -353,6 +354,13 @@ pub fn get_statistics_desc() -> Arc<BTreeMap<ProfileStatisticsName, ProfileDesc>
                 desc: "Time spent on building runtime filters",
                 index: ProfileStatisticsName::RuntimeFilterBuildTime as usize,
                 unit: StatisticsUnit::NanoSeconds,
+                plain_statistics: true,
+            }),
+            (ProfileStatisticsName::ProgressiveTopKPruneParts, ProfileDesc {
+                display_name: "progressive topk pruned parts",
+                desc: "The number of parts pruned by progressive TopK scan",
+                index: ProfileStatisticsName::ProgressiveTopKPruneParts as usize,
+                unit: StatisticsUnit::Count,
                 plain_statistics: true,
             }),
             (ProfileStatisticsName::MemoryUsage, ProfileDesc {

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -23,6 +23,7 @@ use databend_common_catalog::plan::StealablePartitions;
 use databend_common_catalog::plan::TopK;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
+use databend_common_expression::DataSchema;
 use databend_common_expression::TableSchema;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Pipeline;
@@ -42,8 +43,10 @@ use crate::operations::read::DeserializeDataTransform;
 use crate::operations::read::NativeDeserializeDataTransform;
 use crate::operations::read::partition_stream::PartitionStream;
 use crate::operations::read::partition_stream::PartitionStreamSource;
+use crate::operations::read::partition_stream::ProgressiveTopKPartitionStream;
 use crate::operations::read::partition_stream::ReceiverPartitionStream;
 use crate::operations::read::partition_stream::StealPartitionStream;
+use crate::operations::read::progressive_topk::ProgressiveTopKState;
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_fuse_source_pipeline(
@@ -72,19 +75,39 @@ pub fn build_fuse_source_pipeline(
         max_io_requests = max_io_requests.min(16);
     }
 
+    let progressive_topk = create_progressive_topk_state(
+        storage_format,
+        plan,
+        topk.as_ref(),
+        &block_reader.data_schema(),
+        receiver.is_none(),
+        ctx.get_runtime_filters(plan.scan_id).is_empty(),
+    );
+    if progressive_topk.is_some() {
+        max_threads = 1;
+        max_io_requests = 1;
+    }
+
     let waker = pipeline.get_waker();
     let batch_size = ctx.get_settings().get_storage_fetch_part_num()? as usize;
     let stream: Arc<dyn PartitionStream> = match receiver {
         Some(rx) => Arc::new(ReceiverPartitionStream::new(rx)),
         None => {
-            let partitions = dispatch_partitions(ctx.clone(), plan, max_io_requests);
-            let mut partitions = StealablePartitions::new(partitions, ctx.clone());
+            if let Some(progressive_topk) = progressive_topk.clone() {
+                Arc::new(ProgressiveTopKPartitionStream::new(
+                    plan.parts.partitions.clone(),
+                    progressive_topk,
+                ))
+            } else {
+                let partitions = dispatch_partitions(ctx.clone(), plan, max_io_requests);
+                let mut partitions = StealablePartitions::new(partitions, ctx.clone());
 
-            if matches!(storage_format, FuseStorageFormat::Native) && topk.is_some() {
-                partitions.disable_steal();
+                if matches!(storage_format, FuseStorageFormat::Native) && topk.is_some() {
+                    partitions.disable_steal();
+                }
+
+                Arc::new(StealPartitionStream::new(partitions.clone(), batch_size))
             }
-
-            Arc::new(StealPartitionStream::new(partitions.clone(), batch_size))
         }
     };
 
@@ -168,12 +191,49 @@ pub fn build_fuse_source_pipeline(
                     transform_output,
                     index_reader.clone(),
                     virtual_reader.clone(),
+                    progressive_topk.clone(),
                 )
             })?;
         }
     }
 
     Ok(())
+}
+
+fn create_progressive_topk_state(
+    storage_format: FuseStorageFormat,
+    plan: &DataSourcePlan,
+    topk: Option<&TopK>,
+    read_schema: &DataSchema,
+    use_local_partitions: bool,
+    no_runtime_filters: bool,
+) -> Option<Arc<ProgressiveTopKState>> {
+    if !matches!(storage_format, FuseStorageFormat::Parquet)
+        || !use_local_partitions
+        || !no_runtime_filters
+        || !progressive_topk_push_downs_supported(plan)
+        || plan.parts.partitions_type() != PartInfoType::BlockLevel
+        || plan.parts.partitions.is_empty()
+        || !plan.parts.partitions.iter().all(|part| {
+            FuseBlockPartInfo::from_part(part).is_ok_and(|part| part.sort_min_max.is_some())
+        })
+    {
+        return None;
+    }
+
+    ProgressiveTopKState::try_create(topk, read_schema)
+}
+
+fn progressive_topk_push_downs_supported(plan: &DataSourcePlan) -> bool {
+    plan.push_downs.as_ref().is_none_or(|push_downs| {
+        !push_downs.lazy_materialization
+            && push_downs.virtual_column.is_none()
+            && push_downs.agg_index.is_none()
+            && push_downs.change_type.is_none()
+            && push_downs.sample.is_none()
+            && push_downs.secure_filters.is_none()
+            && (push_downs.filters.is_none() || push_downs.prewhere.is_some())
+    })
 }
 
 pub fn dispatch_partitions(

--- a/src/query/storages/fuse/src/operations/read/mod.rs
+++ b/src/query/storages/fuse/src/operations/read/mod.rs
@@ -20,6 +20,7 @@ mod native_data_source_deserializer;
 mod parquet_data_source;
 mod parquet_data_source_deserializer;
 mod parquet_rows_fetcher;
+mod progressive_topk;
 mod raw_data_source;
 mod read_block_context;
 mod read_data_source;

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -41,6 +41,7 @@ use databend_common_pipeline::core::ProcessorPtr;
 use roaring::RoaringTreemap;
 
 use super::parquet_data_source::ParquetDataSource;
+use super::progressive_topk::ProgressiveTopKState;
 use super::read_data_source::ReadDataSource;
 use super::read_state::ReadState;
 use super::util::add_data_block_meta;
@@ -72,6 +73,7 @@ pub struct DeserializeDataTransform {
 
     prewhere_info: Option<PrewhereInfo>,
     read_state: Option<ReadState>,
+    progressive_topk: Option<Arc<ProgressiveTopKState>>,
 }
 
 unsafe impl Send for DeserializeDataTransform {}
@@ -85,6 +87,7 @@ impl DeserializeDataTransform {
         output: Arc<OutputPort>,
         index_reader: Arc<Option<AggIndexReader>>,
         virtual_reader: Arc<Option<VirtualColumnReader>>,
+        progressive_topk: Option<Arc<ProgressiveTopKState>>,
     ) -> Result<ProcessorPtr> {
         let scan_progress = ctx.get_scan_progress();
 
@@ -129,6 +132,7 @@ impl DeserializeDataTransform {
             block_meta_options: plan.block_meta_options.clone(),
             prewhere_info,
             read_state: None,
+            progressive_topk,
         })))
     }
 }
@@ -242,6 +246,10 @@ impl Processor for DeserializeDataTransform {
                             virtual_data,
                             row_selection.as_ref().map(|s| s.selection.clone()),
                         )?;
+                    }
+
+                    if let Some(progressive_topk) = &self.progressive_topk {
+                        progressive_topk.complete_part(&data_block);
                     }
 
                     // Perf.

--- a/src/query/storages/fuse/src/operations/read/partition_stream.rs
+++ b/src/query/storages/fuse/src/operations/read/partition_stream.rs
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::task::Poll;
 
 use async_channel::Receiver;
+use databend_common_base::runtime::profile::Profile;
+use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::StealablePartitions;
 use databend_common_catalog::runtime_filter_info::RuntimeFilterReady;
@@ -33,8 +36,11 @@ use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline::core::SyncTaskHandle;
 use databend_common_pipeline::core::SyncTaskSet;
 use databend_common_sql::IndexType;
+use parking_lot::Mutex;
 
+use crate::FuseBlockPartInfo;
 use crate::operations::read::block_partition_meta::BlockPartitionMeta;
+use crate::operations::read::progressive_topk::ProgressiveTopKState;
 use crate::operations::read::runtime_filter_wait::wait_runtime_filters;
 
 #[async_trait::async_trait]
@@ -60,6 +66,47 @@ impl StealPartitionStream {
 impl PartitionStream for StealPartitionStream {
     async fn fetch(&self, id: usize) -> Result<Option<Vec<PartInfoPtr>>> {
         Ok(self.partitions.steal(id, self.max_batch_size))
+    }
+}
+
+pub struct ProgressiveTopKPartitionStream {
+    partitions: Mutex<VecDeque<PartInfoPtr>>,
+    state: Arc<ProgressiveTopKState>,
+}
+
+impl ProgressiveTopKPartitionStream {
+    pub fn new(partitions: Vec<PartInfoPtr>, state: Arc<ProgressiveTopKState>) -> Self {
+        Self {
+            partitions: Mutex::new(VecDeque::from(partitions)),
+            state,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PartitionStream for ProgressiveTopKPartitionStream {
+    async fn fetch(&self, _id: usize) -> Result<Option<Vec<PartInfoPtr>>> {
+        self.state.wait_for_previous_part().await;
+
+        let mut partitions = self.partitions.lock();
+        let Some(part) = partitions.front() else {
+            return Ok(None);
+        };
+
+        let fuse_part = FuseBlockPartInfo::from_part(part)?;
+        if let Some(sort_min_max) = &fuse_part.sort_min_max
+            && self.state.never_match(sort_min_max)
+        {
+            let skipped_blocks = partitions.len();
+            partitions.clear();
+            self.state.record_skipped_blocks(skipped_blocks);
+            return Ok(None);
+        }
+
+        let part = partitions.pop_front().unwrap();
+        self.state.record_scheduled_part();
+        Profile::record_usize_profile(ProfileStatisticsName::ScanPartitions, 1);
+        Ok(Some(vec![part]))
     }
 }
 

--- a/src/query/storages/fuse/src/operations/read/progressive_topk.rs
+++ b/src/query/storages/fuse/src/operations/read/progressive_topk.rs
@@ -1,0 +1,125 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use databend_common_base::runtime::profile::Profile;
+use databend_common_base::runtime::profile::ProfileStatisticsName;
+use databend_common_catalog::plan::TopK;
+use databend_common_expression::DataBlock;
+use databend_common_expression::DataSchema;
+use databend_common_expression::Scalar;
+use databend_common_expression::TopKSorter;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::MutableBitmap;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+const MAX_PROGRESSIVE_TOPK_LIMIT: usize = 1000;
+
+pub struct ProgressiveTopKState {
+    sorter: Mutex<TopKSorter>,
+    sort_column_offset: usize,
+    scheduled_parts: AtomicUsize,
+    completed_parts: AtomicUsize,
+    skipped_blocks: AtomicUsize,
+    notify: Notify,
+}
+
+impl ProgressiveTopKState {
+    pub(crate) fn try_create(
+        top_k: Option<&TopK>,
+        output_schema: &DataSchema,
+    ) -> Option<Arc<Self>> {
+        let top_k = top_k?;
+        if top_k.limit > MAX_PROGRESSIVE_TOPK_LIMIT {
+            return None;
+        }
+
+        let data_type = DataType::from(top_k.field.data_type());
+        if !supports_progressive_topk(&data_type) {
+            return None;
+        }
+
+        let sort_column_offset = output_schema.index_of(top_k.field.name()).ok()?;
+        Some(Arc::new(Self {
+            sorter: Mutex::new(TopKSorter::new(top_k.limit, top_k.asc)),
+            sort_column_offset,
+            scheduled_parts: AtomicUsize::new(0),
+            completed_parts: AtomicUsize::new(0),
+            skipped_blocks: AtomicUsize::new(0),
+            notify: Notify::new(),
+        }))
+    }
+
+    pub(crate) async fn wait_for_previous_part(&self) {
+        loop {
+            let scheduled = self.scheduled_parts.load(Ordering::Acquire);
+            let completed = self.completed_parts.load(Ordering::Acquire);
+            if scheduled == completed {
+                return;
+            }
+            self.notify.notified().await;
+        }
+    }
+
+    pub(crate) fn record_scheduled_part(&self) {
+        self.scheduled_parts.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn complete_part(&self, data_block: &DataBlock) {
+        self.update(data_block);
+        self.completed_parts.fetch_add(1, Ordering::AcqRel);
+        self.notify.notify_waiters();
+    }
+
+    fn update(&self, data_block: &DataBlock) {
+        let rows = data_block.num_rows();
+        if rows == 0 {
+            return;
+        }
+
+        let column = data_block
+            .get_by_offset(self.sort_column_offset)
+            .to_column();
+        let mut bitmap = MutableBitmap::from_len_set(rows);
+        self.sorter.lock().push_column(&column, &mut bitmap);
+    }
+
+    pub(crate) fn never_match(&self, sort_min_max: &(Scalar, Scalar)) -> bool {
+        self.sorter.lock().never_match(sort_min_max)
+    }
+
+    pub(crate) fn record_skipped_blocks(&self, skipped_blocks: usize) {
+        if skipped_blocks == 0 {
+            return;
+        }
+
+        self.skipped_blocks
+            .fetch_add(skipped_blocks, Ordering::Relaxed);
+        Profile::record_usize_profile(
+            ProfileStatisticsName::ProgressiveTopKPruneParts,
+            skipped_blocks,
+        );
+    }
+}
+
+fn supports_progressive_topk(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Number(_) | DataType::Date | DataType::Timestamp
+    )
+}

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -100,7 +100,6 @@ impl FuseTable {
         let topk = plan
             .push_downs
             .as_ref()
-            .filter(|_| self.is_native()) // Only native format supports topk push down.
             .and_then(|x| x.top_k(plan.schema().as_ref()));
 
         let index_reader = Arc::new(

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -43,6 +43,7 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
+use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::schema::TableIndex;
 use databend_common_meta_app::schema::TableIndexType;
@@ -517,8 +518,8 @@ impl FuseTable {
 
         let top_k = push_down
             .as_ref()
-            .filter(|_| self.is_native()) // Only native format supports topk push down.
             .and_then(|p| p.top_k(self.schema().as_ref()))
+            .filter(|top_k| self.is_native() || supports_fuse_parquet_topk(top_k))
             .map(|topk| {
                 DefaultExprBinder::try_new(ctx.clone())?
                     .get_scalar(&topk.field)
@@ -817,8 +818,8 @@ impl FuseTable {
 
         let top_k = push_downs
             .as_ref()
-            .filter(|_| self.is_native()) // Only native format supports topk push down.
             .and_then(|p| p.top_k(self.schema().as_ref()))
+            .filter(|top_k| self.is_native() || supports_fuse_parquet_topk(top_k))
             .map(|topk| {
                 DefaultExprBinder::try_new(ctx.clone())?
                     .get_scalar(&topk.field)
@@ -1191,4 +1192,11 @@ impl FuseTable {
             create_on,
         )
     }
+}
+
+fn supports_fuse_parquet_topk(top_k: &TopK) -> bool {
+    matches!(
+        DataType::from(top_k.field.data_type()),
+        DataType::Number(_) | DataType::Date | DataType::Timestamp
+    )
 }

--- a/tests/sqllogictests/suites/mode/standalone/explain/fuse_parquet_progressive_topk.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fuse_parquet_progressive_topk.test
@@ -1,0 +1,134 @@
+# Fuse parquet progressive TopK scan
+
+statement ok
+DROP DATABASE IF EXISTS test_fuse_parquet_progressive_topk
+
+statement ok
+CREATE DATABASE test_fuse_parquet_progressive_topk
+
+statement ok
+USE test_fuse_parquet_progressive_topk
+
+statement ok
+DROP TABLE IF EXISTS t_progressive_topk
+
+statement ok
+CREATE TABLE t_progressive_topk (
+    start_time INT NOT NULL,
+    tag STRING NOT NULL,
+    span_events VARIANT
+) row_per_block = 2 block_per_segment = 100 storage_format = 'parquet'
+
+statement ok
+INSERT INTO t_progressive_topk VALUES
+    (100, 'aaa', NULL),
+    (99, 'zzz', NULL),
+    (90, 'hit', parse_json('{"event":1}')),
+    (89, 'hit', parse_json('{"event":2}')),
+    (80, 'hit', parse_json('{"event":3}')),
+    (79, 'hit', parse_json('{"event":4}')),
+    (70, 'hit', parse_json('{"event":5}')),
+    (69, 'hit', parse_json('{"event":6}'))
+
+query I
+SELECT COUNT(*) FROM fuse_block('test_fuse_parquet_progressive_topk', 't_progressive_topk')
+----
+4
+
+query IT
+SELECT start_time, tag FROM t_progressive_topk WHERE lower(tag) = 'hit' ORDER BY start_time DESC LIMIT 3
+----
+90 hit
+89 hit
+80 hit
+
+query I
+SELECT start_time FROM t_progressive_topk WHERE span_events IS NOT NULL ORDER BY start_time DESC LIMIT 3
+----
+90
+89
+80
+
+query T
+EXPLAIN ANALYZE SELECT start_time, tag FROM t_progressive_topk WHERE lower(tag) = 'hit' ORDER BY start_time DESC LIMIT 3
+----
+Limit
+├── cpu time: <slt:ignore>
+├── output rows: 3
+├── output bytes: 60.00 B
+├── output columns: [t_progressive_topk.start_time (#0), t_progressive_topk.tag (#1)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 1.60
+└── Sort(Single)
+    ├── cpu time: <slt:ignore>
+    ├── output rows: 3
+    ├── output bytes: 60.00 B
+    ├── output columns: [t_progressive_topk.start_time (#0), t_progressive_topk.tag (#1)]
+    ├── sort keys: [start_time DESC NULLS LAST]
+    ├── estimated rows: 1.60
+    └── TableScan
+        ├── cpu time: <slt:ignore>
+        ├── wait time: <slt:ignore>
+        ├── output rows: 4
+        ├── output bytes: 108.00 B
+        ├── bytes scanned: 108.00 B
+        ├── partitions scanned: 3
+        ├── read from remote: 198.00 B
+        ├── runtime filter bloom time: <slt:ignore>
+        ├── runtime filter inlist/min-max time: <slt:ignore>
+        ├── progressive topk pruned parts: 1
+        ├── table: default.test_fuse_parquet_progressive_topk.t_progressive_topk
+        ├── scan id: 0
+        ├── output columns: [start_time (#0), tag (#1)]
+        ├── read rows: 8
+        ├── read size: < 1 KiB
+        ├── partitions total: 4
+        ├── partitions scanned: 4
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
+        ├── push downs: [filters: [lower(t_progressive_topk.tag (#1)) = 'hit'], limit: 3]
+        └── estimated rows: 1.60
+
+query T
+EXPLAIN ANALYZE SELECT start_time, tag FROM t_progressive_topk WHERE lower(tag) = 'hit' ORDER BY start_time DESC LIMIT 1001
+----
+Limit
+├── cpu time: <slt:ignore>
+├── output rows: 6
+├── output bytes: 120.00 B
+├── output columns: [t_progressive_topk.start_time (#0), t_progressive_topk.tag (#1)]
+├── limit: 1001
+├── offset: 0
+├── estimated rows: 1.60
+└── Sort(Single)
+    ├── cpu time: <slt:ignore>
+    ├── output rows: 6
+    ├── output bytes: 120.00 B
+    ├── output columns: [t_progressive_topk.start_time (#0), t_progressive_topk.tag (#1)]
+    ├── sort keys: [start_time DESC NULLS LAST]
+    ├── estimated rows: 1.60
+    └── TableScan
+        ├── cpu time: <slt:ignore>
+        ├── wait time: <slt:ignore>
+        ├── output rows: 6
+        ├── output bytes: 162.00 B
+        ├── bytes scanned: 162.00 B
+        ├── read from remote: 264.00 B
+        ├── runtime filter bloom time: <slt:ignore>
+        ├── runtime filter inlist/min-max time: <slt:ignore>
+        ├── table: default.test_fuse_parquet_progressive_topk.t_progressive_topk
+        ├── scan id: 0
+        ├── output columns: [start_time (#0), tag (#1)]
+        ├── read rows: 8
+        ├── read size: < 1 KiB
+        ├── partitions total: 4
+        ├── partitions scanned: 4
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
+        ├── push downs: [filters: [lower(t_progressive_topk.tag (#1)) = 'hit'], limit: 1001]
+        └── estimated rows: 1.60
+
+statement ok
+DROP TABLE t_progressive_topk
+
+statement ok
+DROP DATABASE test_fuse_parquet_progressive_topk


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add a Parquet/Fuse progressive TopK scan path for ordered `LIMIT` queries, inspired by [langsmith](https://www.langchain.com/blog/introducing-smithdb#progressive-querying-over-object-storage).

For eligible single-column `ORDER BY ... LIMIT K` scans, Fuse Parquet partitions are ordered by block-level sort min/max stats. During execution, the Parquet reader feeds back filtered rows into a TopK state after `deserialize_and_filter`, allowing the partition stream to stop scheduling older blocks once they can no longer enter the current TopK result.

**Current limitations**:
- Parquet/Fuse only
- block-level partitions only
- supported sort keys: number, date, timestamp
- `LIMIT <= 1000`
- one block is scheduled at a time
- unsupported complex paths, such as runtime filters, lazy/receiver pruning, virtual columns, agg indexes, samples, and secure filters, fall back to the existing scan behavior

The final Sort/Limit is still preserved for correctness. A follow-up can add bounded batch or in-flight block scheduling to improve object-storage throughput while still limiting overscan.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19903)
<!-- Reviewable:end -->
