### PR TITLE
fix(storage): S3 region detection timeout should not fail the query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,7 +4519,9 @@ name = "databend-common-meta-app-storage"
 version = "0.1.0"
 dependencies = [
  "databend-common-exception",
+ "log",
  "opendal 0.54.1",
+ "parking_lot 0.12.3",
  "serde",
  "tokio",
 ]

--- a/src/meta/app-storage/Cargo.toml
+++ b/src/meta/app-storage/Cargo.toml
@@ -8,7 +8,9 @@ edition.workspace = true
 
 [dependencies]
 databend-common-exception = { workspace = true }
+log = { workspace = true }
 opendal = { workspace = true }
+parking_lot = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 

--- a/src/meta/app-storage/src/storage_params.rs
+++ b/src/meta/app-storage/src/storage_params.rs
@@ -12,18 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::sync::LazyLock;
 use std::time::Duration;
+use std::time::Instant;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use log::warn;
+use parking_lot::RwLock;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::time::timeout;
 
 const DEFAULT_DETECT_REGION_TIMEOUT_SEC: u64 = 10;
+const REGION_CACHE_TTL: Duration = Duration::from_secs(3600);
+const REGION_CACHE_MAX_ENTRIES: usize = 1024;
+
+type RegionCache = LazyLock<RwLock<HashMap<(String, String), (String, Instant)>>>;
+
+/// Cache for S3 region detection results.
+///
+/// Key: (endpoint, bucket) — a bucket name alone is not unique because the same
+/// name can exist on different S3-compatible endpoints (AWS, MinIO, OSS, etc.).
+///
+/// Uses `RwLock<HashMap>` rather than a concurrent map because writes are rare
+/// (only on first access to a new bucket or after TTL expiry) while reads are
+/// frequent. Under this workload the uncontended read-lock path is effectively
+/// free, and write-side contention is negligible.
+pub(crate) static REGION_CACHE: RegionCache = LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Storage params which contains the detailed storage info.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -206,29 +226,33 @@ impl StorageParams {
     pub async fn auto_detect(self) -> Result<Self> {
         let sp = match self {
             StorageParams::S3(mut s3) if s3.region.is_empty() => {
-                // Remove the possible trailing `/` in endpoint.
-                let endpoint = s3.endpoint_url.trim_end_matches('/');
+                let endpoint = normalize_s3_endpoint(&s3.endpoint_url);
+                let cache_key = (endpoint.clone(), s3.bucket.clone());
 
-                // Make sure the endpoint contains the scheme.
-                let endpoint = if endpoint.starts_with("http") {
-                    endpoint.to_string()
+                if let Some(cached) = get_cached_region(&cache_key) {
+                    s3.region = cached;
                 } else {
-                    // Prefix https if endpoint doesn't start with scheme.
-                    format!("https://{}", endpoint)
-                };
+                    s3.region = match timeout(
+                        Duration::from_secs(DEFAULT_DETECT_REGION_TIMEOUT_SEC),
+                        opendal::services::S3::detect_region(&endpoint, &s3.bucket),
+                    )
+                    .await
+                    {
+                        Ok(v) => v.unwrap_or_default(),
+                        Err(_) => {
+                            warn!(
+                                "detect region timeout ({}s) for endpoint={}, bucket={}, \
+                                 will rely on downstream fallback",
+                                DEFAULT_DETECT_REGION_TIMEOUT_SEC, endpoint, s3.bucket
+                            );
+                            String::new()
+                        }
+                    };
 
-                s3.region = timeout(
-                    Duration::from_secs(DEFAULT_DETECT_REGION_TIMEOUT_SEC),
-                    opendal::services::S3::detect_region(&endpoint, &s3.bucket),
-                )
-                .await
-                .map_err(|e| {
-                    ErrorCode::StorageOther(format!(
-                        "detect region timeout: {}s, endpoint: {}, elapsed: {}",
-                        DEFAULT_DETECT_REGION_TIMEOUT_SEC, endpoint, e
-                    ))
-                })?
-                .unwrap_or_default();
+                    if !s3.region.is_empty() {
+                        insert_cached_region(cache_key, s3.region.clone());
+                    }
+                }
 
                 StorageParams::S3(s3)
             }
@@ -535,6 +559,38 @@ fn ensure_path_prefix(path: &str) -> String {
         path.to_string()
     } else {
         format!("/{}", path)
+    }
+}
+
+pub(crate) fn normalize_s3_endpoint(endpoint_url: &str) -> String {
+    let endpoint = endpoint_url.trim_end_matches('/');
+    if endpoint.starts_with("http") {
+        endpoint.to_string()
+    } else {
+        format!("https://{}", endpoint)
+    }
+}
+
+pub(crate) fn get_cached_region(key: &(String, String)) -> Option<String> {
+    let cache = REGION_CACHE.read();
+    if let Some((region, ts)) = cache.get(key)
+        && ts.elapsed() < REGION_CACHE_TTL
+    {
+        return Some(region.clone());
+    }
+    None
+}
+
+pub(crate) fn insert_cached_region(key: (String, String), region: String) {
+    let mut cache = REGION_CACHE.write();
+    // Evict expired entries when hitting the capacity limit to prevent
+    // unbounded growth (e.g. from crafted bucket names).
+    if cache.len() >= REGION_CACHE_MAX_ENTRIES {
+        cache.retain(|_, (_, ts)| ts.elapsed() < REGION_CACHE_TTL);
+    }
+    // If still at capacity after eviction, skip caching this entry.
+    if cache.len() < REGION_CACHE_MAX_ENTRIES {
+        cache.insert(key, (region, Instant::now()));
     }
 }
 

--- a/src/meta/app-storage/src/storage_params_test.rs
+++ b/src/meta/app-storage/src/storage_params_test.rs
@@ -479,3 +479,52 @@ fn test_endpoint_none_when_missing() {
     });
     assert_eq!(ftp.endpoint(), None);
 }
+
+#[test]
+fn test_normalize_s3_endpoint() {
+    use crate::storage_params::normalize_s3_endpoint;
+
+    assert_eq!(
+        normalize_s3_endpoint("https://s3.amazonaws.com/"),
+        "https://s3.amazonaws.com"
+    );
+    assert_eq!(
+        normalize_s3_endpoint("https://s3.amazonaws.com"),
+        "https://s3.amazonaws.com"
+    );
+    assert_eq!(
+        normalize_s3_endpoint("s3.amazonaws.com"),
+        "https://s3.amazonaws.com"
+    );
+    assert_eq!(
+        normalize_s3_endpoint("http://minio:9000/"),
+        "http://minio:9000"
+    );
+}
+
+#[test]
+fn test_region_cache_hit_and_expiry() {
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use crate::storage_params::REGION_CACHE;
+    use crate::storage_params::get_cached_region;
+    use crate::storage_params::insert_cached_region;
+
+    let key = (
+        "https://s3.amazonaws.com".to_string(),
+        "test-bucket-cache-hit".to_string(),
+    );
+
+    // Insert a fresh entry.
+    insert_cached_region(key.clone(), "us-west-2".to_string());
+    assert_eq!(get_cached_region(&key), Some("us-west-2".to_string()));
+
+    // Insert an expired entry directly to simulate TTL expiry.
+    {
+        let mut cache = REGION_CACHE.write();
+        let expired = Instant::now() - Duration::from_secs(7200);
+        cache.insert(key.clone(), ("us-west-2".to_string(), expired));
+    }
+    assert_eq!(get_cached_region(&key), None);
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix occasional `detect region timeout` errors during COPY INTO from S3 external locations.

Previously, a timeout in `S3::detect_region` (HeadBucket API call) was a hard error that failed the entire query, even though a downstream fallback (`AWS_REGION` env → `us-east-1` default) already existed in `init_s3_operator`. Under transient network latency or concurrent load, the 10s timeout could fire and short-circuit the fallback path.

Changes:
- Timeout now logs a warning and returns empty region, letting the existing downstream fallback in `init_s3_operator` take over.
- Add a process-level region cache (`parking_lot::RwLock<HashMap>`) keyed by `(endpoint, bucket)` with 1-hour TTL — avoids redundant HeadBucket calls on every query.
- Cap cache at 1024 entries with expired-entry eviction to prevent unbounded growth.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19985)
<!-- Reviewable:end -->
