### PR TITLE
fix(query): bound ANALYZE statistics commit retry

### DIFF
--- a/src/query/service/src/interpreters/hook/analyze_hook.rs
+++ b/src/query/service/src/interpreters/hook/analyze_hook.rs
@@ -86,6 +86,7 @@ async fn do_analyze(ctx: Arc<QueryContext>, desc: AnalyzeDesc) -> Result<()> {
         &mut pipeline,
         HashMap::new(),
         true,
+        false,
     )?;
     pipeline.set_max_threads(ctx.get_settings().get_max_threads()? as usize);
     let executor_settings = ExecutorSettings::try_create(ctx.clone())?;

--- a/src/query/service/src/interpreters/interpreter_table_analyze.rs
+++ b/src/query/service/src/interpreters/interpreter_table_analyze.rs
@@ -182,6 +182,7 @@ impl Interpreter for AnalyzeTableInterpreter {
             &mut build_res.main_pipeline,
             histogram_info_receivers,
             self.plan.no_scan,
+            true,
         )?;
         Ok(build_res)
     }

--- a/src/query/service/src/interpreters/interpreter_table_set_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_set_options.rs
@@ -353,6 +353,7 @@ async fn analyze_table(
         &mut pipeline,
         HashMap::new(),
         false,
+        true,
     )?;
     pipeline.set_max_threads(ctx.get_settings().get_max_threads()? as usize);
     let executor_settings = ExecutorSettings::try_create(ctx.clone())?;

--- a/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
+++ b/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use async_channel::Receiver;
@@ -57,6 +58,8 @@ use crate::operations::util::set_backoff;
 use crate::statistics::reduce_block_statistics;
 use crate::statistics::reduce_cluster_statistics;
 use crate::statistics::reducers::reduce_virtual_column_statistics;
+
+const ANALYZE_COMMIT_MAX_RETRY_ELAPSED: Duration = Duration::from_secs(15 * 60);
 
 impl FuseTable {
     pub fn do_analyze(
@@ -109,6 +112,7 @@ enum AnalyzeStep {
     CollectNDV,
     CollectHistogram,
     CommitStatistics,
+    Finished,
 }
 
 struct SinkAnalyzeState {
@@ -119,7 +123,6 @@ struct SinkAnalyzeState {
     snapshot_id: SnapshotId,
     histogram_info_receivers: HashMap<u32, Receiver<DataBlock>>,
     input_data: Option<DataBlock>,
-    committed: bool,
     row_count: u64,
     unstats_rows: u64,
     ndv_states: HashMap<ColumnId, MetaHLL>,
@@ -144,7 +147,6 @@ impl SinkAnalyzeState {
             snapshot_id,
             histogram_info_receivers,
             input_data: None,
-            committed: false,
             row_count: 0,
             unstats_rows: 0,
             ndv_states: Default::default(),
@@ -286,7 +288,7 @@ impl SinkAnalyzeState {
         }
 
         let mut retries = 0;
-        let mut backoff = set_backoff(None, None, None);
+        let mut backoff = set_backoff(None, None, Some(ANALYZE_COMMIT_MAX_RETRY_ELAPSED));
         loop {
             match self.commit_statistics().await {
                 Ok(_) => return Ok(()),
@@ -411,11 +413,10 @@ impl Processor for SinkAnalyzeState {
                     return Ok(Event::Async);
                 }
                 AnalyzeStep::CommitStatistics => {
-                    if self.committed {
-                        return Ok(Event::Finished);
-                    } else {
-                        return Ok(Event::Async);
-                    }
+                    return Ok(Event::Async);
+                }
+                AnalyzeStep::Finished => {
+                    return Ok(Event::Finished);
                 }
             }
         }
@@ -475,7 +476,7 @@ impl Processor for SinkAnalyzeState {
             }
             AnalyzeStep::CommitStatistics => {
                 self.commit_statistics_with_retry().await?;
-                self.committed = true;
+                self.step = AnalyzeStep::Finished;
             }
             _ => unreachable!(),
         }

--- a/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
+++ b/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use async_channel::Receiver;
+use backoff::backoff::Backoff;
 use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableExt;
@@ -52,6 +53,7 @@ use crate::FuseTable;
 use crate::io::SegmentsIO;
 use crate::operations::analyze::AnalyzeCollectNDVSource;
 use crate::operations::analyze::AnalyzeNDVMeta;
+use crate::operations::util::set_backoff;
 use crate::statistics::reduce_block_statistics;
 use crate::statistics::reduce_cluster_statistics;
 use crate::statistics::reducers::reduce_virtual_column_statistics;
@@ -64,6 +66,7 @@ impl FuseTable {
         pipeline: &mut Pipeline,
         histogram_info_receivers: HashMap<u32, Receiver<DataBlock>>,
         no_scan: bool,
+        retry_commit: bool,
     ) -> Result<()> {
         let mut parts = Vec::with_capacity(snapshot.segments.len());
         for (idx, segment_location) in snapshot.segments.iter().enumerate() {
@@ -94,6 +97,7 @@ impl FuseTable {
                 snapshot.snapshot_id,
                 input,
                 histogram_info_receivers.clone(),
+                retry_commit,
             )
         })?;
         Ok(())
@@ -121,6 +125,7 @@ struct SinkAnalyzeState {
     ndv_states: HashMap<ColumnId, MetaHLL>,
     histograms: HashMap<ColumnId, Vec<HistogramBucket>>,
     step: AnalyzeStep,
+    retry_commit: bool,
 }
 
 impl SinkAnalyzeState {
@@ -130,6 +135,7 @@ impl SinkAnalyzeState {
         snapshot_id: SnapshotId,
         input_port: Arc<InputPort>,
         histogram_info_receivers: HashMap<u32, Receiver<DataBlock>>,
+        retry_commit: bool,
     ) -> Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(Box::new(SinkAnalyzeState {
             ctx,
@@ -144,6 +150,7 @@ impl SinkAnalyzeState {
             ndv_states: Default::default(),
             histograms: Default::default(),
             step: AnalyzeStep::CollectNDV,
+            retry_commit,
         })))
     }
 
@@ -271,6 +278,35 @@ impl SinkAnalyzeState {
                 &table.operator,
             )
             .await
+    }
+
+    async fn commit_statistics_with_retry(&mut self) -> Result<()> {
+        if !self.retry_commit {
+            return self.commit_statistics().await;
+        }
+
+        let mut retries = 0;
+        let mut backoff = set_backoff(None, None, None);
+        loop {
+            match self.commit_statistics().await {
+                Ok(_) => return Ok(()),
+                Err(e) if e.code() == ErrorCode::TABLE_VERSION_MISMATCHED => {
+                    let Some(duration) = backoff.next_backoff() else {
+                        return Err(ErrorCode::StorageOther(format!(
+                            "commit analyze statistics failed after {retries} retries"
+                        )));
+                    };
+                    retries += 1;
+                    log::warn!(
+                        "Retry analyze statistics commit after TableVersionMismatched, sleep {} ms, retrying {} times",
+                        duration.as_millis(),
+                        retries
+                    );
+                    tokio::time::sleep(duration).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     async fn regenerate_statistics(
@@ -438,18 +474,7 @@ impl Processor for SinkAnalyzeState {
                 }
             }
             AnalyzeStep::CommitStatistics => {
-                let mismatch_code = ErrorCode::TABLE_VERSION_MISMATCHED;
-                loop {
-                    if let Err(e) = self.commit_statistics().await {
-                        if e.code() == mismatch_code {
-                            log::warn!("Retry after got TableVersionMismatched");
-                            continue;
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                    break;
-                }
+                self.commit_statistics_with_retry().await?;
                 self.committed = true;
             }
             _ => unreachable!(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR replaces the unbounded retry loop in `ANALYZE` statistics commit with a bounded backoff retry. Explicit `ANALYZE` paths still retry `TABLE_VERSION_MISMATCHED` conflicts, while the best-effort analyze hook skips retrying so it does not block the original write query on frequently updated tables.
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19942)
<!-- Reviewable:end -->
