### PR TITLE
fix(query): align private task history with cloud

### DIFF
--- a/src/query/service/src/table_functions/mod.rs
+++ b/src/query/service/src/table_functions/mod.rs
@@ -23,6 +23,8 @@ mod list_stage;
 mod numbers;
 mod others;
 mod policy_references;
+#[cfg(feature = "task-support")]
+mod private_task_history;
 mod show_grants;
 mod show_roles;
 mod show_sequences;
@@ -44,6 +46,8 @@ pub use numbers::generate_numbers_parts;
 pub use others::LicenseInfoTable;
 pub use others::TenantQuotaTable;
 pub use policy_references::PolicyReferencesTable;
+#[cfg(feature = "task-support")]
+pub use private_task_history::PrivateTaskHistoryTable;
 pub use system::TableStatisticsFunc;
 pub use system::get_fuse_table_snapshot;
 pub use system::get_fuse_table_statistics;

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -157,9 +157,15 @@ impl PrivateTaskHistorySource {
             .as_any()
             .downcast_ref::<QueryContext>()
             .ok_or_else(|| ErrorCode::Internal("Invalid context type"))?;
+        let owners = self
+            .ctx
+            .get_all_available_roles()
+            .await?
+            .into_iter()
+            .map(|role| role.identity().to_string());
         let executor = ServiceQueryExecutor::new(QueryContext::create_from(ctx));
         executor
-            .execute_query_with_sql_string(&self.args.to_sql())
+            .execute_query_with_sql_string(&self.args.to_sql(owners))
             .await
     }
 }
@@ -232,8 +238,10 @@ impl PrivateTaskHistoryArgs {
         Ok(parsed)
     }
 
-    fn to_sql(&self) -> String {
+    fn to_sql<I>(&self, owners: I) -> String
+    where I: IntoIterator<Item = String> {
         let mut filters = Vec::new();
+        push_owner_filter(&mut filters, owners);
         if let Some(task_name) = &self.task_name {
             filters.push(format!("task_name = {}", sql_string(task_name)));
         }
@@ -300,6 +308,23 @@ impl PrivateTaskHistoryArgs {
 
 fn sql_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+fn push_owner_filter<I>(filters: &mut Vec<String>, owners: I)
+where I: IntoIterator<Item = String> {
+    let mut owners = owners.into_iter();
+    let Some(first_owner) = owners.next() else {
+        filters.push("FALSE".to_string());
+        return;
+    };
+
+    let mut filter = format!("owner IN ({}", sql_string(&first_owner));
+    for owner in owners {
+        filter.push_str(", ");
+        filter.push_str(&sql_string(&owner));
+    }
+    filter.push(')');
+    filters.push(filter);
 }
 
 fn timestamp_expr(name: &str, value: &Scalar) -> Result<String> {

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -1,0 +1,327 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use chrono::DateTime;
+use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::PartStatistics;
+use databend_common_catalog::plan::Partitions;
+use databend_common_catalog::plan::PushDownInfo;
+use databend_common_catalog::table::Table;
+use databend_common_catalog::table_args::TableArgs;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_catalog::table_function::TableFunction;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_expression::Scalar;
+use databend_common_expression::infer_table_schema;
+use databend_common_meta_app::schema::TableIdent;
+use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::TableMeta;
+use databend_common_pipeline::core::OutputPort;
+use databend_common_pipeline::core::Pipeline;
+use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_pipeline::sources::AsyncSource;
+use databend_common_pipeline::sources::AsyncSourcer;
+use databend_common_sql::QueryExecutor;
+use databend_common_sql::plans::task_run_schema;
+
+use crate::schedulers::ServiceQueryExecutor;
+use crate::sessions::QueryContext;
+
+pub struct PrivateTaskHistoryTable {
+    table_info: TableInfo,
+    args_parsed: PrivateTaskHistoryArgs,
+    table_args: TableArgs,
+}
+
+impl PrivateTaskHistoryTable {
+    pub fn create(
+        database_name: &str,
+        table_func_name: &str,
+        table_id: u64,
+        table_args: TableArgs,
+    ) -> Result<Arc<dyn TableFunction>> {
+        let args_parsed = PrivateTaskHistoryArgs::parse(&table_args)?;
+        let table_info = TableInfo {
+            ident: TableIdent::new(table_id, 0),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
+            name: String::from("task_history"),
+            meta: TableMeta {
+                schema: infer_table_schema(&task_run_schema())
+                    .expect("failed to infer task history schema"),
+                engine: String::from(table_func_name),
+                created_on: DateTime::from_timestamp(0, 0).unwrap(),
+                updated_on: DateTime::from_timestamp(0, 0).unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        Ok(Arc::new(Self {
+            table_info,
+            args_parsed,
+            table_args,
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for PrivateTaskHistoryTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    #[async_backtrace::framed]
+    async fn read_partitions(
+        &self,
+        _ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+        _dry_run: bool,
+    ) -> Result<(PartStatistics, Partitions)> {
+        Ok((PartStatistics::new_exact(1, 1, 1, 1), Partitions::default()))
+    }
+
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(self.table_args.clone())
+    }
+
+    fn read_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _plan: &DataSourcePlan,
+        pipeline: &mut Pipeline,
+        _put_cache: bool,
+    ) -> Result<()> {
+        pipeline.add_source(
+            |output| {
+                PrivateTaskHistorySource::create(ctx.clone(), output, self.args_parsed.clone())
+            },
+            1,
+        )?;
+        Ok(())
+    }
+}
+
+impl TableFunction for PrivateTaskHistoryTable {
+    fn function_name(&self) -> &str {
+        self.name()
+    }
+
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
+    where Self: 'a {
+        self
+    }
+}
+
+struct PrivateTaskHistorySource {
+    ctx: Arc<dyn TableContext>,
+    args: PrivateTaskHistoryArgs,
+    blocks: Option<std::vec::IntoIter<DataBlock>>,
+}
+
+impl PrivateTaskHistorySource {
+    fn create(
+        ctx: Arc<dyn TableContext>,
+        output: Arc<OutputPort>,
+        args: PrivateTaskHistoryArgs,
+    ) -> Result<ProcessorPtr> {
+        AsyncSourcer::create(ctx.get_scan_progress(), output, Self {
+            ctx,
+            args,
+            blocks: None,
+        })
+    }
+
+    async fn load_blocks(&self) -> Result<Vec<DataBlock>> {
+        let ctx = self
+            .ctx
+            .as_any()
+            .downcast_ref::<QueryContext>()
+            .ok_or_else(|| ErrorCode::Internal("Invalid context type"))?;
+        let executor = ServiceQueryExecutor::new(QueryContext::create_from(ctx));
+        executor
+            .execute_query_with_sql_string(&self.args.to_sql())
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncSource for PrivateTaskHistorySource {
+    const NAME: &'static str = "task_history";
+
+    #[async_backtrace::framed]
+    async fn generate(&mut self) -> Result<Option<DataBlock>> {
+        if self.blocks.is_none() {
+            self.blocks = Some(self.load_blocks().await?.into_iter());
+        }
+
+        Ok(self.blocks.as_mut().and_then(|blocks| blocks.next()))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PrivateTaskHistoryArgs {
+    task_name: Option<String>,
+    scheduled_time_range_start: Option<String>,
+    scheduled_time_range_end: Option<String>,
+    result_limit: Option<i32>,
+    error_only: Option<bool>,
+    root_task_id: Option<String>,
+}
+
+impl PrivateTaskHistoryArgs {
+    fn parse(table_args: &TableArgs) -> Result<Self> {
+        let args = table_args.expect_all_named("task_history")?;
+
+        let mut parsed = Self {
+            task_name: None,
+            scheduled_time_range_start: None,
+            scheduled_time_range_end: None,
+            result_limit: None,
+            error_only: None,
+            root_task_id: None,
+        };
+
+        for (k, v) in &args {
+            match k.to_lowercase().as_str() {
+                "task_name" => parsed.task_name = v.as_string().cloned(),
+                "scheduled_time_range_start" => {
+                    parsed.scheduled_time_range_start = Some(timestamp_expr(k, v)?);
+                }
+                "scheduled_time_range_end" => {
+                    parsed.scheduled_time_range_end = Some(timestamp_expr(k, v)?);
+                }
+                "result_limit" => {
+                    parsed.result_limit = Some(v.get_i64().ok_or_else(|| {
+                        ErrorCode::BadArguments(format!(
+                            "unsupported data type for {}, only support integer",
+                            k
+                        ))
+                    })? as i32);
+                }
+                "error_only" => parsed.error_only = v.as_boolean().cloned(),
+                "root_task_id" => parsed.root_task_id = v.as_string().cloned(),
+                _ => {
+                    return Err(ErrorCode::BadArguments(format!(
+                        "unknown param {} for {}",
+                        k, "task_history"
+                    )));
+                }
+            }
+        }
+
+        Ok(parsed)
+    }
+
+    fn to_sql(&self) -> String {
+        let mut filters = Vec::new();
+        if let Some(task_name) = &self.task_name {
+            filters.push(format!("task_name = {}", sql_string(task_name)));
+        }
+        if let Some(start) = &self.scheduled_time_range_start {
+            filters.push(format!("scheduled_at >= {start}"));
+        }
+        if let Some(end) = &self.scheduled_time_range_end {
+            filters.push(format!("scheduled_at <= {end}"));
+        }
+        if self.error_only.unwrap_or(false) {
+            filters.push(
+                "(COALESCE(error_code, 0) != 0 OR error_message IS NOT NULL OR state = 'FAILED')"
+                    .to_string(),
+            );
+        }
+        if let Some(root_task_id) = &self.root_task_id {
+            filters.push(format!(
+                "CAST(root_task_id AS STRING) = {}",
+                sql_string(root_task_id)
+            ));
+        }
+
+        let where_clause = if filters.is_empty() {
+            String::new()
+        } else {
+            format!(" WHERE {}", filters.join(" AND "))
+        };
+        let limit_clause = match self.result_limit {
+            Some(limit) if limit > 0 => format!(" LIMIT {limit}"),
+            _ => String::new(),
+        };
+
+        format!(
+            "SELECT
+                task_name AS name,
+                task_id AS id,
+                owner,
+                comment,
+                CASE
+                    WHEN schedule_type = 0 AND interval_milliseconds IS NOT NULL THEN CONCAT('INTERVAL ', COALESCE(CAST(interval AS STRING), '0'), ' SECOND ', CAST(interval_milliseconds AS STRING), ' MILLISECOND')
+                    WHEN schedule_type = 0 THEN CONCAT('INTERVAL ', COALESCE(CAST(interval AS STRING), '0'), ' SECOND')
+                    WHEN schedule_type = 1 AND time_zone IS NOT NULL THEN CONCAT('CRON ', cron, ' TIMEZONE ', time_zone)
+                    WHEN schedule_type = 1 THEN CONCAT('CRON ', cron)
+                    ELSE NULL
+                END AS schedule,
+                warehouse_name AS warehouse,
+                state,
+                query_text AS definition,
+                COALESCE(when_condition, '') AS condition_text,
+                CAST(run_id AS STRING) AS run_id,
+                '' AS query_id,
+                COALESCE(error_code, 0) AS exception_code,
+                error_message AS exception_text,
+                attempt_number,
+                completed_at AS completed_time,
+                scheduled_at AS scheduled_time,
+                CAST(root_task_id AS STRING) AS root_task_id,
+                session_params AS session_parameters
+            FROM system_task.task_run{where_clause}
+            ORDER BY scheduled_at DESC{limit_clause}"
+        )
+    }
+}
+
+fn sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn timestamp_expr(name: &str, value: &Scalar) -> Result<String> {
+    if let Some(timestamp) = value.as_timestamp() {
+        timestamp_literal(*timestamp)
+    } else if let Some(date) = value.as_date() {
+        timestamp_literal(i64::from(*date) * 24 * 60 * 60 * 1_000_000)
+    } else {
+        Err(ErrorCode::BadArguments(format!(
+            "unsupported data type for {}, only support timestamp or date",
+            name
+        )))
+    }
+}
+
+fn timestamp_literal(micros: i64) -> Result<String> {
+    let secs = micros.div_euclid(1_000_000);
+    let nanos = micros.rem_euclid(1_000_000) as u32 * 1_000;
+    let timestamp = DateTime::from_timestamp(secs, nanos)
+        .ok_or_else(|| ErrorCode::BadArguments("timestamp argument is out of range"))?;
+    Ok(format!(
+        "TIMESTAMP '{}'",
+        timestamp.format("%Y-%m-%d %H:%M:%S%.6f")
+    ))
+}

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -43,6 +43,9 @@ use databend_common_sql::plans::task_run_schema;
 use crate::schedulers::ServiceQueryExecutor;
 use crate::task::TaskService;
 
+const TASK_HISTORY_DEFAULT_RESULT_LIMIT: i64 = 100;
+const TASK_HISTORY_MAX_RESULT_LIMIT: i64 = 10_000;
+
 pub struct PrivateTaskHistoryTable {
     table_info: TableInfo,
     args_parsed: PrivateTaskHistoryArgs,
@@ -185,7 +188,7 @@ struct PrivateTaskHistoryArgs {
     task_name: Option<String>,
     scheduled_time_range_start: Option<String>,
     scheduled_time_range_end: Option<String>,
-    result_limit: Option<i32>,
+    result_limit: Option<i64>,
     error_only: Option<bool>,
     root_task_id: Option<String>,
 }
@@ -218,7 +221,7 @@ impl PrivateTaskHistoryArgs {
                             "unsupported data type for {}, only support integer",
                             k
                         ))
-                    })? as i32);
+                    })?);
                 }
                 "error_only" => parsed.error_only = v.as_boolean().cloned(),
                 "root_task_id" => parsed.root_task_id = v.as_string().cloned(),
@@ -266,10 +269,7 @@ impl PrivateTaskHistoryArgs {
         } else {
             format!(" WHERE {}", filters.join(" AND "))
         };
-        let limit_clause = match self.result_limit {
-            Some(limit) if limit > 0 => format!(" LIMIT {limit}"),
-            _ => String::new(),
-        };
+        let limit = self.effective_result_limit();
 
         format!(
             "SELECT
@@ -298,8 +298,15 @@ impl PrivateTaskHistoryArgs {
                 CAST(root_task_id AS STRING) AS root_task_id,
                 session_params AS session_parameters
             FROM system_task.task_run{where_clause}
-            ORDER BY scheduled_at DESC{limit_clause}"
+            ORDER BY scheduled_at DESC LIMIT {limit}"
         )
+    }
+
+    fn effective_result_limit(&self) -> i64 {
+        match self.result_limit {
+            Some(limit) if limit > 0 => limit.min(TASK_HISTORY_MAX_RESULT_LIMIT),
+            _ => TASK_HISTORY_DEFAULT_RESULT_LIMIT,
+        }
     }
 }
 

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -254,6 +254,7 @@ impl PrivateTaskHistoryArgs {
             );
         }
         if let Some(root_task_id) = &self.root_task_id {
+            // TODO: private task runs do not yet propagate DAG root task IDs reliably.
             filters.push(format!(
                 "CAST(root_task_id AS STRING) = {}",
                 sql_string(root_task_id)

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -41,7 +41,7 @@ use databend_common_sql::QueryExecutor;
 use databend_common_sql::plans::task_run_schema;
 
 use crate::schedulers::ServiceQueryExecutor;
-use crate::sessions::QueryContext;
+use crate::task::TaskService;
 
 pub struct PrivateTaskHistoryTable {
     table_info: TableInfo,
@@ -152,18 +152,14 @@ impl PrivateTaskHistorySource {
     }
 
     async fn load_blocks(&self) -> Result<Vec<DataBlock>> {
-        let ctx = self
-            .ctx
-            .as_any()
-            .downcast_ref::<QueryContext>()
-            .ok_or_else(|| ErrorCode::Internal("Invalid context type"))?;
         let owners = self
             .ctx
             .get_all_available_roles()
             .await?
             .into_iter()
             .map(|role| role.identity().to_string());
-        let executor = ServiceQueryExecutor::new(QueryContext::create_from(ctx));
+        let ctx = TaskService::instance().create_context(None).await?;
+        let executor = ServiceQueryExecutor::new(ctx);
         executor
             .execute_query_with_sql_string(&self.args.to_sql(owners))
             .await

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -57,6 +57,8 @@ use crate::storages::fuse::table_functions::ClusteringInformationFunc;
 use crate::storages::fuse::table_functions::FuseSegmentFunc;
 use crate::storages::fuse::table_functions::FuseSnapshotFunc;
 use crate::storages::fuse::table_functions::FuseTagFunc;
+#[cfg(feature = "task-support")]
+use crate::table_functions::PrivateTaskHistoryTable;
 use crate::table_functions::TableFunction;
 use crate::table_functions::async_crash_me::AsyncCrashMeTable;
 use crate::table_functions::copy_history::CopyHistoryTable;
@@ -327,7 +329,12 @@ impl TableFunctionFactory {
         );
 
         #[cfg(feature = "task-support")]
-        if !config.task.on {
+        if config.task.on {
+            creators.insert(
+                "task_history".to_string(),
+                (next_id(), Arc::new(PrivateTaskHistoryTable::create)),
+            );
+        } else {
             creators.insert(
                 "task_dependents".to_string(),
                 (next_id(), Arc::new(TaskDependentsTable::create)),

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -26,7 +26,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use async_stream::stream;
-use chrono::DateTime;
 use chrono::Utc;
 use chrono_tz::Tz;
 use cron::Schedule;
@@ -45,7 +44,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_meta_api::kv_pb_api::decode_seqv;
-use databend_common_meta_app::principal::ScheduleOptions;
 use databend_common_meta_app::principal::ScheduleType;
 use databend_common_meta_app::principal::State;
 use databend_common_meta_app::principal::Status;
@@ -264,24 +262,6 @@ impl TaskService {
                                     .await
                             };
 
-                        let fn_new_task_run = async |task_service: &TaskService, task: &Task| {
-                            task_service
-                                .update_or_create_task_run(&TaskRun {
-                                    task: task.clone(),
-                                    run_id: Self::make_run_id(),
-                                    attempt_number: task
-                                        .suspend_task_after_num_failures
-                                        .unwrap_or(0)
-                                        as i32,
-                                    state: State::Scheduled,
-                                    scheduled_at: Utc::now(),
-                                    completed_at: None,
-                                    error_code: 0,
-                                    error_message: None,
-                                    root_task_id: EMPTY_TASK_ID,
-                                })
-                                .await
-                        };
                         match schedule_options.schedule_type {
                             ScheduleType::IntervalType => {
                                 let task_mgr = task_mgr.clone();
@@ -302,10 +282,12 @@ impl TaskService {
                                                         let Some(_guard) = fn_lock(&task_service, &task_key, duration.as_millis() as u64).await? else {
                                                             continue;
                                                         };
+                                                        if task_service.has_executing_task_run(&task.task_name).await? {
+                                                            continue;
+                                                        }
                                                         if !Self::check_when(&task, &owner, &task_service).await? {
                                                             continue;
                                                         }
-                                                        fn_new_task_run(&task_service, &task).await?;
                                                         task_mgr.send(TaskMessage::ExecuteTask(task.clone())).await.map_err(meta_service_error)?;
                                                     }
                                                     _ = child_token.cancelled() => {
@@ -350,10 +332,12 @@ impl TaskService {
                                                         let Some(_guard) = fn_lock(&task_service, &task_key, duration.as_millis() as u64).await? else {
                                                             continue;
                                                         };
+                                                        if task_service.has_executing_task_run(&task.task_name).await? {
+                                                            continue;
+                                                        }
                                                         if !Self::check_when(&task, &owner, &task_service).await? {
                                                             continue;
                                                         }
-                                                        fn_new_task_run(&task_service, &task).await?;
                                                         task_mgr.send(TaskMessage::ExecuteTask(task.clone())).await.map_err(meta_service_error)?;
                                                     }
                                                     _ = child_token.cancelled() => {
@@ -382,23 +366,26 @@ impl TaskService {
                     }
                     let task_name = task.task_name.clone();
                     let task_service = TaskService::instance();
-
-                    let mut task_run = task_service
-                        .lasted_task_run(&task_name)
+                    let Some(execute_guard) = task_service
+                        .meta_handle
+                        .acquire_with_guard(
+                            &format!(
+                                "{}/execute/lock",
+                                TaskMessage::key_with_type(TaskMessageType::Execute, &task_name)
+                            ),
+                            0,
+                        )
                         .await?
-                        .unwrap_or_else(|| TaskRun {
-                            task: task.clone(),
-                            run_id: Self::make_run_id(),
-                            attempt_number: task.suspend_task_after_num_failures.unwrap_or(0)
-                                as i32,
-                            state: State::Executing,
-                            scheduled_at: Utc::now(),
-                            completed_at: None,
-                            error_code: 0,
-                            error_message: None,
-                            root_task_id: EMPTY_TASK_ID,
-                        });
+                    else {
+                        continue;
+                    };
+
+                    if task_service.has_executing_task_run(&task_name).await? {
+                        continue;
+                    }
+                    let mut task_run = Self::new_task_run(&task);
                     task_service.update_or_create_task_run(&task_run).await?;
+                    drop(execute_guard);
 
                     let task_mgr = task_mgr.clone();
                     let tenant = tenant.clone();
@@ -434,6 +421,12 @@ impl TaskService {
                                             )
                                             .await?
                                             {
+                                                if task_service
+                                                    .has_executing_task_run(&next_task.task_name)
+                                                    .await?
+                                                {
+                                                    continue;
+                                                }
                                                 task_mgr
                                                     .send(TaskMessage::ExecuteTask(next_task))
                                                     .await
@@ -563,6 +556,20 @@ impl TaskService {
         Ok(())
     }
 
+    fn new_task_run(task: &Task) -> TaskRun {
+        TaskRun {
+            task: task.clone(),
+            run_id: Self::make_run_id(),
+            attempt_number: task.suspend_task_after_num_failures.unwrap_or(0) as i32,
+            state: State::Executing,
+            scheduled_at: Utc::now(),
+            completed_at: None,
+            error_code: 0,
+            error_message: None,
+            root_task_id: EMPTY_TASK_ID,
+        }
+    }
+
     async fn check_when(
         task: &Task,
         user: &UserInfo,
@@ -637,55 +644,31 @@ impl TaskService {
         Ok(())
     }
 
-    pub async fn lasted_task_run(&self, task_name: &str) -> Result<Option<TaskRun>> {
+    pub async fn has_executing_task_run(&self, task_name: &str) -> Result<bool> {
         let blocks = self
             .execute_sql(
                 None,
                 &format!(
-                    "SELECT
-        task_id,
-        task_name,
-        query_text,
-        when_condition,
-        after,
-        comment,
-        owner,
-        owner_user,
-        warehouse_name,
-        using_warehouse_size,
-        schedule_type,
-        interval,
-        interval_milliseconds,
-        cron,
-        time_zone,
-        run_id,
-        attempt_number,
-        state,
-        error_code,
-        error_message,
-        root_task_id,
-        scheduled_at,
-        completed_at,
-        next_scheduled_at,
-        error_integration,
-        status,
-        created_at,
-        updated_at,
-        session_params,
-        last_suspended_at,
-        suspend_task_after_num_failures
-    FROM system_task.task_run WHERE task_name = '{task_name}' ORDER BY run_id DESC LIMIT 1;"
+                    "SELECT count(*) FROM system_task.task_run \
+                    WHERE task_name = '{task_name}' \
+                    AND state = 'EXECUTING' \
+                    AND completed_at IS NULL;"
                 ),
             )
             .await?;
 
-        let Some(block) = blocks.first() else {
-            return Ok(None);
-        };
-        if block.num_rows() == 0 {
-            return Ok(None);
-        }
-        Ok(Self::block2task_run(block, 0))
+        let count = blocks
+            .first()
+            .and_then(|block| block.get_by_offset(0).index(0))
+            .and_then(|scalar| {
+                scalar
+                    .as_number()
+                    .and_then(|number| number.as_u_int64())
+                    .cloned()
+            })
+            .unwrap_or(0);
+
+        Ok(count > 0)
     }
 
     pub async fn update_or_create_task_run(&self, task_run: &TaskRun) -> Result<()> {
@@ -978,182 +961,6 @@ WHERE ta.task_name = '{task_name}'
         Ok(sql)
     }
 
-    fn block2task_run(block: &DataBlock, row: usize) -> Option<TaskRun> {
-        let task_id = *block
-            .get_by_offset(0)
-            .index(row)?
-            .as_number()?
-            .as_u_int64()?;
-        let task_name = block.get_by_offset(1).index(row)?.as_string()?.to_string();
-        let query_text = block.get_by_offset(2).index(row)?.as_string()?.to_string();
-        let when_condition = block
-            .get_by_offset(3)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let after = block
-            .get_by_offset(4)
-            .index(row)?
-            .as_string()?
-            .split(", ")
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        let comment = block
-            .get_by_offset(5)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let owner = block.get_by_offset(6).index(row)?.as_string()?.to_string();
-        let owner_user = block.get_by_offset(7).index(row)?.as_string()?.to_string();
-        let warehouse_name = block
-            .get_by_offset(8)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let using_warehouse_size = block
-            .get_by_offset(9)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let schedule_type = block
-            .get_by_offset(10)
-            .index(row)
-            .and_then(|s| s.as_number().and_then(|n| n.as_int32()).cloned());
-        let interval = block
-            .get_by_offset(11)
-            .index(row)
-            .and_then(|s| s.as_number().and_then(|n| n.as_int32()).cloned());
-        let milliseconds_interval = block
-            .get_by_offset(12)
-            .index(row)
-            .and_then(|s| s.as_number().and_then(|n| n.as_u_int64()).cloned());
-        let cron = block
-            .get_by_offset(13)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let time_zone = block
-            .get_by_offset(14)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let run_id = *block
-            .get_by_offset(15)
-            .index(row)?
-            .as_number()?
-            .as_u_int64()?;
-        let attempt_number = block
-            .get_by_offset(16)
-            .index(row)
-            .and_then(|s| s.as_number().and_then(|n| n.as_int32()).cloned());
-        let state = block.get_by_offset(17).index(row)?.as_string()?.to_string();
-        let error_code = *block
-            .get_by_offset(18)
-            .index(row)?
-            .as_number()?
-            .as_int64()?;
-        let error_message = block
-            .get_by_offset(19)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let root_task_id = *block
-            .get_by_offset(20)
-            .index(row)?
-            .as_number()?
-            .as_u_int64()?;
-        let scheduled_at = *block.get_by_offset(21).index(row)?.as_timestamp()?;
-        let completed_at = block
-            .get_by_offset(22)
-            .index(row)
-            .and_then(|s| s.as_timestamp().cloned());
-        let next_scheduled_at = block
-            .get_by_offset(23)
-            .index(row)
-            .and_then(|s| s.as_timestamp().cloned());
-        let error_integration = block
-            .get_by_offset(24)
-            .index(row)
-            .and_then(|s| s.as_string().map(|s| s.to_string()));
-        let status = block.get_by_offset(25).index(row)?.as_string()?.to_string();
-        let created_at = *block.get_by_offset(26).index(row)?.as_timestamp()?;
-        let updated_at = *block.get_by_offset(27).index(row)?.as_timestamp()?;
-        let session_params = block.get_by_offset(28).index(row).and_then(|s| {
-            s.as_variant()
-                .and_then(|bytes| serde_json::from_slice::<BTreeMap<String, String>>(bytes).ok())
-        })?;
-        let last_suspended_at = block
-            .get_by_offset(29)
-            .index(row)
-            .and_then(|s| s.as_timestamp().cloned());
-
-        let schedule_options = if let Some(s) = schedule_type {
-            let schedule_type = match s {
-                0 => ScheduleType::IntervalType,
-                1 => ScheduleType::CronType,
-                _ => {
-                    return None;
-                }
-            };
-            Some(ScheduleOptions {
-                interval,
-                cron,
-                time_zone,
-                schedule_type,
-                milliseconds_interval,
-            })
-        } else {
-            None
-        };
-
-        let warehouse_options = if warehouse_name.is_some() && using_warehouse_size.is_some() {
-            Some(WarehouseOptions {
-                warehouse: warehouse_name,
-                using_warehouse_size,
-            })
-        } else {
-            None
-        };
-        let task = Task {
-            task_id,
-            task_name,
-            task_sql: TaskSql::Sql(query_text),
-            when_condition,
-            after,
-            comment,
-            owner,
-            owner_user,
-            schedule_options,
-            warehouse_options,
-            next_scheduled_at: next_scheduled_at
-                .and_then(|i| DateTime::<Utc>::from_timestamp(i, 0)),
-            suspend_task_after_num_failures: attempt_number.map(|i| i as u64),
-            error_integration,
-            status: match status.as_str() {
-                "SUSPENDED" => Status::Suspended,
-                "STARTED" => Status::Started,
-                _ => return None,
-            },
-            created_at: DateTime::<Utc>::from_timestamp(created_at, 0)?,
-            updated_at: DateTime::<Utc>::from_timestamp(updated_at, 0)?,
-            last_suspended_at: last_suspended_at
-                .and_then(|i| DateTime::<Utc>::from_timestamp(i, 0)),
-            session_params,
-        };
-
-        Some(TaskRun {
-            task,
-            run_id,
-            attempt_number: attempt_number.unwrap_or_default(),
-            state: match state.as_str() {
-                "SCHEDULED" => State::Scheduled,
-                "EXECUTING" => State::Executing,
-                "SUCCEEDED" => State::Succeeded,
-                "FAILED" => State::Failed,
-                "CANCELLED" => State::Cancelled,
-                _ => return None,
-            },
-            scheduled_at: DateTime::<Utc>::from_timestamp(scheduled_at, 0)?,
-            completed_at: completed_at.and_then(|i| DateTime::<Utc>::from_timestamp(i, 0)),
-            error_code,
-            error_message,
-            root_task_id,
-        })
-    }
-
     async fn execute_sql(&self, other_user: Option<UserInfo>, sql: &str) -> Result<Vec<DataBlock>> {
         let context = self.create_context(other_user).await?;
         self.execute_sql_in_context(context, sql).await
@@ -1223,6 +1030,6 @@ WHERE ta.task_name = '{task_name}'
     }
 
     fn make_run_id() -> u64 {
-        Utc::now().timestamp_millis() as u64
+        Utc::now().timestamp_micros() as u64
     }
 }

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -547,12 +547,17 @@ impl TaskService {
 
     async fn spawn_task(task: Task, user: UserInfo) -> Result<()> {
         let task_service = TaskService::instance();
+        let context = task_service.create_task_context(user, &task).await?;
 
         match &task.task_sql {
             TaskSql::Sql(sql) => {
-                task_service.execute_sql(Some(user), sql).await?;
+                task_service.execute_sql_in_context(context, sql).await?;
             }
-            TaskSql::Script(sqls) => task_service.execute_script_sql(Some(user), sqls).await?,
+            TaskSql::Script(sqls) => {
+                task_service
+                    .execute_script_sql_in_context(context, sqls)
+                    .await?
+            }
         }
 
         Ok(())
@@ -566,8 +571,9 @@ impl TaskService {
         let Some(when_condition) = &task.when_condition else {
             return Ok(true);
         };
+        let context = task_service.create_task_context(user.clone(), task).await?;
         let result = task_service
-            .execute_sql(Some(user.clone()), &format!("SELECT {when_condition}"))
+            .execute_sql_in_context(context, &format!("SELECT {when_condition}"))
             .await?;
         Ok(result
             .first()
@@ -607,6 +613,28 @@ impl TaskService {
 
         let session = create_session(user, role).await?;
         session.create_query_context_with_cluster(dummy_cluster, &BUILD_INFO)
+    }
+
+    async fn create_task_context(&self, user: UserInfo, task: &Task) -> Result<Arc<QueryContext>> {
+        let context = self.create_context(Some(user)).await?;
+        Self::apply_task_session_params(&context, &task.session_params).await?;
+        Ok(context)
+    }
+
+    async fn apply_task_session_params(
+        context: &Arc<QueryContext>,
+        session_params: &BTreeMap<String, String>,
+    ) -> Result<()> {
+        for (key, value) in session_params {
+            if key.eq_ignore_ascii_case("database") {
+                context.set_current_database(value.clone()).await?;
+            } else {
+                context
+                    .get_settings()
+                    .set_setting(key.to_lowercase(), value.clone())?;
+            }
+        }
+        Ok(())
     }
 
     pub async fn lasted_task_run(&self, task_name: &str) -> Result<Option<TaskRun>> {
@@ -1128,7 +1156,14 @@ WHERE ta.task_name = '{task_name}'
 
     async fn execute_sql(&self, other_user: Option<UserInfo>, sql: &str) -> Result<Vec<DataBlock>> {
         let context = self.create_context(other_user).await?;
+        self.execute_sql_in_context(context, sql).await
+    }
 
+    async fn execute_sql_in_context(
+        &self,
+        context: Arc<QueryContext>,
+        sql: &str,
+    ) -> Result<Vec<DataBlock>> {
         let mut planner = Planner::new_with_query_executor(
             context.clone(),
             Arc::new(ServiceQueryExecutor::new(QueryContext::create_from(
@@ -1141,12 +1176,11 @@ WHERE ta.task_name = '{task_name}'
         stream.try_collect::<Vec<DataBlock>>().await
     }
 
-    async fn execute_script_sql(
+    async fn execute_script_sql_in_context(
         &self,
-        other_user: Option<UserInfo>,
+        context: Arc<QueryContext>,
         sqls: &[String],
     ) -> Result<()> {
-        let context = self.create_context(other_user).await?;
         let sql_dialect = context.get_settings().get_sql_dialect()?;
         let script = Self::script_sql_to_block(sqls);
         let tokens = tokenize_sql(&script)?;

--- a/src/query/task_support/src/table_functions/task_history.rs
+++ b/src/query/task_support/src/table_functions/task_history.rs
@@ -287,7 +287,8 @@ impl TableHistoryArgsParsed {
         let mut error_only = None;
         let mut root_task_id = None;
         for (k, v) in &args {
-            match k.to_lowercase().as_str() {
+            let key = k.to_lowercase();
+            match key.as_str() {
                 "task_name" => task_name = v.as_string().cloned(),
                 "scheduled_time_range_start" | "scheduled_time_range_end" => {
                     if v.as_timestamp().is_none() && v.as_date().is_none() {
@@ -296,7 +297,7 @@ impl TableHistoryArgsParsed {
                             k,
                         )));
                     }
-                    if k == "scheduled_time_range_start" {
+                    if key == "scheduled_time_range_start" {
                         scheduled_time_range_start = parse_date_or_timestamp(v);
                     } else {
                         scheduled_time_range_end = parse_date_or_timestamp(v);

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -477,6 +477,31 @@ else
     exit 1
 fi
 
+response=$(query_sql_with_auth "root:" "INSERT INTO system_task.task_run (task_id, task_name, query_text, when_condition, after, comment, owner, owner_user, warehouse_name, using_warehouse_size, schedule_type, interval, interval_milliseconds, cron, time_zone, run_id, attempt_number, state, error_code, error_message, root_task_id, scheduled_at, completed_at, next_scheduled_at, error_integration, status, created_at, updated_at, session_params, last_suspended_at, suspend_task_after_num_failures) SELECT 900000 + number, 'limit_history_task', 'SELECT 1', NULL, NULL, NULL, 'account_admin', 'root', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 900000 + number, 0, 'SUCCEEDED', 0, NULL, 0, to_timestamp(1700000000 + number), to_timestamp(1700000000 + number), NULL, NULL, 'SUSPENDED', to_timestamp(1700000000 + number), to_timestamp(1700000000 + number), parse_json('{}'), NULL, NULL FROM numbers(101)")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "SELECT count(*) FROM TASK_HISTORY(TASK_NAME => 'limit_history_task')")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "100" ]; then
+    echo "✅ TASK_HISTORY applies the default result limit"
+else
+    echo "❌ Expected TASK_HISTORY without RESULT_LIMIT to return 100 rows"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT count(*) FROM TASK_HISTORY(TASK_NAME => 'limit_history_task', RESULT_LIMIT => 100000)")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "101" ]; then
+    echo "✅ TASK_HISTORY clamps explicit result limits without dropping valid rows"
+else
+    echo "❌ Expected TASK_HISTORY with large RESULT_LIMIT to return all 101 matching rows"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
 response=$(query_sql_with_auth "root:" "CREATE ROLE task_history_role_a")
 check_response_error "$response"
 response=$(query_sql_with_auth "root:" "CREATE ROLE task_history_role_b")

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -489,9 +489,9 @@ response=$(query_sql_with_auth "root:" "GRANT ROLE task_history_role_a TO task_h
 check_response_error "$response"
 response=$(query_sql_with_auth "root:" "GRANT ROLE task_history_role_b TO task_history_user_b")
 check_response_error "$response"
-response=$(query_sql_with_auth "root:" "GRANT ALL ON *.* TO ROLE task_history_role_a")
+response=$(query_sql_with_auth "root:" "GRANT SUPER ON *.* TO ROLE task_history_role_a")
 check_response_error "$response"
-response=$(query_sql_with_auth "root:" "GRANT ALL ON *.* TO ROLE task_history_role_b")
+response=$(query_sql_with_auth "root:" "GRANT SUPER ON *.* TO ROLE task_history_role_b")
 check_response_error "$response"
 
 response=$(query_sql_with_auth "task_history_user_a:task_history_pwd" "CREATE TASK role_a_history_task AS SELECT 1")

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -219,6 +219,41 @@ else
     exit 1
 fi
 
+response=$(query_sql_with_auth "root:" "CREATE TASK overlap_schedule_task SCHEDULE = 500 MILLISECOND AS SELECT sleep(2)")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK overlap_schedule_task RESUME")
+check_response_error "$response"
+
+sleep 9
+
+response=$(query_sql_with_auth "root:" "ALTER TASK overlap_schedule_task SUSPEND")
+check_response_error "$response"
+
+sleep 3
+
+response=$(query_sql_with_auth "root:" "SELECT count(*) FROM TASK_HISTORY(TASK_NAME => 'overlap_schedule_task', RESULT_LIMIT => 10) WHERE state = 'SUCCEEDED'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" -ge 2 ]; then
+    echo "✅ Slow interval task continues after previous run completes"
+else
+    echo "❌ Expected slow interval task to have at least 2 successful runs"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT count(*) FROM system_task.task_run a, system_task.task_run b WHERE a.task_name = 'overlap_schedule_task' AND b.task_name = 'overlap_schedule_task' AND a.run_id < b.run_id AND a.state = 'SUCCEEDED' AND b.state = 'SUCCEEDED' AND a.scheduled_at < b.completed_at AND b.scheduled_at < a.completed_at")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "0" ]; then
+    echo "✅ Slow interval task runs do not overlap"
+else
+    echo "❌ Expected slow interval task runs not to overlap"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK my_task_1 SCHEDULE = 5 SECOND AS insert into t1 values(0)\"}")
 check_response_error "$response"
 create_task_1_query_id=$(echo $response | jq -r '.id')
@@ -633,19 +668,18 @@ check_response_error "$response"
 alter_task_4_query_id=$(echo $response | jq -r '.id')
 echo "Resume Task 4 ID: $alter_task_4_query_id"
 
-sleep 60
+sleep 80
 
-response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT c1 FROM t2 ORDER BY c1\"}")
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT count(*) FROM t2\"}")
 check_response_error "$response"
 
-actual=$(echo "$response" | jq -c '.data')
-expected='[["0"],["0"],["0"]]'
+actual=$(echo "$response" | jq -r '.data[0][0]')
 
-if [ "$actual" = "$expected" ]; then
+if [ "$actual" -ge 3 ]; then
     echo "✅ Query result matches expected"
 else
     echo "❌ Mismatch"
-    echo "Expected: $expected"
+    echo "Expected at least 3 cron task runs"
     echo "Actual  : $actual"
     exit 1
 fi

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -74,6 +74,13 @@ check_response_error() {
     fi
 }
 
+query_sql_with_auth() {
+    local auth="$1"
+    local sql="$2"
+
+    curl -s -u "$auth" -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "$(jq -nc --arg sql "$sql" '{sql: $sql}')"
+}
+
 license_sql=$(head -n 1 scripts/test-bend-tests/setup.sql)
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"$license_sql\"}")
 check_response_error "$response"
@@ -466,6 +473,100 @@ else
     echo "❌ Expected TASK_HISTORY to preserve millisecond schedule"
     echo "Name: $name"
     echo "Schedule: $schedule"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "CREATE ROLE task_history_role_a")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "CREATE ROLE task_history_role_b")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "CREATE USER task_history_user_a IDENTIFIED BY 'task_history_pwd' WITH DEFAULT_ROLE='task_history_role_a'")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "CREATE USER task_history_user_b IDENTIFIED BY 'task_history_pwd' WITH DEFAULT_ROLE='task_history_role_b'")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "GRANT ROLE task_history_role_a TO task_history_user_a")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "GRANT ROLE task_history_role_b TO task_history_user_b")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "GRANT ALL ON *.* TO ROLE task_history_role_a")
+check_response_error "$response"
+response=$(query_sql_with_auth "root:" "GRANT ALL ON *.* TO ROLE task_history_role_b")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "task_history_user_a:task_history_pwd" "CREATE TASK role_a_history_task AS SELECT 1")
+check_response_error "$response"
+response=$(query_sql_with_auth "task_history_user_a:task_history_pwd" "EXECUTE TASK role_a_history_task")
+check_response_error "$response"
+response=$(query_sql_with_auth "task_history_user_b:task_history_pwd" "CREATE TASK role_b_history_task AS SELECT 1")
+check_response_error "$response"
+response=$(query_sql_with_auth "task_history_user_b:task_history_pwd" "EXECUTE TASK role_b_history_task")
+check_response_error "$response"
+
+sleep 5
+
+response=$(query_sql_with_auth "task_history_user_a:task_history_pwd" "SELECT * FROM TASK_HISTORY(TASK_NAME => 'role_a_history_task', RESULT_LIMIT => 1)")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+name=$(echo "$response" | jq -r '.data[0][0]')
+owner=$(echo "$response" | jq -r '.data[0][2]')
+state=$(echo "$response" | jq -r '.data[0][6]')
+definition=$(echo "$response" | jq -r '.data[0][7]')
+scheduled_time=$(echo "$response" | jq -r '.data[0][15]')
+if [ "$name" = "role_a_history_task" ] &&
+    [ "$owner" = "task_history_role_a" ] &&
+    [ "$state" = "SUCCEEDED" ] &&
+    [ "$definition" = "SELECT 1" ] &&
+    [ -n "$scheduled_time" ]; then
+    echo "✅ TASK_HISTORY returns history for an available owner role"
+else
+    echo "❌ Expected TASK_HISTORY to return role_a_history_task for task_history_role_a"
+    echo "Name: $name"
+    echo "Owner: $owner"
+    echo "State: $state"
+    echo "Definition: $definition"
+    echo "Scheduled Time: $scheduled_time"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "task_history_user_b:task_history_pwd" "SELECT * FROM TASK_HISTORY(TASK_NAME => 'role_a_history_task', RESULT_LIMIT => 1)")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+if [ "$actual" = "[]" ]; then
+    echo "✅ TASK_HISTORY hides explicitly named tasks owned by unavailable roles"
+else
+    echo "❌ Expected TASK_HISTORY to hide role_a_history_task from task_history_role_b"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "task_history_user_b:task_history_pwd" "SELECT name, owner FROM TASK_HISTORY(RESULT_LIMIT => 100) WHERE name IN ('role_a_history_task', 'role_b_history_task') ORDER BY name")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+actual=$(echo "$response" | jq -c '.data')
+expected='[["role_b_history_task","task_history_role_b"]]'
+if [ "$actual" = "$expected" ]; then
+    echo "✅ TASK_HISTORY filters unqualified history by available owner roles"
+else
+    echo "❌ Expected TASK_HISTORY without TASK_NAME to only return available owner roles"
+    echo "Expected: $expected"
     echo "Actual  : $actual"
     exit 1
 fi

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -11,21 +11,24 @@ echo "Cleaning up previous runs"
 killall -9 databend-query || true
 killall -9 databend-meta || true
 rm -rf .databend
+mkdir -p ./.databend/
 
 echo "Starting Databend Query cluster with 2 nodes enable private task"
 
 for node in 1 2; do
-    CONFIG_FILE="./scripts/ci/deploy/config/databend-query-node-${node}.toml"
+    SOURCE_CONFIG_FILE="./scripts/ci/deploy/config/databend-query-node-${node}.toml"
+    CONFIG_FILE="./.databend/databend-query-node-${node}-private-task.toml"
 
-    echo "Appending history table config to node-${node}"
-    cat ./tests/task/private_task.toml >> "$CONFIG_FILE"
+    echo "Creating private task config for node-${node}"
+    cp "$SOURCE_CONFIG_FILE" "$CONFIG_FILE"
     sed -i '/^cloud_control_grpc_server_address/d' $CONFIG_FILE
+    printf '\n' >> "$CONFIG_FILE"
+    cat ./tests/task/private_task.toml >> "$CONFIG_FILE"
+    printf '\n' >> "$CONFIG_FILE"
 done
 
 # Start meta cluster (3 nodes - needed for HA)
 echo 'Start Meta service HA cluster(3 nodes)...'
-
-mkdir -p ./.databend/
 
 nohup ./target/${BUILD_PROFILE}/databend-meta -c scripts/ci/deploy/config/databend-meta-node-1.toml >./.databend/meta-1.out 2>&1 &
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9191
@@ -44,13 +47,13 @@ sleep 1
 
 # Start only 2 query nodes
 echo 'Start databend-query node-1'
-nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
+nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c ./.databend/databend-query-node-1-private-task.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
 
 echo "Waiting on node-1..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9091
 
 echo 'Start databend-query node-2'
-env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
+env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c ./.databend/databend-query-node-2-private-task.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
 
 echo "Waiting on node-2..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9092
@@ -71,10 +74,47 @@ check_response_error() {
     fi
 }
 
+license_sql=$(head -n 1 scripts/test-bend-tests/setup.sql)
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"$license_sql\"}")
+check_response_error "$response"
+echo "Set enterprise license for private task tests"
+
+expected_task_history_schema='["name","id","owner","comment","schedule","warehouse","state","definition","condition_text","run_id","query_id","exception_code","exception_text","attempt_number","completed_time","scheduled_time","root_task_id","session_parameters"]'
+
+check_task_history_schema() {
+    local response="$1"
+    local actual_schema=$(echo "$response" | jq -c '[.schema[].name]')
+
+    if [ "$actual_schema" != "$expected_task_history_schema" ]; then
+        echo "❌ TASK_HISTORY schema mismatch"
+        echo "Expected: $expected_task_history_schema"
+        echo "Actual  : $actual_schema"
+        exit 1
+    fi
+}
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT * FROM TASK_HISTORY(SCHEDULED_TIME_RANGE_START => '2026-01-01')\"}")
+state=$(echo "$response" | jq -r '.state')
+error_msg=$(echo "$response" | jq -r '.error.message // ""')
+if [ "$state" = "Failed" ] && [[ "$error_msg" == *"unsupported data type for SCHEDULED_TIME_RANGE_START"* ]]; then
+    echo "✅ TASK_HISTORY rejects non-date scheduled-time arguments"
+else
+    echo "❌ Expected TASK_HISTORY with string scheduled-time argument to fail"
+    echo "State: $state"
+    echo "Error: $error_msg"
+    exit 1
+fi
+
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TABLE t_script (c1 int)\"}")
 check_response_error "$response"
 create_script_table_query_id=$(echo $response | jq -r '.id')
 echo "Create Script Table Query ID: $create_script_table_query_id"
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE DATABASE task_session_db\"}")
+check_response_error "$response"
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TABLE task_session_db.session_target (c1 int)\"}")
+check_response_error "$response"
 
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK task_missing_wh WAREHOUSE = 'missing_wh' SCHEDULE = 5 SECOND AS insert into t1 values(0)\"}")
 state=$(echo "$response" | jq -r '.state')
@@ -110,6 +150,63 @@ if [ "$actual" = "$expected" ]; then
     echo "✅ Private task executes multiple statements"
 else
     echo "❌ Expected private task script block to execute all statements"
+    echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK db_session_task DATABASE = 'task_session_db' AS insert into session_target values(42)\"}")
+check_response_error "$response"
+create_db_session_task_query_id=$(echo $response | jq -r '.id')
+echo "Create DB Session Task Query ID: $create_db_session_task_query_id"
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"EXECUTE TASK db_session_task\"}")
+check_response_error "$response"
+execute_db_session_task_query_id=$(echo $response | jq -r '.id')
+echo "Execute DB Session Task Query ID: $execute_db_session_task_query_id"
+
+sleep 5
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT c1 FROM task_session_db.session_target ORDER BY c1\"}")
+check_response_error "$response"
+
+actual=$(echo "$response" | jq -c '.data')
+expected='[["42"]]'
+
+if [ "$actual" = "$expected" ]; then
+    echo "✅ Private task applies DATABASE session parameter"
+else
+    echo "❌ Expected private task DATABASE session parameter to resolve unqualified table"
+    echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TABLE t_ms (c1 int)\"}")
+check_response_error "$response"
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK ms_schedule_task SCHEDULE = 500 MILLISECOND AS insert into t_ms values(1)\"}")
+check_response_error "$response"
+create_ms_schedule_task_query_id=$(echo $response | jq -r '.id')
+echo "Create Millisecond Schedule Task Query ID: $create_ms_schedule_task_query_id"
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"EXECUTE TASK ms_schedule_task\"}")
+check_response_error "$response"
+execute_ms_schedule_task_query_id=$(echo $response | jq -r '.id')
+echo "Execute Millisecond Schedule Task Query ID: $execute_ms_schedule_task_query_id"
+
+sleep 5
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT c1 FROM t_ms ORDER BY c1\"}")
+check_response_error "$response"
+
+actual=$(echo "$response" | jq -c '.data')
+expected='[["1"]]'
+
+if [ "$actual" = "$expected" ]; then
+    echo "✅ Private task executes millisecond schedule task"
+else
+    echo "❌ Expected private task millisecond schedule task to execute"
     echo "Expected: $expected"
     echo "Actual  : $actual"
     exit 1
@@ -234,13 +331,13 @@ fi
 killall -9 databend-query || true
 
 echo 'Start databend-query node-1'
-nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-1.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
+nohup env RUST_BACKTRACE=1 target/${BUILD_PROFILE}/databend-query -c ./.databend/databend-query-node-1-private-task.toml --internal-enable-sandbox-tenant >./.databend/query-1.out 2>&1 &
 
 echo "Waiting on node-1..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9091
 
 echo 'Start databend-query node-2'
-env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c scripts/ci/deploy/config/databend-query-node-2.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
+env "RUST_BACKTRACE=1" nohup target/${BUILD_PROFILE}/databend-query -c ./.databend/databend-query-node-2-private-task.toml --internal-enable-sandbox-tenant >./.databend/query-2.out 2>&1 &
 
 echo "Waiting on node-2..."
 python3 scripts/ci/wait_tcp.py --timeout 30 --port 9092
@@ -295,6 +392,84 @@ fi
 actual=$(echo "$response" | jq -c '.data')
 echo "\n\nSELECT * FROM system.task_history: $actual"
 
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT * FROM TASK_HISTORY(TASK_NAME => 'db_session_task', RESULT_LIMIT => 1)\"}")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+name=$(echo "$response" | jq -r '.data[0][0]')
+state=$(echo "$response" | jq -r '.data[0][6]')
+definition=$(echo "$response" | jq -r '.data[0][7]')
+scheduled_time=$(echo "$response" | jq -r '.data[0][15]')
+session_parameters=$(echo "$response" | jq -c '.data[0][17]')
+if [ "$name" = "db_session_task" ] &&
+    [ "$state" = "SUCCEEDED" ] &&
+    [[ "$definition" == *"session_target"* ]] &&
+    [ -n "$scheduled_time" ] &&
+    [[ "$session_parameters" == *"task_session_db"* ]]; then
+    echo "✅ TASK_HISTORY table function matches cloud-style schema and content"
+else
+    echo "❌ Expected TASK_HISTORY table function to return cloud-style db_session_task history"
+    echo "Name: $name"
+    echo "State: $state"
+    echo "Definition: $definition"
+    echo "Scheduled Time: $scheduled_time"
+    echo "Session Parameters: $session_parameters"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT * FROM TASK_HISTORY(TASK_NAME => 'db_session_task', SCHEDULED_TIME_RANGE_START => to_date('2020-01-01'), SCHEDULED_TIME_RANGE_END => to_timestamp('2999-01-01'), RESULT_LIMIT => 1)\"}")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+name=$(echo "$response" | jq -r '.data[0][0]')
+state=$(echo "$response" | jq -r '.data[0][6]')
+scheduled_time=$(echo "$response" | jq -r '.data[0][15]')
+if [ "$name" = "db_session_task" ] &&
+    [ "$state" = "SUCCEEDED" ] &&
+    [ -n "$scheduled_time" ]; then
+    echo "✅ TASK_HISTORY accepts date/timestamp scheduled-time arguments"
+else
+    echo "❌ Expected TASK_HISTORY with date/timestamp scheduled-time arguments to return db_session_task history"
+    echo "Name: $name"
+    echo "State: $state"
+    echo "Scheduled Time: $scheduled_time"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT * FROM TASK_HISTORY(TASK_NAME => 'ms_schedule_task', RESULT_LIMIT => 1)\"}")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+name=$(echo "$response" | jq -r '.data[0][0]')
+schedule=$(echo "$response" | jq -r '.data[0][4]')
+if [ "$name" = "ms_schedule_task" ] &&
+    [ "$schedule" = "INTERVAL 0 SECOND 500 MILLISECOND" ]; then
+    echo "✅ TASK_HISTORY preserves millisecond schedule"
+else
+    echo "❌ Expected TASK_HISTORY to preserve millisecond schedule"
+    echo "Name: $name"
+    echo "Schedule: $schedule"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
 # Drop Task
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"DROP TASK my_task_1\"}")
 check_response_error "$response"
@@ -320,7 +495,7 @@ check_response_error "$response"
 create_table_query_id_1=$(echo $response | jq -r '.id')
 echo "Create Table Query ID: $create_table_query_id_1"
 
-response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK my_task_4 SCHEDULE = USING CRON '*/25 * * * * *' AS insert into t2 values(0)\"}")
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK my_task_4 SCHEDULE = USING CRON '*/25 * * * * *' 'UTC' AS insert into t2 values(0)\"}")
 check_response_error "$response"
 create_task_4_query_id=$(echo $response | jq -r '.id')
 echo "Create Task 4 Query ID: $create_task_4_query_id"
@@ -345,6 +520,28 @@ if [ "$actual" = "$expected" ]; then
 else
     echo "❌ Mismatch"
     echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"SELECT * FROM TASK_HISTORY(TASK_NAME => 'my_task_4', RESULT_LIMIT => 1)\"}")
+check_response_error "$response"
+state=$(echo "$response" | jq -r '.state')
+if [ "$state" != "Succeeded" ]; then
+    echo "❌ Failed"
+    exit 1
+fi
+check_task_history_schema "$response"
+actual=$(echo "$response" | jq -c '.data')
+name=$(echo "$response" | jq -r '.data[0][0]')
+schedule=$(echo "$response" | jq -r '.data[0][4]')
+if [ "$name" = "my_task_4" ] &&
+    [ "$schedule" = "CRON */25 * * * * * TIMEZONE UTC" ]; then
+    echo "✅ TASK_HISTORY preserves cron timezone schedule"
+else
+    echo "❌ Expected TASK_HISTORY to preserve cron timezone schedule"
+    echo "Name: $name"
+    echo "Schedule: $schedule"
     echo "Actual  : $actual"
     exit 1
 fi


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Support private `TASK_HISTORY(...)` when private task is enabled, returning the cloud-style task history schema while keeping `system.task_history` on the existing private schema.
- Align private task history behavior with cloud task semantics for argument validation, default/result limits, role visibility, schedule formatting, and task session parameters.
- Prevent overlapping private task runs so the next scheduled or triggered run waits until the previous run for the same task finishes.

## Changes

- Register a private `TASK_HISTORY` table function implementation when `[task].on = true`.
- Map private task run records from `system_task.task_run` to cloud-style columns such as `name`, `state`, `definition`, `scheduled_time`, and `session_parameters`.
- Reject invalid scheduled-time arguments instead of silently dropping those filters.
- Apply the cloud default `TASK_HISTORY` result limit when `RESULT_LIMIT` is omitted, while clamping explicit limits to the supported range.
- Filter private `TASK_HISTORY` results by the caller's available owner roles without requiring direct `SELECT` privileges on the internal `system_task.task_run` table.
- Preserve private task schedule details in history output, including millisecond intervals and cron time zones.
- Execute private task SQL and WHEN conditions with the task context, including configured database/session settings.
- Skip scheduling or triggering a private task when the same task already has an unfinished executing run.
- Leave private DAG `ROOT_TASK_ID` history support as a visible TODO until private task runs persist the correct root task id.
- Update `tests/task/test-private-task.sh` to use temporary private-task configs, set the enterprise license, and cover multi-statement execution, session parameters, `TASK_HISTORY(...)` schema/content, role filtering, result limits, schedule formatting, and non-overlapping scheduled runs.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo fmt --all`
- `bash -n tests/task/test-private-task.sh`
- `git diff --check`
- `cargo check -p databend-common-management -p databend-query`
- `cargo build --bin databend-query --bin databend-meta`
- `BUILD_PROFILE=debug bash tests/task/test-private-task.sh`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19943)
<!-- Reviewable:end -->
