### PR TITLE
chore: skip copy dedup for log history

### DIFF
--- a/src/common/tracing/src/predefined_tables/history_tables.toml
+++ b/src/common/tracing/src/predefined_tables/history_tables.toml
@@ -3,7 +3,7 @@
 name = "log_history"
 target = ""
 create = "CREATE TABLE IF NOT EXISTS system_history.log_history (timestamp TIMESTAMP NULL, path STRING NULL, target STRING NULL, log_level STRING NULL, cluster_id STRING NULL, node_id STRING NULL, warehouse_id STRING NULL, query_id STRING NULL, message STRING NULL, fields VARIANT NULL, batch_number Int64) CLUSTER BY LINEAR(timestamp, query_id)"
-transform = "settings (timezone='Etc/UTC') COPY INTO system_history.log_history FROM (SELECT timestamp, path, target, log_level, cluster_id,node_id, warehouse_id, query_id, message, fields, {batch_number} FROM @{stage_name}) file_format = (TYPE = PARQUET) PURGE = TRUE MAX_FILES = 5000"
+transform = "settings (timezone='Etc/UTC') COPY INTO system_history.log_history FROM (SELECT timestamp, path, target, log_level, cluster_id,node_id, warehouse_id, query_id, message, fields, {batch_number} FROM @{stage_name}) file_format = (TYPE = PARQUET) PURGE = TRUE FORCE = TRUE MAX_FILES = 5000"
 delete = "DELETE FROM system_history.log_history WHERE timestamp < subtract_hours(NOW(), {retention_hours})"
 
 [[tables]]

--- a/tests/logging/history_table/check_logs_table.sh
+++ b/tests/logging/history_table/check_logs_table.sh
@@ -38,6 +38,16 @@ check_query_log() {
   fi
 }
 
+check_log_history_integrity() {
+  local known_query_ids="'$QUERY_ID', '$CREATE_QUERY_ID', '$CREATE_VIEW_QUERY_ID', '$INSERT_QUERY_ID', '$SELECT_QUERY_ID'"
+
+  local duplicate_query="SELECT count(*) FROM (SELECT query_id, target, message FROM system_history.log_history WHERE query_id IN ($known_query_ids) AND target IN ('databend::log::query', 'databend::log::profile', 'databend::log::access') GROUP BY query_id, target, message HAVING count(*) > 1)"
+  check_query_log "integrity-duplicates" null "$duplicate_query" "0"
+
+  local missing_query="SELECT count(*) FROM (SELECT '$QUERY_ID' AS query_id, 'databend::log::query' AS target, 2 AS expected_count UNION ALL SELECT '$CREATE_QUERY_ID', 'databend::log::query', 2 UNION ALL SELECT '$CREATE_VIEW_QUERY_ID', 'databend::log::query', 2 UNION ALL SELECT '$INSERT_QUERY_ID', 'databend::log::query', 2 UNION ALL SELECT '$SELECT_QUERY_ID', 'databend::log::query', 2 UNION ALL SELECT '$QUERY_ID', 'databend::log::profile', 1 UNION ALL SELECT '$SELECT_QUERY_ID', 'databend::log::profile', 1 UNION ALL SELECT '$CREATE_QUERY_ID', 'databend::log::access', 1 UNION ALL SELECT '$INSERT_QUERY_ID', 'databend::log::access', 1 UNION ALL SELECT '$SELECT_QUERY_ID', 'databend::log::access', 1) AS expected LEFT JOIN (SELECT query_id, target, count(*) AS actual_count FROM system_history.log_history WHERE query_id IN ($known_query_ids) AND target IN ('databend::log::query', 'databend::log::profile', 'databend::log::access') GROUP BY query_id, target) AS actual ON expected.query_id = actual.query_id AND expected.target = actual.target WHERE coalesce(actual.actual_count, 0) != expected.expected_count"
+  check_query_log "integrity-missing" null "$missing_query" "0"
+}
+
 
 # Basic log table tests
 check_query_log "basic-1" "$QUERY_ID" "SELECT count(*) FROM system_history.log_history WHERE target = 'databend::log::profile' and" "1"
@@ -60,6 +70,8 @@ check_query_log "basic-9" "$SELECT_QUERY_ID" "SELECT base_objects_accessed[0]['o
 check_query_log "basic-10" "$CREATE_VIEW_QUERY_ID" "select query_text from system_history.query_history where" "CREATE VIEW v AS SELECT a FROM t"
 
 check_query_log "basic-11" null "SELECT count(*) FROM system_history.login_history WHERE session_id = '$SELECT_SESSION_ID' " "1"
+
+check_log_history_integrity
 
 # Timezone tests - regression test for https://github.com/databendlabs/databend/pull/18059
 check_query_log "timezone-1" "$SELECT_QUERY_ID" "settings (timezone='Asia/Shanghai') SELECT DATE_DIFF(hour, timestamp, now()) FROM system_history.log_history WHERE target = 'databend::log::profile' and" "0"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
 
Reduce meta pressure by relaxing copy deduplication for log history. The current log history
  pipeline can still guarantee deduplication on the normal path.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19979)
<!-- Reviewable:end -->
