### PR TITLE
fix(query): guard tenant override in sessions

### DIFF
--- a/src/query/service/src/auth.rs
+++ b/src/query/service/src/auth.rs
@@ -129,7 +129,7 @@ impl AuthMgr {
                 let tenant = Tenant::new_or_err(claim.tenant.to_string(), func_name!())?;
                 if need_user_info {
                     let identity = UserIdentity::new(claim.user.clone(), "%");
-                    session.set_current_tenant(tenant.clone());
+                    session.set_current_tenant(tenant.clone())?;
                     let user_info = user_api.get_user(&tenant, identity.clone()).await?;
                     session.set_authed_user(user_info, claim.auth_role).await?;
                 }
@@ -154,7 +154,7 @@ impl AuthMgr {
                 // setup tenant if the JWT claims contain extra.tenant_id
                 if let Some(tenant) = jwt.custom.tenant_id {
                     let tenant = Tenant::new_or_err(tenant, func_name!())?;
-                    session.set_current_tenant(tenant);
+                    session.set_current_tenant(tenant)?;
                 };
 
                 let tenant = session.get_current_tenant();

--- a/src/query/service/src/servers/admin/v1/clustering_information.rs
+++ b/src/query/service/src/servers/admin/v1/clustering_information.rs
@@ -75,7 +75,7 @@ async fn load_clustering_information(
     let mut dummy_session = SessionManager::instance()
         .create_session(SessionType::Dummy)
         .await?;
-    dummy_session.set_current_tenant(tenant.clone());
+    dummy_session.set_current_tenant(tenant.clone())?;
     let session = SessionManager::instance().register_session(dummy_session)?;
 
     let ctx: Arc<dyn TableContext> = session

--- a/src/query/service/src/servers/http/middleware/session.rs
+++ b/src/query/service/src/servers/http/middleware/session.rs
@@ -382,7 +382,7 @@ impl<E> HTTPSessionEndpoint<E> {
         if let Some(tenant_id) = req.headers().get(HEADER_TENANT) {
             let tenant_id = tenant_id.to_str().unwrap().to_string();
             let tenant = Tenant::new_or_err(tenant_id.clone(), func_name!())?;
-            session.set_current_tenant(tenant);
+            session.set_current_tenant(tenant)?;
         }
         let (user_name, authed_client_session_id) = self
             .auth_manager

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -252,8 +252,30 @@ impl Session {
         self.session_ctx.get_current_tenant()
     }
 
-    pub fn set_current_tenant(&mut self, tenant: Tenant) {
+    pub fn set_current_tenant(&mut self, tenant: Tenant) -> Result<()> {
+        if tenant.tenant.is_empty() {
+            return Err(ErrorCode::TenantIsEmpty("set_current_tenant"));
+        }
+
+        let config = GlobalConfig::instance();
+        let configured_tenant = &config.query.tenant_id;
+        let allow_tenant_override = config.query.common.management_mode
+            || config.query.common.internal_enable_sandbox_tenant
+            || matches!(self.get_type(), SessionType::Local);
+
+        // Runtime tenant override is only valid for management, sandbox tenant,
+        // and local sessions. In normal mode, callers may still pass the
+        // configured tenant in tests or setup paths.
+        if !allow_tenant_override && &tenant != configured_tenant {
+            return Err(ErrorCode::BadArguments(format!(
+                "tenant override is not allowed: requested tenant `{}`, configured tenant `{}`",
+                tenant.tenant_name(),
+                configured_tenant.tenant_name()
+            )));
+        }
+
         self.session_ctx.set_current_tenant(tenant);
+        Ok(())
     }
 
     pub fn get_current_user(&self) -> Result<UserInfo> {

--- a/src/query/service/tests/it/auth.rs
+++ b/src/query/service/tests/it/auth.rs
@@ -752,6 +752,50 @@ async fn test_jwt_auth_mgr_with_management() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_jwt_tenant_override_requires_management_mode() -> anyhow::Result<()> {
+    let kid = "test_kid";
+    let (key_pair, jwks) = get_jwks_file_rs256(kid);
+
+    let server = MockServer::start().await;
+    let json_path = "/jwks.json";
+    let template = ResponseTemplate::new(200).set_body_raw(jwks, "application/json");
+    Mock::given(method("GET"))
+        .and(path(json_path))
+        .respond_with(template)
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let mut conf = ConfigBuilder::create().config();
+    conf.query.common.jwt_key_file = format!("http://{}{}", server.address(), json_path);
+    let _fixture = TestFixture::setup_with_config(&conf).await?;
+
+    let custom_claims = CustomClaims::new()
+        .with_tenant_id("other")
+        .with_ensure_user(EnsureUser::default());
+    let claims = Claims::with_custom_claims(custom_claims, Duration::from_hours(2))
+        .with_subject("test".to_string());
+    let token = key_pair.sign(claims)?;
+
+    let mut session = TestFixture::create_dummy_session().await;
+    let res = AuthMgr::instance()
+        .auth(
+            &mut session,
+            &Credential::Jwt {
+                token,
+                client_ip: None,
+            },
+            true,
+        )
+        .await;
+
+    assert!(res.is_err());
+    assert_eq!(session.get_current_tenant().tenant_name(), "test");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_auth_mgr_ensure_roles() -> anyhow::Result<()> {
     let kid = "test_kid";
     let key_pair = RS256KeyPair::generate(2048)?.with_key_id(kid);

--- a/src/query/service/tests/it/sessions/session.rs
+++ b/src/query/service/tests/it/sessions/session.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_catalog::session_type::SessionType;
 use databend_common_meta_app::tenant::Tenant;
+use databend_query::sessions::SessionManager;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
 
@@ -27,7 +29,15 @@ async fn test_session() -> anyhow::Result<()> {
         assert_eq!(actual.tenant_name(), "test");
 
         // We are not in management mode, so always get the config tenant.
-        session.set_current_tenant(Tenant::new_literal("tenant2"));
+        assert!(
+            session
+                .set_current_tenant(Tenant::new_literal("tenant2"))
+                .is_err()
+        );
+        let actual = session.get_current_tenant();
+        assert_eq!(actual.tenant_name(), "test");
+
+        session.set_current_tenant(Tenant::new_literal("test"))?;
         let actual = session.get_current_tenant();
         assert_eq!(actual.tenant_name(), "test");
     }
@@ -55,10 +65,25 @@ async fn test_session_in_management_mode() -> anyhow::Result<()> {
         let actual = session.get_current_tenant();
         assert_eq!(actual.tenant_name(), "test");
 
-        session.set_current_tenant(Tenant::new_literal("tenant2"));
+        session.set_current_tenant(Tenant::new_literal("tenant2"))?;
         let actual = session.get_current_tenant();
         assert_eq!(actual.tenant_name(), "tenant2");
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_local_session_can_override_tenant() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut session = SessionManager::instance()
+        .create_session(SessionType::Local)
+        .await?;
+
+    session.set_current_tenant(Tenant::new_literal("tenant2"))?;
+    let actual = session.get_current_tenant();
+    assert_eq!(actual.tenant_name(), "tenant2");
 
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Guard tenant overrides so `X-DATABEND-TENANT` and JWT tenant claims cannot switch away from the configured tenant unless management mode, sandbox tenant mode, or a local session is used.
- Return an error from `Session::set_current_tenant` when a runtime tenant override is not allowed.
- Keep management-mode and local-session tenant switching behavior unchanged without reloading session settings.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added focused Rust integration coverage for normal, management-mode, and local session tenant override behavior, plus JWT tenant override rejection.

- `cargo fmt --check`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19975)
<!-- Reviewable:end -->
