### PR TITLE
fix: propagate config file error with context instead of unwrap

### DIFF
--- a/src/binaries/query/cmd.rs
+++ b/src/binaries/query/cmd.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 use clap::Subcommand;
 use databend_common_config::Config;
 use databend_common_config::InnerConfig;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_version::DATABEND_COMMIT_VERSION;
 
@@ -55,7 +56,12 @@ impl Cmd {
             ..
         } = self;
 
-        let config = config.merge(&config_file).unwrap();
+        let config = config.merge(&config_file).map_err(|e| {
+            ErrorCode::Internal(format!(
+                "failed to load config file {:?}: {}",
+                config_file, e
+            ))
+        })?;
         InnerConfig::init(config, check_meta).await
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When `databend-query` is started with `-c` pointing to a non-existent 
config file, the process panicked with a confusing `unwrap()` backtrace 
instead of a clean error message.

- fixes: #19961 

## Root cause

In `src/binaries/query/cmd.rs`, the result of `.merge()` was unwrapped 
instead of propagated:

```rust
// before
let config = config.merge(&config_file).unwrap();
```

## Changes

Replace `.unwrap()` with `.map_err()` to propagate a structured error 
that includes the offending file path:

```rust
// after
use databend_common_exception::ErrorCode;

let config = config
    .merge(&config_file)
    .map_err(|e| {
        ErrorCode::Internal(format!(
            "failed to load config file {:?}: {}",
            config_file, e
        ))
    })?;
```

## Output

<img width="1613" height="187" alt="image" src="https://github.com/user-attachments/assets/3b672266-5a45-4c33-b82c-a6a288a0f4a1" />

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - error propagation change only, no new logic to test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19972)
<!-- Reviewable:end -->
