### PR TITLE
fix(query): preserve TopN sort semantics

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_sort.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_sort.rs
@@ -66,6 +66,10 @@ impl Rule for RulePushDownFilterSort {
         let sort: Sort = s_expr.child(0)?.plan().clone().try_into()?;
         let sort_expr = s_expr.child(0)?;
 
+        if sort.limit.is_some() {
+            return Ok(());
+        }
+
         let mut result = SExpr::create_unary(
             Arc::new(sort.into()),
             Arc::new(SExpr::create_unary(

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_eliminate_sort.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_eliminate_sort.rs
@@ -52,6 +52,10 @@ impl Rule for RuleEliminateSort {
         let sort: Sort = s_expr.plan().clone().try_into()?;
         let input = s_expr.child(0)?;
 
+        if sort.limit.is_some() {
+            return Ok(());
+        }
+
         let rel_expr = RelExpr::with_s_expr(input);
         let prop = rel_expr.derive_relational_prop()?;
 

--- a/tests/sqllogictests/suites/base/20+_others/20_0001_planner.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0001_planner.test
@@ -662,6 +662,18 @@ select number from numbers(10000) order by number limit 1
 0
 
 
+query I
+select number from (select number from numbers(10) order by number limit 3) where number > 1 order by number
+----
+2
+
+
+query B
+select exists(select number from (select number from numbers(10) order by number limit 1) where number = 5)
+----
+0
+
+
 statement ok
 drop table if exists temp
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -72,6 +72,29 @@ Limit
                 └── estimated rows: 10.00
 
 query T
+explain select number from numbers(10) order by number asc limit 3
+----
+Limit
+├── output columns: [numbers.number (#0)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(Single)
+    ├── output columns: [numbers.number (#0)]
+    ├── sort keys: [number ASC NULLS LAST]
+    ├── estimated rows: 10.00
+    └── TableScan
+        ├── table: default.system.numbers
+        ├── scan id: 0
+        ├── output columns: [number (#0)]
+        ├── read rows: 10
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── push downs: [filters: [], limit: 3]
+        └── estimated rows: 10.00
+
+query T
 explain select t.number from numbers(1) as t, numbers(1) as t1 where t.number = (select count(*) from numbers(1) as t2, numbers(1) as t3 where t.number = t2.number) group by t.number order by t.number desc limit 3
 ----
 Limit


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix `RulePushDownFilterSort` to skip `Sort` nodes with an embedded TopN limit, preserving `ORDER BY ... LIMIT` semantics before filtering.
- Fix `RuleEliminateSort` to avoid eliminating TopN sorts even when the input ordering matches.
- Add sqllogictest coverage for filter-over-TopN behavior and for retaining the TopN sort in explain output.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all`
- `git diff --check`
- `cargo build --bin databend-query --bin databend-sqllogictests`
- `target/debug/databend-sqllogictests --handlers http --run 'tests/sqllogictests/suites/base/20+_others/20_0001_planner.test,tests/sqllogictests/suites/mode/standalone/explain/limit.test'`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19998)
<!-- Reviewable:end -->
