### PR TITLE
fix(query): avoid nested window plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17942,7 +17942,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs 0.8.1",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",

--- a/src/query/service/src/physical_plans/format/format_window.rs
+++ b/src/query/service/src/physical_plans/format/format_window.rs
@@ -116,6 +116,25 @@ impl<'a> PhysicalFormat for WindowGroupFormatter<'a> {
 
     #[recursive::recursive]
     fn format(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
+        if self.inner.windows.len() == 1 {
+            let mut node_children = format_window_spec_children(&self.inner.windows[0], ctx)?;
+            node_children.insert(
+                0,
+                FormatTreeNode::new(format!(
+                    "output columns: [{}]",
+                    format_output_columns(self.inner.output_schema()?, ctx.metadata, true)
+                )),
+            );
+
+            let input_formatter = self.inner.input.formatter()?;
+            node_children.push(input_formatter.dispatch(ctx)?);
+
+            return Ok(FormatTreeNode::with_children(
+                "Window".to_string(),
+                node_children,
+            ));
+        }
+
         let mut node_children = vec![FormatTreeNode::new(format!(
             "output columns: [{}]",
             format_output_columns(self.inner.output_schema()?, ctx.metadata, true)
@@ -149,6 +168,17 @@ fn format_window_spec(
     window: &WindowSpec,
     ctx: &mut FormatContext<'_>,
 ) -> Result<FormatTreeNode<String>> {
+    let node_children = format_window_spec_children(window, ctx)?;
+    Ok(FormatTreeNode::with_children(
+        "Window".to_string(),
+        node_children,
+    ))
+}
+
+fn format_window_spec_children(
+    window: &WindowSpec,
+    ctx: &mut FormatContext<'_>,
+) -> Result<Vec<FormatTreeNode<String>>> {
     let partition_by = window
         .partition_by
         .iter()
@@ -182,8 +212,5 @@ fn format_window_spec(
         node_children.push(FormatTreeNode::new(format!("top: [{}]", top)));
     }
 
-    Ok(FormatTreeNode::with_children(
-        "Window".to_string(),
-        node_children,
-    ))
+    Ok(node_children)
 }

--- a/src/query/service/src/physical_plans/format/format_window.rs
+++ b/src/query/service/src/physical_plans/format/format_window.rs
@@ -19,6 +19,8 @@ use crate::physical_plans::IPhysicalPlan;
 use crate::physical_plans::PhysicalPlanMeta;
 use crate::physical_plans::Window;
 use crate::physical_plans::WindowFunction;
+use crate::physical_plans::WindowGroup;
+use crate::physical_plans::WindowSpec;
 use crate::physical_plans::format::FormatContext;
 use crate::physical_plans::format::PhysicalFormat;
 use crate::physical_plans::format::format_output_columns;
@@ -31,6 +33,16 @@ pub struct WindowFormatter<'a> {
 impl<'a> WindowFormatter<'a> {
     pub fn create(inner: &'a Window) -> Box<dyn PhysicalFormat + 'a> {
         Box::new(WindowFormatter { inner })
+    }
+}
+
+pub struct WindowGroupFormatter<'a> {
+    inner: &'a WindowGroup,
+}
+
+impl<'a> WindowGroupFormatter<'a> {
+    pub fn create(inner: &'a WindowGroup) -> Box<dyn PhysicalFormat + 'a> {
+        Box::new(WindowGroupFormatter { inner })
     }
 }
 
@@ -95,4 +107,83 @@ impl<'a> PhysicalFormat for WindowFormatter<'a> {
     fn partial_format(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
         self.inner.input.formatter()?.partial_format(ctx)
     }
+}
+
+impl<'a> PhysicalFormat for WindowGroupFormatter<'a> {
+    fn get_meta(&self) -> &PhysicalPlanMeta {
+        self.inner.get_meta()
+    }
+
+    #[recursive::recursive]
+    fn format(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
+        let mut node_children = vec![FormatTreeNode::new(format!(
+            "output columns: [{}]",
+            format_output_columns(self.inner.output_schema()?, ctx.metadata, true)
+        ))];
+
+        for window in &self.inner.windows {
+            node_children.push(format_window_spec(window, ctx)?);
+        }
+
+        let input_formatter = self.inner.input.formatter()?;
+        node_children.push(input_formatter.dispatch(ctx)?);
+
+        Ok(FormatTreeNode::with_children(
+            "WindowGroup".to_string(),
+            node_children,
+        ))
+    }
+
+    #[recursive::recursive]
+    fn format_join(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
+        self.inner.input.formatter()?.format_join(ctx)
+    }
+
+    #[recursive::recursive]
+    fn partial_format(&self, ctx: &mut FormatContext<'_>) -> Result<FormatTreeNode<String>> {
+        self.inner.input.formatter()?.partial_format(ctx)
+    }
+}
+
+fn format_window_spec(
+    window: &WindowSpec,
+    ctx: &mut FormatContext<'_>,
+) -> Result<FormatTreeNode<String>> {
+    let partition_by = window
+        .partition_by
+        .iter()
+        .map(|&index| Ok(ctx.metadata.column(index).name()))
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+    let order_by = window
+        .order_by
+        .iter()
+        .map(|v| v.display_name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let frame = window.window_frame.to_string();
+    let func = match &window.func {
+        WindowFunction::Aggregate(agg) => pretty_display_agg_desc(agg, ctx.metadata),
+        func => format!("{}", func),
+    };
+
+    let mut node_children = vec![
+        FormatTreeNode::new(format!("output column: [{}]", window.index)),
+        FormatTreeNode::new(format!("aggregate function: [{}]", func)),
+        FormatTreeNode::new(format!("partition by: [{}]", partition_by)),
+        FormatTreeNode::new(format!("order by: [{}]", order_by)),
+        FormatTreeNode::new(format!("frame: [{}]", frame)),
+    ];
+
+    if let Some(limit) = window.limit {
+        node_children.push(FormatTreeNode::new(format!("limit: [{}]", limit)));
+    }
+    if let Some(top) = window.top {
+        node_children.push(FormatTreeNode::new(format!("top: [{}]", top)));
+    }
+
+    Ok(FormatTreeNode::with_children(
+        "Window".to_string(),
+        node_children,
+    ))
 }

--- a/src/query/service/src/physical_plans/physical_plan_builder.rs
+++ b/src/query/service/src/physical_plans/physical_plan_builder.rs
@@ -107,6 +107,10 @@ impl PhysicalPlanBuilder {
             RelOperator::Window(window) => {
                 self.build_window(s_expr, window, required, stat_info).await
             }
+            RelOperator::WindowGroup(window_group) => {
+                self.build_window_group(s_expr, window_group, required, stat_info)
+                    .await
+            }
             RelOperator::Sort(sort) => self.build_sort(s_expr, sort, required, stat_info).await,
             RelOperator::Limit(limit) => self.build_limit(s_expr, limit, required, stat_info).await,
             RelOperator::Exchange(exchange) => {
@@ -223,6 +227,30 @@ impl PhysicalPlanBuilder {
                 for item in &window.order_by {
                     req.extend(item.order_by_item.scalar.used_columns());
                     req.insert(item.order_by_item.index);
+                }
+            }
+            RelOperator::WindowGroup(window_group) => {
+                let req = &mut child_required[0];
+                for window in &window_group.windows {
+                    req.remove(&window.index);
+                }
+                for item in &window_group.scalar_items {
+                    req.extend(item.scalar.used_columns());
+                    req.insert(item.index);
+                }
+                for window in &window_group.windows {
+                    for item in &window.arguments {
+                        req.extend(item.scalar.used_columns());
+                        req.insert(item.index);
+                    }
+                    for item in &window.partition_by {
+                        req.extend(item.scalar.used_columns());
+                        req.insert(item.index);
+                    }
+                    for item in &window.order_by {
+                        req.extend(item.order_by_item.scalar.used_columns());
+                        req.insert(item.order_by_item.index);
+                    }
                 }
             }
             RelOperator::Sort(sort) => {

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -56,9 +56,6 @@ use super::NthValueFunctionDesc;
 use super::NtileFunctionDesc;
 use super::WindowFunction;
 use crate::physical_plans::PhysicalPlanBuilder;
-use crate::physical_plans::Sort;
-use crate::physical_plans::WindowPartition;
-use crate::physical_plans::WindowPartitionTopN;
 use crate::physical_plans::WindowPartitionTopNFunc;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::format::PhysicalFormat;
@@ -67,7 +64,6 @@ use crate::physical_plans::format::WindowGroupFormatter;
 use crate::physical_plans::physical_plan::IPhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlanMeta;
-use crate::physical_plans::physical_sort::SortStep;
 use crate::pipelines::PipelineBuilder;
 use crate::pipelines::builders::SortPipelineBuilder;
 use crate::pipelines::memory_settings::MemorySettingsExt;
@@ -186,10 +182,13 @@ impl IPhysicalPlan for WindowGroup {
         self.input.build_pipeline(builder)?;
 
         let mut schema = self.input.output_schema()?;
-        let mut previous_order = None;
+        let mut previous_order: Option<WindowOrder<'_>> = None;
         for window in &self.windows {
             let order = WindowOrder::from(window);
-            if previous_order.as_ref() != Some(&order) {
+            if previous_order
+                .as_ref()
+                .is_none_or(|previous| !previous.satisfies(&order))
+            {
                 apply_window_order(builder, &schema, window)?;
             }
             apply_window_transform(builder, &schema, window)?;
@@ -218,6 +217,13 @@ impl<'a> From<&'a WindowSpec> for WindowOrder<'a> {
             partition_by: &window.partition_by,
             order_by: &window.order_by,
         }
+    }
+}
+
+impl WindowOrder<'_> {
+    fn satisfies(&self, required: &WindowOrder) -> bool {
+        self.partition_by == required.partition_by
+            && (required.order_by.is_empty() || self.order_by == required.order_by)
     }
 }
 
@@ -559,34 +565,24 @@ impl PhysicalPlanBuilder {
             self.create_eval_scalar(&eval_scalar, projections, input, stat_info.clone())?
         };
 
-        let settings = self.ctx.get_settings();
-        let enable_fixed_rows = settings.get_enable_fixed_rows_sort()?;
-        let mut plan = input;
-        let mut schema = plan.output_schema()?;
+        let mut window_specs = Vec::with_capacity(window_group.windows.len());
+        let mut schema = input.output_schema()?;
         for window in &window_group.windows {
             let spec = self.create_window_spec(&schema, window)?;
-            let sort_input =
-                apply_window_sort_plan(plan, &spec, enable_fixed_rows, stat_info.clone())?;
-            plan = PhysicalPlan::new(Window {
-                input: sort_input,
-                index: spec.index,
-                func: spec.func.clone(),
-                partition_by: spec.partition_by.clone(),
-                order_by: spec.order_by.clone(),
-                window_frame: spec.window_frame.clone(),
-                limit: spec.limit,
-                top: spec.top,
-                meta: PhysicalPlanMeta::new("Window"),
-            });
             let mut fields = schema.fields().clone();
             fields.push(DataField::new(
                 &spec.index.to_string(),
                 spec.func.data_type()?,
             ));
             schema = DataSchemaRefExt::create(fields);
+            window_specs.push(spec);
         }
 
-        Ok(plan)
+        Ok(PhysicalPlan::new(WindowGroup {
+            meta: PhysicalPlanMeta::new("WindowGroup"),
+            input,
+            windows: window_specs,
+        }))
     }
 
     pub async fn build_window(
@@ -872,49 +868,4 @@ impl PhysicalPlanBuilder {
             WindowFuncType::CumeDist => Ok(WindowFunction::CumeDist),
         }
     }
-}
-
-fn apply_window_sort_plan(
-    input: PhysicalPlan,
-    window: &WindowSpec,
-    enable_fixed_rows: bool,
-    stat_info: PlanStatsInfo,
-) -> Result<PhysicalPlan> {
-    let mut order_by = Vec::with_capacity(window.partition_by.len() + window.order_by.len());
-    for index in &window.partition_by {
-        order_by.push(SortDesc {
-            asc: true,
-            nulls_first: false,
-            order_by: *index,
-            display_name: index.to_string(),
-        });
-    }
-    order_by.extend(window.order_by.clone());
-
-    if order_by.is_empty() {
-        return Ok(input);
-    }
-
-    if !window.partition_by.is_empty() {
-        return Ok(PhysicalPlan::new(WindowPartition {
-            meta: PhysicalPlanMeta::new("WindowPartition"),
-            input,
-            partition_by: window.partition_by.clone(),
-            order_by,
-            top_n: window_top_n(window).map(|(top, func)| WindowPartitionTopN { func, top }),
-            stat_info: Some(stat_info),
-        }));
-    }
-
-    Ok(PhysicalPlan::new(Sort {
-        meta: PhysicalPlanMeta::new("Sort"),
-        input,
-        order_by,
-        limit: None,
-        step: SortStep::Single,
-        pre_projection: None,
-        broadcast_id: None,
-        enable_fixed_rows,
-        stat_info: Some(stat_info),
-    }))
 }

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -186,7 +186,7 @@ impl IPhysicalPlan for WindowGroup {
         self.input.build_pipeline(builder)?;
 
         let mut schema = self.input.output_schema()?;
-        let mut previous_order: Option<WindowOrder<'_>> = None;
+        let mut previous_order = self.windows.first().map(WindowOrder::from);
         for window in &self.windows {
             let order = WindowOrder::from(window);
             if previous_order
@@ -603,6 +603,10 @@ impl PhysicalPlanBuilder {
                 meta: PhysicalPlanMeta::new("Window"),
             }));
         }
+
+        let settings = self.ctx.get_settings();
+        let enable_fixed_rows = settings.get_enable_fixed_rows_sort()?;
+        let input = apply_window_sort_plan(input, &window_specs[0], enable_fixed_rows, stat_info)?;
 
         Ok(PhysicalPlan::new(WindowGroup {
             meta: PhysicalPlanMeta::new("WindowGroup"),

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -56,6 +56,9 @@ use super::NthValueFunctionDesc;
 use super::NtileFunctionDesc;
 use super::WindowFunction;
 use crate::physical_plans::PhysicalPlanBuilder;
+use crate::physical_plans::Sort;
+use crate::physical_plans::WindowPartition;
+use crate::physical_plans::WindowPartitionTopN;
 use crate::physical_plans::WindowPartitionTopNFunc;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::format::PhysicalFormat;
@@ -64,6 +67,7 @@ use crate::physical_plans::format::WindowGroupFormatter;
 use crate::physical_plans::physical_plan::IPhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlanMeta;
+use crate::physical_plans::physical_sort::SortStep;
 use crate::pipelines::PipelineBuilder;
 use crate::pipelines::builders::SortPipelineBuilder;
 use crate::pipelines::memory_settings::MemorySettingsExt;
@@ -222,6 +226,10 @@ impl<'a> From<&'a WindowSpec> for WindowOrder<'a> {
 
 impl WindowOrder<'_> {
     fn satisfies(&self, required: &WindowOrder) -> bool {
+        if required.partition_by.is_empty() {
+            return self.partition_by.is_empty() && self.order_by == required.order_by;
+        }
+
         self.partition_by == required.partition_by
             && (required.order_by.is_empty() || self.order_by == required.order_by)
     }
@@ -578,6 +586,24 @@ impl PhysicalPlanBuilder {
             window_specs.push(spec);
         }
 
+        if window_specs.len() == 1 {
+            let spec = window_specs.remove(0);
+            let settings = self.ctx.get_settings();
+            let enable_fixed_rows = settings.get_enable_fixed_rows_sort()?;
+            let input = apply_window_sort_plan(input, &spec, enable_fixed_rows, stat_info)?;
+            return Ok(PhysicalPlan::new(Window {
+                input,
+                index: spec.index,
+                func: spec.func,
+                partition_by: spec.partition_by,
+                order_by: spec.order_by,
+                window_frame: spec.window_frame,
+                limit: spec.limit,
+                top: spec.top,
+                meta: PhysicalPlanMeta::new("Window"),
+            }));
+        }
+
         Ok(PhysicalPlan::new(WindowGroup {
             meta: PhysicalPlanMeta::new("WindowGroup"),
             input,
@@ -868,4 +894,49 @@ impl PhysicalPlanBuilder {
             WindowFuncType::CumeDist => Ok(WindowFunction::CumeDist),
         }
     }
+}
+
+fn apply_window_sort_plan(
+    input: PhysicalPlan,
+    window: &WindowSpec,
+    enable_fixed_rows: bool,
+    stat_info: PlanStatsInfo,
+) -> Result<PhysicalPlan> {
+    let mut order_by = Vec::with_capacity(window.partition_by.len() + window.order_by.len());
+    for index in &window.partition_by {
+        order_by.push(SortDesc {
+            asc: true,
+            nulls_first: false,
+            order_by: *index,
+            display_name: index.to_string(),
+        });
+    }
+    order_by.extend(window.order_by.clone());
+
+    if order_by.is_empty() {
+        return Ok(input);
+    }
+
+    if !window.partition_by.is_empty() {
+        return Ok(PhysicalPlan::new(WindowPartition {
+            meta: PhysicalPlanMeta::new("WindowPartition"),
+            input,
+            partition_by: window.partition_by.clone(),
+            order_by,
+            top_n: window_top_n(window).map(|(top, func)| WindowPartitionTopN { func, top }),
+            stat_info: Some(stat_info),
+        }));
+    }
+
+    Ok(PhysicalPlan::new(Sort {
+        meta: PhysicalPlanMeta::new("Sort"),
+        input,
+        order_by,
+        limit: None,
+        step: SortStep::Single,
+        pre_projection: None,
+        broadcast_id: None,
+        enable_fixed_rows,
+        stat_info: Some(stat_info),
+    }))
 }

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -13,23 +13,29 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::atomic;
+use std::sync::atomic::AtomicUsize;
 
 use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataField;
+use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::RawExpr;
+use databend_common_expression::SortColumnDescription;
 use databend_common_expression::type_check;
 use databend_common_expression::type_check::common_super_type;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_sql::ColumnSet;
 use databend_common_sql::ScalarExpr;
 use databend_common_sql::Symbol;
@@ -42,6 +48,7 @@ use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::WindowFuncFrame;
 use databend_common_sql::plans::WindowFuncFrameBound;
 use databend_common_sql::plans::WindowFuncType;
+use databend_storages_common_cache::TempDirManager;
 
 use super::LagLeadDefault;
 use super::LagLeadFunctionDesc;
@@ -49,17 +56,31 @@ use super::NthValueFunctionDesc;
 use super::NtileFunctionDesc;
 use super::WindowFunction;
 use crate::physical_plans::PhysicalPlanBuilder;
+use crate::physical_plans::Sort;
+use crate::physical_plans::WindowPartition;
+use crate::physical_plans::WindowPartitionTopN;
+use crate::physical_plans::WindowPartitionTopNFunc;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::format::PhysicalFormat;
 use crate::physical_plans::format::WindowFormatter;
+use crate::physical_plans::format::WindowGroupFormatter;
 use crate::physical_plans::physical_plan::IPhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 use crate::physical_plans::physical_plan::PhysicalPlanMeta;
+use crate::physical_plans::physical_sort::SortStep;
 use crate::pipelines::PipelineBuilder;
+use crate::pipelines::builders::SortPipelineBuilder;
+use crate::pipelines::memory_settings::MemorySettingsExt;
 use crate::pipelines::processors::transforms::FrameBound;
+use crate::pipelines::processors::transforms::SortStrategy;
 use crate::pipelines::processors::transforms::TransformWindow;
+use crate::pipelines::processors::transforms::TransformWindowPartitionCollect;
 use crate::pipelines::processors::transforms::WindowFunctionInfo;
+use crate::pipelines::processors::transforms::WindowPartitionExchange;
+use crate::pipelines::processors::transforms::WindowPartitionTopNExchange;
 use crate::pipelines::processors::transforms::WindowSortDesc;
+use crate::sessions::TableContextQueryIdentity;
+use crate::spillers::SpillerDiskConfig;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Window {
@@ -71,6 +92,133 @@ pub struct Window {
     pub order_by: Vec<SortDesc>,
     pub window_frame: WindowFuncFrame,
     pub limit: Option<usize>,
+    pub top: Option<usize>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct WindowSpec {
+    pub index: Symbol,
+    pub func: WindowFunction,
+    pub partition_by: Vec<Symbol>,
+    pub order_by: Vec<SortDesc>,
+    pub window_frame: WindowFuncFrame,
+    pub limit: Option<usize>,
+    pub top: Option<usize>,
+}
+
+impl Window {
+    fn spec(&self) -> WindowSpec {
+        WindowSpec {
+            index: self.index,
+            func: self.func.clone(),
+            partition_by: self.partition_by.clone(),
+            order_by: self.order_by.clone(),
+            window_frame: self.window_frame.clone(),
+            limit: self.limit,
+            top: self.top,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct WindowGroup {
+    pub meta: PhysicalPlanMeta,
+    pub input: PhysicalPlan,
+    pub windows: Vec<WindowSpec>,
+}
+
+#[typetag::serde]
+impl IPhysicalPlan for WindowGroup {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_meta(&self) -> &PhysicalPlanMeta {
+        &self.meta
+    }
+
+    fn get_meta_mut(&mut self) -> &mut PhysicalPlanMeta {
+        &mut self.meta
+    }
+
+    #[recursive::recursive]
+    fn output_schema(&self) -> Result<DataSchemaRef> {
+        let input_schema = self.input.output_schema()?;
+        let mut fields = Vec::with_capacity(input_schema.fields().len() + self.windows.len());
+        fields.extend_from_slice(input_schema.fields());
+        for window in &self.windows {
+            fields.push(DataField::new(
+                &window.index.to_string(),
+                window.func.data_type()?,
+            ));
+        }
+        Ok(DataSchemaRefExt::create(fields))
+    }
+
+    fn children<'a>(&'a self) -> Box<dyn Iterator<Item = &'a PhysicalPlan> + 'a> {
+        Box::new(std::iter::once(&self.input))
+    }
+
+    fn children_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut PhysicalPlan> + 'a> {
+        Box::new(std::iter::once(&mut self.input))
+    }
+
+    fn formatter(&self) -> Result<Box<dyn PhysicalFormat + '_>> {
+        Ok(WindowGroupFormatter::create(self))
+    }
+
+    #[recursive::recursive]
+    fn try_find_single_data_source(&self) -> Option<&DataSourcePlan> {
+        self.input.try_find_single_data_source()
+    }
+
+    fn derive(&self, mut children: Vec<PhysicalPlan>) -> PhysicalPlan {
+        assert_eq!(children.len(), 1);
+        let input = children.pop().unwrap();
+        PhysicalPlan::new(WindowGroup {
+            meta: self.meta.clone(),
+            input,
+            windows: self.windows.clone(),
+        })
+    }
+
+    fn build_pipeline2(&self, builder: &mut PipelineBuilder) -> Result<()> {
+        self.input.build_pipeline(builder)?;
+
+        let mut schema = self.input.output_schema()?;
+        let mut previous_order = None;
+        for window in &self.windows {
+            let order = WindowOrder::from(window);
+            if previous_order.as_ref() != Some(&order) {
+                apply_window_order(builder, &schema, window)?;
+            }
+            apply_window_transform(builder, &schema, window)?;
+            previous_order = Some(order);
+
+            let mut fields = schema.fields().clone();
+            fields.push(DataField::new(
+                &window.index.to_string(),
+                window.func.data_type()?,
+            ));
+            schema = DataSchemaRefExt::create(fields);
+        }
+        Ok(())
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct WindowOrder<'a> {
+    partition_by: &'a [Symbol],
+    order_by: &'a [SortDesc],
+}
+
+impl<'a> From<&'a WindowSpec> for WindowOrder<'a> {
+    fn from(window: &'a WindowSpec) -> Self {
+        Self {
+            partition_by: &window.partition_by,
+            order_by: &window.order_by,
+        }
+    }
 }
 
 #[typetag::serde]
@@ -155,95 +303,292 @@ impl IPhysicalPlan for Window {
             order_by: self.order_by.clone(),
             window_frame: self.window_frame.clone(),
             limit: self.limit,
+            top: self.top,
         })
     }
 
     fn build_pipeline2(&self, builder: &mut PipelineBuilder) -> Result<()> {
         self.input.build_pipeline(builder)?;
-
         let input_schema = self.input.output_schema()?;
-        let partition_by = self
-            .partition_by
-            .iter()
-            .map(|p| {
-                let offset = input_schema.index_of(&p.to_string())?;
-                Ok(offset)
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let order_by = self
-            .order_by
-            .iter()
-            .map(|o| {
-                let offset = input_schema.index_of(&o.order_by.to_string())?;
-                Ok(WindowSortDesc {
-                    offset,
-                    asc: o.asc,
-                    nulls_first: o.nulls_first,
-                    is_nullable: input_schema.field(offset).is_nullable(),
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let old_output_len = builder.main_pipeline.output_len();
-        // `TransformWindow` is a pipeline breaker.
-        if partition_by.is_empty() {
-            builder.main_pipeline.try_resize(1)?;
-        }
-        let func = WindowFunctionInfo::try_create(&self.func, &input_schema)?;
-        // Window
-        builder.main_pipeline.add_transform(|input, output| {
-            // The transform can only be created here, because it cannot be cloned.
-
-            let transform = if self.window_frame.units.is_rows() {
-                let start_bound = FrameBound::try_from(&self.window_frame.start_bound)?;
-                let end_bound = FrameBound::try_from(&self.window_frame.end_bound)?;
-                Box::new(TransformWindow::try_create_rows(
-                    input,
-                    output,
-                    func.clone(),
-                    partition_by.clone(),
-                    order_by.clone(),
-                    (start_bound, end_bound),
-                )?) as Box<dyn Processor>
-            } else {
-                if order_by.len() == 1 {
-                    let start_bound = FrameBound::try_from(&self.window_frame.start_bound)?;
-                    let end_bound = FrameBound::try_from(&self.window_frame.end_bound)?;
-                    return Ok(ProcessorPtr::create(
-                        Box::new(TransformWindow::try_create_range(
-                            input,
-                            output,
-                            func.clone(),
-                            partition_by.clone(),
-                            order_by.clone(),
-                            (start_bound, end_bound),
-                        )?) as Box<dyn Processor>,
-                    ));
-                }
-
-                // There is no offset in the RANGE frame. (just CURRENT ROW or UNBOUNDED)
-                // So we can use any number type to create the transform.
-                let start_bound = FrameBound::try_from(&self.window_frame.start_bound)?;
-                let end_bound = FrameBound::try_from(&self.window_frame.end_bound)?;
-                Box::new(TransformWindow::try_create_range(
-                    input,
-                    output,
-                    func.clone(),
-                    partition_by.clone(),
-                    order_by.clone(),
-                    (start_bound, end_bound),
-                )?) as Box<dyn Processor>
-            };
-            Ok(ProcessorPtr::create(transform))
-        })?;
-        if partition_by.is_empty() {
-            builder.main_pipeline.try_resize(old_output_len)?;
-        }
-        Ok(())
+        apply_window_transform(builder, &input_schema, &self.spec())
     }
 }
 
+fn apply_window_transform(
+    builder: &mut PipelineBuilder,
+    input_schema: &DataSchema,
+    window: &WindowSpec,
+) -> Result<()> {
+    let partition_by = window
+        .partition_by
+        .iter()
+        .map(|p| input_schema.index_of(&p.to_string()))
+        .collect::<Result<Vec<_>>>()?;
+    let order_by = window
+        .order_by
+        .iter()
+        .map(|o| {
+            let offset = input_schema.index_of(&o.order_by.to_string())?;
+            Ok(WindowSortDesc {
+                offset,
+                asc: o.asc,
+                nulls_first: o.nulls_first,
+                is_nullable: input_schema.field(offset).is_nullable(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let old_output_len = builder.main_pipeline.output_len();
+    if partition_by.is_empty() {
+        builder.main_pipeline.try_resize(1)?;
+    }
+    let func = WindowFunctionInfo::try_create(&window.func, input_schema)?;
+    builder.main_pipeline.add_transform(|input, output| {
+        let transform = if window.window_frame.units.is_rows() {
+            let start_bound = FrameBound::try_from(&window.window_frame.start_bound)?;
+            let end_bound = FrameBound::try_from(&window.window_frame.end_bound)?;
+            Box::new(TransformWindow::try_create_rows(
+                input,
+                output,
+                func.clone(),
+                partition_by.clone(),
+                order_by.clone(),
+                (start_bound, end_bound),
+            )?) as Box<dyn Processor>
+        } else {
+            let start_bound = FrameBound::try_from(&window.window_frame.start_bound)?;
+            let end_bound = FrameBound::try_from(&window.window_frame.end_bound)?;
+            Box::new(TransformWindow::try_create_range(
+                input,
+                output,
+                func.clone(),
+                partition_by.clone(),
+                order_by.clone(),
+                (start_bound, end_bound),
+            )?) as Box<dyn Processor>
+        };
+        Ok(ProcessorPtr::create(transform))
+    })?;
+    if partition_by.is_empty() {
+        builder.main_pipeline.try_resize(old_output_len)?;
+    }
+    Ok(())
+}
+
+fn apply_window_order(
+    builder: &mut PipelineBuilder,
+    input_schema: &DataSchema,
+    window: &WindowSpec,
+) -> Result<()> {
+    let partition_nulls_first = builder.settings.get_nulls_first()(true);
+    let sort_desc = window
+        .partition_by
+        .iter()
+        .map(|index| {
+            let offset = input_schema.index_of(&index.to_string())?;
+            Ok(SortColumnDescription {
+                offset,
+                asc: true,
+                nulls_first: partition_nulls_first,
+            })
+        })
+        .chain(window.order_by.iter().map(|desc| {
+            let offset = input_schema.index_of(&desc.order_by.to_string())?;
+            Ok(SortColumnDescription {
+                offset,
+                asc: desc.asc,
+                nulls_first: desc.nulls_first,
+            })
+        }))
+        .collect::<Result<Vec<_>>>()?;
+
+    if sort_desc.is_empty() {
+        return Ok(());
+    }
+
+    if !window.partition_by.is_empty() {
+        apply_window_partition(builder, input_schema, window, sort_desc)?;
+        return Ok(());
+    }
+
+    let enable_fixed_rows = builder.settings.get_enable_fixed_rows_sort()?;
+    let sort_builder = SortPipelineBuilder::create(
+        builder.ctx.clone(),
+        DataSchemaRefExt::create(input_schema.fields().clone()),
+        sort_desc.into(),
+        None,
+        enable_fixed_rows,
+    )?;
+    let max_threads = builder.settings.get_max_threads()? as usize;
+    if builder.main_pipeline.output_len() == 1 || max_threads == 1 {
+        builder.main_pipeline.try_resize(max_threads)?;
+    }
+    sort_builder.build_full_sort_pipeline(&mut builder.main_pipeline, false)
+}
+
+fn apply_window_partition(
+    builder: &mut PipelineBuilder,
+    input_schema: &DataSchema,
+    window: &WindowSpec,
+    sort_desc: Vec<SortColumnDescription>,
+) -> Result<()> {
+    let num_processors = builder.main_pipeline.output_len();
+    let settings = builder.settings.clone();
+    let num_partitions = builder.settings.get_window_num_partitions()?;
+    let partition_by = window
+        .partition_by
+        .iter()
+        .map(|index| input_schema.index_of(&index.to_string()))
+        .collect::<Result<Vec<_>>>()?;
+
+    if let Some((top, func)) = window_top_n(window) {
+        builder.main_pipeline.exchange(
+            num_processors,
+            WindowPartitionTopNExchange::create(
+                partition_by.clone(),
+                sort_desc.clone(),
+                top,
+                func,
+                num_partitions as u64,
+            ),
+        )?;
+    } else {
+        builder.main_pipeline.exchange(
+            num_processors,
+            WindowPartitionExchange::create(partition_by.clone(), num_partitions),
+        )?;
+    }
+
+    let temp_dir_manager = TempDirManager::instance();
+    let disk_bytes_limit = GlobalConfig::instance()
+        .spill
+        .window_partition_spill_bytes_limit();
+    let enable_dio = settings.get_enable_dio()?;
+    let disk_spill = temp_dir_manager
+        .get_disk_spill_dir(disk_bytes_limit, &builder.ctx.get_id())
+        .map(|temp_dir| SpillerDiskConfig::new(temp_dir, enable_dio))
+        .transpose()?;
+
+    let window_spill_settings = MemorySettings::from_window_settings(&builder.ctx)?;
+    let plan_schema = DataSchemaRefExt::create(input_schema.fields().clone());
+    let processor_id = AtomicUsize::new(0);
+    builder.main_pipeline.add_transform(|input, output| {
+        let strategy = SortStrategy::try_create(&settings, sort_desc.clone(), plan_schema.clone())?;
+        Ok(ProcessorPtr::create(Box::new(
+            TransformWindowPartitionCollect::new(
+                builder.ctx.clone(),
+                input,
+                output,
+                &settings,
+                processor_id.fetch_add(1, atomic::Ordering::AcqRel),
+                num_processors,
+                num_partitions,
+                window_spill_settings.clone(),
+                disk_spill.clone(),
+                strategy,
+            )?,
+        )))
+    })
+}
+
+fn window_top_n(window: &WindowSpec) -> Option<(usize, WindowPartitionTopNFunc)> {
+    let top = window.top?;
+    if top >= 10000 {
+        return None;
+    }
+
+    let func = match window.func {
+        WindowFunction::RowNumber => WindowPartitionTopNFunc::RowNumber,
+        WindowFunction::Rank => WindowPartitionTopNFunc::Rank,
+        WindowFunction::DenseRank => WindowPartitionTopNFunc::DenseRank,
+        WindowFunction::Aggregate(_)
+        | WindowFunction::LagLead(_)
+        | WindowFunction::NthValue(_)
+        | WindowFunction::Ntile(_)
+        | WindowFunction::PercentRank
+        | WindowFunction::CumeDist => return None,
+    };
+
+    Some((top, func))
+}
+
 impl PhysicalPlanBuilder {
+    pub async fn build_window_group(
+        &mut self,
+        s_expr: &SExpr,
+        window_group: &databend_common_sql::plans::WindowGroup,
+        mut required: ColumnSet,
+        stat_info: PlanStatsInfo,
+    ) -> Result<PhysicalPlan> {
+        for window in &window_group.windows {
+            required.remove(&window.index);
+        }
+        for item in &window_group.scalar_items {
+            required.extend(item.scalar.used_columns());
+            required.insert(item.index);
+        }
+        for window in &window_group.windows {
+            for item in &window.arguments {
+                required.extend(item.scalar.used_columns());
+                required.insert(item.index);
+            }
+            for item in &window.partition_by {
+                required.extend(item.scalar.used_columns());
+                required.insert(item.index);
+            }
+            for item in &window.order_by {
+                required.extend(item.order_by_item.scalar.used_columns());
+                required.insert(item.order_by_item.index);
+            }
+        }
+
+        let child = s_expr.child(0)?;
+        let input = self.build(child, required.clone()).await?;
+        let input = if window_group.scalar_items.is_empty() {
+            input
+        } else {
+            let mut projections = required.iter().copied().collect::<Vec<_>>();
+            for item in &window_group.scalar_items {
+                projections.push(item.index);
+            }
+            projections.sort_unstable();
+            projections.dedup();
+            let eval_scalar = databend_common_sql::plans::EvalScalar {
+                items: window_group.scalar_items.clone(),
+            };
+            self.create_eval_scalar(&eval_scalar, projections, input, stat_info.clone())?
+        };
+
+        let settings = self.ctx.get_settings();
+        let enable_fixed_rows = settings.get_enable_fixed_rows_sort()?;
+        let mut plan = input;
+        let mut schema = plan.output_schema()?;
+        for window in &window_group.windows {
+            let spec = self.create_window_spec(&schema, window)?;
+            let sort_input =
+                apply_window_sort_plan(plan, &spec, enable_fixed_rows, stat_info.clone())?;
+            plan = PhysicalPlan::new(Window {
+                input: sort_input,
+                index: spec.index,
+                func: spec.func.clone(),
+                partition_by: spec.partition_by.clone(),
+                order_by: spec.order_by.clone(),
+                window_frame: spec.window_frame.clone(),
+                limit: spec.limit,
+                top: spec.top,
+                meta: PhysicalPlanMeta::new("Window"),
+            });
+            let mut fields = schema.fields().clone();
+            fields.push(DataField::new(
+                &spec.index.to_string(),
+                spec.func.data_type()?,
+            ));
+            schema = DataSchemaRefExt::create(fields);
+        }
+
+        Ok(plan)
+    }
+
     pub async fn build_window(
         &mut self,
         s_expr: &SExpr,
@@ -274,9 +619,28 @@ impl PhysicalPlanBuilder {
 
         // 2. Build physical plan.
         let input = self.build(s_expr.child(0)?, required).await?;
-        let mut w = window.clone();
-
         let input_schema = input.output_schema()?;
+        let spec = self.create_window_spec(&input_schema, window)?;
+
+        Ok(PhysicalPlan::new(Window {
+            input,
+            index: spec.index,
+            func: spec.func,
+            partition_by: spec.partition_by,
+            order_by: spec.order_by,
+            window_frame: spec.window_frame,
+            limit: spec.limit,
+            top: spec.top,
+            meta: PhysicalPlanMeta::new("Window"),
+        }))
+    }
+
+    fn create_window_spec(
+        &self,
+        input_schema: &DataSchema,
+        window: &databend_common_sql::plans::Window,
+    ) -> Result<WindowSpec> {
+        let mut w = window.clone();
 
         if w.frame.units.is_range() && w.order_by.len() == 1 {
             let order_by = &mut w.order_by[0].order_by_item.scalar;
@@ -292,10 +656,7 @@ impl PhysicalPlanBuilder {
                 _ => None,
             };
 
-            let mut common_ty = order_by
-                .type_check(input_schema.as_ref())?
-                .data_type()
-                .clone();
+            let mut common_ty = order_by.type_check(input_schema)?.data_type().clone();
             if common_ty.remove_nullable().is_timestamp() {
                 for scalar in start.iter_mut().chain(end.iter_mut()) {
                     let scalar_ty = scalar.as_ref().infer_data_type();
@@ -379,8 +740,7 @@ impl PhysicalPlanBuilder {
 
         let settings = self.ctx.get_settings();
         let default_nulls_first = settings.get_nulls_first();
-
-        let order_by_items = w
+        let order_by = w
             .order_by
             .iter()
             .map(|v| {
@@ -393,58 +753,78 @@ impl PhysicalPlanBuilder {
                 }
             })
             .collect::<Vec<_>>();
-        let partition_items = w.partition_by.iter().map(|v| v.index).collect::<Vec<_>>();
+        let partition_by = w.partition_by.iter().map(|v| v.index).collect::<Vec<_>>();
 
-        let func = match &w.function {
-            WindowFuncType::Aggregate(agg) => WindowFunction::Aggregate(AggregateFunctionDesc {
-                sig: AggregateFunctionSignature {
-                    name: agg.func_name.clone(),
-                    udaf: None,
-                    return_type: *agg.return_type.clone(),
-                    args: agg
+        let func = self.create_window_function(&w)?;
+
+        Ok(WindowSpec {
+            index: w.index,
+            func,
+            partition_by,
+            order_by,
+            window_frame: w.frame.clone(),
+            limit: w.limit,
+            top: w.top,
+        })
+    }
+
+    fn create_window_function(
+        &self,
+        w: &databend_common_sql::plans::Window,
+    ) -> Result<WindowFunction> {
+        match &w.function {
+            WindowFuncType::Aggregate(agg) => {
+                Ok(WindowFunction::Aggregate(AggregateFunctionDesc {
+                    sig: AggregateFunctionSignature {
+                        name: agg.func_name.clone(),
+                        udaf: None,
+                        return_type: *agg.return_type.clone(),
+                        args: agg
+                            .args
+                            .iter()
+                            .map(|s| s.data_type())
+                            .collect::<Result<_>>()?,
+                        params: agg.params.clone(),
+                        sort_descs: agg
+                            .sort_descs
+                            .iter()
+                            .map(|d| d.try_into())
+                            .collect::<Result<_>>()?,
+                    },
+                    output_column: w.index,
+                    arg_indices: agg
                         .args
                         .iter()
-                        .map(|s| s.data_type())
+                        .map(|arg| {
+                            if let ScalarExpr::BoundColumnRef(col) = arg {
+                                Ok(col.column.index)
+                            } else {
+                                Err(ErrorCode::Internal(
+                                    "Aggregate function argument must be a BoundColumnRef"
+                                        .to_string(),
+                                ))
+                            }
+                        })
                         .collect::<Result<_>>()?,
-                    params: agg.params.clone(),
-                    sort_descs: agg
+                    sort_desc_indices: agg
                         .sort_descs
                         .iter()
-                        .map(|d| d.try_into())
+                        .map(|desc| {
+                            if let ScalarExpr::BoundColumnRef(col) = &desc.expr {
+                                Ok(col.column.index)
+                            } else {
+                                Err(ErrorCode::Internal(
+                                    "Aggregate function sort description must be a BoundColumnRef"
+                                        .to_string(),
+                                ))
+                            }
+                        })
                         .collect::<Result<_>>()?,
-                },
-                output_column: w.index,
-                arg_indices: agg
-                    .args
-                    .iter()
-                    .map(|arg| {
-                        if let ScalarExpr::BoundColumnRef(col) = arg {
-                            Ok(col.column.index)
-                        } else {
-                            Err(ErrorCode::Internal(
-                                "Aggregate function argument must be a BoundColumnRef".to_string(),
-                            ))
-                        }
-                    })
-                    .collect::<Result<_>>()?,
-                sort_desc_indices: agg
-                    .sort_descs
-                    .iter()
-                    .map(|desc| {
-                        if let ScalarExpr::BoundColumnRef(col) = &desc.expr {
-                            Ok(col.column.index)
-                        } else {
-                            Err(ErrorCode::Internal(
-                                "Aggregate function sort description must be a BoundColumnRef"
-                                    .to_string(),
-                            ))
-                        }
-                    })
-                    .collect::<Result<_>>()?,
-                display: ScalarExpr::AggregateFunction(agg.clone())
-                    .as_expr()?
-                    .sql_display(),
-            }),
+                    display: ScalarExpr::AggregateFunction(agg.clone())
+                        .as_expr()?
+                        .sql_display(),
+                }))
+            }
             WindowFuncType::LagLead(lag_lead) => {
                 let new_default = match &lag_lead.default {
                     None => LagLeadDefault::Null,
@@ -455,7 +835,7 @@ impl PhysicalPlanBuilder {
                         _ => unreachable!(),
                     },
                 };
-                WindowFunction::LagLead(LagLeadFunctionDesc {
+                Ok(WindowFunction::LagLead(LagLeadFunctionDesc {
                     is_lag: lag_lead.is_lag,
                     offset: lag_lead.offset,
                     return_type: *lag_lead.return_type.clone(),
@@ -467,10 +847,9 @@ impl PhysicalPlanBuilder {
                         ))
                     }?,
                     default: new_default,
-                })
+                }))
             }
-
-            WindowFuncType::NthValue(func) => WindowFunction::NthValue(NthValueFunctionDesc {
+            WindowFuncType::NthValue(func) => Ok(WindowFunction::NthValue(NthValueFunctionDesc {
                 n: func.n,
                 return_type: *func.return_type.clone(),
                 arg: if let ScalarExpr::BoundColumnRef(col) = &*func.arg {
@@ -481,27 +860,61 @@ impl PhysicalPlanBuilder {
                     ))
                 }?,
                 ignore_null: func.ignore_null,
-            }),
-            WindowFuncType::Ntile(func) => WindowFunction::Ntile(NtileFunctionDesc {
+            })),
+            WindowFuncType::Ntile(func) => Ok(WindowFunction::Ntile(NtileFunctionDesc {
                 n: func.n,
                 return_type: *func.return_type.clone(),
-            }),
-            WindowFuncType::RowNumber => WindowFunction::RowNumber,
-            WindowFuncType::Rank => WindowFunction::Rank,
-            WindowFuncType::DenseRank => WindowFunction::DenseRank,
-            WindowFuncType::PercentRank => WindowFunction::PercentRank,
-            WindowFuncType::CumeDist => WindowFunction::CumeDist,
-        };
-
-        Ok(PhysicalPlan::new(Window {
-            input,
-            index: w.index,
-            func,
-            partition_by: partition_items,
-            order_by: order_by_items,
-            window_frame: w.frame.clone(),
-            limit: w.limit,
-            meta: PhysicalPlanMeta::new("Window"),
-        }))
+            })),
+            WindowFuncType::RowNumber => Ok(WindowFunction::RowNumber),
+            WindowFuncType::Rank => Ok(WindowFunction::Rank),
+            WindowFuncType::DenseRank => Ok(WindowFunction::DenseRank),
+            WindowFuncType::PercentRank => Ok(WindowFunction::PercentRank),
+            WindowFuncType::CumeDist => Ok(WindowFunction::CumeDist),
+        }
     }
+}
+
+fn apply_window_sort_plan(
+    input: PhysicalPlan,
+    window: &WindowSpec,
+    enable_fixed_rows: bool,
+    stat_info: PlanStatsInfo,
+) -> Result<PhysicalPlan> {
+    let mut order_by = Vec::with_capacity(window.partition_by.len() + window.order_by.len());
+    for index in &window.partition_by {
+        order_by.push(SortDesc {
+            asc: true,
+            nulls_first: false,
+            order_by: *index,
+            display_name: index.to_string(),
+        });
+    }
+    order_by.extend(window.order_by.clone());
+
+    if order_by.is_empty() {
+        return Ok(input);
+    }
+
+    if !window.partition_by.is_empty() {
+        return Ok(PhysicalPlan::new(WindowPartition {
+            meta: PhysicalPlanMeta::new("WindowPartition"),
+            input,
+            partition_by: window.partition_by.clone(),
+            order_by,
+            top_n: window_top_n(window).map(|(top, func)| WindowPartitionTopN { func, top }),
+            stat_info: Some(stat_info),
+        }));
+    }
+
+    Ok(PhysicalPlan::new(Sort {
+        meta: PhysicalPlanMeta::new("Sort"),
+        input,
+        order_by,
+        limit: None,
+        step: SortStep::Single,
+        pre_projection: None,
+        broadcast_id: None,
+        enable_fixed_rows,
+        stat_info: Some(stat_info),
+    }))
 }

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -465,8 +465,9 @@ impl Binder {
 
         // bind window
         // window run after the HAVING clause but before the ORDER BY clause.
-        for window_info in &from_context.windows.window_functions {
-            s_expr = self.bind_window_function(window_info, s_expr)?;
+        if !from_context.windows.window_functions.is_empty() {
+            let window_functions = from_context.windows.window_functions.clone();
+            s_expr = self.bind_window_functions(&window_functions, s_expr)?;
         }
 
         // Bind lazy Set-returning functions after aggregate plan.

--- a/src/query/sql/src/planner/binder/util.rs
+++ b/src/query/sql/src/planner/binder/util.rs
@@ -71,6 +71,7 @@ impl Binder {
             | RelOperator::Limit(_)
             | RelOperator::Aggregate(_)
             | RelOperator::Window(_)
+            | RelOperator::WindowGroup(_)
             | RelOperator::Mutation(_)
             | RelOperator::MutationSource(_)
             | RelOperator::CompactBlock(_) => {

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_ast::Span;
@@ -49,17 +50,18 @@ use crate::plans::Window;
 use crate::plans::WindowFunc;
 use crate::plans::WindowFuncFrame;
 use crate::plans::WindowFuncType;
+use crate::plans::WindowGroup;
 use crate::plans::WindowOrderBy;
 use crate::plans::WindowPartition;
 use crate::plans::walk_expr_mut;
 
 impl Binder {
-    pub(super) fn bind_window_function(
+    pub(super) fn bind_window_functions(
         &mut self,
-        window_info: &WindowFunctionInfo,
+        window_infos: &[WindowFunctionInfo],
         child: SExpr,
     ) -> Result<SExpr> {
-        bind_window_function_info(&self.ctx, window_info, child)
+        bind_window_function_infos(&self.ctx, window_infos, child)
     }
 
     pub(super) fn analyze_window_definition(
@@ -595,6 +597,7 @@ pub fn bind_window_function_info(
         order_by: window_info.order_by_items.clone(),
         frame: window_info.frame.clone(),
         limit: None,
+        top: None,
     };
 
     // eval scalars before sort
@@ -669,6 +672,115 @@ pub fn bind_window_function_info(
         Arc::new(window_plan.into()),
         Arc::new(child),
     ))
+}
+
+pub fn bind_window_function_infos(
+    ctx: &Arc<dyn TableContext>,
+    window_infos: &[WindowFunctionInfo],
+    child: SExpr,
+) -> Result<SExpr> {
+    if window_infos.is_empty() {
+        return Ok(child);
+    }
+
+    if window_infos.len() == 1 {
+        return bind_window_function_info(ctx, &window_infos[0], child);
+    }
+
+    let mut groups = Vec::new();
+    let mut windows = Vec::new();
+    let mut scalar_items = Vec::new();
+    let mut current_partition_by: Option<Vec<ScalarExpr>> = None;
+    let mut scalar_indexes = HashSet::new();
+    let mut partition_order_scalar_indexes = HashMap::new();
+
+    for window_info in window_infos {
+        let partition_by = window_info
+            .partition_by_items
+            .iter()
+            .map(|item| item.scalar.clone())
+            .collect::<Vec<_>>();
+        if current_partition_by
+            .as_ref()
+            .is_some_and(|current| current != &partition_by)
+        {
+            groups.push(WindowGroup {
+                windows: std::mem::take(&mut windows),
+                scalar_items: std::mem::take(&mut scalar_items),
+            });
+            scalar_indexes.clear();
+            partition_order_scalar_indexes.clear();
+        }
+        current_partition_by = Some(partition_by);
+
+        let mut window_plan = Window {
+            span: window_info.span,
+            index: window_info.index,
+            function: window_info.func.clone(),
+            arguments: window_info.arguments.clone(),
+            partition_by: window_info.partition_by_items.clone(),
+            order_by: window_info.order_by_items.clone(),
+            frame: window_info.frame.clone(),
+            limit: None,
+            top: None,
+        };
+
+        for item in window_plan.arguments.iter() {
+            if scalar_indexes.insert(item.index) {
+                scalar_items.push(item.clone());
+            }
+        }
+        for item in &mut window_plan.partition_by {
+            canonicalize_window_group_scalar_item(
+                item,
+                &mut scalar_items,
+                &mut scalar_indexes,
+                &mut partition_order_scalar_indexes,
+            );
+        }
+        for order in &mut window_plan.order_by {
+            canonicalize_window_group_scalar_item(
+                &mut order.order_by_item,
+                &mut scalar_items,
+                &mut scalar_indexes,
+                &mut partition_order_scalar_indexes,
+            );
+        }
+
+        windows.push(window_plan);
+    }
+
+    groups.push(WindowGroup {
+        windows,
+        scalar_items,
+    });
+    groups.sort_by_key(|group| {
+        group
+            .windows
+            .first()
+            .is_none_or(|window| window.partition_by.is_empty())
+    });
+
+    Ok(groups.into_iter().rev().fold(child, |child, window_group| {
+        SExpr::create_unary(Arc::new(window_group.into()), Arc::new(child))
+    }))
+}
+
+fn canonicalize_window_group_scalar_item(
+    item: &mut ScalarItem,
+    scalar_items: &mut Vec<ScalarItem>,
+    scalar_indexes: &mut HashSet<Symbol>,
+    scalar_item_indexes: &mut HashMap<ScalarExpr, Symbol>,
+) {
+    if let Some(index) = scalar_item_indexes.get(&item.scalar) {
+        item.index = *index;
+        return;
+    }
+
+    scalar_item_indexes.insert(item.scalar.clone(), item.index);
+    if scalar_indexes.insert(item.index) {
+        scalar_items.push(item.clone());
+    }
 }
 
 impl Binder {

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -690,29 +690,11 @@ pub fn bind_window_function_infos(
     let mut groups = Vec::new();
     let mut windows = Vec::new();
     let mut scalar_items = Vec::new();
-    let mut current_partition_by: Option<Vec<ScalarExpr>> = None;
+    let mut current_window_key: Option<WindowGroupKey> = None;
     let mut scalar_indexes = HashSet::new();
     let mut partition_order_scalar_indexes = HashMap::new();
 
     for window_info in window_infos {
-        let partition_by = window_info
-            .partition_by_items
-            .iter()
-            .map(|item| item.scalar.clone())
-            .collect::<Vec<_>>();
-        if current_partition_by
-            .as_ref()
-            .is_some_and(|current| current != &partition_by)
-        {
-            groups.push(WindowGroup {
-                windows: std::mem::take(&mut windows),
-                scalar_items: std::mem::take(&mut scalar_items),
-            });
-            scalar_indexes.clear();
-            partition_order_scalar_indexes.clear();
-        }
-        current_partition_by = Some(partition_by);
-
         let mut window_plan = Window {
             span: window_info.span,
             index: window_info.index,
@@ -725,28 +707,46 @@ pub fn bind_window_function_infos(
             top: None,
         };
 
-        for item in window_plan.arguments.iter() {
-            if scalar_indexes.insert(item.index) {
-                scalar_items.push(item.clone());
-            }
-        }
+        let arguments = window_plan.arguments.clone();
         for item in &mut window_plan.partition_by {
-            canonicalize_window_group_scalar_item(
-                item,
-                &mut scalar_items,
-                &mut scalar_indexes,
-                &mut partition_order_scalar_indexes,
-            );
+            canonicalize_window_group_scalar_item(item, &mut partition_order_scalar_indexes);
         }
         for order in &mut window_plan.order_by {
             canonicalize_window_group_scalar_item(
                 &mut order.order_by_item,
-                &mut scalar_items,
-                &mut scalar_indexes,
                 &mut partition_order_scalar_indexes,
             );
         }
 
+        let window_key = WindowGroupKey::from_window(&window_plan);
+        if current_window_key
+            .as_ref()
+            .is_some_and(|current| current != &window_key)
+        {
+            groups.push(WindowGroup {
+                windows: std::mem::take(&mut windows),
+                scalar_items: std::mem::take(&mut scalar_items),
+            });
+            scalar_indexes.clear();
+            partition_order_scalar_indexes.clear();
+        }
+        current_window_key = Some(window_key);
+
+        for item in arguments.iter() {
+            if scalar_indexes.insert(item.index) {
+                scalar_items.push(item.clone());
+            }
+        }
+        for item in &window_plan.partition_by {
+            if scalar_indexes.insert(item.index) {
+                scalar_items.push(item.clone());
+            }
+        }
+        for order in &window_plan.order_by {
+            if scalar_indexes.insert(order.order_by_item.index) {
+                scalar_items.push(order.order_by_item.clone());
+            }
+        }
         windows.push(window_plan);
     }
 
@@ -761,15 +761,30 @@ pub fn bind_window_function_infos(
             .is_none_or(|window| window.partition_by.is_empty())
     });
 
-    Ok(groups.into_iter().rev().fold(child, |child, window_group| {
+    Ok(groups.into_iter().fold(child, |child, window_group| {
         SExpr::create_unary(Arc::new(window_group.into()), Arc::new(child))
     }))
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WindowGroupKey {
+    partition_by: Vec<ScalarExpr>,
+}
+
+impl WindowGroupKey {
+    fn from_window(window: &Window) -> Self {
+        Self {
+            partition_by: window
+                .partition_by
+                .iter()
+                .map(|item| item.scalar.clone())
+                .collect(),
+        }
+    }
+}
+
 fn canonicalize_window_group_scalar_item(
     item: &mut ScalarItem,
-    scalar_items: &mut Vec<ScalarItem>,
-    scalar_indexes: &mut HashSet<Symbol>,
     scalar_item_indexes: &mut HashMap<ScalarExpr, Symbol>,
 ) {
     if let Some(index) = scalar_item_indexes.get(&item.scalar) {
@@ -778,9 +793,6 @@ fn canonicalize_window_group_scalar_item(
     }
 
     scalar_item_indexes.insert(item.scalar.clone(), item.index);
-    if scalar_indexes.insert(item.index) {
-        scalar_items.push(item.clone());
-    }
 }
 
 impl Binder {

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -36,6 +36,7 @@ use crate::plans::Sort;
 use crate::plans::Udf;
 use crate::plans::UnionAll;
 use crate::plans::Window;
+use crate::plans::WindowGroup;
 
 impl<I: IdHumanizer> OperatorHumanizer<I> for DefaultOperatorHumanizer {
     fn humanize_operator(&self, id_humanizer: &I, op: &RelOperator) -> FormatTreeNode {
@@ -53,6 +54,7 @@ fn to_format_tree<I: IdHumanizer>(id_humanizer: &I, op: &RelOperator) -> FormatT
         RelOperator::Filter(op) => filter_to_format_tree(id_humanizer, op),
         RelOperator::Aggregate(op) => aggregate_to_format_tree(id_humanizer, op),
         RelOperator::Window(op) => window_to_format_tree(id_humanizer, op),
+        RelOperator::WindowGroup(op) => window_group_to_format_tree(id_humanizer, op),
         RelOperator::Udf(op) => udf_to_format_tree(id_humanizer, op),
         RelOperator::AsyncFunction(op) => async_func_to_format_tree(id_humanizer, op),
         RelOperator::Sort(op) => sort_to_format_tree(id_humanizer, op),
@@ -278,12 +280,29 @@ fn window_to_format_tree<I: IdHumanizer>(id_humanizer: &I, op: &Window) -> Forma
 
     let frame = op.frame.to_string();
 
-    FormatTreeNode::with_children("Window".to_string(), vec![
+    let mut children = vec![
         FormatTreeNode::new(format!("aggregate function: {}", op.function.func_name())),
         FormatTreeNode::new(format!("partition items: [{}]", partition_by_items)),
         FormatTreeNode::new(format!("order by items: [{}]", order_by_items)),
         FormatTreeNode::new(format!("frame: [{}]", frame)),
-    ])
+    ];
+    if let Some(top) = op.top {
+        children.push(FormatTreeNode::new(format!("top: {}", top)));
+    }
+
+    FormatTreeNode::with_children("Window".to_string(), children)
+}
+
+fn window_group_to_format_tree<I: IdHumanizer>(
+    id_humanizer: &I,
+    op: &WindowGroup,
+) -> FormatTreeNode {
+    let children = op
+        .windows
+        .iter()
+        .map(|window| window_to_format_tree(id_humanizer, window))
+        .collect();
+    FormatTreeNode::with_children("WindowGroup".to_string(), children)
 }
 
 fn udf_to_format_tree<I: IdHumanizer>(id_humanizer: &I, op: &Udf) -> FormatTreeNode {

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -297,6 +297,10 @@ fn window_group_to_format_tree<I: IdHumanizer>(
     id_humanizer: &I,
     op: &WindowGroup,
 ) -> FormatTreeNode {
+    if op.windows.len() == 1 {
+        return window_to_format_tree(id_humanizer, &op.windows[0]);
+    }
+
     let children = op
         .windows
         .iter()

--- a/src/query/sql/src/planner/optimizer/ir/format.rs
+++ b/src/query/sql/src/planner/optimizer/ir/format.rs
@@ -79,6 +79,7 @@ fn display_rel_op(rel_op: &RelOperator) -> String {
         RelOperator::DummyTableScan(_) => "DummyTableScan".to_string(),
         RelOperator::ProjectSet(_) => "ProjectSet".to_string(),
         RelOperator::Window(_) => "WindowFunc".to_string(),
+        RelOperator::WindowGroup(_) => "WindowGroup".to_string(),
         RelOperator::ConstantTableScan(s) => s.name().to_string(),
         RelOperator::ExpressionScan(_) => "ExpressionScan".to_string(),
         RelOperator::CacheScan(_) => "CacheScan".to_string(),

--- a/src/query/sql/src/planner/optimizer/optimizers/cascades/cost/model.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/cascades/cost/model.rs
@@ -88,6 +88,7 @@ impl DefaultCostModel {
             RelOperator::EvalScalar(_)
             | RelOperator::Filter(_)
             | RelOperator::Window(_)
+            | RelOperator::WindowGroup(_)
             | RelOperator::Sort(_)
             | RelOperator::ProjectSet(_)
             | RelOperator::Udf(_)

--- a/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
@@ -176,6 +176,7 @@ impl DPhpyOptimizer {
                 | RelOperator::Limit(_)
                 | RelOperator::ProjectSet(_)
                 | RelOperator::Window(_)
+                | RelOperator::WindowGroup(_)
                 | RelOperator::Udf(_)
         )
     }
@@ -400,6 +401,7 @@ impl DPhpyOptimizer {
             | RelOperator::Limit(_)
             | RelOperator::EvalScalar(_)
             | RelOperator::Window(_)
+            | RelOperator::WindowGroup(_)
             | RelOperator::Udf(_)
             | RelOperator::Filter(_)
             | RelOperator::MaterializedCTE(_) => {

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -66,6 +66,7 @@ use crate::plans::WindowFuncFrame;
 use crate::plans::WindowFuncFrameBound;
 use crate::plans::WindowFuncFrameUnits;
 use crate::plans::WindowFuncType;
+use crate::plans::WindowGroup;
 use crate::plans::WindowPartition;
 
 impl SubqueryDecorrelatorOptimizer {
@@ -204,6 +205,14 @@ impl SubqueryDecorrelatorOptimizer {
                 derived_columns,
             ),
             RelOperator::Window(op) => self.flatten_sub_window(
+                outer,
+                subquery,
+                op,
+                correlated_columns,
+                flatten_info,
+                derived_columns,
+            ),
+            RelOperator::WindowGroup(op) => self.flatten_sub_window_group(
                 outer,
                 subquery,
                 op,
@@ -787,6 +796,7 @@ impl SubqueryDecorrelatorOptimizer {
                 end_bound: WindowFuncFrameBound::CurrentRow,
             },
             limit: None,
+            top: None,
         };
 
         let window_child = if sort_items.is_empty() {
@@ -909,6 +919,72 @@ impl SubqueryDecorrelatorOptimizer {
                 order_by: window.order_by.clone(),
                 frame: window.frame.clone(),
                 limit: window.limit,
+                top: window.top,
+            }),
+            derived_columns,
+        ))
+    }
+
+    fn flatten_sub_window_group(
+        &mut self,
+        outer: &SExpr,
+        subquery: &SExpr,
+        window_group: &WindowGroup,
+        correlated_columns: &ColumnSet,
+        flatten_info: &mut FlattenInfo,
+        derived_columns: &DerivedColumnScope,
+    ) -> Result<FlattenPlanResult> {
+        if !window_group.used_columns()?.is_disjoint(correlated_columns) {
+            return Err(ErrorCode::SemanticError(
+                "correlated columns in window functions not supported",
+            ));
+        }
+        let (flatten_plan, derived_columns) = self.flatten_plan_with_scope(
+            outer,
+            subquery.unary_child(),
+            correlated_columns,
+            flatten_info,
+            true,
+            derived_columns,
+        )?;
+
+        let metadata = self.metadata.read();
+        let windows = window_group
+            .windows
+            .iter()
+            .map(|window| {
+                let partition_by = window
+                    .partition_by
+                    .iter()
+                    .cloned()
+                    .map(Ok)
+                    .chain(correlated_columns.iter().copied().map(|old| {
+                        Ok(Self::scalar_item_from_index(
+                            derived_columns.must_resolve(old)?,
+                            "outer.",
+                            &metadata,
+                        ))
+                    }))
+                    .collect::<Result<_>>()?;
+                Ok(Window {
+                    span: window.span,
+                    index: window.index,
+                    function: window.function.clone(),
+                    arguments: window.arguments.clone(),
+                    partition_by,
+                    order_by: window.order_by.clone(),
+                    frame: window.frame.clone(),
+                    limit: window.limit,
+                    top: window.top,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        drop(metadata);
+
+        Ok((
+            flatten_plan.build_unary(WindowGroup {
+                windows,
+                scalar_items: window_group.scalar_items.clone(),
             }),
             derived_columns,
         ))

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -234,6 +234,35 @@ impl SubqueryDecorrelatorOptimizer {
                 Ok(outer.build_unary(plan))
             }
 
+            RelOperator::WindowGroup(plan) => {
+                let mut plan = plan.clone();
+                let mut outer = self.optimize_sync(s_expr.unary_child())?;
+
+                for item in plan.scalar_items.iter_mut() {
+                    (item.scalar, outer) = self.try_rewrite_subquery(&item.scalar, outer, false)?;
+                }
+
+                for window in plan.windows.iter_mut() {
+                    for item in window.partition_by.iter_mut() {
+                        (item.scalar, outer) =
+                            self.try_rewrite_subquery(&item.scalar, outer, false)?;
+                    }
+
+                    for item in window.order_by.iter_mut() {
+                        (item.order_by_item.scalar, outer) =
+                            self.try_rewrite_subquery(&item.order_by_item.scalar, outer, false)?;
+                    }
+
+                    if let WindowFuncType::Aggregate(agg) = &mut window.function {
+                        for item in agg.exprs_mut() {
+                            (*item, outer) = self.try_rewrite_subquery(item, outer, false)?;
+                        }
+                    }
+                }
+
+                Ok(outer.build_unary(plan))
+            }
+
             RelOperator::Sort(sort) => {
                 let mut outer = self.optimize_sync(s_expr.unary_child())?;
 

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window.rs
@@ -22,7 +22,9 @@ use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
 use crate::plans::Filter;
 use crate::plans::RelOp;
+use crate::plans::RelOperator;
 use crate::plans::Window;
+use crate::plans::WindowGroup;
 
 /// Input:   Filter
 ///           \
@@ -56,13 +58,22 @@ impl RulePushDownFilterWindow {
     pub fn new() -> Self {
         Self {
             id: RuleID::PushDownFilterWindow,
-            matchers: vec![Matcher::MatchOp {
-                op_type: RelOp::Filter,
-                children: vec![Matcher::MatchOp {
-                    op_type: RelOp::Window,
-                    children: vec![Matcher::Leaf],
-                }],
-            }],
+            matchers: vec![
+                Matcher::MatchOp {
+                    op_type: RelOp::Filter,
+                    children: vec![Matcher::MatchOp {
+                        op_type: RelOp::Window,
+                        children: vec![Matcher::Leaf],
+                    }],
+                },
+                Matcher::MatchOp {
+                    op_type: RelOp::Filter,
+                    children: vec![Matcher::MatchOp {
+                        op_type: RelOp::WindowGroup,
+                        children: vec![Matcher::Leaf],
+                    }],
+                },
+            ],
         }
     }
 }
@@ -79,14 +90,23 @@ impl Rule for RulePushDownFilterWindow {
     ) -> databend_common_exception::Result<()> {
         let Filter { predicates } = s_expr.plan().clone().try_into()?;
         let window_expr = s_expr.child(0)?;
-        let window: Window = window_expr.plan().clone().try_into()?;
-        let allowed = window.partition_by_columns()?;
-        let rejected = ColumnSet::from_iter(
-            window
-                .order_by_columns()?
-                .into_iter()
-                .chain(window.function.used_columns()),
-        );
+        let (window_plan, allowed, rejected) =
+            if matches!(window_expr.plan(), RelOperator::WindowGroup(_)) {
+                let window_group: WindowGroup = window_expr.plan().clone().try_into()?;
+                let allowed = window_group_partition_by_columns(&window_group)?;
+                let rejected = window_group_rejected_columns(&window_group)?;
+                (RelOperator::WindowGroup(window_group), allowed, rejected)
+            } else {
+                let window: Window = window_expr.plan().clone().try_into()?;
+                let allowed = window.partition_by_columns()?;
+                let rejected = ColumnSet::from_iter(
+                    window
+                        .order_by_columns()?
+                        .into_iter()
+                        .chain(window.function.used_columns()),
+                );
+                (RelOperator::Window(window), allowed, rejected)
+            };
 
         let (pushed_down, remaining): (Vec<_>, Vec<_>) =
             predicates.into_iter().partition(|predicate| {
@@ -102,7 +122,7 @@ impl Rule for RulePushDownFilterWindow {
         };
         let result = if remaining.is_empty() {
             SExpr::create_unary(
-                Arc::new(window.into()),
+                Arc::new(window_plan),
                 Arc::new(SExpr::create_unary(
                     Arc::new(pushed_down_filter.into()),
                     Arc::new(window_expr.child(0)?.clone()),
@@ -115,7 +135,7 @@ impl Rule for RulePushDownFilterWindow {
             let mut s_expr = SExpr::create_unary(
                 Arc::new(remaining_filter.into()),
                 Arc::new(SExpr::create_unary(
-                    Arc::new(window.into()),
+                    Arc::new(window_plan),
                     Arc::new(SExpr::create_unary(
                         Arc::new(pushed_down_filter.into()),
                         Arc::new(window_expr.child(0)?.clone()),
@@ -132,6 +152,34 @@ impl Rule for RulePushDownFilterWindow {
     fn matchers(&self) -> &[Matcher] {
         &self.matchers
     }
+}
+
+fn window_group_partition_by_columns(
+    window_group: &WindowGroup,
+) -> databend_common_exception::Result<ColumnSet> {
+    let Some(first) = window_group.windows.first() else {
+        return Ok(ColumnSet::new());
+    };
+
+    let mut allowed = first.partition_by_columns()?;
+    for window in window_group.windows.iter().skip(1) {
+        allowed = allowed
+            .intersection(&window.partition_by_columns()?)
+            .copied()
+            .collect();
+    }
+    Ok(allowed)
+}
+
+fn window_group_rejected_columns(
+    window_group: &WindowGroup,
+) -> databend_common_exception::Result<ColumnSet> {
+    let mut rejected = ColumnSet::new();
+    for window in &window_group.windows {
+        rejected.extend(window.order_by_columns()?);
+        rejected.extend(window.function.used_columns());
+    }
+    Ok(rejected)
 }
 
 impl Default for RulePushDownFilterWindow {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window_top_n.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window_top_n.rs
@@ -39,6 +39,7 @@ use crate::plans::ScalarExpr;
 use crate::plans::Sort;
 use crate::plans::Window;
 use crate::plans::WindowFuncType;
+use crate::plans::WindowGroup;
 
 /// Input:  Filter
 ///           \
@@ -62,16 +63,25 @@ impl RulePushDownFilterWindowTopN {
         Self {
             id: RuleID::PushDownFilterWindowTopN,
             metadata,
-            matchers: vec![Matcher::MatchOp {
-                op_type: RelOp::Filter,
-                children: vec![Matcher::MatchOp {
-                    op_type: RelOp::Window,
+            matchers: vec![
+                Matcher::MatchOp {
+                    op_type: RelOp::Filter,
                     children: vec![Matcher::MatchOp {
-                        op_type: RelOp::Sort,
+                        op_type: RelOp::Window,
+                        children: vec![Matcher::MatchOp {
+                            op_type: RelOp::Sort,
+                            children: vec![Matcher::Leaf],
+                        }],
+                    }],
+                },
+                Matcher::MatchOp {
+                    op_type: RelOp::Filter,
+                    children: vec![Matcher::MatchOp {
+                        op_type: RelOp::WindowGroup,
                         children: vec![Matcher::Leaf],
                     }],
-                }],
-            }],
+                },
+            ],
         }
     }
 }
@@ -84,6 +94,10 @@ impl Rule for RulePushDownFilterWindowTopN {
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let filter: Filter = s_expr.plan().clone().try_into()?;
         let window_expr = s_expr.child(0)?;
+        if matches!(window_expr.plan().rel_op(), RelOp::WindowGroup) {
+            return self.apply_window_group(s_expr, filter, window_expr, state);
+        }
+
         let window: Window = window_expr.plan().clone().try_into()?;
         let sort_expr = window_expr.child(0)?;
         let mut sort: Sort = sort_expr.plan().clone().try_into()?;
@@ -140,6 +154,67 @@ impl Rule for RulePushDownFilterWindowTopN {
 
     fn matchers(&self) -> &[Matcher] {
         &self.matchers
+    }
+}
+
+impl RulePushDownFilterWindowTopN {
+    fn apply_window_group(
+        &self,
+        s_expr: &SExpr,
+        filter: Filter,
+        window_expr: &SExpr,
+        state: &mut TransformResult,
+    ) -> Result<()> {
+        let mut window_group: WindowGroup = window_expr.plan().clone().try_into()?;
+        let mut top_n_windows = Vec::new();
+
+        for (index, window) in window_group.windows.iter().enumerate() {
+            if !is_ranking_function(&window.function) || window.partition_by.is_empty() {
+                continue;
+            }
+
+            let predicates = filter
+                .predicates
+                .iter()
+                .filter_map(|predicate| extract_top_n(window.index, predicate.clone()))
+                .collect::<Vec<_>>();
+            if let Some(top_n) = predicates.into_iter().min() {
+                top_n_windows.push((index, top_n));
+            }
+        }
+
+        let Some((index, top_n)) = top_n_windows.into_iter().min_by_key(|(_, top_n)| *top_n) else {
+            return Ok(());
+        };
+
+        if top_n == 0 {
+            let output_columns = s_expr
+                .plan()
+                .derive_relational_prop(&RelExpr::with_s_expr(s_expr))?
+                .output_columns
+                .clone();
+            let metadata = self.metadata.read();
+            let mut columns = output_columns.iter().copied().collect::<Vec<_>>();
+            columns.sort();
+            let fields = columns
+                .into_iter()
+                .map(|col| DataField::new(&col.to_string(), metadata.column(col).data_type()))
+                .collect::<Vec<_>>();
+            let empty_scan =
+                ConstantTableScan::new_empty_scan(DataSchemaRefExt::create(fields), output_columns);
+            let result = SExpr::create_leaf(Arc::new(RelOperator::ConstantTableScan(empty_scan)));
+            state.add_result(result);
+            return Ok(());
+        }
+
+        window_group.windows[index].top = Some(top_n);
+        let mut result = s_expr.replace_children(vec![Arc::new(
+            window_expr.replace_plan(Arc::new(window_group.into())),
+        )]);
+        result.set_applied_rule(&self.id);
+        state.add_result(result);
+
+        Ok(())
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
@@ -126,7 +126,10 @@ fn find_group_by_keys(
     group_by_keys: &mut HashMap<Symbol, Box<DataType>>,
 ) -> Result<()> {
     match child.plan() {
-        RelOperator::EvalScalar(_) | RelOperator::Filter(_) | RelOperator::Window(_) => {
+        RelOperator::EvalScalar(_)
+        | RelOperator::Filter(_)
+        | RelOperator::Window(_)
+        | RelOperator::WindowGroup(_) => {
             find_group_by_keys(child.child(0)?, group_by_keys)?;
         }
         RelOperator::Aggregate(agg) => {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_window.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_window.rs
@@ -129,7 +129,7 @@ fn is_valid_frame(frame: &WindowFuncFrame) -> bool {
 
 fn child_has_window(child: &SExpr) -> bool {
     match child.plan() {
-        RelOperator::Window(_) => true,
+        RelOperator::Window(_) | RelOperator::WindowGroup(_) => true,
         RelOperator::Scan(_) => false, // finish recursion
         _ => child.children().any(child_has_window),
     }

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -52,6 +52,7 @@ use crate::plans::Sort;
 use crate::plans::Udf;
 use crate::plans::UnionAll;
 use crate::plans::Window;
+use crate::plans::WindowGroup;
 use crate::plans::r_cte_scan::RecursiveCteScan;
 use crate::plans::sequence::Sequence;
 
@@ -119,6 +120,7 @@ pub enum RelOp {
     UnionAll,
     DummyTableScan,
     Window,
+    WindowGroup,
     ProjectSet,
     ConstantTableScan,
     ExpressionScan,
@@ -156,6 +158,7 @@ pub enum RelOperator {
     UnionAll(UnionAll),
     DummyTableScan(DummyTableScan),
     Window(Window),
+    WindowGroup(WindowGroup),
     ProjectSet(ProjectSet),
     ConstantTableScan(ConstantTableScan),
     ExpressionScan(ExpressionScan),
@@ -260,6 +263,7 @@ impl_try_from_rel_operator! {
     UnionAll,
     DummyTableScan,
     Window,
+    WindowGroup,
     ProjectSet,
     ConstantTableScan,
     ExpressionScan,

--- a/src/query/sql/src/planner/plans/operator_macros.rs
+++ b/src/query/sql/src/planner/plans/operator_macros.rs
@@ -100,6 +100,7 @@ macro_rules! impl_match_rel_op {
             RelOperator::UnionAll($rel_op) => $rel_op.$method($($arg),*),
             RelOperator::DummyTableScan($rel_op) => $rel_op.$method($($arg),*),
             RelOperator::Window($rel_op) => $rel_op.$method($($arg),*),
+            RelOperator::WindowGroup($rel_op) => $rel_op.$method($($arg),*),
             RelOperator::ProjectSet($rel_op) => $rel_op.$method($($arg),*),
             RelOperator::ConstantTableScan($rel_op) => $rel_op.$method($($arg),*),
             RelOperator::ExpressionScan($rel_op) => $rel_op.$method($($arg),*),

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -65,6 +65,63 @@ pub struct Window {
     pub frame: WindowFuncFrame,
     // limit for potentially possible push-down
     pub limit: Option<usize>,
+    // per-partition top-n for ranking window push-down
+    pub top: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct WindowGroup {
+    pub windows: Vec<Window>,
+    pub scalar_items: Vec<ScalarItem>,
+}
+
+impl WindowGroup {
+    pub fn used_columns(&self) -> Result<ColumnSet> {
+        let mut used_columns = ColumnSet::new();
+
+        for item in &self.scalar_items {
+            used_columns.insert(item.index);
+            used_columns.extend(item.scalar.used_columns());
+        }
+
+        for window in &self.windows {
+            used_columns.extend(window.used_columns()?);
+        }
+
+        Ok(used_columns)
+    }
+
+    fn required_distribution(&self, rel_expr: &RelExpr) -> Result<Distribution> {
+        let Some(first) = self.windows.first() else {
+            return Ok(Distribution::Any);
+        };
+
+        if first.partition_by.is_empty() {
+            return Ok(Distribution::Serial);
+        }
+
+        let partition_by = first
+            .partition_by
+            .iter()
+            .map(|item| item.scalar.clone())
+            .collect::<Vec<_>>();
+        if !self.windows.iter().all(|window| {
+            window
+                .partition_by
+                .iter()
+                .map(|item| &item.scalar)
+                .eq(partition_by.iter())
+        }) {
+            return Ok(Distribution::Serial);
+        }
+
+        let child_physical_prop = rel_expr.derive_physical_prop_child(0)?;
+        if child_physical_prop.distribution == Distribution::Serial {
+            return Ok(Distribution::Serial);
+        }
+
+        Ok(Distribution::GlobalHash(partition_by))
+    }
 }
 
 impl Window {
@@ -107,6 +164,83 @@ impl Window {
             col_set.extend(sort.order_by_item.scalar.used_columns())
         }
         Ok(col_set)
+    }
+}
+
+impl Operator for WindowGroup {
+    fn rel_op(&self) -> RelOp {
+        RelOp::WindowGroup
+    }
+
+    fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
+        let scalar_items = self.scalar_items.iter().map(|expr| &expr.scalar);
+        let windows = self
+            .windows
+            .iter()
+            .flat_map(|window| window.scalar_expr_iter());
+        Box::new(scalar_items.chain(windows))
+    }
+
+    fn compute_required_prop_child(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        rel_expr: &RelExpr,
+        _child_index: usize,
+        required: &RequiredProperty,
+    ) -> Result<RequiredProperty> {
+        let mut required = required.clone();
+        match self.required_distribution(rel_expr)? {
+            Distribution::Any => {}
+            distribution => required.distribution = distribution,
+        }
+        Ok(required)
+    }
+
+    fn compute_required_prop_children(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        rel_expr: &RelExpr,
+        required: &RequiredProperty,
+    ) -> Result<Vec<Vec<RequiredProperty>>> {
+        let mut required = required.clone();
+        match self.required_distribution(rel_expr)? {
+            Distribution::Any => {}
+            distribution => required.distribution = distribution,
+        }
+        Ok(vec![vec![required]])
+    }
+
+    fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
+        let input_prop = rel_expr.derive_relational_prop_child(0)?;
+
+        let mut output_columns = input_prop.output_columns.clone();
+        for item in &self.scalar_items {
+            output_columns.insert(item.index);
+        }
+        for window in &self.windows {
+            output_columns.insert(window.index);
+        }
+
+        let outer_columns = input_prop
+            .outer_columns
+            .difference(&output_columns)
+            .cloned()
+            .collect();
+
+        let mut used_columns = self.used_columns()?;
+        used_columns.extend(input_prop.used_columns.clone());
+
+        Ok(Arc::new(RelationalProperty {
+            output_columns,
+            outer_columns,
+            used_columns,
+            orderings: input_prop.orderings.clone(),
+            partition_orderings: input_prop.partition_orderings.clone(),
+        }))
+    }
+
+    fn derive_stats(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
+        rel_expr.derive_cardinality_child(0)
     }
 }
 

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
+use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::Plan;
+use databend_common_sql::plans::RelOperator;
 
 use crate::framework::golden::SqlTestCase;
 use crate::framework::golden::SqlTestOutcome;
@@ -250,6 +252,12 @@ async fn test_binder_window_core_paths() -> Result<()> {
             sql: "SELECT row_number() OVER (ORDER BY number), row_number() OVER (ORDER BY number) FROM t",
         },
         SqlTestCase {
+            name: "multiple_window_expressions_use_window_group",
+            description: "Multiple distinct window expressions should bind through WindowGroup instead of nested Window nodes.",
+            setup_sqls: &["CREATE TABLE t(number UInt64)"],
+            sql: "SELECT row_number() OVER (ORDER BY number), rank() OVER (PARTITION BY number % 3 ORDER BY number) FROM t",
+        },
+        SqlTestCase {
             name: "laglead_window_from_sqllogictest_binds",
             description: "A sqllogictest LEAD window pattern should still bind through the lag/lead rewrite path.",
             setup_sqls: &["CREATE TABLE t(number UInt64)"],
@@ -270,6 +278,103 @@ async fn test_binder_window_core_paths() -> Result<()> {
     ];
 
     run_binder_cases("binder_window_core.txt", &cases).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_many_window_expressions_bind_as_flat_window_group() -> Result<()> {
+    let case = SqlTestCase {
+        name: "many_window_expressions_bind_as_flat_window_group",
+        description: "Many distinct window expressions should bind as one flat WindowGroup instead of a deep Window chain.",
+        setup_sqls: &["CREATE TABLE t(number UInt64)"],
+        sql: "SELECT 1",
+    };
+    let ctx = setup_context(&case).await?;
+
+    let window_count = 128;
+    let select_items = (0..window_count)
+        .map(|i| format!("row_number() OVER (ORDER BY number + {i}) AS w{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!("SELECT {select_items} FROM t");
+
+    let plan = ctx.bind_sql(&sql).await?;
+    let Plan::Query { s_expr, .. } = plan else {
+        panic!("expected query plan");
+    };
+
+    let mut stats = WindowPlanStats::default();
+    collect_window_plan_stats(&s_expr, &mut stats);
+
+    assert_eq!(stats.window_group_nodes, 1);
+    assert_eq!(stats.window_nodes, 0);
+    assert_eq!(stats.window_group_windows, window_count);
+    assert!(
+        stats.max_depth < 16,
+        "window plan should stay shallow, got depth {}",
+        stats.max_depth
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_mixed_partition_windows_bind_as_partitioned_window_groups() -> Result<()> {
+    let case = SqlTestCase {
+        name: "mixed_partition_windows_bind_as_partitioned_window_groups",
+        description: "Window expressions with different partition requirements should bind as separate WindowGroup nodes.",
+        setup_sqls: &["CREATE TABLE t(number UInt64, value UInt64)"],
+        sql: "SELECT row_number() OVER (ORDER BY value) AS w0, rank() OVER (PARTITION BY number % 3 ORDER BY value) AS w1, dense_rank() OVER (PARTITION BY number % 3 ORDER BY value DESC) AS w2 FROM t",
+    };
+    let ctx = setup_context(&case).await?;
+
+    let plan = ctx.bind_sql(case.sql).await?;
+    let Plan::Query { s_expr, .. } = plan else {
+        panic!("expected query plan");
+    };
+
+    let mut stats = WindowPlanStats::default();
+    collect_window_plan_stats(&s_expr, &mut stats);
+
+    assert_eq!(stats.window_group_nodes, 2);
+    assert_eq!(stats.window_nodes, 0);
+    assert_eq!(stats.window_group_windows, 3);
+    assert!(
+        stats.max_depth < 8,
+        "window plan should stay shallow, got depth {}",
+        stats.max_depth
+    );
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct WindowPlanStats {
+    window_group_nodes: usize,
+    window_group_windows: usize,
+    window_nodes: usize,
+    max_depth: usize,
+}
+
+fn collect_window_plan_stats(s_expr: &SExpr, stats: &mut WindowPlanStats) {
+    collect_window_plan_stats_inner(s_expr, stats, 1);
+}
+
+fn collect_window_plan_stats_inner(s_expr: &SExpr, stats: &mut WindowPlanStats, depth: usize) {
+    stats.max_depth = stats.max_depth.max(depth);
+    match s_expr.plan() {
+        RelOperator::Window(_) => {
+            stats.window_nodes += 1;
+        }
+        RelOperator::WindowGroup(window_group) => {
+            stats.window_group_nodes += 1;
+            stats.window_group_windows += window_group.windows.len();
+        }
+        _ => {}
+    }
+
+    for child in s_expr.children() {
+        collect_window_plan_stats_inner(child, stats, depth + 1);
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -292,7 +292,7 @@ async fn test_many_window_expressions_bind_as_flat_window_group() -> Result<()> 
 
     let window_count = 128;
     let select_items = (0..window_count)
-        .map(|i| format!("row_number() OVER (ORDER BY number + {i}) AS w{i}"))
+        .map(|i| format!("lead(number, {i}, number) OVER (ORDER BY number) AS w{i}"))
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!("SELECT {select_items} FROM t");

--- a/src/query/sql/tests/it/semantic/binder_window_core.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_core.txt
@@ -178,27 +178,26 @@ EvalScalar
 
 
 === multiple_window_expressions_use_window_group ===
-description: Multiple distinct window expressions should bind as one flat WindowGroup instead of nested Window nodes.
+description: Multiple distinct window expressions should bind through WindowGroup instead of nested Window nodes.
 sql: SELECT row_number() OVER (ORDER BY number), rank() OVER (PARTITION BY number % 3 ORDER BY number) FROM t
 status: ok
 EvalScalar
 ├── scalars: [row_number() OVER (ORDER BY number) (#1) AS (#1), rank() OVER (PARTITION BY number % 3 ORDER BY number) (#3) AS (#3)]
-└── WindowGroup
-    ├── Window
-    │   ├── aggregate function: row_number
-    │   ├── partition items: []
-    │   ├── order by items: [t.number (#0) AS (#0)]
-    │   └── frame: [Range: Preceding(None) ~ CurrentRow]
-    ├── Window
-    │   ├── aggregate function: rank
-    │   ├── partition items: [modulo(t.number (#0), 3) AS (#2)]
-    │   ├── order by items: [t.number (#0) AS (#0)]
-    │   └── frame: [Range: Preceding(None) ~ CurrentRow]
-    └── Scan
-        ├── table: default.t (#0)
-        ├── filters: []
-        ├── order by: []
-        └── limit: NONE
+└── Window
+    ├── aggregate function: row_number
+    ├── partition items: []
+    ├── order by items: [t.number (#0) AS (#0)]
+    ├── frame: [Range: Preceding(None) ~ CurrentRow]
+    └── Window
+        ├── aggregate function: rank
+        ├── partition items: [modulo(t.number (#0), 3) AS (#2)]
+        ├── order by items: [t.number (#0) AS (#0)]
+        ├── frame: [Range: Preceding(None) ~ CurrentRow]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
 
 
 === laglead_window_from_sqllogictest_binds ===

--- a/src/query/sql/tests/it/semantic/binder_window_core.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_core.txt
@@ -177,6 +177,30 @@ EvalScalar
                 └── limit: NONE
 
 
+=== multiple_window_expressions_use_window_group ===
+description: Multiple distinct window expressions should bind as one flat WindowGroup instead of nested Window nodes.
+sql: SELECT row_number() OVER (ORDER BY number), rank() OVER (PARTITION BY number % 3 ORDER BY number) FROM t
+status: ok
+EvalScalar
+├── scalars: [row_number() OVER (ORDER BY number) (#1) AS (#1), rank() OVER (PARTITION BY number % 3 ORDER BY number) (#3) AS (#3)]
+└── WindowGroup
+    ├── Window
+    │   ├── aggregate function: row_number
+    │   ├── partition items: []
+    │   ├── order by items: [t.number (#0) AS (#0)]
+    │   └── frame: [Range: Preceding(None) ~ CurrentRow]
+    ├── Window
+    │   ├── aggregate function: rank
+    │   ├── partition items: [modulo(t.number (#0), 3) AS (#2)]
+    │   ├── order by items: [t.number (#0) AS (#0)]
+    │   └── frame: [Range: Preceding(None) ~ CurrentRow]
+    └── Scan
+        ├── table: default.t (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
 === laglead_window_from_sqllogictest_binds ===
 description: A sqllogictest LEAD window pattern should still bind through the lag/lead rewrite path.
 sql: SELECT lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) FROM t

--- a/src/query/sql/tests/it/semantic/binder_window_named.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_named.txt
@@ -89,35 +89,22 @@ sql: SELECT rank() OVER w1, dense_rank() OVER w2 FROM empsalary WINDOW w1 AS (PA
 status: ok
 EvalScalar
 ├── scalars: [rank() OVER w1 (#2) AS (#2), dense_rank() OVER w2 (#3) AS (#3)]
-└── Window
-    ├── aggregate function: rank
-    ├── partition items: [empsalary.depname (#0) AS (#0)]
-    ├── order by items: []
-    ├── frame: [Range: Preceding(None) ~ Following(None)]
-    └── Sort
-        ├── sort keys: [empsalary.depname (#0) ASC NULLS LAST]
-        ├── limit: [NONE]
-        ├── window top: NONE
-        ├── window function: Rank
-        └── EvalScalar
-            ├── scalars: [empsalary.depname (#0) AS (#0)]
-            └── Window
-                ├── aggregate function: dense_rank
-                ├── partition items: [empsalary.depname (#0) AS (#0)]
-                ├── order by items: [empsalary.salary (#1) AS (#1) DESC]
-                ├── frame: [Range: Preceding(None) ~ CurrentRow]
-                └── Sort
-                    ├── sort keys: [empsalary.depname (#0) ASC NULLS LAST, empsalary.salary (#1) DESC NULLS LAST]
-                    ├── limit: [NONE]
-                    ├── window top: NONE
-                    ├── window function: DenseRank
-                    └── EvalScalar
-                        ├── scalars: [empsalary.depname (#0) AS (#0), empsalary.salary (#1) AS (#1)]
-                        └── Scan
-                            ├── table: default.empsalary (#0)
-                            ├── filters: []
-                            ├── order by: []
-                            └── limit: NONE
+└── WindowGroup
+    ├── Window
+    │   ├── aggregate function: dense_rank
+    │   ├── partition items: [empsalary.depname (#0) AS (#0)]
+    │   ├── order by items: [empsalary.salary (#1) AS (#1) DESC]
+    │   └── frame: [Range: Preceding(None) ~ CurrentRow]
+    ├── Window
+    │   ├── aggregate function: rank
+    │   ├── partition items: [empsalary.depname (#0) AS (#0)]
+    │   ├── order by items: []
+    │   └── frame: [Range: Preceding(None) ~ Following(None)]
+    └── Scan
+        ├── table: default.empsalary (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
 
 
 === recursive_named_window_chain_binds ===

--- a/tests/sqllogictests/suites/mode/cluster/shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle.test
@@ -67,9 +67,9 @@ Sort(Final)
             │                   ├── output columns: [number (#1)]
             │                   ├── read rows: 14
             │                   ├── read size: < 1 KiB
-            │                   ├── partitions total: 6
-            │                   ├── partitions scanned: 6
-            │                   ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+            │                   ├── partitions total: <slt:ignore>
+            │                   ├── partitions scanned: <slt:ignore>
+            │                   ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
             │                   ├── push downs: [filters: [], limit: NONE]
             │                   └── estimated rows: 14.00
             └── Exchange(Probe)
@@ -81,9 +81,9 @@ Sort(Final)
                     ├── output columns: [number (#0)]
                     ├── read rows: 5
                     ├── read size: < 1 KiB
-                    ├── partitions total: 3
-                    ├── partitions scanned: 3
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                    ├── partitions total: <slt:ignore>
+                    ├── partitions scanned: <slt:ignore>
+                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 5.00

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -150,23 +150,27 @@ Exchange
     │   ├── partition by: [lead_part_0]
     │   ├── order by: [lead_order_0]
     │   └── frame: [Rows: Following(Some(Number(2_u64))) ~ Following(Some(Number(2_u64)))]
-    └── EvalScalar
+    └── WindowPartition
         ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead_default_value (#5)]
-        ├── expressions: [0, numbers.number (#0) % 3, numbers.number (#0) + 1, 0]
+        ├── hash keys: [lead_part_0]
         ├── estimated rows: 50.00
-        └── Exchange
-            ├── output columns: [numbers.number (#0)]
-            ├── exchange type: Hash(numbers.number (#0) % 3)
-            └── TableScan
-                ├── table: default.system.numbers
-                ├── scan id: 0
-                ├── output columns: [number (#0)]
-                ├── read rows: 50
-                ├── read size: < 1 KiB
-                ├── partitions total: 1
-                ├── partitions scanned: 1
-                ├── push downs: [filters: [], limit: NONE]
-                └── estimated rows: 50.00
+        └── EvalScalar
+            ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead_default_value (#5)]
+            ├── expressions: [0, numbers.number (#0) % 3, numbers.number (#0) + 1, 0]
+            ├── estimated rows: 50.00
+            └── Exchange
+                ├── output columns: [numbers.number (#0)]
+                ├── exchange type: Hash(numbers.number (#0) % 3)
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── scan id: 0
+                    ├── output columns: [number (#0)]
+                    ├── read rows: 50
+                    ├── read size: < 1 KiB
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 50.00
 
 statement ok
 CREATE OR REPLACE TABLE sales (

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -128,56 +128,6 @@ Exchange
                     ├── apply join filters: [#0]
                     └── estimated rows: 10.00
 
-query T
-explain select number, lead(number,1, 0) over (partition by number % 3 order by number+ 1),
-    lead(number,2, 0) over (partition by number % 3 order by number + 1)
-    from numbers(50);
-----
-Exchange
-├── output columns: [numbers.number (#0), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead_default_value (#5), lead_part_0 (#6), lead_order_0 (#7), lead(number, 2, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#8)]
-├── exchange type: Merge
-└── Window
-    ├── output columns: [numbers.number (#0), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead_default_value (#5), lead_part_0 (#6), lead_order_0 (#7), lead(number, 2, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#8)]
-    ├── aggregate function: [lead]
-    ├── partition by: [lead_part_0]
-    ├── order by: [lead_order_0]
-    ├── frame: [Rows: Following(Some(Number(2_u64))) ~ Following(Some(Number(2_u64)))]
-    └── WindowPartition
-        ├── output columns: [numbers.number (#0), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead_default_value (#5), lead_part_0 (#6), lead_order_0 (#7)]
-        ├── hash keys: [lead_part_0]
-        ├── estimated rows: 50.00
-        └── EvalScalar
-            ├── output columns: [numbers.number (#0), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead_default_value (#5), lead_part_0 (#6), lead_order_0 (#7)]
-            ├── expressions: [0, numbers.number (#0) % 3, numbers.number (#0) + 1]
-            ├── estimated rows: 50.00
-            └── Window
-                ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4)]
-                ├── aggregate function: [lead]
-                ├── partition by: [lead_part_0]
-                ├── order by: [lead_order_0]
-                ├── frame: [Rows: Following(Some(Number(1_u64))) ~ Following(Some(Number(1_u64)))]
-                └── WindowPartition
-                    ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3)]
-                    ├── hash keys: [lead_part_0]
-                    ├── estimated rows: 50.00
-                    └── Exchange
-                        ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3)]
-                        ├── exchange type: Hash(numbers.number (#0) % 3)
-                        └── EvalScalar
-                            ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3)]
-                            ├── expressions: [0, numbers.number (#0) % 3, numbers.number (#0) + 1]
-                            ├── estimated rows: 50.00
-                            └── TableScan
-                                ├── table: default.system.numbers
-                                ├── scan id: 0
-                                ├── output columns: [number (#0)]
-                                ├── read rows: 50
-                                ├── read size: < 1 KiB
-                                ├── partitions total: 1
-                                ├── partitions scanned: 1
-                                ├── push downs: [filters: [], limit: NONE]
-                                └── estimated rows: 50.00
-
 statement ok
 CREATE OR REPLACE TABLE sales (
     sale_id INT UNSIGNED NOT NULL,
@@ -187,63 +137,6 @@ CREATE OR REPLACE TABLE sales (
     quantity INT NOT NULL,
     net_paid DECIMAL(10, 2) NOT NULL
 );
-
-query T
-explain SELECT customer_id,
-    ROUND(AVG(net_paid) OVER (PARTITION BY customer_id), 3) AS customer_avg,
-    ROUND(AVG(net_paid) OVER () - AVG(net_paid) OVER (PARTITION BY customer_id), 3) AS diff_from_overall_avg
-FROM
-    sales
-ORDER BY
-    diff_from_overall_avg DESC, customer_id ASC
-LIMIT 10;
-----
-Limit
-├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
-├── limit: 10
-├── offset: 0
-├── estimated rows: 0.00
-└── Sort(Single)
-    ├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
-    ├── sort keys: [diff_from_overall_avg DESC NULLS LAST, customer_id ASC NULLS LAST]
-    ├── estimated rows: 0.00
-    └── EvalScalar
-        ├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
-        ├── expressions: [round(3)(AVG(net_paid) OVER (PARTITION BY customer_id) (#6), 3), round(3)(AVG(net_paid) OVER () (#7) - AVG(net_paid) OVER (PARTITION BY customer_id) (#6), 3)]
-        ├── estimated rows: 0.00
-        └── Window
-            ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6), AVG(net_paid) OVER () (#7)]
-            ├── aggregate function: [avg(net_paid)]
-            ├── partition by: []
-            ├── order by: []
-            ├── frame: [Range: Preceding(None) ~ Following(None)]
-            └── Exchange
-                ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6)]
-                ├── exchange type: Merge
-                └── Window
-                    ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6)]
-                    ├── aggregate function: [avg(net_paid)]
-                    ├── partition by: [customer_id]
-                    ├── order by: []
-                    ├── frame: [Range: Preceding(None) ~ Following(None)]
-                    └── WindowPartition
-                        ├── output columns: [sales.customer_id (#2), sales.net_paid (#5)]
-                        ├── hash keys: [customer_id]
-                        ├── estimated rows: 0.00
-                        └── Exchange
-                            ├── output columns: [sales.customer_id (#2), sales.net_paid (#5)]
-                            ├── exchange type: Hash(sales.customer_id (#2))
-                            └── TableScan
-                                ├── table: default.default.sales
-                                ├── scan id: 0
-                                ├── output columns: [customer_id (#2), net_paid (#5)]
-                                ├── read rows: 0
-                                ├── read size: 0
-                                ├── partitions total: 0
-                                ├── partitions scanned: 0
-                                ├── push downs: [filters: [], limit: NONE]
-                                └── estimated rows: 0.00
-
 
 statement ok
 DROP TABLE employees;

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -128,6 +128,46 @@ Exchange
                     ├── apply join filters: [#0]
                     └── estimated rows: 10.00
 
+query T
+explain select number, lead(number,1, 0) over (partition by number % 3 order by number+ 1),
+    lead(number,2, 0) over (partition by number % 3 order by number + 1)
+    from numbers(50);
+----
+Exchange
+├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead_default_value (#5), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead(number, 2, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#8)]
+├── exchange type: Merge
+└── WindowGroup
+    ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead_default_value (#5), lead(number, 1, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#4), lead(number, 2, 0) OVER (PARTITION BY number % 3 ORDER BY number + 1) (#8)]
+    ├── Window
+    │   ├── output column: [4]
+    │   ├── aggregate function: [lead]
+    │   ├── partition by: [lead_part_0]
+    │   ├── order by: [lead_order_0]
+    │   └── frame: [Rows: Following(Some(Number(1_u64))) ~ Following(Some(Number(1_u64)))]
+    ├── Window
+    │   ├── output column: [8]
+    │   ├── aggregate function: [lead]
+    │   ├── partition by: [lead_part_0]
+    │   ├── order by: [lead_order_0]
+    │   └── frame: [Rows: Following(Some(Number(2_u64))) ~ Following(Some(Number(2_u64)))]
+    └── EvalScalar
+        ├── output columns: [numbers.number (#0), lead_default_value (#1), lead_part_0 (#2), lead_order_0 (#3), lead_default_value (#5)]
+        ├── expressions: [0, numbers.number (#0) % 3, numbers.number (#0) + 1, 0]
+        ├── estimated rows: 50.00
+        └── Exchange
+            ├── output columns: [numbers.number (#0)]
+            ├── exchange type: Hash(numbers.number (#0) % 3)
+            └── TableScan
+                ├── table: default.system.numbers
+                ├── scan id: 0
+                ├── output columns: [number (#0)]
+                ├── read rows: 50
+                ├── read size: < 1 KiB
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                ├── push downs: [filters: [], limit: NONE]
+                └── estimated rows: 50.00
+
 statement ok
 CREATE OR REPLACE TABLE sales (
     sale_id INT UNSIGNED NOT NULL,
@@ -137,6 +177,63 @@ CREATE OR REPLACE TABLE sales (
     quantity INT NOT NULL,
     net_paid DECIMAL(10, 2) NOT NULL
 );
+
+query T
+explain SELECT customer_id,
+    ROUND(AVG(net_paid) OVER (PARTITION BY customer_id), 3) AS customer_avg,
+    ROUND(AVG(net_paid) OVER () - AVG(net_paid) OVER (PARTITION BY customer_id), 3) AS diff_from_overall_avg
+FROM
+    sales
+ORDER BY
+    diff_from_overall_avg DESC, customer_id ASC
+LIMIT 10;
+----
+Limit
+├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
+├── limit: 10
+├── offset: 0
+├── estimated rows: 0.00
+└── Sort(Single)
+    ├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
+    ├── sort keys: [diff_from_overall_avg DESC NULLS LAST, customer_id ASC NULLS LAST]
+    ├── estimated rows: 0.00
+    └── EvalScalar
+        ├── output columns: [sales.customer_id (#2), customer_avg (#8), diff_from_overall_avg (#9)]
+        ├── expressions: [round(3)(AVG(net_paid) OVER (PARTITION BY customer_id) (#6), 3), round(3)(AVG(net_paid) OVER () (#7) - AVG(net_paid) OVER (PARTITION BY customer_id) (#6), 3)]
+        ├── estimated rows: 0.00
+        └── Window
+            ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6), AVG(net_paid) OVER () (#7)]
+            ├── aggregate function: [avg(net_paid)]
+            ├── partition by: []
+            ├── order by: []
+            ├── frame: [Range: Preceding(None) ~ Following(None)]
+            └── Exchange
+                ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6)]
+                ├── exchange type: Merge
+                └── Window
+                    ├── output columns: [sales.customer_id (#2), sales.net_paid (#5), AVG(net_paid) OVER (PARTITION BY customer_id) (#6)]
+                    ├── aggregate function: [avg(net_paid)]
+                    ├── partition by: [customer_id]
+                    ├── order by: []
+                    ├── frame: [Range: Preceding(None) ~ Following(None)]
+                    └── WindowPartition
+                        ├── output columns: [sales.customer_id (#2), sales.net_paid (#5)]
+                        ├── hash keys: [customer_id]
+                        ├── estimated rows: 0.00
+                        └── Exchange
+                            ├── output columns: [sales.customer_id (#2), sales.net_paid (#5)]
+                            ├── exchange type: Hash(sales.customer_id (#2))
+                            └── TableScan
+                                ├── table: default.default.sales
+                                ├── scan id: 0
+                                ├── output columns: [customer_id (#2), net_paid (#5)]
+                                ├── read rows: 0
+                                ├── read size: 0
+                                ├── partitions total: 0
+                                ├── partitions scanned: 0
+                                ├── push downs: [filters: [], limit: NONE]
+                                └── estimated rows: 0.00
+
 
 statement ok
 DROP TABLE employees;

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -921,20 +921,24 @@ WindowGroup
 │   ├── partition by: [rank_part_0]
 │   ├── order by: []
 │   └── frame: [Range: Preceding(None) ~ Following(None)]
-└── EvalScalar
+└── WindowPartition
     ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4)]
-    ├── expressions: [numbers.number (#0) % 3, numbers.number (#0) + 1]
+    ├── hash keys: [rank_part_0]
     ├── estimated rows: 50.00
-    └── TableScan
-        ├── table: default.system.numbers
-        ├── scan id: 0
-        ├── output columns: [number (#0)]
-        ├── read rows: 50
-        ├── read size: < 1 KiB
-        ├── partitions total: 1
-        ├── partitions scanned: 1
-        ├── push downs: [filters: [], limit: NONE]
-        └── estimated rows: 50.00
+    └── EvalScalar
+        ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4)]
+        ├── expressions: [numbers.number (#0) % 3, numbers.number (#0) + 1]
+        ├── estimated rows: 50.00
+        └── TableScan
+            ├── table: default.system.numbers
+            ├── scan id: 0
+            ├── output columns: [number (#0)]
+            ├── read rows: 50
+            ├── read size: < 1 KiB
+            ├── partitions total: 1
+            ├── partitions scanned: 1
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 50.00
 
 query T
 explain  select a, sum(number - 1) over (partition by number % 3) from (select number,  rank()over (partition by number % 3 order by number) a from numbers(50));

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -798,11 +798,9 @@ digraph {
     15 [ label = "KWayMergeWorker" ]
     16 [ label = "KWayMergeCombiner" ]
     17 [ label = "Transform Window" ]
-    18 [ label = "CompoundBlockOperator(Map)" ]
+    18 [ label = "Transform Window" ]
     19 [ label = "Transform Window" ]
-    20 [ label = "CompoundBlockOperator(Map)" ]
-    21 [ label = "Transform Window" ]
-    22 [ label = "CompoundBlockOperator(Project)" ]
+    20 [ label = "CompoundBlockOperator(Project)" ]
     0 -> 1 [ label = "" ]
     1 -> 2 [ label = "" ]
     2 -> 3 [ label = "from: 0, to: 0" ]
@@ -829,8 +827,6 @@ digraph {
     17 -> 18 [ label = "" ]
     18 -> 19 [ label = "" ]
     19 -> 20 [ label = "" ]
-    20 -> 21 [ label = "" ]
-    21 -> 22 [ label = "" ]
 }
 
 # same order same partiton by multi window
@@ -844,12 +840,8 @@ digraph {
     3 [ label = "ShuffleMergePartition(Window)" ]
     4 [ label = "TransformWindowPartitionCollect(Sort)" ]
     5 [ label = "Transform Window" ]
-    6 [ label = "CompoundBlockOperator(Map)" ]
-    7 [ label = "ShufflePartition(Window)" ]
-    8 [ label = "ShuffleMergePartition(Window)" ]
-    9 [ label = "TransformWindowPartitionCollect(Sort)" ]
-    10 [ label = "Transform Window" ]
-    11 [ label = "CompoundBlockOperator(Project)" ]
+    6 [ label = "Transform Window" ]
+    7 [ label = "CompoundBlockOperator(Project)" ]
     0 -> 1 [ label = "" ]
     1 -> 2 [ label = "" ]
     2 -> 3 [ label = "" ]
@@ -857,10 +849,6 @@ digraph {
     4 -> 5 [ label = "" ]
     5 -> 6 [ label = "" ]
     6 -> 7 [ label = "" ]
-    7 -> 8 [ label = "" ]
-    8 -> 9 [ label = "" ]
-    9 -> 10 [ label = "" ]
-    10 -> 11 [ label = "" ]
 }
 
 # window partition with empty sort items from same window partition  with sort items
@@ -913,58 +901,40 @@ query T
 explain select number, avg(number) over (partition by number % 3),  rank() over (partition by number % 3 order by number + 1), sum(number) over (partition by number % 3)
     from numbers(50);
 ----
-Window
-├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg(number) OVER (PARTITION BY number % 3) (#2), sum_part_0 (#6), sum(number) OVER (PARTITION BY number % 3) (#7)]
-├── aggregate function: [sum(number)]
-├── partition by: [sum_part_0]
-├── order by: []
-├── frame: [Range: Preceding(None) ~ Following(None)]
-└── WindowPartition
-    ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg(number) OVER (PARTITION BY number % 3) (#2), sum_part_0 (#6)]
-    ├── hash keys: [sum_part_0]
+WindowGroup
+├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg(number) OVER (PARTITION BY number % 3) (#2), sum(number) OVER (PARTITION BY number % 3) (#7)]
+├── Window
+│   ├── output column: [5]
+│   ├── aggregate function: [rank]
+│   ├── partition by: [rank_part_0]
+│   ├── order by: [rank_order_0]
+│   └── frame: [Range: Preceding(None) ~ CurrentRow]
+├── Window
+│   ├── output column: [2]
+│   ├── aggregate function: [avg(number)]
+│   ├── partition by: [rank_part_0]
+│   ├── order by: []
+│   └── frame: [Range: Preceding(None) ~ Following(None)]
+├── Window
+│   ├── output column: [7]
+│   ├── aggregate function: [sum(number)]
+│   ├── partition by: [rank_part_0]
+│   ├── order by: []
+│   └── frame: [Range: Preceding(None) ~ Following(None)]
+└── EvalScalar
+    ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4)]
+    ├── expressions: [numbers.number (#0) % 3, numbers.number (#0) + 1]
     ├── estimated rows: 50.00
-    └── EvalScalar
-        ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg(number) OVER (PARTITION BY number % 3) (#2), sum_part_0 (#6)]
-        ├── expressions: [numbers.number (#0) % 3]
-        ├── estimated rows: 50.00
-        └── Window
-            ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg_part_0 (#1), avg(number) OVER (PARTITION BY number % 3) (#2)]
-            ├── aggregate function: [avg(number)]
-            ├── partition by: [avg_part_0]
-            ├── order by: []
-            ├── frame: [Range: Preceding(None) ~ Following(None)]
-            └── WindowPartition
-                ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg_part_0 (#1)]
-                ├── hash keys: [avg_part_0]
-                ├── estimated rows: 50.00
-                └── EvalScalar
-                    ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5), avg_part_0 (#1)]
-                    ├── expressions: [numbers.number (#0) % 3]
-                    ├── estimated rows: 50.00
-                    └── Window
-                        ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4), rank() OVER (PARTITION BY number % 3 ORDER BY number + 1) (#5)]
-                        ├── aggregate function: [rank]
-                        ├── partition by: [rank_part_0]
-                        ├── order by: [rank_order_0]
-                        ├── frame: [Range: Preceding(None) ~ CurrentRow]
-                        └── WindowPartition
-                            ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4)]
-                            ├── hash keys: [rank_part_0]
-                            ├── estimated rows: 50.00
-                            └── EvalScalar
-                                ├── output columns: [numbers.number (#0), rank_part_0 (#3), rank_order_0 (#4)]
-                                ├── expressions: [numbers.number (#0) % 3, numbers.number (#0) + 1]
-                                ├── estimated rows: 50.00
-                                └── TableScan
-                                    ├── table: default.system.numbers
-                                    ├── scan id: 0
-                                    ├── output columns: [number (#0)]
-                                    ├── read rows: 50
-                                    ├── read size: < 1 KiB
-                                    ├── partitions total: 1
-                                    ├── partitions scanned: 1
-                                    ├── push downs: [filters: [], limit: NONE]
-                                    └── estimated rows: 50.00
+    └── TableScan
+        ├── table: default.system.numbers
+        ├── scan id: 0
+        ├── output columns: [number (#0)]
+        ├── read rows: 50
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── push downs: [filters: [], limit: NONE]
+        └── estimated rows: 50.00
 
 query T
 explain  select a, sum(number - 1) over (partition by number % 3) from (select number,  rank()over (partition by number % 3 order by number) a from numbers(50));

--- a/tests/sqllogictests/suites/query/window_function/window_group.test
+++ b/tests/sqllogictests/suites/query/window_function/window_group.test
@@ -1,0 +1,20 @@
+statement ok
+SET max_threads = 1
+
+query III
+SELECT
+    number,
+    row_number() OVER (ORDER BY number DESC) AS rn_desc,
+    rank() OVER (ORDER BY number % 3, number) AS modulo_rank
+FROM numbers(6)
+ORDER BY number
+----
+0 6 1
+1 5 3
+2 4 5
+3 3 2
+4 2 4
+5 1 6
+
+statement ok
+UNSET max_threads


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR avoids deeply nested logical window plans when a query contains multiple distinct window expressions. The binder now builds one flat WindowGroup for multi-window SELECTs, while preserving the existing single-window path to reduce behavior churn.

Implementation notes:
- Add logical and physical WindowGroup plan nodes.
- Build helper scalar expressions once before the grouped window execution.
- Expand WindowGroup in the physical pipeline by applying the existing sort, partition, and window transforms sequentially.
- Keep optimizer, decorrelator, required-column derivation, plan formatting, and physical explain support aware of WindowGroup.

Sample query covered by the new logic test:

```sql
SELECT
    number,
    row_number() OVER (ORDER BY number DESC) AS rn_desc,
    rank() OVER (ORDER BY number % 3, number) AS modulo_rank
FROM numbers(6)
ORDER BY number;
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_



## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19933)
<!-- Reviewable:end -->
