### PR TITLE
feat(query): improve RECLUSTER FINAL task scheduling

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -55,7 +55,6 @@ use crate::plan::DataSourcePlan;
 use crate::plan::PartStatistics;
 use crate::plan::Partitions;
 use crate::plan::PushDownInfo;
-use crate::plan::ReclusterParts;
 use crate::plan::StreamColumn;
 use crate::statistics::BasicColumnStatistics;
 use crate::table_args::TableArgs;
@@ -401,23 +400,6 @@ pub trait Table: Sync + Send {
 
         Err(ErrorCode::Unimplemented(format!(
             "The 'compact_blocks' operation is not supported for the table '{}'. Table engine: '{}'.",
-            self.name(),
-            self.get_table_info().engine(),
-        )))
-    }
-
-    // return the selected block num.
-    #[async_backtrace::framed]
-    async fn recluster(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        push_downs: Option<PushDownInfo>,
-        limit: Option<usize>,
-    ) -> Result<Option<(ReclusterParts, Arc<TableSnapshot>)>> {
-        let (_, _, _) = (ctx, push_downs, limit);
-
-        Err(ErrorCode::Unimplemented(format!(
-            "The 'recluster' operation is not supported for the table '{}'. Table engine: '{}'.",
             self.name(),
             self.get_table_info().engine(),
         )))

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -50,6 +50,8 @@ use databend_common_sql::plans::ReclusterPlan;
 use databend_common_sql::plans::plan_hilbert_sql;
 use databend_common_sql::plans::replace_with_constant;
 use databend_common_sql::plans::set_update_stream_columns;
+use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::operations::ReclusterMode;
 use databend_enterprise_hilbert_clustering::get_hilbert_clustering_handler;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::meta::TableSnapshot;
@@ -516,8 +518,18 @@ impl ReclusterTableInterpreter {
         push_downs: &mut Option<PushDownInfo>,
         limit: Option<usize>,
     ) -> Result<Option<PhysicalPlan>> {
-        let Some((parts, snapshot)) = tbl
-            .recluster(self.ctx.clone(), push_downs.clone(), limit)
+        let fuse_table = FuseTable::try_from_table(tbl.as_ref())?;
+        let Some((parts, snapshot)) = fuse_table
+            .do_recluster(
+                self.ctx.clone(),
+                push_downs.clone(),
+                limit,
+                if self.plan.is_final {
+                    ReclusterMode::Final
+                } else {
+                    ReclusterMode::Normal
+                },
+            )
             .await?
         else {
             return Ok(None);

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -31,6 +31,7 @@ use databend_common_storages_fuse::FuseBlockPartInfo;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::io::MetaWriter;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
+use databend_common_storages_fuse::operations::ReclusterMode;
 use databend_common_storages_fuse::operations::ReclusterMutator;
 use databend_common_storages_fuse::pruning::create_segment_location_vector;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
@@ -234,10 +235,11 @@ async fn gen_recluster_segments_by_ranges(
     Ok(segment_locations)
 }
 
-async fn target_select_segments_by_level(
+async fn target_select_segments_by_level_with_mode(
     level_counts: &[(i32, usize)],
     thresholds: BlockThresholds,
     max_tasks: usize,
+    mode: ReclusterMode,
 ) -> anyhow::Result<(u64, ReclusterParts)> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
@@ -259,7 +261,7 @@ async fn target_select_segments_by_level(
     .await?;
 
     let ctx: Arc<dyn TableContext> = ctx.clone();
-    let (_, block_num, parts) = target_select_segment_locations(
+    let (_, block_num, parts) = target_select_segment_locations_with_mode(
         ctx,
         data_accessor,
         segment_locations,
@@ -267,12 +269,13 @@ async fn target_select_segments_by_level(
         cluster_key_id,
         max_tasks,
         1000,
+        mode,
     )
     .await?;
     Ok((block_num, parts))
 }
 
-async fn target_select_segment_locations(
+async fn target_select_segment_locations_with_mode(
     ctx: Arc<dyn TableContext>,
     data_accessor: opendal::Operator,
     segment_locations: Vec<meta::Location>,
@@ -280,6 +283,7 @@ async fn target_select_segment_locations(
     cluster_key_id: u32,
     max_tasks: usize,
     max_segments: usize,
+    mode: ReclusterMode,
 ) -> anyhow::Result<(usize, u64, ReclusterParts)> {
     let schema = TableSchemaRef::new(TableSchema::empty());
     let segment_locations = create_segment_location_vector(segment_locations, None);
@@ -293,9 +297,9 @@ async fn target_select_segment_locations(
     .await?;
 
     let mutator = ReclusterMutator::new(
-        ctx,
-        data_accessor,
-        schema,
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
         vec![test_cluster_key_expr()],
         1.0,
         thresholds,
@@ -303,9 +307,20 @@ async fn target_select_segment_locations(
         max_tasks,
     );
 
-    let compact_segments = mutator.select_segments(&compact_segments, max_segments)?;
-    let selected_segments = compact_segments.len();
-    let (block_num, parts) = mutator.target_select(compact_segments).await?;
+    let segment_windows = mutator.select_segments(&compact_segments, max_segments)?;
+    let mut selected_segments = 0;
+    let mut block_num = 0;
+    let mut parts = ReclusterParts::default();
+    for selected_segs in segment_windows {
+        selected_segments = selected_segs.len();
+        let (candidate_block_num, candidate_parts) =
+            mutator.target_select(selected_segs, mode).await?;
+        if !candidate_parts.is_empty() {
+            block_num = candidate_block_num;
+            parts = candidate_parts;
+            break;
+        }
+    }
     Ok((selected_segments, block_num, parts))
 }
 
@@ -345,7 +360,7 @@ async fn test_recluster_mutator_limits_removed_segments_to_selected_blocks() -> 
     .await?;
 
     let ctx: Arc<dyn TableContext> = ctx.clone();
-    let (selected_segments, block_num, parts) = target_select_segment_locations(
+    let (selected_segments, block_num, parts) = target_select_segment_locations_with_mode(
         ctx,
         data_accessor,
         segment_locations,
@@ -353,6 +368,7 @@ async fn test_recluster_mutator_limits_removed_segments_to_selected_blocks() -> 
         cluster_key_id,
         1,
         1000,
+        ReclusterMode::Normal,
     )
     .await?;
 
@@ -389,7 +405,7 @@ async fn test_recluster_mutator_block_select() -> anyhow::Result<()> {
     .await?;
 
     let ctx: Arc<dyn TableContext> = ctx.clone();
-    let (_, _, parts) = target_select_segment_locations(
+    let (_, _, parts) = target_select_segment_locations_with_mode(
         ctx,
         data_accessor,
         segment_locations,
@@ -397,6 +413,7 @@ async fn test_recluster_mutator_block_select() -> anyhow::Result<()> {
         cluster_key_id,
         1,
         8,
+        ReclusterMode::Normal,
     )
     .await?;
     let need_recluster = !parts.is_empty();
@@ -405,6 +422,139 @@ async fn test_recluster_mutator_block_select() -> anyhow::Result<()> {
     assert_eq!(tasks.len(), 1);
     let total_block_nums = tasks.iter().map(|t| t.parts.len()).sum::<usize>();
     assert_eq!(total_block_nums, 3);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recluster_mutator_selects_multiple_segment_windows() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_max_threads(2)?;
+
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
+    let location_generator = TableMetaLocationGenerator::new("_prefix".to_owned());
+    let cluster_key_id = 0;
+    let thresholds = BlockThresholds::new(1000, 100, 100, 2);
+
+    let segment_locations = gen_recluster_segments_by_ranges(
+        &data_accessor,
+        &location_generator,
+        &[
+            vec![(1, 10)],
+            vec![(2, 9)],
+            vec![(20, 30)],
+            vec![(21, 29)],
+            vec![(40, 41)],
+            vec![(50, 51)],
+            vec![(60, 61)],
+        ],
+        1000,
+        100,
+        100,
+        thresholds,
+        cluster_key_id,
+    )
+    .await?;
+
+    let schema = TableSchemaRef::new(TableSchema::empty());
+    let ctx: Arc<dyn TableContext> = ctx.clone();
+    let segment_locations = create_segment_location_vector(segment_locations, None);
+    let compact_segments = FuseTable::segment_pruning(
+        &ctx,
+        schema.clone(),
+        data_accessor.clone(),
+        &None,
+        segment_locations,
+    )
+    .await?;
+
+    let mutator = ReclusterMutator::new(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        vec![test_cluster_key_expr()],
+        1.0,
+        thresholds,
+        cluster_key_id,
+        1,
+    );
+
+    let segment_windows = mutator.select_segments(&compact_segments, 8)?;
+    let window_index_sets = segment_windows
+        .iter()
+        .map(|window| {
+            window
+                .iter()
+                .map(|segment| segment.loc.segment_idx)
+                .collect::<HashSet<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert!(window_index_sets.contains(&HashSet::from([0, 1])));
+    assert!(window_index_sets.contains(&HashSet::from([2, 3])));
+    let selected_segments = window_index_sets
+        .iter()
+        .flat_map(|window| window.iter().copied())
+        .collect::<HashSet<_>>();
+    assert_eq!(selected_segments.len(), 7);
+
+    let thresholds = BlockThresholds::new(1000, 100, 100, 1);
+    let segment_locations = gen_recluster_segments_by_ranges(
+        &data_accessor,
+        &location_generator,
+        &[
+            vec![(1, 10)],
+            vec![(2, 9)],
+            vec![(3, 8)],
+            vec![(4, 7)],
+            vec![(5, 6)],
+        ],
+        1000,
+        100,
+        100,
+        thresholds,
+        cluster_key_id,
+    )
+    .await?;
+    let segment_locations = create_segment_location_vector(segment_locations, None);
+    let compact_segments = FuseTable::segment_pruning(
+        &ctx,
+        schema.clone(),
+        data_accessor.clone(),
+        &None,
+        segment_locations,
+    )
+    .await?;
+    let mutator = ReclusterMutator::new(
+        ctx,
+        data_accessor,
+        schema,
+        vec![test_cluster_key_expr()],
+        1.0,
+        thresholds,
+        cluster_key_id,
+        1,
+    );
+    let segment_windows = mutator.select_segments(&compact_segments, 3)?;
+    let window_sizes = segment_windows
+        .iter()
+        .map(|window| window.len())
+        .collect::<Vec<_>>();
+    assert_eq!(window_sizes, vec![3, 3]);
+    let first_window = segment_windows[0]
+        .iter()
+        .map(|segment| segment.loc.segment_idx)
+        .collect::<HashSet<_>>();
+    let second_window = segment_windows[1]
+        .iter()
+        .map(|segment| segment.loc.segment_idx)
+        .collect::<HashSet<_>>();
+    let union = first_window
+        .union(&second_window)
+        .copied()
+        .collect::<HashSet<_>>();
+    assert_eq!(union.len(), 5);
+    assert_eq!(first_window.intersection(&second_window).count(), 1);
 
     Ok(())
 }
@@ -436,7 +586,7 @@ async fn test_recluster_mutator_split_tasks_by_parallel_budget() -> anyhow::Resu
     .await?;
 
     let ctx: Arc<dyn TableContext> = ctx.clone();
-    let (_, block_num, parts) = target_select_segment_locations(
+    let (_, block_num, parts) = target_select_segment_locations_with_mode(
         ctx,
         data_accessor,
         segment_locations,
@@ -444,6 +594,7 @@ async fn test_recluster_mutator_split_tasks_by_parallel_budget() -> anyhow::Resu
         cluster_key_id,
         4,
         1000,
+        ReclusterMode::Normal,
     )
     .await?;
 
@@ -457,8 +608,13 @@ async fn test_recluster_mutator_split_tasks_by_parallel_budget() -> anyhow::Resu
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recluster_mutator_only_lowest_small_batch_yields() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    let (block_num, parts) =
-        target_select_segments_by_level(&[(0, 3), (1, 3), (2, 10)], thresholds, 1).await?;
+    let (block_num, parts) = target_select_segments_by_level_with_mode(
+        &[(0, 3), (1, 3), (2, 10)],
+        thresholds,
+        1,
+        ReclusterMode::Normal,
+    )
+    .await?;
 
     assert_eq!(block_num, 3);
     assert_eq!(parts.tasks.len(), 1);
@@ -471,8 +627,13 @@ async fn test_recluster_mutator_only_lowest_small_batch_yields() -> anyhow::Resu
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recluster_mutator_backfills_deferred_lowest_batch() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    let (block_num, parts) =
-        target_select_segments_by_level(&[(1, 3), (2, 4)], thresholds, 2).await?;
+    let (block_num, parts) = target_select_segments_by_level_with_mode(
+        &[(1, 3), (2, 4)],
+        thresholds,
+        2,
+        ReclusterMode::Normal,
+    )
+    .await?;
 
     assert_eq!(block_num, 7);
     assert_eq!(parts.tasks.len(), 2);
@@ -485,6 +646,59 @@ async fn test_recluster_mutator_backfills_deferred_lowest_batch() -> anyhow::Res
         vec![2, 1]
     );
     assert_eq!(task_part_counts(&parts), vec![4, 3]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_recluster_defers_small_level0_tail() -> anyhow::Result<()> {
+    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+
+    let (block_num, parts) = target_select_segments_by_level_with_mode(
+        &[(0, 3), (1, 4)],
+        thresholds,
+        1,
+        ReclusterMode::Final,
+    )
+    .await?;
+
+    assert_eq!(block_num, 4);
+    assert_eq!(parts.tasks.len(), 1);
+    assert_eq!(parts.tasks[0].level, 1);
+    assert_eq!(task_part_counts(&parts), vec![4]);
+
+    let (block_num, parts) = target_select_segments_by_level_with_mode(
+        &[(0, 3), (1, 4)],
+        thresholds,
+        2,
+        ReclusterMode::Final,
+    )
+    .await?;
+
+    assert_eq!(block_num, 7);
+    assert_eq!(parts.tasks.len(), 2);
+    assert_eq!(
+        parts
+            .tasks
+            .iter()
+            .map(|task| task.level)
+            .collect::<Vec<_>>(),
+        vec![1, 0]
+    );
+    assert_eq!(task_part_counts(&parts), vec![4, 3]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_recluster_skips_high_level_two_block_batch() -> anyhow::Result<()> {
+    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+    let (block_num, parts) =
+        target_select_segments_by_level_with_mode(&[(2, 2)], thresholds, 1, ReclusterMode::Final)
+            .await?;
+
+    assert_eq!(block_num, 0);
+    assert!(parts.tasks.is_empty());
 
     Ok(())
 }
@@ -577,15 +791,16 @@ async fn test_safety_for_recluster() -> anyhow::Result<()> {
             cluster_key_id,
             max_tasks,
         ));
-        let selected_segs = mutator.select_segments(&compact_segments, 8)?;
+        let segment_windows = mutator.select_segments(&compact_segments, 8)?;
         // select the blocks with the highest depth.
-        if selected_segs.is_empty() {
-            let result = FuseTable::generate_recluster_parts(mutator, compact_segments).await?;
-            if let Some((_, _, recluster_parts)) = result {
-                parts = recluster_parts;
+        for selected_segs in segment_windows {
+            let (_, candidate_parts) = mutator
+                .target_select(selected_segs, ReclusterMode::Normal)
+                .await?;
+            if !candidate_parts.is_empty() {
+                parts = candidate_parts;
+                break;
             }
-        } else {
-            (_, parts) = mutator.target_select(selected_segs).await?;
         }
 
         if !parts.is_empty() {
@@ -631,37 +846,4 @@ async fn test_safety_for_recluster() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-#[test]
-fn test_check_point() {
-    // [1,2] [2,3], check point 2
-    let start = vec![1];
-    let end = vec![0];
-    assert!(ReclusterMutator::check_point(&start, &end));
-
-    // [1,2] [2,2], check point 2
-    let start = vec![1];
-    let end = vec![0, 1];
-    assert!(ReclusterMutator::check_point(&start, &end));
-
-    // [1,1] [1,2], check point 1
-    let start = vec![0, 1];
-    let end = vec![0];
-    assert!(ReclusterMutator::check_point(&start, &end));
-
-    // [1,2] [1,3], check point 1
-    let start = vec![0, 1];
-    let end = vec![];
-    assert!(!ReclusterMutator::check_point(&start, &end));
-
-    // [1,3] [2,3], check point 3
-    let start = vec![];
-    let end = vec![0, 1];
-    assert!(!ReclusterMutator::check_point(&start, &end));
-
-    // [1,3] [3,3] [3,4], check point 3
-    let start = vec![1, 2];
-    let end = vec![0, 1];
-    assert!(!ReclusterMutator::check_point(&start, &end));
 }

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -32,7 +32,6 @@ use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::plan::PushDownInfo;
-use databend_common_catalog::plan::ReclusterParts;
 use databend_common_catalog::plan::StreamColumn;
 use databend_common_catalog::table::Bound;
 use databend_common_catalog::table::ColumnRange;
@@ -1325,16 +1324,6 @@ impl Table for FuseTable {
         limits: CompactionLimits,
     ) -> Result<Option<(Partitions, Arc<TableSnapshot>)>> {
         self.do_compact_blocks(ctx, limits).await
-    }
-
-    #[async_backtrace::framed]
-    async fn recluster(
-        &self,
-        ctx: Arc<dyn TableContext>,
-        push_downs: Option<PushDownInfo>,
-        limit: Option<usize>,
-    ) -> Result<Option<(ReclusterParts, Arc<TableSnapshot>)>> {
-        self.do_recluster(ctx, push_downs, limit).await
     }
 
     #[async_backtrace::framed]

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -51,6 +51,7 @@ pub use read::DeserializeDataTransform;
 pub use read::ReadState;
 pub use read::need_reserve_block_info;
 pub use read::row_fetch_processor;
+pub use recluster::ReclusterMode;
 pub use replace_into::*;
 pub use snapshot_hint::*;
 pub use table_index::do_refresh_table_index;

--- a/src/query/storages/fuse/src/operations/mutation/mutator/mod.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/mod.rs
@@ -19,7 +19,6 @@ mod segment_compact_mutator;
 pub use block_compact_mutator::BlockCompactMutator;
 pub use block_compact_mutator::SegmentCompactChecker;
 pub use recluster_mutator::ReclusterMutator;
-pub(crate) use recluster_mutator::SelectedReclusterSegment;
 pub use segment_compact_mutator::SegmentCompactMutator;
 pub use segment_compact_mutator::SegmentCompactionState;
 pub use segment_compact_mutator::SegmentCompactor;

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -16,6 +16,7 @@ use std::cmp;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt;
 use std::sync::Arc;
 
 use databend_common_base::runtime::execute_futures_in_parallel;
@@ -61,10 +62,10 @@ use crate::MAX_RECLUSTER_DEPTH;
 use crate::MIN_RECLUSTER_DEPTH;
 use crate::SegmentLocation;
 use crate::io::MetaReaders;
+use crate::operations::ReclusterMode;
 use crate::operations::common::BlockMetaIndex as BlockIndex;
 use crate::statistics::get_min_max_stats;
 use crate::statistics::reducers::merge_statistics_mut;
-use crate::statistics::sort_by_cluster_stats;
 
 /// Maximum recluster depth allowed when only two blocks remain.
 /// For two-block layouts, repeated reclustering beyond this level
@@ -76,6 +77,41 @@ struct LevelReclusterTasks {
     selected_block_count: usize,
     min_blocks_per_task: usize,
     tasks: Vec<(ReclusterTask, Vec<usize>)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ReclusterGroup {
+    Level(i32),
+    FinalMature,
+}
+
+impl ReclusterGroup {
+    fn output_level(self, task_indices: &[usize], blocks: &[ReclusterBlock]) -> i32 {
+        match self {
+            ReclusterGroup::Level(level) => level,
+            ReclusterGroup::FinalMature => {
+                let mut level_counts = BTreeMap::new();
+                for &idx in task_indices {
+                    *level_counts.entry(blocks[idx].stats.level).or_insert(0) += 1;
+                }
+
+                level_counts
+                    .into_iter()
+                    .max_by_key(|(level, count)| (*count, cmp::Reverse(*level)))
+                    .map(|(level, _)| level)
+                    .unwrap_or(0)
+            }
+        }
+    }
+}
+
+impl fmt::Display for ReclusterGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReclusterGroup::Level(level) => write!(f, "{}", level),
+            ReclusterGroup::FinalMature => write!(f, "mixed"),
+        }
+    }
 }
 
 struct DepthSelection {
@@ -217,16 +253,8 @@ impl ReclusterMutator {
     pub async fn target_select(
         &self,
         compact_segments: Vec<SelectedReclusterSegment>,
+        mode: ReclusterMode,
     ) -> Result<(u64, ReclusterParts)> {
-        let mut compact_segments = compact_segments;
-        compact_segments.sort_by(|a, b| {
-            sort_by_cluster_stats(
-                &Some(a.stats.clone()),
-                &Some(b.stats.clone()),
-                self.cluster_key_id,
-            )
-        });
-
         // Prepare for reclustering by collecting segment indices, statistics, and blocks
         let mut selected_segs_idx = Vec::with_capacity(compact_segments.len());
         let mut selected_statistics = Vec::with_capacity(compact_segments.len());
@@ -247,14 +275,23 @@ impl ReclusterMutator {
             selected_segments.push((segment.loc.segment_idx, segment.info));
         }
 
-        // Gather blocks and create a block map categorized by clustering levels
+        // Gather blocks from selected segments.
         let blocks = self.gather_blocks(selected_segments).await?;
         let selected_segment_count = selected_statistics.len() as u64;
         let selected_block_count = blocks.len() as u64;
 
-        let mut blocks_map: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+        let mut blocks_map: BTreeMap<ReclusterGroup, Vec<usize>> = BTreeMap::new();
         for (idx, block) in blocks.iter().enumerate() {
-            blocks_map.entry(block.stats.level).or_default().push(idx);
+            if block.stats.level < 0 {
+                continue;
+            }
+
+            let group = match mode {
+                ReclusterMode::Normal => ReclusterGroup::Level(block.stats.level),
+                ReclusterMode::Final if block.stats.level == 0 => ReclusterGroup::Level(0),
+                ReclusterMode::Final => ReclusterGroup::FinalMature,
+            };
+            blocks_map.entry(group).or_default().push(idx);
         }
 
         // Prepare task generation parameters
@@ -263,26 +300,11 @@ impl ReclusterMutator {
 
         let mut tasks = Vec::new();
         let mut selected_blocks_idx = IndexSet::new();
-        let max_level = blocks_map.keys().last().copied();
-        let mut deferred_level_task = None;
-        // Process one clustering level at a time. This avoids mixing blocks whose
-        // clustering stats were produced by different recluster rounds.
-        for (level, indices) in blocks_map.into_iter() {
-            let block_count = indices.len();
-            if level == -1 || block_count < 2 {
-                continue;
-            }
 
-            // For two-block scenarios at the deepest level, limit reclustering depth
-            // to avoid generating repeated tasks with little benefit.
-            if block_count == 2
-                && Some(level) == max_level
-                && level >= MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS
-            {
-                debug!(
-                    "recluster: level selection level={} block_count={} skip_reason=high_level_two_blocks",
-                    level, block_count,
-                );
+        let mut deferred_level_task = None;
+        for (group, indices) in blocks_map.into_iter() {
+            let block_count = indices.len();
+            if block_count < 2 {
                 continue;
             }
 
@@ -290,13 +312,13 @@ impl ReclusterMutator {
             if remaining_budget == 0 {
                 debug!(
                     "recluster: level selection level={} block_count={} skip_reason=task_budget_exhausted",
-                    level, block_count,
+                    group, block_count,
                 );
                 break;
             }
 
-            let Some(level_tasks) = self.build_level_recluster_tasks(
-                level,
+            let Some(level_tasks) = self.build_recluster_tasks_for_indices(
+                group,
                 indices,
                 &blocks,
                 &column_nodes,
@@ -306,17 +328,15 @@ impl ReclusterMutator {
                 continue;
             };
 
-            // When the lowest constructible level batch is too small, defer it
-            // once so the next level gets a chance to consume this round's
-            // budget first.
+            // When the first constructible batch is too small, defer it once so
+            // the next group gets a chance to consume this round's budget first.
             if tasks.is_empty()
                 && deferred_level_task.is_none()
-                && Some(level) != max_level
                 && level_tasks.selected_block_count < level_tasks.min_blocks_per_task
             {
                 debug!(
                     "recluster: level selection level={} block_count={} selected_count={} task_count={} skip_reason=deferred_low_level_batch",
-                    level,
+                    group,
                     block_count,
                     level_tasks.selected_block_count,
                     level_tasks.tasks.len(),
@@ -342,7 +362,7 @@ impl ReclusterMutator {
 
         if tasks.len() < self.max_tasks {
             if let Some(level_tasks) = deferred_level_task {
-                // Backfill deferred low-level work when higher levels did not use
+                // Backfill deferred low-level work when later groups did not use
                 // the full budget, so finite low-level data still converges.
                 let remaining_budget = self.max_tasks - tasks.len();
                 for (task, task_indices) in level_tasks.tasks.into_iter().take(remaining_budget) {
@@ -467,22 +487,32 @@ impl ReclusterMutator {
         }
     }
 
-    fn build_level_recluster_tasks(
+    fn build_recluster_tasks_for_indices(
         &self,
-        level: i32,
+        group: ReclusterGroup,
         indices: Vec<usize>,
         blocks: &[ReclusterBlock],
         column_nodes: &ColumnNodes,
         task_budget: usize,
     ) -> Result<Option<LevelReclusterTasks>> {
         let block_count = indices.len();
+        if block_count == 2
+            && indices
+                .iter()
+                .all(|idx| blocks[*idx].stats.level >= MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS)
+        {
+            debug!(
+                "recluster: level selection level={} block_count={} skip_reason=high_level_two_blocks",
+                group, block_count,
+            );
+            return Ok(None);
+        }
+
         let mut total_rows = 0;
         let mut total_bytes = 0;
         let mut total_compressed = 0;
         let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
 
-        // Build a depth map from this level only. Cross-level overlap is handled
-        // by scheduling levels separately, not by mixing them in one task.
         for &i in indices.iter() {
             let block = &blocks[i];
             let stats = &block.stats;
@@ -505,28 +535,24 @@ impl ReclusterMutator {
         {
             debug!(
                 "recluster: level selection detail level={} block_count={} rows={} bytes={} selected_count={} task_count=1 compact_small_blocks=true",
-                level,
-                block_count,
-                total_rows,
-                total_bytes,
-                indices.len(),
+                group, block_count, total_rows, total_bytes, block_count,
             );
-            let selected_block_count = indices.len();
             let block_metas = indices
                 .iter()
                 .map(|&i| (None, blocks[i].meta.clone()))
                 .collect::<Vec<_>>();
+            let output_level = group.output_level(&indices, blocks);
             let task = self.generate_task(
                 &block_metas,
                 column_nodes,
                 total_rows as usize,
                 total_bytes as usize,
                 total_compressed as usize,
-                level,
+                output_level,
             );
 
             return Ok(Some(LevelReclusterTasks {
-                selected_block_count,
+                selected_block_count: block_count,
                 min_blocks_per_task,
                 tasks: vec![(task, indices)],
             }));
@@ -536,11 +562,12 @@ impl ReclusterMutator {
         // Fetch enough candidates for the remaining workers. The per-node quota is based
         // on the observed block size in selected segments instead of the worst
         // allowed block size, otherwise distributed recluster can under-select.
-        let selection = self.fetch_max_depth(points_map, self.depth_threshold, max_blocks_num)?;
-        let average_depth = selection.average_depth;
-        let max_depth = selection.max_depth;
-        let max_point_overlap_count = selection.max_point_overlap_count;
-        let mut selected_idx = selection.selected_idx;
+        let DepthSelection {
+            mut selected_idx,
+            average_depth,
+            max_depth,
+            max_point_overlap_count,
+        } = self.fetch_max_depth(points_map, self.depth_threshold, max_blocks_num)?;
         let max_total_bytes = self.memory_threshold.saturating_mul(task_budget);
         // Keep the first, highest-depth blocks within the remaining execution budget.
         // This is a second-stage guard after candidate selection: the average
@@ -551,7 +578,7 @@ impl ReclusterMutator {
         if selected_block_count < 2 {
             debug!(
                 "recluster: level selection detail level={} block_count={} average_depth={} max_depth={} max_point_overlap_count={} selected_count={} skip_reason=selected_less_than_two_after_budget",
-                level,
+                group,
                 block_count,
                 average_depth,
                 max_depth,
@@ -604,6 +631,7 @@ impl ReclusterMutator {
 
             if should_split_for_memory || should_split_for_parallelism {
                 let selected_task_indices = std::mem::take(&mut task_indices);
+                let output_level = group.output_level(&selected_task_indices, blocks);
 
                 tasks.push((
                     self.generate_task(
@@ -612,7 +640,7 @@ impl ReclusterMutator {
                         task_rows,
                         task_bytes,
                         task_compressed,
-                        level,
+                        output_level,
                     ),
                     selected_task_indices,
                 ));
@@ -639,6 +667,7 @@ impl ReclusterMutator {
         // remainder after splitting; skip it so recluster does not become a
         // small-block compact path.
         if selected_blocks.len() > 1 {
+            let output_level = group.output_level(&task_indices, blocks);
             tasks.push((
                 self.generate_task(
                     &selected_blocks,
@@ -646,7 +675,7 @@ impl ReclusterMutator {
                     task_rows,
                     task_bytes,
                     task_compressed,
-                    level,
+                    output_level,
                 ),
                 task_indices,
             ));
@@ -655,7 +684,7 @@ impl ReclusterMutator {
         if tasks.is_empty() {
             debug!(
                 "recluster: level selection detail level={} block_count={} average_depth={} max_depth={} max_point_overlap_count={} selected_count={} skip_reason=no_task_after_split",
-                level,
+                group,
                 block_count,
                 average_depth,
                 max_depth,
@@ -667,7 +696,7 @@ impl ReclusterMutator {
 
         info!(
             "recluster: built level task candidates level={} block_count={} avg_depth={} depth_threshold={} max_depth={} max_point_overlap_count={} selected_count={} task_count={}",
-            level,
+            group,
             block_count,
             average_depth,
             self.depth_threshold,
@@ -739,71 +768,226 @@ impl ReclusterMutator {
         &self,
         compact_segments: &[(SegmentLocation, Arc<CompactSegmentInfo>)],
         max_len: usize,
-    ) -> Result<Vec<SelectedReclusterSegment>> {
-        let mut blocks_num = 0;
-        let mut indices = IndexSet::new();
-        let mut segments = vec![None; compact_segments.len()];
-        let mut points_map: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
-        let mut small_segments = IndexSet::new();
+    ) -> Result<Vec<Vec<SelectedReclusterSegment>>> {
+        // Keep a bounded overlap between adjacent hot windows. Anchors carry
+        // still-active segments forward so a long overlap range is not split
+        // into unrelated candidates, while the bound prevents one hot range
+        // from growing into an oversized window.
+        let anchor_len = max_len.saturating_sub(1).min((max_len / 4).max(1));
         let block_per_seg = self.block_thresholds.block_per_segment;
 
-        // Iterate over all segments
+        let mut total_blocks = 0;
+        let mut candidate_indices = IndexSet::new();
+        let mut segments = vec![None; compact_segments.len()];
+        let mut segment_points: HashMap<Vec<Scalar>, (Vec<usize>, Vec<usize>)> = HashMap::new();
+        let mut small_segments = IndexSet::new();
+
+        // Phase 1: collect segment ranges for the sweep-line selection. Large
+        // unclustered segments are ignored here; small segments are recorded so
+        // they can still be considered by the fallback merge path.
         for (i, (loc, compact_segment)) in compact_segments.iter().enumerate() {
             let segment =
                 SelectedReclusterSegment::create(self, loc.clone(), compact_segment.clone());
             let level = segment.stats.level;
 
-            // Skip if segment has more blocks than required and no reclustering is needed
             if level < 0 && compact_segment.summary.block_count as usize >= block_per_seg {
                 continue;
             }
 
-            blocks_num += compact_segment.summary.block_count as usize;
-            // Track small segments for special handling later
-            if blocks_num < block_per_seg {
+            let current_blocks_num = compact_segment.summary.block_count as usize;
+            if current_blocks_num < block_per_seg {
                 small_segments.insert(i);
             }
-            // Add to indices for potential reclustering
-            indices.insert(i);
-            // Update points_map with min and max points of the segment
-            points_map
+            total_blocks += current_blocks_num;
+            candidate_indices.insert(i);
+            segment_points
                 .entry(segment.stats.min().clone())
                 .and_modify(|v| v.0.push(i))
                 .or_insert((vec![i], vec![]));
-            points_map
+            segment_points
                 .entry(segment.stats.max().clone())
                 .and_modify(|v| v.1.push(i))
                 .or_insert((vec![], vec![i]));
             segments[i] = Some(segment);
         }
 
-        let selected_indices = if indices.len() > 1 && blocks_num > block_per_seg {
-            let selection = self.fetch_max_depth(points_map, 1.0, max_len)?;
-            let selected = selection.selected_idx;
-            debug!(
-                "recluster: segment selection segments={} blocks={} average_depth={} max_depth={} max_point_overlap_count={} selected_count={} small_segment_count={}",
-                indices.len(),
-                blocks_num,
-                selection.average_depth,
-                selection.max_depth,
-                selection.max_point_overlap_count,
-                selected.len(),
-                small_segments.len(),
-            );
-            if selected.is_empty() && small_segments.len() > 1 {
-                // If no segments were selected but small segments exist, use those.
-                small_segments
-            } else {
-                selected
-            }
-        } else {
-            indices
-        };
+        let mut windows = Vec::new();
+        let mut seen_windows = HashSet::new();
+        let mut covered_segments = IndexSet::new();
 
-        Ok(selected_indices
+        // Phase 2: enumerate hot windows by segment-level overlap depth. A hot
+        // point means more than one segment covers the same cluster-key point.
+        if candidate_indices.len() > 1 && total_blocks > block_per_seg {
+            let mut unfinished_intervals = BTreeMap::new();
+            let mut current_window = IndexSet::new();
+            let mut current_window_max_depth = 0usize;
+            // Deduplicate segments within one continuous hot range. After a
+            // flush, only bounded anchors remain eligible for the next window.
+            let mut seen_in_hot_range = IndexSet::new();
+            let (keys, values): (Vec<_>, Vec<_>) = segment_points.into_iter().unzip();
+            let sorted_indices = compare_scalars(keys, &self.cluster_key_types)?;
+
+            for idx in sorted_indices {
+                let start = &values[idx as usize].0;
+                let end = &values[idx as usize].1;
+                let point_depth = Self::calc_point_depth(unfinished_intervals.len(), start, end);
+
+                // The active set is captured before applying the point update,
+                // matching fetch_max_depth's inclusive start-point semantics.
+                let active_indices = unfinished_intervals
+                    .keys()
+                    .chain(start.iter())
+                    .copied()
+                    .collect::<IndexSet<_>>();
+
+                if point_depth <= 1 {
+                    Self::flush_segment_window(
+                        &mut current_window,
+                        &mut current_window_max_depth,
+                        &mut seen_windows,
+                        &mut covered_segments,
+                        &mut windows,
+                    );
+                    seen_in_hot_range.clear();
+                } else {
+                    current_window_max_depth = current_window_max_depth.max(point_depth);
+
+                    for active_idx in active_indices.iter().copied() {
+                        if !seen_in_hot_range.insert(active_idx) {
+                            continue;
+                        }
+
+                        current_window.insert(active_idx);
+                        if current_window.len() < max_len {
+                            continue;
+                        }
+
+                        let selected_indices = Self::flush_segment_window(
+                            &mut current_window,
+                            &mut current_window_max_depth,
+                            &mut seen_windows,
+                            &mut covered_segments,
+                            &mut windows,
+                        );
+
+                        // Carry the latest still-active segments into the
+                        // next window so a long hot range remains connected.
+                        current_window.extend(
+                            selected_indices
+                                .iter()
+                                .rev()
+                                .filter(|idx| active_indices.contains(*idx))
+                                .take(anchor_len)
+                                .copied(),
+                        );
+
+                        current_window_max_depth = if current_window.is_empty() {
+                            0
+                        } else {
+                            point_depth
+                        }
+                    }
+                }
+
+                start.iter().for_each(|&idx| {
+                    unfinished_intervals.insert(idx, point_depth);
+                });
+                end.iter().for_each(|idx| {
+                    unfinished_intervals.remove(idx);
+                });
+            }
+            Self::flush_segment_window(
+                &mut current_window,
+                &mut current_window_max_depth,
+                &mut seen_windows,
+                &mut covered_segments,
+                &mut windows,
+            );
+
+            // Try the deepest windows first; for equal depth, prefer the larger
+            // window because it gives target_select more room to build tasks.
+            windows.sort_by(|(left_indices, left_depth), (right_indices, right_depth)| {
+                right_depth
+                    .cmp(left_depth)
+                    .then_with(|| right_indices.len().cmp(&left_indices.len()))
+            });
+
+            debug!(
+                "recluster: segment selection hot windows segments={} blocks={} window_count={} covered_segments={}",
+                candidate_indices.len(),
+                total_blocks,
+                windows.len(),
+                covered_segments.len(),
+            );
+        }
+
+        // Phase 3: append fallback windows for candidates not covered by hot
+        // windows, plus small segments that may need segment-level repacking
+        // even when they do not overlap.
+        let max_threads = (self.ctx.get_settings().get_max_threads()? as usize).max(2);
+        let mut fallback_indices = Vec::new();
+        let mut fallback_blocks = 0;
+        for idx in candidate_indices {
+            if !covered_segments.contains(&idx) || small_segments.contains(&idx) {
+                fallback_blocks += compact_segments[idx].1.summary.block_count as usize;
+                fallback_indices.push(idx);
+            }
+        }
+
+        let fallback_groups = if fallback_blocks <= block_per_seg {
+            vec![fallback_indices]
+        } else {
+            fallback_indices
+                .chunks(max_threads)
+                .map(|chunk| chunk.to_vec())
+                .collect::<Vec<_>>()
+        };
+        for selected_indices in fallback_groups {
+            let mut window_key = selected_indices.clone();
+            window_key.sort_unstable();
+            if seen_windows.insert(window_key) {
+                windows.push((selected_indices, 0));
+            }
+        }
+
+        // Convert index windows back to segment objects. Empty windows can be
+        // produced only by an empty fallback group and are ignored here.
+        Ok(windows
             .into_iter()
-            .filter_map(|i| segments[i].take())
+            .map(|(selected_indices, _)| {
+                selected_indices
+                    .into_iter()
+                    .filter_map(|i| segments[i].clone())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|window| !window.is_empty())
             .collect())
+    }
+
+    fn flush_segment_window(
+        current_indices: &mut IndexSet<usize>,
+        current_max_depth: &mut usize,
+        seen_windows: &mut HashSet<Vec<usize>>,
+        covered_segments: &mut IndexSet<usize>,
+        windows: &mut Vec<(Vec<usize>, usize)>,
+    ) -> Vec<usize> {
+        if current_indices.is_empty() {
+            return vec![];
+        }
+
+        let selected_indices = current_indices.iter().copied().collect::<Vec<_>>();
+        if selected_indices.len() >= 2 {
+            let mut window_key = selected_indices.clone();
+            window_key.sort_unstable();
+            if seen_windows.insert(window_key) {
+                covered_segments.extend(selected_indices.iter().copied());
+                windows.push((selected_indices.clone(), *current_max_depth));
+            }
+        }
+
+        current_indices.clear();
+        *current_max_depth = 0;
+        selected_indices
     }
 
     fn build_cluster_stats_for_recluster(
@@ -833,29 +1017,25 @@ impl ReclusterMutator {
         &self,
         compact_segments: Vec<(usize, Arc<CompactSegmentInfo>)>,
     ) -> Result<Vec<ReclusterBlock>> {
-        // combine all the tasks.
-        let mut iter = compact_segments.into_iter();
-        let tasks = std::iter::from_fn(|| {
-            iter.next().map(|(segment_idx, v)| {
-                async move {
-                    v.block_metas().map(|block_metas| {
-                        block_metas
-                            .into_iter()
-                            .enumerate()
-                            .map(|(block_idx, block_meta)| {
-                                (
-                                    BlockIndex {
-                                        segment_idx,
-                                        block_idx,
-                                    },
-                                    block_meta,
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                }
-                .in_span(Span::enter_with_local_parent(func_path!()))
-            })
+        let tasks = compact_segments.into_iter().map(|(segment_idx, v)| {
+            async move {
+                v.block_metas().map(|block_metas| {
+                    block_metas
+                        .into_iter()
+                        .enumerate()
+                        .map(|(block_idx, block_meta)| {
+                            (
+                                BlockIndex {
+                                    segment_idx,
+                                    block_idx,
+                                },
+                                block_meta,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                })
+            }
+            .in_span(Span::enter_with_local_parent(func_path!()))
         });
 
         let thread_nums = self.ctx.get_settings().get_max_threads()? as usize;
@@ -867,14 +1047,11 @@ impl ReclusterMutator {
             "convert-segments-worker".to_owned(),
         )
         .await?;
-        let block_metas = joint
+        Ok(joint
             .into_iter()
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
-            .collect::<Vec<_>>();
-        let blocks = block_metas
-            .into_iter()
             .map(|(block_index, block_meta)| {
                 // Normalize cluster stats after gathering blocks. Missing or stale
                 // stats are rebuilt once and reused by selection and remained block rebuild.
@@ -888,8 +1065,7 @@ impl ReclusterMutator {
                     stats,
                 }
             })
-            .collect::<Vec<_>>();
-        Ok(blocks)
+            .collect())
     }
 
     #[async_backtrace::framed]
@@ -901,40 +1077,34 @@ impl ReclusterMutator {
             return Ok(HashMap::new());
         }
 
-        // combine all the tasks.
-        let mut iter = hlls.into_iter();
-        let tasks = std::iter::from_fn(|| {
-            iter.next().map(|(segment_idx, location)| {
-                let dal = self.operator.clone();
-                async move {
-                    if let Some((loc, ver)) = location {
-                        let reader = MetaReaders::segment_stats_reader(dal);
-                        let load_params = LoadParams {
-                            location: loc,
-                            len_hint: None,
-                            ver,
-                            put_cache: false,
+        let tasks = hlls.into_iter().map(|(segment_idx, location)| {
+            let dal = self.operator.clone();
+            async move {
+                let Some((loc, ver)) = location else {
+                    return Ok(vec![]);
+                };
+                let reader = MetaReaders::segment_stats_reader(dal);
+                let load_params = LoadParams {
+                    location: loc,
+                    len_hint: None,
+                    ver,
+                    put_cache: true,
+                };
+                let stats = reader.read(&load_params).await?;
+                Ok(stats
+                    .block_hlls
+                    .iter()
+                    .enumerate()
+                    .map(|(block_idx, hll)| {
+                        let block_index = BlockIndex {
+                            segment_idx,
+                            block_idx,
                         };
-                        let stats = reader.read(&load_params).await?;
-                        let res = stats
-                            .block_hlls
-                            .iter()
-                            .enumerate()
-                            .map(|(block_idx, hll)| {
-                                let block_index = BlockIndex {
-                                    segment_idx,
-                                    block_idx,
-                                };
-                                (block_index, Some(hll.clone()))
-                            })
-                            .collect::<Vec<_>>();
-                        Ok(res)
-                    } else {
-                        Ok(vec![])
-                    }
-                }
-                .in_span(Span::enter_with_local_parent(func_path!()))
-            })
+                        (block_index, Some(hll.clone()))
+                    })
+                    .collect::<Vec<_>>())
+            }
+            .in_span(Span::enter_with_local_parent(func_path!()))
         });
 
         let thread_nums = self.ctx.get_settings().get_max_threads()? as usize;
@@ -946,13 +1116,12 @@ impl ReclusterMutator {
             "convert-segments-worker".to_owned(),
         )
         .await?;
-        let blocks = joint
+        Ok(joint
             .into_iter()
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
-            .collect::<HashMap<_, _>>();
-        Ok(blocks)
+            .collect())
     }
 
     fn fetch_max_depth(
@@ -971,11 +1140,7 @@ impl ReclusterMutator {
         for (i, idx) in indices.into_iter().enumerate() {
             let start = &values[idx as usize].0;
             let end = &values[idx as usize].1;
-            let point_depth = if unfinished_intervals.len() == 1 && Self::check_point(start, end) {
-                1
-            } else {
-                unfinished_intervals.len() + start.len()
-            };
+            let point_depth = Self::calc_point_depth(unfinished_intervals.len(), start, end);
 
             if point_depth > max_depth {
                 max_depth = point_depth;
@@ -1006,7 +1171,8 @@ impl ReclusterMutator {
                 unfinished_intervals.len(),
                 max_len,
             );
-            // re-sort the unfinished unfinished_intervals firstly.
+            // Keep unfinished intervals selected first; they indicate malformed
+            // or stale range boundaries but are still valid recluster candidates.
             unfinished_intervals.keys().for_each(|idx| {
                 selected_idx.insert(*idx);
             });
@@ -1018,8 +1184,8 @@ impl ReclusterMutator {
             (10000.0 * sum_depth as f64 / interval_depths.len() as f64).round() / 10000.0;
         let max_point_overlap_count = point_overlaps[max_point].len();
 
-        // find the max point, gather the indices.
-        if average_depth > depth_threshold {
+        // Find the highest-depth point and expand to neighboring hot points.
+        if max_depth as f64 > depth_threshold {
             point_overlaps[max_point].iter().for_each(|idx| {
                 selected_idx.insert(*idx);
             });
@@ -1097,13 +1263,19 @@ impl ReclusterMutator {
         })
     }
 
-    // block1: [1, 2], block2: [2, 3]. The depth of point '2' is 1.
-    pub fn check_point(start: &[usize], end: &[usize]) -> bool {
-        if start.len() + end.len() > 3 || start.is_empty() || end.is_empty() {
-            return false;
+    fn calc_point_depth(open_interval_count: usize, start: &[usize], end: &[usize]) -> usize {
+        // block1: [1, 2], block2: [2, 3]. The depth of point '2' is 1.
+        if open_interval_count == 1
+            && !start.is_empty()
+            && !end.is_empty()
+            && start.len() + end.len() <= 3
+        {
+            let set: HashSet<usize> = HashSet::from_iter(start.iter().chain(end.iter()).cloned());
+            if set.len() == 2 {
+                return 1;
+            }
         }
 
-        let set: HashSet<usize> = HashSet::from_iter(start.iter().chain(end.iter()).cloned());
-        set.len() == 2
+        open_interval_count + start.len()
     }
 }

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -28,8 +28,6 @@ use databend_common_sql::BloomIndexColumns;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::table::ClusterType;
-use futures::stream::FuturesUnordered;
-use futures::stream::StreamExt;
 use log::debug;
 use log::warn;
 use opendal::Operator;
@@ -37,29 +35,30 @@ use opendal::Operator;
 use crate::FuseTable;
 use crate::SegmentLocation;
 use crate::operations::ReclusterMutator;
-use crate::operations::SelectedReclusterSegment;
 use crate::pruning::PruningContext;
 use crate::pruning::SegmentPruner;
 use crate::pruning::create_segment_location_vector;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReclusterMode {
+    Normal,
+    Final,
+}
+
 impl FuseTable {
     #[async_backtrace::framed]
-    pub(crate) async fn do_recluster(
+    pub async fn do_recluster(
         &self,
         ctx: Arc<dyn TableContext>,
         push_downs: Option<PushDownInfo>,
         limit: Option<usize>,
+        mode: ReclusterMode,
     ) -> Result<Option<(ReclusterParts, Arc<TableSnapshot>)>> {
         let start = Instant::now();
 
-        // Status.
-        {
-            let status = "[FUSE-RECLUSTER] Starting recluster operation";
-            ctx.set_status_info(status);
-        }
+        ctx.set_status_info("[FUSE-RECLUSTER] Starting recluster operation");
 
-        let cluster_type = self.cluster_type();
-        if cluster_type.is_none_or(|v| v != ClusterType::Linear) {
+        if self.cluster_type().is_none_or(|v| v != ClusterType::Linear) {
             return Ok(None);
         }
 
@@ -74,11 +73,11 @@ impl FuseTable {
             snapshot.as_ref(),
         )?);
 
-        let segment_locations = snapshot.segments.clone();
-        let segment_locations = create_segment_location_vector(segment_locations, None);
+        let segment_locations = create_segment_location_vector(snapshot.segments.clone(), None);
 
         let max_threads = ctx.get_settings().get_max_threads()? as usize;
         let segment_limit = limit.unwrap_or(1000);
+        let number_segments = segment_locations.len();
         // The default limit might be too small, which makes
         // the scanning of recluster candidates slow.
         let chunk_size = segment_limit.max(max_threads * 4);
@@ -89,7 +88,6 @@ impl FuseTable {
         let mut recluster_blocks_count = 0;
         let mut parts = ReclusterParts::default();
 
-        let number_segments = segment_locations.len();
         let mut segment_idx = 0;
         for chunk in segment_locations.chunks(chunk_size) {
             let mut selected_seg_num = 0;
@@ -131,46 +129,33 @@ impl FuseTable {
                 continue;
             }
 
-            // select the segments with the highest depth.
-            let selected_segs = mutator.select_segments(&compact_segments, max_seg_num)?;
+            // Select segment windows with the highest depth.
+            let segment_windows = mutator.select_segments(&compact_segments, max_seg_num)?;
             debug!(
-                "recluster: selected segments compact_segments={} selected_segments={} max_segments={}",
+                "recluster: selected segment windows compact_segments={} window_count={} max_segments={}",
                 compact_segments.len(),
-                selected_segs.len(),
+                segment_windows.len(),
                 max_seg_num,
             );
-            // select the blocks with the highest depth.
-            if selected_segs.is_empty() {
-                debug!(
-                    "recluster: selected segments empty, fallback to generate_recluster_parts compact_segments={}",
-                    compact_segments.len(),
-                );
-                let result =
-                    Self::generate_recluster_parts(mutator.clone(), compact_segments).await?;
-                if let Some((seg_num, block_num, recluster_parts)) = result {
+            // Select the blocks with the highest depth.
+            for selected_segs in segment_windows {
+                let candidate_seg_num = selected_segs.len();
+                let (block_num, recluster_parts) =
+                    mutator.target_select(selected_segs, mode).await?;
+                let seg_num = recluster_parts.removed_segment_indexes.len() as u64;
+                if !recluster_parts.is_empty() {
+                    debug!(
+                        "recluster: built parts candidate_segments={} selected_segments={} blocks={} tasks={}",
+                        candidate_seg_num,
+                        seg_num,
+                        block_num,
+                        recluster_parts.tasks.len(),
+                    );
                     selected_seg_num = seg_num;
                     recluster_blocks_count = block_num;
                     parts = recluster_parts;
-                    debug!(
-                        "recluster: fallback built parts segments={} blocks={} tasks={}",
-                        selected_seg_num,
-                        recluster_blocks_count,
-                        parts.tasks.len(),
-                    );
-                } else {
-                    debug!("recluster: fallback built no parts skip_reason=empty_parts",);
+                    break;
                 }
-            } else {
-                let candidate_seg_num = selected_segs.len();
-                (recluster_blocks_count, parts) = mutator.target_select(selected_segs).await?;
-                selected_seg_num = parts.removed_segment_indexes.len() as u64;
-                debug!(
-                    "recluster: built parts candidate_segments={} selected_segments={} blocks={} tasks={}",
-                    candidate_seg_num,
-                    selected_seg_num,
-                    recluster_blocks_count,
-                    parts.tasks.len(),
-                );
             }
 
             if !parts.is_empty() || limit.is_some() {
@@ -192,80 +177,6 @@ impl FuseTable {
         Ok(Some((parts, snapshot)))
     }
 
-    pub async fn generate_recluster_parts(
-        mutator: Arc<ReclusterMutator>,
-        compact_segments: Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>,
-    ) -> Result<Option<(u64, u64, ReclusterParts)>> {
-        let mut selected_segs = vec![];
-        let mut block_count = 0;
-
-        let max_threads = mutator.ctx.get_settings().get_max_threads()? as usize;
-        let block_per_segment = mutator.block_thresholds.block_per_segment;
-        let mut segment_batches = Vec::new();
-        for compact_segment in compact_segments {
-            let segment =
-                SelectedReclusterSegment::create(&mutator, compact_segment.0, compact_segment.1);
-            if !(segment.stats.level >= 0
-                || (segment.info.summary.block_count as usize)
-                    < mutator.block_thresholds.block_per_segment)
-            {
-                continue;
-            }
-
-            block_count += segment.info.summary.block_count as usize;
-            selected_segs.push(segment);
-            if block_count >= block_per_segment && selected_segs.len() >= mutator.max_tasks {
-                segment_batches.push(std::mem::take(&mut selected_segs));
-                block_count = 0;
-            }
-        }
-        if !selected_segs.is_empty() {
-            segment_batches.push(selected_segs);
-        }
-
-        if segment_batches.is_empty() {
-            return Ok(None);
-        }
-
-        let evaluate_batch = |selected_segs: Vec<SelectedReclusterSegment>| {
-            let mutator = mutator.clone();
-            async move {
-                let (block_num, parts) = mutator.target_select(selected_segs).await?;
-                let seg_num = parts.removed_segment_indexes.len() as u64;
-                Ok::<_, databend_common_exception::ErrorCode>((seg_num, block_num, parts))
-            }
-        };
-
-        if segment_batches.len() == 1 {
-            let selected_segs = segment_batches.pop().unwrap();
-            let (seg_num, block_num, parts) = evaluate_batch(selected_segs).await?;
-            return Ok((!parts.is_empty()).then_some((seg_num, block_num, parts)));
-        }
-
-        let concurrency = max_threads.min(segment_batches.len());
-        let mut batches = segment_batches.into_iter();
-        let mut pending = FuturesUnordered::new();
-
-        for _ in 0..concurrency {
-            if let Some(selected_segs) = batches.next() {
-                pending.push(evaluate_batch(selected_segs));
-            }
-        }
-
-        while let Some(result) = pending.next().await {
-            let (seg_num, block_num, parts) = result?;
-            if !parts.is_empty() {
-                return Ok(Some((seg_num, block_num, parts)));
-            }
-
-            if let Some(selected_segs) = batches.next() {
-                pending.push(evaluate_batch(selected_segs));
-            }
-        }
-
-        Ok(None)
-    }
-
     pub async fn segment_pruning(
         ctx: &Arc<dyn TableContext>,
         schema: TableSchemaRef,
@@ -273,17 +184,14 @@ impl FuseTable {
         push_down: &Option<PushDownInfo>,
         mut segment_locs: Vec<SegmentLocation>,
     ) -> Result<Vec<(SegmentLocation, Arc<CompactSegmentInfo>)>> {
-        let max_concurrency = {
-            let max_threads = ctx.get_settings().get_max_threads()? as usize;
-            let v = std::cmp::max(max_threads, 10);
-            if v > max_threads {
-                warn!(
-                    "recluster: max_threads setting too low {}, increased to {}",
-                    max_threads, v
-                )
-            }
-            v
-        };
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        let max_concurrency = std::cmp::max(max_threads, 10);
+        if max_concurrency > max_threads {
+            warn!(
+                "recluster: max_threads setting too low {}, increased to {}",
+                max_threads, max_concurrency
+            );
+        }
 
         // during re-cluster, we do not rebuild missing bloom index
         let bloom_index_builder = None;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0017_issue_19150.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0017_issue_19150.test
@@ -62,6 +62,12 @@ insert into t5 values(5);
 1
 
 statement ok
+alter table t5 recluster;
+
+statement ok
+alter table t5 recluster;
+
+statement ok
 alter table t5 recluster final;
 
 query TTI


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR refines recluster planning, especially for RECLUSTER FINAL.
  - Improve RECLUSTER FINAL planning so it is not limited to a single local segment window, improving convergence in high-overlap cases.
  - Add ReclusterMode to separate Normal and Final planning behavior.
  - Change select_segments to return multiple candidate windows prioritized by overlap depth, so planning can try another window when one candidate cannot build tasks.
  - Keep normal recluster per-level, while allowing RECLUSTER FINAL to plan mature level > 0 blocks as a mixed group for cross-level overlap.
  - Keep level = 0 tail blocks separate and defer small tail work when mature work can use the task budget first.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19914)
<!-- Reviewable:end -->
