### PR TITLE
fix(query): rotate parquet spill row groups

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_aggregate_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/new_aggregate/new_aggregate_spiller.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use databend_base::uniq_id::GlobalUniq;
 use databend_common_base::base::ProgressValues;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -31,7 +30,6 @@ use databend_common_storages_parquet::ReadSettings;
 use log::debug;
 use log::info;
 use parking_lot::Mutex;
-use parquet::file::metadata::RowGroupMetaData;
 
 use crate::pipelines::memory_settings::MemorySettingsExt;
 use crate::pipelines::processors::transforms::aggregator::NewSpilledPayload;
@@ -43,27 +41,33 @@ use crate::sessions::TableContextSpillProgress;
 use crate::spillers::Layout;
 use crate::spillers::SpillAdapter;
 use crate::spillers::SpillTarget;
+use crate::spillers::SpilledDataFile;
 use crate::spillers::SpillsBufferPool;
 use crate::spillers::SpillsDataWriter;
 
 const BYTES_PER_MIB: usize = 1024 * 1024;
 
 struct PayloadWriter {
-    path: String,
     writer: SpillsDataWriter,
 }
 
 impl PayloadWriter {
-    fn try_create(prefix: &str, writer_pool_bytes: usize) -> Result<Self> {
+    fn try_create(
+        prefix: &str,
+        writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
+    ) -> Result<Self> {
         let data_operator = DataOperator::instance();
         let operator = data_operator.spill_operator();
         let buffer_pool = SpillsBufferPool::instance();
-        let file_path = format!("{}/{}", prefix, GlobalUniq::unique());
-        let spills_data_writer =
-            buffer_pool.writer(operator, file_path.clone(), writer_pool_bytes)?;
+        let spills_data_writer = buffer_pool.writer(
+            operator,
+            prefix.to_string(),
+            writer_pool_bytes,
+            max_row_groups_per_file,
+        )?;
 
         Ok(PayloadWriter {
-            path: file_path,
             writer: spills_data_writer,
         })
     }
@@ -77,9 +81,8 @@ impl PayloadWriter {
         self.writer.flush()
     }
 
-    fn close(self) -> Result<(String, usize, Vec<RowGroupMetaData>)> {
-        let (bytes_written, row_groups) = self.writer.close()?;
-        Ok((self.path, bytes_written, row_groups))
+    fn close(self) -> Result<Vec<SpilledDataFile>> {
+        self.writer.close()
     }
 }
 
@@ -114,6 +117,7 @@ struct AggregatePayloadWriters {
     spill_prefix: String,
     partition_count: usize,
     writer_pool_bytes: usize,
+    max_row_groups_per_file: usize,
     writers: Vec<Option<PayloadWriter>>,
     write_stats: WriteStats,
     ctx: Arc<QueryContext>,
@@ -124,12 +128,14 @@ impl AggregatePayloadWriters {
         prefix: &str,
         partition_count: usize,
         writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
         ctx: Arc<QueryContext>,
     ) -> Self {
         AggregatePayloadWriters {
             spill_prefix: prefix.to_string(),
             partition_count,
             writer_pool_bytes,
+            max_row_groups_per_file,
             writers: Self::empty_writers(partition_count),
             write_stats: WriteStats::default(),
             ctx,
@@ -147,6 +153,7 @@ impl AggregatePayloadWriters {
             self.writers[bucket] = Some(PayloadWriter::try_create(
                 &self.spill_prefix,
                 self.writer_pool_bytes,
+                self.max_row_groups_per_file,
             )?);
         }
 
@@ -187,40 +194,46 @@ impl AggregatePayloadWriters {
                 continue;
             };
 
-            let (path, written_size, row_groups) = writer.close()?;
-
-            if written_size != 0 {
-                info!(
-                    "Write aggregate spill finished: (bucket: {}, location: {}, bytes: {}, rows: {}, batch_count: {})",
-                    partition_id,
+            for file in writer.close()? {
+                let SpilledDataFile {
                     path,
-                    written_size,
-                    row_groups.iter().map(|rg| rg.num_rows()).sum::<i64>(),
-                    row_groups.len()
+                    bytes_written,
+                    row_groups,
+                } = file;
+
+                if bytes_written != 0 {
+                    info!(
+                        "Write aggregate spill finished: (bucket: {}, location: {}, bytes: {}, rows: {}, batch_count: {})",
+                        partition_id,
+                        path,
+                        bytes_written,
+                        row_groups.iter().map(|rg| rg.num_rows()).sum::<i64>(),
+                        row_groups.len()
+                    );
+                }
+
+                self.ctx.add_spill_file(
+                    Location::Remote(path.clone()),
+                    Layout::Aggregate,
+                    bytes_written,
                 );
-            }
 
-            self.ctx.add_spill_file(
-                Location::Remote(path.clone()),
-                Layout::Aggregate,
-                written_size,
-            );
+                if row_groups.is_empty() {
+                    continue;
+                }
 
-            if row_groups.is_empty() {
-                continue;
-            }
+                if bytes_written > 0 {
+                    self.write_stats.add_bytes(bytes_written);
+                }
 
-            if written_size > 0 {
-                self.write_stats.add_bytes(written_size);
-            }
-
-            for row_group in row_groups {
-                self.write_stats.add_rows(row_group.num_rows() as usize);
-                spilled_payloads.push(NewSpilledPayload {
-                    bucket: partition_id as isize,
-                    location: path.clone(),
-                    row_group,
-                });
+                for row_group in row_groups {
+                    self.write_stats.add_rows(row_group.num_rows() as usize);
+                    spilled_payloads.push(NewSpilledPayload {
+                        bucket: partition_id as isize,
+                        location: path.clone(),
+                        row_group,
+                    });
+                }
             }
         }
 
@@ -353,9 +366,17 @@ impl<P: PartitionStream> NewAggregateSpiller<P> {
             .get_settings()
             .get_spill_writer_memory_pool_size_mb()?
             .saturating_mul(BYTES_PER_MIB);
+        let max_row_groups_per_file = ctx
+            .get_settings()
+            .get_max_parquet_spill_row_groups_per_file()?;
 
-        let payload_writers =
-            AggregatePayloadWriters::create(&spill_prefix, partition_count, writer_pool_bytes, ctx);
+        let payload_writers = AggregatePayloadWriters::create(
+            &spill_prefix,
+            partition_count,
+            writer_pool_bytes,
+            max_row_groups_per_file,
+            ctx,
+        );
 
         Ok(Self {
             memory_settings,

--- a/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
+++ b/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use async_channel::Receiver;
 use async_channel::Sender;
-use databend_base::uniq_id::GlobalUniq;
 use databend_common_base::base::Progress;
 use databend_common_base::base::ProgressValues;
 use databend_common_base::runtime::profile::Profile;
@@ -47,8 +46,6 @@ use crate::spillers::SpillTarget;
 use crate::spillers::SpillsBufferPool;
 
 const MATERIALIZED_CTE_SPILL_UNIT_SIZE: usize = 8 * 1024 * 1024;
-/// Maximum number of row groups per file.
-const MAX_ROW_GROUPS_PER_FILE: usize = 2 << 15;
 
 #[derive(Clone)]
 pub enum MaterializedCtePayload {
@@ -106,6 +103,7 @@ pub struct MaterializedCteSink {
     senders: Vec<Sender<MaterializedCtePayload>>,
     prefix: String,
     writer_pool_bytes: usize,
+    max_row_groups_per_file: usize,
     memory_settings: MemorySettings,
     input_data: Option<DataBlock>,
     pending_payloads: VecDeque<MaterializedCtePayload>,
@@ -126,12 +124,14 @@ impl MaterializedCteSink {
         let writer_pool_bytes = settings
             .get_spill_writer_memory_pool_size_mb()?
             .saturating_mul(1024 * 1024);
+        let max_row_groups_per_file = settings.get_max_parquet_spill_row_groups_per_file()?;
         Ok(ProcessorPtr::create(Box::new(Self {
             ctx,
             input,
             senders,
             prefix,
             writer_pool_bytes,
+            max_row_groups_per_file,
             memory_settings,
             input_data: None,
             pending_payloads: VecDeque::new(),
@@ -154,36 +154,37 @@ impl MaterializedCteSink {
         let data_operator = DataOperator::instance();
         let operator = data_operator.spill_operator();
         let buffer_pool = SpillsBufferPool::instance();
-        let path = format!("{}/{}", self.prefix, GlobalUniq::unique());
-        let mut writer = buffer_pool.writer(operator, path.clone(), self.writer_pool_bytes)?;
+        let mut writer = buffer_pool.writer(
+            operator,
+            self.prefix.clone(),
+            self.writer_pool_bytes,
+            self.max_row_groups_per_file,
+        )?;
 
         let schema = Arc::new(data_blocks[0].infer_schema());
-        let mut row_group_ranges = Vec::with_capacity(data_blocks.len());
-        let mut next_row_group = 0;
+        let mut payloads = Vec::with_capacity(data_blocks.len());
         for block in data_blocks {
             writer.write(block)?;
-            let row_group_count = writer.flush_row_groups()?;
-            row_group_ranges.push(next_row_group..row_group_count);
-            next_row_group = row_group_count;
+            for row_groups in writer.flush_row_groups()? {
+                payloads.push(MaterializedCtePayload::Spilled(
+                    MaterializedCteSpilledPayload {
+                        path: row_groups.path,
+                        row_groups: Arc::new(row_groups.row_groups),
+                        schema: schema.clone(),
+                    },
+                ));
+            }
         }
-        let (bytes_written, row_groups) = writer.close()?;
-        if bytes_written > 0 {
-            self.ctx.add_spill_file(
-                Location::Remote(path.clone()),
-                Layout::Parquet,
-                bytes_written,
-            );
+        for file in writer.close()? {
+            if file.bytes_written > 0 {
+                self.ctx.add_spill_file(
+                    Location::Remote(file.path),
+                    Layout::Parquet,
+                    file.bytes_written,
+                );
+            }
         }
-        Ok(row_group_ranges
-            .into_iter()
-            .map(|range| {
-                MaterializedCtePayload::Spilled(MaterializedCteSpilledPayload {
-                    path: path.clone(),
-                    row_groups: Arc::new(row_groups[range].to_vec()),
-                    schema: schema.clone(),
-                })
-            })
-            .collect())
+        Ok(payloads)
     }
 
     fn consume_block(&mut self, data_block: DataBlock) -> Result<()> {
@@ -192,9 +193,7 @@ impl MaterializedCteSink {
             self.spilling_bytes += data_block.memory_size();
             self.spilling_blocks.push(data_block);
 
-            if self.spilling_bytes >= self.spill_unit_size()
-                || self.spilling_blocks.len() >= MAX_ROW_GROUPS_PER_FILE
-            {
+            if self.spilling_bytes >= self.spill_unit_size() {
                 self.flush_spilling_blocks()?;
             }
         } else {

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
@@ -17,7 +17,6 @@ use std::collections::btree_map::Entry;
 use std::sync::Arc;
 use std::sync::PoisonError;
 
-use databend_base::uniq_id::GlobalUniq;
 use databend_common_base::base::ProgressValues;
 use databend_common_exception::Result;
 use databend_common_expression::BlockPartitionStream;
@@ -42,6 +41,7 @@ use crate::sessions::TableContextSettings;
 use crate::spillers::Layout;
 use crate::spillers::SpillAdapter;
 use crate::spillers::SpillTarget;
+use crate::spillers::SpilledDataFile;
 use crate::spillers::SpillsBufferPool;
 use crate::spillers::SpillsDataReader;
 use crate::spillers::SpillsDataWriter;
@@ -55,6 +55,7 @@ pub struct GraceHashJoin<T: GraceMemoryJoin> {
 
     pub(crate) location_prefix: String,
     pub(crate) writer_pool_bytes: usize,
+    pub(crate) max_row_groups_per_file: usize,
     pub(crate) shift_bits: usize,
 
     pub(crate) stage: RestoreStage,
@@ -84,8 +85,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
         };
 
         for (id, data_block) in ready_partitions {
-            self.partitions[id].writer.write(data_block)?;
-            self.partitions[id].writer.flush()?;
+            self.partitions[id].write_block(data_block)?;
         }
 
         Ok(())
@@ -96,23 +96,33 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
 
         let mut ready_partitions = Vec::with_capacity(self.partitions.len());
         for id in 0..self.partitions.len() {
-            let mut partition =
-                GraceJoinPartition::create(&self.location_prefix, self.writer_pool_bytes)?;
+            let mut partition = GraceJoinPartition::create(
+                &self.location_prefix,
+                self.writer_pool_bytes,
+                self.max_row_groups_per_file,
+            )?;
 
             std::mem::swap(&mut self.partitions[id], &mut partition);
             ready_partitions.push(partition);
         }
 
         for (id, partition) in ready_partitions.into_iter().enumerate() {
-            let path = partition.path;
-            let (written, row_groups) = partition.writer.close()?;
+            for file in partition.close()? {
+                let SpilledDataFile {
+                    path,
+                    bytes_written,
+                    row_groups,
+                } = file;
 
-            self.state
-                .ctx
-                .add_spill_file(Location::Remote(path.clone()), Layout::Parquet, written);
+                self.state.ctx.add_spill_file(
+                    Location::Remote(path.clone()),
+                    Layout::Parquet,
+                    bytes_written,
+                );
 
-            if !row_groups.is_empty() {
-                partitions_meta.push((id, SpillMetadata { path, row_groups }));
+                if !row_groups.is_empty() {
+                    partitions_meta.push((id, SpillMetadata { path, row_groups }));
+                }
             }
         }
 
@@ -139,8 +149,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
         let ready_partitions = self.partition_probe_data(data)?;
 
         for (id, data_block) in ready_partitions {
-            self.partitions[id].writer.write(data_block)?;
-            self.partitions[id].writer.flush()?;
+            self.partitions[id].write_block(data_block)?;
         }
 
         Ok(Box::new(EmptyJoinStream))
@@ -213,6 +222,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
         let writer_pool_bytes = settings
             .get_spill_writer_memory_pool_size_mb()?
             .saturating_mul(BYTES_PER_MIB);
+        let max_row_groups_per_file = settings.get_max_parquet_spill_row_groups_per_file()?;
 
         let mut partitions = Vec::with_capacity(16);
 
@@ -220,6 +230,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
             partitions.push(GraceJoinPartition::create(
                 &location_prefix,
                 writer_pool_bytes,
+                max_row_groups_per_file,
             )?);
         }
 
@@ -235,6 +246,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
             stage: RestoreStage::FlushMemory,
             partitions,
             read_settings: ReadSettings::from_settings(&ctx.get_settings())?,
+            max_row_groups_per_file,
             build_partition_stream: BlockPartitionStream::create(rows, bytes, 16),
             probe_partition_stream: BlockPartitionStream::create(rows, bytes, 16),
         })
@@ -358,8 +370,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
 
         for id in ready_partitions_id {
             if let Some(data_block) = self.probe_partition_stream.finalize_partition(id) {
-                self.partitions[id].writer.write(data_block)?;
-                self.partitions[id].writer.flush()?;
+                self.partitions[id].write_block(data_block)?;
             }
         }
 
@@ -367,15 +378,22 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
         let mut partitions_meta = Vec::with_capacity(self.partitions.len());
 
         for (id, partition) in ready_partitions.into_iter().enumerate() {
-            let path = partition.path;
-            let (written, row_groups) = partition.writer.close()?;
+            for file in partition.close()? {
+                let SpilledDataFile {
+                    path,
+                    bytes_written,
+                    row_groups,
+                } = file;
 
-            self.state
-                .ctx
-                .add_spill_file(Location::Remote(path.clone()), Layout::Parquet, written);
+                self.state.ctx.add_spill_file(
+                    Location::Remote(path.clone()),
+                    Layout::Parquet,
+                    bytes_written,
+                );
 
-            if !row_groups.is_empty() {
-                partitions_meta.push((id, SpillMetadata { path, row_groups }));
+                if !row_groups.is_empty() {
+                    partitions_meta.push((id, SpillMetadata { path, row_groups }));
+                }
             }
         }
 
@@ -422,24 +440,38 @@ pub enum RestoreStage {
 }
 
 pub struct GraceJoinPartition {
-    path: String,
     writer: SpillsDataWriter,
 }
 
 impl GraceJoinPartition {
-    pub fn create(prefix: &str, writer_pool_bytes: usize) -> Result<GraceJoinPartition> {
+    pub fn create(
+        prefix: &str,
+        writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
+    ) -> Result<GraceJoinPartition> {
         let data_operator = DataOperator::instance();
 
         let operator = data_operator.spill_operator();
         let buffer_pool = SpillsBufferPool::instance();
-        let file_path = format!("{}/{}", prefix, GlobalUniq::unique());
-        let spills_data_writer =
-            buffer_pool.writer(operator, file_path.clone(), writer_pool_bytes)?;
+        let spills_data_writer = buffer_pool.writer(
+            operator,
+            prefix.to_string(),
+            writer_pool_bytes,
+            max_row_groups_per_file,
+        )?;
 
         Ok(GraceJoinPartition {
-            path: file_path,
             writer: spills_data_writer,
         })
+    }
+
+    fn write_block(&mut self, block: DataBlock) -> Result<()> {
+        self.writer.write(block)?;
+        self.writer.flush()
+    }
+
+    fn close(self) -> Result<Vec<SpilledDataFile>> {
+        self.writer.close()
     }
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
@@ -80,12 +80,14 @@ impl<S: DataProcessorStrategy> TransformWindowPartitionCollect<S> {
         let writer_pool_bytes = settings
             .get_spill_writer_memory_pool_size_mb()?
             .saturating_mul(1024 * 1024);
+        let max_row_groups_per_file = settings.get_max_parquet_spill_row_groups_per_file()?;
 
         let sort_block_size = settings.get_window_partition_sort_block_size()? as usize;
         let buffer = WindowPartitionBuffer::new(
             ctx.clone(),
             prefix,
             writer_pool_bytes,
+            max_row_groups_per_file,
             partitions.len(),
             sort_block_size,
             memory_settings,

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_buffer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_buffer.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use databend_base::uniq_id::GlobalUniq;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
@@ -30,9 +29,6 @@ use crate::spillers::SpillAdapter;
 use crate::spillers::SpillTarget;
 use crate::spillers::SpillsBufferPool;
 use crate::spillers::SpillsDataWriter;
-
-/// Maximum number of row groups per file before rotating to a new file.
-const MAX_ROW_GROUPS_PER_FILE: usize = 2 << 15;
 
 fn concat_data_blocks(data_blocks: Vec<DataBlock>, target_size: usize) -> Result<Vec<DataBlock>> {
     let mut num_rows = 0;
@@ -57,62 +53,71 @@ fn concat_data_blocks(data_blocks: Vec<DataBlock>, target_size: usize) -> Result
 }
 
 struct PartitionFileWriter {
-    path: String,
     writer: SpillsDataWriter,
     schema: Option<DataSchemaRef>,
 }
 
 impl PartitionFileWriter {
-    fn create(prefix: &str, writer_pool_bytes: usize) -> Result<Self> {
+    fn create(
+        prefix: &str,
+        writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
+    ) -> Result<Self> {
         let data_operator = DataOperator::instance();
         let operator = data_operator.spill_operator();
         let buffer_pool = SpillsBufferPool::instance();
-        let path = format!("{}/{}", prefix, GlobalUniq::unique());
-        let writer = buffer_pool.writer(operator, path.clone(), writer_pool_bytes)?;
+        let writer = buffer_pool.writer(
+            operator,
+            prefix.to_string(),
+            writer_pool_bytes,
+            max_row_groups_per_file,
+        )?;
         Ok(Self {
-            path,
             writer,
             schema: None,
         })
     }
 
-    fn write_blocks(&mut self, blocks: Vec<DataBlock>) -> Result<usize> {
+    fn write_blocks(&mut self, blocks: Vec<DataBlock>) -> Result<()> {
         for block in blocks {
             if self.schema.is_none() {
                 self.schema = Some(Arc::new(block.infer_schema()));
             }
             self.writer.write(block)?;
         }
-        self.writer.flush_row_groups()
+        self.writer.flush_row_groups()?;
+        Ok(())
     }
 
-    fn close(self, ctx: &Arc<QueryContext>) -> Result<PartitionFileReader> {
-        let Self {
-            path,
-            writer,
-            schema,
-        } = self;
-        let (bytes_written, row_groups) = writer.close()?;
-        log::debug!(
-            path = path,
-            bytes_written;
-            "partition file closed"
-        );
+    fn close(self, ctx: &Arc<QueryContext>) -> Result<Vec<PartitionFileReader>> {
+        let Self { writer, schema } = self;
+        let schema = schema.unwrap_or_else(|| Arc::new(Default::default()));
+        let mut readers = Vec::new();
 
-        if bytes_written > 0 {
-            SpillAdapter::add_spill_file(
-                ctx,
-                Location::Remote(path.clone()),
-                Layout::Parquet,
-                bytes_written,
+        for file in writer.close()? {
+            log::debug!(
+                path = file.path,
+                bytes_written = file.bytes_written;
+                "partition file closed"
             );
+
+            if file.bytes_written > 0 {
+                SpillAdapter::add_spill_file(
+                    ctx,
+                    Location::Remote(file.path.clone()),
+                    Layout::Parquet,
+                    file.bytes_written,
+                );
+            }
+
+            readers.push(PartitionFileReader {
+                path: file.path,
+                row_groups: file.row_groups,
+                schema: schema.clone(),
+            });
         }
 
-        Ok(PartitionFileReader {
-            path,
-            row_groups,
-            schema: schema.unwrap_or_else(|| Arc::new(Default::default())),
-        })
+        Ok(readers)
     }
 }
 
@@ -196,9 +201,9 @@ impl PartitionSlot {
     #[fastrace::trace(name = "PartitionSlot::spill_blocks")]
     fn spill_blocks(
         &mut self,
-        ctx: &Arc<QueryContext>,
         prefix: &str,
         writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
         blocks: Vec<DataBlock>,
     ) -> Result<()> {
         let row_group_size: usize = blocks.iter().map(|b| b.memory_size()).sum();
@@ -206,14 +211,13 @@ impl PartitionSlot {
 
         match &mut self.state {
             PartitionSpillState::Empty => {
-                let mut writer = PartitionFileWriter::create(prefix, writer_pool_bytes)?;
-                let row_group_count = writer.write_blocks(blocks)?;
-                if row_group_count >= MAX_ROW_GROUPS_PER_FILE {
-                    let reader = writer.close(ctx)?;
-                    self.readers.push(reader);
-                } else {
-                    self.state = PartitionSpillState::Writing { writer };
-                }
+                let mut writer = PartitionFileWriter::create(
+                    prefix,
+                    writer_pool_bytes,
+                    max_row_groups_per_file,
+                )?;
+                writer.write_blocks(blocks)?;
+                self.state = PartitionSpillState::Writing { writer };
                 Ok(())
             }
             PartitionSpillState::Writing { .. } => {
@@ -223,14 +227,8 @@ impl PartitionSlot {
                     unreachable!()
                 };
 
-                let row_group_count = writer.write_blocks(blocks)?;
-
-                if row_group_count >= MAX_ROW_GROUPS_PER_FILE {
-                    let reader = writer.close(ctx)?;
-                    self.readers.push(reader);
-                } else {
-                    self.state = PartitionSpillState::Writing { writer };
-                }
+                writer.write_blocks(blocks)?;
+                self.state = PartitionSpillState::Writing { writer };
                 Ok(())
             }
             PartitionSpillState::Reading => unreachable!("partition already closed"),
@@ -241,8 +239,7 @@ impl PartitionSlot {
         if let PartitionSpillState::Writing { writer } =
             std::mem::replace(&mut self.state, PartitionSpillState::Reading)
         {
-            let reader = writer.close(ctx)?;
-            self.readers.push(reader);
+            self.readers.extend(writer.close(ctx)?);
         }
         Ok(std::mem::take(&mut self.readers))
     }
@@ -252,6 +249,7 @@ pub(super) struct WindowPartitionBuffer {
     ctx: Arc<QueryContext>,
     prefix: String,
     writer_pool_bytes: usize,
+    max_row_groups_per_file: usize,
     partitions: Vec<PartitionSlot>,
     memory_settings: MemorySettings,
     min_row_group_size: usize,
@@ -265,6 +263,7 @@ impl WindowPartitionBuffer {
         ctx: Arc<QueryContext>,
         prefix: String,
         writer_pool_bytes: usize,
+        max_row_groups_per_file: usize,
         num_partitions: usize,
         sort_block_size: usize,
         memory_settings: MemorySettings,
@@ -274,6 +273,7 @@ impl WindowPartitionBuffer {
             ctx,
             prefix,
             writer_pool_bytes,
+            max_row_groups_per_file,
             partitions,
             memory_settings,
             min_row_group_size: 10 * 1024 * 1024,
@@ -312,7 +312,12 @@ impl WindowPartitionBuffer {
                 continue;
             }
             if let Some(blocks) = partition.take_blocks(Some(spill_unit_size)) {
-                partition.spill_blocks(&self.ctx, &self.prefix, self.writer_pool_bytes, blocks)?;
+                partition.spill_blocks(
+                    &self.prefix,
+                    self.writer_pool_bytes,
+                    self.max_row_groups_per_file,
+                    blocks,
+                )?;
                 return Ok(());
             }
 
@@ -330,7 +335,12 @@ impl WindowPartitionBuffer {
             && size >= self.min_row_group_size
         {
             let blocks = partition.take_blocks(None).unwrap();
-            partition.spill_blocks(&self.ctx, &self.prefix, self.writer_pool_bytes, blocks)?;
+            partition.spill_blocks(
+                &self.prefix,
+                self.writer_pool_bytes,
+                self.max_row_groups_per_file,
+                blocks,
+            )?;
         } else {
             self.can_spill = false;
         }

--- a/src/query/service/src/spillers/async_buffer.rs
+++ b/src/query/service/src/spillers/async_buffer.rs
@@ -27,6 +27,7 @@ use std::time::Instant;
 use arrow_schema::Schema;
 use bytes::Bytes;
 use bytes::BytesMut;
+use databend_base::uniq_id::GlobalUniq;
 use databend_common_base::base::GlobalInstance;
 use databend_common_base::runtime::Runtime;
 use databend_common_base::runtime::spawn;
@@ -223,11 +224,17 @@ impl SpillsBufferPool {
     pub fn writer(
         self: &Arc<Self>,
         op: Operator,
-        path: String,
+        prefix: String,
         pool_bytes: usize,
+        max_row_groups_per_file: usize,
     ) -> Result<SpillsDataWriter> {
-        let writer = self.buffer_writer(op, path, pool_bytes)?;
-        Ok(SpillsDataWriter::Uninitialize(Some(writer)))
+        Ok(SpillsDataWriter::create(
+            op,
+            prefix,
+            pool_bytes,
+            self.clone(),
+            max_row_groups_per_file,
+        ))
     }
 
     pub(super) fn buffer_writer(
@@ -394,24 +401,38 @@ pub struct InitializedBlocksStreamWriter {
     writer: ArrowWriter<BufferWriter>,
 }
 
-pub enum SpillsDataWriter {
+pub struct SpilledDataFile {
+    pub path: String,
+    pub bytes_written: usize,
+    pub row_groups: Vec<RowGroupMetaData>,
+}
+
+pub struct SpilledRowGroups {
+    pub path: String,
+    pub row_groups: Vec<RowGroupMetaData>,
+}
+
+enum PhysicalSpillsDataWriter {
     Uninitialize(Option<BufferWriter>),
     Initialized(InitializedBlocksStreamWriter),
 }
 
-impl SpillsDataWriter {
-    pub fn create(writer: BufferWriter) -> Self {
+impl PhysicalSpillsDataWriter {
+    fn create(writer: BufferWriter) -> Self {
         Self::Uninitialize(Some(writer))
     }
 
-    pub fn write(&mut self, block: DataBlock) -> Result<()> {
+    fn write(&mut self, block: DataBlock) -> Result<()> {
         match self {
-            SpillsDataWriter::Uninitialize(writer) => {
+            PhysicalSpillsDataWriter::Uninitialize(writer) => {
                 let data_schema = block.infer_schema();
                 let table_schema = infer_table_schema(&data_schema)?;
 
                 let props = WriterProperties::builder()
                     .set_compression(Compression::LZ4_RAW)
+                    // Spills explicitly flush row groups at operator boundaries; do not let
+                    // ArrowWriter split one spill block into extra row groups by row count.
+                    .set_max_row_group_row_count(Some(usize::MAX))
                     .set_statistics_enabled(EnabledStatistics::None)
                     .set_bloom_filter_enabled(false)
                     .set_dictionary_enabled(false)
@@ -422,39 +443,42 @@ impl SpillsDataWriter {
                 let mut writer = ArrowWriter::try_new(buffer_writer, arrow_schema, Some(props))?;
                 let record_batch = block.to_record_batch(&table_schema)?;
                 writer.write(&record_batch)?;
-                *self = SpillsDataWriter::Initialized(InitializedBlocksStreamWriter {
+                *self = PhysicalSpillsDataWriter::Initialized(InitializedBlocksStreamWriter {
                     writer,
                     table_schema,
                 });
 
                 Ok(())
             }
-            SpillsDataWriter::Initialized(writer) => {
+            PhysicalSpillsDataWriter::Initialized(writer) => {
                 let record_batch = block.to_record_batch(&writer.table_schema)?;
                 Ok(writer.writer.write(&record_batch)?)
             }
         }
     }
 
-    pub fn flush(&mut self) -> Result<()> {
+    fn row_group_count(&self) -> usize {
         match self {
-            SpillsDataWriter::Uninitialize(_) => Err(ErrorCode::Internal(
-                "Bad state, BlockStreamWriter is uninitialized",
-            )),
-            SpillsDataWriter::Initialized(writer) => {
-                writer.writer.flush()?;
-                Ok(writer.writer.inner_mut().flush()?)
+            PhysicalSpillsDataWriter::Uninitialize(_) => 0,
+            PhysicalSpillsDataWriter::Initialized(writer) => {
+                writer.writer.flushed_row_groups().len()
             }
         }
     }
 
-    /// Flush current buffered data as complete row groups and return the total flushed row group count.
-    pub fn flush_row_groups(&mut self) -> Result<usize> {
+    fn row_groups(&self) -> &[RowGroupMetaData] {
         match self {
-            SpillsDataWriter::Uninitialize(_) => Err(ErrorCode::Internal(
+            PhysicalSpillsDataWriter::Uninitialize(_) => &[],
+            PhysicalSpillsDataWriter::Initialized(writer) => writer.writer.flushed_row_groups(),
+        }
+    }
+
+    fn flush_row_groups(&mut self) -> Result<usize> {
+        match self {
+            PhysicalSpillsDataWriter::Uninitialize(_) => Err(ErrorCode::Internal(
                 "Bad state, BlockStreamWriter is uninitialized",
             )),
-            SpillsDataWriter::Initialized(writer) => {
+            PhysicalSpillsDataWriter::Initialized(writer) => {
                 writer.writer.flush()?;
                 writer.writer.inner_mut().flush()?;
                 Ok(writer.writer.flushed_row_groups().len())
@@ -462,16 +486,16 @@ impl SpillsDataWriter {
         }
     }
 
-    pub fn close(self) -> Result<(usize, Vec<RowGroupMetaData>)> {
+    fn close(self) -> Result<(usize, Vec<RowGroupMetaData>)> {
         match self {
-            SpillsDataWriter::Uninitialize(mut writer) => {
+            PhysicalSpillsDataWriter::Uninitialize(mut writer) => {
                 if let Some(writer) = writer.take() {
                     writer.close()?;
                 }
 
                 Ok((0, vec![]))
             }
-            SpillsDataWriter::Initialized(mut writer) => {
+            PhysicalSpillsDataWriter::Initialized(mut writer) => {
                 writer.writer.flush()?;
                 let row_groups = writer.writer.flushed_row_groups().to_vec();
                 let bytes_written = writer.writer.bytes_written();
@@ -480,6 +504,137 @@ impl SpillsDataWriter {
                 Ok((bytes_written, row_groups))
             }
         }
+    }
+}
+
+struct ActiveSpillsDataWriter {
+    path: String,
+    writer: PhysicalSpillsDataWriter,
+}
+
+pub struct SpillsDataWriter {
+    operator: Operator,
+    prefix: String,
+    pool_bytes: usize,
+    buffer_pool: Arc<SpillsBufferPool>,
+    current: Option<ActiveSpillsDataWriter>,
+    closed_files: Vec<SpilledDataFile>,
+    max_row_groups_per_file: usize,
+}
+
+impl SpillsDataWriter {
+    fn create(
+        operator: Operator,
+        prefix: String,
+        pool_bytes: usize,
+        buffer_pool: Arc<SpillsBufferPool>,
+        max_row_groups_per_file: usize,
+    ) -> Self {
+        Self {
+            operator,
+            prefix,
+            pool_bytes,
+            buffer_pool,
+            current: None,
+            closed_files: Vec::new(),
+            max_row_groups_per_file,
+        }
+    }
+
+    fn create_physical_writer(
+        buffer_pool: &Arc<SpillsBufferPool>,
+        operator: Operator,
+        prefix: &str,
+        pool_bytes: usize,
+    ) -> Result<ActiveSpillsDataWriter> {
+        let path = format!("{}/{}", prefix, GlobalUniq::unique());
+        let writer = buffer_pool.buffer_writer(operator, path.clone(), pool_bytes)?;
+        Ok(ActiveSpillsDataWriter {
+            path,
+            writer: PhysicalSpillsDataWriter::create(writer),
+        })
+    }
+
+    fn ensure_current(&mut self) -> Result<&mut ActiveSpillsDataWriter> {
+        if self.current.is_none() {
+            self.current = Some(Self::create_physical_writer(
+                &self.buffer_pool,
+                self.operator.clone(),
+                &self.prefix,
+                self.pool_bytes,
+            )?);
+        }
+        Ok(self.current.as_mut().unwrap())
+    }
+
+    fn close_current(&mut self) -> Result<()> {
+        let Some(current) = self.current.take() else {
+            return Ok(());
+        };
+
+        let (bytes_written, row_groups) = current.writer.close()?;
+        if bytes_written != 0 || !row_groups.is_empty() {
+            self.closed_files.push(SpilledDataFile {
+                path: current.path,
+                bytes_written,
+                row_groups,
+            });
+        }
+        Ok(())
+    }
+
+    fn rotate_if_full(&mut self) -> Result<()> {
+        if self
+            .current
+            .as_ref()
+            .is_some_and(|current| current.writer.row_group_count() >= self.max_row_groups_per_file)
+        {
+            self.close_current()?;
+        }
+        Ok(())
+    }
+
+    pub fn write(&mut self, block: DataBlock) -> Result<()> {
+        if block.is_empty() {
+            return Ok(());
+        }
+
+        self.rotate_if_full()?;
+        self.ensure_current()?.writer.write(block)
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        let _ = self.flush_row_groups()?;
+        Ok(())
+    }
+
+    /// Flush the current in-progress row group and return the row groups produced
+    /// by this flush. The physical file boundary is owned here so every caller is
+    /// protected from Parquet's per-file row group limit.
+    pub fn flush_row_groups(&mut self) -> Result<Vec<SpilledRowGroups>> {
+        let Some(current) = self.current.as_mut() else {
+            return Ok(Vec::new());
+        };
+
+        let before = current.writer.row_group_count();
+        let row_group_count = current.writer.flush_row_groups()?;
+        let row_groups = current.writer.row_groups()[before..row_group_count].to_vec();
+        let path = current.path.clone();
+
+        if row_group_count >= self.max_row_groups_per_file {
+            self.close_current()?;
+        }
+
+        if row_groups.is_empty() {
+            Ok(Vec::new())
+        } else {
+            Ok(vec![SpilledRowGroups { path, row_groups }])
+        }
+    }
+
+    pub fn close(mut self) -> Result<Vec<SpilledDataFile>> {
+        self.close_current()?;
+        Ok(self.closed_files)
     }
 }
 
@@ -769,6 +924,9 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use databend_common_base::runtime::spawn;
+    use databend_common_expression::DataBlock;
+    use databend_common_expression::FromData;
+    use databend_common_expression::types::number::Int32Type;
     use opendal::Operator;
 
     use super::*;
@@ -776,6 +934,10 @@ mod tests {
     fn create_test_operator() -> std::io::Result<Operator> {
         let builder = opendal::services::Fs::default().root("/tmp");
         Ok(Operator::new(builder)?.finish())
+    }
+
+    fn sample_block(value: i32) -> DataBlock {
+        DataBlock::new_from_columns(vec![Int32Type::from_data(vec![value])])
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -935,6 +1097,33 @@ mod tests {
         buffer_writer.write_all(b"minimum chunk").unwrap();
         let metadata = buffer_writer.close().unwrap();
         assert!(metadata.content_length() > 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_spills_data_writer_rotates_by_row_group_count() {
+        let pool = SpillsBufferPool::create(1).unwrap();
+        let operator = create_test_operator().unwrap();
+        let mut writer = SpillsDataWriter::create(
+            operator,
+            "row_group_rotate_test".to_string(),
+            CHUNK_SIZE,
+            pool,
+            2,
+        );
+
+        writer.write(sample_block(1)).unwrap();
+        writer.flush().unwrap();
+        writer.write(sample_block(2)).unwrap();
+        writer.flush().unwrap();
+        writer.write(sample_block(3)).unwrap();
+        writer.flush().unwrap();
+
+        let files = writer.close().unwrap();
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].row_groups.len(), 2);
+        assert_eq!(files[1].row_groups.len(), 1);
+        assert!(files.iter().all(|file| file.bytes_written > 0));
+        assert_ne!(files[0].path, files[1].path);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/query/service/src/spillers/mod.rs
+++ b/src/query/service/src/spillers/mod.rs
@@ -25,6 +25,8 @@ mod test_memory;
 pub use adapter::*;
 pub use async_buffer::BufferWriter;
 pub use async_buffer::SpillTarget;
+pub use async_buffer::SpilledDataFile;
+pub use async_buffer::SpilledRowGroups;
 pub use async_buffer::SpillsBufferPool;
 pub use async_buffer::SpillsDataReader;
 pub use async_buffer::SpillsDataWriter;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -246,6 +246,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(1..=1024)),
                 }),
+                ("max_parquet_spill_row_groups_per_file", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(i16::MAX as u64),
+                    desc: "Sets the maximum number of row groups per Parquet spill file before rotating to a new file.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(1..=i16::MAX as u64)),
+                }),
                 ("grouping_sets_channel_size", DefaultSettingValue {
                     value: UserSettingValue::UInt64(2),
                     desc: "Sets the channel size for grouping sets to union transformation.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -1043,6 +1043,10 @@ impl Settings {
         self.try_get_u64("max_spill_io_requests")
     }
 
+    pub fn get_max_parquet_spill_row_groups_per_file(&self) -> Result<usize> {
+        Ok(self.try_get_u64("max_parquet_spill_row_groups_per_file")? as usize)
+    }
+
     // Get grouping_sets_channel_size.
     pub fn get_grouping_sets_channel_size(&self) -> Result<u64> {
         self.try_get_u64("grouping_sets_channel_size")

--- a/tests/sqllogictests/suites/query/spill_row_group_limit.test
+++ b/tests/sqllogictests/suites/query/spill_row_group_limit.test
@@ -10,7 +10,7 @@ INNER JOIN (SELECT number AS k FROM numbers(4)) AS r ON l.k = r.k
 1000
 
 query I
-settings (enable_experiment_aggregate = 1, force_aggregate_data_spill = 1, max_threads = 1, max_block_size = 1, max_block_bytes = 1048576, max_parquet_spill_row_groups_per_file = 2)
+settings (force_aggregate_data_spill = 1, max_threads = 1, max_block_size = 1, max_block_bytes = 1048576, max_parquet_spill_row_groups_per_file = 2)
 SELECT COUNT()
 FROM (
     SELECT concat(number::string, repeat('x', 1024)) AS k, COUNT()

--- a/tests/sqllogictests/suites/query/spill_row_group_limit.test
+++ b/tests/sqllogictests/suites/query/spill_row_group_limit.test
@@ -1,0 +1,21 @@
+# related PR: #19990
+# Use a small Parquet spill row-group limit to exercise spill file rotation while
+# verifying that restore still returns the correct result.
+query I
+settings (force_join_data_spill = 1, max_threads = 1, max_block_size = 1, max_parquet_spill_row_groups_per_file = 2)
+SELECT COUNT()
+FROM (SELECT number % 4 AS k FROM numbers(1000)) AS l
+INNER JOIN (SELECT number AS k FROM numbers(4)) AS r ON l.k = r.k
+----
+1000
+
+query I
+settings (enable_experiment_aggregate = 1, force_aggregate_data_spill = 1, max_threads = 1, max_block_size = 1, max_block_bytes = 1048576, max_parquet_spill_row_groups_per_file = 2)
+SELECT COUNT()
+FROM (
+    SELECT concat(number::string, repeat('x', 1024)) AS k, COUNT()
+    FROM numbers(20000)
+    GROUP BY k
+)
+----
+20000


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Rotate parquet spill files before a single file reaches parquet's row group ordinal limit.
- Support multiple spill files per aggregate bucket / grace hash join partition when rotation happens.
- Add unit coverage for rolling spill writer file rotation.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19990)
<!-- Reviewable:end -->
