### PR TITLE
feat: add runtime watchdog task dumps

### DIFF
--- a/src/common/base/src/runtime/mod.rs
+++ b/src/common/base/src/runtime/mod.rs
@@ -27,6 +27,7 @@ mod runtime;
 mod runtime_tracker;
 mod thread;
 mod time_series;
+mod watchdog;
 pub mod workload_group;
 
 pub use backtrace::AsyncTaskItem;

--- a/src/common/base/src/runtime/runtime.rs
+++ b/src/common/base/src/runtime/runtime.rs
@@ -27,9 +27,10 @@ use tokio::runtime::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
-use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+use super::watchdog::WatchdogEvent;
+use super::watchdog::run_watchdog_loop;
 use crate::runtime::Thread;
 use crate::runtime::ThreadJoinHandle;
 use crate::runtime::ThreadTracker;
@@ -42,9 +43,8 @@ pub struct Runtime {
     /// Runtime handle.
     handle: Handle,
 
-    /// Prefix injected into root async-backtrace frames spawned by this wrapper.
-    /// This makes existing task dumps show which named Databend runtime owns a task.
-    task_dump_marker: String,
+    /// Prefix injected into task frames and used to filter task dumps.
+    task_marker: String,
 
     /// Use to receive a drop signal when dropper is dropped.
     _dropper: Dropper,
@@ -56,17 +56,29 @@ impl Runtime {
             .build()
             .map_err(|tokio_error| ErrorCode::TokioError(tokio_error.to_string()))?;
 
-        let (send_stop, recv_stop) = oneshot::channel();
+        let (watchdog_tx, watchdog_rx) = std::sync::mpsc::channel::<WatchdogEvent>();
 
         let handle = runtime.handle().clone();
         let runtime_name = name.clone().unwrap_or_else(|| "unnamed".to_string());
-        let task_dump_marker = format!("[{runtime_name}]");
+        let runtime_id = handle.id().to_string();
+        let runtime_label = format!("{runtime_name} id={runtime_id}");
+        let task_marker = format!("[{runtime_label}]");
 
         let n = name.clone();
-        // Block the runtime to shutdown.
+        let watchdog_handle = handle.clone();
+        let watchdog_marker = task_marker.clone();
+        let watchdog_event_tx = watchdog_tx.clone();
+        // The wait-to-drop thread blocks until the runtime is dropped, and in
+        // the meantime periodically probes the runtime to check that tasks are
+        // still being scheduled in a timely manner.
         let join_handler =
             Thread::named_spawn(n.as_ref().map(|n| format!("wait-to-drop-{n}")), move || {
-                let _ = runtime.block_on(recv_stop);
+                run_watchdog_loop(
+                    &watchdog_handle,
+                    &watchdog_marker,
+                    &watchdog_event_tx,
+                    &watchdog_rx,
+                );
 
                 if cfg!(debug_assertions) {
                     let instant = Instant::now();
@@ -80,10 +92,10 @@ impl Runtime {
 
         Ok(Runtime {
             handle,
-            task_dump_marker,
+            task_marker,
             _dropper: Dropper {
                 name,
-                close: Some(send_stop),
+                close: Some(watchdog_tx),
                 join_handler: Some(join_handler),
             },
         })
@@ -139,7 +151,7 @@ impl Runtime {
     }
 
     fn task_location_name(&self, location_name: String) -> String {
-        format!("{} {}", self.task_dump_marker, location_name)
+        format!("{} {}", self.task_marker, location_name)
     }
 
     #[track_caller]
@@ -284,7 +296,7 @@ impl Runtime {
 /// Dropping the dropper will cause runtime to shutdown.
 pub struct Dropper {
     name: Option<String>,
-    close: Option<oneshot::Sender<()>>,
+    close: Option<std::sync::mpsc::Sender<WatchdogEvent>>,
     join_handler: Option<ThreadJoinHandle<bool>>,
 }
 
@@ -293,7 +305,7 @@ impl Drop for Dropper {
         drop_guard(move || {
             // Send a signal to say i am dropping.
             if let Some(close_sender) = self.close.take()
-                && close_sender.send(()).is_ok()
+                && close_sender.send(WatchdogEvent::Stop).is_ok()
             {
                 match self.join_handler.take().unwrap().join() {
                     Err(e) => warn!("Runtime dropper panic, {:?}", e),
@@ -468,11 +480,14 @@ where F: Future {
             .to_string()
     });
 
-    if let Ok(handle) = Handle::try_current()
-        && let Some(name) = handle.name()
-    {
-        return format!("[{name}] {frame_name}");
+    if let Ok(handle) = Handle::try_current() {
+        return format!("{} {frame_name}", current_runtime_marker(&handle));
     }
 
     frame_name
+}
+
+fn current_runtime_marker(handle: &Handle) -> String {
+    let runtime_name = handle.name().unwrap_or("unnamed");
+    format!("[{} id={}]", runtime_name, handle.id())
 }

--- a/src/common/base/src/runtime/watchdog.rs
+++ b/src/common/base/src/runtime/watchdog.rs
@@ -1,0 +1,162 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Write;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::mpsc::Sender;
+use std::time::Duration;
+use std::time::Instant;
+
+use log::warn;
+use tokio::runtime::Handle;
+
+use super::backtrace::get_all_tasks;
+
+/// How often the watchdog spawns a probe task to check the runtime is responsive.
+const RUNTIME_WATCHDOG_PROBE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// If a probe task is not scheduled within this duration, the runtime is
+/// considered unhealthy and its tasks are dumped to the log.
+const RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD: Duration = Duration::from_secs(3);
+
+pub(super) enum WatchdogEvent {
+    Stop,
+    ProbeScheduled(u64),
+}
+
+/// Periodically spawn a probe task on the runtime and measure how long it
+/// takes to be scheduled. If the probe takes longer than the unhealthy
+/// threshold, dump the tasks that belong to this runtime to the log.
+///
+/// Returns when the stop signal is received (or the sender is dropped).
+pub(super) fn run_watchdog_loop(
+    handle: &Handle,
+    task_dump_marker: &str,
+    event_tx: &Sender<WatchdogEvent>,
+    event_rx: &Receiver<WatchdogEvent>,
+) {
+    let mut probe_id = 0u64;
+
+    loop {
+        if wait_probe_interval(event_rx) {
+            return;
+        }
+
+        // Spawn a tiny probe task and measure how long until it actually runs.
+        probe_id = probe_id.wrapping_add(1);
+        let current_probe_id = probe_id;
+        let probe_tx = event_tx.clone();
+        let scheduled_at = Instant::now();
+        #[expect(clippy::disallowed_methods)]
+        handle.spawn(async move {
+            let _ = probe_tx.send(WatchdogEvent::ProbeScheduled(current_probe_id));
+        });
+
+        match wait_probe_scheduled(event_rx, current_probe_id) {
+            ProbeWaitResult::Stop => return,
+            ProbeWaitResult::Scheduled => {}
+            ProbeWaitResult::Timeout => {
+                let elapsed = scheduled_at.elapsed();
+                let dump = dump_runtime_tasks(task_dump_marker);
+                warn!(
+                    "Runtime {:?} watchdog probe was not scheduled within {:?} (waited {:?}); dumping owned tasks:\n{}",
+                    task_dump_marker, RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD, elapsed, dump,
+                );
+            }
+        }
+    }
+}
+
+enum ProbeWaitResult {
+    Stop,
+    Scheduled,
+    Timeout,
+}
+
+fn wait_probe_interval(event_rx: &Receiver<WatchdogEvent>) -> bool {
+    let wait_until = Instant::now() + RUNTIME_WATCHDOG_PROBE_INTERVAL;
+
+    loop {
+        let Some(timeout) = wait_until.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+
+        match event_rx.recv_timeout(timeout) {
+            Ok(WatchdogEvent::Stop) => return true,
+            Ok(WatchdogEvent::ProbeScheduled(_)) => {
+                // Ignore stale probe completions from an earlier timed-out round.
+            }
+            Err(RecvTimeoutError::Timeout) => return false,
+            Err(RecvTimeoutError::Disconnected) => return true,
+        }
+    }
+}
+
+fn wait_probe_scheduled(event_rx: &Receiver<WatchdogEvent>, probe_id: u64) -> ProbeWaitResult {
+    let wait_until = Instant::now() + RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD;
+
+    loop {
+        let Some(timeout) = wait_until.checked_duration_since(Instant::now()) else {
+            return ProbeWaitResult::Timeout;
+        };
+
+        match event_rx.recv_timeout(timeout) {
+            Ok(WatchdogEvent::Stop) => return ProbeWaitResult::Stop,
+            Ok(WatchdogEvent::ProbeScheduled(id)) if id == probe_id => {
+                return ProbeWaitResult::Scheduled;
+            }
+            Ok(WatchdogEvent::ProbeScheduled(_)) => {
+                // Ignore stale probe completions from an earlier timed-out round.
+            }
+            Err(RecvTimeoutError::Timeout) => return ProbeWaitResult::Timeout,
+            Err(RecvTimeoutError::Disconnected) => return ProbeWaitResult::Stop,
+        }
+    }
+}
+
+/// Dump only the tasks whose stack frames contain `task_dump_marker`
+/// (i.e. tasks owned by this runtime). Returns an empty-style placeholder
+/// when no matching task is found.
+fn dump_runtime_tasks(task_dump_marker: &str) -> String {
+    let (tasks, polling_tasks) = get_all_tasks(false);
+
+    let mut output = String::new();
+    let mut matched = 0usize;
+    for mut tasks in [tasks, polling_tasks] {
+        tasks.sort_by(|l, r| Ord::cmp(&l.stack_frames.len(), &r.stack_frames.len()));
+
+        for item in tasks.into_iter().rev() {
+            if !item
+                .stack_frames
+                .iter()
+                .any(|frame| frame.contains(task_dump_marker))
+            {
+                continue;
+            }
+
+            matched += 1;
+            for frame in item.stack_frames {
+                writeln!(output, "{}", frame).unwrap();
+            }
+            writeln!(output).unwrap();
+        }
+    }
+
+    if matched == 0 {
+        format!("<no tasks tagged with {task_dump_marker} were found>\n")
+    } else {
+        output
+    }
+}

--- a/src/common/base/src/runtime/watchdog.rs
+++ b/src/common/base/src/runtime/watchdog.rs
@@ -50,7 +50,7 @@ pub(super) fn run_watchdog_loop(
     let mut probe_id = 0u64;
 
     loop {
-        if wait_probe_interval(event_rx) {
+        if wait_probe_interval_for(event_rx, RUNTIME_WATCHDOG_PROBE_INTERVAL) {
             return;
         }
 
@@ -64,7 +64,11 @@ pub(super) fn run_watchdog_loop(
             let _ = probe_tx.send(WatchdogEvent::ProbeScheduled(current_probe_id));
         });
 
-        match wait_probe_scheduled(event_rx, current_probe_id) {
+        match wait_probe_scheduled_for(
+            event_rx,
+            current_probe_id,
+            RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD,
+        ) {
             ProbeWaitResult::Stop => return,
             ProbeWaitResult::Scheduled => {}
             ProbeWaitResult::Timeout => {
@@ -86,10 +90,6 @@ enum ProbeWaitResult {
     Timeout,
 }
 
-fn wait_probe_interval(event_rx: &Receiver<WatchdogEvent>) -> bool {
-    wait_probe_interval_for(event_rx, RUNTIME_WATCHDOG_PROBE_INTERVAL)
-}
-
 fn wait_probe_interval_for(event_rx: &Receiver<WatchdogEvent>, interval: Duration) -> bool {
     let wait_until = Instant::now() + interval;
 
@@ -107,10 +107,6 @@ fn wait_probe_interval_for(event_rx: &Receiver<WatchdogEvent>, interval: Duratio
             Err(RecvTimeoutError::Disconnected) => return true,
         }
     }
-}
-
-fn wait_probe_scheduled(event_rx: &Receiver<WatchdogEvent>, probe_id: u64) -> ProbeWaitResult {
-    wait_probe_scheduled_for(event_rx, probe_id, RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD)
 }
 
 fn wait_probe_scheduled_for(

--- a/src/common/base/src/runtime/watchdog.rs
+++ b/src/common/base/src/runtime/watchdog.rs
@@ -139,17 +139,53 @@ fn wait_probe_scheduled_for(
     }
 }
 
+/// Dump only the tasks whose stack frames contain `task_dump_marker`
+/// (i.e. tasks owned by this runtime). Returns an empty-style placeholder
+/// when no matching task is found.
+fn dump_runtime_tasks(task_dump_marker: &str) -> String {
+    let (tasks, polling_tasks) = get_all_tasks(false);
+
+    let mut output = String::new();
+    let mut matched = 0usize;
+    for mut tasks in [tasks, polling_tasks] {
+        tasks.sort_by(|l, r| Ord::cmp(&l.stack_frames.len(), &r.stack_frames.len()));
+
+        for item in tasks.into_iter().rev() {
+            if !item
+                .stack_frames
+                .iter()
+                .any(|frame| frame.contains(task_dump_marker))
+            {
+                continue;
+            }
+
+            matched += 1;
+            for frame in item.stack_frames {
+                writeln!(output, "{}", frame).unwrap();
+            }
+            writeln!(output).unwrap();
+        }
+    }
+
+    if matched == 0 {
+        format!("<no tasks tagged with {task_dump_marker} were found>\n")
+    } else {
+        output
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
     use std::thread;
 
     use super::*;
+    use crate::runtime::Thread;
 
     #[test]
     fn test_wait_probe_scheduled_returns_stop_immediately() {
         let (event_tx, event_rx) = mpsc::channel();
-        thread::spawn(move || {
+        let _join = Thread::spawn(move || {
             thread::sleep(Duration::from_millis(20));
             event_tx.send(WatchdogEvent::Stop).unwrap();
         });
@@ -200,40 +236,5 @@ mod tests {
         let should_stop = wait_probe_interval_for(&event_rx, Duration::from_secs(5));
 
         assert!(should_stop);
-    }
-}
-
-/// Dump only the tasks whose stack frames contain `task_dump_marker`
-/// (i.e. tasks owned by this runtime). Returns an empty-style placeholder
-/// when no matching task is found.
-fn dump_runtime_tasks(task_dump_marker: &str) -> String {
-    let (tasks, polling_tasks) = get_all_tasks(false);
-
-    let mut output = String::new();
-    let mut matched = 0usize;
-    for mut tasks in [tasks, polling_tasks] {
-        tasks.sort_by(|l, r| Ord::cmp(&l.stack_frames.len(), &r.stack_frames.len()));
-
-        for item in tasks.into_iter().rev() {
-            if !item
-                .stack_frames
-                .iter()
-                .any(|frame| frame.contains(task_dump_marker))
-            {
-                continue;
-            }
-
-            matched += 1;
-            for frame in item.stack_frames {
-                writeln!(output, "{}", frame).unwrap();
-            }
-            writeln!(output).unwrap();
-        }
-    }
-
-    if matched == 0 {
-        format!("<no tasks tagged with {task_dump_marker} were found>\n")
-    } else {
-        output
     }
 }

--- a/src/common/base/src/runtime/watchdog.rs
+++ b/src/common/base/src/runtime/watchdog.rs
@@ -79,6 +79,7 @@ pub(super) fn run_watchdog_loop(
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
 enum ProbeWaitResult {
     Stop,
     Scheduled,
@@ -86,7 +87,11 @@ enum ProbeWaitResult {
 }
 
 fn wait_probe_interval(event_rx: &Receiver<WatchdogEvent>) -> bool {
-    let wait_until = Instant::now() + RUNTIME_WATCHDOG_PROBE_INTERVAL;
+    wait_probe_interval_for(event_rx, RUNTIME_WATCHDOG_PROBE_INTERVAL)
+}
+
+fn wait_probe_interval_for(event_rx: &Receiver<WatchdogEvent>, interval: Duration) -> bool {
+    let wait_until = Instant::now() + interval;
 
     loop {
         let Some(timeout) = wait_until.checked_duration_since(Instant::now()) else {
@@ -105,7 +110,15 @@ fn wait_probe_interval(event_rx: &Receiver<WatchdogEvent>) -> bool {
 }
 
 fn wait_probe_scheduled(event_rx: &Receiver<WatchdogEvent>, probe_id: u64) -> ProbeWaitResult {
-    let wait_until = Instant::now() + RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD;
+    wait_probe_scheduled_for(event_rx, probe_id, RUNTIME_WATCHDOG_UNHEALTHY_THRESHOLD)
+}
+
+fn wait_probe_scheduled_for(
+    event_rx: &Receiver<WatchdogEvent>,
+    probe_id: u64,
+    threshold: Duration,
+) -> ProbeWaitResult {
+    let wait_until = Instant::now() + threshold;
 
     loop {
         let Some(timeout) = wait_until.checked_duration_since(Instant::now()) else {
@@ -123,6 +136,70 @@ fn wait_probe_scheduled(event_rx: &Receiver<WatchdogEvent>, probe_id: u64) -> Pr
             Err(RecvTimeoutError::Timeout) => return ProbeWaitResult::Timeout,
             Err(RecvTimeoutError::Disconnected) => return ProbeWaitResult::Stop,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn test_wait_probe_scheduled_returns_stop_immediately() {
+        let (event_tx, event_rx) = mpsc::channel();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            event_tx.send(WatchdogEvent::Stop).unwrap();
+        });
+
+        let started_at = Instant::now();
+        let result = wait_probe_scheduled_for(&event_rx, 1, Duration::from_secs(5));
+
+        assert_eq!(result, ProbeWaitResult::Stop);
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_wait_probe_scheduled_ignores_stale_probe_events() {
+        let (event_tx, event_rx) = mpsc::channel();
+        event_tx.send(WatchdogEvent::ProbeScheduled(1)).unwrap();
+        event_tx.send(WatchdogEvent::ProbeScheduled(2)).unwrap();
+
+        let result = wait_probe_scheduled_for(&event_rx, 2, Duration::from_millis(100));
+
+        assert_eq!(result, ProbeWaitResult::Scheduled);
+    }
+
+    #[test]
+    fn test_wait_probe_scheduled_times_out_on_stale_probe_events() {
+        let (event_tx, event_rx) = mpsc::channel();
+        event_tx.send(WatchdogEvent::ProbeScheduled(1)).unwrap();
+
+        let result = wait_probe_scheduled_for(&event_rx, 2, Duration::from_millis(20));
+
+        assert_eq!(result, ProbeWaitResult::Timeout);
+    }
+
+    #[test]
+    fn test_wait_probe_interval_ignores_stale_probe_events() {
+        let (event_tx, event_rx) = mpsc::channel();
+        event_tx.send(WatchdogEvent::ProbeScheduled(1)).unwrap();
+
+        let should_stop = wait_probe_interval_for(&event_rx, Duration::from_millis(20));
+
+        assert!(!should_stop);
+    }
+
+    #[test]
+    fn test_wait_probe_interval_returns_stop() {
+        let (event_tx, event_rx) = mpsc::channel();
+        event_tx.send(WatchdogEvent::Stop).unwrap();
+
+        let should_stop = wait_probe_interval_for(&event_rx, Duration::from_secs(5));
+
+        assert!(should_stop);
     }
 }
 

--- a/src/common/base/tests/it/runtime.rs
+++ b/src/common/base/tests/it/runtime.rs
@@ -87,8 +87,9 @@ async fn test_shutdown_long_run_runtime() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_runtime_task_dump_contains_runtime_name() -> anyhow::Result<()> {
+async fn test_runtime_task_dump_contains_runtime_id() -> anyhow::Result<()> {
     let runtime = Runtime::with_worker_threads(1, Some("task-marker-runtime".to_string()))?;
+    let runtime_marker = format!("[task-marker-runtime id={}]", runtime.inner().id());
     let (started_tx, started_rx) = std::sync::mpsc::channel();
 
     let named_started_tx = started_tx.clone();
@@ -110,12 +111,14 @@ async fn test_runtime_task_dump_contains_runtime_name() -> anyhow::Result<()> {
 
     let dump = dump_backtrace(false);
     assert!(dump.contains(&format!(
-        "[task-marker-runtime] task-marker-test at {}:{}:",
+        "{} task-marker-test at {}:{}:",
+        runtime_marker,
         file!(),
         named_spawn_line
     )));
     assert!(dump.contains(&format!(
-        "[task-marker-runtime] Global spawn task at {}:{}:",
+        "{} Global spawn task at {}:{}:",
+        runtime_marker,
         file!(),
         global_spawn_line
     )));
@@ -126,8 +129,9 @@ async fn test_runtime_task_dump_contains_runtime_name() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_free_spawn_task_dump_contains_runtime_name() -> anyhow::Result<()> {
+fn test_free_spawn_task_dump_contains_runtime_id() -> anyhow::Result<()> {
     let runtime = Runtime::with_worker_threads(1, Some("free-spawn-runtime-test".to_string()))?;
+    let runtime_marker = format!("[free-spawn-runtime-test id={}]", runtime.inner().id());
 
     runtime.block_on(async {
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
@@ -144,7 +148,7 @@ fn test_free_spawn_task_dump_contains_runtime_name() -> anyhow::Result<()> {
 
         let dump = dump_backtrace(false);
         assert!(dump.lines().any(|line| {
-            line.contains("[free-spawn-runtime-test]")
+            line.contains(&runtime_marker)
                 && line.contains(&format!(" at {}:{}:", file!(), free_spawn_line))
         }));
         assert!(!dump.contains("[spawn-thread="));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary



If the runtime is blocking, we can see logs as follows:

```
2026-05-25T12:18:25.991255+08:00  WARN databend_common_base::runtime::watchdog: watchdog.rs:73 Runtime "[IO-worker id=2]" watchdog probe was not scheduled within 3s (waited 3.001160542s); dumping owned tasks:
╼ [IO-worker id=2] Global spawn task at src/query/service/src/locks/lock_manager.rs:48:37

╼ [IO-worker id=2] Running query 019e5d5acf6171238bcfc311300da12e spawn task at src/common/base/src/runtime/global_runtime.rs:50:11
  └┈ [POLLING]
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19917)
<!-- Reviewable:end -->
