### PR TITLE
fix(query): preserve union coercion in filter pushdown

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_union.rs
@@ -93,7 +93,7 @@ impl Rule for RulePushDownFilterUnion {
                 .zip(union_side.iter())
                 .map(|(index, side)| {
                     let replacement = match &side.1 {
-                        Some(expr) => UnionOutputReplacement::Scalar(expr.clone()),
+                        Some(expr) => UnionOutputReplacement::Scalar(Box::new(expr.clone())),
                         None => UnionOutputReplacement::Column(side.0),
                     };
                     (*index, replacement)
@@ -132,7 +132,7 @@ impl Rule for RulePushDownFilterUnion {
 
 enum UnionOutputReplacement {
     Column(Symbol),
-    Scalar(ScalarExpr),
+    Scalar(Box<ScalarExpr>),
 }
 
 fn replace_union_output(
@@ -161,7 +161,7 @@ fn replace_union_output(
                             column.column = new_column;
                         }
                         UnionOutputReplacement::Scalar(new_scalar) => {
-                            *expr = new_scalar.clone();
+                            *expr = new_scalar.as_ref().clone();
                         }
                     }
                     return Ok(());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_union.rs
@@ -25,12 +25,12 @@ use crate::optimizer::ir::SExpr;
 use crate::optimizer::optimizers::rule::Rule;
 use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
-use crate::plans::BoundColumnRef;
 use crate::plans::Filter;
 use crate::plans::RelOp;
 use crate::plans::ScalarExpr;
 use crate::plans::UnionAll;
 use crate::plans::VisitorMut;
+use crate::plans::walk_expr_mut;
 
 // For a union query, it's not allowed to add `filter` after union
 // Such as: `(select * from t1 union all select * from t2) where a > 1`, it's invalid.
@@ -87,17 +87,23 @@ impl Rule for RulePushDownFilterUnion {
             .zip([&mut union_left_child, &mut union_right_child].iter_mut())
         {
             // Create a filter which matches union's right child.
-            let index_pairs: HashMap<Symbol, Symbol> = union
+            let replacements: HashMap<Symbol, UnionOutputReplacement> = union
                 .output_indexes
                 .iter()
                 .zip(union_side.iter())
-                .map(|(index, side)| (*index, side.0))
+                .map(|(index, side)| {
+                    let replacement = match &side.1 {
+                        Some(expr) => UnionOutputReplacement::Scalar(expr.clone()),
+                        None => UnionOutputReplacement::Column(side.0),
+                    };
+                    (*index, replacement)
+                })
                 .collect();
 
             let new_predicates = filter
                 .predicates
                 .iter()
-                .map(|predicate| replace_column_binding(&index_pairs, predicate.clone()))
+                .map(|predicate| replace_union_output(&replacements, predicate.clone()))
                 .collect::<Result<Vec<_>>>()?;
 
             let filter = Filter {
@@ -124,33 +130,48 @@ impl Rule for RulePushDownFilterUnion {
     }
 }
 
-fn replace_column_binding(
-    index_pairs: &HashMap<Symbol, Symbol>,
+enum UnionOutputReplacement {
+    Column(Symbol),
+    Scalar(ScalarExpr),
+}
+
+fn replace_union_output(
+    replacements: &HashMap<Symbol, UnionOutputReplacement>,
     mut scalar: ScalarExpr,
 ) -> Result<ScalarExpr> {
     struct ReplaceColumnVisitor<'a> {
-        index_pairs: &'a HashMap<Symbol, Symbol>,
+        replacements: &'a HashMap<Symbol, UnionOutputReplacement>,
     }
 
-    impl<'a> VisitorMut<'a> for ReplaceColumnVisitor<'a> {
-        fn visit_bound_column_ref(&mut self, column: &mut BoundColumnRef) -> Result<()> {
-            let index = column.column.index;
-            if self.index_pairs.contains_key(&index) {
-                let new_column = ColumnBindingBuilder::new(
-                    column.column.column_name.clone(),
-                    *self.index_pairs.get(&index).unwrap(),
-                    column.column.data_type.clone(),
-                    Visibility::Visible,
-                )
-                .virtual_expr(column.column.virtual_expr.clone())
-                .build();
-                column.column = new_column;
+    impl VisitorMut<'_> for ReplaceColumnVisitor<'_> {
+        fn visit(&mut self, expr: &mut ScalarExpr) -> Result<()> {
+            if let ScalarExpr::BoundColumnRef(column) = expr {
+                let index = column.column.index;
+                if let Some(replacement) = self.replacements.get(&index) {
+                    match replacement {
+                        UnionOutputReplacement::Column(new_index) => {
+                            let new_column = ColumnBindingBuilder::new(
+                                column.column.column_name.clone(),
+                                *new_index,
+                                column.column.data_type.clone(),
+                                Visibility::Visible,
+                            )
+                            .virtual_expr(column.column.virtual_expr.clone())
+                            .build();
+                            column.column = new_column;
+                        }
+                        UnionOutputReplacement::Scalar(new_scalar) => {
+                            *expr = new_scalar.clone();
+                        }
+                    }
+                    return Ok(());
+                }
             }
-            Ok(())
+            walk_expr_mut(self, expr)
         }
     }
 
-    let mut visitor = ReplaceColumnVisitor { index_pairs };
+    let mut visitor = ReplaceColumnVisitor { replacements };
     visitor.visit(&mut scalar)?;
 
     Ok(scalar)

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -359,6 +359,11 @@ query I
 select number::int32 from numbers(100) union all select number::int from numbers(100) where number > 0 ignore_result;
 ----
 
+query RTT
+select a, typeof(a), cast(a as string) as s from (select '1' as a union all select 0 as a) as u where cast(a as string) = '1.00000' order by 1;
+----
+1.00000 DECIMAL(38, 5) 1.00000
+
 statement ok
 create or replace table t1 (a int, b int);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Preserve `UnionAll` branch coercion expressions when pushing filters below union branches
- Replace union output columns with branch `Some(ScalarExpr)` outputs, such as coercion casts, instead of only remapping column indexes
- Add a regression case where string/int union coercion must happen before an outer string cast predicate

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19997)
<!-- Reviewable:end -->
