### PR TITLE
ci: remove bendsave from release and upgrade github actions

### DIFF
--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
         echo "path=${path}" >> $GITHUB_OUTPUT
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       if: env.RUNNER_PROVIDER == 'github'
       with:
         name: ${{ env.BUILD_PROFILE }}-${{ inputs.sha }}-${{ inputs.target }}-${{ inputs.category }}

--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -24,7 +24,7 @@ runs:
 
         mkdir -p target
         find -type d -name .databend -print0 | xargs -0 tar -zcf target/failure-${{ inputs.name }}.tar.gz
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: target/failure-${{ inputs.name }}.tar.gz

--- a/.github/actions/artifact_meta_container_failure/action.yml
+++ b/.github/actions/artifact_meta_container_failure/action.yml
@@ -31,7 +31,7 @@ runs:
         done
 
         tar -zcf logs/failure-${{ inputs.name }}.tar.gz logs/*
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: logs/failure-${{ inputs.name }}.tar.gz

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Upload artifact to github
       if: env.RUNNER_PROVIDER == 'github'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.BUILD_PROFILE }}-${{ inputs.sha }}-${{ inputs.target }}-${{ inputs.category }}
         path: ${{ steps.info.outputs.path }}/databend-*

--- a/.github/actions/benchmark_cloud/action.yml
+++ b/.github/actions/benchmark_cloud/action.yml
@@ -94,7 +94,7 @@ runs:
         python3 benchmark_cloud.py
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: benchmark-${{ inputs.dataset }}-${{ inputs.size }}-cache-${{ inputs.cache_size }}
         path: |

--- a/.github/actions/benchmark_local/action.yml
+++ b/.github/actions/benchmark_local/action.yml
@@ -54,7 +54,7 @@ runs:
         mv result.json result-${{ inputs.dataset }}-local.json
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: benchmark-${{ inputs.dataset }}-local
         path: benchmark/result-${{ inputs.dataset }}-local.json

--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -85,7 +85,7 @@ runs:
         echo "JEMALLOC_SYS_WITH_MALLOC_CONF=oversize_threshold:0,dirty_decay_ms:5000,muzzy_decay_ms:5000" >> $GITHUB_ENV
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/.github/actions/build_bindings_python/action.yml
+++ b/.github/actions/build_bindings_python/action.yml
@@ -85,7 +85,7 @@ runs:
         echo "JEMALLOC_SYS_WITH_MALLOC_CONF=oversize_threshold:0,dirty_decay_ms:5000,muzzy_decay_ms:5000" >> $GITHUB_ENV
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8
       with:
         enable-cache: true
 

--- a/.github/actions/build_linux/action.yml
+++ b/.github/actions/build_linux/action.yml
@@ -109,7 +109,7 @@ runs:
 
     # - name: Compress Binaries with UPX
     #   if: env.BUILD_PROFILE == 'debug'
-    #   uses: crazy-max/ghaction-upx@v2
+    #   uses: crazy-max/ghaction-upx@v4
     #   with:
     #     files: ./target/${{ inputs.target }}/${{ env.BUILD_PROFILE }}/databend-*
 

--- a/.github/actions/build_macos/action.yml
+++ b/.github/actions/build_macos/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.10
 
     - name: Rust setup
       shell: bash

--- a/.github/actions/check_macos/action.yml
+++ b/.github/actions/check_macos/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.10
       continue-on-error: true
 
     - name: Setup macOS check environment

--- a/.github/actions/pack_binaries/action.yml
+++ b/.github/actions/pack_binaries/action.yml
@@ -57,13 +57,13 @@ runs:
         sha256sum ${pkg_name}.tar.gz >> sha256-${pkg_name}.txt
         echo "pkg_name=$pkg_name" >> $GITHUB_OUTPUT
     - name: post sha256
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sha256sums-${{ inputs.category }}-${{ inputs.target }}
         path: sha256-${{ steps.pack_binaries.outputs.pkg_name }}.txt
         retention-days: 1
     # - name: post binaries
-    #   uses: actions/upload-artifact@v4
+    #   uses: actions/upload-artifact@v7
     #   with:
     #     name: ${{ steps.pack_binaries.outputs.pkg_name }}.tar.gz
     #     path: ${{ steps.pack_binaries.outputs.pkg_name }}.tar.gz

--- a/.github/actions/pack_binaries/action.yml
+++ b/.github/actions/pack_binaries/action.yml
@@ -22,7 +22,7 @@ runs:
         target: ${{ inputs.target }}
         category: ${{ inputs.category }}
         path: distro/bin
-        artifacts: metactl,meta,metabench,query,bendsave
+        artifacts: metactl,meta,metabench,query
     - name: Get Latest BendSQL
       id: bendsql
       uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/actions/setup_docker/action.yml
+++ b/.github/actions/setup_docker/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx for AWS Runner
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       if: env.RUNNER_PROVIDER == 'aws'
       with:
         driver-opts: |
@@ -37,11 +37,11 @@ runs:
         buildkitd-config: ./.github/misc/buildkitd.toml
     - name: Setup Docker Buildx for GitHub Hosted Runner
       if: env.RUNNER_PROVIDER != 'aws'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Configure AWS Credentials
       if: inputs.ecr_role_arn
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.ecr_role_arn }}
         role-duration-seconds: 900
@@ -55,13 +55,13 @@ runs:
 
     - name: Login to DockerHub
       if: inputs.dockerhub_token
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.dockerhub_user }}
         password: ${{ inputs.dockerhub_token }}
 
     - name: Login to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/actions/setup_test/action.yml
+++ b/.github/actions/setup_test/action.yml
@@ -33,7 +33,7 @@ runs:
         artifacts: ${{ inputs.artifacts }}
         path: ${{ inputs.path }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -44,7 +44,7 @@ runs:
         pip install databend_driver
         pip install duckdb
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: "11"

--- a/.github/actions/test_compat_client_cluster/action.yml
+++ b/.github/actions/test_compat_client_cluster/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - uses: wntrblm/nox@2025.05.01
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       if: ${{ inputs.nox_session == 'java_client' }}
       with:
         distribution: temurin
@@ -30,7 +30,7 @@ runs:
 
     - name: Setup Go
       if: ${{ inputs.nox_session == 'go_client' }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: "1.25"
 

--- a/.github/actions/test_sqllogic_iceberg_tpch/action.yml
+++ b/.github/actions/test_sqllogic_iceberg_tpch/action.yml
@@ -17,7 +17,7 @@ runs:
         artifacts: sqllogictests,meta,query
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
 
     - name: Iceberg Setup for (ubuntu-latest only)
       shell: bash

--- a/.github/actions/test_sqllogic_iceberg_tpch/action.yml
+++ b/.github/actions/test_sqllogic_iceberg_tpch/action.yml
@@ -17,7 +17,7 @@ runs:
         artifacts: sqllogictests,meta,query
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
 
     - name: Iceberg Setup for (ubuntu-latest only)
       shell: bash

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get and validate version
@@ -64,7 +64,7 @@ jobs:
       - 4c
       - aws
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build_bindings_python
@@ -89,7 +89,7 @@ jobs:
           - { arch: x86_64, runner: X64 }
           - { arch: aarch64, runner: ARM64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build_bindings_python
@@ -97,7 +97,7 @@ jobs:
           target: ${{ matrix.arch }}-unknown-linux-gnu
           version: ${{ needs.get-version.outputs.version }}
       - name: Upload Linux wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-linux-${{ matrix.arch }}
           path: src/bendpy/dist/*.whl
@@ -113,7 +113,7 @@ jobs:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -132,7 +132,7 @@ jobs:
           target: ${{ matrix.target }}
           version: ${{ needs.get-version.outputs.version }}
       - name: Upload macOS wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-macos-${{ matrix.target }}
           path: src/bendpy/dist/*.whl
@@ -144,8 +144,8 @@ jobs:
     needs: [get-version, test, linux]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: python-*
           merge-multiple: true

--- a/.github/workflows/build_tool.yml
+++ b/.github/workflows/build_tool.yml
@@ -16,7 +16,7 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_docker
         id: login
         with:
@@ -30,7 +30,7 @@ jobs:
           version=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' scripts/setup/rust-toolchain.toml)
           echo "TOOLCHAIN=${version}" >> $GITHUB_OUTPUT
       - name: Build and publish databend build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           pull: true
           push: true
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: debian
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_docker
         id: login
         with:
@@ -59,7 +59,7 @@ jobs:
           version=$(awk -F'[ ="]+' '$1 == "channel" { print $2 }' scripts/setup/rust-toolchain.toml)
           echo "TOOLCHAIN=${version}" >> $GITHUB_OUTPUT
       - name: Build and publish databend build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           pull: true
           push: true

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -26,7 +26,7 @@ jobs:
       sha: ${{ steps.sha.outputs.sha }}
       target: ${{ steps.sha.outputs.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "refs/pull/${{ github.event.number }}/merge"
@@ -59,7 +59,7 @@ jobs:
           - { arch: x86_64, runner: X64, opt_level: s }
           - { arch: aarch64, runner: ARM64, opt_level: 3 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "refs/pull/${{ github.event.number }}/merge"
@@ -92,7 +92,7 @@ jobs:
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifact for x86_64
         uses: ./.github/actions/artifact_download
         with:
@@ -124,7 +124,7 @@ jobs:
           echo "tag=pr-${{ github.event.pull_request.number }}-${short_sha}-${ts}" >> $GITHUB_OUTPUT
       - name: Get Image Tags
         id: tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           REPO_DOCKERHUB: ${{ steps.login.outputs.dockerhub_repo }}
           REPO_ECR: ${{ steps.login.outputs.ecr_repo }}
@@ -139,7 +139,7 @@ jobs:
             }
             core.setOutput('tags', tags.join(','));
       - name: push service image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -8,7 +8,7 @@ jobs:
   deb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/publish_deb
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,11 +21,11 @@ jobs:
       any_src_changed: ${{ steps.src.outputs.any_changed }}
       bendpy_changed: ${{ steps.bendpy.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Source File Changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: src
         with:
           files_ignore: |
@@ -37,7 +37,7 @@ jobs:
             scripts/distribution/**
             .devcontainer/**
       - name: Check Bendpy File Changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: bendpy
         with:
           files: |
@@ -69,7 +69,7 @@ jobs:
     if: needs.changes.outputs.any_src_changed == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/check_macos
@@ -85,7 +85,7 @@ jobs:
       - 4c
       - aws
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build_bindings_python
@@ -103,7 +103,7 @@ jobs:
       - test_bendpy
     steps:
       - name: Check Ready to Merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SRC_CHANGED: ${{ needs.changes.outputs.any_src_changed }}
           BENDPY_CHANGED: ${{ needs.changes.outputs.bendpy_changed }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,11 +10,11 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Restore lychee cache
         id: restore-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -36,7 +36,7 @@ jobs:
             --exclude-path './src/query/service/tests/it/storages/testdata/'
 
       - name: Save lychee cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         if: always()
         with:
           path: .lycheecache
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     outputs:
       any_src_changed: ${{ steps.src.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Source File Changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: src
         with:
           files_ignore: |
@@ -64,7 +64,7 @@ jobs:
       - linux
     steps:
       - name: Check Ready to Merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SRC_CHANGED: ${{ needs.changes.outputs.any_src_changed }}
           LINUX_BUILD_RESULT: ${{ needs.linux.result }}

--- a/.github/workflows/merge_group.yml
+++ b/.github/workflows/merge_group.yml
@@ -23,11 +23,11 @@ jobs:
     outputs:
       any_src_changed: ${{ steps.src.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Source File Changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: src
         with:
           files_ignore: |
@@ -55,7 +55,7 @@ jobs:
     env:
       RUNNER_PROVIDER: aws
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags, metasrv and metaclient need tag as its version.
           fetch-depth: 0
@@ -72,7 +72,7 @@ jobs:
       - check
     steps:
       - name: Check Ready to Merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SRC_CHANGED: ${{ needs.changes.outputs.any_src_changed }}
           CHECK_RESULT: ${{ needs.check.result }}

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -24,7 +24,7 @@ jobs:
       sha: ${{ steps.sha.outputs.sha }}
       target: ${{ steps.sha.outputs.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "refs/pull/${{ github.event.number }}/merge"
@@ -47,7 +47,7 @@ jobs:
         include:
           - { arch: x86_64, runner: X64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: "refs/pull/${{ github.event.number }}/merge"
@@ -68,7 +68,7 @@ jobs:
       - 4c
       - aws
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Download artifact

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,9 +18,9 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check PR title if not sematic
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: check
         with:
           script: |
@@ -66,9 +66,9 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check CLA if not signed
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: check
         with:
           script: |
@@ -109,9 +109,9 @@ jobs:
   description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check PR description checkbox
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: check
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.target }}
-          artifacts: sqllogictests,sqlsmith,query,meta,metactl,metabench,metaverifier,bendsave
+          artifacts: sqllogictests,sqlsmith,query,meta,metactl,metabench,metaverifier
       - name: Basic Sqllogic Test
         shell: bash
         env:
@@ -237,7 +237,7 @@ jobs:
         with:
           sha: ${{ github.sha }}
           target: ${{ matrix.target }}
-          artifacts: sqllogictests,sqlsmith,metactl,meta,query,bendsave
+          artifacts: sqllogictests,sqlsmith,metactl,meta,query
           features: python-udf
           category: docker
 
@@ -389,7 +389,7 @@ jobs:
           sha: ${{ github.sha }}
           target: x86_64-unknown-linux-gnu
           category: default
-          artifacts: metactl,meta,query,bendsave
+          artifacts: metactl,meta,query
           path: distro/linux/amd64
       - name: Download artifacts for aarch64
         uses: ./.github/actions/artifact_download
@@ -397,7 +397,7 @@ jobs:
           sha: ${{ github.sha }}
           target: aarch64-unknown-linux-gnu
           category: default
-          artifacts: metactl,meta,query,bendsave
+          artifacts: metactl,meta,query
           path: distro/linux/arm64
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,12 @@ jobs:
       type: ${{ steps.bump.outputs.type }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Bump version
         id: bump
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TYPE: "${{ inputs.type }}"
           TAG: "${{ inputs.tag }}"
@@ -68,7 +68,7 @@ jobs:
             await script({ github, context, core })
       - name: Generate release notes
         id: notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = '${{ steps.bump.outputs.tag }}';
@@ -124,12 +124,12 @@ jobs:
     if: needs.create_release.outputs.type == 'stable'
     steps:
       - name: Checkout Docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: databendlabs/databend-docs
           ref: main
       - name: Checkout Scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/scripts
           path: databend
@@ -138,7 +138,7 @@ jobs:
         shell: bash
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Generate Release Note
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           VERSION: ${{ needs.create_release.outputs.version }}
           DATE: ${{ steps.date.outputs.DATE }}
@@ -152,7 +152,7 @@ jobs:
         run: |
           git add docs/release-stable
           git status
-      - uses: peter-evans/create-pull-request@v4
+      - uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.DATABEND_BOT_TOKEN }}
           title: "chore(docs): Update Release Notes - ${{ steps.date.outputs.DATE }}"
@@ -177,7 +177,7 @@ jobs:
           - { target: aarch64-unknown-linux-gnu, runner: ARM64, opt_level: 3 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
           fetch-depth: 0
@@ -220,7 +220,7 @@ jobs:
           - { target: aarch64-unknown-linux-gnu, runner: ARM64, opt_level: 3 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
           fetch-depth: 0
@@ -259,7 +259,7 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Pack Binaries
@@ -299,7 +299,7 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Download artifact
@@ -319,7 +319,7 @@ jobs:
           tar -C ./distro -czvf ${pkg_name}.tar.gz bin suites
           sha256sum ${pkg_name}.tar.gz >> sha256-${pkg_name}.txt
       - name: post sha256
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sha256sums-testsuite-${{ matrix.target }}
           path: sha256-*.txt
@@ -355,7 +355,7 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Publish Debug Symbols
@@ -380,7 +380,7 @@ jobs:
       - build_default
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Download artifacts for x86_64
@@ -400,7 +400,7 @@ jobs:
           artifacts: metactl,meta,query
           path: distro/linux/arm64
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - uses: ./.github/actions/setup_docker
         id: login
         with:
@@ -410,7 +410,7 @@ jobs:
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check release SHA is on default branch
         id: default_branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RELEASE_SHA: ${{ needs.create_release.outputs.sha }}
         with:
@@ -427,7 +427,7 @@ jobs:
             core.setOutput('contains_release_sha', containsReleaseSha ? 'true' : 'false');
       - name: Get Image Tags
         id: tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           REPO_DOCKERHUB: ${{ steps.login.outputs.dockerhub_repo }}
           REPO_ECR: ${{ steps.login.outputs.ecr_repo }}
@@ -456,7 +456,7 @@ jobs:
             core.setOutput('tags', tags.join(','));
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
@@ -465,7 +465,7 @@ jobs:
           file: ./docker/Dockerfile
       - name: Update repo description
         continue-on-error: true
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -491,7 +491,7 @@ jobs:
           - query
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Download artifacts for x86_64
@@ -511,7 +511,7 @@ jobs:
           artifacts: ${{ matrix.service }},metactl
           path: distro/linux/arm64
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - uses: ./.github/actions/setup_docker
         id: login
         with:
@@ -521,7 +521,7 @@ jobs:
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check release SHA is on default branch
         id: default_branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RELEASE_SHA: ${{ needs.create_release.outputs.sha }}
         with:
@@ -538,7 +538,7 @@ jobs:
             core.setOutput('contains_release_sha', containsReleaseSha ? 'true' : 'false');
       - name: Get Image Tags
         id: tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           REPO_DOCKERHUB: ${{ steps.login.outputs.dockerhub_repo }}
           REPO_ECR: ${{ steps.login.outputs.ecr_repo }}
@@ -566,7 +566,7 @@ jobs:
             }
             core.setOutput('tags', tags.join(','));
       - name: push service image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
@@ -591,7 +591,7 @@ jobs:
           - aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Pack deb
@@ -620,11 +620,11 @@ jobs:
       - docker_service
       - distribution
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Notify Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           JOBS_STATUS: ${{ join(needs.*.result, ',') }}
           REPORT_WEBHOOK: ${{ secrets.RELEASE_REPORT_WEBHOOK }}
@@ -647,11 +647,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: download sha256sums
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sha256sums-*
           merge-multiple: true
@@ -680,7 +680,7 @@ jobs:
       - create_release
       - notify
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Download artifacts
@@ -712,7 +712,7 @@ jobs:
       - create_release
       - notify
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.create_release.outputs.sha }}
       - name: Download artifacts
@@ -731,7 +731,7 @@ jobs:
           name: meta-io-delay-chaos
       - name: Notify failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           REPORT_WEBHOOK: ${{ secrets.META_REPORT_WEBHOOK }}
           TITLE: Meta Service chaos tests failed

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Retry failed jobs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}

--- a/.github/workflows/reuse.benchmark.yml
+++ b/.github/workflows/reuse.benchmark.yml
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/download-artifact@v8
         with:
           path: benchmark/results
@@ -252,7 +252,7 @@ jobs:
           - "internal"
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/download-artifact@v8
         with:
           path: benchmark/results

--- a/.github/workflows/reuse.benchmark.yml
+++ b/.github/workflows/reuse.benchmark.yml
@@ -56,16 +56,16 @@ jobs:
     env:
       RUNNER_PROVIDER: aws
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'release'
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'pr'
         with:
           ref: "refs/pull/${{ inputs.source_id }}/merge"
       - uses: ./.github/actions/setup_bendsql
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Download artifact
@@ -95,11 +95,11 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'release'
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'pr'
         with:
           ref: "refs/pull/${{ inputs.source_id }}/merge"
@@ -148,11 +148,11 @@ jobs:
       fail-fast: true
       max-parallel: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'release'
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.source == 'pr'
         with:
           ref: "refs/pull/${{ inputs.source_id }}/merge"
@@ -188,9 +188,9 @@ jobs:
     if: inputs.source == 'pr'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
+      - uses: actions/download-artifact@v8
         with:
           path: benchmark/results
           pattern: benchmark-*
@@ -251,9 +251,9 @@ jobs:
           - "tpch1000"
           - "internal"
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
+      - uses: actions/download-artifact@v8
         with:
           path: benchmark/results
           pattern: benchmark-${{ matrix.dataset }}-*

--- a/.github/workflows/reuse.explain.yml
+++ b/.github/workflows/reuse.explain.yml
@@ -21,7 +21,7 @@ jobs:
   cloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup_bendsql
 
@@ -71,7 +71,7 @@ jobs:
           verbose: 'true'
 
       - name: Upload Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: explainb-report
           path: report.html

--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -56,11 +56,11 @@ jobs:
     outputs:
       any_changed: ${{ steps.proxy.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check PROXY benchmark related changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: proxy
         with:
           files: |
@@ -81,7 +81,7 @@ jobs:
       - 8c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags, metasrv and metaclient need tag as its version.
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
       - 16c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags, metasrv and meta client need tag as its version.
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
           artifacts: all
       - name: upload sccache log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sccache-build-${{ needs.info.outputs.target }}
           path: target/sccache.log
@@ -132,7 +132,7 @@ jobs:
       - 16c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags, metasrv and metaclient need tag as its version.
           fetch-depth: 0
@@ -150,7 +150,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_metactl
         timeout-minutes: 10
 
@@ -163,7 +163,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_meta_query
         timeout-minutes: 10
 
@@ -176,7 +176,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_fuse
         timeout-minutes: 20
 
@@ -189,7 +189,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_meta_meta
         timeout-minutes: 20
 
@@ -202,7 +202,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_client_cluster
         with:
           nox_session: python_client
@@ -217,7 +217,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_client_cluster
         with:
           nox_session: java_client
@@ -232,7 +232,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_compat_client_cluster
         with:
           nox_session: go_client
@@ -247,7 +247,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -264,7 +264,7 @@ jobs:
       - 8c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -303,7 +303,7 @@ jobs:
       WARMUP_ROUNDS: "0"
       MEASURE_ROUNDS: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_test
         with:
           artifacts: meta,query
@@ -320,7 +320,7 @@ jobs:
       - 8c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -337,7 +337,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_meta_cluster
         timeout-minutes: 10
 
@@ -350,7 +350,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateless_standalone_linux
         timeout-minutes: 25
 
@@ -363,7 +363,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -380,7 +380,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateful_standalone_linux
         timeout-minutes: 15
       - name: Upload failure
@@ -398,7 +398,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -421,7 +421,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateful_large_data
         timeout-minutes: 60
 
@@ -434,7 +434,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateful_iceberg_catalogs_standalone
         timeout-minutes: 10
       - name: Upload failure
@@ -453,7 +453,7 @@ jobs:
   #     - 2c
   #     - "${{ inputs.runner_provider }}"
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #     - uses: ./.github/actions/test_stateful_hive_standalone
   #       timeout-minutes: 10
   #     - name: Upload failure
@@ -471,7 +471,7 @@ jobs:
   #     - 2c
   #     - "${{ inputs.runner_provider }}"
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #     - uses: ./.github/actions/test_fuzz_standalone_linux
   #       timeout-minutes: 10
   #       continue-on-error: true
@@ -485,7 +485,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -512,7 +512,7 @@ jobs:
   #      - 2c
   #      - "${{ inputs.runner_provider }}"
   #    steps:
-  #      - uses: actions/checkout@v4
+  #      - uses: actions/checkout@v6
   #      - uses: ./.github/actions/setup_license
   #        with:
   #          runner_provider: ${{ inputs.runner_provider }}
@@ -534,7 +534,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_bendsql
       - uses: ./.github/actions/setup_license
         with:

--- a/.github/workflows/reuse.macos.yml
+++ b/.github/workflows/reuse.macos.yml
@@ -22,7 +22,7 @@ jobs:
           - x86_64
           - aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags,  metasrv and metaclient need tag as its version.
           fetch-depth: 0
@@ -34,14 +34,14 @@ jobs:
     runs-on: macos-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateless_standalone_macos
 
   test_stateless_cluster:
     runs-on: macos-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_stateless_cluster_macos
         timeout-minutes: 30
 
@@ -53,7 +53,7 @@ jobs:
         dirs:
           - "base"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_standalone_macos
         timeout-minutes: 20
         with:

--- a/.github/workflows/reuse.sqllogic.yml
+++ b/.github/workflows/reuse.sqllogic.yml
@@ -37,7 +37,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_management_mode_linux
         timeout-minutes: 10
         with:
@@ -67,7 +67,7 @@ jobs:
           - "hybrid"
           - "http"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_standalone_linux
         timeout-minutes: 20
         with:
@@ -89,9 +89,9 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
       - uses: ./.github/actions/setup_minio
       - name: Start UDF Server
         working-directory: tests/udf
@@ -120,9 +120,9 @@ jobs:
       - 4c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
       - name: Start Cloud Control Server
         working-directory: tests/cloud_control_server
         run: |
@@ -160,7 +160,7 @@ jobs:
           - "native"
           - "parquet"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_standalone_linux_minio
         timeout-minutes: 15
         with:
@@ -181,7 +181,7 @@ jobs:
       - 2c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -209,7 +209,7 @@ jobs:
         handler:
           - "ttc-rust"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_test
         with:
           artifacts: sqllogictests,meta,query
@@ -235,8 +235,8 @@ jobs:
       - 4c
       - "${{ inputs.runner_provider }}"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
@@ -274,7 +274,7 @@ jobs:
           - "hybrid"
           - "http"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}
@@ -314,7 +314,7 @@ jobs:
           - "small"
           - "large"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_stage
         timeout-minutes: 15
         with:
@@ -344,7 +344,7 @@ jobs:
         handler:
           - "http"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/test_sqllogic_standalone_linux
         timeout-minutes: 15
         with:
@@ -372,7 +372,7 @@ jobs:
           - "parquet"
           - "native"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_license
         with:
           runner_provider: ${{ inputs.runner_provider }}

--- a/.github/workflows/reuse.sqllogic.yml
+++ b/.github/workflows/reuse.sqllogic.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - uses: ./.github/actions/setup_minio
       - name: Start UDF Server
         working-directory: tests/udf
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Start Cloud Control Server
         working-directory: tests/cloud_control_server
         run: |

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check spelling
         env:
           CLICOLOR: 1
-        uses: crate-ci/typos@v1.33.1
+        uses: crate-ci/typos@v1.47.2

--- a/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
+++ b/src/query/storages/common/cache/tests/it/providers/disk_cache.rs
@@ -160,7 +160,7 @@ fn test_evict_until_enough_space() {
     // file1 and file2 MUST be evicted
     assert!(!c.contains_key("file1"));
     assert!(!c.contains_key("file2"));
-    // file3 MUST be keeped
+    // file3 MUST be kept
     assert!(c.contains_key("file3"));
 }
 

--- a/src/query/storages/fuse/src/pruning/block_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/block_pruner.rs
@@ -533,7 +533,7 @@ struct BlockPruneResult {
     block_location: String,
     // whether keep the block after pruning
     keep: bool,
-    // the page ranges should keeped in the block
+    // the page ranges should be kept in the block
     range: Option<Range<usize>>,
     // the matched rows in the block (aligned with `matched_scores` when present)
     // only used by inverted index search

--- a/src/query/storages/parquet/src/parquet_reader/topk.rs
+++ b/src/query/storages/parquet/src/parquet_reader/topk.rs
@@ -69,7 +69,7 @@ impl ParquetTopK {
     }
 }
 
-/// The information used for evalaute TopK.
+/// The information used for evaluate TopK.
 pub struct BuiltTopK {
     pub topk: Arc<ParquetTopK>,
     pub field: TableField,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Remove bendsave from release artifacts (binaries and docker images). CI build and test pipelines still build and test bendsave as before.
- Upgrade all GitHub Actions to their latest major versions.

### Actions upgraded

| Action | From | To |
|--------|------|----|
| actions/checkout | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/cache | v3 | v5 |
| actions/setup-python | v5 | v6 |
| actions/setup-go | v5 | v6 |
| actions/setup-java | v4 | v5 |
| actions/github-script | v7 | v9 |
| docker/build-push-action | v5 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| aws-actions/configure-aws-credentials | v4 | v6 |
| mozilla-actions/sccache-action | v0.0.3 | v0.0.10 |
| crazy-max/ghaction-upx | v2 | v4 |
| peter-evans/create-pull-request | v4 | v8 |
| peter-evans/create-issue-from-file | v4 | v6 |
| peter-evans/dockerhub-description | v4 | v5 |
| astral-sh/setup-uv | v5/v7 | v8 |
| tj-actions/changed-files | v46 | v47 |
| crate-ci/typos | v1.33.1 | v1.47.2 |

## Tests

- [x] No Test - CI configuration changes only

## Type of change

- [x] Refactoring

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19964)
<!-- Reviewable:end -->
