### PR TITLE
fix(query): reject duplicate named windows

### DIFF
--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use databend_common_ast::Span;
@@ -97,9 +98,25 @@ impl Binder {
         let mut window_specs = HashMap::new();
         let mut resolved_window_specs = HashMap::new();
         for window in window_list {
-            window_specs.insert(window.name.name.clone(), window.spec.clone());
-            if window.spec.existing_window_name.is_none() {
-                resolved_window_specs.insert(window.name.name.clone(), window.spec.clone());
+            let window_name = self.normalize_identifier(&window.name).name;
+            let mut window_spec = window.spec.clone();
+            if let Some(existing_window_name) = &mut window_spec.existing_window_name {
+                *existing_window_name = self.normalize_identifier(existing_window_name);
+            }
+
+            match window_specs.entry(window_name.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(window_spec.clone());
+                }
+                Entry::Occupied(_) => {
+                    return Err(ErrorCode::SemanticError(format!(
+                        "Duplicate window name: {window_name}"
+                    )));
+                }
+            }
+
+            if window_spec.existing_window_name.is_none() {
+                resolved_window_specs.insert(window_name, window_spec);
             }
         }
         Ok((window_specs, resolved_window_specs))

--- a/src/query/sql/src/planner/semantic/type_check/window.rs
+++ b/src/query/sql/src/planner/semantic/type_check/window.rs
@@ -45,6 +45,7 @@ use super::CoreOrderByExprs;
 use super::TypeCheckAdapter;
 use super::TypeChecker;
 use crate::binder::ExprContext;
+use crate::planner::semantic::normalize_identifier;
 use crate::plans::CastExpr;
 use crate::plans::LagLeadFunction;
 use crate::plans::NthValueFunction;
@@ -377,10 +378,12 @@ where A: TypeCheckAdapter
         let spec = match window {
             CoreWindow::WindowSpec(spec) => spec,
             CoreWindow::WindowReference(window_name) => {
+                let normalized_window_name =
+                    normalize_identifier(window_name, self.name_resolution_ctx).name;
                 let spec = self
                     .bind_context
                     .window_definitions
-                    .get(&window_name.name)
+                    .get(&normalized_window_name)
                     .ok_or_else(|| {
                         ErrorCode::SyntaxException(format!(
                             "Window definition {} not found",

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -445,6 +445,12 @@ async fn test_binder_named_window_paths() -> Result<()> {
             sql: "SELECT depname, sum(sum(salary)) OVER w FROM empsalary GROUP BY depname",
         },
         SqlTestCase {
+            name: "named_window_rejects_duplicate_name",
+            description: "A WINDOW clause must reject duplicate names instead of silently keeping the later definition.",
+            setup_sqls: &["CREATE TABLE empsalary(depname String, salary UInt64)"],
+            sql: "SELECT rank() OVER w FROM empsalary WINDOW w AS (PARTITION BY depname), W AS (ORDER BY salary)",
+        },
+        SqlTestCase {
             name: "inherited_named_window_rejects_partition_override",
             description: "Referencing a named window must not add a new PARTITION BY clause.",
             setup_sqls: &["CREATE TABLE empsalary(depname String, salary UInt64)"],

--- a/src/query/sql/tests/it/semantic/binder_window_named.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_named.txt
@@ -139,6 +139,13 @@ status: error
 code: 1005
 message: Window definition w not found
 
+=== named_window_rejects_duplicate_name ===
+description: A WINDOW clause must reject duplicate names instead of silently keeping the later definition.
+sql: SELECT rank() OVER w FROM empsalary WINDOW w AS (PARTITION BY depname), W AS (ORDER BY salary)
+status: error
+code: 1065
+message: Duplicate window name: w
+
 === inherited_named_window_rejects_partition_override ===
 description: Referencing a named window must not add a new PARTITION BY clause.
 sql: SELECT rank() OVER w2 FROM empsalary WINDOW w1 AS (ORDER BY salary), w2 AS (w1 PARTITION BY depname)

--- a/tests/sqllogictests/suites/query/window_function/named_window_basic.test
+++ b/tests/sqllogictests/suites/query/window_function/named_window_basic.test
@@ -313,5 +313,8 @@ SELECT sum(a) OVER w FROM t1 WINDOW w AS (ORDER BY unnest([1,2,3]))
 statement error 1065
 SELECT sum(a) OVER w FROM t1 WINDOW w AS (PARTITION BY (sum(a) OVER()))
 
+statement error (?s)1065.*Duplicate window name: w
+SELECT rank() OVER w FROM empsalary WINDOW w AS (PARTITION BY depname), W AS (ORDER BY salary)
+
 statement ok
 DROP DATABASE test_named_window_basic


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Reject duplicate named WINDOW definitions during binder pre-processing instead of silently keeping the later definition
- Add SQL binder golden coverage and sqllogictest coverage for duplicate named windows

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19978)
<!-- Reviewable:end -->
