### PR TITLE
fix(query): handle malformed UDF script metadata

### DIFF
--- a/src/query/script_udf_support/src/transform_udf_script.rs
+++ b/src/query/script_udf_support/src/transform_udf_script.rs
@@ -609,7 +609,7 @@ impl TransformUdfScript {
                     imports_stage_info,
                     ..
                 }) => {
-                    let mut dependencies = Self::extract_deps(&code_str);
+                    let mut dependencies = Self::extract_deps(&code_str)?;
                     dependencies.extend_from_slice(packages.as_slice());
 
                     let stage_fingerprints = Self::collect_stage_fingerprints(imports_stage_info)?;
@@ -677,7 +677,7 @@ impl TransformUdfScript {
         Ok(script_runtimes)
     }
 
-    fn extract_deps(script: &str) -> Vec<String> {
+    fn extract_deps(script: &str) -> Result<Vec<String>> {
         let mut ss = String::new();
         let mut meta_start = false;
         for line in script.lines() {
@@ -693,19 +693,23 @@ impl TransformUdfScript {
             }
         }
 
-        let parsed = ss.parse::<toml::Value>().unwrap();
+        let parsed = ss.parse::<toml::Value>().map_err(|err| {
+            ErrorCode::SemanticError(format!("Failed to parse UDF script metadata as TOML: {err}"))
+        })?;
 
         if parsed.get("dependencies").is_none() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
-        if let Some(deps) = parsed["dependencies"].as_array() {
-            deps.iter()
+        let deps = if let Some(deps) = parsed["dependencies"].as_array() {
+            deps
+                .iter()
                 .filter_map(|v| v.as_str().map(|s| s.to_string()))
                 .collect()
         } else {
             Vec::new()
-        }
+        };
+        Ok(deps)
     }
 
     fn prepare_block_entries(
@@ -1177,4 +1181,26 @@ mod venv {
 
     pub static PY_VENV_CACHE: LazyLock<RwLock<LruCache<PyVenvKeyEntry, PyVenvCacheEntry>>> =
         LazyLock::new(|| RwLock::new(LruCache::with_items_capacity(64)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_deps_returns_error_for_malformed_toml() {
+        let err = TransformUdfScript::extract_deps(
+            r#"# /// script
+# dependencies = [
+# ///
+"#,
+        )
+        .expect_err("malformed UDF script metadata should return an error");
+
+        assert_eq!(err.code(), ErrorCode::SEMANTIC_ERROR);
+        assert!(
+            err.message()
+                .contains("Failed to parse UDF script metadata as TOML")
+        );
+    }
 }

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -264,7 +264,7 @@ fn escape_python_double_quoted(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-fn extract_script_metadata_deps(script: &str) -> Vec<String> {
+fn extract_script_metadata_deps(script: &str) -> Result<Vec<String>> {
     let mut ss = String::new();
     let mut meta_start = false;
     for line in script.lines() {
@@ -280,19 +280,24 @@ fn extract_script_metadata_deps(script: &str) -> Vec<String> {
         }
     }
 
-    let parsed = ss.parse::<toml::Value>().unwrap();
+    let parsed = ss.parse::<toml::Value>().map_err(|err| {
+        ErrorCode::SemanticError(format!(
+            "Failed to parse UDF script metadata as TOML: {err}"
+        ))
+    })?;
 
     if parsed.get("dependencies").is_none() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    if let Some(deps) = parsed["dependencies"].as_array() {
+    let deps = if let Some(deps) = parsed["dependencies"].as_array() {
         deps.iter()
             .filter_map(|value| value.as_str().map(|item| item.to_string()))
             .collect()
     } else {
         Vec::new()
-    }
+    };
+    Ok(deps)
 }
 
 fn unique_heredoc_marker(base: &str, contents: &[&str]) -> String {
@@ -607,7 +612,7 @@ impl UdfAdapter for FullTypeCheckAdapter {
             ErrorCode::SemanticError(format!("Failed to parse UDF code as utf-8: {err}"))
         })?;
         let import_assets = self.build_udf_cloud_imports(&imports)?;
-        let mut merged_packages = extract_script_metadata_deps(&resolved_code);
+        let mut merged_packages = extract_script_metadata_deps(&resolved_code)?;
         merged_packages.extend_from_slice(&packages);
         let input_types = arg_types.iter().map(udf_type_string).collect::<Vec<_>>();
         let result_type = udf_type_string(&return_type);
@@ -1218,5 +1223,27 @@ where A: UdfAdapter
             parameters,
             return_type: udf_definition.return_type,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_script_metadata_deps_returns_error_for_malformed_toml() {
+        let err = extract_script_metadata_deps(
+            r#"# /// script
+# dependencies = [
+# ///
+"#,
+        )
+        .expect_err("malformed UDF script metadata should return an error");
+
+        assert_eq!(err.code(), ErrorCode::SEMANTIC_ERROR);
+        assert!(
+            err.message()
+                .contains("Failed to parse UDF script metadata as TOML")
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Return a semantic error when UDF script metadata contains malformed TOML instead of panicking during dependency extraction.
- Apply the same error propagation to script UDF runtime dependency extraction so malformed `# /// script` metadata is handled consistently.
- Add regression coverage for malformed `dependencies = [` metadata.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

```bash
cargo fmt --package databend-common-sql --package databend-query-script-udf-support
cargo test -p databend-common-sql test_extract_script_metadata_deps_returns_error_for_malformed_toml
cargo test -p databend-query-script-udf-support --features script-udf test_extract_deps_returns_error_for_malformed_toml
git diff --check
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19983)
<!-- Reviewable:end -->
