### PR TITLE
fix(storage): handle Decimal64 in replace-into row hash

### DIFF
--- a/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
@@ -72,8 +72,10 @@ pub fn row_hash_of_columns(
             ScalarRef::String(v) => sip.write(v.as_bytes()),
             ScalarRef::Bitmap(v) => sip.write(v),
             ScalarRef::Decimal(v) => match v {
-                DecimalScalar::Decimal64(_, _) => {
-                    unreachable!()
+                DecimalScalar::Decimal64(i, size) => {
+                    sip.write_i64(i);
+                    sip.write_u8(size.precision());
+                    sip.write_u8(size.scale())
                 }
                 DecimalScalar::Decimal128(i, size) => {
                     sip.write_i128(i);

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_decimal_key.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0024_replace_into_decimal_key.test
@@ -1,0 +1,109 @@
+statement ok
+DROP DATABASE IF EXISTS replace_into_decimal_key
+
+statement ok
+CREATE DATABASE replace_into_decimal_key
+
+statement ok
+USE replace_into_decimal_key
+
+# Regression: replace-into used to panic with `unreachable!()` when the
+# on-conflict key was deserialized as DecimalScalar::Decimal64. The hash
+# function in fuse's replace-into mutator needs to handle every decimal
+# width, so this exercises Decimal64 (precision <= 18), Decimal128
+# (precision <= 38), and Decimal256.
+
+# --- Decimal64 (precision = 18, stored as i64) ---
+
+statement ok
+create or replace table t_d64 (k decimal(18, 2), v string)
+
+statement ok
+replace into t_d64 on(k) values (1.23, 'a'), (4.56, 'b')
+
+query RT
+select k, v from t_d64 order by k
+----
+1.23 a
+4.56 b
+
+# Same logical key value, different payload: must replace, not duplicate.
+statement ok
+replace into t_d64 on(k) values (1.23, 'a2'), (7.89, 'c')
+
+query RT
+select k, v from t_d64 order by k
+----
+1.23 a2
+4.56 b
+7.89 c
+
+query I
+select count() from t_d64
+----
+3
+
+# --- Decimal128 (precision > 18, stored as i128) ---
+
+statement ok
+create or replace table t_d128 (k decimal(28, 2), v string)
+
+statement ok
+replace into t_d128 on(k) values (1.23, 'a'), (4.56, 'b')
+
+statement ok
+replace into t_d128 on(k) values (1.23, 'a2'), (7.89, 'c')
+
+query RT
+select k, v from t_d128 order by k
+----
+1.23 a2
+4.56 b
+7.89 c
+
+# --- Decimal256 (precision > 38) ---
+
+statement ok
+create or replace table t_d256 (k decimal(40, 2), v string)
+
+statement ok
+replace into t_d256 on(k) values (1.23, 'a'), (4.56, 'b')
+
+statement ok
+replace into t_d256 on(k) values (1.23, 'a2'), (7.89, 'c')
+
+query RT
+select k, v from t_d256 order by k
+----
+1.23 a2
+4.56 b
+7.89 c
+
+# --- NULL key handling on a Decimal64 column ---
+# Rows whose on-conflict key is NULL are kept as-is (row hash returns None).
+
+statement ok
+create or replace table t_d64_null (k decimal(18, 2) null, v string)
+
+statement ok
+replace into t_d64_null on(k) values (NULL, 'x'), (NULL, 'y'), (1.00, 'z')
+
+query I
+select count() from t_d64_null
+----
+3
+
+statement ok
+drop table t_d64
+
+statement ok
+drop table t_d128
+
+statement ok
+drop table t_d256
+
+statement ok
+drop table t_d64_null
+
+statement ok
+DROP DATABASE replace_into_decimal_key


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The row-hash function used by `replace-into` hit `unreachable!()` when an on-conflict key was materialized as `DecimalScalar::Decimal64`, panicking the writer.

This PR hashes `Decimal64` alongside `Decimal128` and `Decimal256`, and adds a sqllogic test exercising replace-into across all three decimal widths including a nullable `Decimal64` key.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19935)
<!-- Reviewable:end -->
