### PR TITLE
feat(query): add local admin handlers for tenant-prefixed routes

### DIFF
--- a/src/query/service/src/servers/admin/admin_service.rs
+++ b/src/query/service/src/servers/admin/admin_service.rs
@@ -72,6 +72,43 @@ impl AdminService {
                 get(super::v1::tenant_table_stats::get_tables_stats_handler),
             )
             .at(
+                "/v1/databases/:database/tables/:table/clustering_information",
+                get(super::v1::clustering_information::clustering_information_local_handler),
+            )
+            .at(
+                "/v1/databases/:database/tables/:table/stats",
+                get(super::v1::table_statistics::get_table_stats_local_handler),
+            )
+            .at(
+                "/v1/stream_status",
+                get(super::v1::stream_status::stream_status_local_handler),
+            )
+            .at(
+                "/v1/settings",
+                get(super::v1::settings::list_settings_local),
+            )
+            .at(
+                "/v1/settings/:key",
+                post(super::v1::settings::set_settings_local)
+                    .delete(super::v1::settings::unset_settings_local),
+            )
+            .at(
+                "/v1/user_functions",
+                get(super::v1::user_functions::user_functions_local),
+            )
+            .at(
+                "/v1/procedures",
+                get(super::v1::procedures::list_procedures_local),
+            )
+            .at(
+                "/v1/procedures/:procedure_id",
+                get(super::v1::procedures::get_procedure_by_id_local),
+            )
+            .at(
+                "/v1/procedures/:name",
+                get(super::v1::procedures::get_procedure_by_name_local),
+            )
+            .at(
                 "/v1/cluster/list",
                 get(super::v1::cluster::cluster_list_handler),
             )

--- a/src/query/service/src/servers/admin/v1/clustering_information.rs
+++ b/src/query/service/src/servers/admin/v1/clustering_information.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::session_type::SessionType;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::tenant::Tenant;
@@ -46,6 +47,19 @@ pub async fn clustering_information_handler(
 ) -> poem::Result<impl IntoResponse> {
     let tenant = Tenant::new_or_err(tenant, func_name!()).map_err(poem::error::BadRequest)?;
     let resp = load_clustering_information(&tenant, &database, &table, params)
+        .await
+        .map_err(clustering_information_error)?;
+    Ok(Json(resp))
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn clustering_information_local_handler(
+    Path((database, table)): Path<(String, String)>,
+    Query(params): Query<ClusteringInformationQuery>,
+) -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    let resp = load_clustering_information(tenant, &database, &table, params)
         .await
         .map_err(clustering_information_error)?;
     Ok(Json(resp))

--- a/src/query/service/src/servers/admin/v1/procedures.rs
+++ b/src/query/service/src/servers/admin/v1/procedures.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_config::GlobalConfig;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_storages_system::ProceduresTable;
 use http::StatusCode;
@@ -58,6 +59,59 @@ pub async fn get_procedure_by_name(
 ) -> poem::Result<impl IntoResponse> {
     let args = params.get("args").map(|s| s.as_str()).unwrap_or("");
     match ProceduresTable::get_procedure(&Tenant::new_literal(&tenant), &name, args).await {
+        Ok(Some(procedure)) => Ok(Json(procedure)),
+        Ok(None) => Err(poem::Error::from_string(
+            format!("procedure not found: {}({})", name, args),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to get procedure. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn list_procedures_local() -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    match ProceduresTable::get_procedures(tenant).await {
+        Ok(procedures) => Ok(Json(procedures)),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to list procedures. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn get_procedure_by_id_local(
+    Path(procedure_id): Path<u64>,
+) -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    match ProceduresTable::get_procedure_by_id(tenant, procedure_id).await {
+        Ok(Some(procedure)) => Ok(Json(procedure)),
+        Ok(None) => Err(poem::Error::from_string(
+            format!("procedure not found with id: {}", procedure_id),
+            StatusCode::NOT_FOUND,
+        )),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to get procedure. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn get_procedure_by_name_local(
+    Path(name): Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    let args = params.get("args").map(|s| s.as_str()).unwrap_or("");
+    match ProceduresTable::get_procedure(tenant, &name, args).await {
         Ok(Some(procedure)) => Ok(Json(procedure)),
         Ok(None) => Err(poem::Error::from_string(
             format!("procedure not found: {}({})", name, args),

--- a/src/query/service/src/servers/admin/v1/settings.rs
+++ b/src/query/service/src/servers/admin/v1/settings.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::tenant::Tenant;
@@ -136,6 +137,47 @@ pub async fn unset_settings(
 ) -> poem::Result<impl IntoResponse> {
     Ok(Json(
         unset_setting_impl(&tenant, &key)
+            .await
+            .map_err(poem::error::InternalServerError)?,
+    ))
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn list_settings_local() -> poem::Result<impl IntoResponse> {
+    let config = GlobalConfig::instance();
+    let tenant = config.query.tenant_id.tenant_name();
+    Ok(Json(
+        list_settings_impl(tenant)
+            .await
+            .map_err(poem::error::InternalServerError)?,
+    ))
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn set_settings_local(
+    Path(key): Path<String>,
+    value: Json<String>,
+) -> poem::Result<impl IntoResponse> {
+    let config = GlobalConfig::instance();
+    let tenant = config.query.tenant_id.tenant_name();
+    Ok(Json(
+        set_setting_impl(tenant, &key, value.0)
+            .await
+            .map_err(poem::error::InternalServerError)?,
+    ))
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn unset_settings_local(
+    Path(key): Path<String>,
+) -> poem::Result<impl IntoResponse> {
+    let config = GlobalConfig::instance();
+    let tenant = config.query.tenant_id.tenant_name();
+    Ok(Json(
+        unset_setting_impl(tenant, &key)
             .await
             .map_err(poem::error::InternalServerError)?,
     ))

--- a/src/query/service/src/servers/admin/v1/settings.rs
+++ b/src/query/service/src/servers/admin/v1/settings.rs
@@ -171,9 +171,7 @@ pub async fn set_settings_local(
 
 #[poem::handler]
 #[async_backtrace::framed]
-pub async fn unset_settings_local(
-    Path(key): Path<String>,
-) -> poem::Result<impl IntoResponse> {
+pub async fn unset_settings_local(Path(key): Path<String>) -> poem::Result<impl IntoResponse> {
     let config = GlobalConfig::instance();
     let tenant = config.query.tenant_id.tenant_name();
     Ok(Json(

--- a/src/query/service/src/servers/admin/v1/stream_status.rs
+++ b/src/query/service/src/servers/admin/v1/stream_status.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_catalog::catalog::CatalogManager;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::UnknownTableId;
@@ -81,6 +82,23 @@ pub async fn stream_status_handler(
     let tenant = Tenant::new_or_err(tenant, func_name!()).map_err(poem::error::BadRequest)?;
 
     let resp = check_stream_status(&tenant, params)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+    Ok(Json(resp))
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn stream_status_local_handler(
+    params: Query<StreamStatusQuery>,
+) -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    debug!(
+        "check_stream_status(local): tenant: {:?}, params: {:?}",
+        tenant, params
+    );
+
+    let resp = check_stream_status(tenant, params)
         .await
         .map_err(poem::error::InternalServerError)?;
     Ok(Json(resp))

--- a/src/query/service/src/servers/admin/v1/table_statistics.rs
+++ b/src/query/service/src/servers/admin/v1/table_statistics.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use databend_common_catalog::catalog::CatalogManager;
 use databend_common_catalog::session_type::SessionType;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_storages_system::StatisticsTable;
@@ -33,6 +34,19 @@ pub async fn get_table_stats_handler(
     Path((tenant, database, table)): Path<(String, String, String)>,
 ) -> poem::Result<impl IntoResponse> {
     match dump_columns(&tenant, &database, &table).await {
+        Ok(columns) => Ok(Json(columns)),
+        Err(error) => Err(poem::error::InternalServerError(error)),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn get_table_stats_local_handler(
+    Path((database, table)): Path<(String, String)>,
+) -> poem::Result<impl IntoResponse> {
+    let config = GlobalConfig::instance();
+    let tenant = config.query.tenant_id.tenant_name();
+    match dump_columns(tenant, &database, &table).await {
         Ok(columns) => Ok(Json(columns)),
         Err(error) => Err(poem::error::InternalServerError(error)),
     }

--- a/src/query/service/src/servers/admin/v1/user_functions.rs
+++ b/src/query/service/src/servers/admin/v1/user_functions.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_config::GlobalConfig;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_storages_system::UserFunctionsTable;
 use http::StatusCode;
@@ -23,6 +24,19 @@ use poem::web::Path;
 #[async_backtrace::framed]
 pub async fn user_functions(Path(tenant): Path<String>) -> poem::Result<impl IntoResponse> {
     match UserFunctionsTable::get_udfs(&Tenant::new_literal(&tenant)).await {
+        Ok(v) => Ok(Json(v)),
+        Err(cause) => Err(poem::Error::from_string(
+            format!("failed to user functions. cause: {:?}", cause),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+#[poem::handler]
+#[async_backtrace::framed]
+pub async fn user_functions_local() -> poem::Result<impl IntoResponse> {
+    let tenant = &GlobalConfig::instance().query.tenant_id;
+    match UserFunctionsTable::get_udfs(tenant).await {
         Ok(v) => Ok(Json(v)),
         Err(cause) => Err(poem::Error::from_string(
             format!("failed to user functions. cause: {:?}", cause),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The `/v1/tenants/:tenant/*` admin API routes are only registered when `management_mode = true`, causing 404s on nodes running with `management_mode = false`.

This PR adds local versions of all tenant-prefixed handlers that read the tenant from `GlobalConfig`, following the existing `list_tables_handler` / `get_tables_stats_handler` pattern. The new routes are registered unconditionally:

- `/v1/stream_status`
- `/v1/settings` / `/v1/settings/:key`
- `/v1/user_functions`
- `/v1/procedures` / `/v1/procedures/:procedure_id` / `/v1/procedures/:name`
- `/v1/databases/:database/tables/:table/stats`
- `/v1/databases/:database/tables/:table/clustering_information`

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Handlers delegate to the same internal functions as the existing tenant-prefixed ones; verified via cargo check and make lint.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19956)
<!-- Reviewable:end -->
