### PR TITLE
refactor(query): split aggregate row pointer capabilities

### DIFF
--- a/src/query/expression/src/aggregate/aggregate_hashtable.rs
+++ b/src/query/expression/src/aggregate/aggregate_hashtable.rs
@@ -40,6 +40,9 @@ use crate::types::DataType;
 const SMALL_CAPACITY_RESIZE_COUNT: usize = 4;
 
 pub struct AggregateHashTable {
+    // Hash index entries store RowRef values into these payload pages. Any path
+    // that replaces or repartitions payload must clear or rebuild the index
+    // before probing it again.
     pub payload: PartitionedPayload,
     // use for append rows directly during deserialize
     pub direct_append: bool,
@@ -436,7 +439,7 @@ impl AggregateHashTable {
         for payload in self.payload.payloads.iter() {
             for page in payload.pages.iter() {
                 for idx in 0..page.rows {
-                    let row_ptr = page.data_ptr(idx, payload.tuple_size);
+                    let row_ptr = payload.data_ptr(page, idx);
                     let hash = row_ptr.hash(&payload.row_layout);
 
                     hash_index.probe_slot_and_set(hash, row_ptr);

--- a/src/query/expression/src/aggregate/legacy_hash_index.rs
+++ b/src/query/expression/src/aggregate/legacy_hash_index.rs
@@ -167,7 +167,7 @@ impl Entry {
     }
 
     pub fn get_pointer(&self) -> RowPtr {
-        RowPtr::new((self.0 & POINTER_MASK) as *mut u8)
+        RowPtr::new((self.0 & POINTER_MASK) as *const u8)
     }
 
     pub fn set_pointer(&mut self, ptr: RowPtr) {
@@ -365,7 +365,7 @@ mod tests {
             RowPtr::new(unsafe {
                 self.pin_data
                     .as_ptr()
-                    .add(if incoimg { row + self.init_count } else { row }) as _
+                    .add(if incoimg { row + self.init_count } else { row })
             })
         }
 

--- a/src/query/expression/src/aggregate/partitioned_payload.rs
+++ b/src/query/expression/src/aggregate/partitioned_payload.rs
@@ -215,7 +215,7 @@ impl PartitionedPayload {
         );
 
         state.clear();
-        for payload in payloads.into_iter() {
+        for payload in payloads {
             new_partition_payload.combine_single(payload, state)
         }
 

--- a/src/query/expression/src/aggregate/payload.rs
+++ b/src/query/expression/src/aggregate/payload.rs
@@ -33,6 +33,7 @@ use super::payload_row::serialize_column_to_rowformat;
 use super::payload_row::serialize_const_column_to_rowformat;
 use super::probe_state::SelectVector;
 use super::row_ptr::RowLayout;
+use super::row_ptr::RowMut;
 use super::row_ptr::RowPtr;
 use crate::BlockEntry;
 use crate::Column;
@@ -53,7 +54,7 @@ pub struct Payload {
     pub(super) aggrs: Vec<AggregateFunctionRef>,
     pub(super) row_layout: RowLayout,
 
-    pub(super) pages: Pages,
+    pub(super) pages: Vec<Page>,
     pub(super) tuple_size: usize,
     row_per_page: usize,
 
@@ -153,12 +154,14 @@ unsafe impl Send for Payload {}
 unsafe impl Sync for Payload {}
 
 pub(super) struct Page {
-    pub(super) data: Vec<MaybeUninit<u8>>,
+    // RowRef values into this buffer may be stored in hash indexes and flush
+    // state. A page must not reallocate after such row refs are published.
+    data: Vec<MaybeUninit<u8>>,
     pub(super) rows: usize,
     // state_offset = state_rows * agg_len
     // which mark that the offset to clean the agg states
-    pub(super) state_offsets: usize,
-    pub(super) capacity: usize,
+    state_offsets: usize,
+    capacity: usize,
 }
 
 impl Page {
@@ -166,12 +169,23 @@ impl Page {
         self.rows * agg_len != self.state_offsets
     }
 
-    pub(super) fn data_ptr(&self, row: usize, row_size: usize) -> RowPtr {
-        RowPtr::new(unsafe { self.data.as_ptr().add(row * row_size) as _ })
+    pub(super) fn row_ptr(&self, row: usize, row_size: usize) -> RowPtr {
+        debug_assert!(row < self.rows);
+        debug_assert_eq!(self.data.len(), self.rows * row_size);
+        RowPtr::new(unsafe { self.data.as_ptr().add(row * row_size) as *const u8 })
+    }
+
+    fn reserve_row(&mut self, row_size: usize) -> RowMut {
+        debug_assert!(self.rows < self.capacity);
+        let row_offset = self.data.len();
+        unsafe {
+            self.data.set_len(row_offset + row_size);
+        }
+        self.rows += 1;
+        let ptr = unsafe { self.data.as_mut_ptr().add(row_offset) as *mut u8 };
+        RowMut::new(ptr)
     }
 }
-
-pub(super) type Pages = Vec<Page>;
 
 impl Payload {
     pub fn new(
@@ -262,9 +276,8 @@ impl Payload {
         {
             self.current_write_page += 1;
             if self.current_write_page > self.pages.len() {
-                let data = Vec::with_capacity(self.row_per_page * self.tuple_size);
                 self.pages.push(Page {
-                    data,
+                    data: Vec::with_capacity(self.row_per_page * self.tuple_size),
                     rows: 0,
                     state_offsets: 0,
                     capacity: self.row_per_page,
@@ -276,7 +289,7 @@ impl Payload {
     }
 
     pub(super) fn data_ptr(&self, page: &Page, row: usize) -> RowPtr {
-        page.data_ptr(row, self.tuple_size)
+        page.row_ptr(row, self.tuple_size)
     }
 
     pub(super) fn reserve_append_rows(
@@ -289,10 +302,17 @@ impl Payload {
     ) {
         let tuple_size = self.tuple_size;
         let (mut page, mut page_index_value) = self.writable_page();
+        let address = unsafe {
+            // SAFETY: RowRef and RowMut are repr(transparent) wrappers over raw
+            // u8 pointers. Raw pointer mutability does not change layout, and
+            // row_ptr.rs has compile-time size/alignment assertions for these
+            // two wrappers.
+            std::mem::transmute::<&mut [RowPtr; BATCH_SIZE], &mut [RowMut; BATCH_SIZE]>(address)
+        };
         for row in select_vector {
-            address[*row] = page.data_ptr(page.rows, tuple_size);
+            let row_mut = page.reserve_row(tuple_size);
+            address[*row] = row_mut;
             page_index[*row] = page_index_value;
-            page.rows += 1;
 
             if page.rows == page.capacity {
                 (page, page_index_value) = self.writable_page();
@@ -312,7 +332,7 @@ impl Payload {
         &mut self,
         select_vector: &[RowID],
         group_hashes: &[u64; BATCH_SIZE],
-        address: &mut [RowPtr; BATCH_SIZE],
+        address: &mut [RowMut; BATCH_SIZE],
         page_index: &mut [usize],
         group_columns: ProjectedBlock,
     ) {
@@ -454,7 +474,7 @@ impl Payload {
     fn copy_state_addr_rows_for_transfer(
         &mut self,
         select_vector: &[RowID],
-        address: &[RowPtr; BATCH_SIZE],
+        row_refs: &[RowPtr; BATCH_SIZE],
     ) -> Vec<(usize, usize)> {
         let tuple_size = self.tuple_size;
         let agg_len = self.aggrs.len();
@@ -463,14 +483,14 @@ impl Payload {
         let mut page_state_offset = 0;
 
         for index in select_vector {
+            let mut row_mut = page.reserve_row(tuple_size);
             unsafe {
                 std::ptr::copy_nonoverlapping(
-                    address[*index].as_ptr(),
-                    page.data.as_mut_ptr().add(page.rows * tuple_size) as _,
+                    row_refs[*index].as_ptr(),
+                    row_mut.as_mut_ptr(),
                     tuple_size,
                 )
             }
-            page.rows += 1;
             page_state_offset += agg_len;
 
             if page.rows == page.capacity {

--- a/src/query/expression/src/aggregate/payload_flush.rs
+++ b/src/query/expression/src/aggregate/payload_flush.rs
@@ -48,17 +48,17 @@ use crate::types::string::StringColumnBuilder;
 use crate::with_number_mapped_type;
 
 pub struct PayloadFlushState {
-    pub probe_state: Box<ProbeState>,
-    pub group_columns: Vec<BlockEntry>,
+    pub(super) probe_state: Box<ProbeState>,
+    pub(super) group_columns: Vec<BlockEntry>,
     pub(super) aggregate_results: Vec<BlockEntry>,
-    pub row_count: usize,
+    pub(super) row_count: usize,
 
-    pub flush_partition: usize,
-    pub flush_page: usize,
-    pub flush_page_row: usize,
+    flush_partition: usize,
+    pub(super) flush_page: usize,
+    pub(super) flush_page_row: usize,
 
-    pub addresses: [RowPtr; BATCH_SIZE],
-    pub state_places: [StateAddr; BATCH_SIZE],
+    pub(super) addresses: [RowPtr; BATCH_SIZE],
+    pub(super) state_places: [StateAddr; BATCH_SIZE],
 }
 
 impl Default for PayloadFlushState {

--- a/src/query/expression/src/aggregate/payload_row.rs
+++ b/src/query/expression/src/aggregate/payload_row.rs
@@ -22,6 +22,7 @@ use databend_common_io::prelude::bincode_serialize_into_buf;
 use super::BATCH_SIZE;
 use super::RowID;
 use super::RowLayout;
+use super::RowMut;
 use super::RowPtr;
 use crate::BlockEntry;
 use crate::Column;
@@ -84,7 +85,7 @@ pub(super) unsafe fn serialize_column_to_rowformat(
     arena: &Bump,
     column: &Column,
     select_vector: &[RowID],
-    address: &mut [RowPtr; BATCH_SIZE],
+    address: &mut [RowMut; BATCH_SIZE],
     offset: usize,
     scratch: &mut Vec<u8>,
 ) {
@@ -207,7 +208,7 @@ pub(super) unsafe fn serialize_const_column_to_rowformat(
     scalar: &Scalar,
     data_type: &DataType,
     select_vector: &[RowID],
-    address: &mut [RowPtr; BATCH_SIZE],
+    address: &mut [RowMut; BATCH_SIZE],
     offset: usize,
     scratch: &mut Vec<u8>,
 ) {
@@ -299,7 +300,7 @@ pub(super) unsafe fn serialize_const_column_to_rowformat(
 unsafe fn serialize_fixed_size_column_to_rowformat<T>(
     column: &T::Column,
     select_vector: &[RowID],
-    address: &mut [RowPtr; BATCH_SIZE],
+    address: &mut [RowMut; BATCH_SIZE],
     offset: usize,
 ) where
     T: AccessType<Scalar: Copy>,
@@ -635,9 +636,9 @@ mod tests {
 
         let mut row0 = vec![0u8; row_size];
         let mut row1 = vec![0u8; row_size];
-        let mut addresses = [RowPtr::null(); BATCH_SIZE];
-        addresses[0] = RowPtr::new(row0.as_mut_ptr());
-        addresses[1] = RowPtr::new(row1.as_mut_ptr());
+        let mut row_muts: [RowMut; BATCH_SIZE] = std::array::from_fn(|_| RowMut::dangling());
+        row_muts[0] = RowMut::new(row0.as_mut_ptr());
+        row_muts[1] = RowMut::new(row1.as_mut_ptr());
 
         let select_vector = [RowID::from(0), RowID::from(1)];
         let mut scratch = Vec::new();
@@ -646,14 +647,15 @@ mod tests {
                 &arena,
                 &column,
                 &select_vector,
-                &mut addresses,
+                &mut row_muts,
                 0,
                 &mut scratch,
             );
         }
 
-        let bytes0 = unsafe { addresses[0].read_bytes(0) };
-        let bytes1 = unsafe { addresses[1].read_bytes(0) };
+        let row_refs = row_muts.map(RowMut::into_ref);
+        let bytes0 = unsafe { row_refs[0].read_bytes(0) };
+        let bytes1 = unsafe { row_refs[1].read_bytes(0) };
 
         assert_eq!(bytes0, bytes1);
         assert!(bytes0.starts_with(b"HB"));

--- a/src/query/expression/src/aggregate/row_ptr.rs
+++ b/src/query/expression/src/aggregate/row_ptr.rs
@@ -17,43 +17,26 @@ use super::StateAddr;
 use super::StatesLayout;
 use crate::types::StringColumn;
 
-/// A wrapper around raw pointer that provides safe and convenient methods
-/// for accessing row data in the aggregate hash table.
+/// A read-only row pointer into aggregate payload storage.
+#[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct RowPtr(*mut u8);
+pub struct RowPtr(*const u8);
 
 impl RowPtr {
-    pub(super) fn new(ptr: *mut u8) -> Self {
+    pub(super) fn new(ptr: *const u8) -> Self {
         Self(ptr)
     }
 
     pub(super) fn null() -> Self {
-        Self(std::ptr::null_mut())
+        Self(std::ptr::null())
     }
 
     pub(super) fn as_ptr(&self) -> *const u8 {
-        self.0.cast_const()
+        self.0
     }
 
     pub(super) unsafe fn read<T>(&self, offset: usize) -> T {
-        unsafe { core::ptr::read_unaligned(self.0.add(offset).cast::<T>().cast_const()) }
-    }
-
-    pub(super) unsafe fn write<T: Copy>(&mut self, offset: usize, value: &T) {
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                value as *const T as *const u8,
-                self.0.add(offset),
-                size_of::<T>(),
-            );
-        }
-    }
-
-    pub(super) unsafe fn write_bytes(&mut self, offset: usize, value: &[u8]) {
-        unsafe {
-            self.write(offset, &(value.len() as u32));
-            self.write(offset + 4, &(value.as_ptr() as u64));
-        }
+        unsafe { core::ptr::read_unaligned(self.0.add(offset).cast::<T>()) }
     }
 
     pub(super) unsafe fn read_bytes(&self, offset: usize) -> &[u8] {
@@ -97,24 +80,69 @@ impl RowPtr {
         unsafe { self.read::<u8>(offset) != 0 }
     }
 
+    pub(super) fn hash(&self, layout: &RowLayout) -> u64 {
+        unsafe { self.read::<u64>(layout.hash_offset) }
+    }
+
+    pub(super) fn state_addr(&self, layout: &RowLayout) -> StateAddr {
+        unsafe { self.read::<StateAddr>(layout.state_offset) }
+    }
+}
+
+/// A writable row pointer used while constructing aggregate payload rows.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq)]
+pub struct RowMut(*mut u8);
+
+const _: () = {
+    assert!(core::mem::size_of::<RowPtr>() == core::mem::size_of::<RowMut>());
+    assert!(core::mem::align_of::<RowPtr>() == core::mem::align_of::<RowMut>());
+};
+
+impl RowMut {
+    pub(super) fn new(ptr: *mut u8) -> Self {
+        Self(ptr)
+    }
+
+    pub(super) fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.0
+    }
+
+    pub(super) fn dangling() -> Self {
+        Self(std::ptr::NonNull::<u8>::dangling().as_ptr())
+    }
+
+    pub(super) fn into_ref(self) -> RowPtr {
+        RowPtr::new(self.0.cast_const())
+    }
+
+    pub(super) unsafe fn write<T: Copy>(&mut self, offset: usize, value: &T) {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                value as *const T as *const u8,
+                self.0.add(offset),
+                size_of::<T>(),
+            );
+        }
+    }
+
+    pub(super) unsafe fn write_bytes(&mut self, offset: usize, value: &[u8]) {
+        unsafe {
+            self.write(offset, &(value.len() as u32));
+            self.write(offset + 4, &(value.as_ptr() as u64));
+        }
+    }
+
     pub(super) unsafe fn write_u8(&mut self, offset: usize, value: u8) {
         unsafe {
             self.write::<u8>(offset, &value);
         }
     }
 
-    pub(super) fn hash(&self, layout: &RowLayout) -> u64 {
-        unsafe { self.read::<u64>(layout.hash_offset) }
-    }
-
     pub(super) fn set_hash(&mut self, layout: &RowLayout, value: u64) {
         unsafe {
             self.write(layout.hash_offset, &value);
         }
-    }
-
-    pub(super) fn state_addr(&self, layout: &RowLayout) -> StateAddr {
-        unsafe { self.read::<StateAddr>(layout.state_offset) }
     }
 
     pub(super) fn set_state_addr(&mut self, layout: &RowLayout, value: &StateAddr) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Split aggregate payload row pointers into read-only `RowRef` and writable `RowMut`.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19986)
<!-- Reviewable:end -->
