### PR TITLE
fix(query): require alter for copy schema evolution

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -1902,6 +1902,17 @@ impl AccessChecker for PrivilegeAccess {
             Plan::CopyIntoTable(plan) => {
                 self.validate_stage_access(&plan.stage_table_info.stage_info, UserPrivilegeType::Read).await?;
                 self.validate_table_access(plan.catalog_info.catalog_name(), &plan.database_name, &plan.table_name, UserPrivilegeType::Insert, false, false).await?;
+                if plan.enable_schema_evolution && plan.query.is_none() && !plan.no_file_to_copy {
+                    self.validate_table_access(
+                        plan.catalog_info.catalog_name(),
+                        &plan.database_name,
+                        &plan.table_name,
+                        UserPrivilegeType::Alter,
+                        false,
+                        false,
+                    )
+                    .await?;
+                }
                 if let Some(query) = &plan.query {
                     self.check(ctx, query).await?;
                 }

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
@@ -22,7 +22,7 @@ csv/data_UUID_0000_00000000.csv	20	0	NULL	NULL
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [Read] is required on STAGE s2 for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
 data_UUID_0000_00000000.csv	20	0	NULL	NULL
 ==== check schema evolution alter priv ===
-Error: APIError: QueryFailed: [1063]Permission denied: privilege [Alter] is required on 'default'.'default'.'se_table' for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
+Error: APIError: QueryFailed: [1063]Permission denied: privilege [Alter] is required on 'default'.'default'.'se_table' for user 'u1'@'%' with roles [public]
 data_UUID_0000_00000000.ndjson	1	0	NULL	NULL
 1	2
 data_UUID_0000_00000000.ndjson	1	0	NULL	NULL

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.result
@@ -21,6 +21,12 @@ csv/data_UUID_0000_00000000.csv	20	0	NULL	NULL
 ==== check internal stage read priv ===
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [Read] is required on STAGE s2 for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
 data_UUID_0000_00000000.csv	20	0	NULL	NULL
+==== check schema evolution alter priv ===
+Error: APIError: QueryFailed: [1063]Permission denied: privilege [Alter] is required on 'default'.'default'.'se_table' for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
+data_UUID_0000_00000000.ndjson	1	0	NULL	NULL
+1	2
+data_UUID_0000_00000000.ndjson	1	0	NULL	NULL
+1
 === check presign ===
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [Write] is required on STAGE presign_stage for user 'u1'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
 000

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
@@ -54,6 +54,29 @@ echo "copy into test_table from @s2 FILE_FORMAT = (type = CSV skip_header = 0) f
 echo "grant Read on stage s2 to 'u1'" | $BENDSQL_CLIENT_CONNECT
 echo "copy into test_table from @s2 FILE_FORMAT = (type = CSV skip_header = 0) force=true;" | $TEST_USER_CONNECT | $RM_UUID
 
+echo "==== check schema evolution alter priv ==="
+echo "drop table if exists se_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists se_query_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
+echo "create table se_table(a int);" | $BENDSQL_CLIENT_CONNECT
+echo "alter table se_table set options(enable_schema_evolution = true);" | $BENDSQL_CLIENT_CONNECT
+echo "create table se_query_table(a int);" | $BENDSQL_CLIENT_CONNECT
+echo "alter table se_query_table set options(enable_schema_evolution = true);" | $BENDSQL_CLIENT_CONNECT
+echo "create stage s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s_schema_evolution from (select 1 as a, 2 as b) file_format=(type=ndjson);" | $BENDSQL_CLIENT_CONNECT >/dev/null
+echo "grant read on stage s_schema_evolution to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant insert on default.se_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into se_table from @s_schema_evolution/ file_format=(type=ndjson missing_field_as=field_default) force=true;" | $TEST_USER_CONNECT | $RM_UUID
+echo "grant alter on default.se_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into se_table from @s_schema_evolution/ file_format=(type=ndjson missing_field_as=field_default) force=true;" | $TEST_USER_CONNECT | $RM_UUID
+echo "select a, b from se_table;" | $BENDSQL_CLIENT_CONNECT
+echo "grant insert on default.se_query_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into se_query_table from (select to_int32(\$1:a) from @s_schema_evolution) file_format=(type=ndjson) force=true;" | $TEST_USER_CONNECT | $RM_UUID
+echo "select * from se_query_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table se_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table se_query_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
+
 echo "remove @s2;" | $TEST_USER_CONNECT
 echo "remove @s1;" | $BENDSQL_CLIENT_CONNECT
 echo "drop STAGE s2;" | $BENDSQL_CLIENT_CONNECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Require `ALTER` on the target table when `COPY INTO <table>` will run schema evolution inference. This closes a permission gap where a user with only `INSERT` on a schema-evolution-enabled table could trigger a copy path that may alter the table schema.

The extra check is limited to stage/location COPY paths that enter schema evolution inference. Query-based COPY remains unchanged and only requires the existing privileges.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added stateful SQL coverage in `tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh` for missing `ALTER`, successful COPY after granting `ALTER`, and query-based COPY remaining unaffected.


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19932)
<!-- Reviewable:end -->
