### PR TITLE
fix(query): handle regexp_instr position overflow

### DIFF
--- a/src/query/functions/src/scalars/string_multi_args.rs
+++ b/src/query/functions/src/scalars/string_multi_args.rs
@@ -798,8 +798,14 @@ fn regexp_instr_fn(args: &[Value<AnyType>], ctx: &mut EvalContext) -> Value<AnyT
         let occur = occur.unwrap_or(1);
         let ro = ro.unwrap_or(0);
 
-        if let Some((idx, _)) = source.char_indices().nth((pos - 1) as usize) {
-            source = &source[idx..];
+        match source.char_indices().nth((pos - 1) as usize) {
+            Some((idx, _)) => {
+                source = &source[idx..];
+            }
+            None => {
+                builder.push(0);
+                continue;
+            }
         }
         let instr = regexp::regexp_instr(source, re, pos, occur, ro);
         builder.push(instr);

--- a/src/query/functions/tests/it/scalars/regexp.rs
+++ b/src/query/functions/tests/it/scalars/regexp.rs
@@ -36,6 +36,7 @@ fn test_string() {
 
 fn test_regexp_instr(file: &mut impl Write) {
     run_ast(file, "regexp_instr('dog cat dog', 'dog', 1)", &[]);
+    run_ast(file, "regexp_instr('abc', 'a', 5)", &[]);
     run_ast(
         file,
         "regexp_instr('aa aaa aaaa aa aaa aaaa', 'a{2}', 1)",

--- a/src/query/functions/tests/it/scalars/testdata/regexp.txt
+++ b/src/query/functions/tests/it/scalars/testdata/regexp.txt
@@ -7,6 +7,15 @@ output domain  : {1..=1}
 output         : 1
 
 
+ast            : regexp_instr('abc', 'a', 5)
+raw expr       : regexp_instr('abc', 'a', 5)
+checked expr   : regexp_instr<String, String, Int64>("abc", "a", CAST<UInt8>(5_u8 AS Int64))
+optimized expr : 0_u64
+output type    : UInt64
+output domain  : {0..=0}
+output         : 0
+
+
 ast            : regexp_instr('aa aaa aaaa aa aaa aaaa', 'a{2}', 1)
 raw expr       : regexp_instr('aa aaa aaaa aa aaa aaaa', 'a{2}', 1)
 checked expr   : regexp_instr<String, String, Int64>("aa aaa aaaa aa aaa aaaa", "a{2}", CAST<UInt8>(1_u8 AS Int64))

--- a/tests/sqllogictests/suites/query/functions/02_0050_function_string_regexp_instr.test
+++ b/tests/sqllogictests/suites/query/functions/02_0050_function_string_regexp_instr.test
@@ -12,6 +12,11 @@ SELECT REGEXP_INSTR('dog cat dog', 'dog', 2)
 9
 
 query I
+SELECT REGEXP_INSTR('abc', 'a', 5)
+----
+0
+
+query I
 SELECT REGEXP_INSTR('dog cat dog', 'dog', 1, 2)
 ----
 9
@@ -73,4 +78,3 @@ dog cat dog
 
 statement ok
 DROP TABLE t1
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix `regexp_instr` when `position` is greater than the source string character length.

Previously, if `source.char_indices().nth(position - 1)` returned `None`, evaluation kept using the original source string and could return a non-zero result. Now it returns `0` immediately for that row.

Added regression coverage for:

```sql
SELECT REGEXP_INSTR('abc', 'a', 5);
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation run locally:

- `cargo fmt --check`
- `cargo test -p databend-common-functions --test it scalars::regexp::test_string`
- `git diff --check`

Also attempted:

- `cargo run -p databend-sqllogictests --bin databend-sqllogictests -- --handlers http --run_dir functions --run_file 02_0050_function_string_regexp_instr.test --debug --parallel 2`

This sqllogictest command built successfully but could not execute because no local databend-query service was listening on `127.0.0.1:8000`.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19910)
<!-- Reviewable:end -->
