### PR TITLE
chore: include runtime name in async task dumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,7 +1749,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -9746,7 +9746,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.9",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9833,7 +9833,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -11030,9 +11030,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libflate"
@@ -11599,13 +11599,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12163,7 +12163,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -13653,7 +13653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -13673,7 +13673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -15805,12 +15805,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17122,17 +17122,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio 1.2.0",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -17140,9 +17140,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -19034,15 +19034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -483,7 +483,7 @@ thiserror = { version = "1" }
 thrift = "0.17.0"
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["use_std", "stats"] }
 tikv-jemalloc-sys = "0.6.0"
-tokio = { version = "1.35.0", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.13" }
 toml = { version = "0.8", features = ["parse"] }

--- a/src/binaries/query/ee_main.rs
+++ b/src/binaries/query/ee_main.rs
@@ -49,7 +49,7 @@ fn main() {
     // Thread tracker
     ThreadTracker::init();
 
-    match Runtime::with_default_worker_threads() {
+    match Runtime::with_default_worker_threads(Some("main-worker".to_string())) {
         Err(cause) => {
             eprintln!("Databend Query start failure, cause: {:?}", cause);
             std::process::exit(cause.code() as i32);

--- a/src/binaries/query/oss_main.rs
+++ b/src/binaries/query/oss_main.rs
@@ -49,7 +49,7 @@ fn main() {
     // Thread tracker
     ThreadTracker::init();
 
-    match Runtime::with_default_worker_threads() {
+    match Runtime::with_default_worker_threads(Some("main-worker".to_string())) {
         Err(cause) => {
             eprintln!("Databend Query start failure, cause: {:?}", cause);
             std::process::exit(cause.code() as i32);

--- a/src/common/base/src/runtime/global_runtime.rs
+++ b/src/common/base/src/runtime/global_runtime.rs
@@ -71,7 +71,7 @@ impl GlobalQueryRuntime {
         let thread_num = std::cmp::max(num_cpus, num_cpus::get() / 2);
         let thread_num = std::cmp::max(2, thread_num);
 
-        let rt = Runtime::with_worker_threads(thread_num, Some("g-query-worker".to_owned()))?;
+        let rt = Runtime::with_worker_threads(thread_num, Some("query-worker".to_owned()))?;
         GlobalInstance::set(Arc::new(GlobalQueryRuntime(rt)));
         Ok(())
     }

--- a/src/common/base/src/runtime/runtime.rs
+++ b/src/common/base/src/runtime/runtime.rs
@@ -42,6 +42,10 @@ pub struct Runtime {
     /// Runtime handle.
     handle: Handle,
 
+    /// Prefix injected into root async-backtrace frames spawned by this wrapper.
+    /// This makes existing task dumps show which named Databend runtime owns a task.
+    task_dump_marker: String,
+
     /// Use to receive a drop signal when dropper is dropped.
     _dropper: Dropper,
 }
@@ -55,6 +59,8 @@ impl Runtime {
         let (send_stop, recv_stop) = oneshot::channel();
 
         let handle = runtime.handle().clone();
+        let runtime_name = name.clone().unwrap_or_else(|| "unamed".to_string());
+        let task_dump_marker = format!("rt-name={runtime_name}");
 
         let n = name.clone();
         // Block the runtime to shutdown.
@@ -74,6 +80,7 @@ impl Runtime {
 
         Ok(Runtime {
             handle,
+            task_dump_marker,
             _dropper: Dropper {
                 name,
                 close: Some(send_stop),
@@ -128,6 +135,10 @@ impl Runtime {
 
     pub fn inner(&self) -> tokio::runtime::Handle {
         self.handle.clone()
+    }
+
+    fn task_location_name(&self, location_name: String) -> String {
+        format!("{} {}", self.task_dump_marker, location_name)
     }
 
     #[track_caller]
@@ -197,9 +208,11 @@ impl Runtime {
             let permit = semaphore.acquire_owned().await.map_err(|e| {
                 ErrorCode::Internal(format!("semaphore closed, acquire permit failure. {}", e))
             })?;
+            let task_location_name =
+                self.task_location_name("Runtime::try_spawn_batch task".to_string());
             #[expect(clippy::disallowed_methods)]
             let handler = self.handle.spawn(ThreadTracker::tracking_future(
-                async_backtrace::location!().frame(async move {
+                async_backtrace::location!(task_location_name).frame(async move {
                     // take the ownership of the permit, (implicitly) drop it when task is done
                     fut(permit).await
                 }),
@@ -261,7 +274,7 @@ impl Runtime {
             Some(query_id) => format!("Running query {} spawn task", query_id),
         });
 
-        let task = async_backtrace::location!(location_name).frame(task);
+        let task = async_backtrace::location!(self.task_location_name(location_name)).frame(task);
 
         #[expect(clippy::disallowed_methods)]
         self.handle.spawn(task)

--- a/src/common/base/src/runtime/runtime.rs
+++ b/src/common/base/src/runtime/runtime.rs
@@ -59,7 +59,7 @@ impl Runtime {
         let (send_stop, recv_stop) = oneshot::channel();
 
         let handle = runtime.handle().clone();
-        let runtime_name = name.clone().unwrap_or_else(|| "unamed".to_string());
+        let runtime_name = name.clone().unwrap_or_else(|| "unnamed".to_string());
         let task_dump_marker = format!("rt-name={runtime_name}");
 
         let n = name.clone();
@@ -92,8 +92,8 @@ impl Runtime {
     /// Spawns a new tokio runtime with a default thread count on a background
     /// thread and returns a `Handle` which can be used to spawn tasks via
     /// its executor.
-    pub fn with_default_worker_threads() -> Result<Self> {
-        Self::create_runtime(None, None)
+    pub fn with_default_worker_threads(thread_name: Option<String>) -> Result<Self> {
+        Self::create_runtime(None, thread_name)
     }
 
     pub fn with_worker_threads(workers: usize, thread_name: Option<String>) -> Result<Self> {

--- a/src/common/base/src/runtime/runtime.rs
+++ b/src/common/base/src/runtime/runtime.rs
@@ -60,7 +60,7 @@ impl Runtime {
 
         let handle = runtime.handle().clone();
         let runtime_name = name.clone().unwrap_or_else(|| "unnamed".to_string());
-        let task_dump_marker = format!("rt-name={runtime_name}");
+        let task_dump_marker = format!("[{runtime_name}]");
 
         let n = name.clone();
         // Block the runtime to shutdown.
@@ -120,7 +120,8 @@ impl Runtime {
         }
 
         if let Some(ref name) = thread_name {
-            builder.thread_name(name);
+            builder.name(name.clone());
+            builder.thread_name(name.clone());
         }
 
         if let Some(n) = workers {
@@ -262,19 +263,18 @@ impl Runtime {
     /// Spawns a new asynchronous task with an optional name, returning a JoinHandle for it.
     ///
     /// If `name` is `None`, generates a default name based on the current query context.
+    #[track_caller]
     fn spawn_with_name<T>(&self, task: T, name: Option<String>) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let task = ThreadTracker::tracking_future(task);
-
         let location_name = name.unwrap_or_else(|| match ThreadTracker::query_id() {
             None => String::from(GLOBAL_TASK_DESC),
             Some(query_id) => format!("Running query {} spawn task", query_id),
         });
 
-        let task = async_backtrace::location!(self.task_location_name(location_name)).frame(task);
+        let task = location_future(task, Some(self.task_location_name(location_name)));
 
         #[expect(clippy::disallowed_methods)]
         self.handle.spawn(task)
@@ -349,8 +349,9 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
+    let name = current_runtime_location_name::<F>(None);
     #[expect(clippy::disallowed_methods)]
-    tokio::spawn(location_future(future, None))
+    tokio::spawn(location_future(future, Some(name)))
 }
 
 #[track_caller]
@@ -359,6 +360,7 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
+    let name = current_runtime_location_name::<F>(Some(name));
     #[expect(clippy::disallowed_methods)]
     tokio::spawn(location_future(future, Some(name)))
 }
@@ -369,8 +371,9 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
+    let name = current_runtime_location_name::<F>(None);
     #[expect(clippy::disallowed_methods)]
-    tokio::task::spawn_local(location_future(future, None))
+    tokio::task::spawn_local(location_future(future, Some(name)))
 }
 
 #[track_caller]
@@ -455,4 +458,21 @@ where
         frame_location.column()
     )
     .frame(future)
+}
+
+fn current_runtime_location_name<F>(frame_name: Option<String>) -> String
+where F: Future {
+    let frame_name = frame_name.unwrap_or_else(|| {
+        std::any::type_name::<F>()
+            .trim_end_matches("::{{closure}}")
+            .to_string()
+    });
+
+    if let Ok(handle) = Handle::try_current()
+        && let Some(name) = handle.name()
+    {
+        return format!("[{name}] {frame_name}");
+    }
+
+    frame_name
 }

--- a/src/common/base/tests/it/runtime.rs
+++ b/src/common/base/tests/it/runtime.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use databend_common_base::runtime::Runtime;
+use databend_common_base::runtime::dump_backtrace;
 use rand::distributions::Distribution;
 use rand::distributions::Uniform;
 use tokio::sync::Semaphore;
@@ -77,6 +78,27 @@ async fn test_shutdown_long_run_runtime() -> anyhow::Result<()> {
     let instant = Instant::now();
     drop(runtime);
     assert!(instant.elapsed() < Duration::from_secs(6));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_runtime_task_dump_contains_runtime_name() -> anyhow::Result<()> {
+    let runtime = Runtime::with_worker_threads(1, Some("task-marker-runtime".to_string()))?;
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+
+    runtime.spawn_named(
+        async move {
+            started_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        },
+        "task-marker-test".to_string(),
+    );
+    started_rx.recv_timeout(Duration::from_secs(1))?;
+
+    let dump = dump_backtrace(false);
+    assert!(dump.contains("rt-name=task-marker-runtime"));
+    assert!(dump.contains("task-marker-test"));
 
     Ok(())
 }

--- a/src/common/base/tests/it/runtime.rs
+++ b/src/common/base/tests/it/runtime.rs
@@ -29,16 +29,20 @@ use tokio::time::sleep;
 async fn test_runtime() -> anyhow::Result<()> {
     let counter = Arc::new(Mutex::new(0));
 
-    let runtime = Runtime::with_default_worker_threads()?;
+    let runtime = Runtime::with_default_worker_threads(Some("runtime-test".to_string()))?;
     let runtime_counter = Arc::clone(&counter);
     let runtime_header = runtime.spawn(async move {
-        let rt1 = Runtime::with_default_worker_threads().unwrap();
+        let rt1 =
+            Runtime::with_default_worker_threads(Some("runtime-test-rt1".to_string())).unwrap();
         let rt1_counter = Arc::clone(&runtime_counter);
         let rt1_header = rt1.spawn(async move {
-            let rt2 = Runtime::with_worker_threads(1, None).unwrap();
+            let rt2 =
+                Runtime::with_worker_threads(1, Some("runtime-test-rt2".to_string())).unwrap();
             let rt2_counter = Arc::clone(&rt1_counter);
             let rt2_header = rt2.spawn(async move {
-                let rt3 = Runtime::with_default_worker_threads().unwrap();
+                let rt3 =
+                    Runtime::with_default_worker_threads(Some("runtime-test-rt3".to_string()))
+                        .unwrap();
                 let rt3_counter = Arc::clone(&rt2_counter);
                 let rt3_header = rt3.spawn(async move {
                     let mut num = rt3_counter.lock().unwrap();
@@ -69,7 +73,7 @@ async fn test_runtime() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shutdown_long_run_runtime() -> anyhow::Result<()> {
-    let runtime = Runtime::with_default_worker_threads()?;
+    let runtime = Runtime::with_default_worker_threads(Some("runtime-shutdown-test".to_string()))?;
 
     runtime.spawn(async move {
         tokio::time::sleep(Duration::from_secs(6)).await;
@@ -128,7 +132,7 @@ async fn mock_get_page(i: usize) -> Vec<usize> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_runtime_try_spawn_batch() -> anyhow::Result<()> {
-    let runtime = Runtime::with_default_worker_threads()?;
+    let runtime = Runtime::with_default_worker_threads(Some("runtime-batch-test".to_string()))?;
 
     let mut futs = vec![];
     for i in 0..20 {

--- a/src/common/base/tests/it/runtime.rs
+++ b/src/common/base/tests/it/runtime.rs
@@ -91,18 +91,66 @@ async fn test_runtime_task_dump_contains_runtime_name() -> anyhow::Result<()> {
     let runtime = Runtime::with_worker_threads(1, Some("task-marker-runtime".to_string()))?;
     let (started_tx, started_rx) = std::sync::mpsc::channel();
 
+    let named_started_tx = started_tx.clone();
+    let named_spawn_line = line!() + 1;
     runtime.spawn_named(
         async move {
-            started_tx.send(()).unwrap();
+            named_started_tx.send(()).unwrap();
             std::future::pending::<()>().await;
         },
         "task-marker-test".to_string(),
     );
+    let global_spawn_line = line!() + 1;
+    runtime.spawn(async move {
+        started_tx.send(()).unwrap();
+        std::future::pending::<()>().await;
+    });
+    started_rx.recv_timeout(Duration::from_secs(1))?;
     started_rx.recv_timeout(Duration::from_secs(1))?;
 
     let dump = dump_backtrace(false);
-    assert!(dump.contains("rt-name=task-marker-runtime"));
-    assert!(dump.contains("task-marker-test"));
+    assert!(dump.contains(&format!(
+        "[task-marker-runtime] task-marker-test at {}:{}:",
+        file!(),
+        named_spawn_line
+    )));
+    assert!(dump.contains(&format!(
+        "[task-marker-runtime] Global spawn task at {}:{}:",
+        file!(),
+        global_spawn_line
+    )));
+    assert!(!dump.contains("task-marker-test at src/common/base/src/runtime/runtime.rs"));
+    assert!(!dump.contains("Global spawn task at src/common/base/src/runtime/runtime.rs"));
+
+    Ok(())
+}
+
+#[test]
+fn test_free_spawn_task_dump_contains_runtime_name() -> anyhow::Result<()> {
+    let runtime = Runtime::with_worker_threads(1, Some("free-spawn-runtime-test".to_string()))?;
+
+    runtime.block_on(async {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let free_spawn_line = line!() + 1;
+        databend_common_base::runtime::spawn(async move {
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.map_err(|err| {
+            databend_common_exception::ErrorCode::Internal(format!(
+                "free spawn marker task did not start: {err}"
+            ))
+        })?;
+
+        let dump = dump_backtrace(false);
+        assert!(dump.lines().any(|line| {
+            line.contains("[free-spawn-runtime-test]")
+                && line.contains(&format!(" at {}:{}:", file!(), free_spawn_line))
+        }));
+        assert!(!dump.contains("[spawn-thread="));
+
+        Ok::<(), databend_common_exception::ErrorCode>(())
+    })?;
 
     Ok(())
 }

--- a/src/meta/runtime/src/lib.rs
+++ b/src/meta/runtime/src/lib.rs
@@ -216,7 +216,7 @@ impl RuntimeApi for DatabendRuntime {
     fn new(workers: Option<usize>, name: Option<String>) -> Result<Self, String> {
         let rt = match workers {
             Some(n) => runtime::Runtime::with_worker_threads(n, name),
-            None => runtime::Runtime::with_default_worker_threads(),
+            None => runtime::Runtime::with_default_worker_threads(name),
         };
         rt.map(|inner| Self {
             inner: Arc::new(inner),

--- a/src/query/service/src/servers/mysql/mysql_handler.rs
+++ b/src/query/service/src/servers/mysql/mysql_handler.rs
@@ -141,7 +141,7 @@ impl Server for MySQLHandler {
             None => Err(ErrorCode::Internal("MySQLHandler already running.")),
             Some(registration) => {
                 let rejected_rt = Arc::new(Runtime::with_worker_threads(
-                    1,
+                    2,
                     Some("mysql-handler".to_string()),
                 )?);
                 let (stream, listener) = Self::listener_tcp(listening).await?;

--- a/src/query/service/src/servers/mysql/mysql_session.rs
+++ b/src/query/service/src/servers/mysql/mysql_session.rs
@@ -143,7 +143,7 @@ impl MySQLConnection {
         info!("MySQL connection coming: {}", client_addr);
 
         let query_executor =
-            Runtime::with_worker_threads(1, Some("mysql-query-executor".to_string()))?;
+            Runtime::with_worker_threads(2, Some("mysql-query-executor".to_string()))?;
 
         Thread::spawn(move || {
             let tls_clone = tls.clone();

--- a/src/query/service/tests/it/servers/flight_sql/flight_sql_handler.rs
+++ b/src/query/service/tests/it/servers/flight_sql/flight_sql_handler.rs
@@ -101,7 +101,7 @@ fn prepare_config() -> InnerConfig {
 async fn test_query() -> Result<()> {
     let _fixture = TestFixture::setup_with_config(&prepare_config()).await?;
 
-    let runtime = Runtime::with_default_worker_threads()?;
+    let runtime = Runtime::with_default_worker_threads(Some("flight-sql-test".to_string()))?;
     runtime.block_on(async {
         let file = NamedTempFile::new().unwrap();
         let path = file.into_temp_path().to_str().unwrap().to_string();

--- a/src/query/service/tests/it/sql/exec/mod.rs
+++ b/src/query/service/tests/it/sql/exec/mod.rs
@@ -143,7 +143,7 @@ pub async fn test_snapshot_consistency() -> anyhow::Result<()> {
     let db2 = db.clone();
     let tbl2 = tbl.clone();
 
-    let runtime = Runtime::with_default_worker_threads()?;
+    let runtime = Runtime::with_default_worker_threads(Some("sql-exec-test".to_string()))?;
 
     // 1. insert into tbl
     let mut planner = Planner::new(ctx.clone());


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


- chore: bump tokio from 1.48.0 to 1.52.3 (We need 1.51 to get runtime name from Handle https://github.com/tokio-rs/tokio/issues/5545)
- chore: include runtime name in async task dumps


after this PR, we can know the task is spawed in which runtime:


<img width="960" height="757" alt="image" src="https://github.com/user-attachments/assets/9326e5bd-4c22-4971-83f8-f8fc6fc453be" />


## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19911)
<!-- Reviewable:end -->
