### PR TITLE
fix(storage): project parquet array tuple fields

### DIFF
--- a/src/query/storages/common/stage/src/read/columnar/projection.rs
+++ b/src/query/storages/common/stage/src/read/columnar/projection.rs
@@ -16,6 +16,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_expression::ColumnRef;
 use databend_common_expression::Constant;
 use databend_common_expression::Expr;
+use databend_common_expression::LambdaFunctionCall;
 use databend_common_expression::RemoteDefaultExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
@@ -27,7 +28,6 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::principal::NullAs;
-use databend_common_meta_app::principal::StageFileFormatType;
 
 use crate::read::cast::load_can_auto_cast_to;
 
@@ -42,7 +42,6 @@ pub fn project_columnar(
     default_exprs: &Option<Vec<RemoteDefaultExpr>>,
     location: &str,
     case_sensitive: bool,
-    fmt: StageFileFormatType,
 ) -> databend_common_exception::Result<(Vec<Expr>, Vec<usize>)> {
     let mut pushdown_columns = vec![];
     let mut output_projection = vec![];
@@ -88,7 +87,7 @@ pub fn project_columnar(
                         &to_field.data_type().into(),
                         &BUILTIN_FUNCTIONS,
                     )?
-                } else if fmt == StageFileFormatType::Orc && !matches!(missing_as, NullAs::Error) {
+                } else if !matches!(missing_as, NullAs::Error) {
                     // special cast for tuple type, fill in default values for the missing fields.
                     match (
                         from_field.data_type.remove_nullable(),
@@ -98,35 +97,23 @@ pub fn project_columnar(
                             TableDataType::Array(box TableDataType::Nullable(
                                 box TableDataType::Tuple {
                                     fields_name: from_fields_name,
-                                    fields_type: _from_fields_type,
+                                    fields_type: from_fields_type,
                                 },
                             )),
                             TableDataType::Array(box TableDataType::Nullable(
                                 box TableDataType::Tuple {
                                     fields_name: to_fields_name,
-                                    fields_type: _to_fields_type,
+                                    fields_type: to_fields_type,
                                 },
                             )),
-                        ) => {
-                            let mut v = vec![];
-                            for to in to_fields_name.iter() {
-                                match from_fields_name.iter().position(|k| k == to) {
-                                    Some(p) => v.push(p as i32),
-                                    None => v.push(-1),
-                                };
-                            }
-                            let name = v
-                                .iter()
-                                .map(|v| v.to_string())
-                                .collect::<Vec<_>>()
-                                .join(",");
-                            Expr::ColumnRef(ColumnRef {
-                                span: None,
-                                id: pos,
-                                data_type: from_field.data_type().into(),
-                                display_name: format!("#!{name}",),
-                            })
-                        }
+                        ) => project_array_tuple(
+                            expr,
+                            to_field,
+                            &from_fields_name,
+                            &from_fields_type,
+                            &to_fields_name,
+                            &to_fields_type,
+                        )?,
                         (
                             TableDataType::Tuple {
                                 fields_name: from_fields_name,
@@ -138,8 +125,8 @@ pub fn project_columnar(
                             },
                         ) => project_tuple(
                             expr,
-                            from_field,
-                            to_field,
+                            &from_field.data_type,
+                            &to_field.data_type,
                             &from_fields_name,
                             &from_fields_type,
                             &to_fields_name,
@@ -220,10 +207,65 @@ pub fn project_columnar(
     Ok((output_projection, pushdown_columns))
 }
 
+fn project_array_tuple(
+    expr: Expr,
+    to_field: &TableField,
+    from_fields_name: &[String],
+    from_fields_type: &[TableDataType],
+    to_fields_name: &[String],
+    to_fields_type: &[TableDataType],
+) -> databend_common_exception::Result<Expr> {
+    let from_tuple_type = TableDataType::Nullable(Box::new(TableDataType::Tuple {
+        fields_name: from_fields_name.to_vec(),
+        fields_type: from_fields_type.to_vec(),
+    }));
+    let to_tuple_type = TableDataType::Nullable(Box::new(TableDataType::Tuple {
+        fields_name: to_fields_name.to_vec(),
+        fields_type: to_fields_type.to_vec(),
+    }));
+    let lambda_arg = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: 0,
+        data_type: (&from_tuple_type).into(),
+        display_name: "x".to_string(),
+    });
+    let lambda_expr = project_tuple(
+        lambda_arg,
+        &from_tuple_type,
+        &to_tuple_type,
+        from_fields_name,
+        from_fields_type,
+        to_fields_name,
+        to_fields_type,
+    )?;
+
+    let array_map_return_type = if expr.data_type().is_nullable_or_null() {
+        DataType::Array(Box::new(lambda_expr.data_type().clone())).wrap_nullable()
+    } else {
+        DataType::Array(Box::new(lambda_expr.data_type().clone()))
+    };
+    let array_map = Expr::LambdaFunctionCall(LambdaFunctionCall {
+        span: None,
+        name: "array_map".to_string(),
+        args: vec![expr],
+        lambda_expr: Box::new(lambda_expr.as_remote_expr()),
+        lambda_display: "x -> tuple projection".to_string(),
+        return_type: array_map_return_type,
+    });
+
+    check_cast(
+        None,
+        false,
+        array_map,
+        &to_field.data_type().into(),
+        &BUILTIN_FUNCTIONS,
+    )
+}
+
 fn project_tuple(
     expr: Expr,
-    from_field: &TableField,
-    to_field: &TableField,
+    from_data_type: &TableDataType,
+    to_data_type: &TableDataType,
     from_fields_name: &[String],
     from_fields_type: &[TableDataType],
     to_fields_name: &[String],
@@ -269,14 +311,14 @@ fn project_tuple(
         inner_columns.push(inner_column);
     }
     let tuple_column = check_function(None, "tuple", &[], &inner_columns, &BUILTIN_FUNCTIONS)?;
-    let tuple_column = if from_field.data_type != to_field.data_type {
-        let dest_ty: DataType = (&to_field.data_type).into();
+    let tuple_column = if from_data_type != to_data_type {
+        let dest_ty: DataType = to_data_type.into();
         check_cast(None, false, tuple_column, &dest_ty, &BUILTIN_FUNCTIONS)?
     } else {
         tuple_column
     };
 
-    if from_field.data_type.is_nullable() && to_field.data_type.is_nullable() {
+    if from_data_type.is_nullable() && to_data_type.is_nullable() {
         // add if function to cast null value
         let is_not_null = check_function(
             None,
@@ -299,5 +341,81 @@ fn project_tuple(
         )
     } else {
         Ok(tuple_column)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::types::NumberDataType;
+
+    use super::*;
+
+    #[test]
+    fn test_project_array_nullable_tuple_with_lambda_for_parquet() {
+        let input_schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "a",
+            TableDataType::Array(Box::new(TableDataType::Nullable(Box::new(
+                TableDataType::Tuple {
+                    fields_name: vec!["x".to_string(), "y".to_string()],
+                    fields_type: vec![
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::Int32,
+                        ))),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::Int32,
+                        ))),
+                    ],
+                },
+            )))),
+        )]));
+        let output_schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "a",
+            TableDataType::Nullable(Box::new(TableDataType::Array(Box::new(
+                TableDataType::Nullable(Box::new(TableDataType::Tuple {
+                    fields_name: vec!["y".to_string(), "z".to_string(), "x".to_string()],
+                    fields_type: vec![
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::Int32,
+                        ))),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::Int32,
+                        ))),
+                        TableDataType::Nullable(Box::new(TableDataType::Number(
+                            NumberDataType::Int32,
+                        ))),
+                    ],
+                })),
+            )))),
+        )]));
+
+        let (projection, pushdowns) = project_columnar(
+            &input_schema,
+            &output_schema,
+            &NullAs::Null,
+            &None,
+            "test.parquet",
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(pushdowns, vec![0]);
+        assert_eq!(projection.len(), 1);
+        let Expr::Cast(cast) = &projection[0] else {
+            panic!("expected array tuple projection to be cast to the target type");
+        };
+        assert_eq!(cast.dest_type, output_schema.field(0).data_type().into());
+        let Expr::LambdaFunctionCall(lambda) = cast.expr.as_ref() else {
+            panic!("expected array tuple projection to be a lambda expression");
+        };
+        assert_eq!(lambda.name, "array_map");
+        assert_eq!(lambda.args.len(), 1);
+        let Expr::ColumnRef(arg) = &lambda.args[0] else {
+            panic!("expected array_map input to be the source column");
+        };
+        assert_eq!(arg.id, 0);
+        assert_eq!(lambda.return_type, cast.dest_type.remove_nullable());
     }
 }

--- a/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
+++ b/src/query/storages/orc/src/copy_into_table/processors/decoder.rs
@@ -24,17 +24,11 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::BlockMetaInfoDowncast;
-use databend_common_expression::Column;
-use databend_common_expression::ColumnBuilder;
-use databend_common_expression::ColumnRef;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Evaluator;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
-use databend_common_expression::types::ArrayColumn;
-use databend_common_expression::types::DataType;
-use databend_common_expression::types::NullableColumn;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline::core::Event;
 use databend_common_pipeline::core::InputPort;
@@ -103,66 +97,6 @@ impl StripeDecoderForCopy {
         let mut entries = Vec::with_capacity(projection.len());
         let num_rows = block.num_rows();
         for (field, expr) in self.output_schema.fields().iter().zip(projection.iter()) {
-            if let Expr::ColumnRef(ColumnRef {
-                display_name, id, ..
-            }) = expr
-            {
-                if let Some(display_name) = display_name.strip_prefix("#!") {
-                    let types = match field.data_type() {
-                        DataType::Nullable(box DataType::Array(box DataType::Nullable(
-                            box DataType::Tuple(v),
-                        ))) => v,
-                        _ => {
-                            log::error!("expect array of tuple, got {:?}", field);
-                            unreachable!("expect value: array of tuple")
-                        }
-                    };
-                    let positions = display_name
-                        .split(',')
-                        .map(|s| s.parse::<i32>().unwrap())
-                        .collect::<Vec<i32>>();
-                    let entry = block.get_by_offset(*id);
-                    if let Some(Column::Nullable(box NullableColumn {
-                        column: Column::Array(box array_column),
-                        validity,
-                    })) = entry.as_column()
-                    {
-                        let column = array_column.underlying_column();
-                        let offsets = array_column.underlying_offsets();
-
-                        if let Column::Nullable(box NullableColumn {
-                            column: Column::Tuple(ref v),
-                            validity: inner_validity,
-                        }) = column
-                        {
-                            let len = v[0].len();
-                            let mut v2 = Vec::with_capacity(v.len());
-                            for (i, p) in positions.iter().enumerate() {
-                                if *p < 0 {
-                                    v2.push(ColumnBuilder::repeat_default(&types[i], len).build());
-                                } else {
-                                    v2.push(v[*p as usize].clone());
-                                }
-                            }
-                            let new_tuple_column = Column::Nullable(Box::new(NullableColumn {
-                                column: Column::Tuple(v2),
-                                validity: inner_validity.clone(),
-                            }));
-
-                            let new_array_column = ArrayColumn::new(new_tuple_column, offsets);
-                            let column = Column::Nullable(Box::new(NullableColumn {
-                                column: Column::Array(Box::new(new_array_column)),
-                                validity: validity.clone(),
-                            }));
-
-                            entries.push(column.into());
-                            continue;
-                        }
-                    }
-                    log::error!("expect array of tuple, got {:?} {:?}", field, entry.value());
-                    unreachable!("expect value: array of tuple")
-                }
-            }
             let entry = BlockEntry::new(evaluator.run(expr)?, || {
                 (field.data_type().clone(), num_rows)
             });

--- a/src/query/storages/orc/src/copy_into_table/projection.rs
+++ b/src/query/storages/orc/src/copy_into_table/projection.rs
@@ -19,7 +19,6 @@ use databend_common_expression::Expr;
 use databend_common_expression::RemoteDefaultExpr;
 use databend_common_expression::TableSchemaRef;
 use databend_common_meta_app::principal::NullAs;
-use databend_common_meta_app::principal::StageFileFormatType;
 use databend_storages_common_stage::project_columnar;
 
 use crate::hashable_schema::HashableSchema;
@@ -57,7 +56,6 @@ impl ProjectionFactory {
                 &self.default_exprs,
                 location,
                 false,
-                StageFileFormatType::Orc,
             )?
             .0;
             self.projections.insert(schema.clone(), v.clone());

--- a/src/query/storages/parquet/src/copy_into_table/reader.rs
+++ b/src/query/storages/parquet/src/copy_into_table/reader.rs
@@ -18,12 +18,12 @@ use std::sync::Arc;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::RemoteDefaultExpr;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::expr::*;
 use databend_common_meta_app::principal::NullAs;
-use databend_common_meta_app::principal::StageFileFormatType;
 use databend_common_storage::parquet::infer_schema_with_extension;
 use databend_storages_common_stage::project_columnar;
 use opendal::Operator;
@@ -88,7 +88,6 @@ impl RowGroupReaderForCopy {
             &default_exprs,
             location,
             case_sensitive,
-            StageFileFormatType::Parquet,
         )?;
         pushdown_columns.sort();
         let mapping = pushdown_columns
@@ -97,16 +96,18 @@ impl RowGroupReaderForCopy {
             .enumerate()
             .map(|(i, pos)| (pos, i))
             .collect::<HashMap<_, _>>();
-        for expr in output_projection.iter_mut() {
-            match expr {
-                Expr::ColumnRef(ColumnRef { id, .. }) => *id = mapping[id],
-                Expr::Cast(Cast {
-                    expr: box Expr::ColumnRef(ColumnRef { id, .. }),
-                    ..
-                }) => *id = mapping[id],
-                _ => {}
-            }
-        }
+        output_projection = output_projection
+            .into_iter()
+            .map(|expr| {
+                expr.project_column_ref(|id| {
+                    mapping.get(id).copied().ok_or_else(|| {
+                        ErrorCode::Internal(format!(
+                            "missing parquet projection mapping for column {id}"
+                        ))
+                    })
+                })
+            })
+            .collect::<Result<_>>()?;
         let pushdowns = PushDownInfo {
             projection: Some(Projection::Columns(pushdown_columns)),
             ..Default::default()

--- a/src/query/storages/parquet/src/parquet_reader/reader/streaming_load_reader.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/streaming_load_reader.rs
@@ -19,14 +19,13 @@ use bytes::Bytes;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::RemoteDefaultExpr;
 use databend_common_expression::TableSchemaRef;
-use databend_common_expression::expr::*;
 use databend_common_meta_app::principal::NullAs;
-use databend_common_meta_app::principal::StageFileFormatType;
 use databend_common_storage::parquet::infer_schema_with_extension;
 use databend_storages_common_stage::project_columnar;
 use opendal::Operator;
@@ -82,7 +81,6 @@ impl InmMemoryFile {
             &default_exprs,
             &self.location,
             case_sensitive,
-            StageFileFormatType::Parquet,
         )?;
         pushdown_columns.sort();
         let mapping = pushdown_columns
@@ -91,16 +89,18 @@ impl InmMemoryFile {
             .enumerate()
             .map(|(i, pos)| (pos, i))
             .collect::<HashMap<_, _>>();
-        for expr in output_projection.iter_mut() {
-            match expr {
-                Expr::ColumnRef(ColumnRef { id, .. }) => *id = mapping[id],
-                Expr::Cast(Cast {
-                    expr: box Expr::ColumnRef(ColumnRef { id, .. }),
-                    ..
-                }) => *id = mapping[id],
-                _ => {}
-            }
-        }
+        output_projection = output_projection
+            .into_iter()
+            .map(|expr| {
+                expr.project_column_ref(|id| {
+                    mapping.get(id).copied().ok_or_else(|| {
+                        ErrorCode::Internal(format!(
+                            "missing parquet projection mapping for column {id}"
+                        ))
+                    })
+                })
+            })
+            .collect::<Result<_>>()?;
         let pushdowns = PushDownInfo {
             projection: Some(Projection::Columns(pushdown_columns)),
             ..Default::default()

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_field.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_field.test
@@ -55,3 +55,41 @@ NULL 229 NULL 249
 query TIITI
 copy into t1 from @data/parquet/diff_schema/ file_format=(type=parquet  missing_field_as = FIELD_DEFAULT) pattern='.*[.]parquet'
 ----
+
+statement ok
+drop table if exists parquet_array_tuple_src
+
+statement ok
+drop table if exists parquet_array_tuple_dst
+
+statement ok
+drop stage if exists parquet_array_tuple_stage
+
+statement ok
+create table parquet_array_tuple_src(id int, a array(tuple(x int, y int)))
+
+statement ok
+insert into parquet_array_tuple_src values (1, [(1, 10), (2, 20)]), (2, [null, (3, 30)]), (3, [])
+
+statement ok
+create stage parquet_array_tuple_stage file_format=(type=parquet)
+
+statement ok
+remove @parquet_array_tuple_stage
+
+statement ok
+copy into @parquet_array_tuple_stage from parquet_array_tuple_src file_format=(type=parquet)
+
+statement ok
+create table parquet_array_tuple_dst(id int, a array(tuple(y int, z int, x int)))
+
+query TIITI
+copy into parquet_array_tuple_dst from @parquet_array_tuple_stage file_format=(type=parquet missing_field_as=field_default) force=true return_failed_only=true
+----
+
+query IT
+select id, a from parquet_array_tuple_dst order by id
+----
+1 [(10,NULL,1),(20,NULL,2)]
+2 [NULL,(30,NULL,3)]
+3 []


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes parquet copy/load projection for `Array(Nullable(Tuple))` columns when the target tuple fields are reordered or contain missing fields.

Previously, `project_columnar` encoded array tuple field projection through the ORC-specific `#!` display-name convention. Parquet did not understand that convention, so parquet loading failed when it needed to project nested tuple fields and fill defaults. This PR represents the projection as a normal expression instead:

- build `array_map` lambda expressions for array tuple projection
- reuse `get`, `tuple`, and `if(is_not_null(...))` to reorder fields, fill defaults, and preserve null tuple elements
- remap parquet projection column refs recursively with `Expr::project_column_ref`
- remove the now-unused file-format parameter from `project_columnar`

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19934)
<!-- Reviewable:end -->
