### PR TITLE
fix(query): avoid task context for warehouse filter

### DIFF
--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -86,7 +86,6 @@ use crate::meta_client_error;
 use crate::meta_service_error;
 use crate::schedulers::ServiceQueryExecutor;
 use crate::sessions::QueryContext;
-use crate::sessions::TableContextCluster;
 use crate::sessions::TableContextSettings;
 use crate::task::meta::TaskMetaHandle;
 use crate::task::session::create_session;
@@ -222,13 +221,11 @@ impl TaskService {
                 ..
             }) = task_message.warehouse_options()
             {
-                if warehouse
-                    != &self
-                        .create_context(None)
-                        .await?
-                        .get_cluster()
-                        .get_warehouse_id()?
-                {
+                let current_warehouse = ClusterDiscovery::instance()
+                    .single_node_cluster(&GlobalConfig::instance())
+                    .await?
+                    .get_warehouse_id()?;
+                if warehouse != &current_warehouse {
                     continue;
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Avoid creating a full task `QueryContext` only to filter task messages by warehouse
- Use the same `ClusterDiscovery::single_node_cluster(GlobalConfig)` path that task context creation already uses for the local cluster
- Keep task execution sessions as `SessionType::MySQL` so task SQL behavior, including temporary table support, remains unchanged

This PR is scoped to reducing task scheduling overhead in warehouse filtering. It does not include the storage/cache accounting investigation or fix.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - No SQL behavior change; validated with formatting and compile checks below

Validation:

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p databend-query`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19993)
<!-- Reviewable:end -->
