### PR TITLE
chore: remove legacy stream source database fallback after migration window

### DIFF
--- a/src/query/service/src/interpreters/common/stream.rs
+++ b/src/query/service/src/interpreters/common/stream.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_license::license::Feature;
 use databend_common_license::license_manager::LicenseManagerSwitch;
@@ -26,11 +25,7 @@ use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_stream::stream_table::StreamTable;
 use databend_meta_client::types::MatchSeq;
-use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
-use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_NAME;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
-use databend_storages_common_table_meta::table::OPT_KEY_SOURCE_DATABASE_ID;
-use databend_storages_common_table_meta::table::OPT_KEY_TABLE_NAME;
 use databend_storages_common_table_meta::table::OPT_KEY_TABLE_VER;
 
 use crate::sessions::QueryContext;
@@ -61,26 +56,6 @@ pub async fn dml_build_update_stream_req(
         options.insert(OPT_KEY_TABLE_VER.to_string(), table_version.to_string());
         if let Some(snapshot_loc) = inner_fuse.snapshot_loc() {
             options.insert(OPT_KEY_SNAPSHOT_LOCATION.to_string(), snapshot_loc);
-        }
-
-        // To be compatible with older versions, set source database id.
-        if !options.contains_key(OPT_KEY_SOURCE_DATABASE_ID) {
-            let source_db_id = inner_fuse
-                .get_table_info()
-                .options()
-                .get(OPT_KEY_DATABASE_ID)
-                .ok_or_else(|| {
-                    ErrorCode::Internal(format!(
-                        "Invalid fuse table, table option {} not found when building update stream req",
-                        OPT_KEY_DATABASE_ID
-                    ))
-                })?;
-            options.insert(
-                OPT_KEY_SOURCE_DATABASE_ID.to_owned(),
-                source_db_id.to_string(),
-            );
-            options.remove(OPT_KEY_DATABASE_NAME);
-            options.remove(OPT_KEY_TABLE_NAME);
         }
 
         reqs.push(UpdateStreamMetaReq {

--- a/src/query/storages/common/table_meta/src/table/stream_keys.rs
+++ b/src/query/storages/common/table_meta/src/table/stream_keys.rs
@@ -18,9 +18,6 @@ pub const OPT_KEY_SOURCE_TABLE_ID: &str = "table_id";
 pub const OPT_KEY_TABLE_VER: &str = "table_version";
 pub const OPT_KEY_MODE: &str = "mode";
 
-pub const OPT_KEY_TABLE_NAME: &str = "table_name";
-pub const OPT_KEY_DATABASE_NAME: &str = "table_database";
-
 pub const MODE_APPEND_ONLY: &str = "append_only";
 pub const MODE_STANDARD: &str = "standard";
 

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -46,7 +47,6 @@ use databend_common_storages_fuse::io::MetaReaders;
 use databend_common_storages_fuse::io::SnapshotHistoryReader;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
 use databend_storages_common_table_meta::table::ChangeType;
-use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_MODE;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use databend_storages_common_table_meta::table::OPT_KEY_SOURCE_DATABASE_ID;
@@ -231,35 +231,32 @@ impl StreamTable {
     }
 
     pub fn offset(&self) -> Result<u64> {
-        let table_version = self
-            .info
-            .options()
-            .get(OPT_KEY_TABLE_VER)
-            .ok_or_else(|| ErrorCode::Internal("table version must be set"))?
-            .parse::<u64>()?;
-        Ok(table_version)
+        self.get_option(OPT_KEY_TABLE_VER)
     }
 
     pub fn mode(&self) -> StreamMode {
-        self.info
-            .options()
-            .get(OPT_KEY_MODE)
-            .and_then(|s| s.parse::<StreamMode>().ok())
-            .unwrap_or(StreamMode::AppendOnly)
+        self.info.get_option(OPT_KEY_MODE, StreamMode::AppendOnly)
     }
 
     pub fn snapshot_loc(&self) -> Option<String> {
         self.info.options().get(OPT_KEY_SNAPSHOT_LOCATION).cloned()
     }
 
-    pub fn source_table_id(&self) -> Result<u64> {
-        let table_id = self
-            .info
+    fn get_option<T>(&self, opt_key: &str) -> Result<T>
+    where
+        T: FromStr,
+        T::Err: std::fmt::Display,
+    {
+        self.info
             .options()
-            .get(OPT_KEY_SOURCE_TABLE_ID)
-            .ok_or_else(|| ErrorCode::Internal("source table id must be set"))?
-            .parse::<u64>()?;
-        Ok(table_id)
+            .get(opt_key)
+            .ok_or_else(|| ErrorCode::Internal(format!("stream option '{}' must be set", opt_key)))?
+            .parse::<T>()
+            .map_err(|e| ErrorCode::Internal(format!("Invalid stream option '{}': {}", opt_key, e)))
+    }
+
+    pub fn source_table_id(&self) -> Result<u64> {
+        self.get_option(OPT_KEY_SOURCE_TABLE_ID)
     }
 
     pub async fn source_table_name(&self, catalog: &dyn Catalog) -> Result<String> {
@@ -274,40 +271,12 @@ impl StreamTable {
             })
     }
 
-    pub async fn source_database_id(&self, catalog: &dyn Catalog) -> Result<u64> {
-        let source_db_id_opt = self
-            .info
-            .options()
-            .get(OPT_KEY_SOURCE_DATABASE_ID)
-            .map(|s| s.parse::<u64>().map_err(|e| e.to_string()))
-            .transpose()?;
-
-        let source_db_id = match source_db_id_opt {
-            Some(v) => v,
-            None => {
-                let source_table_id = self.source_table_id()?;
-                let source_table_meta = catalog
-                    .get_table_meta_by_id(source_table_id)
-                    .await?
-                    .ok_or_else(|| ErrorCode::Internal("source database id must be set"))?;
-                source_table_meta
-                    .data
-                    .options
-                    .get(OPT_KEY_DATABASE_ID)
-                    .ok_or_else(|| {
-                        ErrorCode::Internal(format!(
-                            "Invalid fuse table, table option {} not found when getting source database id",
-                            OPT_KEY_DATABASE_ID
-                        ))
-                    })?
-                    .parse::<u64>()?
-            }
-        };
-        Ok(source_db_id)
+    pub fn source_database_id(&self) -> Result<u64> {
+        self.get_option(OPT_KEY_SOURCE_DATABASE_ID)
     }
 
     pub async fn source_database_name(&self, catalog: &dyn Catalog) -> Result<String> {
-        let source_db_id = self.source_database_id(catalog).await?;
+        let source_db_id = self.source_database_id()?;
         catalog.get_db_name_by_id(source_db_id).await
     }
 

--- a/src/query/storages/system/src/streams_table.rs
+++ b/src/query/storages/system/src/streams_table.rs
@@ -195,7 +195,7 @@ impl<const T: bool> AsyncSystemTable for StreamsTable<T> {
                     let stream_info = table.get_table_info();
                     let stream_table = StreamTable::try_from_table(table.as_ref())?;
 
-                    let source_db_id = stream_table.source_database_id(ctl.as_ref()).await.ok();
+                    let source_db_id = stream_table.source_database_id().ok();
                     if let Some(source_db_id) = source_db_id {
                         source_db_id_set.insert(source_db_id);
                     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  - Removes the legacy fallback that derived a stream’s source database id from the source table metadata when `source_db_id` was missing.
  - `source_db_id` has been written for newly created streams since `2024-06-27`. Streams created before that were lazily migrated on consumption: stream metadata updates backfilled source_db_id and removed the old name-based options.
  - Active legacy streams that have been consumed since then should already be migrated. Streams still missing `source_db_id` are effectively stale, unmigrated metadata, and their base snapshots are expected to be outside the normal retention window.
  - Simplifies stream option handling by treating required stream options consistently and returning a clear error when they are missing.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19921)
<!-- Reviewable:end -->
