### PR TITLE
fix(query): avoid eliminating aggregate union branch

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
@@ -55,12 +55,20 @@ impl RuleEliminateUnion {
             return Ok(false);
         }
         if child_num == 0 {
-            Ok(matches!(
+            return Ok(matches!(
                 s_expr.plan(),
                 RelOperator::ConstantTableScan(ConstantTableScan { num_rows: 0, .. })
-            ))
-        } else {
+            ));
+        }
+
+        // Only pass through unary operators that preserve empty input as empty output.
+        if matches!(
+            s_expr.plan().rel_op(),
+            RelOp::Filter | RelOp::EvalScalar | RelOp::Sort | RelOp::Limit | RelOp::Exchange
+        ) {
             Self::is_empty_scan(s_expr.child(0)?)
+        } else {
+            Ok(false)
         }
     }
 }
@@ -120,5 +128,37 @@ impl Rule for RuleEliminateUnion {
 
     fn matchers(&self) -> &[Matcher] {
         &self.matchers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::plans::Aggregate;
+    use crate::plans::Filter;
+
+    fn empty_scan_expr() -> SExpr {
+        let empty_scan =
+            ConstantTableScan::new_empty_scan(DataSchemaRefExt::create(vec![]), BTreeSet::new());
+        SExpr::create_leaf(Arc::new(RelOperator::ConstantTableScan(empty_scan)))
+    }
+
+    #[test]
+    fn only_empty_preserving_unary_nodes_are_transparent() -> Result<()> {
+        let filter = SExpr::create_unary(
+            Arc::new(RelOperator::Filter(Filter { predicates: vec![] })),
+            Arc::new(empty_scan_expr()),
+        );
+        assert!(RuleEliminateUnion::is_empty_scan(&filter)?);
+
+        let aggregate = SExpr::create_unary(
+            Arc::new(RelOperator::Aggregate(Aggregate::default())),
+            Arc::new(empty_scan_expr()),
+        );
+        assert!(!RuleEliminateUnion::is_empty_scan(&aggregate)?);
+
+        Ok(())
     }
 }

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -174,6 +174,16 @@ select 1 as c union all select 3.3::Double;
 3.3
 
 query I
+SELECT x FROM (
+  SELECT 1 AS x
+  UNION ALL
+  SELECT count(*) AS x FROM (SELECT * FROM numbers(1) WHERE false)
+) ORDER BY x
+----
+0
+1
+
+query I
 with
 t1 as (select number as a from numbers(10)),
 t2 as (select number as a from numbers(1000)),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix `RuleEliminateUnion` so it only treats an empty branch as removable through unary operators that preserve empty input as empty output.

`Aggregate` is no longer transparent for empty-branch detection, because global aggregates such as `count(*)` still produce one row for empty input. This prevents `UNION ALL` from incorrectly dropping an aggregate branch after `Filter(false)` is rewritten to an empty scan.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --check --package databend-common-sql`
- `cargo test -p databend-common-sql only_empty_preserving_unary_nodes_are_transparent -- --nocapture`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19987)
<!-- Reviewable:end -->
