### PR TITLE
fix(storage): separate variable row hash fields

### DIFF
--- a/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/column_hash.rs
@@ -43,6 +43,12 @@ impl RowScalarValue for Value<AnyType> {
     }
 }
 
+#[inline]
+fn write_bytes_with_len(hasher: &mut impl Hasher, bytes: &[u8]) {
+    hasher.write_u64(bytes.len() as u64);
+    hasher.write(bytes);
+}
+
 /// For row contains null value, None will be returned
 pub fn row_hash_of_columns(
     column_values: &[&Value<AnyType>],
@@ -69,8 +75,8 @@ pub fn row_hash_of_columns(
                 NumberScalar::Float64(v) => sip.write_u64(v.to_bits()),
             },
             ScalarRef::Timestamp(v) => sip.write_i64(v),
-            ScalarRef::String(v) => sip.write(v.as_bytes()),
-            ScalarRef::Bitmap(v) => sip.write(v),
+            ScalarRef::String(v) => write_bytes_with_len(&mut sip, v.as_bytes()),
+            ScalarRef::Bitmap(v) => write_bytes_with_len(&mut sip, v),
             ScalarRef::Decimal(v) => match v {
                 DecimalScalar::Decimal64(_, _) => {
                     unreachable!()
@@ -91,7 +97,7 @@ pub fn row_hash_of_columns(
             ScalarRef::Date(d) => sip.write_i32(d),
             _ => {
                 let string = value.to_string();
-                sip.write(string.as_bytes());
+                write_bytes_with_len(&mut sip, string.as_bytes());
             }
         }
     }

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -129,6 +129,45 @@ SELECT * FROM test order by c;
 statement ok
 DROP TABLE test;
 
+############################################################
+# variable-length on-conflict columns with ambiguous bytes #
+############################################################
+
+statement ok
+CREATE TABLE test(a string not null, b string not null, marker int not null);
+
+statement ok
+REPLACE INTO test ON(a,b) VALUES ('a', 'bc', 1), ('ab', 'c', 2);
+
+query TTI
+SELECT a, b, marker FROM test ORDER BY marker;
+----
+a bc 1
+ab c 2
+
+statement ok
+DROP TABLE test;
+
+statement ok
+CREATE TABLE test(a string not null, b string not null, marker int not null);
+
+statement ok
+INSERT INTO test VALUES ('a', 'bc', 1), ('ab', 'z', 10), ('q', 'c', 11);
+
+statement ok
+REPLACE INTO test ON(a,b) VALUES ('ab', 'c', 2);
+
+query TTI
+SELECT a, b, marker FROM test ORDER BY marker;
+----
+a bc 1
+ab c 2
+ab z 10
+q c 11
+
+statement ok
+DROP TABLE test;
+
 
 ############################
 # on conflict (2nd column) #


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prefix variable-length row-hash fields with their byte length for `REPLACE INTO ... ON(...)` conflict detection.
- Prevent ambiguous multi-column values like `('a', 'bc')` and `('ab', 'c')` from producing the same row hash input.
- Add sqllogictest coverage for both same-batch false duplicate detection and incorrect existing-row deletion.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

Test command:

```shell
NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost target/debug/databend-sqllogictests --handlers mysql,http --run_file 09_0023_replace_into.test --enable_sandbox --parallel 1
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19937)
<!-- Reviewable:end -->
