### PR TITLE
fix(query): support delete by internal columns

### DIFF
--- a/src/query/service/src/interpreters/interpreter_mutation.rs
+++ b/src/query/service/src/interpreters/interpreter_mutation.rs
@@ -28,6 +28,7 @@ use databend_common_expression::SendableDataBlockStream;
 use databend_common_expression::types::UInt64Type;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline::sinks::EmptySink;
+use databend_common_sql::ColumnEntry;
 use databend_common_sql::binder::MutationStrategy;
 use databend_common_sql::binder::MutationType;
 use databend_common_sql::executor::physical_plans::MutationKind;
@@ -270,11 +271,18 @@ async fn mutation_source_partitions(
     let (filters, filter_used_columns) = if !mutation.direct_filter.is_empty() {
         let filters =
             create_push_down_filters(&ctx.get_function_context()?, &mutation.direct_filter)?;
+        let metadata = mutation.metadata.read();
         let filter_used_columns = mutation
             .direct_filter
             .iter()
             .flat_map(|expr| expr.used_columns())
-            .map(|i| i.as_usize())
+            .filter_map(|i| match metadata.column(i) {
+                ColumnEntry::InternalColumn(_) => None,
+                column => fuse_table
+                    .schema_with_stream()
+                    .index_of(&column.name())
+                    .ok(),
+            })
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();

--- a/src/query/service/src/physical_plans/physical_mutation_source.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_source.rs
@@ -42,7 +42,6 @@ use databend_common_sql::ColumnSet;
 use databend_common_sql::IndexType;
 use databend_common_sql::ScalarExpr;
 use databend_common_sql::StreamContext;
-use databend_common_sql::Symbol;
 use databend_common_sql::binder::MutationType;
 use databend_common_sql::executor::cast_expr_to_non_null_boolean;
 use databend_common_storages_fuse::FuseLazyPartInfo;
@@ -321,11 +320,8 @@ impl PhysicalPlanBuilder {
             .iter()
             .filter_map(|column_index| {
                 let column = metadata.column(*column_index);
-                mutation_source
-                    .schema
-                    .index_of(&column.name())
-                    .ok()
-                    .map(Symbol::from_field_index)
+                mutation_source.schema.index_of(&column.name()).ok()?;
+                Some(*column_index)
             })
             .collect();
         let delete_meta_only = mutation_source.mutation_type == MutationType::Delete

--- a/src/query/service/src/physical_plans/physical_mutation_source.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_source.rs
@@ -23,12 +23,14 @@ use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
+use databend_common_expression::BLOCK_NAME_COL_NAME;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::SEGMENT_NAME_COL_NAME;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -40,6 +42,7 @@ use databend_common_sql::ColumnSet;
 use databend_common_sql::IndexType;
 use databend_common_sql::ScalarExpr;
 use databend_common_sql::StreamContext;
+use databend_common_sql::Symbol;
 use databend_common_sql::binder::MutationType;
 use databend_common_sql::executor::cast_expr_to_non_null_boolean;
 use databend_common_storages_fuse::FuseLazyPartInfo;
@@ -67,6 +70,8 @@ pub struct MutationSource {
     pub table_index: IndexType,
     pub table_info: TableInfo,
     pub filters: Option<Filters>,
+    #[serde(default)]
+    pub row_filters: Option<Filters>,
     pub display_filters: Option<Filters>,
     #[serde(default)]
     pub has_hidden_secure_filters: bool,
@@ -74,6 +79,8 @@ pub struct MutationSource {
     pub input_type: MutationType,
     pub read_partition_columns: ColumnSet,
     pub truncate_table: bool,
+    #[serde(default)]
+    pub delete_meta_only: bool,
 
     pub partitions: Partitions,
     pub statistics: PartStatistics,
@@ -112,12 +119,14 @@ impl IPhysicalPlan for MutationSource {
             table_index: self.table_index,
             table_info: self.table_info.clone(),
             filters: self.filters.clone(),
+            row_filters: self.row_filters.clone(),
             display_filters: self.display_filters.clone(),
             has_hidden_secure_filters: self.has_hidden_secure_filters,
             output_schema: self.output_schema.clone(),
             input_type: self.input_type.clone(),
             read_partition_columns: self.read_partition_columns.clone(),
             truncate_table: self.truncate_table,
+            delete_meta_only: self.delete_meta_only,
             partitions: self.partitions.clone(),
             statistics: self.statistics.clone(),
         })
@@ -196,7 +205,11 @@ impl IPhysicalPlan for MutationSource {
             builder.ctx.set_partitions(self.partitions.clone())?;
         }
 
-        let filter = self.filters.clone().map(|v| v.filter);
+        let filter = if self.row_filters.is_some() || self.delete_meta_only {
+            self.row_filters.clone().map(|v| v.filter)
+        } else {
+            self.filters.clone().map(|v| v.filter)
+        };
         let mutation_action = if is_delete {
             MutationAction::Deletion
         } else {
@@ -261,6 +274,16 @@ impl PhysicalPlanBuilder {
         } else {
             None
         };
+        let (row_predicates, has_internal_filter) =
+            mutation_source_row_predicates(mutation_source.mutation_type.clone(), &all_predicates)?;
+        let row_filters = if !row_predicates.is_empty() {
+            Some(create_push_down_filters(
+                &self.ctx.get_function_context()?,
+                &row_predicates,
+            )?)
+        } else {
+            None
+        };
         let mutation_info = self.mutation_build_info.as_ref().unwrap();
 
         let metadata = self.metadata.read();
@@ -293,21 +316,72 @@ impl PhysicalPlanBuilder {
 
         let truncate_table =
             mutation_source.mutation_type == MutationType::Delete && filters.is_none();
+        let read_partition_columns = mutation_source
+            .read_partition_columns
+            .iter()
+            .filter_map(|column_index| {
+                let column = metadata.column(*column_index);
+                mutation_source
+                    .schema
+                    .index_of(&column.name())
+                    .ok()
+                    .map(Symbol::from_field_index)
+            })
+            .collect();
+        let delete_meta_only = mutation_source.mutation_type == MutationType::Delete
+            && filters.is_some()
+            && row_filters.is_none()
+            && has_internal_filter;
         Ok(PhysicalPlan::new(MutationSource {
             table_index: mutation_source.table_index,
             output_schema,
             table_info: mutation_info.table_info.clone(),
             filters,
+            row_filters,
             display_filters,
             has_hidden_secure_filters: !mutation_source.secure_predicates.is_empty(),
             input_type: mutation_source.mutation_type.clone(),
-            read_partition_columns: mutation_source.read_partition_columns.clone(),
+            read_partition_columns,
             truncate_table,
+            delete_meta_only,
             meta: PhysicalPlanMeta::new("MutationSource"),
             partitions: mutation_info.partitions.clone(),
             statistics: mutation_info.statistics.clone(),
         }))
     }
+}
+
+fn mutation_source_row_predicates(
+    mutation_type: MutationType,
+    predicates: &[ScalarExpr],
+) -> Result<(Vec<ScalarExpr>, bool)> {
+    if mutation_type != MutationType::Delete {
+        return Ok((predicates.to_vec(), false));
+    }
+
+    let mut has_internal_column = false;
+    let mut row_predicates = Vec::new();
+    for predicate in predicates {
+        let expr = predicate
+            .as_expr()?
+            .project_column_ref(|col| Ok(col.column_name.clone()))?;
+
+        let mut has_column_ref = false;
+        let mut internal_only = true;
+        for name in expr.column_refs().keys() {
+            has_column_ref = true;
+            if name == SEGMENT_NAME_COL_NAME || name == BLOCK_NAME_COL_NAME {
+                has_internal_column = true;
+            } else {
+                internal_only = false;
+            }
+        }
+
+        if !has_column_ref || !internal_only || !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
+            row_predicates.push(predicate.clone());
+        }
+    }
+    Ok((row_predicates, has_internal_column))
 }
 
 /// create push down filters

--- a/src/query/storages/common/pruner/src/internal_column_pruner.rs
+++ b/src/query/storages/common/pruner/src/internal_column_pruner.rs
@@ -27,6 +27,13 @@ use databend_common_expression::types::string::StringDomain;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
 /// Only support `_segment_name` and `_block_name` now.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InternalColumnPruneResult {
+    Pruned,
+    Keep,
+    FullMatch,
+}
+
 pub struct InternalColumnPruner {
     func_ctx: FunctionContext,
     expr: Expr<String>,
@@ -58,30 +65,44 @@ impl InternalColumnPruner {
     }
 
     pub fn should_keep(&self, col_name: &str, value: &str) -> bool {
-        if self.input_domains.contains_key(col_name) {
-            let mut input_domains = self.input_domains.clone();
-            let domain = Domain::String(StringDomain {
-                min: value.to_string(),
-                max: Some(value.to_string()),
-            });
-            input_domains.insert(col_name.to_string(), domain);
+        self.eval(&[(col_name, value)]) != InternalColumnPruneResult::Pruned
+    }
 
-            let (folded_expr, _) = ConstantFolder::fold_with_domain(
-                &self.expr,
-                &input_domains,
-                &self.func_ctx,
-                &BUILTIN_FUNCTIONS,
-            );
+    pub fn eval(&self, column_values: &[(&str, &str)]) -> InternalColumnPruneResult {
+        let mut input_domains = self.input_domains.clone();
+        let mut has_internal_column_value = false;
+        for (col_name, value) in column_values {
+            if self.input_domains.contains_key(*col_name) {
+                has_internal_column_value = true;
+                let domain = Domain::String(StringDomain {
+                    min: value.to_string(),
+                    max: Some(value.to_string()),
+                });
+                input_domains.insert((*col_name).to_string(), domain);
+            }
+        }
 
-            !matches!(
-                folded_expr,
-                Expr::Constant(Constant {
-                    scalar: Scalar::Boolean(false),
-                    ..
-                })
-            )
-        } else {
-            true
+        if !has_internal_column_value {
+            return InternalColumnPruneResult::Keep;
+        }
+
+        let (folded_expr, _) = ConstantFolder::fold_with_domain(
+            &self.expr,
+            &input_domains,
+            &self.func_ctx,
+            &BUILTIN_FUNCTIONS,
+        );
+
+        match folded_expr {
+            Expr::Constant(Constant {
+                scalar: Scalar::Boolean(false),
+                ..
+            }) => InternalColumnPruneResult::Pruned,
+            Expr::Constant(Constant {
+                scalar: Scalar::Boolean(true),
+                ..
+            }) => InternalColumnPruneResult::FullMatch,
+            _ => InternalColumnPruneResult::Keep,
         }
     }
 }

--- a/src/query/storages/common/pruner/src/lib.rs
+++ b/src/query/storages/common/pruner/src/lib.rs
@@ -26,6 +26,7 @@ pub use block_meta::BlockMetaIndex;
 pub use block_meta::VirtualBlockMetaIndex;
 pub use block_meta::VirtualColumnReadPlan;
 pub use databend_storages_common_index::VirtualColumnSharedDataType;
+pub use internal_column_pruner::InternalColumnPruneResult;
 pub use internal_column_pruner::InternalColumnPruner;
 pub use limiter_pruner::Limiter;
 pub use limiter_pruner::LimiterPruner;

--- a/src/query/storages/fuse/src/operations/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation_source.rs
@@ -239,6 +239,12 @@ impl FuseTable {
                 }
             }
         }
+        whole_block_deletions.extend(
+            pruner
+                .whole_block_deletions
+                .iter()
+                .map(|index| (index.segment_idx, index.block_idx)),
+        );
 
         let range_block_metas = block_metas
             .clone()

--- a/src/query/storages/fuse/src/pruning/block_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/block_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::future::Future;
 use std::ops::Range;
 use std::pin::Pin;
@@ -22,9 +23,11 @@ use databend_common_catalog::plan::block_id_in_segment;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BLOCK_NAME_COL_NAME;
+use databend_common_expression::SEGMENT_NAME_COL_NAME;
 use databend_common_expression::types::F32;
 use databend_common_metrics::storage::*;
 use databend_storages_common_pruner::BlockMetaIndex;
+use databend_storages_common_pruner::InternalColumnPruneResult;
 use databend_storages_common_pruner::RangeIndexInput;
 use databend_storages_common_pruner::VirtualBlockMetaIndex;
 use databend_storages_common_table_meta::meta::BlockMeta;
@@ -143,6 +146,48 @@ impl BlockPruner {
         Ok(result)
     }
 
+    #[async_backtrace::framed]
+    pub async fn delete_pruning(
+        &self,
+        segment_location: SegmentLocation,
+        block_metas: Arc<Vec<Arc<BlockMeta>>>,
+    ) -> Result<(Vec<(BlockMetaIndex, Arc<BlockMeta>)>, Vec<BlockMetaIndex>)> {
+        let (block_meta_indexes, whole_block_deletions) =
+            self.internal_column_delete_pruning(&segment_location, &block_metas);
+
+        let block_metas = if self.pruning_ctx.bloom_pruner.is_some()
+            || self.pruning_ctx.inverted_index_pruner.is_some()
+            || self.pruning_ctx.spatial_index_pruner.is_some()
+            || self.pruning_ctx.virtual_column_pruner.is_some()
+        {
+            self.block_pruning(
+                segment_location.clone(),
+                block_metas,
+                block_meta_indexes,
+                None,
+            )
+            .await?
+        } else {
+            self.block_pruning_sync(
+                segment_location.clone(),
+                block_metas,
+                block_meta_indexes,
+                None,
+            )?
+        };
+
+        let whole_block_indexes = whole_block_deletions.into_iter().collect::<HashSet<_>>();
+        let whole_block_deletions = block_metas
+            .iter()
+            .filter_map(|(index, _)| {
+                whole_block_indexes
+                    .contains(&index.block_idx)
+                    .then_some(index.clone())
+            })
+            .collect();
+        Ok((block_metas, whole_block_deletions))
+    }
+
     /// Apply internal column pruning.
     pub fn internal_column_pruning(
         &self,
@@ -162,6 +207,46 @@ impl BlockPruner {
                 .enumerate()
                 .map(|(index, block_meta)| (index, block_meta.clone()))
                 .collect(),
+        }
+    }
+
+    /// Apply internal column pruning for delete and collect blocks that can be
+    /// deleted without reading row data.
+    pub fn internal_column_delete_pruning(
+        &self,
+        segment_location: &SegmentLocation,
+        block_metas: &[Arc<BlockMeta>],
+    ) -> (Vec<(usize, Arc<BlockMeta>)>, Vec<usize>) {
+        match &self.pruning_ctx.internal_column_pruner {
+            Some(pruner) => {
+                let mut whole_block_deletions = Vec::new();
+                let block_meta_indexes = block_metas
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, block_meta)| {
+                        match pruner.eval(&[
+                            (SEGMENT_NAME_COL_NAME, &segment_location.location.0),
+                            (BLOCK_NAME_COL_NAME, &block_meta.location.0),
+                        ]) {
+                            InternalColumnPruneResult::Pruned => None,
+                            InternalColumnPruneResult::Keep => Some((index, block_meta.clone())),
+                            InternalColumnPruneResult::FullMatch => {
+                                whole_block_deletions.push(index);
+                                Some((index, block_meta.clone()))
+                            }
+                        }
+                    })
+                    .collect();
+                (block_meta_indexes, whole_block_deletions)
+            }
+            None => (
+                block_metas
+                    .iter()
+                    .enumerate()
+                    .map(|(index, block_meta)| (index, block_meta.clone()))
+                    .collect(),
+                Vec::new(),
+            ),
         }
     }
 

--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -41,6 +41,7 @@ use databend_storages_common_index::NgramArgs;
 use databend_storages_common_index::RangeIndex;
 use databend_storages_common_io::ReadSettings;
 use databend_storages_common_pruner::BlockMetaIndex;
+use databend_storages_common_pruner::InternalColumnPruneResult;
 use databend_storages_common_pruner::InternalColumnPruner;
 use databend_storages_common_pruner::Limiter;
 use databend_storages_common_pruner::LimiterPrunerCreator;
@@ -263,6 +264,7 @@ pub struct FusePruner {
     pub push_down: Option<PushDownInfo>,
     pub inverse_range_index: Option<RangeIndex>,
     pub deleted_segments: Vec<DeletedSegmentInfo>,
+    pub whole_block_deletions: Vec<BlockMetaIndex>,
     pub block_meta_cache: Option<SegmentBlockMetasCache>,
 }
 
@@ -371,6 +373,7 @@ impl FusePruner {
             pruning_ctx,
             inverse_range_index: None,
             deleted_segments: vec![],
+            whole_block_deletions: vec![],
             block_meta_cache: CacheManager::instance().get_segment_block_metas_cache(),
         })
     }
@@ -426,22 +429,44 @@ impl FusePruner {
 
                 async move {
                     // Build pruning tasks.
-                    if let Some(internal_column_pruner) = &pruning_ctx.internal_column_pruner {
-                        batch = batch
-                            .into_iter()
-                            .filter(|segment| {
-                                internal_column_pruner
-                                    .should_keep(SEGMENT_NAME_COL_NAME, &segment.location.0)
-                            })
-                            .collect::<Vec<_>>();
-                    }
+                    let whole_segment_matches =
+                        if let Some(internal_column_pruner) = &pruning_ctx.internal_column_pruner {
+                            let mut whole_segment_matches = HashSet::new();
+                            batch = batch
+                                .into_iter()
+                                .filter(|segment| {
+                                    match internal_column_pruner
+                                        .eval(&[(SEGMENT_NAME_COL_NAME, &segment.location.0)])
+                                    {
+                                        InternalColumnPruneResult::Pruned => false,
+                                        InternalColumnPruneResult::Keep => true,
+                                        InternalColumnPruneResult::FullMatch => {
+                                            whole_segment_matches.insert(segment.segment_idx);
+                                            true
+                                        }
+                                    }
+                                })
+                                .collect::<Vec<_>>();
+                            whole_segment_matches
+                        } else {
+                            HashSet::new()
+                        };
 
                     let mut res = vec![];
                     let mut deleted_segments = vec![];
+                    let mut whole_block_deletions = vec![];
                     let pruned_segments = segment_pruner.pruning(batch).await?;
 
                     if delete_pruning {
                         for (segment_location, compact_segment_info) in &pruned_segments {
+                            if whole_segment_matches.contains(&segment_location.segment_idx) {
+                                deleted_segments.push(DeletedSegmentInfo {
+                                    index: segment_location.segment_idx,
+                                    summary: compact_segment_info.summary.clone(),
+                                });
+                                continue;
+                            }
+
                             if let Some(range_index) = &inverse_range_index {
                                 let range_input = RangeIndexInput::new(
                                     &compact_segment_info.summary.col_stats,
@@ -464,11 +489,11 @@ impl FusePruner {
                                 compact_segment_info,
                                 populate_block_meta_cache,
                             )?;
-                            res.extend(
-                                block_pruner
-                                    .pruning(segment_location.clone(), block_metas)
-                                    .await?,
-                            );
+                            let (mut pruned_blocks, mut whole_blocks) = block_pruner
+                                .delete_pruning(segment_location.clone(), block_metas)
+                                .await?;
+                            res.append(&mut pruned_blocks);
+                            whole_block_deletions.append(&mut whole_blocks);
                         }
                     } else {
                         let sample_probability = table_sample(&push_down)?;
@@ -513,7 +538,7 @@ impl FusePruner {
                             res.extend(block_pruner.pruning(location.clone(), block_metas).await?);
                         }
                     }
-                    Result::<_>::Ok((res, deleted_segments))
+                    Result::<_>::Ok((res, deleted_segments, whole_block_deletions))
                 }
             }));
         }
@@ -525,6 +550,7 @@ impl FusePruner {
             let mut res = worker?;
             metas.extend(res.0);
             self.deleted_segments.append(&mut res.1);
+            self.whole_block_deletions.append(&mut res.2);
         }
         if delete_pruning {
             Ok(metas)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0053_delete_by_internal_columns.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0053_delete_by_internal_columns.test
@@ -36,6 +36,16 @@ select count(*) from t_delete_internal_block
 20
 
 query I
+delete from t_delete_internal_block where _block_name = $delete_block_name and _block_name = '__not_existing_block__'
+----
+0
+
+query I
+select count(*) from t_delete_internal_block
+----
+20
+
+query I
 delete from t_delete_internal_block where _block_name in ($delete_block_name)
 ----
 10
@@ -44,6 +54,19 @@ query I
 select count(*) from t_delete_internal_block
 ----
 10
+
+statement ok
+set variable delete_block_name = (select min(_block_name) from t_delete_internal_block)
+
+query I
+delete from t_delete_internal_block where _block_name = $delete_block_name
+----
+10
+
+query I
+select count(*) from t_delete_internal_block
+----
+0
 
 statement ok
 create table t_delete_internal_segment(a int)
@@ -77,6 +100,16 @@ select count(*) from t_delete_internal_segment
 20
 
 query I
+delete from t_delete_internal_segment where _segment_name = $delete_segment_name and _segment_name = '__not_existing_segment__'
+----
+0
+
+query I
+select count(*) from t_delete_internal_segment
+----
+20
+
+query I
 delete from t_delete_internal_segment where _segment_name in ($delete_segment_name)
 ----
 10
@@ -85,6 +118,19 @@ query I
 select count(*) from t_delete_internal_segment
 ----
 10
+
+statement ok
+set variable delete_segment_name = (select min(_segment_name) from t_delete_internal_segment)
+
+query I
+delete from t_delete_internal_segment where _segment_name = $delete_segment_name
+----
+10
+
+query I
+select count(*) from t_delete_internal_segment
+----
+0
 
 statement ok
 unset variable (delete_block_name, delete_segment_name)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0053_delete_by_internal_columns.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0053_delete_by_internal_columns.test
@@ -1,0 +1,96 @@
+statement ok
+drop table if exists t_delete_internal_block
+
+statement ok
+drop table if exists t_delete_internal_segment
+
+statement ok
+create table t_delete_internal_block(a int)
+
+query I
+insert into t_delete_internal_block select number from numbers(10)
+----
+10
+
+query I
+insert into t_delete_internal_block select number + 10 from numbers(10)
+----
+10
+
+query I
+select count(*) from t_delete_internal_block
+----
+20
+
+statement ok
+set variable delete_block_name = (select min(_block_name) from t_delete_internal_block)
+
+query I
+delete from t_delete_internal_block where _block_name in ('__not_existing_block__')
+----
+0
+
+query I
+select count(*) from t_delete_internal_block
+----
+20
+
+query I
+delete from t_delete_internal_block where _block_name in ($delete_block_name)
+----
+10
+
+query I
+select count(*) from t_delete_internal_block
+----
+10
+
+statement ok
+create table t_delete_internal_segment(a int)
+
+query I
+insert into t_delete_internal_segment select number from numbers(10)
+----
+10
+
+query I
+insert into t_delete_internal_segment select number + 10 from numbers(10)
+----
+10
+
+query I
+select count(*) from t_delete_internal_segment
+----
+20
+
+statement ok
+set variable delete_segment_name = (select min(_segment_name) from t_delete_internal_segment)
+
+query I
+delete from t_delete_internal_segment where _segment_name in ('__not_existing_segment__')
+----
+0
+
+query I
+select count(*) from t_delete_internal_segment
+----
+20
+
+query I
+delete from t_delete_internal_segment where _segment_name in ($delete_segment_name)
+----
+10
+
+query I
+select count(*) from t_delete_internal_segment
+----
+10
+
+statement ok
+unset variable (delete_block_name, delete_segment_name)
+
+statement ok
+drop table t_delete_internal_block all
+
+statement ok
+drop table t_delete_internal_segment all


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix DELETE predicates on Fuse internal metadata columns so `_segment_name` and `_block_name` can be used for metadata-only delete pruning instead of reaching row-level mutation execution and panicking.

This supports statements like:

```sql
DELETE FROM t WHERE _block_name IN (...);
DELETE FROM t WHERE _segment_name IN (...);
DELETE FROM  t WHERE _segment_name = 's1' and _segment_name = 's2';
  ```

Known limitation: meta-only DELETE currently supports _block_name / _segment_name with constant IN lists only; IN (SELECT ...) subqueries are not supported yet and may fail through the existing mutation subquery path.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19977)
<!-- Reviewable:end -->
