### PR TITLE
fix(query): use to_hex instead of hex in stream change tracking row ID generation

### DIFF
--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -132,7 +132,7 @@ impl FuseTable {
                             'INSERT' as change$action, \
                             false as change$is_update, \
                             if(is_not_null(_origin_block_id), \
-                                concat(to_uuid(_origin_block_id), lpad(hex(_origin_block_row_num), 6, '0')), \
+                                concat(to_uuid(_origin_block_id), lpad(to_hex(_origin_block_row_num), 6, '0')), \
                                 {append_alias}._base_row_id \
                             ) as change$row_id \
                     from {table_desc} as {append_alias} \
@@ -181,7 +181,7 @@ impl FuseTable {
                             select {a_cols}, \
                                     'INSERT' as a_change$action, \
                                     if(is_not_null(_origin_block_id), \
-                                        concat(to_uuid(_origin_block_id), lpad(hex(_origin_block_row_num), 6, '0')), \
+                                        concat(to_uuid(_origin_block_id), lpad(to_hex(_origin_block_row_num), 6, '0')), \
                                         {a_table_alias}._base_row_id \
                                     ) as a_change$row_id \
                             from {table_desc} as {a_table_alias} \
@@ -190,7 +190,7 @@ impl FuseTable {
                             select {d_cols_alias}, \
                                     'DELETE' as d_change$action, \
                                     if(is_not_null(_origin_block_id), \
-                                        concat(to_uuid(_origin_block_id), lpad(hex(_origin_block_row_num), 6, '0')), \
+                                        concat(to_uuid(_origin_block_id), lpad(to_hex(_origin_block_row_num), 6, '0')), \
                                         {d_table_alias}._base_row_id \
                                     ) as d_change$row_id \
                             from {table_desc} as {d_table_alias} \

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0014_stream_issue_19945.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0014_stream_issue_19945.test
@@ -1,0 +1,79 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Test that change$row_id is always lowercase hex after compaction.
+## Regression test for: hex() producing uppercase after PR #19892 causes
+## standard stream FULL OUTER JOIN mismatch on change$row_id.
+
+statement ok
+DROP DATABASE IF EXISTS test_stream_row_id_case
+
+statement ok
+CREATE DATABASE test_stream_row_id_case
+
+statement ok
+USE test_stream_row_id_case
+
+statement ok
+CREATE TABLE t(a int)
+
+statement ok
+ALTER TABLE t SET OPTIONS(change_tracking = true)
+
+## Insert rows in separate batches to ensure compaction merges blocks.
+## We need row numbers >= 10 (0xa) so that hex output contains a-f digits.
+statement ok
+INSERT INTO t VALUES(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16)
+
+statement ok
+CREATE STREAM s_standard ON TABLE t APPEND_ONLY = false
+
+statement ok
+CREATE STREAM s_append ON TABLE t APPEND_ONLY = true
+
+## Insert another batch so the stream has data to track.
+statement ok
+INSERT INTO t VALUES(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32)
+
+## Compact to trigger _origin_block_id path in change$row_id generation.
+statement ok
+OPTIMIZE TABLE t COMPACT
+
+## Do an update so standard stream has both INSERT and DELETE sides.
+statement ok
+UPDATE t SET a = a + 100 WHERE a >= 10 AND a <= 16
+
+## Verify: all change$row_id values in standard stream must be lowercase.
+## If hex() produces uppercase, rows with row_num containing a-f will have uppercase chars.
+query I
+SELECT count(*) FROM s_standard WHERE change$row_id <> lower(change$row_id)
+----
+0
+
+## Verify: standard stream correctness - the update should produce matched INSERT/DELETE pairs.
+## Rows 10-16 should appear as DELETE(old) + INSERT(new) with is_update=true.
+query I
+SELECT count(*) FROM s_standard WHERE change$is_update = true
+----
+14
+
+## Verify: append_only stream row_id is also lowercase.
+query I
+SELECT count(*) FROM s_append WHERE change$row_id <> lower(change$row_id)
+----
+0
+
+## Cleanup
+statement ok
+DROP DATABASE test_stream_row_id_case


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

PR #19892 separated `hex()` from `to_hex()` for integer inputs. The new `hex(integer)` produces **uppercase** hex (e.g., FF), while [`_base_row_id`](https://github.com/databendlabs/databend/blob/main/src/query/catalog/src/plan/internal_column.rs#L253-L272) is generated with **lowercase** hex `(format!("{:06x}", i))`. In changes.rs, compacted rows reconstruct [`change$row_id`](https://github.com/databendlabs/databend/blob/main/src/query/storages/fuse/src/operations/changes.rs#L135) via `hex(_origin_block_row_num)`, which now yields uppercase. The standard stream uses a case-sensitive FULL OUTER JOIN on `change$row_id` to correlate inserts and deletes — the case mismatch causes rows containing a-f in the row number to fail matching, creating spurious DELETE+INSERT pairs and corrupting sink tables during MERGE consumption.

Fix: replace `hex(_origin_block_row_num)` with `to_hex(_origin_block_row_num)` in all 3 occurrences in changes.rs. `to_hex` retains lowercase output, consistent with `_base_row_id`.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19945)
<!-- Reviewable:end -->
