### PR TITLE
fix(binder): allow unresolved complex GROUP BY alias fallback

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -129,6 +129,34 @@ pub struct GroupingSetsInfo {
     pub dup_group_items: Vec<(Symbol, DataType)>,
 }
 
+#[derive(Clone)]
+struct GroupItem {
+    expr: Expr,
+    disable_select_alias_fallback: bool,
+}
+
+impl GroupItem {
+    fn normal(expr: Expr) -> Self {
+        Self {
+            expr,
+            disable_select_alias_fallback: false,
+        }
+    }
+
+    fn grouping_construct(expr: Expr) -> Self {
+        Self {
+            expr,
+            disable_select_alias_fallback: true,
+        }
+    }
+}
+
+enum ExpandedGroup {
+    Normal(Vec<GroupItem>),
+    All,
+    GroupingSets(Vec<Vec<GroupItem>>),
+}
+
 #[derive(Default, Clone, PartialEq, Eq, Debug)]
 pub struct AggregateInfo {
     /// Builtin aggregation functions.
@@ -898,16 +926,20 @@ impl Binder {
         let result = (|| {
             let group_by = Self::expand_group(group_by.clone())?;
             match &group_by {
-                GroupBy::Normal(exprs) => self.resolve_group_items(
+                ExpandedGroup::Normal(items) => self.resolve_group_items(
                     bind_context,
                     select_list,
-                    exprs,
+                    items,
                     group_by_aliases,
                     false,
                     &mut vec![],
                 )?,
-                GroupBy::All => {
+                ExpandedGroup::All => {
                     let groups = self.resolve_group_all(select_list)?;
+                    let groups = groups
+                        .into_iter()
+                        .map(GroupItem::normal)
+                        .collect::<Vec<_>>();
                     self.resolve_group_items(
                         bind_context,
                         select_list,
@@ -917,10 +949,9 @@ impl Binder {
                         &mut vec![],
                     )?;
                 }
-                GroupBy::GroupingSets(sets) => {
+                ExpandedGroup::GroupingSets(sets) => {
                     self.resolve_grouping_sets(bind_context, select_list, sets, group_by_aliases)?;
                 }
-                _ => unreachable!(),
             }
             Ok(())
         })();
@@ -928,38 +959,53 @@ impl Binder {
         result
     }
 
-    pub fn expand_group(group_by: GroupBy) -> Result<GroupBy> {
+    fn expand_group(group_by: GroupBy) -> Result<ExpandedGroup> {
         match group_by {
-            GroupBy::Normal(_) | GroupBy::All | GroupBy::GroupingSets(_) => Ok(group_by),
+            GroupBy::Normal(exprs) => Ok(ExpandedGroup::Normal(
+                exprs.into_iter().map(GroupItem::normal).collect(),
+            )),
+            GroupBy::All => Ok(ExpandedGroup::All),
+            GroupBy::GroupingSets(sets) => Ok(ExpandedGroup::GroupingSets(
+                Self::grouping_construct_sets(sets),
+            )),
             GroupBy::Cube(exprs) => {
                 // Expand CUBE to GroupingSets
-                let sets = Self::generate_cube_sets(exprs);
-                Ok(GroupBy::GroupingSets(sets))
+                Ok(ExpandedGroup::GroupingSets(
+                    Self::generate_cube_sets(exprs)
+                        .into_iter()
+                        .map(|set| set.into_iter().map(GroupItem::grouping_construct).collect())
+                        .collect(),
+                ))
             }
             GroupBy::Rollup(exprs) => {
                 // Expand ROLLUP to GroupingSets
-                let sets = Self::generate_rollup_sets(exprs);
-                Ok(GroupBy::GroupingSets(sets))
+                Ok(ExpandedGroup::GroupingSets(
+                    Self::generate_rollup_sets(exprs)
+                        .into_iter()
+                        .map(|set| set.into_iter().map(GroupItem::grouping_construct).collect())
+                        .collect(),
+                ))
             }
             GroupBy::Combined(groups) => {
                 // Flatten and expand all nested GroupBy variants
                 let mut combined_sets = Vec::new();
                 for group in groups {
                     match Self::expand_group(group)? {
-                        GroupBy::Normal(exprs) => {
-                            combined_sets = Self::cartesian_product(combined_sets, vec![exprs]);
+                        ExpandedGroup::Normal(items) => {
+                            combined_sets = Self::cartesian_product(combined_sets, vec![items]);
                         }
-                        GroupBy::GroupingSets(sets) => {
+                        ExpandedGroup::GroupingSets(sets) => {
                             combined_sets = Self::cartesian_product(combined_sets, sets);
                         }
-                        other => {
+                        ExpandedGroup::All => {
                             return Err(ErrorCode::SyntaxException(format!(
-                                "COMBINED GROUP BY does not support {other:?}"
+                                "COMBINED GROUP BY does not support {:?}",
+                                GroupBy::All
                             )));
                         }
                     }
                 }
-                Ok(GroupBy::GroupingSets(combined_sets))
+                Ok(ExpandedGroup::GroupingSets(combined_sets))
             }
         }
     }
@@ -980,8 +1026,17 @@ impl Binder {
         result
     }
 
+    fn grouping_construct_sets(sets: Vec<Vec<Expr>>) -> Vec<Vec<GroupItem>> {
+        sets.into_iter()
+            .map(|set| set.into_iter().map(GroupItem::grouping_construct).collect())
+            .collect()
+    }
+
     /// Perform Cartesian product of two sets of grouping sets
-    fn cartesian_product(set1: Vec<Vec<Expr>>, set2: Vec<Vec<Expr>>) -> Vec<Vec<Expr>> {
+    fn cartesian_product(
+        set1: Vec<Vec<GroupItem>>,
+        set2: Vec<Vec<GroupItem>>,
+    ) -> Vec<Vec<GroupItem>> {
         if set1.is_empty() {
             return set2;
         }
@@ -1068,7 +1123,7 @@ impl Binder {
         &mut self,
         bind_context: &mut BindContext,
         select_list: &SelectList<'_>,
-        sets: &[Vec<Expr>],
+        sets: &[Vec<GroupItem>],
         group_by_aliases: &ClauseAliasBindings,
     ) -> Result<()> {
         let mut grouping_sets = Vec::with_capacity(sets.len());
@@ -1169,7 +1224,7 @@ impl Binder {
         &mut self,
         bind_context: &mut BindContext,
         select_list: &SelectList<'_>,
-        group_by: &[Expr],
+        group_by: &[GroupItem],
         group_by_aliases: &ClauseAliasBindings,
         collect_grouping_sets: bool,
         grouping_sets: &mut Vec<Vec<ScalarExpr>>,
@@ -1178,7 +1233,8 @@ impl Binder {
             grouping_sets.push(Vec::with_capacity(group_by.len()));
         }
         let mut group_by_aliases = group_by_aliases.clone();
-        for expr in group_by.iter() {
+        for item in group_by.iter() {
+            let expr = &item.expr;
             // If expr is a number literal, then this is a index group item.
             if let Expr::Literal {
                 value: Literal::UInt64(index),
@@ -1211,7 +1267,7 @@ impl Binder {
             }
 
             let (preferred_aliases, fallback_aliases) =
-                group_by_aliases.group_item_aliases(expr, collect_grouping_sets);
+                group_by_aliases.group_item_aliases(expr, item.disable_select_alias_fallback);
 
             let (mut scalar_expr, _) = {
                 let mut type_checker = TypeChecker::try_create_with_alias_fallback(

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -1210,7 +1210,8 @@ impl Binder {
                 continue;
             }
 
-            let (preferred_aliases, fallback_aliases) = group_by_aliases.group_item_aliases(expr);
+            let (preferred_aliases, fallback_aliases) =
+                group_by_aliases.group_item_aliases(expr, collect_grouping_sets);
 
             let (mut scalar_expr, _) = {
                 let mut type_checker = TypeChecker::try_create_with_alias_fallback(
@@ -1230,8 +1231,8 @@ impl Binder {
             //
             // `SELECT i AS k FROM t GROUP BY k, abs(k)` should let `abs(k)`
             // use the preceding group item alias `k`.
-            // `SELECT i AS k FROM t GROUP BY abs(k)` is still rejected because
-            // complex GROUP BY items do not expand SELECT aliases directly.
+            // Without a preceding group item alias, complex GROUP BY items
+            // still bind input columns before falling back to SELECT aliases.
             let group_alias = group_by_aliases.matched_group_item_alias(expr, &scalar_expr);
 
             let mut analyzer = SetReturningAnalyzer::new(bind_context, self.metadata.clone());

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -83,7 +83,7 @@ impl ClauseAliasBindings {
     pub(crate) fn group_item_aliases(
         &self,
         expr: &Expr,
-        in_grouping_sets: bool,
+        disable_select_alias_fallback: bool,
     ) -> ClauseAliasLookup<'_> {
         // Complex GROUP BY items bind input columns first, then fall back to
         // SELECT aliases only for unresolved names in a normal GROUP BY.
@@ -97,7 +97,7 @@ impl ClauseAliasBindings {
             // GROUPING SETS keep prior alias reuse scoped to the current
             // generated set. A complex item in a later set must not bypass that
             // boundary by falling back to SELECT aliases directly.
-            let fallback_aliases = if in_grouping_sets || self.available.is_empty() {
+            let fallback_aliases = if disable_select_alias_fallback || self.available.is_empty() {
                 None
             } else {
                 Some(self.available.as_slice())

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -80,19 +80,33 @@ pub(crate) type ClauseAliasLookup<'a> = (
 );
 
 impl ClauseAliasBindings {
-    pub(crate) fn group_item_aliases(&self, expr: &Expr) -> ClauseAliasLookup<'_> {
-        // Only simple GROUP BY items can resolve SELECT aliases directly.
+    pub(crate) fn group_item_aliases(
+        &self,
+        expr: &Expr,
+        in_grouping_sets: bool,
+    ) -> ClauseAliasLookup<'_> {
+        // Complex GROUP BY items bind input columns first, then fall back to
+        // SELECT aliases only for unresolved names in a normal GROUP BY.
         //
         // `SELECT i AS k FROM t GROUP BY k` may bind `k` as the alias for `i`.
-        // `SELECT i AS k FROM t GROUP BY abs(k)` must not expand `k` directly
-        // from the SELECT list. A complex item may only reuse an alias that an
-        // earlier simple item has already grouped, for example
-        // `GROUP BY k, abs(k)`.
+        // `SELECT 1 AS k FROM t GROUP BY k + 1` may bind `k` from the SELECT
+        // list if there is no input column named `k`.
+        // `GROUP BY k, abs(k)` should still prefer the earlier GROUP BY item
+        // alias inside later complex items, even if an input column conflicts.
         if Self::simple_unqualified_column_name(expr).is_none() {
+            // GROUPING SETS keep prior alias reuse scoped to the current
+            // generated set. A complex item in a later set must not bypass that
+            // boundary by falling back to SELECT aliases directly.
+            let fallback_aliases = if in_grouping_sets || self.available.is_empty() {
+                None
+            } else {
+                Some(self.available.as_slice())
+            };
+
             return (
                 (!self.prior_group_aliases.is_empty())
                     .then_some(self.prior_group_aliases.as_slice()),
-                None,
+                fallback_aliases,
             );
         }
 

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
@@ -247,9 +247,78 @@ EvalScalar
             └── limit: NONE
 
 
+=== group_by_alias__group_by_complex_select_alias_conflict_uses_input ===
+matrix: group_by_alias
+key: G0N2S1_7_0
+setting: enable_group_by_column_first=0
+sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#3) AS (#3), 1 AS (#4)]
+└── Aggregate(Initial)
+    ├── group items: [plus(t.k (#1), 1) AS (#2)]
+    ├── aggregate functions: [count() AS (#3)]
+    └── EvalScalar
+        ├── scalars: [plus(t.k (#1), 1) AS (#2)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== group_by_alias__group_by_complex_select_alias_no_input_fallback__group_by_column_first_off__run_1 ===
+matrix: group_by_alias
+key: G0N2S1_7_1
+setting: enable_group_by_column_first=0
+sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#2) AS (#2), 1 AS (#3)]
+└── Aggregate(Initial)
+    ├── group items: [2 AS (#1)]
+    ├── aggregate functions: [count() AS (#2)]
+    └── EvalScalar
+        ├── scalars: [2 AS (#1)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== group_by_alias__group_by_complex_select_alias_no_input_fallback__group_by_column_first_on__run_2 ===
+matrix: group_by_alias
+key: G0N2S1_7_1
+setting: enable_group_by_column_first=1
+sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#2) AS (#2), 1 AS (#3)]
+└── Aggregate(Initial)
+    ├── group items: [2 AS (#1)]
+    ├── aggregate functions: [count() AS (#2)]
+    └── EvalScalar
+        ├── scalars: [2 AS (#1)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== group_by_alias__group_by_complex_select_alias_ambiguous_input_rejected ===
+matrix: group_by_alias
+key: G0N2S1_7_2
+setting: enable_group_by_column_first=0
+sql: SELECT 1 AS k, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY k + 1
+status: error
+code: 1065
+message: column k reference or alias is ambiguous, please use another alias name
+
 === group_by_alias__group_by_aggregate_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N0S2_8_0
+key: G0N0S2_9_0
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS x FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) GROUP BY x
 status: ok
@@ -276,7 +345,7 @@ EvalScalar
 
 === group_by_alias__group_by_aggregate_alias_no_input_rejected ===
 matrix: group_by_alias
-key: G0N0S2_8_1
+key: G0N0S2_9_1
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c FROM t GROUP BY c
 status: error
@@ -285,7 +354,7 @@ message: GROUP BY items can't contain aggregate functions or window functions: C
 
 === group_by_alias__group_by_srf_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N0S4_9_0
+key: G0N0S4_10_0
 setting: enable_group_by_column_first=0
 sql: SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col2 FROM t_str AS t GROUP BY col1, col2 ORDER BY col2
 status: ok
@@ -309,7 +378,7 @@ Sort
 
 === group_by_alias__group_by_srf_alias_no_input ===
 matrix: group_by_alias
-key: G0N0S4_9_1
+key: G0N0S4_10_1
 setting: enable_group_by_column_first=0
 sql: SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col3 FROM t_str AS t GROUP BY col1, col3 ORDER BY col3
 status: ok
@@ -333,7 +402,7 @@ Sort
 
 === group_by_alias__group_by_ordinal_uses_select_item_position ===
 matrix: group_by_alias
-key: G0N4N0_11_
+key: G0N4N0_12_
 setting: enable_group_by_column_first=0
 sql: SELECT i AS k, count(*) FROM t GROUP BY 1
 status: ok
@@ -353,7 +422,7 @@ EvalScalar
 
 === group_by_alias__group_by_all_expands_non_aggregate_select_items ===
 matrix: group_by_alias
-key: G5N5N0_12_
+key: G5N5N0_13_
 setting: enable_group_by_column_first=0
 sql: SELECT i AS k, count(*) FROM t GROUP BY ALL
 status: ok
@@ -373,7 +442,7 @@ EvalScalar
 
 === group_by_alias__group_by_qualified_name_does_not_consume_prior_group_alias ===
 matrix: group_by_alias
-key: G0N1G0_13_
+key: G0N1G0_14_
 setting: enable_group_by_column_first=0
 sql: SELECT i AS k, count(*) FROM t GROUP BY k, t.k
 status: error
@@ -382,7 +451,7 @@ message: column k doesn't exist
 
 === group_by_alias__group_by_qualified_complex_does_not_fallback_to_select_alias ===
 matrix: group_by_alias
-key: G0N3S1_13_
+key: G0N3S1_14_
 setting: enable_group_by_column_first=0
 sql: SELECT i AS k, count(*) FROM t GROUP BY t.k + 1
 status: error
@@ -391,9 +460,36 @@ message: column k doesn't exist
 
 === group_by_alias__grouping_sets_qualified_name_does_not_fallback_to_select_alias ===
 matrix: group_by_alias
-key: G1N1S1_13_
+key: G1N1S1_14_
 setting: enable_group_by_column_first=0
 sql: SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((t.k))
+status: error
+code: 1065
+message: column k doesn't exist
+
+=== group_by_alias__grouping_sets_complex_select_alias_does_not_fallback ===
+matrix: group_by_alias
+key: G1N2S1_14_
+setting: enable_group_by_column_first=0
+sql: SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((abs(k)))
+status: error
+code: 1065
+message: column k doesn't exist
+
+=== group_by_alias__rollup_complex_select_alias_does_not_fallback ===
+matrix: group_by_alias
+key: G2N2S1_14_
+setting: enable_group_by_column_first=0
+sql: SELECT i AS k, count(*) FROM t GROUP BY ROLLUP(abs(k))
+status: error
+code: 1065
+message: column k doesn't exist
+
+=== group_by_alias__cube_complex_select_alias_does_not_fallback ===
+matrix: group_by_alias
+key: G3N2S1_14_
+setting: enable_group_by_column_first=0
+sql: SELECT i AS k, count(*) FROM t GROUP BY CUBE(abs(k))
 status: error
 code: 1065
 message: column k doesn't exist

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
@@ -494,3 +494,23 @@ status: error
 code: 1065
 message: column k doesn't exist
 
+=== group_by_alias__combined_normal_complex_select_alias_fallback ===
+matrix: group_by_alias
+key: G4N2S1_14_
+setting: enable_group_by_column_first=0
+sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1, GROUPING SETS (())
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#4) AS (#4), 1 AS (#5)]
+└── Aggregate(Initial)
+    ├── group items: [2 AS (#1), _grouping_id (#3) AS (#3)]
+    ├── aggregate functions: [count() AS (#4)]
+    └── EvalScalar
+        ├── scalars: [2 AS (#1)]
+        └── Scan
+            ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
@@ -360,3 +360,9 @@ regions:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY CUBE(abs(k))"
+      - key: G4N2S1_14_
+        name: combined_normal_complex_select_alias_fallback
+        setup_sqls:
+          - "CREATE TABLE t(i Int32)"
+        runs:
+          - sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1, GROUPING SETS (())"

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
@@ -194,6 +194,35 @@ regions:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, GROUPING SETS ((abs(k)))"
+  - description: complex GROUP BY expressions bind input columns first and fall back to SELECT scalar aliases only for unresolved names
+    main:
+      consumers: [G0]
+      name_shapes: [N2]
+      producers: [S1]
+    local:
+      relation: [input-conflict, no-input, input-ambiguous]
+    cases:
+      - key: G0N2S1_7_0
+        name: group_by_complex_select_alias_conflict_uses_input
+        setup_sqls:
+          - "CREATE TABLE t(i Int32, k Int32)"
+        runs:
+          - sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
+      - key: G0N2S1_7_1
+        name: group_by_complex_select_alias_no_input_fallback
+        setup_sqls:
+          - "CREATE TABLE t(i Int32)"
+        runs:
+          - sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
+          - settings:
+              enable_group_by_column_first: true
+            sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
+      - key: G0N2S1_7_2
+        name: group_by_complex_select_alias_ambiguous_input_rejected
+        setup_sqls:
+          - "CREATE TABLE t(k Int32)"
+        runs:
+          - sql: "SELECT 1 AS k, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY k + 1"
   - description: qualified GROUP BY names included to document why they are outside alias lookup
     main:
       consumers: [G0]
@@ -218,12 +247,12 @@ regions:
     local:
       relation: [input-conflict, no-input]
     cases:
-      - key: G0N0S2_8_0
+      - key: G0N0S2_9_0
         name: group_by_aggregate_alias_conflict_uses_input
         setup_sqls: []
         runs:
           - sql: "SELECT count(*) AS x FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) GROUP BY x"
-      - key: G0N0S2_8_1
+      - key: G0N0S2_9_1
         name: group_by_aggregate_alias_no_input_rejected
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -237,13 +266,13 @@ regions:
     local:
       relation: [input-conflict, no-input]
     cases:
-      - key: G0N0S4_9_0
+      - key: G0N0S4_10_0
         name: group_by_srf_alias_conflict_uses_input
         setup_sqls:
           - "CREATE TABLE t_str(col1 String, col2 String)"
         runs:
           - sql: "SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col2 FROM t_str AS t GROUP BY col1, col2 ORDER BY col2"
-      - key: G0N0S4_9_1
+      - key: G0N0S4_10_1
         name: group_by_srf_alias_no_input
         setup_sqls:
           - "CREATE TABLE t_str(col1 String, col2 String)"
@@ -269,7 +298,7 @@ regions:
       name_shapes: [N4]
       producers: [N0]
     cases:
-      - key: G0N4N0_11_
+      - key: G0N4N0_12_
         name: group_by_ordinal_uses_select_item_position
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -281,7 +310,7 @@ regions:
       name_shapes: [N5]
       producers: [N0]
     cases:
-      - key: G5N5N0_12_
+      - key: G5N5N0_13_
         name: group_by_all_expands_non_aggregate_select_items
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -295,21 +324,39 @@ regions:
       name_shapes: [N0, N1, N2, N3, N4, N5]
       producers: [I0, S0, S1, S2, S3, S4, G0, N0]
     cases:
-      - key: G0N1G0_13_
+      - key: G0N1G0_14_
         name: group_by_qualified_name_does_not_consume_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY k, t.k"
-      - key: G0N3S1_13_
+      - key: G0N3S1_14_
         name: group_by_qualified_complex_does_not_fallback_to_select_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY t.k + 1"
-      - key: G1N1S1_13_
+      - key: G1N1S1_14_
         name: grouping_sets_qualified_name_does_not_fallback_to_select_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((t.k))"
+      - key: G1N2S1_14_
+        name: grouping_sets_complex_select_alias_does_not_fallback
+        setup_sqls:
+          - "CREATE TABLE t(i Int32)"
+        runs:
+          - sql: "SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((abs(k)))"
+      - key: G2N2S1_14_
+        name: rollup_complex_select_alias_does_not_fallback
+        setup_sqls:
+          - "CREATE TABLE t(i Int32)"
+        runs:
+          - sql: "SELECT i AS k, count(*) FROM t GROUP BY ROLLUP(abs(k))"
+      - key: G3N2S1_14_
+        name: cube_complex_select_alias_does_not_fallback
+        setup_sqls:
+          - "CREATE TABLE t(i Int32)"
+        runs:
+          - sql: "SELECT i AS k, count(*) FROM t GROUP BY CUBE(abs(k))"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Allow complex ordinary `GROUP BY` expressions to fall back to SELECT scalar aliases only when input-column resolution is unresolved.

- fixes: #19954

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19958)
<!-- Reviewable:end -->
