### PR TITLE
refactor(query): planner cache key remove tenant

### DIFF
--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -249,22 +249,12 @@ impl Planner {
         let settings = self.ctx.get_settings();
         // Step 3: Bind AST with catalog, and generate a pure logical SExpr
         let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
-        let enable_planner_cache = self.ctx.get_settings().get_enable_planner_cache()?
-            && matches!(stmt, Statement::Query(_));
 
-        let plan_cache_context = enable_planner_cache
-            .then(|| self.build_plan_cache_context(name_resolution_ctx.clone(), stmt))
-            .filter(|ctx| ctx.is_cacheable());
+        let plan_cache_context =
+            self.build_plan_cache_context(name_resolution_ctx.clone(), stmt)?;
 
-        let planner_cache_key = plan_cache_context
-            .as_ref()
-            .map(|ctx| self.planner_cache_key_for_stmt(stmt, ctx))
-            .transpose()?;
-
-        if let Some((cache_key, cache_ctx)) =
-            planner_cache_key.as_ref().zip(plan_cache_context.as_ref())
-        {
-            if let Some(plan) = self.get_cache(cache_key, cache_ctx) {
+        if let Some(cache_ctx) = &plan_cache_context {
+            if let Some(plan) = self.get_cache(cache_ctx) {
                 info!(
                     "Logical plan retrieved from cache, elapsed: {:?}",
                     start.elapsed()
@@ -319,8 +309,8 @@ impl Planner {
 
         let optimized_plan = optimize(opt_ctx, plan).await?;
 
-        if let Some(cache_key) = planner_cache_key {
-            self.set_cache(cache_key, optimized_plan.clone());
+        if let Some(cache_ctx) = plan_cache_context {
+            self.set_cache(cache_ctx, optimized_plan.clone());
         }
 
         info!(

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -22,7 +22,9 @@ use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::IdentifierType;
 use databend_common_ast::ast::Statement;
 use databend_common_ast::ast::TableReference;
+use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
@@ -42,6 +44,7 @@ use sha2::Sha256;
 
 use crate::NameResolutionContext;
 use crate::Planner;
+use crate::TableEntry;
 use crate::normalize_identifier;
 use crate::plans::Plan;
 
@@ -71,7 +74,13 @@ impl Planner {
         &self,
         name_resolution_ctx: NameResolutionContext,
         stmt: &Statement,
-    ) -> PlanCacheContext {
+    ) -> Result<Option<PlanCacheContext>> {
+        if !matches!(stmt, Statement::Query(_))
+            || !self.ctx.get_settings().get_enable_planner_cache()?
+        {
+            return Ok(None);
+        }
+
         let mut visitor = TableRefVisitor {
             ctx: self.ctx.clone(),
             table_snapshots: vec![],
@@ -81,45 +90,26 @@ impl Planner {
         };
         stmt.drive(&mut visitor);
 
-        PlanCacheContext {
-            table_snapshots: visitor.table_snapshots,
-            cache_miss: visitor.cache_miss,
-            has_security_policy: visitor.has_security_policy,
+        if visitor.cache_miss || visitor.table_snapshots.is_empty() {
+            return Ok(None);
         }
+
+        let cache_key = self.planner_cache_key_for_stmt(stmt, visitor.has_security_policy)?;
+        Ok(Some(PlanCacheContext {
+            cache_key,
+            table_snapshots: visitor.table_snapshots,
+        }))
     }
 
-    pub(crate) fn planner_cache_key_for_stmt(
+    fn planner_cache_key_for_stmt(
         &self,
         stmt: &Statement,
-        cache_ctx: &PlanCacheContext,
-    ) -> databend_common_exception::Result<String> {
-        if cache_ctx.has_security_policy {
-            let user = self
-                .ctx
-                .get_current_user()?
-                .identity()
-                .display()
-                .to_string();
-            let role = self
-                .ctx
-                .get_current_role()
-                .map(|r| r.name)
-                .unwrap_or_default();
-            let mut secondary_roles = self.ctx.get_secondary_roles();
-            if let Some(roles) = &mut secondary_roles {
-                roles.sort();
-            }
-            let secondary_roles_key = match secondary_roles {
-                None => "ALL".to_string(),
-                Some(roles) if roles.is_empty() => "NONE".to_string(),
-                Some(roles) => format!("SOME:{}", roles.join(",")),
-            };
+        has_security_policy: bool,
+    ) -> Result<String> {
+        if has_security_policy {
             return Ok(Self::planner_cache_key(&format!(
-                "secure\0{}\0{}\0{}\0{}\0{}",
-                self.ctx.get_tenant().tenant_name(),
-                user,
-                role,
-                secondary_roles_key,
+                "{}\0{}",
+                self.security_policy_cache_key_prefix()?,
                 stmt
             )));
         }
@@ -127,76 +117,82 @@ impl Planner {
         Ok(Self::planner_cache_key(&stmt.to_string()))
     }
 
-    pub(crate) fn get_cache(
-        &self,
-        key: &str,
-        cache_ctx: &PlanCacheContext,
-    ) -> Option<PlanCacheItem> {
-        debug_assert!(!cache_ctx.table_snapshots.is_empty());
-        debug_assert!(!cache_ctx.cache_miss);
+    fn security_policy_cache_key_prefix(&self) -> Result<String> {
+        let user = self
+            .ctx
+            .get_current_user()?
+            .identity()
+            .display()
+            .to_string();
+        let role = self
+            .ctx
+            .get_current_role()
+            .map(|r| r.name)
+            .unwrap_or_default();
 
-        let cache = LazyLock::force(&PLAN_CACHE);
-        if let Some(plan_item) = cache.get(key) {
-            let settings = self.ctx.get_settings();
-            if settings.changes().len() != plan_item.setting_changes.len() {
-                return None;
-            }
-
-            let setting_changes = settings
-                .changes()
-                .iter()
-                .map(|s| (s.key().clone(), s.value().clone()))
-                .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
-                .collect::<Vec<_>>();
-
-            if setting_changes != plan_item.setting_changes
-                || self.ctx.get_all_variables() != plan_item.variables
-            {
-                return None;
-            }
-
-            if let Plan::Query { metadata, .. } = &plan_item.plan {
-                let metadata = metadata.read();
-                if cache_ctx.table_snapshots.iter().all(|ss| {
-                    metadata.tables().iter().any(|table| {
-                        let tbl = table.table();
-                        if tbl.is_temp() || tbl.schema().ne(&ss.schema) {
-                            return false;
-                        }
-                        let snapshot = tbl.options().get(OPT_KEY_SNAPSHOT_LOCATION);
-                        if snapshot != Some(&ss.snapshot_location) {
-                            return false;
-                        }
-                        SecurityPolicySnapshot::from(&tbl.get_table_info().meta)
-                            == ss.security_policy
-                    })
-                }) {
-                    return Some(plan_item.as_ref().clone());
-                }
-            }
+        let mut secondary_roles = self.ctx.get_secondary_roles();
+        if let Some(roles) = &mut secondary_roles {
+            roles.sort();
         }
-        None
+
+        Ok(format!(
+            "secure\0{}\0{}\0{}",
+            user,
+            role,
+            Self::secondary_roles_cache_key(secondary_roles.as_deref()),
+        ))
     }
 
-    pub(crate) fn set_cache(&self, key: String, plan: Plan) {
-        let setting_changes = self
-            .ctx
+    fn secondary_roles_cache_key(secondary_roles: Option<&[String]>) -> String {
+        match secondary_roles {
+            None => "ALL".to_string(),
+            Some([]) => "NONE".to_string(),
+            Some(roles) => format!("SOME:{}", roles.join(",")),
+        }
+    }
+
+    pub(crate) fn get_cache(&self, cache_ctx: &PlanCacheContext) -> Option<PlanCacheItem> {
+        debug_assert!(!cache_ctx.table_snapshots.is_empty());
+
+        let cache = LazyLock::force(&PLAN_CACHE);
+        let plan_item = cache.get(&cache_ctx.cache_key)?;
+
+        let settings = self.ctx.get_settings();
+        if settings.changes().len() != plan_item.setting_changes.len()
+            || self.setting_changes() != plan_item.setting_changes
+            || self.ctx.get_all_variables() != plan_item.variables
+        {
+            return None;
+        }
+
+        let Plan::Query { metadata, .. } = &plan_item.plan else {
+            return None;
+        };
+
+        let metadata = metadata.read();
+        cache_ctx
+            .matches_metadata_tables(metadata.tables())
+            .then(|| plan_item.as_ref().clone())
+    }
+
+    pub(crate) fn set_cache(&self, cache_ctx: PlanCacheContext, plan: Plan) {
+        let plan_item = PlanCacheItem {
+            plan,
+            setting_changes: self.setting_changes(),
+            variables: self.ctx.get_all_variables(),
+        };
+        let cache = LazyLock::force(&PLAN_CACHE);
+        cache.insert(cache_ctx.cache_key, plan_item);
+    }
+
+    fn setting_changes(&self) -> Vec<(String, ChangeValue)> {
+        self.ctx
             .get_settings()
             .changes()
             .iter()
             .map(|s| (s.key().clone(), s.value().clone()))
             .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
-            .collect::<Vec<_>>();
-
-        let variables = self.ctx.get_all_variables();
-
-        let plan_item = PlanCacheItem {
-            plan,
-            setting_changes,
-            variables,
-        };
-        let cache = LazyLock::force(&PLAN_CACHE);
-        cache.insert(key, plan_item);
+            .collect()
     }
 }
 
@@ -211,14 +207,17 @@ struct TableRefVisitor {
 }
 
 pub(crate) struct PlanCacheContext {
+    cache_key: String,
     table_snapshots: Vec<TableSnapshot>,
-    cache_miss: bool,
-    has_security_policy: bool,
 }
 
 impl PlanCacheContext {
-    pub(crate) fn is_cacheable(&self) -> bool {
-        !self.cache_miss && !self.table_snapshots.is_empty()
+    fn matches_metadata_tables(&self, tables: &[TableEntry]) -> bool {
+        self.table_snapshots.iter().all(|snapshot| {
+            tables
+                .iter()
+                .any(|table| snapshot.matches_table_entry(table))
+        })
     }
 }
 
@@ -227,6 +226,39 @@ struct TableSnapshot {
     schema: TableSchemaRef,
     snapshot_location: String,
     security_policy: SecurityPolicySnapshot,
+}
+
+impl TableSnapshot {
+    fn from_resolved_table(table: &dyn Table) -> Option<Self> {
+        if table.is_temp() || table.is_stage_table() || table.is_stream() {
+            return None;
+        }
+
+        let snapshot_location = table.options().get(OPT_KEY_SNAPSHOT_LOCATION)?.clone();
+        Some(Self {
+            schema: table.schema(),
+            snapshot_location,
+            security_policy: SecurityPolicySnapshot::from(&table.get_table_info().meta),
+        })
+    }
+
+    fn has_security_policy(&self) -> bool {
+        self.security_policy.has_policy()
+    }
+
+    fn matches_table_entry(&self, table_entry: &TableEntry) -> bool {
+        let table = table_entry.table();
+        self.matches_table(table.as_ref())
+    }
+
+    fn matches_table(&self, table: &dyn Table) -> bool {
+        if table.is_temp() || table.schema().ne(&self.schema) {
+            return false;
+        }
+
+        table.options().get(OPT_KEY_SNAPSHOT_LOCATION) == Some(&self.snapshot_location)
+            && SecurityPolicySnapshot::from(&table.get_table_info().meta) == self.security_policy
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -302,7 +334,7 @@ impl TableRefVisitor {
                 .map(|v| normalize_identifier(v, &self.name_resolution_ctx).name);
 
             databend_common_base::runtime::block_on(async move {
-                if let Ok(table_meta) = self
+                if let Ok(table) = self
                     .ctx
                     .resolve_data_source(
                         &catalog_name,
@@ -313,24 +345,10 @@ impl TableRefVisitor {
                     )
                     .await
                 {
-                    if !table_meta.is_temp()
-                        && !table_meta.is_stage_table()
-                        && !table_meta.is_stream()
-                    {
-                        let snapshot = table_meta.options().get(OPT_KEY_SNAPSHOT_LOCATION).cloned();
-                        if let Some(sn) = snapshot {
-                            let table_info = table_meta.get_table_info();
-                            let security_policy = SecurityPolicySnapshot::from(&table_info.meta);
-                            if security_policy.has_policy() {
-                                self.has_security_policy = true;
-                            }
-                            self.table_snapshots.push(TableSnapshot {
-                                schema: table_meta.schema(),
-                                snapshot_location: sn,
-                                security_policy,
-                            });
-                            return;
-                        }
+                    if let Some(snapshot) = TableSnapshot::from_resolved_table(table.as_ref()) {
+                        self.has_security_policy |= snapshot.has_security_policy();
+                        self.table_snapshots.push(snapshot);
+                        return;
                     }
                 }
                 self.cache_miss = true;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Planner cache dose not store in meta. So no need to use tenant as cache key.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Keep ci run

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19904)
<!-- Reviewable:end -->
