### PR TITLE
fix(query): escape rewritten SQL string literals

### DIFF
--- a/src/query/ast/src/ast/common.rs
+++ b/src/query/ast/src/ast/common.rs
@@ -238,13 +238,13 @@ pub(crate) fn write_comma_separated_list(
 /// Write input items into `'a', 'b', 'c'`
 pub(crate) fn write_comma_separated_string_list(
     f: &mut Formatter,
-    items: impl IntoIterator<Item = impl Display>,
+    items: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> std::fmt::Result {
     for (i, item) in items.into_iter().enumerate() {
         if i > 0 {
             write!(f, ", ")?;
         }
-        write!(f, "'{item}'")?;
+        write!(f, "{}", QuotedString(item, '\''))?;
     }
     Ok(())
 }

--- a/src/query/ast/src/ast/statements/show.rs
+++ b/src/query/ast/src/ast/statements/show.rs
@@ -21,6 +21,7 @@ use derive_visitor::Drive;
 use derive_visitor::DriveMut;
 
 use crate::ast::Expr;
+use crate::ast::quote::QuotedString;
 
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut, Walk, WalkMut)]
 pub enum ShowLimit {
@@ -31,7 +32,7 @@ pub enum ShowLimit {
 impl Display for ShowLimit {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            ShowLimit::Like { pattern } => write!(f, "LIKE '{pattern}'"),
+            ShowLimit::Like { pattern } => write!(f, "LIKE {}", QuotedString(pattern, '\'')),
             ShowLimit::Where { selection } => write!(f, "WHERE {selection}"),
         }
     }

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -995,7 +995,7 @@ impl Display for Statement {
             Statement::ListStage { location, pattern } => {
                 write!(f, "LIST @{location}")?;
                 if let Some(pattern) = pattern {
-                    write!(f, " PATTERN = '{pattern}'")?;
+                    write!(f, " PATTERN = {}", QuotedString(pattern, '\''))?;
                 }
             }
             Statement::ShowStages { show_options } => {
@@ -1019,7 +1019,7 @@ impl Display for Statement {
             Statement::RemoveStage { location, pattern } => {
                 write!(f, "REMOVE @{location}")?;
                 if !pattern.is_empty() {
-                    write!(f, " PATTERN = '{pattern}'")?;
+                    write!(f, " PATTERN = {}", QuotedString(pattern, '\''))?;
                 }
             }
             Statement::DescribeStage { stage_name } => write!(f, "DESC STAGE {stage_name}")?,

--- a/src/query/ast/tests/it/display.rs
+++ b/src/query/ast/tests/it/display.rs
@@ -60,6 +60,19 @@ fn test_like_escape_display_escapes_escape_literal() {
 }
 
 #[test]
+fn test_rewrite_statement_display_escapes_string_literals() {
+    for sql in [
+        r#"SHOW SETTINGS LIKE 'a''b%';"#,
+        r#"SHOW TABLES LIKE 'a''b%';"#,
+        r#"LIST @test_stage PATTERN = 'a''b.*';"#,
+        r#"REMOVE @test_stage PATTERN = 'a''b.*';"#,
+        r#"CALL admin$tenant_quota('a''b');"#,
+    ] {
+        test_stmt_display(sql);
+    }
+}
+
+#[test]
 fn test_parse_sql_nested_join_conditions_without_panic() {
     let cases = [
         r#"

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -24,6 +24,7 @@ use databend_common_ast::ast::Hint;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Settings;
 use databend_common_ast::ast::Statement;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_ast::parser::Dialect;
 use databend_common_ast::parser::parse_sql;
 use databend_common_ast::parser::tokenize_sql;
@@ -453,14 +454,17 @@ impl Binder {
             }
             Statement::ListStage { location, pattern } => {
                 let pattern = if let Some(pattern) = pattern {
-                    format!(", pattern => '{pattern}'")
+                    format!(", pattern => {}", QuotedString(pattern, '\''))
                 } else {
                     "".to_string()
                 };
                 self.bind_rewrite_to_query(
                     bind_context,
-                    format!("SELECT * FROM LIST_STAGE(location => '@{location}'{pattern})")
-                        .as_str(),
+                    format!(
+                        "SELECT * FROM LIST_STAGE(location => {}{pattern})",
+                        QuotedString(format!("@{location}"), '\'')
+                    )
+                    .as_str(),
                     RewriteKind::ListStage,
                 )
                 .await?
@@ -468,8 +472,11 @@ impl Binder {
             Statement::DescribeStage { stage_name } => {
                 self.bind_rewrite_to_query(
                     bind_context,
-                    format!("SELECT * FROM default.system.stages WHERE name = '{stage_name}'")
-                        .as_str(),
+                    format!(
+                        "SELECT * FROM default.system.stages WHERE name = {}",
+                        QuotedString(stage_name, '\'')
+                    )
+                    .as_str(),
                     RewriteKind::DescribeStage,
                 )
                 .await?

--- a/src/query/sql/src/planner/binder/call.rs
+++ b/src/query/sql/src/planner/binder/call.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_ast::ast::CallStmt;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
@@ -40,15 +41,15 @@ impl Binder {
                 )));
             }
             format!(
-                "SELECT * FROM system.tables WHERE name like '%{}%' ORDER BY database, name",
-                stmt.args[0]
+                "SELECT * FROM system.tables WHERE name like {} ORDER BY database, name",
+                QuotedString(format!("%{}%", stmt.args[0]), '\'')
             )
         } else {
             format!(
                 "SELECT * from {table_function_name}({})",
                 stmt.args
                     .iter()
-                    .map(|x| format!("'{}'", x))
+                    .map(|x| QuotedString(x, '\'').to_string())
                     .collect::<Vec<_>>()
                     .join(", "),
             )

--- a/src/query/sql/src/planner/binder/ddl/account.rs
+++ b/src/query/sql/src/planner/binder/ddl/account.rs
@@ -27,6 +27,7 @@ use databend_common_ast::ast::ShowGranteesOfRoleStmt;
 use databend_common_ast::ast::ShowObjectPrivilegesStmt;
 use databend_common_ast::ast::ShowOptions;
 use databend_common_ast::ast::UserOptionItem;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -635,15 +636,24 @@ impl Binder {
         let query = if let Some(principal) = principal {
             match principal {
                 AstPrincipalIdentity::User(user) => {
-                    format!("SELECT * FROM show_grants('user', '{}')", user.username)
+                    format!(
+                        "SELECT * FROM show_grants('user', {})",
+                        QuotedString(&user.username, '\'')
+                    )
                 }
                 AstPrincipalIdentity::Role(role) => {
-                    format!("SELECT * FROM show_grants('role', '{}')", role)
+                    format!(
+                        "SELECT * FROM show_grants('role', {})",
+                        QuotedString(role, '\'')
+                    )
                 }
             }
         } else {
             let name = self.ctx.get_current_user()?.name;
-            format!("SELECT * FROM show_grants('user', '{}')", name)
+            format!(
+                "SELECT * FROM show_grants('user', {})",
+                QuotedString(name, '\'')
+            )
         };
 
         let (show_limit, limit_str) =
@@ -661,8 +671,8 @@ impl Binder {
         stmt: &ShowGranteesOfRoleStmt,
     ) -> Result<Plan> {
         let query = format!(
-            "SELECT * FROM show_grants('role_grantee', '{}')",
-            &stmt.name
+            "SELECT * FROM show_grants('role_grantee', {})",
+            QuotedString(&stmt.name, '\'')
         );
 
         let (show_limit, limit_str) =
@@ -688,8 +698,9 @@ impl Binder {
         let query = match object {
             GrantObjectName::Database(db) => {
                 format!(
-                    "SELECT * FROM show_grants('database', '{}', '{}')",
-                    db, catalog
+                    "SELECT * FROM show_grants('database', {}, {})",
+                    QuotedString(db, '\''),
+                    QuotedString(&catalog, '\'')
                 )
             }
             GrantObjectName::Table(db, tb) => {
@@ -699,24 +710,41 @@ impl Binder {
                     self.ctx.get_current_database()
                 };
                 format!(
-                    "SELECT * FROM show_grants('table', '{}', '{}', '{}')",
-                    tb, catalog, db
+                    "SELECT * FROM show_grants('table', {}, {}, {})",
+                    QuotedString(tb, '\''),
+                    QuotedString(&catalog, '\''),
+                    QuotedString(&db, '\'')
                 )
             }
             GrantObjectName::UDF(name) => {
-                format!("SELECT * FROM show_grants('udf', '{}')", name)
+                format!(
+                    "SELECT * FROM show_grants('udf', {})",
+                    QuotedString(name, '\'')
+                )
             }
             GrantObjectName::Stage(name) => {
-                format!("SELECT * FROM show_grants('stage', '{}')", name)
+                format!(
+                    "SELECT * FROM show_grants('stage', {})",
+                    QuotedString(name, '\'')
+                )
             }
             GrantObjectName::Warehouse(name) => {
-                format!("SELECT * FROM show_grants('warehouse', '{}')", name)
+                format!(
+                    "SELECT * FROM show_grants('warehouse', {})",
+                    QuotedString(name, '\'')
+                )
             }
             GrantObjectName::Connection(name) => {
-                format!("SELECT * FROM show_grants('connection', '{}')", name)
+                format!(
+                    "SELECT * FROM show_grants('connection', {})",
+                    QuotedString(name, '\'')
+                )
             }
             GrantObjectName::Sequence(name) => {
-                format!("SELECT * FROM show_grants('sequence', '{}')", name)
+                format!(
+                    "SELECT * FROM show_grants('sequence', {})",
+                    QuotedString(name, '\'')
+                )
             }
             GrantObjectName::Procedure(p) => {
                 let procedure_ident = ProcedureIdentity::from(p.clone());
@@ -729,7 +757,10 @@ impl Binder {
                     .await
                     .map_err(meta_service_error)?;
                 if let Some(procedure) = procedure {
-                    format!("SELECT * FROM show_grants('procedure', '{}')", procedure.id)
+                    format!(
+                        "SELECT * FROM show_grants('procedure', {})",
+                        QuotedString(procedure.id.to_string(), '\'')
+                    )
                 } else {
                     return Err(ErrorCode::UnknownProcedure(format!(
                         "Unknown procedure {}",
@@ -740,15 +771,15 @@ impl Binder {
             GrantObjectName::MaskingPolicy(policy) => {
                 let policy_id = self.resolve_masking_policy_id(policy).await?;
                 format!(
-                    "SELECT * FROM show_grants('masking_policy', '{}')",
-                    policy_id
+                    "SELECT * FROM show_grants('masking_policy', {})",
+                    QuotedString(policy_id.to_string(), '\'')
                 )
             }
             GrantObjectName::RowAccessPolicy(policy) => {
                 let policy_id = self.resolve_row_access_policy_id(policy).await?;
                 format!(
-                    "SELECT * FROM show_grants('row_access_policy', '{}')",
-                    policy_id
+                    "SELECT * FROM show_grants('row_access_policy', {})",
+                    QuotedString(policy_id.to_string(), '\'')
                 )
             }
         };

--- a/src/query/sql/src/planner/binder/ddl/catalog.rs
+++ b/src/query/sql/src/planner/binder/ddl/catalog.rs
@@ -24,6 +24,7 @@ use databend_common_ast::ast::ShowCatalogsStmt;
 use databend_common_ast::ast::ShowCreateCatalogStmt;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::UriLocation;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -69,7 +70,7 @@ impl Binder {
         .unwrap();
         match limit {
             Some(ShowLimit::Like { pattern }) => {
-                write!(query, " WHERE name LIKE '{pattern}'").unwrap();
+                write!(query, " WHERE name LIKE {}", QuotedString(pattern, '\'')).unwrap();
             }
             Some(ShowLimit::Where { selection }) => {
                 write!(query, " WHERE {selection}").unwrap();

--- a/src/query/sql/src/planner/binder/ddl/column.rs
+++ b/src/query/sql/src/planner/binder/ddl/column.rs
@@ -14,6 +14,7 @@
 
 use databend_common_ast::ast::ShowColumnsStmt;
 use databend_common_ast::ast::ShowLimit;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::Result;
 use log::debug;
 
@@ -92,13 +93,14 @@ impl Binder {
             .with_order_by("column_name");
 
         select_builder
-            .with_filter(format!("table_schema = '{database}'"))
-            .with_filter(format!("table_name = '{table}'"));
+            .with_filter(format!("table_schema = {}", QuotedString(&database, '\'')))
+            .with_filter(format!("table_name = {}", QuotedString(&table, '\'')));
 
         let query = match limit {
             None => select_builder.build(),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("column_name LIKE '{pattern}'"));
+                select_builder
+                    .with_filter(format!("column_name LIKE {}", QuotedString(pattern, '\'')));
                 select_builder.build()
             }
             Some(ShowLimit::Where { selection }) => {

--- a/src/query/sql/src/planner/binder/ddl/database.rs
+++ b/src/query/sql/src/planner/binder/ddl/database.rs
@@ -26,6 +26,7 @@ use databend_common_ast::ast::ShowDatabasesStmt;
 use databend_common_ast::ast::ShowDropDatabasesStmt;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::UndropDatabaseStmt;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -83,7 +84,7 @@ impl Binder {
         let mut select_builder =
             SelectBuilder::from(&format!("{}.system.databases", ctl.to_lowercase()));
 
-        select_builder.with_filter(format!("catalog = '{ctl}'"));
+        select_builder.with_filter(format!("catalog = {}", QuotedString(&ctl, '\'')));
 
         if *full {
             select_builder.with_column("catalog AS Catalog");
@@ -95,7 +96,7 @@ impl Binder {
 
         match limit {
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
             }
             Some(ShowLimit::Where { selection }) => {
                 select_builder.with_filter(format!("({selection})"));
@@ -129,7 +130,7 @@ impl Binder {
             self.ctx.get_current_catalog().to_string()
         };
 
-        select_builder.with_filter(format!("catalog = '{ctl}'"));
+        select_builder.with_filter(format!("catalog = {}", QuotedString(&ctl, '\'')));
 
         select_builder.with_column("catalog");
         select_builder.with_column("name");
@@ -141,7 +142,7 @@ impl Binder {
 
         match limit {
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
             }
             Some(ShowLimit::Where { selection }) => {
                 select_builder.with_filter(format!("({selection})"));

--- a/src/query/sql/src/planner/binder/ddl/dictionary.rs
+++ b/src/query/sql/src/planner/binder/ddl/dictionary.rs
@@ -22,6 +22,7 @@ use databend_common_ast::ast::RenameDictionaryStmt;
 use databend_common_ast::ast::ShowCreateDictionaryStmt;
 use databend_common_ast::ast::ShowDictionariesStmt;
 use databend_common_ast::ast::ShowLimit;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataField;
@@ -417,12 +418,12 @@ impl Binder {
             .with_order_by("name");
 
         let database = self.check_database_exist(&None, database).await?;
-        select_builder.with_filter(format!("database = '{}'", database.clone()));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
 
         match limit {
             None => (),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
             }
             Some(ShowLimit::Where { selection }) => {
                 select_builder.with_filter(format!("({selection})"));

--- a/src/query/sql/src/planner/binder/ddl/stream.rs
+++ b/src/query/sql/src/planner/binder/ddl/stream.rs
@@ -17,6 +17,7 @@ use databend_common_ast::ast::DescribeStreamStmt;
 use databend_common_ast::ast::DropStreamStmt;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::ShowStreamsStmt;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::Result;
 use databend_common_license::license::Feature;
 use databend_common_license::license_manager::LicenseManagerSwitch;
@@ -156,15 +157,16 @@ impl Binder {
             .with_order_by("database")
             .with_order_by("name");
 
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
         if let Some(catalog) = catalog {
             let catalog = normalize_identifier(catalog, &self.name_resolution_ctx).name;
-            select_builder.with_filter(format!("catalog = '{catalog}'"));
+            select_builder.with_filter(format!("catalog = {}", QuotedString(catalog, '\'')));
         }
         if let Some(limit) = limit {
             match limit {
                 ShowLimit::Like { pattern } => {
-                    select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                    select_builder
+                        .with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
                 }
                 ShowLimit::Where { selection } => {
                     select_builder.with_filter(format!("({selection})"));
@@ -213,9 +215,9 @@ impl Binder {
             .with_column("mode")
             .with_column("invalid_reason")
             .with_column("has_data");
-        select_builder.with_filter(format!("catalog = '{catalog}'"));
-        select_builder.with_filter(format!("database = '{database}'"));
-        select_builder.with_filter(format!("name = '{stream}'"));
+        select_builder.with_filter(format!("catalog = {}", QuotedString(&catalog, '\'')));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
+        select_builder.with_filter(format!("name = {}", QuotedString(&stream, '\'')));
         let query = select_builder.build();
         self.bind_rewrite_to_query(
             bind_context,

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -59,6 +59,7 @@ use databend_common_ast::ast::UriLocation;
 use databend_common_ast::ast::VacuumDropTableStmt;
 use databend_common_ast::ast::VacuumTableStmt;
 use databend_common_ast::ast::VacuumTemporaryFiles;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_ast::parser::parse_sql;
 use databend_common_ast::parser::tokenize_sql;
 use databend_common_base::runtime::GlobalIORuntime;
@@ -243,14 +244,14 @@ impl Binder {
             .with_order_by("database")
             .with_order_by("name");
 
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
         select_builder.with_filter("table_type = 'BASE TABLE'".to_string());
 
-        select_builder.with_filter(format!("catalog = '{catalog_name}'"));
+        select_builder.with_filter(format!("catalog = {}", QuotedString(&catalog_name, '\'')));
         let query = match limit {
             None => select_builder.build(),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
                 select_builder.build()
             }
             Some(ShowLimit::Where { selection }) => {
@@ -357,14 +358,14 @@ impl Binder {
                 database
             }
         };
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
 
         if let ShowStatsTarget::Table(table) = target {
             let table_name = normalize_identifier(table, &self.name_resolution_ctx).name;
             catalog
                 .get_table(&self.ctx.get_tenant(), database.as_str(), &table_name)
                 .await?;
-            select_builder.with_filter(format!("table = '{table_name}'"));
+            select_builder.with_filter(format!("table = {}", QuotedString(table_name, '\'')));
         }
 
         select_builder
@@ -418,18 +419,26 @@ impl Binder {
         // (unlike mysql, alias of derived table is not required in databend).
         let query = match limit {
             None => format!(
-                "SELECT {} FROM {}.system.tables WHERE database = '{}' ORDER BY Name",
-                select_cols, default_catalog, database
+                "SELECT {} FROM {}.system.tables WHERE database = {} ORDER BY Name",
+                select_cols,
+                default_catalog,
+                QuotedString(&database, '\'')
             ),
             Some(ShowLimit::Like { pattern }) => format!(
-                "SELECT * from (SELECT {} FROM {}.system.tables WHERE database = '{}') \
-            WHERE Name LIKE '{}' ORDER BY Name",
-                select_cols, default_catalog, database, pattern
+                "SELECT * from (SELECT {} FROM {}.system.tables WHERE database = {}) \
+            WHERE Name LIKE {} ORDER BY Name",
+                select_cols,
+                default_catalog,
+                QuotedString(&database, '\''),
+                QuotedString(pattern, '\'')
             ),
             Some(ShowLimit::Where { selection }) => format!(
-                "SELECT * from (SELECT {} FROM {}.system.tables WHERE database = '{}') \
+                "SELECT * from (SELECT {} FROM {}.system.tables WHERE database = {}) \
             WHERE ({}) ORDER BY Name",
-                select_cols, default_catalog, database, selection
+                select_cols,
+                default_catalog,
+                QuotedString(&database, '\''),
+                selection
             ),
         };
 
@@ -472,13 +481,13 @@ impl Binder {
             .with_order_by("database")
             .with_order_by("name");
 
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
         select_builder.with_filter("dropped_on IS NOT NULL".to_string());
 
         let query = match limit {
             None => select_builder.build(),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
                 select_builder.build()
             }
             Some(ShowLimit::Where { selection }) => {

--- a/src/query/sql/src/planner/binder/ddl/tag.rs
+++ b/src/query/sql/src/planner/binder/ddl/tag.rs
@@ -23,6 +23,7 @@ use databend_common_ast::ast::ProcedureIdentity as AstProcedureIdentity;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::ShowTagsStmt;
 use databend_common_ast::ast::TagSetItem;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
@@ -106,8 +107,10 @@ impl Binder {
 
         match &stmt.filter {
             Some(ShowLimit::Like { pattern }) => {
-                select_builder
-                    .with_filter(format!("LOWER(name) LIKE '{}'", pattern.to_lowercase()));
+                select_builder.with_filter(format!(
+                    "LOWER(name) LIKE {}",
+                    QuotedString(pattern.to_lowercase(), '\'')
+                ));
             }
             Some(ShowLimit::Where { selection }) => {
                 select_builder.with_filter(format!("({selection})"));

--- a/src/query/sql/src/planner/binder/ddl/view.rs
+++ b/src/query/sql/src/planner/binder/ddl/view.rs
@@ -18,6 +18,7 @@ use databend_common_ast::ast::DescribeViewStmt;
 use databend_common_ast::ast::DropViewStmt;
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::ShowViewsStmt;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_ast::visit::WalkMut;
 use databend_common_exception::Result;
 use databend_common_expression::DataField;
@@ -184,7 +185,7 @@ impl Binder {
             .with_order_by("database")
             .with_order_by("name");
 
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
 
         let catalog_name = match catalog {
             None => self.ctx.get_current_catalog(),
@@ -195,11 +196,11 @@ impl Binder {
             }
         };
 
-        select_builder.with_filter(format!("catalog = '{catalog_name}'"));
+        select_builder.with_filter(format!("catalog = {}", QuotedString(&catalog_name, '\'')));
         let query = match limit {
             None => select_builder.build(),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("name LIKE '{pattern}'"));
+                select_builder.with_filter(format!("name LIKE {}", QuotedString(pattern, '\'')));
                 select_builder.build()
             }
             Some(ShowLimit::Where { selection }) => {

--- a/src/query/sql/src/planner/binder/show.rs
+++ b/src/query/sql/src/planner/binder/show.rs
@@ -15,6 +15,7 @@
 use databend_common_ast::ast::ShowLimit;
 use databend_common_ast::ast::ShowLocksStmt;
 use databend_common_ast::ast::ShowOptions;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_exception::Result;
 use log::debug;
 
@@ -187,7 +188,7 @@ impl Binder {
 
         if *in_account {
             let user = self.ctx.get_current_user()?.name;
-            select_builder.with_filter(format!("user = '{user}'"));
+            select_builder.with_filter(format!("user = {}", QuotedString(user, '\'')));
         }
         if let Some(ShowLimit::Where { selection }) = limit {
             select_builder.with_filter(format!("({selection})"));
@@ -211,10 +212,11 @@ pub(crate) fn get_show_options(
         match &show_option.show_limit {
             Some(ShowLimit::Like { pattern }) => {
                 // convert like pattern to lowercase to uses case-insensitive pattern matching
+                let pattern = QuotedString(pattern.to_lowercase(), '\'');
                 if let Some(col) = &col {
-                    show_limit = format!("WHERE LOWER({}) LIKE '{}'", col, pattern.to_lowercase());
+                    show_limit = format!("WHERE LOWER({}) LIKE {}", col, pattern);
                 } else {
-                    show_limit = format!("WHERE LOWER(name) LIKE '{}'", pattern.to_lowercase());
+                    show_limit = format!("WHERE LOWER(name) LIKE {}", pattern);
                 }
             }
             Some(ShowLimit::Where { selection }) => {

--- a/src/query/sql/src/planner/binder/virtual_column.rs
+++ b/src/query/sql/src/planner/binder/virtual_column.rs
@@ -33,6 +33,7 @@ use databend_common_ast::ast::ShowVirtualColumnsStmt;
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::VacuumVirtualColumnStmt;
 use databend_common_ast::ast::With;
+use databend_common_ast::ast::quote::QuotedString;
 use databend_common_ast::visit::VisitControl;
 use databend_common_ast::visit::Visitor;
 use databend_common_ast::visit::VisitorMut;
@@ -133,16 +134,19 @@ impl Binder {
             .with_column("virtual_column_name")
             .with_column("virtual_column_type");
 
-        select_builder.with_filter(format!("database = '{database}'"));
+        select_builder.with_filter(format!("database = {}", QuotedString(&database, '\'')));
         if let Some(table) = table {
             let table = normalize_identifier(table, &self.name_resolution_ctx).name;
-            select_builder.with_filter(format!("table = '{table}'"));
+            select_builder.with_filter(format!("table = {}", QuotedString(table, '\'')));
         }
 
         let query = match limit {
             None => select_builder.build(),
             Some(ShowLimit::Like { pattern }) => {
-                select_builder.with_filter(format!("virtual_column_name LIKE '{pattern}'"));
+                select_builder.with_filter(format!(
+                    "virtual_column_name LIKE {}",
+                    QuotedString(pattern, '\'')
+                ));
                 select_builder.build()
             }
             Some(ShowLimit::Where { selection }) => {

--- a/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0016_ddl_stage.test
@@ -19,6 +19,19 @@ CREATE STAGE test_stage_internal file_format=(type=csv compression=AUTO record_d
 statement ok
 LIST @test_stage_internal
 
+query III
+copy into '@test_stage_internal/a''b' from (select 1) file_format=(type=csv)
+----
+1 2 2
+
+query TITTT
+LIST @test_stage_internal PATTERN='a''b.*'
+----
+a'b/<slt:ignore> 2 NULL <slt:ignore> NULL
+
+statement ok
+REMOVE @test_stage_internal PATTERN='a''b.*'
+
 statement ok
 desc stage test_stage_internal
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0029_ddl_create_catalog.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0029_ddl_create_catalog.test
@@ -9,6 +9,12 @@ SHOW CATALOGS;
 ----
 default
 
+# A matching catalog would require a valid external catalog backend, so keep
+# this empty result as rewrite escaping coverage.
+query T
+SHOW CATALOGS LIKE 'a''b%'
+----
+
 statement error 1001
 CREATE CATALOG ctl TYPE=ICEBERG CONNECTION=(TYPE='REST' ADDRESS='http://127.0.0.1:1000' WAREHOUSE='default' );
 

--- a/tests/sqllogictests/suites/base/05_ddl/05_0060_ddl_tag.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0060_ddl_tag.test
@@ -19,6 +19,9 @@ DROP TAG IF EXISTS owner_tag
 statement ok
 DROP TAG IF EXISTS cost_center_tag
 
+statement ok
+DROP TAG IF EXISTS `a'b_tag`
+
 ## Basic CREATE TAG with ALLOWED_VALUES and COMMENT
 statement ok
 CREATE TAG env_tag ALLOWED_VALUES = ('dev', 'staging', 'prod') COMMENT = 'Environment classification tag'
@@ -30,6 +33,9 @@ CREATE TAG owner_tag COMMENT = 'Data owner information'
 ## CREATE TAG without ALLOWED_VALUES or COMMENT
 statement ok
 CREATE TAG cost_center_tag
+
+statement ok
+CREATE TAG `a'b_tag` COMMENT = 'escaping tag'
 
 ## Error: CREATE TAG that already exists (error code 2750)
 statement error 2750
@@ -58,6 +64,11 @@ SHOW TAGS
 
 statement ok
 SHOW TAGS LIKE 'env%'
+
+query TTT?
+SHOW TAGS LIKE 'a''b%'
+----
+a'b_tag NULL escaping tag <slt:ignore>
 
 statement ok
 SHOW TAGS WHERE name = 'owner_tag'
@@ -314,6 +325,9 @@ DROP TAG IF EXISTS owner_tag
 
 statement ok
 DROP TAG IF EXISTS cost_center_tag
+
+statement ok
+DROP TAG IF EXISTS `a'b_tag`
 
 statement ok
 DROP DATABASE IF EXISTS test_tag_db

--- a/tests/sqllogictests/suites/base/06_show/06_0000_show_databases.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0000_show_databases.test
@@ -8,6 +8,9 @@ statement ok
 DROP DATABASE IF EXISTS ss2
 
 statement ok
+DROP DATABASE IF EXISTS `a'b_db`
+
+statement ok
 CREATE DATABASE ss
 
 statement ok
@@ -16,6 +19,9 @@ CREATE DATABASE ss1
 statement ok
 CREATE DATABASE ss2
 
+statement ok
+CREATE DATABASE `a'b_db`
+
 query T
 SHOW DATABASES like 'ss%'
 ----
@@ -23,12 +29,22 @@ ss
 ss1
 ss2
 
+query T
+SHOW DATABASES LIKE 'a''b%'
+----
+a'b_db
+
 query TTT
 SHOW FULL DATABASES like 'ss%';
 ----
 default account_admin ss
 default account_admin ss1
 default account_admin ss2
+
+query TTT
+SHOW FULL DATABASES LIKE 'a''b%'
+----
+default account_admin a'b_db
 
 query TTT
 SHOW FULL DATABASES FROM default like 'ss%';
@@ -53,3 +69,5 @@ DROP DATABASE IF EXISTS ss1
 statement ok
 DROP DATABASE IF EXISTS ss2
 
+statement ok
+DROP DATABASE IF EXISTS `a'b_db`

--- a/tests/sqllogictests/suites/base/06_show/06_0003_show_settings.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0003_show_settings.test
@@ -31,6 +31,12 @@ SHOW SETTINGS
 statement ok
 SHOW SETTINGS LIKE 'enable%'
 
+# Settings are built-in and cannot be created by the test fixture; this empty
+# result still covers escaping the rewritten LIKE pattern.
+query TTTTTTT
+SHOW SETTINGS LIKE 'a''b%'
+----
+
 query TTTTTTT
 SHOW SETTINGS LIKE 'max_block_size%' LIMIT 1
 ----

--- a/tests/sqllogictests/suites/base/06_show/06_0004_show_tables.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0004_show_tables.test
@@ -30,6 +30,17 @@ t1
 t2
 t3
 
+statement ok
+CREATE TABLE showtable.`a'b_table`(c1 int) ENGINE = Null
+
+query T
+SHOW TABLES LIKE 'a''b%'
+----
+a'b_table
+
+statement ok
+DROP TABLE showtable.`a'b_table`
+
 query T
 SHOW TABLES LIKE 't2'
 ----

--- a/tests/sqllogictests/suites/base/06_show/06_0008_show_table_status.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0008_show_table_status.test
@@ -14,6 +14,9 @@ statement ok
 CREATE TABLE showtabstat.t3(c1 int) ENGINE = Null
 
 statement ok
+CREATE TABLE showtabstat.`a'b_table`(c1 int) ENGINE = Null
+
+statement ok
 USE showtabstat
 
 # query TTITTTTTTTTTRTTTT
@@ -37,6 +40,11 @@ USE showtabstat
 
 statement ok
 SHOW TABLE STATUS LIKE 't'
+
+query TTI?I?I?I???????TT
+SHOW TABLE STATUS LIKE 'a''b%'
+----
+a'b_table NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL <slt:ignore> NULL NULL NULL NULL (empty) (empty)
 
 # query TTITTTTTTTTTRTTTT
 # SHOW TABLE STATUS WHERE Name LIKE 't%'

--- a/tests/sqllogictests/suites/base/06_show/06_0015_show_columns.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0015_show_columns.test
@@ -13,6 +13,9 @@ CREATE TABLE showcolumn.t2(c1 int not null) ENGINE = Null
 statement ok
 CREATE TABLE showcolumn.t3(c1 int null default 4, c2 Datetime not null default '2022-02-02 12:00:00', c3 String not null Default 'c3') ENGINE = Null;
 
+statement ok
+CREATE TABLE showcolumn.t_quote(`a'b_col` int null default 7) ENGINE = Null;
+
 query TTTT??
 SHOW COLUMNS FROM default.showcolumn.t3
 ----
@@ -52,6 +55,11 @@ SHOW FULL COLUMNS IN t3 like '%1';
 ----
 c1 int YES 4 NULL NULL NULL NULL (empty)
 
+query TTTT??T?T
+SHOW FULL COLUMNS IN t_quote like 'a''b%'
+----
+a'b_col int YES 7 NULL NULL NULL NULL (empty)
+
 query TTTT??
 SHOW COLUMNS IN t3 where column_name like '%1';
 ----
@@ -81,6 +89,12 @@ SHOW COLUMNS IN columns from system like '%type%'
 ----
 data_type varchar(16382) NO (empty) NULL NULL
 type varchar(16382) NO (empty) NULL NULL
+
+# system.columns is read-only, so the test cannot create a system column whose
+# name matches a'b%; keep this empty result as rewrite escaping coverage.
+query TTTT??
+SHOW COLUMNS IN columns from system like 'a''b%'
+----
 
 query TTTT??
 SHOW COLUMNS IN columns from system where column_name != '%type%' and is_nullable!='YES'

--- a/tests/sqllogictests/suites/base/06_show/06_0023_show_views.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0023_show_views.test
@@ -40,6 +40,17 @@ v1
 v2
 v3
 
+statement ok
+CREATE VIEW showview.`a'b_view` AS SELECT * FROM showview.t1
+
+query T
+SHOW VIEWS LIKE 'a''b%'
+----
+a'b_view
+
+statement ok
+DROP VIEW showview.`a'b_view`
+
 query T
 SHOW VIEWS LIKE 'v2'
 ----

--- a/tests/sqllogictests/suites/base/06_show/06_0024_show_dictionaries.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0024_show_dictionaries.test
@@ -42,6 +42,17 @@ show_dictionary d1 ["c1"] ["VARCHAR"] ["c2"] ["VARCHAR"] mysql(db=db1 host=local
 show_dictionary d2 ["a"] ["INT"] ["b"] ["INT"] mysql(db=db1 host=localhost password=[hidden] port=3306 table=test_table username=root) (empty)
 show_dictionary d3 ["a"] ["INT"] ["b"] ["INT"] mysql(db=db1 host=localhost password=[hidden] port=3306 table=test_table username=root) (empty)
 
+statement ok
+CREATE OR REPLACE DICTIONARY show_dictionary.`a'b_dict`(c1 VARCHAR NOT NULL, c2 VARCHAR NOT NULL) PRIMARY KEY c1 SOURCE(mysql(host='localhost' port='3306' username='root' password='1234' db='db1' table='test_table'))
+
+query TT????TT
+show dictionaries from show_dictionary like 'a''b%'
+----
+show_dictionary a'b_dict ["c1"] ["VARCHAR"] ["c2"] ["VARCHAR"] mysql(db=db1 host=localhost password=[hidden] port=3306 table=test_table username=root) (empty)
+
+statement ok
+DROP DICTIONARY show_dictionary.`a'b_dict`
+
 query TT????TT
 show dictionaries from show_dictionary WHERE name = 'd2' OR 1 = 1
 ----

--- a/tests/sqllogictests/suites/base/15_procedure/15_0009_procedure_call.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0009_procedure_call.test
@@ -77,3 +77,7 @@ BEGIN
 END;
 $$;
 
+query IIII
+call admin$tenant_quota('a''b')
+----
+0 0 0 0

--- a/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
+++ b/tests/sqllogictests/suites/ee/01_ee_system/01_0002_virtual_column.test
@@ -37,6 +37,12 @@ query TTTITT
 show virtual columns from t1
 ----
 
+# This EE fixture does not expose a creatable virtual-column name matching
+# a'b%; keep this empty result as rewrite escaping coverage.
+query TTTITT
+show virtual columns from t1 like 'a''b%'
+----
+
 statement ok
 insert into t1 values(4, '{"a":44,"b":4,"c":"value"}'), (5, '{"a":55,"b":5,"c":"bend"}'), (6, '6')
 

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0000_stream.test
@@ -49,6 +49,17 @@ statement ok
 create stream s1 on table t append_only = true
 
 statement ok
+create stream `a'b_stream` on table t append_only = true
+
+query TTT
+show streams like 'a''b%'
+----
+a'b_stream test_stream.t append_only
+
+statement ok
+drop stream `a'b_stream`
+
+statement ok
 insert into t values(3)
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix SQL rewrites that embedded user-provided string values directly inside single quotes. These rewrites now use the existing `QuotedString(value, '\'')` display helper, covering `SHOW ... LIKE`, `LIST`/`DESCRIBE STAGE`, `CALL` table functions, `SHOW GRANTS`, and related `SHOW` rewrites.

Also updates AST display paths so round-tripped SQL escapes string literals for `SHOW LIKE`, `LIST`/`REMOVE PATTERN`, `CALL` args, and shared comma-separated string lists.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Additional checks:

- `cargo check -p databend-common-sql`
- `cargo build --bin databend-query`
- `git diff --check`

Note: EE stream/virtual-column sqllogictests include added coverage but were not runnable locally because the environment has no EE license.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19957)
<!-- Reviewable:end -->
