### PR TITLE
fix(query): include scalar function params in agg index key

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/agg_index/query_rewrite.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/agg_index/query_rewrite.rs
@@ -1279,15 +1279,19 @@ fn format_scalar(scalar: &ScalarExpr, column_map: &HashMap<Symbol, ScalarExpr>) 
             s => format_scalar(s, column_map),
         },
         ScalarExpr::ConstantExpr(val) => format!("{}", val.value),
-        ScalarExpr::FunctionCall(func) => format!(
-            "{}({})",
-            &func.func_name,
-            func.arguments
+        ScalarExpr::FunctionCall(func) => {
+            let params = func.params.iter().map(|param| param.to_string()).join(", ");
+            let args = func
+                .arguments
                 .iter()
-                .map(|arg| { format_scalar(arg, column_map) })
-                .collect::<Vec<String>>()
-                .join(", ")
-        ),
+                .map(|arg| format_scalar(arg, column_map))
+                .join(", ");
+            if !params.is_empty() {
+                format!("{}({})({})", &func.func_name, params, args)
+            } else {
+                format!("{}({})", &func.func_name, args)
+            }
+        }
         ScalarExpr::CastExpr(cast) => {
             let func_name = if cast.is_try { "try_cast" } else { "cast" };
             format!(

--- a/tests/sqllogictests/suites/query/index/02_aggregating_index/02_0000_async_agg_index_base.test
+++ b/tests/sqllogictests/suites/query/index/02_aggregating_index/02_0000_async_agg_index_base.test
@@ -264,6 +264,31 @@ DROP AGGREGATING INDEX testi
 statement ok
 DROP TABLE t
 
+# scalar function params should participate in the agg index expression key
+statement ok
+CREATE TABLE t (d DECIMAL(10, 3), v INT)
+
+statement ok
+INSERT INTO t VALUES (1.241, 10), (1.249, 20)
+
+statement ok
+CREATE ASYNC AGGREGATING INDEX testi AS SELECT round(d, 1) AS r, sum(v) FROM t GROUP BY r
+
+statement ok
+REFRESH AGGREGATING INDEX testi
+
+query RI rowsort
+SELECT round(d, 2), sum(v) FROM t GROUP BY round(d, 2)
+----
+1.24 10
+1.25 20
+
+statement ok
+DROP AGGREGATING INDEX testi
+
+statement ok
+DROP TABLE t
+
 statement ok
 CREATE TABLE t(id int, user_id int, event_name varchar)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Include scalar function params when formatting aggregation-index rewrite keys for scalar function calls.
- Avoid matching expressions such as `round(d, 1)` and `round(d, 2)` to the same aggregation-index output key after type checking injects decimal function params.
- Add a sqllogictest regression covering decimal `round` grouping with an async aggregating index.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --check`
- `cargo check -p databend-common-sql`
- `target/debug/databend-sqllogictests --handlers http --run tests/sqllogictests/suites/query/index/02_aggregating_index/02_0000_async_agg_index_base.test`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19919)
<!-- Reviewable:end -->
