### PR TITLE
feat(sql): support nested lambda functions

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -124,6 +124,19 @@ where A: super::TypeCheckAdapter
     ) -> Result<Box<(ScalarExpr, DataType)>> {
         lambda_context.expr_context = ExprContext::InLambdaFunction;
 
+        // Hide existing columns with the same name as lambda parameters
+        // to implement parameter shadowing for nested lambdas.
+        // Use UnqualifiedWildcardInVisible so that unqualified references
+        // resolve to the lambda parameter, while qualified references
+        // (e.g. table.column) still work.
+        for (lambda_column, _) in lambda_columns.iter() {
+            for col in lambda_context.columns.iter_mut() {
+                if col.column_name == *lambda_column {
+                    col.visibility = Visibility::UnqualifiedWildcardInVisible;
+                }
+            }
+        }
+
         for (lambda_column, lambda_column_type) in lambda_columns.iter() {
             let column_index = lambda_context.next_column_index();
             lambda_context.add_column_binding(
@@ -192,16 +205,6 @@ where A: super::TypeCheckAdapter
         lambda_params: &[Identifier],
         lambda_expr: CoreExprId,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
-        if matches!(
-            self.bind_context.expr_context,
-            ExprContext::InLambdaFunction
-        ) {
-            return Err(ErrorCode::SemanticError(
-                "lambda functions can not be used in lambda function".to_string(),
-            )
-            .set_span(span));
-        }
-
         if args.len() != 1 {
             return Err(ErrorCode::SemanticError(format!(
                 "invalid arguments for lambda function, {} expects 1 argument, but got {}",

--- a/src/query/sql/tests/it/semantic/type_check/lambda.rs
+++ b/src/query/sql/tests/it/semantic/type_check/lambda.rs
@@ -16,8 +16,8 @@ async fn test_type_check_lambda_functions() -> Result<()> {
             sql: "array_transform([number])",
         },
         SqlTestCase {
-            name: "lambda_functions_cannot_be_nested",
-            description: "Lambda functions should remain rejected while resolving another lambda body.",
+            name: "lambda_functions_can_be_nested",
+            description: "Lambda functions should be allowed inside another lambda body.",
             setup_sqls: &[],
             sql: "array_transform([number], x -> array_transform([x], y -> y))",
         },

--- a/src/query/sql/tests/it/semantic/type_check/lambda.txt
+++ b/src/query/sql/tests/it/semantic/type_check/lambda.txt
@@ -12,12 +12,12 @@ status: error
 code: 1065
 message: function array_transform must have a lambda expression
 
-=== lambda_functions_cannot_be_nested ===
-description: Lambda functions should remain rejected while resolving another lambda body.
+=== lambda_functions_can_be_nested ===
+description: Lambda functions should be allowed inside another lambda body.
 sql: array_transform([number], x -> array_transform([x], y -> y))
-status: error
-code: 1065
-message: lambda functions can not be used in lambda function
+status: ok
+scalar: array_transform(array(number (#0)), ["x"] -> array_transform(array(x (#7)), ["y"] -> y (#8)))
+type: Array(Array(Int64 NULL))
 
 === lambda_function_requires_collection_argument ===
 description: Lambda functions should require an array or map input argument.

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -426,6 +426,44 @@ select array_reduce([1,2,3,4]::Variant, (x, y) -> 3 + x + y), array_transform(pa
 ----
 19 []
 
+## nested lambda functions
+
+# nested array_transform
+query T
+select array_transform([[1,2,3],[4,5,6]], arr -> array_transform(arr, x -> x + 10))
+----
+[[11,12,13],[14,15,16]]
+
+# nested json_array_transform
+query T
+select json_array_transform(parse_json('[[1,2,3],[4,5,6]]'), arr -> json_array_transform(arr, x -> x::Int + 10))
+----
+[[11,12,13],[14,15,16]]
+
+# nested lambda: outer param referenced in inner lambda (closure semantics)
+query T
+select array_transform([1,2,3], x -> array_transform([10,20,30], y -> x + y))
+----
+[[11,21,31],[12,22,32],[13,23,33]]
+
+# nested lambda: inner param shadows outer param
+query T
+select array_transform([1,2,3], x -> array_transform([10,20,30], x -> x + 100))
+----
+[[110,120,130],[110,120,130],[110,120,130]]
+
+# nested lambda: array_filter inside array_transform
+query T
+select array_transform([[1,2,3,4,5],[6,7,8,9,10]], arr -> array_filter(arr, x -> x > 3))
+----
+[[4,5],[6,7,8,9,10]]
+
+# nested lambda: json_array_transform with object_insert (OTel truncate pattern)
+query T
+select json_array_transform(parse_json('[{"attrs":[{"key":"body","value":{"s":"hello world this is long"}},{"key":"flag","value":{"b":true}}]},{"attrs":[{"key":"body","value":{"s":"another long string here"}}]}]'), e -> object_insert(e, 'attrs', json_array_transform(e:attrs, a -> CASE WHEN a:key::string = 'body' THEN object_insert(a, 'value', object_insert(a:value, 's', to_variant(left(a:value:s::string, 5)), true), true) ELSE a END), true))
+----
+[{"attrs":[{"key":"body","value":{"s":"hello"}},{"key":"flag","value":{"b":true}}]},{"attrs":[{"key":"body","value":{"s":"anoth"}}]}]
+
 statement ok
 create or replace table t4(col1 Variant Null)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Remove the restriction that prevented lambda functions from being used inside other lambda functions, aligning with Snowflake's `TRANSFORM` behavior.

**Problem:** Multi-level nested array transformations (e.g. `events[*].attributes[*].value.stringValue`) required verbose LATERAL FLATTEN + GROUP BY workarounds because `json_array_transform` could not be nested inside another `json_array_transform`.

**Root cause:** A conservative guard added in the initial lambda implementation (PR #12217, 2023) blocked all lambda-in-lambda usage at the type checker level. However, the evaluator already supports recursive execution — `eval_lambda_block` creates a new `Evaluator` that naturally handles nested `LambdaFunctionCall` nodes.

**Fix:**
1. Remove the type checker guard that rejected nested lambdas.
2. Implement parameter shadowing via `UnqualifiedWildcardInVisible` — when a lambda parameter has the same name as an outer column, the outer column is hidden from unqualified lookup but remains accessible via qualified reference (e.g. `table.column`). This preserves backward compatibility with existing queries.

**After this change:**
```sql
SELECT json_array_transform(
  raw_data:events,
  e -> object_insert(e, 'attributes',
    json_array_transform(e:attributes, a ->
      CASE WHEN a:key::string = 'body'
        THEN object_insert(a, 'value',
          object_insert(a:value, 'stringValue',
            to_variant(left(a:value:stringValue::string, 50)), true), true)
        ELSE a END
    ), true)
) FROM traces_table;
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19936)
<!-- Reviewable:end -->
