### PR TITLE
refactor(sql): Skip redundant Filter [SECURE] when prewhere covers all secure predicates

### DIFF
--- a/scripts/bench_common/__init__.py
+++ b/scripts/bench_common/__init__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Shared benchmark utilities for Databend benchmark scripts."""
+
+from scripts.bench_common.bendsql import BendSQL
+from scripts.bench_common.bendsql import QueryResult
+from scripts.bench_common.bendsql import csv_records
+from scripts.bench_common.bendsql import kv_map
+from scripts.bench_common.runner import CONFIG_DIR
+from scripts.bench_common.runner import ROOT
+from scripts.bench_common.runner import find_meta_bin
+from scripts.bench_common.runner import start_process
+from scripts.bench_common.runner import start_services
+from scripts.bench_common.runner import stop_existing
+from scripts.bench_common.runner import terminate
+from scripts.bench_common.runner import wait_tcp
+
+__all__ = [
+    "BendSQL",
+    "QueryResult",
+    "csv_records",
+    "kv_map",
+    "CONFIG_DIR",
+    "ROOT",
+    "find_meta_bin",
+    "start_process",
+    "start_services",
+    "stop_existing",
+    "terminate",
+    "wait_tcp",
+]

--- a/scripts/bench_common/bendsql.py
+++ b/scripts/bench_common/bendsql.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Common benchmark utilities shared across benchmark scripts."""
+
+from __future__ import annotations
+
+import csv
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class QueryResult:
+    label: str
+    sql: str
+    elapsed_sec: float
+    stdout: str
+    stderr: str
+
+
+class BendSQL:
+    def __init__(self, binary: str, dsn: str | None, dry_run: bool) -> None:
+        self.binary = binary
+        self.dsn = dsn
+        self.dry_run = dry_run
+
+    def run(
+        self, sql: str, label: str, output: str = "csv", echo_stdout: bool = True
+    ) -> QueryResult:
+        cmd = [self.binary, "--output", output, f"--query={sql}"]
+        if self.dsn:
+            cmd[1:1] = ["--dsn", self.dsn]
+
+        printable = " ".join(shlex.quote(part) for part in cmd)
+        print(f"\n[{label}] {printable}", flush=True)
+        start = time.monotonic()
+        if self.dry_run:
+            return QueryResult(label, sql, 0.0, "", "")
+
+        proc = subprocess.run(cmd, text=True, capture_output=True)
+        elapsed = time.monotonic() - start
+        if proc.returncode != 0:
+            print(proc.stdout, end="", file=sys.stdout)
+            print(proc.stderr, end="", file=sys.stderr)
+            raise RuntimeError(f"bendsql failed for {label}, exit={proc.returncode}")
+        if echo_stdout and proc.stdout.strip():
+            print(proc.stdout.strip(), flush=True)
+        if proc.stderr.strip():
+            print(proc.stderr.strip(), file=sys.stderr, flush=True)
+        return QueryResult(label, sql, elapsed, proc.stdout, proc.stderr)
+
+    def try_run(
+        self, sql: str, label: str, output: str = "csv", echo_stdout: bool = True
+    ) -> QueryResult:
+        try:
+            return self.run(sql, label, output, echo_stdout)
+        except RuntimeError as err:
+            print(f"[{label}] skipped: {err}", file=sys.stderr, flush=True)
+            return QueryResult(label, sql, 0.0, "", str(err))
+
+    def run_time_server(self, sql: str, label: str) -> float | None:
+        """Run query with --time=server, return server-side duration in seconds."""
+        cmd = [self.binary, "--time=server", f"--query={sql}"]
+        if self.dsn:
+            cmd[1:1] = ["--dsn", self.dsn]
+        if self.dry_run:
+            return None
+        proc = subprocess.run(cmd, text=True, capture_output=True)
+        if proc.returncode != 0:
+            return None
+        try:
+            return float(proc.stdout.strip())
+        except ValueError:
+            return None
+
+
+def csv_records(stdout: str) -> list[list[str]]:
+    text = stdout.strip()
+    if not text:
+        return []
+    return list(csv.reader(text.splitlines()))
+
+
+def kv_map(stdout: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for row in csv_records(stdout):
+        if len(row) >= 2:
+            out[row[0]] = row[1]
+    return out

--- a/scripts/bench_common/runner.py
+++ b/scripts/bench_common/runner.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Common runner utilities for starting/stopping Databend services."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_DIR = ROOT / "scripts/ci/deploy/config"
+
+
+def find_meta_bin() -> Path:
+    for path in (ROOT / "target/release/databend-meta", ROOT / "target/debug/databend-meta"):
+        if path.exists():
+            return path
+    raise FileNotFoundError("databend-meta not found in target/release or target/debug")
+
+
+def wait_tcp(port: int, timeout: int = 60) -> None:
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts/ci/wait_tcp.py"), "--timeout", str(timeout), "--port", str(port)],
+        check=True,
+    )
+
+
+def stop_existing() -> None:
+    subprocess.run(["killall", "databend-query"], check=False)
+    subprocess.run(["killall", "databend-meta"], check=False)
+    time.sleep(1)
+    subprocess.run(["killall", "-9", "databend-query"], check=False)
+    subprocess.run(["killall", "-9", "databend-meta"], check=False)
+    time.sleep(1)
+
+
+def start_process(cmd: list[str], log: Path) -> subprocess.Popen[str]:
+    log.parent.mkdir(parents=True, exist_ok=True)
+    fd = log.open("w", encoding="utf-8")
+    return subprocess.Popen(cmd, cwd=ROOT, stdout=fd, stderr=subprocess.STDOUT, text=True)
+
+
+def terminate(proc: subprocess.Popen[str] | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def start_services(
+    query_bin: Path,
+    meta_bin: Path,
+    work_dir: Path,
+) -> tuple[subprocess.Popen[str], subprocess.Popen[str]]:
+    """Start meta + query services, return (meta_proc, query_proc)."""
+    import shutil
+
+    logs = work_dir / "logs"
+    data = work_dir / "data"
+
+    stop_existing()
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    logs.mkdir(parents=True, exist_ok=True)
+    data.mkdir(parents=True, exist_ok=True)
+
+    meta_proc = start_process(
+        [
+            str(meta_bin),
+            "-c", str(CONFIG_DIR / "databend-meta-node-1.toml"),
+            "--raft-dir", str(data / "meta"),
+            "--log-dir", str(logs / "meta"),
+        ],
+        logs / "meta.out",
+    )
+    wait_tcp(9191)
+
+    query_proc = start_process(
+        [
+            str(query_bin),
+            "-c", str(CONFIG_DIR / "databend-query-node-1.toml"),
+            "--internal-enable-sandbox-tenant",
+        ],
+        logs / "query.out",
+    )
+    wait_tcp(8000)
+
+    return meta_proc, query_proc

--- a/scripts/recluster/recluster_bench.py
+++ b/scripts/recluster/recluster_bench.py
@@ -9,18 +9,17 @@ intended for local experiments and is not part of the repository test suite.
 from __future__ import annotations
 
 import argparse
-import csv
 import json
 import os
 import re
-import shlex
-import subprocess
 import sys
 import time
 from dataclasses import asdict
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.bench_common.bendsql import BendSQL, QueryResult, csv_records, kv_map
 
 
 RECLUSTER_METRICS = (
@@ -31,15 +30,6 @@ RECLUSTER_METRICS = (
     "fuse_recluster_row_nums_to_read",
     "fuse_recluster_write_block_nums",
 )
-
-
-@dataclass
-class QueryResult:
-    label: str
-    sql: str
-    elapsed_sec: float
-    stdout: str
-    stderr: str
 
 
 def parse_args() -> argparse.Namespace:
@@ -138,63 +128,6 @@ def parse_args() -> argparse.Namespace:
         help="Width of sampled range predicates for --prune-samples.",
     )
     return parser.parse_args()
-
-
-class BendSQL:
-    def __init__(self, binary: str, dsn: str | None, dry_run: bool) -> None:
-        self.binary = binary
-        self.dsn = dsn
-        self.dry_run = dry_run
-
-    def run(
-        self, sql: str, label: str, output: str = "csv", echo_stdout: bool = True
-    ) -> QueryResult:
-        cmd = [self.binary, "--output", output, f"--query={sql}"]
-        if self.dsn:
-            cmd[1:1] = ["--dsn", self.dsn]
-
-        printable = " ".join(shlex.quote(part) for part in cmd)
-        print(f"\n[{label}] {printable}", flush=True)
-        start = time.monotonic()
-        if self.dry_run:
-            elapsed = time.monotonic() - start
-            return QueryResult(label, sql, elapsed, "", "")
-
-        proc = subprocess.run(cmd, text=True, capture_output=True)
-        elapsed = time.monotonic() - start
-        if proc.returncode != 0:
-            print(proc.stdout, end="", file=sys.stdout)
-            print(proc.stderr, end="", file=sys.stderr)
-            raise RuntimeError(f"bendsql failed for {label}, exit={proc.returncode}")
-        if echo_stdout and proc.stdout.strip():
-            print(proc.stdout.strip(), flush=True)
-        if proc.stderr.strip():
-            print(proc.stderr.strip(), file=sys.stderr, flush=True)
-        return QueryResult(label, sql, elapsed, proc.stdout, proc.stderr)
-
-    def try_run(
-        self, sql: str, label: str, output: str = "csv", echo_stdout: bool = True
-    ) -> QueryResult:
-        try:
-            return self.run(sql, label, output, echo_stdout)
-        except RuntimeError as err:
-            print(f"[{label}] skipped: {err}", file=sys.stderr, flush=True)
-            return QueryResult(label, sql, 0.0, "", str(err))
-
-
-def csv_records(stdout: str) -> list[list[str]]:
-    text = stdout.strip()
-    if not text:
-        return []
-    return list(csv.reader(text.splitlines()))
-
-
-def kv_map(stdout: str) -> dict[str, str]:
-    out: dict[str, str] = {}
-    for row in csv_records(stdout):
-        if len(row) >= 2:
-            out[row[0]] = row[1]
-    return out
 
 
 def parse_value(value: str | None) -> Any:

--- a/scripts/recluster/run_recluster_bench_with_bin.py
+++ b/scripts/recluster/run_recluster_bench_with_bin.py
@@ -10,16 +10,18 @@ from __future__ import annotations
 
 import argparse
 import os
-import shutil
-import signal
 import subprocess
 import sys
-import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.bench_common.runner import (
+    ROOT,
+    find_meta_bin,
+    start_services,
+    terminate,
+)
 
-ROOT = Path(__file__).resolve().parents[2]
-CONFIG_DIR = ROOT / "scripts/ci/deploy/config"
 BENCH_SCRIPT = ROOT / "scripts/recluster/recluster_bench.py"
 
 
@@ -38,92 +40,21 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def find_meta_bin() -> Path:
-    for path in (ROOT / "target/release/databend-meta", ROOT / "target/debug/databend-meta"):
-        if path.exists():
-            return path
-    raise FileNotFoundError("databend-meta not found in target/release or target/debug")
-
-
-def wait_tcp(port: int, timeout: int = 60) -> None:
-    subprocess.run(
-        [sys.executable, str(ROOT / "scripts/ci/wait_tcp.py"), "--timeout", str(timeout), "--port", str(port)],
-        check=True,
-    )
-
-
-def stop_existing() -> None:
-    subprocess.run(["killall", "databend-query"], check=False)
-    subprocess.run(["killall", "databend-meta"], check=False)
-    time.sleep(1)
-    subprocess.run(["killall", "-9", "databend-query"], check=False)
-    subprocess.run(["killall", "-9", "databend-meta"], check=False)
-    time.sleep(1)
-
-
-def start_process(cmd: list[str], log: Path) -> subprocess.Popen[str]:
-    log.parent.mkdir(parents=True, exist_ok=True)
-    fd = log.open("w", encoding="utf-8")
-    return subprocess.Popen(cmd, cwd=ROOT, stdout=fd, stderr=subprocess.STDOUT, text=True)
-
-
-def terminate(proc: subprocess.Popen[str] | None) -> None:
-    if proc is None or proc.poll() is not None:
-        return
-    proc.send_signal(signal.SIGTERM)
-    try:
-        proc.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait(timeout=10)
-
-
 def main() -> int:
     args = parse_args()
     query_bin = Path(args.query_bin).resolve()
     meta_bin = Path(args.meta_bin).resolve() if args.meta_bin else find_meta_bin()
     work_dir = Path(args.work_dir).resolve()
-    logs = work_dir / "logs"
-    data = work_dir / "data"
 
     if not query_bin.exists():
         raise FileNotFoundError(query_bin)
     if not meta_bin.exists():
         raise FileNotFoundError(meta_bin)
 
-    stop_existing()
-    if work_dir.exists():
-        shutil.rmtree(work_dir)
-    logs.mkdir(parents=True, exist_ok=True)
-    data.mkdir(parents=True, exist_ok=True)
-
     meta_proc = None
     query_proc = None
     try:
-        meta_proc = start_process(
-            [
-                str(meta_bin),
-                "-c",
-                str(CONFIG_DIR / "databend-meta-node-1.toml"),
-                "--raft-dir",
-                str(data / "meta"),
-                "--log-dir",
-                str(logs / "meta"),
-            ],
-            logs / "meta.out",
-        )
-        wait_tcp(9191)
-
-        query_proc = start_process(
-            [
-                str(query_bin),
-                "-c",
-                str(CONFIG_DIR / "databend-query-node-1.toml"),
-                "--internal-enable-sandbox-tenant",
-            ],
-            logs / "query.out",
-        )
-        wait_tcp(8000)
+        meta_proc, query_proc = start_services(query_bin, meta_bin, work_dir)
 
         cmd = [
             sys.executable,

--- a/scripts/security_policy/README.md
+++ b/scripts/security_policy/README.md
@@ -1,0 +1,124 @@
+# Security Policy Benchmark
+
+Local benchmark for measuring Row Access Policy (RAP) and Data Mask Policy
+performance overhead in Databend.
+
+## What It Measures
+
+1. **RAP vs WHERE**: Overhead of row access policy (auto prewhere pushdown) compared
+   to an equivalent hand-written WHERE clause.
+2. **Mask vs Function**: Overhead of masking policy (auto function replacement) compared
+   to an equivalent hand-written function call in SELECT.
+3. **Planner Cache**: Cold vs warm plan cache latency with and without security policies.
+
+## Usage
+
+### Against a running Databend instance
+
+```bash
+# Default: 5M rows, all complexity levels, 5 bench rounds
+python3 scripts/security_policy/security_policy_bench.py \
+    --dsn "databend://root@127.0.0.1:8000/default?sslmode=disable" \
+    --output tmp/security_policy_bench_result.json
+
+# Quick run: single complexity, fewer rounds
+python3 scripts/security_policy/security_policy_bench.py \
+    --complexity simple --bench-rounds 3 --output tmp/quick.json
+
+# Dry run: print generated SQL without executing
+python3 scripts/security_policy/security_policy_bench.py --dry-run
+```
+
+### With a specific binary (auto start/stop services)
+
+```bash
+python3 scripts/security_policy/run_security_policy_bench_with_bin.py \
+    --query-bin target/release/databend-query \
+    --output tmp/result.json
+```
+
+### Cross-version A/B comparison
+
+```bash
+python3 scripts/security_policy/run_security_policy_bench_with_bin.py \
+    --query-bin target/release/databend-query \
+    --compare-bin /path/to/other/databend-query \
+    --output tmp/result.json
+```
+
+This runs the benchmark on both binaries and outputs a diff report. Regressions
+(>5% slower) are flagged.
+
+## CLI Arguments
+
+### security_policy_bench.py
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--dsn` | env `BENDSQL_DSN` | bendsql connection string |
+| `--rows` | 5,000,000 | Total rows to insert |
+| `--rows-per-batch` | 1,000,000 | Rows per INSERT batch |
+| `--rows-per-block` | 10,000 | ROW_PER_BLOCK table option |
+| `--blocks-per-segment` | 10 | BLOCK_PER_SEGMENT table option |
+| `--complexity` | all | RAP/mask complexity: simple, range, complex, all |
+| `--pattern` | all | Query pattern filter |
+| `--warmup-rounds` | 2 | Warmup iterations before measurement |
+| `--bench-rounds` | 5 | Measurement iterations |
+| `--output` | none | JSON output path |
+| `--keep` | false | Don't drop database before run |
+| `--drop-after` | false | Drop database after run |
+| `--dry-run` | false | Print SQL without executing |
+
+### run_security_policy_bench_with_bin.py
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--query-bin` | required | Path to databend-query binary |
+| `--meta-bin` | auto-detect | Path to databend-meta binary |
+| `--compare-bin` | none | Second binary for A/B comparison |
+| `--bench-arg` | none | Extra args passed to bench script (repeatable) |
+| `--no-stop` | false | Leave services running after bench |
+
+## Metrics
+
+### Primary metrics (per query)
+
+- `duration_ms`: Best-of-N wall time (ms)
+- `duration_avg_ms`: Average wall time across rounds
+- `all_ms`: All individual round timings
+
+### Pruning stats (RAP queries)
+
+- `segments_before/after`: Segment range pruning
+- `blocks_before/after`: Block range pruning
+- `*_pruned_pct`: Percentage pruned
+
+### Summary output
+
+- `rap_vs_where.overhead_pct`: Policy overhead relative to manual WHERE
+- `mask_vs_func.overhead_pct`: Policy overhead relative to manual function
+
+## Test Table
+
+```sql
+CREATE TABLE bench_security (
+    id         INT NOT NULL,
+    tenant_id  INT NOT NULL,
+    email      VARCHAR NOT NULL,
+    amount     DECIMAL(18,2) NOT NULL,
+    status     VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL
+) CLUSTER BY (created_at);
+```
+
+- Clustered by time (realistic production pattern)
+- 100 distinct tenant_id values scattered across all blocks
+- RAP predicates on tenant_id force prewhere filtering (no cluster pruning shortcut)
+
+## Policy Complexity Levels
+
+| Level | RAP predicate | Mask expression |
+|-------|--------------|-----------------|
+| simple | `tenant_id = 1` | `'***'` |
+| range | `tenant_id BETWEEN 10 AND 30` | `CONCAT(LEFT(val,3), '***@***.com')` |
+| complex | `tenant_id % 10 = 0 AND status = 'active'` | `CASE WHEN ... END` |

--- a/scripts/security_policy/run_security_policy_bench_with_bin.py
+++ b/scripts/security_policy/run_security_policy_bench_with_bin.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Runner for security policy benchmarks.
+
+Starts databend-meta and databend-query from specified binaries, runs
+security_policy_bench.py, and shuts services down. Supports --compare-bin
+for cross-version A/B comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.bench_common.runner import (
+    ROOT,
+    find_meta_bin,
+    start_services,
+    stop_existing,
+    terminate,
+)
+
+BENCH_SCRIPT = ROOT / "scripts/security_policy/security_policy_bench.py"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query-bin", required=True, help="Path to databend-query binary")
+    parser.add_argument("--meta-bin", default=None, help="Path to databend-meta binary")
+    parser.add_argument("--compare-bin", default=None, help="Second query binary for A/B comparison")
+    parser.add_argument("--work-dir", default=str(ROOT / ".databend/security_policy_bench"))
+    parser.add_argument("--output", default=str(ROOT / "tmp/security_policy_bench_result.json"))
+    parser.add_argument(
+        "--dsn",
+        default=os.getenv("BENDSQL_DSN", "databend://root@127.0.0.1:8000/default?sslmode=disable"),
+    )
+    parser.add_argument("--bench-arg", action="append", default=[])
+    parser.add_argument("--no-stop", action="store_true", help="Leave services running after bench")
+    return parser.parse_args()
+
+
+def run_bench(dsn: str, output: str, extra_args: list[str]) -> dict:
+    cmd = [
+        sys.executable,
+        str(BENCH_SCRIPT),
+        "--dsn", dsn,
+        "--output", output,
+    ]
+    for item in extra_args:
+        cmd.extend(item.split())
+    print(f"running: {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, cwd=ROOT, check=True)
+    with open(output, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compare_results(result_a: dict, result_b: dict) -> dict:
+    comparison = []
+    results_a = {(r["complexity"], r["pattern"], r["mode"], r["cache"]): r for r in result_a.get("results", [])}
+    results_b = {(r["complexity"], r["pattern"], r["mode"], r["cache"]): r for r in result_b.get("results", [])}
+
+    for key in results_a:
+        if key not in results_b:
+            continue
+        ma = results_a[key]["metrics"]
+        mb = results_b[key]["metrics"]
+        dur_a = ma["duration_ms"]
+        dur_b = mb["duration_ms"]
+        diff_pct = ((dur_b - dur_a) / dur_a * 100) if dur_a > 0 else 0
+        comparison.append({
+            "complexity": key[0],
+            "pattern": key[1],
+            "mode": key[2],
+            "cache": key[3],
+            "binary_a_ms": dur_a,
+            "binary_b_ms": dur_b,
+            "diff_pct": round(diff_pct, 2),
+            "regression": diff_pct > 5.0,
+        })
+
+    return {"comparison": comparison}
+
+
+def main() -> int:
+    args = parse_args()
+    query_bin = Path(args.query_bin).resolve()
+    meta_bin = Path(args.meta_bin).resolve() if args.meta_bin else find_meta_bin()
+    work_dir = Path(args.work_dir).resolve()
+
+    if not query_bin.exists():
+        raise FileNotFoundError(query_bin)
+    if not meta_bin.exists():
+        raise FileNotFoundError(meta_bin)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    meta_proc = None
+    query_proc = None
+    try:
+        meta_proc, query_proc = start_services(query_bin, meta_bin, work_dir)
+        result_a = run_bench(args.dsn, args.output, args.bench_arg)
+    finally:
+        if not args.no_stop:
+            terminate(query_proc)
+            terminate(meta_proc)
+
+    if args.compare_bin:
+        compare_bin = Path(args.compare_bin).resolve()
+        if not compare_bin.exists():
+            raise FileNotFoundError(compare_bin)
+
+        output_b = str(output_path.with_stem(output_path.stem + "_b"))
+        try:
+            meta_proc, query_proc = start_services(compare_bin, meta_bin, work_dir)
+            result_b = run_bench(args.dsn, output_b, args.bench_arg)
+        finally:
+            if not args.no_stop:
+                terminate(query_proc)
+                terminate(meta_proc)
+
+        diff = compare_results(result_a, result_b)
+        diff_path = str(output_path.with_stem(output_path.stem + "_diff"))
+        with open(diff_path, "w", encoding="utf-8") as f:
+            json.dump(diff, f, indent=2)
+        print(f"\nComparison written to: {diff_path}")
+
+        regressions = [c for c in diff["comparison"] if c["regression"]]
+        if regressions:
+            print(f"\n*** {len(regressions)} REGRESSIONS DETECTED (>5% slower) ***")
+            for r in regressions:
+                print(f"  {r['complexity']}/{r['pattern']}/{r['mode']}: "
+                      f"{r['binary_a_ms']:.1f}ms -> {r['binary_b_ms']:.1f}ms ({r['diff_pct']:+.1f}%)")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security_policy/security_policy_bench.py
+++ b/scripts/security_policy/security_policy_bench.py
@@ -1,0 +1,740 @@
+#!/usr/bin/env python3
+"""
+Security policy (RAP / Data Mask) benchmark.
+
+Measures performance overhead of row access policies and data masking policies
+compared to equivalent manual WHERE clauses and function calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.bench_common.bendsql import BendSQL, QueryResult, csv_records, kv_map
+
+
+# ---------------------------------------------------------------------------
+# Policy and query definitions
+# ---------------------------------------------------------------------------
+
+RAP_POLICIES: dict[str, dict[str, str]] = {
+    "simple": {
+        "body": "(tenant_id INT, status VARCHAR) RETURNS BOOLEAN -> tenant_id = 1",
+        "columns": "(tenant_id, status)",
+    },
+    "range": {
+        "body": "(tenant_id INT, status VARCHAR) RETURNS BOOLEAN -> tenant_id BETWEEN 10 AND 30",
+        "columns": "(tenant_id, status)",
+    },
+    "complex": {
+        "body": "(tenant_id INT, status VARCHAR) RETURNS BOOLEAN -> tenant_id % 10 = 0 AND status = 'active'",
+        "columns": "(tenant_id, status)",
+    },
+}
+
+MASK_POLICIES: dict[str, dict[str, str]] = {
+    "simple": {
+        "body": "(val STRING) RETURNS STRING -> '***'",
+        "column": "email",
+    },
+    "range": {
+        "body": "(val STRING) RETURNS STRING -> CONCAT(LEFT(val, 3), '***@***.com')",
+        "column": "email",
+    },
+    "complex": {
+        "body": "(val STRING) RETURNS STRING -> CASE WHEN LENGTH(val) > 5 THEN CONCAT(LEFT(val, 2), REPEAT('*', LENGTH(val) - 4), RIGHT(val, 2)) ELSE '***' END",
+        "column": "email",
+    },
+}
+
+def rap_where_equivalent(complexity: str) -> str:
+    mapping = {
+        "simple": "tenant_id = 1",
+        "range": "tenant_id BETWEEN 10 AND 30",
+        "complex": "tenant_id % 10 = 0 AND status = 'active'",
+    }
+    return mapping[complexity]
+
+
+def mask_func_equivalent(complexity: str) -> str:
+    mapping = {
+        "simple": "'***' AS email",
+        "range": "CONCAT(LEFT(email, 3), '***@***.com') AS email",
+        "complex": "CASE WHEN LENGTH(email) > 5 THEN CONCAT(LEFT(email, 2), REPEAT('*', LENGTH(email) - 4), RIGHT(email, 2)) ELSE '***' END AS email",
+    }
+    return mapping[complexity]
+
+
+def query_patterns(table: str, complexity: str) -> list[dict[str, str]]:
+    where_clause = rap_where_equivalent(complexity)
+    return [
+        {
+            "name": "point",
+            "rap": f"SELECT id, email, amount FROM {table} LIMIT 50000",
+            "where": f"SELECT id, email, amount FROM {table} WHERE {where_clause} LIMIT 50000",
+        },
+        {
+            "name": "range_scan",
+            "rap": f"SELECT id, email FROM {table}",
+            "where": f"SELECT id, email FROM {table} WHERE {where_clause}",
+        },
+        {
+            "name": "order_limit",
+            "rap": f"SELECT id, email, amount FROM {table} ORDER BY created_at DESC LIMIT 100",
+            "where": f"SELECT id, email, amount FROM {table} WHERE {where_clause} ORDER BY created_at DESC LIMIT 100",
+        },
+        {
+            "name": "agg",
+            "rap": f"SELECT COUNT(*), SUM(amount) FROM {table}",
+            "where": f"SELECT COUNT(*), SUM(amount) FROM {table} WHERE {where_clause}",
+        },
+    ]
+
+
+def mask_query_patterns(table: str, complexity: str) -> list[dict[str, str]]:
+    func_expr = mask_func_equivalent(complexity)
+    return [
+        {
+            "name": "full_scan",
+            "mask": f"SELECT email, id FROM {table} LIMIT 50000",
+            "func": f"SELECT {func_expr}, id FROM {table} LIMIT 50000",
+        },
+        {
+            "name": "full_scan_large",
+            "mask": f"SELECT email FROM {table}",
+            "func": f"SELECT {func_expr} FROM {table}",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Metrics collection
+# ---------------------------------------------------------------------------
+
+def collect_query_metrics(bs: BendSQL, query_id: str) -> dict[str, Any]:
+    sql = f"""
+SELECT query_duration_ms, scan_rows, scan_bytes, scan_partitions,
+       total_partitions, result_rows, result_bytes
+FROM system.query_log
+WHERE query_id = '{query_id}' AND exception_code = 0
+ORDER BY event_time DESC LIMIT 1
+"""
+    res = bs.try_run(sql, f"metrics-{query_id[:8]}", echo_stdout=False)
+    rows = csv_records(res.stdout)
+    if not rows:
+        return {}
+    r = rows[0]
+    if len(r) < 7:
+        return {}
+    return {
+        "duration_ms": float(r[0]),
+        "scan_rows": int(r[1]),
+        "scan_bytes": int(r[2]),
+        "scan_partitions": int(r[3]),
+        "total_partitions": int(r[4]),
+        "result_rows": int(r[5]),
+        "result_bytes": int(r[6]),
+    }
+
+
+def parse_pruning_stats(explain_output: str) -> dict[str, Any]:
+    stats: dict[str, Any] = {}
+    seg_match = __import__("re").search(
+        r"segments:\s*<range pruning:\s*(\d+)\s*to\s*(\d+)", explain_output
+    )
+    if seg_match:
+        before, after = int(seg_match.group(1)), int(seg_match.group(2))
+        stats["segments_before"] = before
+        stats["segments_after"] = after
+        stats["segments_pruned_pct"] = round((before - after) / before * 100, 2) if before > 0 else 0
+
+    block_match = __import__("re").search(
+        r"blocks:\s*<\s*range pruning:\s*(\d+)\s*to\s*(\d+)", explain_output
+    )
+    if block_match:
+        before, after = int(block_match.group(1)), int(block_match.group(2))
+        stats["blocks_before"] = before
+        stats["blocks_after"] = after
+        stats["blocks_pruned_pct"] = round((before - after) / before * 100, 2) if before > 0 else 0
+
+    return stats
+
+
+def collect_cache_stats(bs: BendSQL) -> dict[str, dict[str, int]]:
+    res = bs.try_run(
+        "SELECT name, num_items, size, access, hit, miss FROM system.caches",
+        "caches", echo_stdout=False,
+    )
+    out: dict[str, dict[str, int]] = {}
+    for row in csv_records(res.stdout):
+        if len(row) >= 6:
+            out[row[0]] = {
+                "num_items": int(row[1]),
+                "size": int(row[2]),
+                "access": int(row[3]),
+                "hit": int(row[4]),
+                "miss": int(row[5]),
+            }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Data generation
+# ---------------------------------------------------------------------------
+
+def create_table_sql(database: str, table: str, row_per_block: int, block_per_segment: int) -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {database}.{table} (
+    id         INT NOT NULL,
+    tenant_id  INT NOT NULL,
+    email      VARCHAR NOT NULL,
+    amount     DECIMAL(18,2) NOT NULL,
+    status     VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL
+)
+CLUSTER BY (created_at)
+ROW_PER_BLOCK = {row_per_block}
+BLOCK_PER_SEGMENT = {block_per_segment}
+"""
+
+
+def insert_sql(database: str, table: str, batch: int, rows_per_batch: int) -> str:
+    offset = batch * rows_per_batch
+    return f"""
+INSERT INTO {database}.{table}
+SELECT
+    (number + {offset})::INT AS id,
+    (number % 100)::INT AS tenant_id,
+    CONCAT('user', to_string(number + {offset}), '@example.com') AS email,
+    ((number % 10000) * 1.5)::DECIMAL(18,2) AS amount,
+    CASE WHEN number % 3 = 0 THEN 'active' WHEN number % 3 = 1 THEN 'inactive' ELSE 'pending' END AS status,
+    to_timestamp({offset} + number) AS created_at
+FROM numbers({rows_per_batch})
+"""
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+def run_query_timed(bs: BendSQL, sql: str, label: str, rounds: int) -> tuple[list[float], list[float]]:
+    """Returns (client_times_sec, server_times_sec)."""
+    client_times = []
+    server_times = []
+    for i in range(rounds):
+        res = bs.run(sql, f"{label}-r{i}", output="null", echo_stdout=False)
+        client_times.append(res.elapsed_sec)
+        # Get server-side time via --time=server
+        if not bs.dry_run:
+            srv = bs.run_time_server(sql, f"{label}-srv-r{i}")
+            if srv is not None:
+                server_times.append(srv)
+    return client_times, server_times
+
+
+def bench_rap(
+    bs: BendSQL,
+    database: str,
+    table: str,
+    complexity: str,
+    warmup: int,
+    rounds: int,
+) -> list[dict[str, Any]]:
+    full_table = f"{database}.{table}"
+    policy_name = f"bench_rap_{complexity}"
+    policy_def = RAP_POLICIES[complexity]
+    results = []
+
+    patterns = query_patterns(full_table, complexity)
+    for pat in patterns:
+        # Mode: where (baseline)
+        run_query_timed(bs, pat["where"], f"warmup-where-{complexity}-{pat['name']}", warmup)
+        client_times, server_times = run_query_timed(bs, pat["where"], f"where-{complexity}-{pat['name']}", rounds)
+        metrics: dict[str, Any] = {
+            "duration_ms": round(min(client_times) * 1000, 2),
+            "duration_avg_ms": round(sum(client_times) / len(client_times) * 1000, 2),
+            "all_ms": [round(t * 1000, 2) for t in client_times],
+        }
+        if server_times:
+            metrics["server_min_ms"] = round(min(server_times) * 1000, 2)
+            metrics["server_avg_ms"] = round(sum(server_times) / len(server_times) * 1000, 2)
+        results.append({
+            "complexity": complexity,
+            "pattern": pat["name"],
+            "mode": "where",
+            "cache": "warm",
+            "metrics": metrics,
+        })
+
+        # Mode: rap
+        bs.try_run(
+            f"DROP ROW ACCESS POLICY IF EXISTS {policy_name}",
+            f"drop-rap-pre-{complexity}", output="null",
+        )
+        bs.run(
+            f"CREATE ROW ACCESS POLICY {policy_name} AS {policy_def['body']}",
+            f"create-rap-{complexity}", output="null",
+        )
+        bs.run(
+            f"ALTER TABLE {full_table} ADD ROW ACCESS POLICY {policy_name} ON {policy_def['columns']}",
+            f"attach-rap-{complexity}", output="null",
+        )
+
+        run_query_timed(bs, pat["rap"], f"warmup-rap-{complexity}-{pat['name']}", warmup)
+        client_times, server_times = run_query_timed(bs, pat["rap"], f"rap-{complexity}-{pat['name']}", rounds)
+        metrics = {
+            "duration_ms": round(min(client_times) * 1000, 2),
+            "duration_avg_ms": round(sum(client_times) / len(client_times) * 1000, 2),
+            "all_ms": [round(t * 1000, 2) for t in client_times],
+        }
+        if server_times:
+            metrics["server_min_ms"] = round(min(server_times) * 1000, 2)
+            metrics["server_avg_ms"] = round(sum(server_times) / len(server_times) * 1000, 2)
+        results.append({
+            "complexity": complexity,
+            "pattern": pat["name"],
+            "mode": "rap",
+            "cache": "warm",
+            "metrics": metrics,
+        })
+
+        # Collect EXPLAIN pruning stats for the rap query
+        explain_res = bs.try_run(
+            f"EXPLAIN ANALYZE {pat['rap']}", f"explain-rap-{complexity}-{pat['name']}",
+            echo_stdout=False,
+        )
+        pruning = parse_pruning_stats(explain_res.stdout)
+        if pruning:
+            results[-1]["pruning"] = pruning
+
+        bs.run(
+            f"ALTER TABLE {full_table} DROP ROW ACCESS POLICY {policy_name}",
+            f"drop-rap-{complexity}-{pat['name']}", output="null",
+        )
+
+    return results
+
+
+def bench_mask(
+    bs: BendSQL,
+    database: str,
+    table: str,
+    complexity: str,
+    warmup: int,
+    rounds: int,
+) -> list[dict[str, Any]]:
+    full_table = f"{database}.{table}"
+    policy_name = f"bench_mask_{complexity}"
+    mask_def = MASK_POLICIES[complexity]
+    results = []
+
+    patterns = mask_query_patterns(full_table, complexity)
+    for pat in patterns:
+        # Mode: func (baseline)
+        run_query_timed(bs, pat["func"], f"warmup-func-{complexity}-{pat['name']}", warmup)
+        client_times, server_times = run_query_timed(bs, pat["func"], f"func-{complexity}-{pat['name']}", rounds)
+        metrics: dict[str, Any] = {
+            "duration_ms": round(min(client_times) * 1000, 2),
+            "duration_avg_ms": round(sum(client_times) / len(client_times) * 1000, 2),
+            "all_ms": [round(t * 1000, 2) for t in client_times],
+        }
+        if server_times:
+            metrics["server_min_ms"] = round(min(server_times) * 1000, 2)
+            metrics["server_avg_ms"] = round(sum(server_times) / len(server_times) * 1000, 2)
+        results.append({
+            "complexity": complexity,
+            "pattern": pat["name"],
+            "mode": "func",
+            "cache": "warm",
+            "metrics": metrics,
+        })
+
+        # Mode: mask
+        bs.try_run(
+            f"DROP MASKING POLICY IF EXISTS {policy_name}",
+            f"drop-mask-pre-{complexity}", output="null",
+        )
+        bs.run(
+            f"CREATE MASKING POLICY {policy_name} AS {mask_def['body']}",
+            f"create-mask-{complexity}", output="null",
+        )
+        bs.run(
+            f"ALTER TABLE {full_table} MODIFY COLUMN {mask_def['column']} SET MASKING POLICY {policy_name}",
+            f"attach-mask-{complexity}", output="null",
+        )
+
+        run_query_timed(bs, pat["mask"], f"warmup-mask-{complexity}-{pat['name']}", warmup)
+        client_times, server_times = run_query_timed(bs, pat["mask"], f"mask-{complexity}-{pat['name']}", rounds)
+        metrics = {
+            "duration_ms": round(min(client_times) * 1000, 2),
+            "duration_avg_ms": round(sum(client_times) / len(client_times) * 1000, 2),
+            "all_ms": [round(t * 1000, 2) for t in client_times],
+        }
+        if server_times:
+            metrics["server_min_ms"] = round(min(server_times) * 1000, 2)
+            metrics["server_avg_ms"] = round(sum(server_times) / len(server_times) * 1000, 2)
+        results.append({
+            "complexity": complexity,
+            "pattern": pat["name"],
+            "mode": "mask",
+            "cache": "warm",
+            "metrics": metrics,
+        })
+
+        bs.run(
+            f"ALTER TABLE {full_table} MODIFY COLUMN {mask_def['column']} UNSET MASKING POLICY",
+            f"drop-mask-{complexity}-{pat['name']}", output="null",
+        )
+
+    return results
+
+
+def bench_planner_cache(
+    bs: BendSQL,
+    database: str,
+    table: str,
+    complexity: str,
+    rounds: int,
+) -> list[dict[str, Any]]:
+    full_table = f"{database}.{table}"
+    policy_name = f"bench_rap_cache_{complexity}"
+    policy_def = RAP_POLICIES[complexity]
+    results = []
+
+    test_sql = f"SELECT COUNT(*) FROM {full_table}"
+
+    # Without policy: cold vs warm (baseline)
+    bs.run("SET enable_planner_cache = 1", "cache-enable", output="null")
+
+    cold = bs.run(test_sql, "cache-cold-no-policy", output="null", echo_stdout=False)
+    warm_times, _ = run_query_timed(bs, test_sql, "cache-warm-no-policy", rounds)
+    results.append({
+        "complexity": complexity,
+        "pattern": "planner_cache",
+        "mode": "where",
+        "cache": "cold",
+        "metrics": {"duration_ms": round(cold.elapsed_sec * 1000, 2)},
+    })
+    results.append({
+        "complexity": complexity,
+        "pattern": "planner_cache",
+        "mode": "where",
+        "cache": "warm",
+        "metrics": {
+            "duration_ms": round(min(warm_times) * 1000, 2),
+            "duration_avg_ms": round(sum(warm_times) / len(warm_times) * 1000, 2),
+        },
+    })
+
+    # With RAP policy: 3-layer cache isolation
+    # Layer 1: both_cold - first query after fresh policy attach (policy cache miss + planner cache miss)
+    # Layer 2: policy_warm_planner_cold - different SQL text forces planner miss, policy cache hit
+    # Layer 3: both_warm - same SQL repeated (both caches hit)
+
+    # Fresh policy: drop and recreate to ensure policy cache miss
+    bs.try_run(
+        f"DROP ROW ACCESS POLICY IF EXISTS {policy_name}",
+        "cache-drop-rap-pre", output="null",
+    )
+    bs.run(
+        f"CREATE ROW ACCESS POLICY {policy_name} AS {policy_def['body']}",
+        "cache-create-rap", output="null",
+    )
+    bs.run(
+        f"ALTER TABLE {full_table} ADD ROW ACCESS POLICY {policy_name} ON {policy_def['columns']}",
+        "cache-attach-rap", output="null",
+    )
+
+    # Layer 1: both_cold (first query - policy cache miss + planner cache miss)
+    # Use SQL variant A
+    sql_a = f"SELECT COUNT(*) FROM {full_table}"
+    both_cold = bs.run(sql_a, "cache-both-cold", output="null", echo_stdout=False)
+    results.append({
+        "complexity": complexity,
+        "pattern": "planner_cache",
+        "mode": "rap",
+        "cache": "both_cold",
+        "metrics": {"duration_ms": round(both_cold.elapsed_sec * 1000, 2)},
+    })
+
+    # Layer 2: policy_warm_planner_cold
+    # Different SQL text → planner cache miss; same policy_id → policy cache hit
+    sql_b = f"SELECT COUNT(1) FROM {full_table}"
+    policy_warm = bs.run(sql_b, "cache-policy-warm-planner-cold", output="null", echo_stdout=False)
+    results.append({
+        "complexity": complexity,
+        "pattern": "planner_cache",
+        "mode": "rap",
+        "cache": "policy_warm",
+        "metrics": {"duration_ms": round(policy_warm.elapsed_sec * 1000, 2)},
+    })
+
+    # Layer 3: both_warm (repeat sql_a - both caches hit from Layer 1)
+    warm_times, _ = run_query_timed(bs, sql_a, "cache-both-warm", rounds)
+    results.append({
+        "complexity": complexity,
+        "pattern": "planner_cache",
+        "mode": "rap",
+        "cache": "both_warm",
+        "metrics": {
+            "duration_ms": round(min(warm_times) * 1000, 2),
+            "duration_avg_ms": round(sum(warm_times) / len(warm_times) * 1000, 2),
+        },
+    })
+
+    bs.run(
+        f"ALTER TABLE {full_table} DROP ROW ACCESS POLICY {policy_name}",
+        "cache-drop-rap", output="null",
+    )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Summary computation
+# ---------------------------------------------------------------------------
+
+def compute_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    rap_vs_where: list[dict[str, Any]] = []
+    mask_vs_func: list[dict[str, Any]] = []
+    cache_results: list[dict[str, Any]] = []
+
+    by_key: dict[tuple, dict] = {}
+    for r in results:
+        key = (r["complexity"], r["pattern"], r["mode"], r["cache"])
+        by_key[key] = r
+
+    complexities = {r["complexity"] for r in results}
+    patterns = {r["pattern"] for r in results}
+
+    for c in sorted(complexities):
+        for p in sorted(patterns):
+            if p == "planner_cache":
+                # Planner cache: output 3-layer comparison
+                for mode in ("where",):
+                    cold_r = by_key.get((c, p, mode, "cold"))
+                    warm_r = by_key.get((c, p, mode, "warm"))
+                    if cold_r and warm_r:
+                        cold_ms = cold_r["metrics"]["duration_ms"]
+                        warm_ms = warm_r["metrics"]["duration_ms"]
+                        speedup = ((cold_ms - warm_ms) / cold_ms * 100) if cold_ms > 0 else 0
+                        cache_results.append({
+                            "complexity": c, "mode": mode, "layer": "planner",
+                            "cold_ms": cold_ms, "warm_ms": warm_ms,
+                            "speedup_pct": round(speedup, 2),
+                        })
+
+                both_cold_r = by_key.get((c, p, "rap", "both_cold"))
+                policy_warm_r = by_key.get((c, p, "rap", "policy_warm"))
+                both_warm_r = by_key.get((c, p, "rap", "both_warm"))
+                if both_cold_r and policy_warm_r and both_warm_r:
+                    both_cold_ms = both_cold_r["metrics"]["duration_ms"]
+                    policy_warm_ms = policy_warm_r["metrics"]["duration_ms"]
+                    both_warm_ms = both_warm_r["metrics"]["duration_ms"]
+                    meta_cost = round(both_cold_ms - policy_warm_ms, 2)
+                    planning_cost = round(policy_warm_ms - both_warm_ms, 2)
+                    cache_results.append({
+                        "complexity": c, "mode": "rap", "layer": "3-layer",
+                        "both_cold_ms": both_cold_ms,
+                        "policy_warm_ms": policy_warm_ms,
+                        "both_warm_ms": both_warm_ms,
+                        "meta_rpc_cost_ms": meta_cost,
+                        "planning_cost_ms": planning_cost,
+                    })
+                continue
+
+            rap_r = by_key.get((c, p, "rap", "warm"))
+            where_r = by_key.get((c, p, "where", "warm"))
+            if rap_r and where_r:
+                rap_ms = rap_r["metrics"].get("server_min_ms", rap_r["metrics"]["duration_ms"])
+                where_ms = where_r["metrics"].get("server_min_ms", where_r["metrics"]["duration_ms"])
+                overhead = ((rap_ms - where_ms) / where_ms * 100) if where_ms > 0 else 0
+                rap_vs_where.append({
+                    "complexity": c, "pattern": p,
+                    "rap_ms": rap_ms, "where_ms": where_ms,
+                    "overhead_pct": round(overhead, 2),
+                    "source": "server" if "server_min_ms" in rap_r["metrics"] else "client",
+                })
+
+            mask_r = by_key.get((c, p, "mask", "warm"))
+            func_r = by_key.get((c, p, "func", "warm"))
+            if mask_r and func_r:
+                mask_ms = mask_r["metrics"].get("server_min_ms", mask_r["metrics"]["duration_ms"])
+                func_ms = func_r["metrics"].get("server_min_ms", func_r["metrics"]["duration_ms"])
+                overhead = ((mask_ms - func_ms) / func_ms * 100) if func_ms > 0 else 0
+                mask_vs_func.append({
+                    "complexity": c, "pattern": p,
+                    "mask_ms": mask_ms, "func_ms": func_ms,
+                    "overhead_pct": round(overhead, 2),
+                    "source": "server" if "server_min_ms" in mask_r["metrics"] else "client",
+                })
+
+    return {
+        "rap_vs_where": rap_vs_where,
+        "mask_vs_func": mask_vs_func,
+        "planner_cache": cache_results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI and main
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark RAP and Data Mask policy overhead."
+    )
+    parser.add_argument("--dsn", default=os.getenv("BENDSQL_DSN"), help="bendsql DSN")
+    parser.add_argument("--bendsql", default=os.getenv("BENDSQL", "bendsql"))
+    parser.add_argument("--database", default="tmp_security_policy_bench")
+    parser.add_argument("--table", default="bench_security")
+    parser.add_argument("--rows", type=int, default=5_000_000)
+    parser.add_argument("--rows-per-batch", type=int, default=1_000_000)
+    parser.add_argument("--rows-per-block", type=int, default=10_000)
+    parser.add_argument("--blocks-per-segment", type=int, default=10)
+    parser.add_argument(
+        "--complexity",
+        choices=["simple", "range", "complex", "all"],
+        default="all",
+    )
+    parser.add_argument(
+        "--pattern",
+        choices=["point", "range_scan", "order_limit", "agg", "full_scan", "all"],
+        default="all",
+    )
+    parser.add_argument("--warmup-rounds", type=int, default=2)
+    parser.add_argument("--bench-rounds", type=int, default=5)
+    parser.add_argument("--output", default=None, help="Write JSON result to this file")
+    parser.add_argument("--keep", action="store_true", help="Do not drop database first")
+    parser.add_argument("--drop-after", action="store_true", help="Drop database after run")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def print_summary(summary: dict[str, Any]) -> None:
+    print("\n" + "=" * 70)
+    print("SUMMARY: RAP vs WHERE (overhead %)")
+    print("-" * 70)
+    for item in summary.get("rap_vs_where", []):
+        flag = "!!!" if item["overhead_pct"] > 5 else "   "
+        print(f"  {flag} {item['complexity']:8s} | {item['pattern']:12s} | "
+              f"rap={item['rap_ms']:8.1f}ms  where={item['where_ms']:8.1f}ms  "
+              f"overhead={item['overhead_pct']:+.1f}%")
+
+    print("\nSUMMARY: MASK vs FUNC (overhead %)")
+    print("-" * 70)
+    for item in summary.get("mask_vs_func", []):
+        flag = "!!!" if item["overhead_pct"] > 5 else "   "
+        print(f"  {flag} {item['complexity']:8s} | {item['pattern']:12s} | "
+              f"mask={item['mask_ms']:8.1f}ms  func={item['func_ms']:8.1f}ms  "
+              f"overhead={item['overhead_pct']:+.1f}%")
+
+    print("\nSUMMARY: CACHE LAYERS (cost isolation)")
+    print("-" * 70)
+    for item in summary.get("planner_cache", []):
+        if item.get("layer") == "planner":
+            print(f"       {item['complexity']:8s} | {item['mode']:5s} | "
+                  f"cold={item['cold_ms']:8.1f}ms  warm={item['warm_ms']:8.1f}ms  "
+                  f"speedup={item['speedup_pct']:+.1f}%")
+        elif item.get("layer") == "3-layer":
+            print(f"       {item['complexity']:8s} | rap   | "
+                  f"both_cold={item['both_cold_ms']:.1f}ms  "
+                  f"policy_warm={item['policy_warm_ms']:.1f}ms  "
+                  f"both_warm={item['both_warm_ms']:.1f}ms")
+            print(f"       {'':8s} |       | "
+                  f"meta_rpc={item['meta_rpc_cost_ms']:+.1f}ms  "
+                  f"planning={item['planning_cost_ms']:+.1f}ms")
+    print("=" * 70)
+
+
+def main() -> int:
+    args = parse_args()
+    bs = BendSQL(args.bendsql, args.dsn, args.dry_run)
+
+    complexities = ["simple", "range", "complex"] if args.complexity == "all" else [args.complexity]
+
+    # Setup
+    if not args.keep:
+        bs.try_run(f"DROP DATABASE IF EXISTS {args.database}", "drop-db", output="null")
+    bs.run(f"CREATE DATABASE IF NOT EXISTS {args.database}", "create-db", output="null")
+    bs.run(
+        create_table_sql(args.database, args.table, args.rows_per_block, args.blocks_per_segment),
+        "create-table", output="null",
+    )
+
+    # Insert data (skip if --keep and table already has data)
+    if not args.keep:
+        batches = (args.rows + args.rows_per_batch - 1) // args.rows_per_batch
+        print(f"\nInserting {args.rows} rows in {batches} batches...", flush=True)
+        for i in range(batches):
+            batch_rows = min(args.rows_per_batch, args.rows - i * args.rows_per_batch)
+            bs.run(
+                insert_sql(args.database, args.table, i, batch_rows),
+                f"insert-batch-{i}", output="null",
+            )
+
+    # Verify data setup
+    full_table = f"{args.database}.{args.table}"
+    count_res = bs.try_run(f"SELECT COUNT(*) FROM {full_table}", "count-rows", echo_stdout=False)
+    snapshot_res = bs.try_run(
+        f"SELECT segment_count, block_count, row_count FROM fuse_snapshot('{args.database}', '{args.table}') LIMIT 1",
+        "snapshot-info", echo_stdout=False,
+    )
+    data_setup: dict[str, Any] = {"rows": args.rows}
+    snap_rows = csv_records(snapshot_res.stdout)
+    if snap_rows and len(snap_rows[0]) >= 3:
+        data_setup["segments"] = int(snap_rows[0][0])
+        data_setup["blocks"] = int(snap_rows[0][1])
+        data_setup["actual_rows"] = int(snap_rows[0][2])
+    print(f"Data setup: {data_setup}", flush=True)
+
+    # Switch to the benchmark database for policy DDL (policies don't support db.name syntax)
+    bs.run(f"USE {args.database}", "use-db", output="null")
+    all_results: list[dict[str, Any]] = []
+
+    for complexity in complexities:
+        print(f"\n{'='*40} RAP complexity={complexity} {'='*40}", flush=True)
+        all_results.extend(bench_rap(bs, args.database, args.table, complexity, args.warmup_rounds, args.bench_rounds))
+
+        print(f"\n{'='*40} MASK complexity={complexity} {'='*40}", flush=True)
+        all_results.extend(bench_mask(bs, args.database, args.table, complexity, args.warmup_rounds, args.bench_rounds))
+
+        print(f"\n{'='*40} CACHE complexity={complexity} {'='*40}", flush=True)
+        all_results.extend(bench_planner_cache(bs, args.database, args.table, complexity, args.bench_rounds))
+
+    # Filter by pattern if specified
+    if args.pattern != "all":
+        all_results = [r for r in all_results if r["pattern"] == args.pattern]
+
+    # Compute summary
+    summary = compute_summary(all_results)
+    print_summary(summary)
+
+    # Output
+    output = {
+        "args": vars(args),
+        "data_setup": data_setup,
+        "results": all_results,
+        "summary": summary,
+    }
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(output, f, indent=2)
+        print(f"\nResults written to: {args.output}")
+
+    if args.drop_after:
+        bs.try_run(f"DROP DATABASE IF EXISTS {args.database}", "drop-db-after", output="null")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -549,7 +549,7 @@ impl PhysicalPlanBuilder {
         }
 
         if let Some(secure_preds) = &scan.secure_predicates {
-            if !secure_preds.is_empty() {
+            if !secure_preds.is_empty() && scan.has_secure_predicates_not_applied_by_prewhere() {
                 let input_schema = plan.output_schema()?;
                 let retained = self.metadata.read().get_retained_column().clone();
                 let mut projections = BTreeSet::new();

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
@@ -92,21 +92,17 @@ Sort(Single)
 ├── output columns: [rap_cache_test.id (#0), rap_cache_test.app_name (#1), rap_cache_test.data (#2)]
 ├── sort keys: [id ASC NULLS LAST]
 ├── estimated rows: 2.50
-└── Filter [SECURE]
-    ├── output columns: [rap_cache_test.id (#0), rap_cache_test.app_name (#1), rap_cache_test.data (#2)]
-    ├── filters: [ROW ACCESS POLICY APPLIED]
-    ├── estimated rows: 2.50
-    └── TableScan
-        ├── table: default.default.rap_cache_test
-        ├── scan id: 0
-        ├── output columns: [id (#0), app_name (#1), data (#2)]
-        ├── read rows: 5
-        ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
-        ├── push downs: [filters: [], secure_filters: REDACTED, limit: NONE]
-        └── estimated rows: 2.50
+└── TableScan
+    ├── table: default.default.rap_cache_test
+    ├── scan id: 0
+    ├── output columns: [id (#0), app_name (#1), data (#2)]
+    ├── read rows: 5
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], secure_filters: REDACTED, limit: NONE]
+    └── estimated rows: 2.50
 
 ## ========================================
 ## Step 3: SELECT, EXPLAIN SELECT (should hit cache now)

--- a/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.result
+++ b/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.result
@@ -13,9 +13,9 @@
 ├── push downs: [filters: [is_true(rap_pushdown_test.id (#0) > 0)], secure_filters: REDACTED, limit: NONE]
 #### test 2: limit pushdown with RAP and user WHERE after RAP enters prewhere
 ├── push downs: [filters: [is_true(rap_pushdown_test.id (#0) > 0)], secure_filters: REDACTED, limit: 1]
-#### test 3: verify Filter [SECURE] node exists for RAP enforcement
-#### Filter [SECURE] should appear in the plan; secure predicates are enforced by pipeline Filter
-1
+#### test 3: verify Filter [SECURE] is skipped when prewhere covers all secure predicates
+#### Filter [SECURE] should NOT appear because secure predicates are fully applied by prewhere
+0
 #### test 4: limit pushdown with RAP and no user WHERE after RAP enters prewhere
 ├── push downs: [filters: [], secure_filters: REDACTED, limit: 1]
 #### test 5: sort (ORDER BY + LIMIT) pushdown with RAP after RAP enters prewhere

--- a/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.sh
+++ b/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.sh
@@ -23,9 +23,9 @@ echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_C
 comment "test 2: limit pushdown with RAP and user WHERE after RAP enters prewhere"
 echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0 LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
 
-comment "test 3: verify Filter [SECURE] node exists for RAP enforcement"
-comment "Filter [SECURE] should appear in the plan; secure predicates are enforced by pipeline Filter"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -c "Filter \[SECURE\]"
+comment "test 3: verify Filter [SECURE] is skipped when prewhere covers all secure predicates"
+comment "Filter [SECURE] should NOT appear because secure predicates are fully applied by prewhere"
+echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -c "Filter \[SECURE\]" || true
 
 comment "test 4: limit pushdown with RAP and no user WHERE after RAP enters prewhere"
 echo "EXPLAIN SELECT * FROM rap_pushdown_test LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Row Access Policy (RAP) queries had measurable overhead compared to semantically equivalent manual WHERE clauses. After this optimization, **RAP achieves zero performance penalty**.

  ### Performance Comparison

  Server-side timing (`bendsql --time=server`), 5M rows, single node (meta + query on same machine).

  **RAP vs equivalent WHERE:**

  | Query Pattern | RAP | Manual WHERE | Overhead |
  |---|---|---|---|
  | Full scan + filter | 21ms | 22ms | ≈0% |
  | Point lookup (LIMIT 50K) | 30ms | 29ms | ≈0% |
  | Aggregation (COUNT/SUM) | 14ms | 16ms | ≈0% |
  | ORDER BY + LIMIT | 24ms | 23ms | ≈0% |

  **Data Mask vs equivalent function call:**

  | Query Pattern | Mask Policy | Manual Function | Overhead |
  |---|---|---|---|
  | 50K rows | 4ms | 4ms | 0% |
  | 5M rows | 7ms | 7ms | 0% |

  **Before this PR:** range_scan showed +57% overhead (33ms vs 21ms). **After:** ≈0%.

  Note: First query with a newly created policy incurs a one-time ~17ms meta RPC to load the policy definition. This was measured on a single-node setup (`databend-meta --single` with gRPC at `127.0.0.1:9193`, co-located with query node). In 
  distributed deployments with remote meta, this cost would be higher but still one-time only — subsequent queries hit the in-memory `SecurityPolicyCacheManager`.

  ### Root Cause

  Secure predicate was evaluated twice:
  1. Prewhere (storage layer) — same as regular WHERE
  2. Post-scan `Filter [SECURE]` — redundant re-evaluation on already-filtered rows

  This PR skips step 2 when prewhere already covers all secure predicates.

  ### Changes

  - `physical_table_scan.rs`: Add `has_secure_predicates_not_applied_by_prewhere()` guard (1 line)
  - 3 test files updated for new EXPLAIN output

  ### Safety

  `Filter [SECURE]` is still added when predicates cannot enter prewhere (virtual columns, future subquery-based policies). Result cache and query correctness unchanged.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19923)
<!-- Reviewable:end -->
