### PR TITLE
feat(io): optimize HybridBitmap deserialization-free calculations (#19101)

### DIFF
--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -738,14 +738,16 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
                 Ok(payload[0] as u64)
             }
             HYBRID_KIND_LARGE => {
-                Ok(reader::bitmap_len(payload)? as u64)
+                let len = reader::bitmap_len(payload).map_err(ErrorCode::from)?;
+                Ok(len as u64)
             }
             kind => Err(ErrorCode::BadBytes(format!(
                 "unknown hybrid bitmap kind: {kind}"
             ))),
         }
     } else {
-        Ok(reader::bitmap_len(buf)? as u64)
+        let len = reader::bitmap_len(buf).map_err(ErrorCode::from)?;
+        Ok(len as u64)
     }
 }
 
@@ -762,16 +764,18 @@ pub fn bitmap_contains(buf: &[u8], value: u64) -> Result<bool> {
                 Ok(values.binary_search(&value).is_ok())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload)?;
-                Ok(reader.contains(value)?)
+                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
+                let contains = reader.contains(value).map_err(ErrorCode::from)?;
+                Ok(contains)
             }
             kind => Err(ErrorCode::BadBytes(format!(
                 "unknown hybrid bitmap kind: {kind}"
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf)?;
-        Ok(reader.contains(value)?)
+        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
+        let contains = reader.contains(value).map_err(ErrorCode::from)?;
+        Ok(contains)
     }
 }
 
@@ -788,16 +792,18 @@ pub fn bitmap_max(buf: &[u8]) -> Result<Option<u64>> {
                 Ok(values.last().copied())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload)?;
-                Ok(reader.max()?)
+                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
+                let max = reader.max().map_err(ErrorCode::from)?;
+                Ok(max)
             }
             kind => Err(ErrorCode::BadBytes(format!(
                 "unknown hybrid bitmap kind: {kind}"
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf)?;
-        Ok(reader.max()?)
+        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
+        let max = reader.max().map_err(ErrorCode::from)?;
+        Ok(max)
     }
 }
 
@@ -814,16 +820,18 @@ pub fn bitmap_min(buf: &[u8]) -> Result<Option<u64>> {
                 Ok(values.first().copied())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload)?;
-                Ok(reader.min()?)
+                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
+                let min = reader.min().map_err(ErrorCode::from)?;
+                Ok(min)
             }
             kind => Err(ErrorCode::BadBytes(format!(
                 "unknown hybrid bitmap kind: {kind}"
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf)?;
-        Ok(reader.min()?)
+        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
+        let min = reader.min().map_err(ErrorCode::from)?;
+        Ok(min)
     }
 }
 

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -728,14 +728,102 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
         return Ok(0);
     }
 
-    if buf.len() > 3
-        && buf[3] == HYBRID_KIND_LARGE
-        && buf[..2] == HYBRID_MAGIC
-        && buf[2] == HYBRID_VERSION
-    {
-        Ok(reader::bitmap_len(&buf[HYBRID_HEADER_LEN..])? as u64)
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                if payload.is_empty() {
+                    return Err(ErrorCode::BadBytes("invalid hybrid bitmap: missing small length".to_string()));
+                }
+                Ok(payload[0] as u64)
+            }
+            HYBRID_KIND_LARGE => {
+                Ok(reader::bitmap_len(payload)? as u64)
+            }
+            kind => Err(ErrorCode::BadBytes(format!(
+                "unknown hybrid bitmap kind: {kind}"
+            ))),
+        }
     } else {
-        Ok(deserialize_bitmap(buf)?.len())
+        Ok(reader::bitmap_len(buf)? as u64)
+    }
+}
+
+pub fn bitmap_contains(buf: &[u8], value: u64) -> Result<bool> {
+    if buf.is_empty() {
+        return Ok(false);
+    }
+
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                let values = decode_small_values(payload)?;
+                Ok(values.binary_search(&value).is_ok())
+            }
+            HYBRID_KIND_LARGE => {
+                let reader = reader::TreemapReader::new(payload)?;
+                Ok(reader.contains(value)?)
+            }
+            kind => Err(ErrorCode::BadBytes(format!(
+                "unknown hybrid bitmap kind: {kind}"
+            ))),
+        }
+    } else {
+        let reader = reader::TreemapReader::new(buf)?;
+        Ok(reader.contains(value)?)
+    }
+}
+
+pub fn bitmap_max(buf: &[u8]) -> Result<Option<u64>> {
+    if buf.is_empty() {
+        return Ok(None);
+    }
+
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                let values = decode_small_values(payload)?;
+                Ok(values.last().copied())
+            }
+            HYBRID_KIND_LARGE => {
+                let reader = reader::TreemapReader::new(payload)?;
+                Ok(reader.max()?)
+            }
+            kind => Err(ErrorCode::BadBytes(format!(
+                "unknown hybrid bitmap kind: {kind}"
+            ))),
+        }
+    } else {
+        let reader = reader::TreemapReader::new(buf)?;
+        Ok(reader.max()?)
+    }
+}
+
+pub fn bitmap_min(buf: &[u8]) -> Result<Option<u64>> {
+    if buf.is_empty() {
+        return Ok(None);
+    }
+
+    if buf.len() >= HYBRID_HEADER_LEN && buf[..2] == HYBRID_MAGIC && buf[2] == HYBRID_VERSION {
+        let payload = &buf[HYBRID_HEADER_LEN..];
+        match buf[3] {
+            HYBRID_KIND_SMALL => {
+                let values = decode_small_values(payload)?;
+                Ok(values.first().copied())
+            }
+            HYBRID_KIND_LARGE => {
+                let reader = reader::TreemapReader::new(payload)?;
+                Ok(reader.min()?)
+            }
+            kind => Err(ErrorCode::BadBytes(format!(
+                "unknown hybrid bitmap kind: {kind}"
+            ))),
+        }
+    } else {
+        let reader = reader::TreemapReader::new(buf)?;
+        Ok(reader.min()?)
     }
 }
 
@@ -1428,5 +1516,68 @@ mod tests {
 
         let decoded = deserialize_bitmap(&legacy).unwrap();
         assert_eq!(decoded.into_iter().collect::<Vec<_>>(), vec![1, 5, 42]);
+    }
+
+    #[test]
+    fn test_hybrid_bitmap_ops() {
+        // Test kinds:
+        // 1. Empty
+        // 2. Hybrid Small
+        // 3. Hybrid Large
+        // 4. Legacy (pure roaring)
+
+        // 1. Empty
+        let empty_buf = Vec::new();
+        assert_eq!(bitmap_len(&empty_buf).unwrap(), 0);
+        assert!(!bitmap_contains(&empty_buf, 42).unwrap());
+        assert_eq!(bitmap_max(&empty_buf).unwrap(), None);
+        assert_eq!(bitmap_min(&empty_buf).unwrap(), None);
+
+        // 2. Hybrid Small
+        let mut small = HybridBitmap::new();
+        small.insert(10);
+        small.insert(20);
+        small.insert(30);
+        let mut small_buf = Vec::new();
+        small.serialize_into(&mut small_buf).unwrap();
+
+        assert_eq!(bitmap_len(&small_buf).unwrap(), 3);
+        assert!(bitmap_contains(&small_buf, 10).unwrap());
+        assert!(bitmap_contains(&small_buf, 20).unwrap());
+        assert!(bitmap_contains(&small_buf, 30).unwrap());
+        assert!(!bitmap_contains(&small_buf, 15).unwrap());
+        assert_eq!(bitmap_max(&small_buf).unwrap(), Some(30));
+        assert_eq!(bitmap_min(&small_buf).unwrap(), Some(10));
+
+        // 3. Hybrid Large
+        let mut large = HybridBitmap::new();
+        for i in 0..100 {
+            large.insert(i * 1000);
+        }
+        let mut large_buf = Vec::new();
+        large.serialize_into(&mut large_buf).unwrap();
+
+        assert_eq!(bitmap_len(&large_buf).unwrap(), 100);
+        assert!(bitmap_contains(&large_buf, 0).unwrap());
+        assert!(bitmap_contains(&large_buf, 99000).unwrap());
+        assert!(!bitmap_contains(&large_buf, 42).unwrap());
+        assert_eq!(bitmap_max(&large_buf).unwrap(), Some(99000));
+        assert_eq!(bitmap_min(&large_buf).unwrap(), Some(0));
+
+        // 4. Legacy (roaring)
+        let mut roaring = RoaringTreemap::new();
+        roaring.insert(5);
+        roaring.insert(50);
+        roaring.insert(500);
+        let mut roaring_buf = Vec::new();
+        roaring.serialize_into(&mut roaring_buf).unwrap();
+
+        assert_eq!(bitmap_len(&roaring_buf).unwrap(), 3);
+        assert!(bitmap_contains(&roaring_buf, 5).unwrap());
+        assert!(bitmap_contains(&roaring_buf, 50).unwrap());
+        assert!(bitmap_contains(&roaring_buf, 500).unwrap());
+        assert!(!bitmap_contains(&roaring_buf, 42).unwrap());
+        assert_eq!(bitmap_max(&roaring_buf).unwrap(), Some(500));
+        assert_eq!(bitmap_min(&roaring_buf).unwrap(), Some(5));
     }
 }

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -740,7 +740,7 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
                 Ok(payload[0] as u64)
             }
             HYBRID_KIND_LARGE => {
-                let len = reader::bitmap_len(payload).map_err(ErrorCode::from)?;
+                let len = reader::bitmap_len(payload)?;
                 Ok(len as u64)
             }
             kind => Err(ErrorCode::BadBytes(format!(
@@ -748,7 +748,7 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
             ))),
         }
     } else {
-        let len = reader::bitmap_len(buf).map_err(ErrorCode::from)?;
+        let len = reader::bitmap_len(buf)?;
         Ok(len as u64)
     }
 }
@@ -766,8 +766,8 @@ pub fn bitmap_contains(buf: &[u8], value: u64) -> Result<bool> {
                 Ok(values.binary_search(&value).is_ok())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
-                let contains = reader.contains(value).map_err(ErrorCode::from)?;
+                let reader = reader::TreemapReader::new(payload)?;
+                let contains = reader.contains(value)?;
                 Ok(contains)
             }
             kind => Err(ErrorCode::BadBytes(format!(
@@ -775,8 +775,8 @@ pub fn bitmap_contains(buf: &[u8], value: u64) -> Result<bool> {
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
-        let contains = reader.contains(value).map_err(ErrorCode::from)?;
+        let reader = reader::TreemapReader::new(buf)?;
+        let contains = reader.contains(value)?;
         Ok(contains)
     }
 }
@@ -794,8 +794,8 @@ pub fn bitmap_max(buf: &[u8]) -> Result<Option<u64>> {
                 Ok(values.last().copied())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
-                let max = reader.max().map_err(ErrorCode::from)?;
+                let reader = reader::TreemapReader::new(payload)?;
+                let max = reader.max()?;
                 Ok(max)
             }
             kind => Err(ErrorCode::BadBytes(format!(
@@ -803,8 +803,8 @@ pub fn bitmap_max(buf: &[u8]) -> Result<Option<u64>> {
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
-        let max = reader.max().map_err(ErrorCode::from)?;
+        let reader = reader::TreemapReader::new(buf)?;
+        let max = reader.max()?;
         Ok(max)
     }
 }
@@ -822,8 +822,8 @@ pub fn bitmap_min(buf: &[u8]) -> Result<Option<u64>> {
                 Ok(values.first().copied())
             }
             HYBRID_KIND_LARGE => {
-                let reader = reader::TreemapReader::new(payload).map_err(ErrorCode::from)?;
-                let min = reader.min().map_err(ErrorCode::from)?;
+                let reader = reader::TreemapReader::new(payload)?;
+                let min = reader.min()?;
                 Ok(min)
             }
             kind => Err(ErrorCode::BadBytes(format!(
@@ -831,8 +831,8 @@ pub fn bitmap_min(buf: &[u8]) -> Result<Option<u64>> {
             ))),
         }
     } else {
-        let reader = reader::TreemapReader::new(buf).map_err(ErrorCode::from)?;
-        let min = reader.min().map_err(ErrorCode::from)?;
+        let reader = reader::TreemapReader::new(buf)?;
+        let min = reader.min()?;
         Ok(min)
     }
 }

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -733,7 +733,9 @@ pub fn bitmap_len(buf: &[u8]) -> Result<u64> {
         match buf[3] {
             HYBRID_KIND_SMALL => {
                 if payload.is_empty() {
-                    return Err(ErrorCode::BadBytes("invalid hybrid bitmap: missing small length".to_string()));
+                    return Err(ErrorCode::BadBytes(
+                        "invalid hybrid bitmap: missing small length".to_string(),
+                    ));
                 }
                 Ok(payload[0] as u64)
             }

--- a/src/common/io/src/bitmap/reader.rs
+++ b/src/common/io/src/bitmap/reader.rs
@@ -47,6 +47,45 @@ impl<'a> TreemapReader<'a> {
             offset: 0,
         }
     }
+
+    pub fn contains(&self, value: u64) -> io::Result<bool> {
+        let high = (value >> 32) as u32;
+        let low = (value & 0xFFFFFFFF) as u32;
+        for bitmap_res in self.iter() {
+            let bitmap = bitmap_res?;
+            if bitmap.prefix() == high {
+                return bitmap.contains(low);
+            } else if bitmap.prefix() > high {
+                break;
+            }
+        }
+        Ok(false)
+    }
+
+    pub fn max(&self) -> io::Result<Option<u64>> {
+        let mut last_bitmap = None;
+        for bitmap_res in self.iter() {
+            last_bitmap = Some(bitmap_res?);
+        }
+        if let Some(bitmap) = last_bitmap {
+            let high = bitmap.prefix() as u64;
+            let low = bitmap.max()? as u64;
+            Ok(Some((high << 32) | low))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn min(&self) -> io::Result<Option<u64>> {
+        if let Some(bitmap_res) = self.iter().next() {
+            let bitmap = bitmap_res?;
+            let high = bitmap.prefix() as u64;
+            let low = bitmap.min()? as u64;
+            Ok(Some((high << 32) | low))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 pub struct TreeMapIter<'a> {
@@ -163,6 +202,151 @@ impl BitmapReader<'_> {
 
     pub fn bitmap_buf(&self) -> &[u8] {
         &self.buf[4..]
+    }
+
+    pub fn contains(&self, value: u32) -> io::Result<bool> {
+        let high = (value >> 16) as u16;
+        let low = (value & 0xFFFF) as u16;
+
+        for i in 0..self.containers() {
+            let desc = self.description(i)?;
+            if desc.prefix == high {
+                let offset_pos = 12 + self.containers() * 4 + i * 4;
+                if offset_pos + 4 > self.buf.len() {
+                    return Err(Error::new(ErrorKind::UnexpectedEof, "offset out of bounds"));
+                }
+                let mut offset_bytes = &self.buf[offset_pos..offset_pos + 4];
+                let offset = offset_bytes.read_u32::<LittleEndian>()? as usize;
+
+                let container_start = 4 + offset;
+                let cardinality = desc.cardinality();
+
+                const ARRAY_LIMIT: usize = 4096;
+                if cardinality <= ARRAY_LIMIT {
+                    let container_len = cardinality * 2;
+                    if container_start + container_len > self.buf.len() {
+                        return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                    }
+                    let container_buf = &self.buf[container_start..container_start + container_len];
+
+                    let mut l = 0;
+                    let mut r = cardinality;
+                    while l < r {
+                        let mid = (l + r) / 2;
+                        let val_pos = mid * 2;
+                        let mut val_bytes = &container_buf[val_pos..val_pos + 2];
+                        let val = val_bytes.read_u16::<LittleEndian>()?;
+                        match val.cmp(&low) {
+                            std::cmp::Ordering::Equal => return Ok(true),
+                            std::cmp::Ordering::Less => l = mid + 1,
+                            std::cmp::Ordering::Greater => r = mid,
+                        }
+                    }
+                    return Ok(false);
+                } else {
+                    const BITMAP_LENGTH: usize = 8192;
+                    if container_start + BITMAP_LENGTH > self.buf.len() {
+                        return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                    }
+                    let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
+                    let byte_idx = (low >> 3) as usize;
+                    let bit_idx = (low & 7) as u8;
+                    let byte = container_buf[byte_idx];
+                    return Ok((byte & (1 << bit_idx)) != 0);
+                }
+            } else if desc.prefix > high {
+                break;
+            }
+        }
+        Ok(false)
+    }
+
+    pub fn max(&self) -> io::Result<u32> {
+        let containers = self.containers();
+        if containers == 0 {
+            return Err(Error::new(ErrorKind::InvalidData, "empty bitmap"));
+        }
+        let last_idx = containers - 1;
+        let desc = self.description(last_idx)?;
+        let high = desc.prefix;
+
+        let offset_pos = 12 + containers * 4 + last_idx * 4;
+        if offset_pos + 4 > self.buf.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "offset out of bounds"));
+        }
+        let mut offset_bytes = &self.buf[offset_pos..offset_pos + 4];
+        let offset = offset_bytes.read_u32::<LittleEndian>()? as usize;
+        let container_start = 4 + offset;
+        let cardinality = desc.cardinality();
+
+        const ARRAY_LIMIT: usize = 4096;
+        if cardinality <= ARRAY_LIMIT {
+            let last_val_pos = container_start + (cardinality - 1) * 2;
+            if last_val_pos + 2 > self.buf.len() {
+                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+            }
+            let mut val_bytes = &self.buf[last_val_pos..last_val_pos + 2];
+            let low = val_bytes.read_u16::<LittleEndian>()?;
+            Ok(((high as u32) << 16) | (low as u32))
+        } else {
+            const BITMAP_LENGTH: usize = 8192;
+            if container_start + BITMAP_LENGTH > self.buf.len() {
+                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+            }
+            let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
+            for idx in (0..BITMAP_LENGTH).rev() {
+                let byte = container_buf[idx];
+                if byte != 0 {
+                    let bit_idx = 7 - byte.leading_zeros() as u16;
+                    let low = (idx as u32 * 8) + bit_idx as u32;
+                    return Ok(((high as u32) << 16) | low);
+                }
+            }
+            Err(Error::new(ErrorKind::InvalidData, "invalid empty bitmap container"))
+        }
+    }
+
+    pub fn min(&self) -> io::Result<u32> {
+        let containers = self.containers();
+        if containers == 0 {
+            return Err(Error::new(ErrorKind::InvalidData, "empty bitmap"));
+        }
+        let desc = self.description(0)?;
+        let high = desc.prefix;
+
+        let offset_pos = 12 + containers * 4;
+        if offset_pos + 4 > self.buf.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEof, "offset out of bounds"));
+        }
+        let mut offset_bytes = &self.buf[offset_pos..offset_pos + 4];
+        let offset = offset_bytes.read_u32::<LittleEndian>()? as usize;
+        let container_start = 4 + offset;
+        let cardinality = desc.cardinality();
+
+        const ARRAY_LIMIT: usize = 4096;
+        if cardinality <= ARRAY_LIMIT {
+            if container_start + 2 > self.buf.len() {
+                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+            }
+            let mut val_bytes = &self.buf[container_start..container_start + 2];
+            let low = val_bytes.read_u16::<LittleEndian>()?;
+            Ok(((high as u32) << 16) | (low as u32))
+        } else {
+            const BITMAP_LENGTH: usize = 8192;
+            if container_start + BITMAP_LENGTH > self.buf.len() {
+                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+            }
+            let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
+            for idx in 0..BITMAP_LENGTH {
+                let byte = container_buf[idx];
+                if byte != 0 {
+                    let bit_idx = byte.trailing_zeros() as u16;
+                    let low = (idx as u32 * 8) + bit_idx as u32;
+                    return Ok(((high as u32) << 16) | low);
+                }
+            }
+            Err(Error::new(ErrorKind::InvalidData, "invalid empty bitmap container"))
+        }
     }
 }
 
@@ -285,6 +469,44 @@ mod tests {
         intersection_with_serialized(&mut v, &buf)?;
 
         assert_eq!(v, v2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_contains_max_min() -> io::Result<()> {
+        let bitmap = create_bitmap(123);
+        let mut buf = Vec::new();
+        bitmap.serialize_into(&mut buf)?;
+
+        let reader = TreemapReader::new(&buf)?;
+
+        // Verify min and max bounds
+        assert_eq!(reader.min()?, bitmap.min());
+        assert_eq!(reader.max()?, bitmap.max());
+
+        // Verify all present values
+        for val in &bitmap {
+            assert!(reader.contains(val)?, "bitmap should contain {}", val);
+        }
+
+        // Verify some absent values
+        let mut rng = SmallRng::seed_from_u64(999);
+        for _ in 0..100 {
+            let val = rng.r#gen::<u64>();
+            if !bitmap.contains(val) {
+                assert!(!reader.contains(val)?, "bitmap should NOT contain {}", val);
+            }
+        }
+
+        // Verify empty bitmap
+        let empty_bitmap = RoaringTreemap::new();
+        let mut empty_buf = Vec::new();
+        empty_bitmap.serialize_into(&mut empty_buf)?;
+        let empty_reader = TreemapReader::new(&empty_buf)?;
+        assert_eq!(empty_reader.min()?, None);
+        assert_eq!(empty_reader.max()?, None);
+        assert!(!empty_reader.contains(42)?);
 
         Ok(())
     }

--- a/src/common/io/src/bitmap/reader.rs
+++ b/src/common/io/src/bitmap/reader.rs
@@ -225,7 +225,10 @@ impl BitmapReader<'_> {
                 if cardinality <= ARRAY_LIMIT {
                     let container_len = cardinality * 2;
                     if container_start + container_len > self.buf.len() {
-                        return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                        return Err(Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "container out of bounds",
+                        ));
                     }
                     let container_buf = &self.buf[container_start..container_start + container_len];
 
@@ -246,7 +249,10 @@ impl BitmapReader<'_> {
                 } else {
                     const BITMAP_LENGTH: usize = 8192;
                     if container_start + BITMAP_LENGTH > self.buf.len() {
-                        return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                        return Err(Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "container out of bounds",
+                        ));
                     }
                     let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
                     let byte_idx = (low >> 3) as usize;
@@ -283,7 +289,10 @@ impl BitmapReader<'_> {
         if cardinality <= ARRAY_LIMIT {
             let last_val_pos = container_start + (cardinality - 1) * 2;
             if last_val_pos + 2 > self.buf.len() {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "container out of bounds",
+                ));
             }
             let mut val_bytes = &self.buf[last_val_pos..last_val_pos + 2];
             let low = val_bytes.read_u16::<LittleEndian>()?;
@@ -291,7 +300,10 @@ impl BitmapReader<'_> {
         } else {
             const BITMAP_LENGTH: usize = 8192;
             if container_start + BITMAP_LENGTH > self.buf.len() {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "container out of bounds",
+                ));
             }
             let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
             for idx in (0..BITMAP_LENGTH).rev() {
@@ -302,7 +314,10 @@ impl BitmapReader<'_> {
                     return Ok(((high as u32) << 16) | low);
                 }
             }
-            Err(Error::new(ErrorKind::InvalidData, "invalid empty bitmap container"))
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                "invalid empty bitmap container",
+            ))
         }
     }
 
@@ -326,7 +341,10 @@ impl BitmapReader<'_> {
         const ARRAY_LIMIT: usize = 4096;
         if cardinality <= ARRAY_LIMIT {
             if container_start + 2 > self.buf.len() {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "container out of bounds",
+                ));
             }
             let mut val_bytes = &self.buf[container_start..container_start + 2];
             let low = val_bytes.read_u16::<LittleEndian>()?;
@@ -334,7 +352,10 @@ impl BitmapReader<'_> {
         } else {
             const BITMAP_LENGTH: usize = 8192;
             if container_start + BITMAP_LENGTH > self.buf.len() {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "container out of bounds"));
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "container out of bounds",
+                ));
             }
             let container_buf = &self.buf[container_start..container_start + BITMAP_LENGTH];
             for idx in 0..BITMAP_LENGTH {
@@ -345,7 +366,10 @@ impl BitmapReader<'_> {
                     return Ok(((high as u32) << 16) | low);
                 }
             }
-            Err(Error::new(ErrorKind::InvalidData, "invalid empty bitmap container"))
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                "invalid empty bitmap container",
+            ))
         }
     }
 }

--- a/src/query/functions/src/scalars/bitmap.rs
+++ b/src/query/functions/src/scalars/bitmap.rs
@@ -37,7 +37,10 @@ use databend_common_expression::vectorize_with_builder_3_arg;
 use databend_common_expression::with_signed_integer_mapped_type;
 use databend_common_expression::with_unsigned_integer_mapped_type;
 use databend_common_io::HybridBitmap;
+use databend_common_io::bitmap::bitmap_contains;
 use databend_common_io::bitmap::bitmap_len;
+use databend_common_io::bitmap::bitmap_max;
+use databend_common_io::bitmap::bitmap_min;
 use databend_common_io::deserialize_bitmap;
 use databend_common_io::parse_bitmap;
 use itertools::join;
@@ -269,9 +272,9 @@ pub fn register(registry: &mut FunctionRegistry) {
                     builder.push(false);
                     return;
                 }
-                match deserialize_bitmap(b) {
-                    Ok(rb) => {
-                        builder.push(rb.contains(item));
+                match bitmap_contains(b, item) {
+                    Ok(contains) => {
+                        builder.push(contains);
                     }
                     Err(e) => {
                         ctx.set_error(builder.len(), e.to_string());
@@ -443,14 +446,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                     builder.push(0);
                     return;
                 }
-                let val = match deserialize_bitmap(b) {
-                    Ok(rb) => match rb.max() {
-                        Some(val) => val,
-                        None => {
-                            ctx.set_error(builder.len(), "The bitmap is empty");
-                            0
-                        }
-                    },
+                let val = match bitmap_max(b) {
+                    Ok(Some(val)) => val,
+                    Ok(None) => {
+                        ctx.set_error(builder.len(), "The bitmap is empty");
+                        0
+                    }
                     Err(e) => {
                         ctx.set_error(builder.len(), e.to_string());
                         0
@@ -475,14 +476,12 @@ pub fn register(registry: &mut FunctionRegistry) {
                     builder.push(0);
                     return;
                 }
-                let val = match deserialize_bitmap(b) {
-                    Ok(rb) => match rb.min() {
-                        Some(val) => val,
-                        None => {
-                            ctx.set_error(builder.len(), "The bitmap is empty");
-                            0
-                        }
-                    },
+                let val = match bitmap_min(b) {
+                    Ok(Some(val)) => val,
+                    Ok(None) => {
+                        ctx.set_error(builder.len(), "The bitmap is empty");
+                        0
+                    }
                     Err(e) => {
                         ctx.set_error(builder.len(), e.to_string());
                         0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR implements deserialization-free calculations (`contains`, `max`, `min`, `len`) on serialized `HybridBitmap` bytes based on the `RoaringFormatSpec` schema. 

By operating directly on the serialized buffer headers, offset descriptors, and container bytes, we bypass full roaring/treemap deserialization. This significantly reduces CPU overhead and memory footprint for query scalar functions like `bitmap_contains`, `bitmap_max`, and `bitmap_min`.

- fixes: #19101

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19915)
<!-- Reviewable:end -->
