### PR TITLE
feat(query): refine ndjson infer schema

### DIFF
--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -88,6 +88,7 @@ use crate::sql::plans::CopyIntoTablePlan;
 use crate::sql::plans::Plan;
 use crate::stream::DataBlockStream;
 use crate::table_functions::infer_schema::InferSchemaSeparator;
+use crate::table_functions::infer_schema::InferredJsonSchema;
 use crate::table_functions::infer_schema::merge_schema;
 
 const NDJSON_SCHEMA_EVOLUTION_AUTO_SAMPLE_FILES: usize = 64;
@@ -95,6 +96,7 @@ const NDJSON_SCHEMA_EVOLUTION_AUTO_RECORDS_PER_FILE: usize = 1000;
 const NDJSON_SCHEMA_EVOLUTION_AUTO_TOTAL_RECORDS: usize = 10000;
 const NDJSON_SCHEMA_EVOLUTION_SAMPLE_BYTES_PER_FILE: usize = 32 * 1024 * 1024;
 const NDJSON_SCHEMA_EVOLUTION_COMPRESSED_READ_CHUNK_BYTES: usize = 1024 * 1024;
+const NDJSON_SCHEMA_EVOLUTION_JSON_MAX_DEPTH: usize = 1;
 
 #[derive(Clone, Copy)]
 struct NdJsonSchemaEvolutionOptions {
@@ -491,7 +493,11 @@ impl CopyIntoTableInterpreter {
                             return Ok(None);
                         }
                         let schema =
-                            InferSchemaSeparator::infer_ndjson_schema(bytes, Some(max_records))?;
+                            InferSchemaSeparator::infer_ndjson_schema_state_with_max_depth(
+                                bytes,
+                                Some(max_records),
+                                NDJSON_SCHEMA_EVOLUTION_JSON_MAX_DEPTH,
+                            )?;
                         Ok::<_, ErrorCode>(Some((path, max_records, schema)))
                     });
                 }
@@ -505,7 +511,7 @@ impl CopyIntoTableInterpreter {
                 )
                 .await?;
 
-                let mut inferred_schema: Option<TableSchema> = None;
+                let mut inferred_schema: Option<InferredJsonSchema> = None;
                 let mut sampled_records_limit = 0usize;
                 let mut sampled_file_count = 0usize;
                 for result in results {
@@ -516,13 +522,17 @@ impl CopyIntoTableInterpreter {
                     sampled_file_count += 1;
                     inferred_schema = Some(match inferred_schema {
                         None => schema,
-                        Some(existing) => merge_schema(existing, schema),
+                        Some(mut existing) => {
+                            existing.merge(schema);
+                            existing
+                        }
                     });
                 }
 
                 let Some(inferred_schema) = inferred_schema else {
                     return Ok(None);
                 };
+                let inferred_schema = inferred_schema.into_table_schema();
 
                 let case_sensitive = stage_table_info.copy_into_table_options.column_match_mode
                     == Some(ColumnMatchMode::CaseSensitive);
@@ -1087,6 +1097,27 @@ mod tests {
         assert_eq!(options.sample_files, 3);
         assert_eq!(options.sample_records_per_file, 10);
         assert_eq!(options.sample_total_records, 20);
+    }
+
+    #[test]
+    fn test_ndjson_schema_evolution_default_depth() -> Result<()> {
+        let schema = InferSchemaSeparator::infer_ndjson_schema_state_with_max_depth(
+            b"{\"a\":1,\"b\":{\"c\":2}}\n",
+            None,
+            NDJSON_SCHEMA_EVOLUTION_JSON_MAX_DEPTH,
+        )?
+        .into_table_schema();
+
+        assert_eq!(
+            schema.field_with_name("a")?.data_type(),
+            &TableDataType::Number(databend_common_expression::types::NumberDataType::Int64)
+                .wrap_nullable()
+        );
+        assert_eq!(
+            schema.field_with_name("b")?.data_type(),
+            &TableDataType::Variant.wrap_nullable()
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/query/service/src/table_functions/infer_schema/csv.rs
+++ b/src/query/service/src/table_functions/infer_schema/csv.rs
@@ -1,0 +1,253 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow_schema::ArrowError;
+use arrow_schema::Field;
+use arrow_schema::Fields;
+use arrow_schema::Schema;
+use csv_core::ReadRecordResult;
+use databend_common_formats::RecordDelimiter;
+use databend_common_meta_app::principal::CsvFileFormatParams;
+
+use crate::table_functions::infer_schema::text::TextInferredDataType;
+
+const MAX_CSV_COLUMNS: usize = 1024;
+
+fn trim_ascii_space(data: &[u8]) -> &[u8] {
+    data.trim_ascii()
+}
+
+fn process_csv_record(
+    params: &CsvFileFormatParams,
+    row: &[u8],
+    ends: &[usize],
+    headers: &mut Option<Vec<String>>,
+    column_types: &mut Vec<TextInferredDataType>,
+    expected_num_fields: &mut Option<usize>,
+) -> std::result::Result<bool, ArrowError> {
+    if let Some(expected) = *expected_num_fields {
+        if ends.len() != expected {
+            return Err(ArrowError::CsvError(format!(
+                "incorrect number of fields in CSV record: expected {expected}, got {}",
+                ends.len()
+            )));
+        }
+    }
+
+    let mut field_start = 0usize;
+    let mut fields = Vec::with_capacity(ends.len());
+    for field_end in ends {
+        let field = &row[field_start..*field_end];
+        let field = if params.trim_space {
+            trim_ascii_space(field)
+        } else {
+            field
+        };
+        fields.push(field);
+        field_start = *field_end;
+    }
+
+    if headers.is_none() {
+        *expected_num_fields = Some(fields.len());
+        *headers = Some(if params.headers != 0 {
+            fields
+                .iter()
+                .map(|f| String::from_utf8_lossy(f).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            (0..fields.len())
+                .map(|i| format!("column_{}", i + 1))
+                .collect::<Vec<_>>()
+        });
+        *column_types = vec![TextInferredDataType::default(); fields.len()];
+
+        if params.headers != 0 {
+            return Ok(false);
+        }
+    }
+
+    for (idx, inferred) in column_types.iter_mut().enumerate() {
+        if let Some(field) = fields.get(idx) {
+            inferred.update(field);
+        }
+    }
+    Ok(true)
+}
+
+pub(super) fn infer_csv_schema(
+    bytes: &[u8],
+    params: &CsvFileFormatParams,
+    is_eof: bool,
+    max_records: Option<usize>,
+) -> std::result::Result<Schema, Option<ArrowError>> {
+    let escape = if params.escape.is_empty() {
+        None
+    } else {
+        Some(params.escape.as_bytes()[0])
+    };
+    let terminator = match params.record_delimiter.as_str().try_into() {
+        Ok(RecordDelimiter::Crlf) => csv_core::Terminator::CRLF,
+        Ok(RecordDelimiter::Any(v)) => csv_core::Terminator::Any(v),
+        Err(err) => return Err(Some(ArrowError::ParseError(err.message()))),
+    };
+
+    let mut reader = csv_core::ReaderBuilder::new()
+        .delimiter_bytes(params.field_delimiter.as_bytes())
+        .quote(params.quote.as_bytes()[0])
+        .escape(escape)
+        .terminator(terminator)
+        .build();
+
+    let max_records = max_records.unwrap_or(usize::MAX);
+    let mut headers: Option<Vec<String>> = None;
+    let mut column_types = vec![];
+    let mut expected_num_fields = None;
+    let mut rows_seen = 0usize;
+
+    let mut buf_in = bytes;
+    let mut flush_on_eof = is_eof;
+    let mut buf_out = vec![0u8; bytes.len().max(1)];
+    let mut buf_out_pos = 0usize;
+    let mut field_ends = vec![0usize; MAX_CSV_COLUMNS];
+    let mut n_end = 0usize;
+
+    loop {
+        let input = if !buf_in.is_empty() {
+            buf_in
+        } else if flush_on_eof {
+            flush_on_eof = false;
+            &[]
+        } else {
+            break;
+        };
+
+        let (result, n_in, n_out, new_ends) =
+            reader.read_record(input, &mut buf_out[buf_out_pos..], &mut field_ends[n_end..]);
+        n_end += new_ends;
+
+        match result {
+            ReadRecordResult::InputEmpty => {
+                if input.is_empty() {
+                    return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
+                }
+                buf_out_pos += n_out;
+            }
+            ReadRecordResult::OutputFull => {
+                return Err(Some(ArrowError::CsvError(
+                    "csv output buffer full when inferring schema".to_string(),
+                )));
+            }
+            ReadRecordResult::OutputEndsFull => {
+                return Err(Some(ArrowError::CsvError(
+                    "csv field buffer full when inferring schema".to_string(),
+                )));
+            }
+            ReadRecordResult::Record => {
+                let row_end = buf_out_pos + n_out;
+                let counted = process_csv_record(
+                    params,
+                    &buf_out[..row_end],
+                    &field_ends[..n_end],
+                    &mut headers,
+                    &mut column_types,
+                    &mut expected_num_fields,
+                )
+                .map_err(Some)?;
+                buf_out_pos = 0;
+                n_end = 0;
+                if counted {
+                    rows_seen += 1;
+                }
+
+                if rows_seen >= max_records {
+                    break;
+                }
+            }
+            ReadRecordResult::End => {
+                if !input.is_empty() {
+                    return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
+                }
+                buf_out_pos += n_out;
+            }
+        }
+
+        if !input.is_empty() {
+            buf_in = &buf_in[n_in..];
+        }
+    }
+
+    if (!buf_in.is_empty() || buf_out_pos != 0 || n_end != 0) && rows_seen < max_records {
+        return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
+    }
+
+    let Some(headers) = headers else {
+        return Err(None);
+    };
+
+    let fields: Fields = column_types
+        .iter()
+        .zip(headers.iter())
+        .map(|(inferred, field_name)| Field::new(field_name, inferred.get(), true))
+        .collect();
+    Ok(Schema::new(fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::DataType;
+    use databend_common_meta_app::principal::CsvFileFormatParams;
+
+    use super::infer_csv_schema;
+
+    #[test]
+    fn test_infer_csv_schema_trim_space_numbers() {
+        let params = CsvFileFormatParams {
+            trim_space: true,
+            ..CsvFileFormatParams::default()
+        };
+        let schema = infer_csv_schema(b" 42 , 123 \n", &params, true, None).unwrap();
+
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Int64);
+    }
+
+    #[test]
+    fn test_infer_csv_schema_trim_space_header_names() {
+        let params = CsvFileFormatParams {
+            headers: 1,
+            trim_space: true,
+            ..CsvFileFormatParams::default()
+        };
+        let schema =
+            infer_csv_schema(b"  id  ,  value  \n 42 , hello \n", &params, true, None).unwrap();
+
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "value");
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_infer_csv_schema_trim_space_quoted_values() {
+        let params = CsvFileFormatParams {
+            trim_space: true,
+            ..CsvFileFormatParams::default()
+        };
+        let schema = infer_csv_schema(b"\" 42 \",\" 3.14 \"\n", &params, true, None).unwrap();
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Float64);
+    }
+}

--- a/src/query/service/src/table_functions/infer_schema/json.rs
+++ b/src/query/service/src/table_functions/infer_schema/json.rs
@@ -1,0 +1,490 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use arrow_json::reader::ValueIter;
+use arrow_schema::ArrowError;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
+use databend_common_expression::types::NumberDataType;
+use serde_json::Value;
+
+// NDJSON inference keeps its own ordered intermediate schema and materializes Databend table
+// types directly instead of going through Arrow types. The rules are kept explicit here because
+// they differ from Arrow's JSON inference and must be shared by infer_schema and schema evolution:
+//
+// - `json_max_depth` limits recursive inference for structured values (array/object). The root
+//   NDJSON record object is not counted as a table column type; top-level field values start at
+//   depth 1. When a structured value reaches the limit, inference stops and the field becomes
+//   VARIANT.
+// - Null samples only mark the final field nullable; they do not force a non-null scalar or
+//   structured type to STRING/VARIANT.
+// - Integer and floating point scalar conflicts merge to FLOAT64/DOUBLE. Other non-null scalar
+//   conflicts are readable as text, so they merge to STRING.
+// - Any conflict that involves a structured type or VARIANT merges to VARIANT. In particular,
+//   scalar values mixed with arrays do not promote the column to ARRAY.
+// - Empty arrays and empty objects stay refinable while more samples are merged. If they are still
+//   empty when materialized, [] becomes ARRAY(VARIANT) and {} becomes VARIANT.
+// - Object fields are stored in a HashMap plus a first-seen order vector, so repeated merges avoid
+//   per-record linear field lookup while preserving stable output order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum InferredJsonType {
+    Any,
+    Scalar(TableDataType),
+    Array(Box<InferredJsonType>),
+    Object(InferredJsonSchema),
+    Variant,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct InferredJsonSchema {
+    order: Vec<String>,
+    fields: HashMap<String, InferredJsonType>,
+}
+
+impl InferredJsonSchema {
+    pub(crate) fn merge(&mut self, mut other: InferredJsonSchema) {
+        for name in other.order {
+            let ty = other
+                .fields
+                .remove(&name)
+                .expect("inferred JSON field order must reference an existing field");
+            self.merge_field(name, ty);
+        }
+    }
+
+    pub(crate) fn into_table_schema(mut self) -> TableSchema {
+        TableSchema::new(
+            self.order
+                .into_iter()
+                .map(|name| {
+                    let ty = self
+                        .fields
+                        .remove(&name)
+                        .expect("inferred JSON field order must reference an existing field");
+                    TableField::new(&name, ty.into_table_type().wrap_nullable())
+                })
+                .collect(),
+        )
+    }
+
+    fn into_tuple_type(mut self) -> TableDataType {
+        if self.order.is_empty() {
+            return TableDataType::Variant;
+        }
+
+        let (fields_name, fields_type) = self
+            .order
+            .into_iter()
+            .map(|name| {
+                let ty = self
+                    .fields
+                    .remove(&name)
+                    .expect("inferred JSON field order must reference an existing field");
+                (name, ty.into_table_type().wrap_nullable())
+            })
+            .unzip();
+        TableDataType::Tuple {
+            fields_name,
+            fields_type,
+        }
+    }
+
+    fn merge_field(&mut self, name: String, ty: InferredJsonType) {
+        if let Some(existing) = self.fields.get_mut(&name) {
+            existing.merge(ty);
+        } else {
+            self.order.push(name.clone());
+            self.fields.insert(name, ty);
+        }
+    }
+
+    fn merge_record(
+        &mut self,
+        value: Value,
+        json_max_depth: Option<usize>,
+    ) -> Result<(), ArrowError> {
+        match value {
+            Value::Object(map) => {
+                for (name, value) in map {
+                    self.merge_field(name, infer_value(&value, 1, json_max_depth));
+                }
+                Ok(())
+            }
+            value => Err(ArrowError::JsonError(format!(
+                "Expected JSON record to be an object, found {value:?}"
+            ))),
+        }
+    }
+}
+
+impl InferredJsonType {
+    fn merge(&mut self, other: InferredJsonType) {
+        match self {
+            InferredJsonType::Any => {
+                *self = other;
+            }
+            InferredJsonType::Variant => {}
+            InferredJsonType::Scalar(left) => match other {
+                InferredJsonType::Any => {}
+                InferredJsonType::Variant => *self = InferredJsonType::Variant,
+                InferredJsonType::Scalar(right) => {
+                    if matches!(left, TableDataType::Null) {
+                        *left = right;
+                    } else if matches!(right, TableDataType::Null) {
+                    } else if matches!(
+                        (&*left, &right),
+                        (
+                            TableDataType::Number(NumberDataType::Int64),
+                            TableDataType::Number(NumberDataType::Float64)
+                        ) | (
+                            TableDataType::Number(NumberDataType::Float64),
+                            TableDataType::Number(NumberDataType::Int64)
+                        )
+                    ) {
+                        *left = TableDataType::Number(NumberDataType::Float64);
+                    } else if left != &right {
+                        // Different scalar types cannot be represented precisely as one typed
+                        // column, so Databend keeps the value readable as text instead of choosing
+                        // an Arrow numeric promotion.
+                        *left = TableDataType::String;
+                    }
+                }
+                InferredJsonType::Array(_) | InferredJsonType::Object(_)
+                    if matches!(left, TableDataType::Null) =>
+                {
+                    *self = other;
+                }
+                InferredJsonType::Array(_) | InferredJsonType::Object(_) => {
+                    // Scalar plus array does not promote to array.
+                    *self = InferredJsonType::Variant;
+                }
+            },
+            InferredJsonType::Array(left) => match other {
+                InferredJsonType::Any => {}
+                InferredJsonType::Array(right) => left.merge(*right),
+                InferredJsonType::Scalar(TableDataType::Null) => {}
+                InferredJsonType::Scalar(_)
+                | InferredJsonType::Object(_)
+                | InferredJsonType::Variant => *self = InferredJsonType::Variant,
+            },
+            InferredJsonType::Object(left) => match other {
+                InferredJsonType::Any => {}
+                InferredJsonType::Object(right) => left.merge(right),
+                InferredJsonType::Scalar(TableDataType::Null) => {}
+                InferredJsonType::Scalar(_)
+                | InferredJsonType::Array(_)
+                | InferredJsonType::Variant => *self = InferredJsonType::Variant,
+            },
+        }
+    }
+
+    fn into_table_type(self) -> TableDataType {
+        match self {
+            InferredJsonType::Any => TableDataType::Null,
+            InferredJsonType::Scalar(ty) => ty,
+            InferredJsonType::Array(inner) => {
+                let inner_type = match *inner {
+                    // Empty arrays do not provide an element sample. Keep the in-memory state as
+                    // `Any` so later non-empty arrays can still refine the element type, but
+                    // materialize an array of VARIANT if the element type remains unknown.
+                    InferredJsonType::Any => TableDataType::Variant,
+                    inner => inner.into_table_type(),
+                };
+                TableDataType::Array(Box::new(inner_type.wrap_nullable()))
+            }
+            InferredJsonType::Object(schema) => schema.into_tuple_type(),
+            InferredJsonType::Variant => TableDataType::Variant,
+        }
+    }
+}
+
+fn scalar_type(value: &Value) -> Option<TableDataType> {
+    match value {
+        Value::Null => Some(TableDataType::Null),
+        Value::Bool(_) => Some(TableDataType::Boolean),
+        Value::Number(number) if number.is_i64() => {
+            Some(TableDataType::Number(NumberDataType::Int64))
+        }
+        Value::Number(_) => Some(TableDataType::Number(NumberDataType::Float64)),
+        Value::String(_) => Some(TableDataType::String),
+        Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn infer_value(value: &Value, depth: usize, json_max_depth: Option<usize>) -> InferredJsonType {
+    if let Some(scalar) = scalar_type(value) {
+        return InferredJsonType::Scalar(scalar);
+    }
+
+    match value {
+        Value::Array(values) => {
+            if json_max_depth.is_some_and(|max_depth| depth >= max_depth) {
+                return InferredJsonType::Variant;
+            }
+            let mut element_type = InferredJsonType::Any;
+            for value in values {
+                element_type.merge(infer_value(value, depth + 1, json_max_depth));
+            }
+            InferredJsonType::Array(Box::new(element_type))
+        }
+        Value::Object(map) => {
+            if json_max_depth.is_some_and(|max_depth| depth >= max_depth) {
+                return InferredJsonType::Variant;
+            }
+            let mut schema = InferredJsonSchema::default();
+            for (name, value) in map {
+                schema.merge_field(name.clone(), infer_value(value, depth + 1, json_max_depth));
+            }
+            InferredJsonType::Object(schema)
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => unreachable!(),
+    }
+}
+
+pub(super) fn infer_ndjson_schema_state(
+    file_bytes: &[u8],
+    max_records: Option<usize>,
+    json_max_depth: Option<usize>,
+) -> std::result::Result<InferredJsonSchema, ArrowError> {
+    let records = ValueIter::new(Cursor::new(file_bytes), max_records);
+    let mut schema = InferredJsonSchema::default();
+
+    for record in records {
+        schema.merge_record(record?, json_max_depth)?;
+    }
+
+    Ok(schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::types::NumberDataType;
+
+    use super::infer_ndjson_schema_state;
+
+    fn infer_ndjson_schema(
+        ndjson: &[u8],
+        max_records: Option<usize>,
+        json_max_depth: Option<usize>,
+    ) -> super::InferredJsonSchema {
+        infer_ndjson_schema_state(ndjson, max_records, json_max_depth).unwrap()
+    }
+
+    fn field_type(ndjson: &str, field: &str) -> TableDataType {
+        infer_ndjson_schema(ndjson.as_bytes(), None, None)
+            .into_table_schema()
+            .field_with_name(field)
+            .unwrap()
+            .data_type()
+            .clone()
+    }
+
+    #[test]
+    fn test_scalar_conflicts_become_string() {
+        assert_eq!(
+            field_type("{\"a\":true}\n{\"a\":\"yes\"}\n", "a"),
+            TableDataType::String.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_integer_float_conflict_becomes_float() {
+        assert_eq!(
+            field_type("{\"a\":1}\n{\"a\":1.5}\n", "a"),
+            TableDataType::Number(NumberDataType::Float64).wrap_nullable()
+        );
+        assert_eq!(
+            field_type("{\"a\":1.5}\n{\"a\":1}\n", "a"),
+            TableDataType::Number(NumberDataType::Float64).wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_null_does_not_force_scalar_to_string() {
+        assert_eq!(
+            field_type("{\"a\":null}\n{\"a\":1}\n", "a"),
+            TableDataType::Number(NumberDataType::Int64).wrap_nullable()
+        );
+        assert_eq!(
+            field_type("{\"a\":true}\n{\"a\":null}\n", "a"),
+            TableDataType::Boolean.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_null_does_not_force_structured_to_variant() {
+        assert_eq!(
+            field_type("{\"a\":null}\n{\"a\":[1]}\n", "a"),
+            TableDataType::Array(Box::new(
+                TableDataType::Number(NumberDataType::Int64).wrap_nullable()
+            ))
+            .wrap_nullable()
+        );
+        assert_eq!(
+            field_type("{\"a\":{\"b\":1}}\n{\"a\":null}\n", "a"),
+            TableDataType::Tuple {
+                fields_name: vec!["b".to_string()],
+                fields_type: vec![TableDataType::Number(NumberDataType::Int64).wrap_nullable()],
+            }
+            .wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_structured_conflicts_become_variant() {
+        assert_eq!(
+            field_type("{\"a\":1}\n{\"a\":[1]}\n", "a"),
+            TableDataType::Variant.wrap_nullable()
+        );
+        assert_eq!(
+            field_type("{\"a\":{\"b\":1}}\n{\"a\":[1]}\n", "a"),
+            TableDataType::Variant.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_object_merge_without_depth_limit() {
+        let schema =
+            infer_ndjson_schema(b"{\"a\":{\"b\":1}}\n{\"a\":{\"c\":\"text\"}}\n", None, None)
+                .into_table_schema();
+
+        assert_eq!(
+            schema.field_with_name("a").unwrap().data_type(),
+            &TableDataType::Tuple {
+                fields_name: vec!["b".to_string(), "c".to_string()],
+                fields_type: vec![
+                    TableDataType::Number(NumberDataType::Int64).wrap_nullable(),
+                    TableDataType::String.wrap_nullable(),
+                ],
+            }
+            .wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_state_merge_matches_single_file_object_merge() {
+        let mut merged = infer_ndjson_schema_state(b"{\"a\":{\"x\":1}}\n", None, None).unwrap();
+        merged.merge(infer_ndjson_schema_state(b"{\"a\":{\"y\":2}}\n", None, None).unwrap());
+
+        let single = infer_ndjson_schema(b"{\"a\":{\"x\":1}}\n{\"a\":{\"y\":2}}\n", None, None)
+            .into_table_schema();
+        assert_eq!(merged.into_table_schema(), single);
+    }
+
+    #[test]
+    fn test_state_merge_matches_single_file_array_merge() {
+        let mut merged = infer_ndjson_schema_state(b"{\"a\":[1]}\n", None, None).unwrap();
+        merged.merge(infer_ndjson_schema_state(b"{\"a\":[\"x\"]}\n", None, None).unwrap());
+
+        let single =
+            infer_ndjson_schema(b"{\"a\":[1]}\n{\"a\":[\"x\"]}\n", None, None).into_table_schema();
+        assert_eq!(merged.into_table_schema(), single);
+        assert_eq!(
+            single.field_with_name("a").unwrap().data_type(),
+            &TableDataType::Array(Box::new(TableDataType::String.wrap_nullable())).wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_empty_array_materializes_as_array_variant() {
+        assert_eq!(
+            field_type("{\"a\":[]}\n", "a"),
+            TableDataType::Array(Box::new(TableDataType::Variant.wrap_nullable())).wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_empty_array_can_still_refine_from_later_samples() {
+        assert_eq!(
+            field_type("{\"a\":[]}\n{\"a\":[1]}\n", "a"),
+            TableDataType::Array(Box::new(
+                TableDataType::Number(NumberDataType::Int64).wrap_nullable()
+            ))
+            .wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_empty_object_materializes_as_variant() {
+        assert_eq!(
+            field_type("{\"a\":{}}\n", "a"),
+            TableDataType::Variant.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_empty_object_can_still_refine_from_later_samples() {
+        assert_eq!(
+            field_type("{\"a\":{}}\n{\"a\":{\"b\":1}}\n", "a"),
+            TableDataType::Tuple {
+                fields_name: vec!["b".to_string()],
+                fields_type: vec![TableDataType::Number(NumberDataType::Int64).wrap_nullable()],
+            }
+            .wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_state_merge_scalar_array_conflict_becomes_variant() {
+        let mut merged = infer_ndjson_schema_state(b"{\"a\":1}\n", None, None).unwrap();
+        merged.merge(infer_ndjson_schema_state(b"{\"a\":[1]}\n", None, None).unwrap());
+
+        assert_eq!(
+            merged
+                .into_table_schema()
+                .field_with_name("a")
+                .unwrap()
+                .data_type(),
+            &TableDataType::Variant.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_depth_limit_uses_variant_for_structured_values() {
+        let schema = infer_ndjson_schema(
+            b"{\"a\":1,\"b\":{\"c\":2},\"c\":[{\"d\":3}]}\n",
+            None,
+            Some(1),
+        )
+        .into_table_schema();
+
+        assert_eq!(
+            schema.field_with_name("a").unwrap().data_type(),
+            &TableDataType::Number(NumberDataType::Int64).wrap_nullable()
+        );
+        assert_eq!(
+            schema.field_with_name("b").unwrap().data_type(),
+            &TableDataType::Variant.wrap_nullable()
+        );
+        assert_eq!(
+            schema.field_with_name("c").unwrap().data_type(),
+            &TableDataType::Variant.wrap_nullable()
+        );
+    }
+
+    #[test]
+    fn test_max_records_limits_rows() {
+        let schema = infer_ndjson_schema(b"{\"a\":1}\n{\"a\":\"text\"}\n", Some(1), None)
+            .into_table_schema();
+        assert_eq!(
+            schema.field_with_name("a").unwrap().data_type(),
+            &TableDataType::Number(NumberDataType::Int64).wrap_nullable()
+        );
+    }
+}

--- a/src/query/service/src/table_functions/infer_schema/mod.rs
+++ b/src/query/service/src/table_functions/infer_schema/mod.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod csv;
 mod infer_schema_table;
+mod json;
 mod merge;
 mod parquet;
 mod separator;
 mod table_args;
+mod text;
 
 pub use infer_schema_table::InferSchemaTable;
+pub(crate) use json::InferredJsonSchema;
 pub(crate) use merge::merge_schema;
 pub(crate) use separator::InferSchemaSeparator;

--- a/src/query/service/src/table_functions/infer_schema/separator.rs
+++ b/src/query/service/src/table_functions/infer_schema/separator.rs
@@ -13,17 +13,11 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::io::Cursor;
-use std::sync::LazyLock;
 
-use arrow_json::reader::ValueIter;
-use arrow_json::reader::infer_json_schema_from_iterator;
 use arrow_schema::ArrowError;
-use arrow_schema::DataType;
 use arrow_schema::Field;
 use arrow_schema::Fields;
 use arrow_schema::Schema;
-use csv_core::ReadRecordResult;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoDowncast;
@@ -33,88 +27,26 @@ use databend_common_expression::TableSchema;
 use databend_common_expression::types::BooleanType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::UInt64Type;
-use databend_common_formats::RecordDelimiter;
-use databend_common_meta_app::principal::CsvFileFormatParams;
 use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::TextFileFormatParams;
 use databend_common_pipeline_transforms::AccumulatingTransform;
 use databend_query_storage_stage_support::BytesBatch;
 use databend_query_storage_stage_support::parse_tsv_records_for_infer_schema;
 use itertools::Itertools;
-use regex::RegexSet;
 
+use crate::table_functions::infer_schema::csv::infer_csv_schema;
+use crate::table_functions::infer_schema::json;
 use crate::table_functions::infer_schema::merge::merge_schema;
+use crate::table_functions::infer_schema::text::TextInferredDataType;
 
 const MAX_SINGLE_FILE_BYTES: usize = 100 * 1024 * 1024;
-const MAX_CSV_COLUMNS: usize = 1024;
-static TEXT_INFER_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
-    RegexSet::new([
-        r"(?i)^(true)$|^(false)$(?-i)", // BOOLEAN
-        r"^-?(\d+)$",                   // INTEGER
-        r"^-?((\d*\.\d+|\d+\.\d*)([eE][-+]?\d+)?|\d+([eE][-+]?\d+))$", // DECIMAL
-        r"^\d{4}-\d\d-\d\d$",           // DATE32
-        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d(?:[^\d\.].*)?$", // Timestamp(Second)
-        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,3}(?:[^\d].*)?$", // Timestamp(Millisecond)
-        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,6}(?:[^\d].*)?$", // Timestamp(Microsecond)
-        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,9}(?:[^\d].*)?$", // Timestamp(Nanosecond)
-    ])
-    .expect("failed to build tsv infer regex set")
-});
-
-#[derive(Default, Copy, Clone)]
-struct TextInferredDataType {
-    // 0:Boolean,1:Integer,2:Float64,3:Date32,4:TsS,5:TsMS,6:TsUS,7:TsNS,8:Utf8
-    packed: u16,
-}
-
-impl TextInferredDataType {
-    fn get(&self) -> DataType {
-        match self.packed {
-            0 => DataType::Null,
-            1 => DataType::Boolean,
-            2 => DataType::Int64,
-            4 | 6 => DataType::Float64,
-            b if b != 0 && (b & !0b11111000) == 0 => match b.leading_zeros() {
-                8 => DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
-                9 => DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, None),
-                10 => DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None),
-                11 => DataType::Timestamp(arrow_schema::TimeUnit::Second, None),
-                12 => DataType::Date32,
-                _ => unreachable!(),
-            },
-            _ => DataType::Utf8,
-        }
-    }
-
-    fn update(&mut self, field: &[u8]) {
-        if field.is_empty() {
-            return;
-        }
-
-        let Ok(string) = std::str::from_utf8(field) else {
-            self.packed |= 1 << 8;
-            return;
-        };
-
-        self.packed |= if let Some(m) = TEXT_INFER_REGEX_SET.matches(string).into_iter().next() {
-            if m == 1 && string.len() >= 19 && string.parse::<i64>().is_err() {
-                1 << 8
-            } else {
-                1 << m
-            }
-        } else if string == "NaN" || string == "nan" || string == "inf" || string == "-inf" {
-            1 << 2
-        } else {
-            1 << 8
-        };
-    }
-}
 
 pub struct InferSchemaSeparator {
     pub file_format_params: FileFormatParams,
     files: HashMap<String, Vec<u8>>,
     pub max_records: Option<usize>,
     schemas: Option<TableSchema>,
+    json_schema: Option<json::InferredJsonSchema>,
     files_len: usize,
     filenames: Vec<String>,
     is_finished: bool,
@@ -131,34 +63,23 @@ impl InferSchemaSeparator {
             files: HashMap::new(),
             max_records,
             schemas: None,
+            json_schema: None,
             files_len,
             filenames: Vec::with_capacity(files_len),
             is_finished: false,
         }
     }
 
-    pub(crate) fn infer_ndjson_schema(
+    pub(crate) fn infer_ndjson_schema_state_with_max_depth(
         file_bytes: &[u8],
         max_records: Option<usize>,
-    ) -> Result<TableSchema> {
-        TableSchema::try_from(&Self::infer_ndjson_arrow_schema(file_bytes, max_records)?)
-    }
-
-    fn infer_ndjson_arrow_schema(
-        file_bytes: &[u8],
-        max_records: Option<usize>,
-    ) -> std::result::Result<Schema, ArrowError> {
-        let mut records = ValueIter::new(Cursor::new(file_bytes), max_records);
-        if let Some(max_record) = max_records {
-            let mut tmp: Vec<std::result::Result<_, ArrowError>> = Vec::with_capacity(max_record);
-
-            for result in records {
-                tmp.push(Ok(result?));
-            }
-            infer_json_schema_from_iterator(tmp.into_iter())
-        } else {
-            infer_json_schema_from_iterator(&mut records)
-        }
+        json_max_depth: usize,
+    ) -> Result<json::InferredJsonSchema> {
+        Ok(json::infer_ndjson_schema_state(
+            file_bytes,
+            max_records,
+            Some(json_max_depth),
+        )?)
     }
 
     fn infer_tsv_schema(
@@ -257,181 +178,6 @@ impl InferSchemaSeparator {
             .collect();
         Ok(Schema::new(fields))
     }
-
-    fn process_csv_record(
-        params: &CsvFileFormatParams,
-        row: &[u8],
-        ends: &[usize],
-        headers: &mut Option<Vec<String>>,
-        column_types: &mut Vec<TextInferredDataType>,
-        expected_num_fields: &mut Option<usize>,
-    ) -> std::result::Result<bool, ArrowError> {
-        if let Some(expected) = *expected_num_fields {
-            if ends.len() != expected {
-                return Err(ArrowError::CsvError(format!(
-                    "incorrect number of fields in CSV record: expected {expected}, got {}",
-                    ends.len()
-                )));
-            }
-        }
-
-        let mut field_start = 0usize;
-        let mut fields = Vec::with_capacity(ends.len());
-        for field_end in ends {
-            let field = &row[field_start..*field_end];
-            let field = if params.trim_space {
-                trim_ascii_space(field)
-            } else {
-                field
-            };
-            fields.push(field);
-            field_start = *field_end;
-        }
-
-        if headers.is_none() {
-            *expected_num_fields = Some(fields.len());
-            *headers = Some(if params.headers != 0 {
-                fields
-                    .iter()
-                    .map(|f| String::from_utf8_lossy(f).to_string())
-                    .collect::<Vec<_>>()
-            } else {
-                (0..fields.len())
-                    .map(|i| format!("column_{}", i + 1))
-                    .collect::<Vec<_>>()
-            });
-            *column_types = vec![TextInferredDataType::default(); fields.len()];
-
-            if params.headers != 0 {
-                return Ok(false);
-            }
-        }
-
-        for (idx, inferred) in column_types.iter_mut().enumerate() {
-            if let Some(field) = fields.get(idx) {
-                inferred.update(field);
-            }
-        }
-        Ok(true)
-    }
-
-    fn infer_csv_schema(
-        bytes: &[u8],
-        params: &CsvFileFormatParams,
-        is_eof: bool,
-        max_records: Option<usize>,
-    ) -> std::result::Result<Schema, Option<ArrowError>> {
-        let escape = if params.escape.is_empty() {
-            None
-        } else {
-            Some(params.escape.as_bytes()[0])
-        };
-        let terminator = match params.record_delimiter.as_str().try_into() {
-            Ok(RecordDelimiter::Crlf) => csv_core::Terminator::CRLF,
-            Ok(RecordDelimiter::Any(v)) => csv_core::Terminator::Any(v),
-            Err(err) => return Err(Some(ArrowError::ParseError(err.message()))),
-        };
-
-        let mut reader = csv_core::ReaderBuilder::new()
-            .delimiter_bytes(params.field_delimiter.as_bytes())
-            .quote(params.quote.as_bytes()[0])
-            .escape(escape)
-            .terminator(terminator)
-            .build();
-
-        let max_records = max_records.unwrap_or(usize::MAX);
-        let mut headers: Option<Vec<String>> = None;
-        let mut column_types = vec![];
-        let mut expected_num_fields = None;
-        let mut rows_seen = 0usize;
-
-        let mut buf_in = bytes;
-        let mut flush_on_eof = is_eof;
-        let mut buf_out = vec![0u8; bytes.len().max(1)];
-        let mut buf_out_pos = 0usize;
-        let mut field_ends = vec![0usize; MAX_CSV_COLUMNS];
-        let mut n_end = 0usize;
-
-        loop {
-            let input = if !buf_in.is_empty() {
-                buf_in
-            } else if flush_on_eof {
-                flush_on_eof = false;
-                &[]
-            } else {
-                break;
-            };
-
-            let (result, n_in, n_out, new_ends) =
-                reader.read_record(input, &mut buf_out[buf_out_pos..], &mut field_ends[n_end..]);
-            n_end += new_ends;
-
-            match result {
-                ReadRecordResult::InputEmpty => {
-                    if input.is_empty() {
-                        return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
-                    }
-                    buf_out_pos += n_out;
-                }
-                ReadRecordResult::OutputFull => {
-                    return Err(Some(ArrowError::CsvError(
-                        "csv output buffer full when inferring schema".to_string(),
-                    )));
-                }
-                ReadRecordResult::OutputEndsFull => {
-                    return Err(Some(ArrowError::CsvError(
-                        "csv field buffer full when inferring schema".to_string(),
-                    )));
-                }
-                ReadRecordResult::Record => {
-                    let row_end = buf_out_pos + n_out;
-                    let counted = Self::process_csv_record(
-                        params,
-                        &buf_out[..row_end],
-                        &field_ends[..n_end],
-                        &mut headers,
-                        &mut column_types,
-                        &mut expected_num_fields,
-                    )
-                    .map_err(Some)?;
-                    buf_out_pos = 0;
-                    n_end = 0;
-                    if counted {
-                        rows_seen += 1;
-                    }
-
-                    if rows_seen >= max_records {
-                        break;
-                    }
-                }
-                ReadRecordResult::End => {
-                    if !input.is_empty() {
-                        return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
-                    }
-                    buf_out_pos += n_out;
-                }
-            }
-
-            if !input.is_empty() {
-                buf_in = &buf_in[n_in..];
-            }
-        }
-
-        if (!buf_in.is_empty() || buf_out_pos != 0 || n_end != 0) && rows_seen < max_records {
-            return Err(Some(ArrowError::CsvError("unexpected eof".to_string())));
-        }
-
-        let Some(headers) = headers else {
-            return Err(None);
-        };
-
-        let fields: Fields = column_types
-            .iter()
-            .zip(headers.iter())
-            .map(|(inferred, field_name)| Field::new(field_name, inferred.get(), true))
-            .collect();
-        Ok(Schema::new(fields))
-    }
 }
 
 impl AccumulatingTransform for InferSchemaSeparator {
@@ -467,15 +213,20 @@ impl AccumulatingTransform for InferSchemaSeparator {
             Arrow(ArrowError),
             Error(ErrorCode),
         }
+        enum InferResult {
+            Table(TableSchema),
+            Json(json::InferredJsonSchema),
+        }
 
-        let result: std::result::Result<TableSchema, InferError> = match &self.file_format_params {
+        let result: std::result::Result<InferResult, InferError> = match &self.file_format_params {
             FileFormatParams::Csv(params) => {
-                Self::infer_csv_schema(file_bytes, params, batch.is_eof, self.max_records)
+                infer_csv_schema(file_bytes, params, batch.is_eof, self.max_records)
                     .map_err(|err| match err {
                         Some(err) => InferError::Arrow(err),
                         None => InferError::Incomplete,
                     })
                     .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
+                    .map(InferResult::Table)
             }
             FileFormatParams::Text(params) => {
                 Self::infer_tsv_schema(file_bytes, params, batch.is_eof, self.max_records)
@@ -484,11 +235,12 @@ impl AccumulatingTransform for InferSchemaSeparator {
                         None => InferError::Incomplete,
                     })
                     .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
+                    .map(InferResult::Table)
             }
             FileFormatParams::NdJson(_) => {
-                Self::infer_ndjson_arrow_schema(file_bytes, self.max_records)
+                json::infer_ndjson_schema_state(file_bytes, self.max_records, None)
                     .map_err(InferError::Arrow)
-                    .and_then(|schema| TableSchema::try_from(&schema).map_err(InferError::Error))
+                    .map(InferResult::Json)
             }
             _ => {
                 return Err(ErrorCode::BadArguments(
@@ -496,8 +248,8 @@ impl AccumulatingTransform for InferSchemaSeparator {
                 ));
             }
         };
-        let table_schema = match result {
-            Ok(schema) => schema,
+        let inferred = match result {
+            Ok(inferred) => inferred,
             Err(InferError::Incomplete) => return Ok(vec![DataBlock::empty()]),
             Err(InferError::Arrow(err)) => {
                 if self.max_records.is_some()
@@ -518,18 +270,34 @@ impl AccumulatingTransform for InferSchemaSeparator {
         self.files.remove(&batch.path);
         self.filenames.push(batch.path);
 
-        let merge_schema = match self.schemas.take() {
-            None => table_schema,
-            Some(schema) => merge_schema(schema, table_schema),
-        };
-        self.schemas = Some(merge_schema);
+        match inferred {
+            InferResult::Table(table_schema) => {
+                let merge_schema = match self.schemas.take() {
+                    None => table_schema,
+                    Some(schema) => merge_schema(schema, table_schema),
+                };
+                self.schemas = Some(merge_schema);
+            }
+            InferResult::Json(json_schema) => match self.json_schema.as_mut() {
+                Some(schema) => schema.merge(json_schema),
+                None => self.json_schema = Some(json_schema),
+            },
+        }
 
         if self.files_len > self.filenames.len() {
             return Ok(vec![DataBlock::empty()]);
         }
         self.is_finished = true;
-        let Some(table_schema) = self.schemas.take() else {
-            return Ok(vec![DataBlock::empty()]);
+        let table_schema = if matches!(self.file_format_params, FileFormatParams::NdJson(_)) {
+            let Some(json_schema) = self.json_schema.take() else {
+                return Ok(vec![DataBlock::empty()]);
+            };
+            json_schema.into_table_schema()
+        } else {
+            let Some(table_schema) = self.schemas.take() else {
+                return Ok(vec![DataBlock::empty()]);
+            };
+            table_schema
         };
 
         let mut names: Vec<String> = vec![];
@@ -577,10 +345,6 @@ fn human_readable_size(bytes: usize) -> String {
     }
 }
 
-fn trim_ascii_space(data: &[u8]) -> &[u8] {
-    data.trim_ascii()
-}
-
 fn is_ndjson_incomplete_parse_error(
     err: &ArrowError,
     file_bytes: &[u8],
@@ -593,7 +357,7 @@ fn is_ndjson_incomplete_parse_error(
 
 #[cfg(test)]
 mod tests {
-    use databend_common_meta_app::principal::CsvFileFormatParams;
+    use arrow_schema::DataType;
     use databend_common_meta_app::principal::NdJsonFileFormatParams;
     use databend_common_meta_app::principal::TextFileFormatParams;
 
@@ -749,54 +513,5 @@ mod tests {
             "TIMESTAMP NULL"
         );
         assert_eq!(table_schema.field(8).data_type().sql_name(), "VARCHAR NULL");
-    }
-
-    #[test]
-    fn test_infer_csv_schema_trim_space_numbers() {
-        let params = CsvFileFormatParams {
-            trim_space: true,
-            ..CsvFileFormatParams::default()
-        };
-        let schema =
-            InferSchemaSeparator::infer_csv_schema(b" 42 , 123 \n", &params, true, None).unwrap();
-
-        assert_eq!(schema.fields().len(), 2);
-        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
-        assert_eq!(schema.field(1).data_type(), &DataType::Int64);
-    }
-
-    #[test]
-    fn test_infer_csv_schema_trim_space_header_names() {
-        let params = CsvFileFormatParams {
-            headers: 1,
-            trim_space: true,
-            ..CsvFileFormatParams::default()
-        };
-        let schema = InferSchemaSeparator::infer_csv_schema(
-            b"  id  ,  value  \n 42 , hello \n",
-            &params,
-            true,
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(schema.field(0).name(), "id");
-        assert_eq!(schema.field(1).name(), "value");
-        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
-        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
-    }
-
-    #[test]
-    fn test_infer_csv_schema_trim_space_quoted_values() {
-        let params = CsvFileFormatParams {
-            trim_space: true,
-            ..CsvFileFormatParams::default()
-        };
-        let schema =
-            InferSchemaSeparator::infer_csv_schema(b"\" 42 \",\" 3.14 \"\n", &params, true, None)
-                .unwrap();
-
-        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
-        assert_eq!(schema.field(1).data_type(), &DataType::Float64);
     }
 }

--- a/src/query/service/src/table_functions/infer_schema/text.rs
+++ b/src/query/service/src/table_functions/infer_schema/text.rs
@@ -1,0 +1,81 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::LazyLock;
+
+use arrow_schema::DataType;
+use regex::RegexSet;
+
+static TEXT_INFER_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+    RegexSet::new([
+        r"(?i)^(true)$|^(false)$(?-i)", // BOOLEAN
+        r"^-?(\d+)$",                   // INTEGER
+        r"^-?((\d*\.\d+|\d+\.\d*)([eE][-+]?\d+)?|\d+([eE][-+]?\d+))$", // DECIMAL
+        r"^\d{4}-\d\d-\d\d$",           // DATE32
+        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d(?:[^\d\.].*)?$", // Timestamp(Second)
+        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,3}(?:[^\d].*)?$", // Timestamp(Millisecond)
+        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,6}(?:[^\d].*)?$", // Timestamp(Microsecond)
+        r"^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d\.\d{1,9}(?:[^\d].*)?$", // Timestamp(Nanosecond)
+    ])
+    .expect("failed to build text infer regex set")
+});
+
+#[derive(Default, Copy, Clone)]
+pub(super) struct TextInferredDataType {
+    // 0:Boolean,1:Integer,2:Float64,3:Date32,4:TsS,5:TsMS,6:TsUS,7:TsNS,8:Utf8
+    packed: u16,
+}
+
+impl TextInferredDataType {
+    pub(super) fn get(&self) -> DataType {
+        match self.packed {
+            0 => DataType::Null,
+            1 => DataType::Boolean,
+            2 => DataType::Int64,
+            4 | 6 => DataType::Float64,
+            b if b != 0 && (b & !0b11111000) == 0 => match b.leading_zeros() {
+                8 => DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
+                9 => DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, None),
+                10 => DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None),
+                11 => DataType::Timestamp(arrow_schema::TimeUnit::Second, None),
+                12 => DataType::Date32,
+                _ => unreachable!(),
+            },
+            _ => DataType::Utf8,
+        }
+    }
+
+    pub(super) fn update(&mut self, field: &[u8]) {
+        if field.is_empty() {
+            return;
+        }
+
+        let Ok(string) = std::str::from_utf8(field) else {
+            self.packed |= 1 << 8;
+            return;
+        };
+
+        self.packed |= if let Some(m) = TEXT_INFER_REGEX_SET.matches(string).into_iter().next() {
+            if m == 1 && string.len() >= 19 && string.parse::<i64>().is_err() {
+                1 << 8
+            } else {
+                1 << m
+            }
+        } else if string == "NaN" || string == "nan" || string == "inf" || string == "-inf" {
+            1 << 2
+        } else {
+            1 << 8
+        };
+    }
+}

--- a/tests/data/ndjson/infer_schema_conflicts.ndjson
+++ b/tests/data/ndjson/infer_schema_conflicts.ndjson
@@ -1,0 +1,2 @@
+{"scalar_conflict":1,"int_float":1,"scalar_array_conflict":1,"object_conflict":{"a":1},"nested":{"leaf":{"x":1}},"arr":[1],"empty_arr":[],"nullable_num":null,"nullable_bool":null}
+{"scalar_conflict":"text","int_float":1.5,"scalar_array_conflict":[1],"object_conflict":"text","nested":{"leaf":{"y":"s"}},"arr":["s"],"nullable_num":1,"nullable_bool":true}

--- a/tests/sqllogictests/suites/stage/formats/ndjson/schema_evolution.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/schema_evolution.test
@@ -98,3 +98,43 @@ drop table t_ndjson_schema_evolution
 
 statement ok
 drop stage s_ndjson_schema_evolution
+
+statement ok
+drop table if exists t_ndjson_schema_evolution_depth
+
+statement ok
+drop stage if exists s_ndjson_schema_evolution_depth
+
+statement ok
+create table t_ndjson_schema_evolution_depth(a int)
+
+statement ok
+create stage s_ndjson_schema_evolution_depth
+
+statement ok
+copy into @s_ndjson_schema_evolution_depth from (select 1 as a, parse_json('{"c":2}') as b) file_format=(type=ndjson)
+
+statement ok
+alter table t_ndjson_schema_evolution_depth set options(enable_schema_evolution = true)
+
+statement ok
+copy into t_ndjson_schema_evolution_depth
+from @s_ndjson_schema_evolution_depth/
+file_format=(type=ndjson)
+schema_evolution=(
+  sample_files=auto,
+  sample_records_per_file=auto,
+  sample_total_records=auto
+)
+
+query ???
+desc t_ndjson_schema_evolution_depth;
+----
+a INT YES NULL (empty)
+b VARIANT YES NULL (empty)
+
+statement ok
+drop table t_ndjson_schema_evolution_depth
+
+statement ok
+drop stage s_ndjson_schema_evolution_depth

--- a/tests/sqllogictests/suites/stage/formats/parquet/infer_schema.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/infer_schema.test
@@ -253,6 +253,19 @@ col3 VARCHAR 1 2
 col4 VARCHAR 1 3
 col5 VARCHAR 1 4
 
+query TTBI
+select column_name, type, nullable, order_id from infer_schema(location => '@data/ndjson/infer_schema_conflicts.ndjson', file_format => 'NDJSON');
+----
+scalar_conflict VARCHAR 1 0
+int_float DOUBLE 1 1
+scalar_array_conflict VARIANT 1 2
+object_conflict VARIANT 1 3
+nested TUPLE(LEAF TUPLE(X INT64, Y STRING),) 1 4
+arr ARRAY(STRING) 1 5
+empty_arr ARRAY(VARIANT) 1 6
+nullable_num BIGINT 1 7
+nullable_bool BOOLEAN 1 8
+
 query T
 select CASE
                WHEN filenames LIKE '%,%'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Refine NDJSON schema inference so Databend no longer depends on Arrow's JSON schema inference behavior.

This PR:
- implements Databend-owned NDJSON inference that returns `TableSchema` directly
- documents the NDJSON inference rules near the implementation
- keeps `infer_schema` unlimited-depth while using a shallow default for NDJSON schema evolution so nested object/array columns evolve as `VARIANT`
- changes conflict handling so scalar conflicts become `VARCHAR`, while structured/variant conflicts become `VARIANT`
- splits CSV, JSON, and shared text inference logic into separate files
- adds unit and sqllogictest coverage for the new conflict and schema evolution behavior

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Executed locally:

```text
cargo test -p databend-query infer_schema --lib
```

Logic tests were updated and left for CI to run on the draft PR.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19928)
<!-- Reviewable:end -->
