### PR TITLE
ci(release): add custom release type and restrict sha to custom only

### DIFF
--- a/.github/scripts/bump_version.js
+++ b/.github/scripts/bump_version.js
@@ -244,16 +244,24 @@ module.exports = async ({ github, context, core }) => {
       if (match) {
         const baseVersion = match[1];
         let found = false;
-        const releases = await github.rest.repos.listReleases({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-        });
-        for (const release of releases.data) {
-          if (release.tag_name === baseVersion || release.tag_name === `${baseVersion}-nightly`) {
-            core.setOutput("previous", release.tag_name);
-            core.info(`Custom release with previous release: ${release.tag_name}`);
-            found = true;
+        let page = 1;
+        while (!found) {
+          const releases = await github.rest.repos.listReleases({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            page,
+          });
+          if (releases.data.length === 0) {
             break;
+          }
+          page++;
+          for (const release of releases.data) {
+            if (release.tag_name === baseVersion || release.tag_name === `${baseVersion}-nightly`) {
+              core.setOutput("previous", release.tag_name);
+              core.info(`Custom release with previous release: ${release.tag_name}`);
+              found = true;
+              break;
+            }
           }
         }
         if (!found) {

--- a/.github/scripts/bump_version.js
+++ b/.github/scripts/bump_version.js
@@ -119,17 +119,16 @@ module.exports = async ({ github, context, core }) => {
     }
   }
 
-  // Determine the SHA to use: custom SHA if provided, otherwise context.sha
-  const targetSha = SHA || context.sha;
-
+  // Determine the SHA to use
   switch (TYPE) {
     case "":
     case "nightly": {
-      core.setOutput("sha", targetSha);
-      core.info(`Nightly release triggered by (${targetSha})${SHA ? " [custom SHA]" : ""}`);
       if (SHA) {
-        core.info(`Using custom SHA: ${SHA}`);
+        core.setFailed("Custom SHA is not supported for nightly release, please use 'custom' type instead");
+        return;
       }
+      core.setOutput("sha", context.sha);
+      core.info(`Nightly release triggered by (${context.sha})`);
 
       const previous = await getPreviousNightlyRelease(github, context);
       if (!previous) {
@@ -155,15 +154,16 @@ module.exports = async ({ github, context, core }) => {
     }
 
     case "stable": {
-      core.setOutput("sha", targetSha);
+      if (SHA) {
+        core.setFailed("Custom SHA is not supported for stable release, please use 'custom' type instead");
+        return;
+      }
       if (!TAG) {
         core.setFailed("Stable release must be triggered with a nightly tag");
         return;
       }
-      core.info(`Stable release triggered by ${TAG} (${targetSha})${SHA ? " [custom SHA]" : ""}`);
-      if (SHA) {
-        core.info(`Using custom SHA: ${SHA}`);
-      }
+      core.setOutput("sha", context.sha);
+      core.info(`Stable release triggered by ${TAG} (${context.sha})`);
       const nextTag = getNextStableRelease();
       if (!nextTag) {
         core.setFailed(`No stable release from ${TAG}`);
@@ -183,6 +183,10 @@ module.exports = async ({ github, context, core }) => {
     }
 
     case "patch": {
+      if (SHA) {
+        core.setFailed("Custom SHA is not supported for patch release, please use 'custom' type instead");
+        return;
+      }
       if (!TAG) {
         core.setFailed("Patch release must be triggered with a stable tag");
         return;
@@ -194,24 +198,14 @@ module.exports = async ({ github, context, core }) => {
         return;
       }
 
-      let patchSha;
-      if (SHA) {
-        // Use custom SHA if provided
-        patchSha = SHA;
-        core.info(`Using custom SHA: ${SHA}`);
-      } else {
-        // Otherwise use the backport branch SHA
-        const branch = await github.rest.repos.getBranch({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          branch: `backport/${TAG}`,
-        });
-        patchSha = branch.data.commit.sha;
-      }
+      const branch = await github.rest.repos.getBranch({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        branch: `backport/${TAG}`,
+      });
+      const patchSha = branch.data.commit.sha;
       core.setOutput("sha", patchSha);
-      core.info(
-        `Patch release triggered by ${TAG} (${patchSha})${SHA ? " [custom SHA]" : ""}`
-      );
+      core.info(`Patch release triggered by ${TAG} (${patchSha})`);
 
       const previous = await getPreviousPatchRelease(github, context);
       if (!previous) {
@@ -228,6 +222,44 @@ module.exports = async ({ github, context, core }) => {
       }
       core.setOutput("tag", nextTag);
       core.info(`Patch release ${nextTag} from ${previous}`);
+      return;
+    }
+
+    case "custom": {
+      if (!TAG) {
+        core.setFailed("Custom release must be triggered with a tag");
+        return;
+      }
+      if (!SHA) {
+        core.setFailed("Custom release must be triggered with a SHA");
+        return;
+      }
+      core.setOutput("tag", TAG);
+      core.setOutput("sha", SHA);
+      core.info(`Custom release ${TAG} (${SHA})`);
+
+      // Best-effort: try to find a previous release for release notes
+      const RE_TAG_CUSTOM = /^(v\d+\.\d+\.\d+)-.+$/;
+      const match = RE_TAG_CUSTOM.exec(TAG);
+      if (match) {
+        const baseVersion = match[1];
+        let found = false;
+        const releases = await github.rest.repos.listReleases({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+        });
+        for (const release of releases.data) {
+          if (release.tag_name === baseVersion || release.tag_name === `${baseVersion}-nightly`) {
+            core.setOutput("previous", release.tag_name);
+            core.info(`Custom release with previous release: ${release.tag_name}`);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          core.info(`No previous release found for base version ${baseVersion}, skipping release notes`);
+        }
+      }
       return;
     }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,10 +423,13 @@ jobs:
             let tags = [];
             for (const repo of repos) {
               tags.push(`${repo}:${VERSION}`);
-              if (TYPE === 'stable') {
-                tags.push(`${repo}:latest`);
-              } else if (TYPE === 'nightly') {
-                tags.push(`${repo}:nightly`);
+              switch (TYPE) {
+                case 'stable':
+                  tags.push(`${repo}:latest`);
+                  break;
+                case 'nightly':
+                  tags.push(`${repo}:nightly`);
+                  break;
               }
             }
             core.setOutput('tags', tags.join(','));
@@ -510,10 +513,13 @@ jobs:
             let tags = [];
             for (const repo of repos) {
               tags.push(`${repo}:${VERSION}`);
-              if (TYPE === 'stable') {
-                tags.push(`${repo}:latest`);
-              } else if (TYPE === 'nightly') {
-                tags.push(`${repo}:nightly`);
+              switch (TYPE) {
+                case 'stable':
+                  tags.push(`${repo}:latest`);
+                  break;
+                case 'nightly':
+                  tags.push(`${repo}:nightly`);
+                  break;
               }
             }
             core.setOutput('tags', tags.join(','));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
               tags.push(`${repo}:${VERSION}`);
               if (TYPE === 'stable') {
                 tags.push(`${repo}:latest`);
-              } else {
+              } else if (TYPE === 'nightly') {
                 tags.push(`${repo}:nightly`);
               }
             }
@@ -512,7 +512,7 @@ jobs:
               tags.push(`${repo}:${VERSION}`);
               if (TYPE === 'stable') {
                 tags.push(`${repo}:latest`);
-              } else {
+              } else if (TYPE === 'nightly') {
                 tags.push(`${repo}:nightly`);
               }
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
       tag:
         description: |
           The tags to be released.
-          Nightly release dose not require a tag.
+          Nightly release does not require a tag.
           Stable release requires a nightly version (v1.0.0-nightly).
           Patch release requires a stable version (v1.0.0).
+          Custom release requires a custom tag (v1.0.0-patch.1).
         required: false
         type: string
       sha:
         description: |
-          The commit SHA to release from.
-          If not specified, uses the current HEAD of the branch.
+          The commit SHA to release from (only for custom type).
           Example: cc3d1e657cc8731c976d90764589eb9c748dbca9
         required: false
         type: string
@@ -29,6 +29,7 @@ on:
           - nightly
           - stable
           - patch
+          - custom
 
 permissions:
   id-token: write
@@ -73,6 +74,12 @@ jobs:
             const tag = '${{ steps.bump.outputs.tag }}';
             const previous = '${{ steps.bump.outputs.previous }}';
             const sha = '${{ steps.bump.outputs.sha }}';
+            const fs = require('fs');
+            if (!previous) {
+              core.info('No previous release found, skipping release notes generation');
+              fs.writeFileSync('/tmp/release_notes.md', '');
+              return;
+            }
             const { data } = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -86,7 +93,6 @@ jobs:
               core.warning(`Release notes too long (${body.length} chars), truncating to ${MAX_LEN}`);
               body = body.substring(0, MAX_LEN) + '\n\n> **Note**: changelog truncated due to GitHub size limits. See commit history for full details.';
             }
-            const fs = require('fs');
             fs.writeFileSync('/tmp/release_notes.md', body);
       - name: Create release
         env:
@@ -102,6 +108,9 @@ jobs:
               gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --title ${{ steps.bump.outputs.tag }} --latest --draft
               ;;
             patch)
+              gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --title ${{ steps.bump.outputs.tag }} --prerelease --draft
+              ;;
+            custom)
               gh release create ${{ steps.bump.outputs.tag }} --target ${{ steps.bump.outputs.sha }} --notes-file /tmp/release_notes.md --title ${{ steps.bump.outputs.tag }} --prerelease --draft
               ;;
             *)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add a new `custom` release type to `workflow_dispatch` for releasing from arbitrary branches/commits, and restrict the `sha` parameter to `custom` type only.

Previously, mixing `sha` with nightly/stable/patch was confusing and error-prone. For example, trying to release a patch from a custom branch (like `v1-2-768-patch-1`) without a corresponding stable release would fail with misleading errors. The `custom` type makes this use case explicit and straightforward.

Changes:
- nightly/stable/patch now reject `sha` with a clear error pointing to `custom` type
- New `custom` type requires both `tag` and `sha`, does best-effort lookup of a previous release (stable or nightly) based on the tag's version prefix for release notes
- Release notes generation gracefully handles missing previous release

Usage: type=`custom`, tag=`v1.2.768-patch.1`, sha=`<commit>`

## Tests

- [x] No Test - CI workflow changes, verified by manual trigger

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19950)
<!-- Reviewable:end -->
