### PR TITLE
refactor(meta): remove kvapi::Value impls for blanket marker trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked-wal"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb4664e0ebe1a145b88ebc9973327512d3997f796ce49d41b08196cf0d51285"
+dependencies = [
+ "base2histogram",
+ "byteorder",
+ "codeq 0.6.1",
+ "fs2",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cidr"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3008,19 @@ name = "codeq"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a72a59f33777d39160f5b4a8a258732cb6b538607c28b65eaa3b96f7cd35b994"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "crc32fast",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "codeq"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8fe1daf1baea90d2ac126b40786bb514d07e7a8d9389773f81aef62f4fef91"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3757,7 +3784,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3865,7 +3892,7 @@ dependencies = [
  "databend-common-exception",
  "enquote",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libc",
  "log",
  "micromarshal",
@@ -3943,7 +3970,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -4057,7 +4084,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "log",
  "serde",
  "serde_ignored",
@@ -4297,7 +4324,7 @@ dependencies = [
  "anyhow",
  "databend-common-base",
  "databend-common-exception",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "hyper 1.8.1",
  "hyper-util",
  "log",
@@ -4404,7 +4431,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -4432,7 +4459,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "display-more 0.2.6",
  "fastrace",
  "futures",
@@ -4467,7 +4494,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "derive_more 1.0.0",
  "display-more 0.2.6",
  "encoding_rs",
@@ -4511,7 +4538,7 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "display-more 0.2.6",
  "futures",
@@ -4553,7 +4580,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "fastrace",
  "log",
  "maplit",
@@ -4569,7 +4596,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4585,7 +4612,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4707,7 +4734,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "enumflags2",
  "fastrace",
  "log",
@@ -4814,7 +4841,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4940,7 +4967,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -5038,7 +5065,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -5098,7 +5125,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
  "fastrace",
@@ -5136,7 +5163,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -5342,7 +5369,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -5435,7 +5462,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5496,7 +5523,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
 ]
 
 [[package]]
@@ -5568,7 +5595,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5596,7 +5623,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
 ]
 
 [[package]]
@@ -5608,7 +5635,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
 ]
 
 [[package]]
@@ -5760,8 +5787,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5771,13 +5798,13 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260512.3.0",
- "databend-meta-kvapi 260512.3.0",
+ "databend-meta-client 260512.4.0",
+ "databend-meta-kvapi 260512.4.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260512.3.0",
+ "databend-meta-runtime-api 260512.4.0",
  "databend-meta-sled-store",
- "databend-meta-types 260512.3.0",
- "databend-meta-version 260512.3.0",
+ "databend-meta-types 260512.4.0",
+ "databend-meta-version 260512.4.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -5838,8 +5865,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5873,7 +5900,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
@@ -5910,19 +5937,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.10.0",
- "databend-meta-kvapi-test-suite 260205.10.0",
- "databend-meta-runtime-api 260205.10.0",
- "databend-meta-types 260205.10.0",
- "databend-meta-version 260205.10.0",
+ "databend-meta-kvapi 260205.11.0",
+ "databend-meta-kvapi-test-suite 260205.11.0",
+ "databend-meta-runtime-api 260205.11.0",
+ "databend-meta-types 260205.11.0",
+ "databend-meta-version 260205.11.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5942,8 +5969,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
@@ -5952,10 +5979,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260512.3.0",
- "databend-meta-kvapi-test-suite 260512.3.0",
- "databend-meta-runtime-api 260512.3.0",
- "databend-meta-version 260512.3.0",
+ "databend-meta-kvapi 260512.4.0",
+ "databend-meta-kvapi-test-suite 260512.4.0",
+ "databend-meta-runtime-api 260512.4.0",
+ "databend-meta-version 260512.4.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5976,8 +6003,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -6000,18 +6027,18 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "async-trait",
- "databend-meta-types 260205.10.0",
+ "databend-meta-types 260205.11.0",
  "display-more 0.2.6",
  "futures-util",
  "log",
@@ -6021,8 +6048,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -6035,12 +6062,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.10.0",
- "databend-meta-types 260205.10.0",
+ "databend-meta-kvapi 260205.11.0",
+ "databend-meta-types 260205.11.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -6051,12 +6078,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260512.3.0",
+ "databend-meta-kvapi 260512.4.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -6071,7 +6098,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -6088,8 +6115,8 @@ name = "databend-meta-plugin-semaphore"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "codeq",
- "databend-meta-client 260205.10.0",
+ "codeq 0.5.2",
+ "databend-meta-client 260205.11.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
@@ -6107,8 +6134,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6130,18 +6157,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260512.3.0",
- "databend-meta-runtime-api 260512.3.0",
+ "databend-meta-kvapi 260512.4.0",
+ "databend-meta-runtime-api 260512.4.0",
  "databend-meta-sled-store",
- "databend-meta-types 260512.3.0",
+ "databend-meta-types 260512.4.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -6178,7 +6205,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "fastrace",
  "hyper-util",
  "tokio",
@@ -6187,11 +6214,11 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "env_logger 0.11.8",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "log",
  "thiserror 1.0.69",
  "tokio",
@@ -6200,11 +6227,11 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "env_logger 0.11.8",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "log",
  "thiserror 1.0.69",
  "tokio",
@@ -6213,12 +6240,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260512.3.0",
+ "databend-meta-types 260512.4.0",
  "fastrace",
  "log",
  "serde",
@@ -6231,14 +6258,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260512.3.0",
- "databend-meta-types 260512.3.0",
+ "databend-meta-runtime-api 260512.4.0",
+ "databend-meta-types 260512.4.0",
  "fastrace",
  "log",
  "tempfile",
@@ -6248,8 +6275,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -6276,8 +6303,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6311,16 +6338,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.10.0"
-source = "git+https://github.com/drmingdrmer/databend-meta.git?tag=v260205.10.0#dcbd65b5f7a5adc258fcf8f119029ebf00dceb0e"
+version = "260205.11.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.11.0#ea61fd47b444c2ea0abbda638acc22e84327cccf"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260512.3.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.3.0#80bb122ecac36c46c85ec5a98907dbb74c0e006a"
+version = "260512.4.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260512.4.0#2bd1a2beda70dedf2f726ef94ce414adc832074b"
 dependencies = [
  "semver",
 ]
@@ -6414,7 +6441,7 @@ dependencies = [
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
  "databend-enterprise-virtual-column",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6766,7 +6793,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.10.0",
+ "databend-meta-client 260205.11.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -9814,6 +9841,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9839,6 +9890,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9846,7 +9917,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -9854,6 +9925,32 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10168,8 +10265,8 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
- "system-configuration",
+ "socket2 0.6.3",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -10741,6 +10838,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -10953,6 +11053,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12350,6 +12499,12 @@ dependencies = [
  "num-traits",
  "rawpointer",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -13864,6 +14019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14637,15 +14803,15 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "raft-log"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b38acccc1f19eac73c16dbfaf5eecf0ea4f6af71844ef06acd297d5311ab0cc"
+checksum = "4290f29c4516c8bbd0bf3ce01d59db968dfc071d056e458ff38e74457473c506"
 dependencies = [
  "base2histogram",
  "byteorder",
- "codeq",
+ "chunked-wal",
+ "codeq 0.6.1",
  "display-more 0.2.6",
- "fs2",
  "log",
  "thiserror 1.0.69",
 ]
@@ -15102,7 +15268,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4466c6958bbbd3024ace15426f7b5369222c0ad517167d10056fd5cc76aec99b"
 dependencies = [
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "rand 0.9.2",
  "reqwest",
 ]
@@ -15284,7 +15450,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
- "codeq",
+ "codeq 0.5.2",
  "futures",
  "futures-async-stream",
  "log",
@@ -16150,6 +16316,16 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -17147,6 +17323,17 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,11 +168,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260512.3.0"
-databend-meta-test-harness = "260512.3.0"
+databend-meta = "260512.4.0"
+databend-meta-test-harness = "260512.4.0"
 
 # External meta client
-databend-meta-client = "260205.10.0"
+databend-meta-client = "260205.11.0"
 structkey = "0.1.1"
 
 # Crates.io dependencies
@@ -632,9 +632,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260512.3.0" }
-databend-meta-client = { git = "https://github.com/drmingdrmer/databend-meta.git", tag = "v260205.10.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260512.3.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260512.4.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.11.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260512.4.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 lance-arrow = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-core = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }

--- a/src/meta/app/src/data_id.rs
+++ b/src/meta/app/src/data_id.rs
@@ -208,6 +208,7 @@ mod prost_message_impl {
 
         #[derive(Debug, Default, PartialEq, Eq, kvapi::StructKey)]
         #[structkey(prefix = "foo")]
+        #[allow(dead_code)]
         struct Foo {
             id: u64,
         }
@@ -218,10 +219,6 @@ mod prost_message_impl {
 
         #[derive(Debug)]
         struct Bar;
-
-        impl kvapi::Value for Bar {
-            type KeyType = Foo;
-        }
 
         #[test]
         fn test_id_as_protobuf_message() {

--- a/src/meta/app/src/data_mask/data_mask_id_ident.rs
+++ b/src/meta/app/src/data_mask/data_mask_id_ident.rs
@@ -43,9 +43,6 @@ impl DataMaskIdIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::data_mask::DataMaskIdIdent;
     use crate::data_mask::DatamaskMeta;
     use crate::tenant_key::resource::TenantResource;
 
@@ -55,10 +52,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DataMaskIdIdent";
         const HAS_TENANT: bool = false;
         type ValueType = DatamaskMeta;
-    }
-
-    impl kvapi::Value for DatamaskMeta {
-        type KeyType = DataMaskIdIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/data_mask/data_mask_id_to_name_ident.rs
+++ b/src/meta/app/src/data_mask/data_mask_id_to_name_ident.rs
@@ -38,9 +38,6 @@ impl DataMaskIdToNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::data_mask::data_mask_id_to_name_ident::DataMaskIdToNameIdent;
     use crate::data_mask::data_mask_name_ident::DataMaskNameIdentRaw;
     use crate::tenant_key::resource::TenantResource;
 
@@ -50,10 +47,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DataMaskIdToNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = DataMaskNameIdentRaw;
-    }
-
-    impl kvapi::Value for DataMaskNameIdentRaw {
-        type KeyType = DataMaskIdToNameIdent;
     }
 }
 

--- a/src/meta/app/src/data_mask/data_mask_name_ident.rs
+++ b/src/meta/app/src/data_mask/data_mask_name_ident.rs
@@ -34,10 +34,7 @@ impl DataMaskNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::data_mask::DataMaskId;
-    use crate::data_mask::DataMaskNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -46,10 +43,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DataMaskNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = DataMaskId;
-    }
-
-    impl kvapi::Value for DataMaskId {
-        type KeyType = DataMaskNameIdent;
     }
 }
 

--- a/src/meta/app/src/data_mask/mask_policy_policy_table_id_ident.rs
+++ b/src/meta/app/src/data_mask/mask_policy_policy_table_id_ident.rs
@@ -33,10 +33,7 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::data_mask::MaskPolicyTableId;
-    use crate::data_mask::mask_policy_policy_table_id_ident::MaskPolicyTableIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -45,10 +42,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "MaskPolicyTableIdIdent";
         const HAS_TENANT: bool = true;
         type ValueType = MaskPolicyTableId;
-    }
-
-    impl kvapi::Value for MaskPolicyTableId {
-        type KeyType = MaskPolicyTableIdIdent;
     }
 }
 

--- a/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
+++ b/src/meta/app/src/data_mask/mask_policy_table_id_list_ident.rs
@@ -22,9 +22,6 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::data_mask::MaskPolicyTableIdListIdent;
     use crate::data_mask::MaskpolicyTableIdList;
     use crate::tenant_key::resource::TenantResource;
 
@@ -34,10 +31,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "MaskPolicyTableIdListIdent";
         const HAS_TENANT: bool = true;
         type ValueType = MaskpolicyTableIdList;
-    }
-
-    impl kvapi::Value for MaskpolicyTableIdList {
-        type KeyType = MaskPolicyTableIdListIdent;
     }
 }
 

--- a/src/meta/app/src/id_generator.rs
+++ b/src/meta/app/src/id_generator.rs
@@ -124,10 +124,6 @@ impl kvapi::Key for IdGenerator {
 #[derive(Debug)]
 pub struct IdGeneratorValue;
 
-impl kvapi::Value for IdGeneratorValue {
-    type KeyType = IdGenerator;
-}
-
 #[cfg(test)]
 mod t {
 

--- a/src/meta/app/src/principal/client_session_ident.rs
+++ b/src/meta/app/src/principal/client_session_ident.rs
@@ -28,10 +28,7 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::principal::client_session::ClientSession;
-    use crate::principal::client_session_ident::ClientSessionIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -40,10 +37,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "ClientSession";
         const HAS_TENANT: bool = true;
         type ValueType = ClientSession;
-    }
-
-    impl kvapi::Value for ClientSession {
-        type KeyType = ClientSessionIdent;
     }
 }
 

--- a/src/meta/app/src/principal/connection_ident.rs
+++ b/src/meta/app/src/principal/connection_ident.rs
@@ -25,7 +25,6 @@ mod kvapi_impl {
     use databend_meta_client::kvapi;
 
     use crate::principal::UserDefinedConnection;
-    use crate::principal::connection_ident::ConnectionIdent;
     use crate::tenant_key::errors::ExistError;
     use crate::tenant_key::errors::UnknownError;
     use crate::tenant_key::resource::TenantResource;
@@ -36,10 +35,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "ConnectionIdent";
         const HAS_TENANT: bool = true;
         type ValueType = UserDefinedConnection;
-    }
-
-    impl kvapi::Value for UserDefinedConnection {
-        type KeyType = ConnectionIdent;
     }
 
     impl kvapi::ValueWithName for UserDefinedConnection {

--- a/src/meta/app/src/principal/network_policy_ident.rs
+++ b/src/meta/app/src/principal/network_policy_ident.rs
@@ -25,7 +25,6 @@ mod kvapi_impl {
     use databend_meta_client::kvapi;
 
     use crate::principal::NetworkPolicy;
-    use crate::principal::NetworkPolicyIdent;
     use crate::tenant_key::errors::ExistError;
     use crate::tenant_key::errors::UnknownError;
     use crate::tenant_key::resource::TenantResource;
@@ -36,10 +35,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "NetworkPolicyIdent";
         const HAS_TENANT: bool = true;
         type ValueType = NetworkPolicy;
-    }
-
-    impl kvapi::Value for NetworkPolicy {
-        type KeyType = NetworkPolicyIdent;
     }
 
     impl kvapi::ValueWithName for NetworkPolicy {

--- a/src/meta/app/src/principal/password_policy_ident.rs
+++ b/src/meta/app/src/principal/password_policy_ident.rs
@@ -25,7 +25,6 @@ mod kvapi_impl {
     use databend_meta_client::kvapi;
 
     use crate::principal::PasswordPolicy;
-    use crate::principal::PasswordPolicyIdent;
     use crate::tenant_key::errors::ExistError;
     use crate::tenant_key::errors::UnknownError;
     use crate::tenant_key::resource::TenantResource;
@@ -37,10 +36,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "PasswordPolicyIdent";
         const HAS_TENANT: bool = true;
         type ValueType = PasswordPolicy;
-    }
-
-    impl kvapi::Value for PasswordPolicy {
-        type KeyType = PasswordPolicyIdent;
     }
 
     impl kvapi::ValueWithName for PasswordPolicy {

--- a/src/meta/app/src/principal/procedure_id_ident.rs
+++ b/src/meta/app/src/principal/procedure_id_ident.rs
@@ -42,10 +42,7 @@ impl ProcedureIdIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::principal::ProcedureMeta;
-    use crate::principal::procedure_id_ident::ProcedureIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -54,10 +51,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "ProcedureIdIdent";
         const HAS_TENANT: bool = false;
         type ValueType = ProcedureMeta;
-    }
-
-    impl kvapi::Value for ProcedureMeta {
-        type KeyType = ProcedureIdIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/principal/procedure_id_to_name.rs
+++ b/src/meta/app/src/principal/procedure_id_to_name.rs
@@ -36,10 +36,7 @@ impl ProcedureIdToNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::principal::ProcedureIdentity;
-    use crate::principal::procedure_id_to_name::ProcedureIdToNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     // TODO(TIdent): parent should return Some(ProcedureIdIdent::new(self.procedure_id).to_string_key())
@@ -49,10 +46,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "ProcedureIdToNameIdent";
         const HAS_TENANT: bool = false;
         type ValueType = ProcedureIdentity;
-    }
-
-    impl kvapi::Value for ProcedureIdentity {
-        type KeyType = ProcedureIdToNameIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/principal/procedure_name_ident.rs
+++ b/src/meta/app/src/principal/procedure_name_ident.rs
@@ -35,9 +35,7 @@ impl ProcedureNameIdent {
 }
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
-    use crate::principal::ProcedureNameIdent;
     use crate::principal::procedure_id_ident::ProcedureId;
     use crate::tenant_key::resource::TenantResource;
 
@@ -46,10 +44,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_procedure";
         const HAS_TENANT: bool = true;
         type ValueType = ProcedureId;
-    }
-
-    impl kvapi::Value for ProcedureId {
-        type KeyType = ProcedureNameIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/principal/role_ident.rs
+++ b/src/meta/app/src/principal/role_ident.rs
@@ -37,9 +37,7 @@ impl RoleIdentRaw {
 mod kvapi_impl {
 
     use databend_common_exception::ErrorCode;
-    use databend_meta_client::kvapi;
 
-    use crate::principal::RoleIdent;
     use crate::principal::RoleInfo;
     use crate::tenant_key::errors::UnknownError;
     use crate::tenant_key::resource::TenantResource;
@@ -50,10 +48,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "RoleIdent";
         const HAS_TENANT: bool = true;
         type ValueType = RoleInfo;
-    }
-
-    impl kvapi::Value for RoleInfo {
-        type KeyType = RoleIdent;
     }
 
     // ExistError<Resource> is no longer produced: create_role returns bool.

--- a/src/meta/app/src/principal/stage_file_ident.rs
+++ b/src/meta/app/src/principal/stage_file_ident.rs
@@ -44,9 +44,6 @@ impl StageFileIdent {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use super::StageFileIdent;
     use crate::principal::StageFile;
     use crate::tenant_key::resource::TenantResource;
 
@@ -56,10 +53,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "StageFileIdent";
         const HAS_TENANT: bool = true;
         type ValueType = StageFile;
-    }
-
-    impl kvapi::Value for StageFile {
-        type KeyType = StageFileIdent;
     }
 }
 

--- a/src/meta/app/src/principal/task_ident.rs
+++ b/src/meta/app/src/principal/task_ident.rs
@@ -21,10 +21,8 @@ pub type TaskIdentRaw = TIdent<Resource>;
 pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use crate::principal::task::Task;
-    use crate::principal::task_ident::TaskIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -33,9 +31,5 @@ mod kvapi_impl {
         const TYPE: &'static str = "TaskIdent";
         const HAS_TENANT: bool = true;
         type ValueType = Task;
-    }
-
-    impl kvapi::Value for Task {
-        type KeyType = TaskIdent;
     }
 }

--- a/src/meta/app/src/principal/task_message_ident.rs
+++ b/src/meta/app/src/principal/task_message_ident.rs
@@ -21,10 +21,8 @@ pub type TaskMessageIdentRaw = TIdent<Resource>;
 pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use crate::principal::task::TaskMessage;
-    use crate::principal::task_message_ident::TaskMessageIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -33,9 +31,5 @@ mod kvapi_impl {
         const TYPE: &'static str = "TaskMessageIdent";
         const HAS_TENANT: bool = true;
         type ValueType = TaskMessage;
-    }
-
-    impl kvapi::Value for TaskMessage {
-        type KeyType = TaskMessageIdent;
     }
 }

--- a/src/meta/app/src/principal/tenant_ownership_object_ident.rs
+++ b/src/meta/app/src/principal/tenant_ownership_object_ident.rs
@@ -77,10 +77,7 @@ impl TenantOwnershipObjectIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::principal::OwnershipInfo;
-    use crate::principal::TenantOwnershipObjectIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -89,10 +86,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TenantOwnershipObjectIdent";
         const HAS_TENANT: bool = true;
         type ValueType = OwnershipInfo;
-    }
-
-    impl kvapi::Value for OwnershipInfo {
-        type KeyType = TenantOwnershipObjectIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/principal/tenant_user_ident.rs
+++ b/src/meta/app/src/principal/tenant_user_ident.rs
@@ -36,9 +36,7 @@ impl TenantUserIdent {
 
 mod kvapi_impl {
     use databend_common_exception::ErrorCode;
-    use databend_meta_client::kvapi;
 
-    use crate::principal::TenantUserIdent;
     use crate::principal::UserIdentity;
     use crate::principal::UserInfo;
     use crate::tenant_key::errors::ExistError;
@@ -63,10 +61,6 @@ mod kvapi_impl {
         fn from(err: UnknownError<Resource, UserIdentity>) -> Self {
             ErrorCode::UnknownUser(format!("User {} does not exist.", err.name().display()))
         }
-    }
-
-    impl kvapi::Value for UserInfo {
-        type KeyType = TenantUserIdent;
     }
 }
 

--- a/src/meta/app/src/principal/udf_ident.rs
+++ b/src/meta/app/src/principal/udf_ident.rs
@@ -36,9 +36,6 @@ impl UdfIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::principal::UdfIdent;
     use crate::principal::UserDefinedFunction;
     use crate::tenant_key::resource::TenantResource;
 
@@ -48,10 +45,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "UdfIdent";
         const HAS_TENANT: bool = true;
         type ValueType = UserDefinedFunction;
-    }
-
-    impl kvapi::Value for UserDefinedFunction {
-        type KeyType = UdfIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/principal/user_defined_file_format_ident.rs
+++ b/src/meta/app/src/principal/user_defined_file_format_ident.rs
@@ -25,7 +25,6 @@ mod kvapi_impl {
     use databend_meta_client::kvapi;
 
     use crate::principal::UserDefinedFileFormat;
-    use crate::principal::user_defined_file_format_ident::UserDefinedFileFormatIdent;
     use crate::tenant_key::errors::ExistError;
     use crate::tenant_key::errors::UnknownError;
     use crate::tenant_key::resource::TenantResource;
@@ -36,10 +35,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "UserDefinedFileFormatIdent";
         const HAS_TENANT: bool = true;
         type ValueType = UserDefinedFileFormat;
-    }
-
-    impl kvapi::Value for UserDefinedFileFormat {
-        type KeyType = UserDefinedFileFormatIdent;
     }
 
     impl kvapi::ValueWithName for UserDefinedFileFormat {

--- a/src/meta/app/src/principal/user_setting_ident.rs
+++ b/src/meta/app/src/principal/user_setting_ident.rs
@@ -21,9 +21,6 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::principal::SettingIdent;
     use crate::principal::UserSetting;
     use crate::tenant_key::resource::TenantResource;
 
@@ -33,10 +30,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "SettingIdent";
         const HAS_TENANT: bool = true;
         type ValueType = UserSetting;
-    }
-
-    impl kvapi::Value for UserSetting {
-        type KeyType = SettingIdent;
     }
 }
 

--- a/src/meta/app/src/principal/user_stage_ident.rs
+++ b/src/meta/app/src/principal/user_stage_ident.rs
@@ -35,9 +35,6 @@ impl StageIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use super::StageIdent;
     use crate::principal::StageInfo;
     use crate::tenant_key::resource::TenantResource;
 
@@ -47,10 +44,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "StageIdent";
         const HAS_TENANT: bool = true;
         type ValueType = StageInfo;
-    }
-
-    impl kvapi::Value for StageInfo {
-        type KeyType = StageIdent;
     }
 }
 

--- a/src/meta/app/src/principal/user_token_ident.rs
+++ b/src/meta/app/src/principal/user_token_ident.rs
@@ -21,10 +21,7 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::principal::user_token::QueryTokenInfo;
-    use crate::principal::user_token_ident::TokenIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -33,10 +30,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TokenIdent";
         const HAS_TENANT: bool = true;
         type ValueType = QueryTokenInfo;
-    }
-
-    impl kvapi::Value for QueryTokenInfo {
-        type KeyType = TokenIdent;
     }
 }
 

--- a/src/meta/app/src/row_access_policy/row_access_policy_id_ident.rs
+++ b/src/meta/app/src/row_access_policy/row_access_policy_id_ident.rs
@@ -43,9 +43,6 @@ impl RowAccessPolicyIdIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::row_access_policy::RowAccessPolicyIdIdent;
     use crate::row_access_policy::RowAccessPolicyMeta;
     use crate::tenant_key::resource::TenantResource;
 
@@ -55,10 +52,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "RowAccessPolicyIdIdent";
         const HAS_TENANT: bool = true;
         type ValueType = RowAccessPolicyMeta;
-    }
-
-    impl kvapi::Value for RowAccessPolicyMeta {
-        type KeyType = RowAccessPolicyIdIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/row_access_policy/row_access_policy_id_to_name_ident.rs
+++ b/src/meta/app/src/row_access_policy/row_access_policy_id_to_name_ident.rs
@@ -37,10 +37,7 @@ impl RowAccessPolicyIdToNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::row_access_policy::RowAccessPolicyNameIdentRaw;
-    use crate::row_access_policy::row_access_policy_id_to_name_ident::RowAccessPolicyIdToNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -49,10 +46,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "RowAccessPolicyIdToNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = RowAccessPolicyNameIdentRaw;
-    }
-
-    impl kvapi::Value for RowAccessPolicyNameIdentRaw {
-        type KeyType = RowAccessPolicyIdToNameIdent;
     }
 }
 

--- a/src/meta/app/src/row_access_policy/row_access_policy_name_ident.rs
+++ b/src/meta/app/src/row_access_policy/row_access_policy_name_ident.rs
@@ -34,10 +34,7 @@ impl RowAccessPolicyNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::row_access_policy::RowAccessPolicyId;
-    use crate::row_access_policy::RowAccessPolicyNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -46,10 +43,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "RowAccessPolicyNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = RowAccessPolicyId;
-    }
-
-    impl kvapi::Value for RowAccessPolicyId {
-        type KeyType = RowAccessPolicyNameIdent;
     }
 }
 

--- a/src/meta/app/src/row_access_policy/row_access_policy_table_id_ident.rs
+++ b/src/meta/app/src/row_access_policy/row_access_policy_table_id_ident.rs
@@ -33,10 +33,7 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::row_access_policy::RowAccessPolicyTableId;
-    use crate::row_access_policy::RowAccessPolicyTableIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -45,10 +42,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "RowAccessPolicyTableIdIdent";
         const HAS_TENANT: bool = true;
         type ValueType = RowAccessPolicyTableId;
-    }
-
-    impl kvapi::Value for RowAccessPolicyTableId {
-        type KeyType = RowAccessPolicyTableIdIdent;
     }
 }
 

--- a/src/meta/app/src/schema/auto_increment_storage.rs
+++ b/src/meta/app/src/schema/auto_increment_storage.rs
@@ -23,8 +23,6 @@ pub type AutoIncrementStorageIdent = TIdent<AutoIncrementStorageRsc, AutoIncreme
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::tenant_key::resource::TenantResource;
     use crate::value_id::ValueId;
 
@@ -37,10 +35,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_autoincrement_storage";
         const HAS_TENANT: bool = true;
         type ValueType = ValueId<AutoIncrementStorageValue>;
-    }
-
-    impl kvapi::Value for ValueId<AutoIncrementStorageValue> {
-        type KeyType = super::AutoIncrementStorageIdent;
     }
 
     pub struct AutoIncrementStorageValue;

--- a/src/meta/app/src/schema/catalog_id_ident.rs
+++ b/src/meta/app/src/schema/catalog_id_ident.rs
@@ -42,9 +42,6 @@ impl CatalogIdIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::schema::CatalogIdIdent;
     use crate::schema::CatalogMeta;
     use crate::tenant_key::resource::TenantResource;
 
@@ -54,10 +51,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "CatalogIdIdent";
         const HAS_TENANT: bool = false;
         type ValueType = CatalogMeta;
-    }
-
-    impl kvapi::Value for CatalogMeta {
-        type KeyType = CatalogIdIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/catalog_id_to_name_ident.rs
+++ b/src/meta/app/src/schema/catalog_id_to_name_ident.rs
@@ -36,9 +36,6 @@ impl CatalogIdToNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::schema::CatalogIdToNameIdent;
     use crate::schema::catalog_name_ident::CatalogNameIdentRaw;
     use crate::tenant_key::resource::TenantResource;
 
@@ -49,10 +46,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "CatalogIdToNameIdent";
         const HAS_TENANT: bool = false;
         type ValueType = CatalogNameIdentRaw;
-    }
-
-    impl kvapi::Value for CatalogNameIdentRaw {
-        type KeyType = CatalogIdToNameIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/catalog_name_ident.rs
+++ b/src/meta/app/src/schema/catalog_name_ident.rs
@@ -25,9 +25,6 @@ use crate::tenant_key::raw::TIdentRaw;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::schema::CatalogNameIdent;
     use crate::schema::catalog_id_ident::CatalogId;
     use crate::tenant_key::resource::TenantResource;
 
@@ -37,10 +34,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "CatalogNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = CatalogId;
-    }
-
-    impl kvapi::Value for CatalogId {
-        type KeyType = CatalogNameIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -360,10 +360,6 @@ mod kvapi_key_impl {
     impl kvapi::Key for DatabaseIdToName {
         type ValueType = DatabaseNameIdentRaw;
     }
-
-    impl kvapi::Value for DatabaseNameIdentRaw {
-        type KeyType = DatabaseIdToName;
-    }
 }
 
 #[cfg(test)]

--- a/src/meta/app/src/schema/database_id.rs
+++ b/src/meta/app/src/schema/database_id.rs
@@ -56,10 +56,6 @@ mod kvapi_key_impl {
     impl kvapi::Key for DatabaseId {
         type ValueType = DatabaseMeta;
     }
-
-    impl kvapi::Value for DatabaseMeta {
-        type KeyType = DatabaseId;
-    }
 }
 
 #[cfg(test)]

--- a/src/meta/app/src/schema/database_id_history_ident.rs
+++ b/src/meta/app/src/schema/database_id_history_ident.rs
@@ -36,9 +36,6 @@ impl DatabaseIdHistoryIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
-    use crate::schema::DatabaseIdHistoryIdent;
     use crate::schema::DbIdList;
     use crate::tenant_key::resource::TenantResource;
 
@@ -48,10 +45,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DatabaseIdHistoryIdent";
         const HAS_TENANT: bool = true;
         type ValueType = DbIdList;
-    }
-
-    impl kvapi::Value for DbIdList {
-        type KeyType = DatabaseIdHistoryIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/database_name_ident.rs
+++ b/src/meta/app/src/schema/database_name_ident.rs
@@ -34,10 +34,7 @@ impl DatabaseNameIdentRaw {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::DatabaseId;
-    use crate::schema::database_name_ident::DatabaseNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct DatabaseNameRsc;
@@ -46,10 +43,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DatabaseNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = DatabaseId;
-    }
-
-    impl kvapi::Value for DatabaseId {
-        type KeyType = DatabaseNameIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/dictionary_id_ident.rs
+++ b/src/meta/app/src/schema/dictionary_id_ident.rs
@@ -34,10 +34,7 @@ impl DictionaryIdIdent {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::DictionaryMeta;
-    use crate::schema::dictionary_id_ident::DictionaryIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct DictionaryIdRsc;
@@ -46,10 +43,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DictionaryId";
         const HAS_TENANT: bool = false;
         type ValueType = DictionaryMeta;
-    }
-
-    impl kvapi::Value for DictionaryMeta {
-        type KeyType = DictionaryIdIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/dictionary_name_ident.rs
+++ b/src/meta/app/src/schema/dictionary_name_ident.rs
@@ -43,8 +43,6 @@ impl DictionaryNameIdent {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::dictionary_id_ident::DictionaryId;
     use crate::tenant_key::resource::TenantResource;
 
@@ -54,10 +52,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "DictionaryName";
         const HAS_TENANT: bool = true;
         type ValueType = DictionaryId;
-    }
-
-    impl kvapi::Value for DictionaryId {
-        type KeyType = super::DictionaryNameIdent;
     }
 }
 

--- a/src/meta/app/src/schema/index_id_ident.rs
+++ b/src/meta/app/src/schema/index_id_ident.rs
@@ -25,10 +25,7 @@ pub use kvapi_impl::IndexIdResource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::IndexMeta;
-    use crate::schema::index_id_ident::IndexIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct IndexIdResource;
@@ -37,10 +34,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "IndexIdIdent";
         const HAS_TENANT: bool = false;
         type ValueType = IndexMeta;
-    }
-
-    impl kvapi::Value for IndexMeta {
-        type KeyType = IndexIdIdent;
     }
 }
 

--- a/src/meta/app/src/schema/index_id_to_name_ident.rs
+++ b/src/meta/app/src/schema/index_id_to_name_ident.rs
@@ -23,10 +23,7 @@ pub use kvapi_impl::IndexIdToName;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::IndexNameIdentRaw;
-    use crate::schema::index_id_to_name_ident::IndexIdToNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct IndexIdToName;
@@ -35,10 +32,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "IndexIdToNameIdent";
         const HAS_TENANT: bool = false;
         type ValueType = IndexNameIdentRaw;
-    }
-
-    impl kvapi::Value for IndexNameIdentRaw {
-        type KeyType = IndexIdToNameIdent;
     }
 }
 

--- a/src/meta/app/src/schema/index_name_ident.rs
+++ b/src/meta/app/src/schema/index_name_ident.rs
@@ -36,9 +36,7 @@ impl TIdentRaw<IndexName> {
 }
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
-    use crate::schema::IndexNameIdent;
     use crate::schema::index_id_ident::IndexId;
     use crate::tenant_key::resource::TenantResource;
 
@@ -47,10 +45,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_index";
         const HAS_TENANT: bool = true;
         type ValueType = IndexId;
-    }
-
-    impl kvapi::Value for IndexId {
-        type KeyType = IndexNameIdent;
     }
 }
 

--- a/src/meta/app/src/schema/least_visible_time_ident.rs
+++ b/src/meta/app/src/schema/least_visible_time_ident.rs
@@ -25,10 +25,8 @@ impl LeastVisibleTimeIdent {
 }
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use crate::schema::LeastVisibleTime;
-    use crate::schema::least_visible_time_ident::LeastVisibleTimeIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct LeastVisibleTimeRsc;
@@ -36,10 +34,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_table_lvt";
         const HAS_TENANT: bool = false;
         type ValueType = LeastVisibleTime;
-    }
-
-    impl kvapi::Value for LeastVisibleTime {
-        type KeyType = LeastVisibleTimeIdent;
     }
 }
 

--- a/src/meta/app/src/schema/marked_deleted_index_ident.rs
+++ b/src/meta/app/src/schema/marked_deleted_index_ident.rs
@@ -22,10 +22,7 @@ use super::marked_deleted_index_id::MarkedDeletedIndexId;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::MarkedDeletedIndexMeta;
-    use crate::schema::marked_deleted_index_ident::MarkedDeletedIndexIdIdent;
     use crate::tenant_key::resource::TenantResource;
 
     /// The meta-service key for storing id of dropped but not vacuumed index
@@ -35,10 +32,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "MarkedDeletedIndexIdent";
         const HAS_TENANT: bool = false;
         type ValueType = MarkedDeletedIndexMeta;
-    }
-
-    impl kvapi::Value for MarkedDeletedIndexMeta {
-        type KeyType = MarkedDeletedIndexIdIdent;
     }
 }
 

--- a/src/meta/app/src/schema/sequence.rs
+++ b/src/meta/app/src/schema/sequence.rs
@@ -132,8 +132,6 @@ pub struct DropSequenceReply {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use super::SequenceMeta;
     use crate::tenant_key::resource::TenantResource;
 
@@ -142,10 +140,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_sequence";
         const HAS_TENANT: bool = true;
         type ValueType = SequenceMeta;
-    }
-
-    impl kvapi::Value for SequenceMeta {
-        type KeyType = super::SequenceIdent;
     }
 }
 

--- a/src/meta/app/src/schema/sequence_storage.rs
+++ b/src/meta/app/src/schema/sequence_storage.rs
@@ -22,8 +22,6 @@ pub type SequenceStorageIdent = TIdent<SequenceStorageRsc>;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::tenant_key::resource::TenantResource;
     use crate::value_id::ValueId;
 
@@ -36,10 +34,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_sequence_storage";
         const HAS_TENANT: bool = true;
         type ValueType = ValueId<SequenceStorageValue>;
-    }
-
-    impl kvapi::Value for ValueId<SequenceStorageValue> {
-        type KeyType = super::SequenceStorageIdent;
     }
 
     pub struct SequenceStorageValue;

--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -1247,26 +1247,6 @@ mod kvapi_key_impl {
     impl kvapi::Key for TableCopiedFileNameIdent {
         type ValueType = TableCopiedFileInfo;
     }
-
-    impl kvapi::Value for TableId {
-        type KeyType = DBIdTableName;
-    }
-
-    impl kvapi::Value for DBIdTableName {
-        type KeyType = TableIdToName;
-    }
-
-    impl kvapi::Value for TableMeta {
-        type KeyType = TableId;
-    }
-
-    impl kvapi::Value for TableIdList {
-        type KeyType = TableIdHistoryIdent;
-    }
-
-    impl kvapi::Value for TableCopiedFileInfo {
-        type KeyType = TableCopiedFileNameIdent;
-    }
 }
 
 #[cfg(test)]

--- a/src/meta/app/src/schema/table/refs.rs
+++ b/src/meta/app/src/schema/table/refs.rs
@@ -100,10 +100,6 @@ mod kvapi_key_impl {
     impl kvapi::Key for TableIdTagName {
         type ValueType = TableTag;
     }
-
-    impl kvapi::Value for TableTag {
-        type KeyType = TableIdTagName;
-    }
 }
 
 #[cfg(test)]

--- a/src/meta/app/src/schema/table_lock_ident.rs
+++ b/src/meta/app/src/schema/table_lock_ident.rs
@@ -48,10 +48,7 @@ impl TableLockIdent {
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::schema::LockMeta;
-    use crate::schema::TableLockIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -60,10 +57,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TableLockIdent";
         const HAS_TENANT: bool = true;
         type ValueType = LockMeta;
-    }
-
-    impl kvapi::Value for LockMeta {
-        type KeyType = TableLockIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/schema/tag/id_ident.rs
+++ b/src/meta/app/src/schema/tag/id_ident.rs
@@ -37,9 +37,7 @@ pub type TagIdIdentRaw = TIdentRaw<Resource, TagId>;
 pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
-    use crate::schema::TagIdIdent;
     use crate::schema::TagMeta;
     use crate::tenant_key::resource::TenantResource;
 
@@ -49,10 +47,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TagIdIdent";
         const HAS_TENANT: bool = true;
         type ValueType = TagMeta;
-    }
-
-    impl kvapi::Value for TagMeta {
-        type KeyType = TagIdIdent;
     }
 }
 

--- a/src/meta/app/src/schema/tag/id_to_name_ident.rs
+++ b/src/meta/app/src/schema/tag/id_to_name_ident.rs
@@ -27,10 +27,8 @@ pub type TagIdToNameIdentRaw = TIdentRaw<Resource, TagId>;
 pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use super::super::name_ident::TagNameIdentRaw;
-    use crate::schema::TagIdToNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -39,10 +37,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TagIdToNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = TagNameIdentRaw;
-    }
-
-    impl kvapi::Value for TagNameIdentRaw {
-        type KeyType = TagIdToNameIdent;
     }
 }
 

--- a/src/meta/app/src/schema/tag/name_ident.rs
+++ b/src/meta/app/src/schema/tag/name_ident.rs
@@ -36,10 +36,8 @@ impl TagNameIdentRaw {
 }
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use super::super::id_ident::TagId;
-    use crate::schema::TagNameIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct Resource;
@@ -48,10 +46,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TagNameIdent";
         const HAS_TENANT: bool = true;
         type ValueType = TagId;
-    }
-
-    impl kvapi::Value for TagId {
-        type KeyType = TagNameIdent;
     }
 }
 

--- a/src/meta/app/src/schema/tag/ref_ident.rs
+++ b/src/meta/app/src/schema/tag/ref_ident.rs
@@ -81,12 +81,9 @@ pub type TagIdObjectRefIdentRaw = TIdentRaw<TagIdObjectRefResource, TagIdObjectR
 pub use kvapi_impl::TagIdObjectRefResource;
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use crate::schema::EmptyProto;
-    use crate::schema::ObjectTagIdRefIdent;
     use crate::schema::ObjectTagIdRefValue;
-    use crate::schema::TagIdObjectRefIdent;
     use crate::tenant_key::resource::TenantResource;
 
     /// Resource marker for object -> tag reference keys.
@@ -98,10 +95,6 @@ mod kvapi_impl {
         type ValueType = ObjectTagIdRefValue;
     }
 
-    impl kvapi::Value for ObjectTagIdRefValue {
-        type KeyType = ObjectTagIdRefIdent;
-    }
-
     /// Resource marker for tag -> object reference keys.
     pub struct TagIdObjectRefResource;
     impl TenantResource for TagIdObjectRefResource {
@@ -109,10 +102,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TagIdObjectRefIdent";
         const HAS_TENANT: bool = true;
         type ValueType = EmptyProto;
-    }
-
-    impl kvapi::Value for EmptyProto {
-        type KeyType = TagIdObjectRefIdent;
     }
 }
 

--- a/src/meta/app/src/schema/vacuum_watermark_ident.rs
+++ b/src/meta/app/src/schema/vacuum_watermark_ident.rs
@@ -25,10 +25,8 @@ impl VacuumWatermarkIdent {
 }
 
 mod kvapi_impl {
-    use databend_meta_client::kvapi;
 
     use crate::schema::vacuum_watermark::VacuumWatermark;
-    use crate::schema::vacuum_watermark_ident::VacuumWatermarkIdent;
     use crate::tenant_key::resource::TenantResource;
 
     pub struct VacuumWatermarkRsc;
@@ -37,10 +35,6 @@ mod kvapi_impl {
         const PREFIX: &'static str = "__fd_vacuum_watermark_ts";
         const HAS_TENANT: bool = true;
         type ValueType = VacuumWatermark;
-    }
-
-    impl kvapi::Value for VacuumWatermark {
-        type KeyType = VacuumWatermarkIdent;
     }
 }
 

--- a/src/meta/app/src/tenant/tenant.rs
+++ b/src/meta/app/src/tenant/tenant.rs
@@ -119,8 +119,4 @@ mod kvapi_key_impl {
     impl kvapi::Key for Tenant {
         type ValueType = EmptyTenantValue;
     }
-
-    impl kvapi::Value for EmptyTenantValue {
-        type KeyType = Tenant;
-    }
 }

--- a/src/meta/app/src/tenant/tenant_quota_ident.rs
+++ b/src/meta/app/src/tenant/tenant_quota_ident.rs
@@ -22,8 +22,6 @@ pub use kvapi_impl::Resource;
 
 mod kvapi_impl {
 
-    use databend_meta_client::kvapi;
-
     use crate::tenant::TenantQuota;
     use crate::tenant_key::resource::TenantResource;
 
@@ -33,10 +31,6 @@ mod kvapi_impl {
         const TYPE: &'static str = "TenantQuotaIdent";
         const HAS_TENANT: bool = true;
         type ValueType = TenantQuota;
-    }
-
-    impl kvapi::Value for TenantQuota {
-        type KeyType = super::TenantQuotaIdent;
     }
 
     // // Use these error types to replace usage of ErrorCode if possible.

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -266,7 +266,6 @@ mod kvapi_key_impl {
 #[cfg(test)]
 mod tests {
 
-    use databend_meta_client::kvapi;
     use databend_meta_client::kvapi::testing::assert_round_trip;
 
     use crate::tenant::Tenant;
@@ -284,10 +283,6 @@ mod tests {
             const PREFIX: &'static str = "foo";
             const HAS_TENANT: bool = true;
             type ValueType = FooValue;
-        }
-
-        impl kvapi::Value for FooValue {
-            type KeyType = TIdent<Foo>;
         }
 
         let tenant = Tenant::new_literal("test");
@@ -316,10 +311,6 @@ mod tests {
             const PREFIX: &'static str = "foo";
             const HAS_TENANT: bool = true;
             type ValueType = FooValue;
-        }
-
-        impl kvapi::Value for FooValue {
-            type KeyType = TIdent<Foo, u64>;
         }
 
         let tenant = Tenant::new_literal("test");

--- a/src/meta/control/src/dump_raft_log_wal.rs
+++ b/src/meta/control/src/dump_raft_log_wal.rs
@@ -23,6 +23,7 @@ use databend_common_meta_process::pb_value_decoder::raw_cmd_values;
 use databend_meta::raft_store::raft_log::Config;
 use databend_meta::raft_store::raft_log::Dump;
 use databend_meta::raft_store::raft_log::DumpApi;
+use databend_meta::raft_store::raft_log::RaftLogAction;
 use databend_meta::raft_store::raft_log::WALRecord;
 use databend_meta::raft_store::raft_log::dump_writer::write_record_display;
 use databend_meta::raft_store::raft_log_v004::RaftLogTypes;
@@ -45,10 +46,7 @@ pub fn dump_wal(
     raw: bool,
     mut w: impl Write,
 ) -> anyhow::Result<()> {
-    let config = Arc::new(Config {
-        dir: wal_dir.to_string_lossy().to_string(),
-        ..Default::default()
-    });
+    let config = Arc::new(Config::new(wal_dir.to_string_lossy().to_string()));
 
     let dump = Dump::<RaftLogTypes>::new(config)?;
 
@@ -62,7 +60,7 @@ pub fn dump_wal(
     dump.write_with(|chunk_id, idx, res| {
         let mut extra_lines = vec![];
 
-        if let Ok((_seg, WALRecord::Append(_log_id, payload))) = &res
+        if let Ok((_seg, WALRecord::Action(RaftLogAction::Append(_log_id, payload)))) = &res
             && let EntryPayload::Normal(log_entry) = &payload.0
         {
             if decode_values {
@@ -113,10 +111,7 @@ mod tests {
         let wal_dir = tmp.path().join("log");
         std::fs::create_dir_all(&wal_dir)?;
 
-        let config = Arc::new(Config {
-            dir: wal_dir.to_string_lossy().to_string(),
-            ..Default::default()
-        });
+        let config = Arc::new(Config::new(wal_dir.to_string_lossy().to_string()));
 
         let mut log = RaftLogV004::open(config)?;
         log.append([(Cw(new_log_id(1, 0, 0)), Cw(EntryPayload::Blank))])?;
@@ -132,7 +127,7 @@ mod tests {
             concat!(
                 "RaftLog:\n",
                 "ChunkId(00_000_000_000_000_000_000)\n",
-                "  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
+                "  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
                 "  R-00001: [000_000_018, 000_000_070) Size(52): Append(log_id: T1-N0.0, payload: blank)\n",
             )
         );
@@ -146,10 +141,7 @@ mod tests {
         let wal_dir = tmp.path().join("log");
         std::fs::create_dir_all(&wal_dir)?;
 
-        let config = Arc::new(Config {
-            dir: wal_dir.to_string_lossy().to_string(),
-            ..Default::default()
-        });
+        let config = Arc::new(Config::new(wal_dir.to_string_lossy().to_string()));
 
         // Use a fixed timestamp to ensure deterministic protobuf encoding size
         // across platforms. `Utc::now()` in `DatabaseMeta::default()` produces
@@ -187,7 +179,7 @@ mod tests {
             concat!(
                 "RaftLog:\n",
                 "ChunkId(00_000_000_000_000_000_000)\n",
-                "  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
+                "  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
                 r#"  R-00001: [000_000_018, 000_000_218) Size(200): Append(log_id: T1-N0.0, payload: normal: cmd: upsert_kv:__fd_database_by_id/123(GE(0)) = Update("[binary]") (None))"#,
                 "\n",
                 r#"    value(__fd_database_by_id/123): DatabaseMeta { engine: "", engine_options: {}, options: {}, created_on: 2024-01-01T00:00:00Z, updated_on: 2024-01-01T00:00:00Z, comment: "", drop_on: None, gc_in_progress: false }"#,
@@ -204,10 +196,7 @@ mod tests {
         let wal_dir = tmp.path().join("log");
         std::fs::create_dir_all(&wal_dir)?;
 
-        let config = Arc::new(Config {
-            dir: wal_dir.to_string_lossy().to_string(),
-            ..Default::default()
-        });
+        let config = Arc::new(Config::new(wal_dir.to_string_lossy().to_string()));
 
         let ts = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let meta = DatabaseMeta {
@@ -251,7 +240,7 @@ mod tests {
             concat!(
                 "RaftLog:\n",
                 "ChunkId(00_000_000_000_000_000_000)\n",
-                "  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
+                "  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
                 r#"  R-00001: [000_000_018, 000_000_218) Size(200): Append(log_id: T1-N0.0, payload: normal: cmd: upsert_kv:__fd_database_by_id/123(GE(0)) = Update("[binary]") (None))"#,
                 "\n",
                 "    raw(__fd_database_by_id/123): {}\n",
@@ -270,7 +259,7 @@ mod tests {
             concat!(
                 "RaftLog:\n",
                 "ChunkId(00_000_000_000_000_000_000)\n",
-                "  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
+                "  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))\n",
                 r#"  R-00001: [000_000_018, 000_000_218) Size(200): Append(log_id: T1-N0.0, payload: normal: cmd: upsert_kv:__fd_database_by_id/123(GE(0)) = Update("[binary]") (None))"#,
                 "\n",
                 r#"    value(__fd_database_by_id/123): DatabaseMeta {{ engine: "", engine_options: {{}}, options: {{}}, created_on: 2024-01-01T00:00:00Z, updated_on: 2024-01-01T00:00:00Z, comment: "", drop_on: None, gc_in_progress: false }}"#,

--- a/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
+++ b/tests/metactl/subcommands/cmd_dump_raft_log_wal.py
@@ -83,8 +83,8 @@ def test_dump_raft_log_wal():
     # Expected output with time field that will be masked
     expected = """RaftLog:
 ChunkId(00_000_000_000_000_000_000)
-  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
-  R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
+  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
+  R-00001: [000_000_018, 000_000_046) Size(28): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
   R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
   R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)
@@ -104,8 +104,8 @@ ChunkId(00_000_000_000_000_000_000)
 
     expected2 = """RaftLog:
 ChunkId(00_000_000_000_000_000_000)
-  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
-  R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
+  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
+  R-00001: [000_000_018, 000_000_046) Size(28): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
   R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
   R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)
@@ -125,8 +125,8 @@ ChunkId(00_000_000_000_000_000_000)
 
     expected3 = """RaftLog:
 ChunkId(00_000_000_000_000_000_000)
-  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
-  R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
+  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
+  R-00001: [000_000_018, 000_000_046) Size(28): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
   R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
   R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)

--- a/tests/metactl/subcommands/data/dump_raft_log_wal/expected_decoded.txt
+++ b/tests/metactl/subcommands/data/dump_raft_log_wal/expected_decoded.txt
@@ -1,7 +1,7 @@
 RaftLog:
 ChunkId(00_000_000_000_000_000_000)
-  R-00000: [000_000_000, 000_000_018) Size(18): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
-  R-00001: [000_000_018, 000_000_046) Size(28): RaftLogState(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
+  R-00000: [000_000_000, 000_000_018) Size(18): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: None))
+  R-00001: [000_000_018, 000_000_046) Size(28): Checkpoint(RaftLogState(vote: None, last: None, committed: None, purged: None, user_data: LogStoreMeta{ node_id: Some(1) }))
   R-00002: [000_000_046, 000_000_125) Size(79): Append(log_id: T0-N1.0, payload: membership:{voters:[{1:EmptyNode}], learners:[]})
   R-00003: [000_000_125, 000_000_175) Size(50): SaveVote(<T1-N1:->)
   R-00004: [000_000_175, 000_000_225) Size(50): SaveVote(<T1-N1:Q>)


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor(meta): remove kvapi::Value impls for blanket marker trait
# Summary

The upstream meta release redefines `kvapi::Value` as a blanket marker
trait (`impl<V: Debug> Value for V`) and drops its `KeyType` associated
type. That makes every explicit `impl kvapi::Value for T` redundant and
conflicting, so they are removed. The meta dependencies are repointed to
the databendlabs releases that carry this change.

# Details

- Remove all `impl kvapi::Value for T { type KeyType = ... }` blocks
  throughout `databend-common-meta-app`; each `T` now satisfies `Value`
  via the blanket impl, and nothing read the `KeyType` back-pointer, so
  round-trip encoding is unchanged. Drop the imports this leaves unused.
- Source all meta crates from databendlabs: `databend-meta-client`
  260205.11.0, with `databend-meta` and `databend-meta-test-harness`
  bumped 260512.3.0 -> 260512.4.0 (the client previously came from a
  personal fork).
- Adapt `dump_raft_log_wal.rs` to the raft-log 0.4.4 API the service
  bump pulls in: `Config { dir }` -> `Config::new(dir)`, and
  `WALRecord::Append` -> `WALRecord::Action(RaftLogAction::Append)`.
- Mark the `Foo` test key fixture in `data_id.rs` `#[allow(dead_code)]`;
  its only remaining reference was the deleted `KeyType`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19974)
<!-- Reviewable:end -->
