### PR TITLE
fix(query): preserve offset above outer join limit pushdown

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/limit_rules/rule_push_down_limit_join.rs
@@ -32,11 +32,11 @@ use crate::plans::RelOperator;
 ///            *      *
 ///
 /// Output:
-///             Limit(offset removed)
+///             Limit
 ///               |
 ///        Left Outer Join
 ///             /     \
-///           Limit    *
+///           Limit(limit + offset, offset removed)    *
 ///           /
 ///          *
 pub struct RulePushDownLimitOuterJoin {
@@ -71,26 +71,26 @@ impl Rule for RulePushDownLimitOuterJoin {
     ) -> databend_common_exception::Result<()> {
         let limit: Limit = s_expr.plan().clone().try_into()?;
         if limit.limit.is_some() {
+            let push_down_limit = Limit {
+                before_exchange: false,
+                limit: limit
+                    .limit
+                    .map(|origin_limit| origin_limit.saturating_add(limit.offset)),
+                offset: 0,
+                lazy_columns: Default::default(),
+            };
             let child = s_expr.child(0)?;
             let join: Join = child.plan().clone().try_into()?;
             match join.join_type {
                 JoinType::Left => {
                     let child = child.replace_children(vec![
                         Arc::new(SExpr::create_unary(
-                            Arc::new(RelOperator::Limit(limit.without_lazy_columns())),
+                            Arc::new(RelOperator::Limit(push_down_limit)),
                             Arc::new(child.child(0)?.clone()),
                         )),
                         Arc::new(child.child(1)?.clone()),
                     ]);
-                    let mut result = SExpr::create_unary(
-                        Arc::new(RelOperator::Limit(Limit {
-                            before_exchange: limit.before_exchange,
-                            limit: limit.limit,
-                            offset: 0,
-                            lazy_columns: limit.lazy_columns.clone(),
-                        })),
-                        Arc::new(child),
-                    );
+                    let mut result = s_expr.replace_children(vec![Arc::new(child)]);
                     result.set_applied_rule(&self.id);
                     state.add_result(result)
                 }
@@ -98,19 +98,11 @@ impl Rule for RulePushDownLimitOuterJoin {
                     let child = Arc::new(child.replace_children(vec![
                         Arc::new(child.child(0)?.clone()),
                         Arc::new(SExpr::create_unary(
-                            Arc::new(RelOperator::Limit(limit.without_lazy_columns())),
+                            Arc::new(RelOperator::Limit(push_down_limit)),
                             Arc::new(child.child(1)?.clone()),
                         )),
                     ]));
-                    let mut result = SExpr::create_unary(
-                        Arc::new(RelOperator::Limit(Limit {
-                            before_exchange: limit.before_exchange,
-                            limit: limit.limit,
-                            offset: 0,
-                            lazy_columns: limit.lazy_columns.clone(),
-                        })),
-                        child,
-                    );
+                    let mut result = s_expr.replace_children(vec![child]);
                     result.set_applied_rule(&self.id);
                     state.add_result(result)
                 }

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -129,7 +129,7 @@ explain select * from t left join t1 on t.a = t1.a limit 1,2
 Limit
 ├── output columns: [t1.a (#1), t.a (#0)]
 ├── limit: 2
-├── offset: 0
+├── offset: 1
 ├── estimated rows: 2.00
 └── HashJoin
     ├── output columns: [t1.a (#1), t.a (#0)]
@@ -143,8 +143,8 @@ Limit
     ├── estimated rows: 2.00
     ├── Limit(Build)
     │   ├── output columns: [t.a (#0)]
-    │   ├── limit: 2
-    │   ├── offset: 1
+    │   ├── limit: 3
+    │   ├── offset: 0
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t
@@ -176,7 +176,7 @@ explain select * from t1 right join t on t.a = t1.a limit 1,2
 Limit
 ├── output columns: [t1.a (#0), t.a (#1)]
 ├── limit: 2
-├── offset: 0
+├── offset: 1
 ├── estimated rows: 2.00
 └── HashJoin
     ├── output columns: [t1.a (#0), t.a (#1)]
@@ -190,8 +190,8 @@ Limit
     ├── estimated rows: 2.00
     ├── Limit(Build)
     │   ├── output columns: [t.a (#1)]
-    │   ├── limit: 2
-    │   ├── offset: 1
+    │   ├── limit: 3
+    │   ├── offset: 0
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/select_limit_offset.test
@@ -129,7 +129,7 @@ explain select * from t left join t1 on t.a = t1.a limit 1,2
 Limit
 ├── output columns: [t1.a (#1), t.a (#0)]
 ├── limit: 2
-├── offset: 0
+├── offset: 1
 ├── estimated rows: 2.00
 └── HashJoin
     ├── output columns: [t1.a (#1), t.a (#0)]
@@ -143,8 +143,8 @@ Limit
     ├── estimated rows: 2.00
     ├── Limit(Build)
     │   ├── output columns: [t.a (#0)]
-    │   ├── limit: 2
-    │   ├── offset: 1
+    │   ├── limit: 3
+    │   ├── offset: 0
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t
@@ -176,7 +176,7 @@ explain select * from t1 right join t on t.a = t1.a limit 1,2
 Limit
 ├── output columns: [t1.a (#0), t.a (#1)]
 ├── limit: 2
-├── offset: 0
+├── offset: 1
 ├── estimated rows: 2.00
 └── HashJoin
     ├── output columns: [t1.a (#0), t.a (#1)]
@@ -190,8 +190,8 @@ Limit
     ├── estimated rows: 2.00
     ├── Limit(Build)
     │   ├── output columns: [t.a (#1)]
-    │   ├── limit: 2
-    │   ├── offset: 1
+    │   ├── limit: 3
+    │   ├── offset: 0
     │   ├── estimated rows: 1.00
     │   └── TableScan
     │       ├── table: default.default.t

--- a/tests/sqllogictests/suites/query/join/left_outer.test
+++ b/tests/sqllogictests/suites/query/join/left_outer.test
@@ -336,6 +336,50 @@ select distinct try_cast(flag as int) as f from t2 order by f;
 statement ok
 select * from numbers(10000) a left join numbers(10000) b on a.number % 5 > 1 and b.number % 5 <= 2 and a.number = b.number;
 
+statement ok
+DROP TABLE IF EXISTS limit_outer_l;
+
+statement ok
+DROP TABLE IF EXISTS limit_outer_r;
+
+statement ok
+CREATE TABLE limit_outer_l(a int);
+
+statement ok
+CREATE TABLE limit_outer_r(a int);
+
+statement ok
+INSERT INTO limit_outer_l VALUES (1);
+
+statement ok
+INSERT INTO limit_outer_r VALUES (1), (1), (1);
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT l.a FROM limit_outer_l AS l LEFT JOIN limit_outer_r AS r ON l.a = r.a LIMIT 1 OFFSET 2
+) AS q;
+----
+1
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT l.a FROM limit_outer_r AS r RIGHT JOIN limit_outer_l AS l ON l.a = r.a LIMIT 1 OFFSET 2
+) AS q;
+----
+1
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT l.a FROM limit_outer_l AS l LEFT JOIN limit_outer_r AS r ON l.a = r.a LIMIT 1 OFFSET 18446744073709551615
+) AS q;
+----
+0
+
+statement ok
+DROP TABLE IF EXISTS limit_outer_l;
+
+statement ok
+DROP TABLE IF EXISTS limit_outer_r;
 
 statement ok
 DROP TABLE IF EXISTS t1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix `PushDownLimitOuterJoin` so pushed-down limits on the preserved side use `limit + offset` with `offset = 0`.
- Keep the original top-level `LIMIT/OFFSET` above the outer join so OFFSET is applied to join output rows, not input rows.
- Update explain snapshots and add result coverage for LEFT/RIGHT outer joins where one preserved row matches multiple rows.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p databend-common-sql`
- `cargo clippy -p databend-common-sql --tests -- -D warnings`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19988)
<!-- Reviewable:end -->
