### PR TITLE
refactor(functions): Optimize `jq` function performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9919,9 +9919,9 @@ dependencies = [
 
 [[package]]
 name = "hifijson"
-version = "0.2.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9958ab3ce3170c061a27679916bd9b969eceeb5e8b120438e6751d0987655c42"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hive_metastore"
@@ -10903,9 +10903,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-core"
-version = "2.2.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -10914,31 +10914,37 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "1.1.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
 dependencies = [
+ "bstr",
+ "bytes",
  "foldhash 0.1.5",
  "hifijson",
  "indexmap 2.14.0",
  "jaq-core",
  "jaq-std",
- "serde_json",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
 ]
 
 [[package]]
 name = "jaq-std"
-version = "2.1.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
- "chrono",
+ "bstr",
  "jaq-core",
+ "jiff",
  "libm",
  "log",
- "regex-lite",
+ "regex-bites",
  "urlencoding",
 ]
 
@@ -11088,13 +11094,13 @@ dependencies = [
 [[package]]
 name = "jsonb"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb98fb29636087c40ad0d1274d9a30c0c1e83e03ae93f6e7e89247b37fcc6953"
+source = "git+https://github.com/databendlabs/jsonb.git?rev=a16344417d1fec6df4a62d8e77679211e909f86e#a16344417d1fec6df4a62d8e77679211e909f86e"
 dependencies = [
  "byteorder",
  "ethnum",
  "fast-float2",
  "itoa",
+ "jaq-json",
  "jiff",
  "nom 8.0.0",
  "num-traits",
@@ -15092,6 +15098,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-bites"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,11 +318,11 @@ aws-smithy-types = "1.2.13"
 indexmap = "2.0.0"
 indicatif = "0.17.5"
 itertools = "0.13.0"
-jaq-core = "2.2.1"
+jaq-core = "3.1.0"
 jaq-interpret = "1.5.0"
-jaq-json = { version = "1.1.3", features = ["serde_json"] }
+jaq-json = "2.0.1"
 jaq-parse = "1.0.3"
-jaq-std = "2.1.2"
+jaq-std = "3.0.1"
 jiff = { version = "0.2.16", features = ["serde", "tzdb-bundle-always"] }
 jsonb = "0.5.6"
 jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
@@ -635,6 +635,7 @@ databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag
 databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.11.0" }
 databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260512.4.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
+jsonb = { git = "https://github.com/databendlabs/jsonb.git", rev = "a16344417d1fec6df4a62d8e77679211e909f86e" }
 lance-arrow = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-core = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-encoding = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }

--- a/src/query/functions/src/srfs/variant.rs
+++ b/src/query/functions/src/srfs/variant.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use databend_common_exception::ErrorCode;
-use databend_common_exception::Result;
 use databend_common_expression::Column;
 use databend_common_expression::FromData;
 use databend_common_expression::Function;
@@ -44,15 +41,16 @@ use databend_common_expression::types::string::StringColumnBuilder;
 use jaq_core;
 use jaq_core::Compiler;
 use jaq_core::Ctx;
-use jaq_core::RcIter;
+use jaq_core::Vars;
+use jaq_core::data::JustLut;
 use jaq_core::load::Arena;
 use jaq_core::load::File;
 use jaq_core::load::Loader;
+use jaq_core::unwrap_valr;
 use jaq_json::Val;
 use jaq_std;
 use jsonb::OwnedJsonb;
 use jsonb::RawJsonb;
-use jsonb::from_raw_jsonb;
 use jsonb::jsonpath::parse_json_path;
 
 pub fn register(registry: &mut FunctionRegistry) {
@@ -468,8 +466,13 @@ pub fn register(registry: &mut FunctionRegistry) {
                             return vec![];
                         }
                     };
+
                     let arena = Arena::default();
-                    let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
+                    let loader = Loader::new(
+                        jaq_core::defs()
+                            .chain(jaq_std::defs())
+                            .chain(jaq_json::defs()),
+                    );
                     let Ok(modules) = loader.load(&arena, File {
                         path: (),
                         code: jq_filter,
@@ -479,18 +482,20 @@ pub fn register(registry: &mut FunctionRegistry) {
                     };
 
                     let Ok(filter) = Compiler::default()
-                        .with_funs(jaq_std::funs().chain(jaq_json::funs()))
+                        .with_funs(
+                            jaq_core::funs::<JustLut<jaq_json::Val>>()
+                                .chain(jaq_std::funs::<JustLut<jaq_json::Val>>())
+                                .chain(jaq_json::funs::<JustLut<jaq_json::Val>>()),
+                        )
                         .compile(modules)
                     else {
                         ctx.set_error(0, "Invalid jq filter compile error");
                         return vec![];
                     };
 
-                    let jaq_args = vec![];
                     // You can pass additional scalar inputs as args to the jq filter.
                     // This could be a useful enhancement, but leaving it out for now.
-                    let inputs = RcIter::new(core::iter::empty());
-                    let jaq_ctx = Ctx::new(jaq_args, &inputs);
+                    let jaq_ctx = Ctx::<JustLut<jaq_json::Val>>::new(&filter.lut, Vars::new([]));
 
                     let json_arg = args[1].clone().to_owned();
                     (0..ctx.num_rows)
@@ -508,25 +513,24 @@ pub fn register(registry: &mut FunctionRegistry) {
                                 }
                                 Some(ScalarRef::Variant(v)) => {
                                     let raw_jsonb = RawJsonb::new(v);
-                                    let s = from_raw_jsonb::<serde_json::Value>(&raw_jsonb);
-                                    match s {
+                                    match Val::try_from(raw_jsonb) {
                                         Err(e) => {
                                             ctx.set_error(row, e.to_string());
                                             return null_result;
                                         }
-                                        Ok(s) => {
-                                            let jaq_val = Val::from(s);
-                                            let jaq_out = filter.run((jaq_ctx.clone(), jaq_val));
+                                        Ok(jaq_val) => {
+                                            let jaq_out = filter.id.run((jaq_ctx.clone(), jaq_val));
 
                                             for res in jaq_out {
-                                                match res {
+                                                match unwrap_valr(res) {
                                                     Err(err) => {
                                                         ctx.set_error(row, err.to_string());
                                                         return null_result;
                                                     }
-                                                    Ok(res) => match jaq_val_to_jsonb(&res) {
+                                                    Ok(res) => match OwnedJsonb::try_from(&res) {
                                                         Ok(res_jsonb) => {
-                                                            res_builder.put_slice(&res_jsonb);
+                                                            let data = res_jsonb.to_vec();
+                                                            res_builder.put_slice(&data);
                                                             res_builder.commit_row();
                                                         }
                                                         Err(err) => {
@@ -556,55 +560,6 @@ pub fn register(registry: &mut FunctionRegistry) {
         }))
     }));
     registry.register_function_factory("jq", jq);
-}
-
-// Convert a Jaq val to a jsonb value.
-fn jaq_val_to_jsonb(val: &Val) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    let jsonb_value = match val {
-        Val::Null => jsonb::Value::Null,
-        Val::Bool(b) => jsonb::Value::Bool(*b),
-        Val::Num(n) => {
-            if let Ok(f) = n.parse::<f64>() {
-                f.into()
-            } else {
-                return Err(ErrorCode::BadBytes(format!(
-                    "parse string `{}` to f64 failed",
-                    n
-                )));
-            }
-        }
-        Val::Float(f) => (*f).into(),
-        Val::Int(i) => (*i).into(),
-        Val::Str(s) => jsonb::Value::String((**s).clone().into()),
-        Val::Arr(arr) => {
-            let items = arr
-                .iter()
-                .map(jaq_val_to_jsonb)
-                .collect::<Result<Vec<_>>>()?;
-            let owned_jsonb = OwnedJsonb::build_array(items.iter().map(|v| RawJsonb::new(v)))
-                .map_err(|e| {
-                    ErrorCode::Internal(format!("failed to build array error: {:?}", e))
-                })?;
-            return Ok(owned_jsonb.to_vec());
-        }
-        Val::Obj(obj) => {
-            let mut kvs = BTreeMap::new();
-            for (k, v) in obj.iter() {
-                let key = (**k).clone();
-                let val = jaq_val_to_jsonb(v)?;
-                kvs.insert(key, val);
-            }
-            let owned_jsonb =
-                OwnedJsonb::build_object(kvs.iter().map(|(k, v)| (k, RawJsonb::new(&v[..]))))
-                    .map_err(|e| {
-                        ErrorCode::Internal(format!("failed to build object error: {:?}", e))
-                    })?;
-            return Ok(owned_jsonb.to_vec());
-        }
-    };
-    jsonb_value.write_to_vec(&mut buf);
-    Ok(buf)
 }
 
 pub(crate) fn unnest_variant_array(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces a significant performance optimization for the `jq` function when working with `jsonb` data. Previously, invoking the `jq` function required an additional conversion step where `jsonb` data had to be transformed into `serde_json::Value`. After the execution of the jq function, another conversion was necessary to convert the result back into `jsonb`. This overhead not only added complexity but also resulted in suboptimal performance.

### Changes
- Eliminated the need for converting jsonb to `serde_json::Value` executing the `jq` function.
- Enabled direct execution of the `jq` function on `jsonb` data, thus avoiding the extra conversion steps.

fixes: #[Link the issue here]


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19946)
<!-- Reviewable:end -->
