### PR TITLE
fix(binder):  type check UDF and NOT LIKE ESCAPE regressions

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -301,13 +301,14 @@ impl<'a> CoreExprArena<'a> {
                 right,
                 is_not,
                 escape,
-            } => self.lower_like_escape_expr(
-                *span,
-                if *is_not { "notlike" } else { "like" },
-                left,
-                right,
-                Some(escape),
-            )?,
+            } => {
+                let like = self.lower_like_escape_expr(*span, "like", left, right, Some(escape))?;
+                if *is_not {
+                    self.call(*span, "not", smallvec![like])
+                } else {
+                    like
+                }
+            }
             Expr::Case {
                 span,
                 operand,
@@ -924,6 +925,21 @@ mod tests {
 
         assert_sql_lowers_to("a LIKE 'x' ESCAPE '!'", |arena, root| {
             assert!(matches!(arena.get(root), CoreExpr::Call {
+                func_name: "like",
+                ..
+            }));
+        });
+
+        assert_sql_lowers_to("a NOT LIKE 'x' ESCAPE '!'", |arena, root| {
+            let CoreExpr::Call {
+                func_name: "not",
+                args,
+                ..
+            } = arena.get(root)
+            else {
+                panic!("NOT LIKE ESCAPE should lower to a not call");
+            };
+            assert!(matches!(arena.get(args[0]), CoreExpr::Call {
                 func_name: "like",
                 ..
             }));

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -50,6 +50,7 @@ use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_meta_app::storage::StorageParams;
 use databend_common_storage::init_stage_operator;
 use itertools::Itertools;
+use parking_lot::RwLock;
 use serde_json::json;
 use serde_json::to_string;
 use unicase::Ascii;
@@ -65,6 +66,7 @@ use super::UdfAdapter;
 use super::rewrite_function::rewrite_function_name;
 use crate::BindContext;
 use crate::ColumnBindingBuilder;
+use crate::Metadata;
 use crate::NameResolutionContext;
 use crate::Symbol;
 use crate::Visibility;
@@ -742,13 +744,17 @@ where A: super::TypeCheckAdapter
         parameters: Vec<(String, DataType, ScalarExpr)>,
         return_type: Option<DataType>,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
+        // TODO: UDF definitions are not validated thoroughly before expansion.
+        // Recursive or mutually recursive UDFs can recurse during type checking and
+        // overflow the stack; other unchecked definition risks may exist as well.
         let sql_tokens = tokenize_sql(definition)?;
         let expr = parse_expr(&sql_tokens, self.adapter.settings().get_sql_dialect()?)?;
 
         let mut bind_context = BindContext::new();
+        let mut metadata = Metadata::default();
         let mut replacements = HashMap::new();
         for (name, data_type, scalar) in parameters {
-            let column_index = bind_context.next_column_index();
+            let column_index = metadata.add_derived_column(name.clone(), data_type.clone());
             bind_context.add_column_binding(
                 ColumnBindingBuilder::new(
                     name,
@@ -769,8 +775,8 @@ where A: super::TypeCheckAdapter
             &mut bind_context,
             self.adapter.clone(),
             &name_resolution_ctx,
-            self.metadata.clone(),
-            self.aliases,
+            RwLock::new(metadata).into(),
+            &[],
         )?
         .resolve(&expr)?;
 
@@ -795,7 +801,14 @@ where A: super::TypeCheckAdapter
         impl VisitorMut<'_> for HashMap<Symbol, ScalarExpr> {
             fn visit(&mut self, expr: &mut ScalarExpr) -> Result<()> {
                 if let ScalarExpr::BoundColumnRef(column) = expr {
-                    *expr = self[&column.column.index].clone();
+                    let Some(replacement) = self.get(&column.column.index) else {
+                        return Err(ErrorCode::SemanticError(format!(
+                            "UDF definition references unresolved column {}",
+                            column.column.column_name
+                        ))
+                        .set_span(column.span));
+                    };
+                    *expr = replacement.clone();
                     Ok(())
                 } else {
                     walk_expr_mut(self, expr)

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::time::Duration;
 
 use databend_common_ast::Span;
@@ -65,6 +66,7 @@ use super::rewrite_function::rewrite_function_name;
 use crate::BindContext;
 use crate::ColumnBindingBuilder;
 use crate::NameResolutionContext;
+use crate::Symbol;
 use crate::Visibility;
 use crate::binder::resolve_file_location;
 use crate::binder::resolve_stage_locations;
@@ -81,6 +83,8 @@ use crate::plans::UDFLambdaCall;
 use crate::plans::UDFLanguage;
 use crate::plans::UDFScriptCode;
 use crate::plans::UDFType;
+use crate::plans::VisitorMut;
+use crate::plans::walk_expr_mut;
 
 #[derive(Debug, Clone)]
 struct UdfAsset {
@@ -700,19 +704,19 @@ where A: super::TypeCheckAdapter
                 func_name,
                 definition,
                 parameters,
-            } => self.resolve_lambda_udf_definition(span, func_name, &definition, parameters),
+            } => self.resolve_udf_definition(span, func_name, &definition, parameters, None),
             UdfResolveResult::ScalarDefinition {
                 span,
                 func_name,
                 definition,
                 parameters,
                 return_type,
-            } => self.resolve_scalar_udf_definition(
+            } => self.resolve_udf_definition(
                 span,
                 func_name,
                 &definition,
                 parameters,
-                return_type,
+                Some(return_type),
             ),
         }
     }
@@ -732,14 +736,17 @@ where A: super::TypeCheckAdapter
 
     fn resolve_udf_definition(
         &mut self,
+        span: Span,
+        func_name: String,
         definition: &str,
         parameters: Vec<(String, DataType, ScalarExpr)>,
+        return_type: Option<DataType>,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
         let sql_tokens = tokenize_sql(definition)?;
         let expr = parse_expr(&sql_tokens, self.adapter.settings().get_sql_dialect()?)?;
 
-        let mut bind_context = BindContext::with_parent(self.bind_context.clone())?;
-        let mut replacements = Vec::with_capacity(parameters.len());
+        let mut bind_context = BindContext::new();
+        let mut replacements = HashMap::new();
         for (name, data_type, scalar) in parameters {
             let column_index = bind_context.next_column_index();
             bind_context.add_column_binding(
@@ -751,14 +758,14 @@ where A: super::TypeCheckAdapter
                 )
                 .build(),
             );
-            replacements.push((column_index, scalar));
+            replacements.insert(column_index, scalar);
         }
 
         let name_resolution_ctx = NameResolutionContext {
             deny_column_reference: false,
             ..self.name_resolution_ctx.clone()
         };
-        let box (mut scalar, data_type) = TypeChecker::try_create_with_adapter(
+        let box (scalar, data_type) = TypeChecker::try_create_with_adapter(
             &mut bind_context,
             self.adapter.clone(),
             &name_resolution_ctx,
@@ -767,56 +774,38 @@ where A: super::TypeCheckAdapter
         )?
         .resolve(&expr)?;
 
-        for (column_index, arg) in replacements {
-            scalar.replace_column_with_scalar(column_index, &arg)?;
+        let (scalar, data_type) = if let Some(return_type) = return_type {
+            let expr = CastExpr {
+                span,
+                is_try: false,
+                argument: Box::new(scalar),
+                target_type: Box::new(return_type.clone()),
+            };
+            (expr.into(), return_type)
+        } else {
+            (scalar, data_type)
+        };
+        let mut scalar = UDFLambdaCall {
+            span,
+            func_name,
+            scalar: Box::new(scalar),
+        }
+        .into();
+
+        impl VisitorMut<'_> for HashMap<Symbol, ScalarExpr> {
+            fn visit(&mut self, expr: &mut ScalarExpr) -> Result<()> {
+                if let ScalarExpr::BoundColumnRef(column) = expr {
+                    *expr = self[&column.column.index].clone();
+                    Ok(())
+                } else {
+                    walk_expr_mut(self, expr)
+                }
+            }
         }
 
+        let mut visitor = replacements;
+        visitor.visit(&mut scalar)?;
         Ok(Box::new((scalar, data_type)))
-    }
-
-    fn resolve_lambda_udf_definition(
-        &mut self,
-        span: Span,
-        func_name: String,
-        definition: &str,
-        parameters: Vec<(String, DataType, ScalarExpr)>,
-    ) -> Result<Box<(ScalarExpr, DataType)>> {
-        let box (scalar, data_type) = self.resolve_udf_definition(definition, parameters)?;
-        Ok(Box::new((
-            UDFLambdaCall {
-                span,
-                func_name,
-                scalar: Box::new(scalar),
-            }
-            .into(),
-            data_type,
-        )))
-    }
-
-    fn resolve_scalar_udf_definition(
-        &mut self,
-        span: Span,
-        func_name: String,
-        definition: &str,
-        parameters: Vec<(String, DataType, ScalarExpr)>,
-        return_type: DataType,
-    ) -> Result<Box<(ScalarExpr, DataType)>> {
-        let box (expr, _) = self.resolve_udf_definition(definition, parameters)?;
-        let expr = CastExpr {
-            span,
-            is_try: false,
-            argument: Box::new(expr),
-            target_type: Box::new(return_type.clone()),
-        };
-        Ok(Box::new((
-            UDFLambdaCall {
-                span,
-                func_name,
-                scalar: Box::new(expr.into()),
-            }
-            .into(),
-            return_type,
-        )))
     }
 }
 

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -162,6 +162,7 @@ async fn test_like_escape_preserves_existing_binding_semantics() -> Result<()> {
 
     for sql in [
         "SELECT 'a' LIKE 'a' ESCAPE ''",
+        "SELECT '%++' NOT LIKE '*%++' ESCAPE '*'",
         "SELECT 'a' LIKE concat('a') ESCAPE ''",
         "SELECT '%' LIKE '\\\\%' ESCAPE ''",
         "SELECT like_any('%', '\\\\%', '')",
@@ -171,6 +172,42 @@ async fn test_like_escape_preserves_existing_binding_semantics() -> Result<()> {
         ctx.bind_sql(sql).await?;
     }
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_subquery_project_set_keeps_lambda_udf_argument_columns() -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_setup_sql(
+        "CREATE FUNCTION ddb_string_split_compat AS (s, delim) -> CASE
+            WHEN s IS NULL THEN NULL
+            WHEN delim IS NULL THEN [s]
+            WHEN delim = '' THEN REGEXP_SPLIT_TO_ARRAY(s, '')
+            ELSE SPLIT(s, delim)
+        END",
+    )
+    .await?;
+    ctx.register_setup_sql("CREATE TABLE documents(id INT, s VARCHAR)")
+        .await?;
+
+    let plan = ctx
+        .bind_sql(
+            "SELECT ss FROM (
+                SELECT id, UNNEST(ddb_string_split_compat(s, 'bb')) AS ss
+                FROM documents WHERE 1
+            ) AS q ORDER BY id",
+        )
+        .await?;
+    let plan = ctx.optimize_plan(plan).await?;
+    let plan = plan.format_indent(Default::default())?;
+    assert!(
+        plan.contains("split(documents.s"),
+        "ProjectSet should keep the lambda UDF body bound to documents.s:\n{plan}"
+    );
+    assert!(
+        !plan.contains("split('bb'"),
+        "UDF parameter replacement should not overwrite outer column references:\n{plan}"
+    );
     Ok(())
 }
 

--- a/src/query/sql/tests/it/semantic/type_check/mod.rs
+++ b/src/query/sql/tests/it/semantic/type_check/mod.rs
@@ -346,6 +346,15 @@ fn resolve_type_check_sql(
     adapter: TestTypeCheckAdapter,
     bind_context: &mut BindContext,
 ) -> Result<(ScalarExpr, DataType)> {
+    resolve_type_check_sql_with_aliases(sql, adapter, bind_context, &[])
+}
+
+fn resolve_type_check_sql_with_aliases(
+    sql: &str,
+    adapter: TestTypeCheckAdapter,
+    bind_context: &mut BindContext,
+    aliases: &[(String, ScalarExpr)],
+) -> Result<(ScalarExpr, DataType)> {
     init_testing_globals();
     let tokens = tokenize_sql(sql)?;
     let dialect = adapter.settings().get_sql_dialect()?;
@@ -358,7 +367,7 @@ fn resolve_type_check_sql(
         adapter,
         &name_resolution_ctx,
         metadata,
-        &[],
+        aliases,
     )?;
     type_checker.resolve(&expr).map(|resolved| *resolved)
 }

--- a/src/query/sql/tests/it/semantic/type_check/udf.rs
+++ b/src/query/sql/tests/it/semantic/type_check/udf.rs
@@ -4,6 +4,7 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::ScalarUDF;
 use databend_common_meta_app::principal::UDAFScript;
 use databend_common_meta_app::principal::UDFDefinition;
+use databend_common_sql::plans::BoundColumnRef;
 
 use super::*;
 
@@ -107,6 +108,7 @@ struct UdfGoldenCase {
     case: SqlTestCase,
     adapter: TestTypeCheckAdapter,
     cached_udf: Option<UserDefinedFunction>,
+    aliases: &'static [(&'static str, &'static str)],
 }
 
 async fn run_udf_golden_cases(cases: &[UdfGoldenCase]) -> Result<()> {
@@ -124,10 +126,12 @@ async fn run_udf_golden_cases(cases: &[UdfGoldenCase]) -> Result<()> {
                 .write()
                 .insert(udf.name.clone(), Some(udf.clone()));
         }
-        let outcome = match resolve_type_check_sql(
+        let aliases = aliases_from_columns(&bind_context, golden_case.aliases);
+        let outcome = match resolve_type_check_sql_with_aliases(
             golden_case.case.sql,
             golden_case.adapter.clone(),
             &mut bind_context,
+            &aliases,
         ) {
             Ok((scalar, data_type)) => SqlTestOutcome::Plan(format!(
                 "scalar: {}\ntype: {}",
@@ -172,11 +176,25 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
         DataType::String,
         "x",
     );
+    let scope_probe = UserDefinedFunction::create_lambda_udf(
+        "scope_probe",
+        vec!["x".to_string(), "arr".to_string()],
+        "array_transform(arr, y -> x + y)",
+        "",
+    );
+    let variant_probe = UserDefinedFunction::create_lambda_udf(
+        "variant_probe",
+        vec!["x".to_string()],
+        "x::variant",
+        "",
+    );
 
     let (main_adapter, _) = adapter_with_udfs([
         lambda_one,
         lambda_two,
         scalar_to_string,
+        scope_probe,
+        variant_probe,
         server_udf(),
         script_udf(),
         udaf_script("udaf_script"),
@@ -198,6 +216,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: unknown_adapter,
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -208,6 +227,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: blocked_adapter,
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -218,6 +238,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: cache_adapter,
             cached_udf: Some(cached_udf()),
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -228,6 +249,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter.clone(),
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -238,6 +260,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter.clone(),
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -248,6 +271,29 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter.clone(),
             cached_udf: None,
+            aliases: &[],
+        },
+        UdfGoldenCase {
+            case: SqlTestCase {
+                name: "lambda_udf_definition_ignores_alias_scope",
+                description: "Lambda UDF definition should resolve against its own parameters even when call-site aliases use the same names.",
+                setup_sqls: &[],
+                sql: "scope_probe(delta, [number])",
+            },
+            adapter: main_adapter.clone(),
+            cached_udf: None,
+            aliases: &[("x", "number"), ("arr", "text"), ("y", "delta")],
+        },
+        UdfGoldenCase {
+            case: SqlTestCase {
+                name: "lambda_udf_definition_registers_parameter_metadata",
+                description: "Lambda UDF parameters should be present in the isolated metadata used while resolving the definition.",
+                setup_sqls: &[],
+                sql: "variant_probe((number, delta))",
+            },
+            adapter: main_adapter.clone(),
+            cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -258,6 +304,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter.clone(),
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -268,6 +315,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter.clone(),
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -278,6 +326,7 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: cloud_adapter,
             cached_udf: None,
+            aliases: &[],
         },
         UdfGoldenCase {
             case: SqlTestCase {
@@ -288,10 +337,32 @@ async fn test_type_check_udf_behaviors() -> Result<()> {
             },
             adapter: main_adapter,
             cached_udf: None,
+            aliases: &[],
         },
     ];
 
     run_udf_golden_cases(&cases).await
+}
+
+fn aliases_from_columns(
+    bind_context: &BindContext,
+    aliases: &[(&str, &str)],
+) -> Vec<(String, ScalarExpr)> {
+    aliases
+        .iter()
+        .map(|(alias, column_name)| {
+            let column = bind_context
+                .all_column_bindings()
+                .iter()
+                .find(|column| column.column_name == *column_name)
+                .unwrap_or_else(|| panic!("missing test column {column_name}"))
+                .clone();
+            (
+                (*alias).to_string(),
+                BoundColumnRef { span: None, column }.into(),
+            )
+        })
+        .collect()
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/src/query/sql/tests/it/semantic/type_check/udf.txt
+++ b/src/query/sql/tests/it/semantic/type_check/udf.txt
@@ -40,6 +40,20 @@ status: ok
 scalar: scalar_to_string(CAST(CAST(number (#0) AS Int32 NULL) AS String))
 type: String
 
+=== lambda_udf_definition_ignores_alias_scope ===
+description: Lambda UDF definition should resolve against its own parameters even when call-site aliases use the same names.
+sql: scope_probe(delta, [number])
+status: ok
+scalar: scope_probe(array_transform(delta (#3), array(number (#0)), ["y"] -> x (#0) + y (#2)))
+type: Array(Int64 NULL)
+
+=== lambda_udf_definition_registers_parameter_metadata ===
+description: Lambda UDF parameters should be present in the isolated metadata used while resolving the definition.
+sql: variant_probe((number, delta))
+status: ok
+scalar: variant_probe(CAST(tuple(number (#0), delta (#3)) AS Variant))
+type: Variant
+
 === server_udf_requires_config_enablement ===
 description: Server UDF should remain rejected when UDF server support is disabled.
 sql: server_udf(number)

--- a/tests/sqllogictests/suites/query/issues/issue_19905.test
+++ b/tests/sqllogictests/suites/query/issues/issue_19905.test
@@ -1,0 +1,44 @@
+# GitHub issue: https://github.com/databendlabs/databend/issues/19905
+
+query B
+SELECT '%++' NOT LIKE '*%++' ESCAPE '*'
+----
+0
+
+statement ok
+DROP FUNCTION IF EXISTS ddb_string_split_compat
+
+statement ok
+DROP TABLE IF EXISTS issue19905_documents
+
+statement ok
+CREATE FUNCTION ddb_string_split_compat AS (s, delim) -> CASE
+    WHEN s IS NULL THEN NULL
+    WHEN delim IS NULL THEN [s]
+    WHEN delim = '' THEN REGEXP_SPLIT_TO_ARRAY(s, '')
+    ELSE SPLIT(s, delim)
+END
+
+statement ok
+CREATE TABLE issue19905_documents(id INT, s VARCHAR)
+
+statement ok
+INSERT INTO issue19905_documents VALUES (1, 'baabbaa'), (2, 'aabbaab'), (3, 'ababababa')
+
+query IT
+SELECT id, ss FROM (
+    SELECT id, UNNEST(ddb_string_split_compat(s, 'bb')) AS ss
+    FROM issue19905_documents WHERE 1
+) AS q ORDER BY id, ss
+----
+1	aa
+1	baa
+2	aa
+2	aab
+3	ababababa
+
+statement ok
+DROP TABLE issue19905_documents
+
+statement ok
+DROP FUNCTION ddb_string_split_compat


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #19905
- Fix `NOT LIKE ... ESCAPE` CoreExpr lowering to use `not(like(...))` instead of calling non-existent `notlike(..., escape)`.
- Fix lambda/scalar UDF definition resolution to use an independent parameter binding context, then insert resolved arguments
  only after the final `UDFLambdaCall` expression is built.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19907)
<!-- Reviewable:end -->
