### PR TITLE
fix(query): preserve single join null filtering

### DIFF
--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/push_down_filter_join_test.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/push_down_filter_join_test.rs
@@ -24,6 +24,7 @@ use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::optimizer::optimizers::rule::Rule;
 use databend_common_sql::optimizer::optimizers::rule::RulePushDownFilterJoin;
 use databend_common_sql::optimizer::optimizers::rule::TransformResult;
+use databend_common_sql::planner::plans::FunctionCall;
 use databend_common_sql::planner::plans::JoinEquiCondition;
 use databend_common_sql::planner::plans::JoinType;
 use databend_common_sql::planner::plans::RelOperator;
@@ -209,6 +210,21 @@ fn normalize_string(s: &str) -> String {
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn is_null(expr: ScalarExpr) -> ScalarExpr {
+    let is_not_null = ScalarExpr::FunctionCall(FunctionCall {
+        span: None,
+        func_name: "is_not_null".to_string(),
+        params: vec![],
+        arguments: vec![expr],
+    });
+    ScalarExpr::FunctionCall(FunctionCall {
+        span: None,
+        func_name: "not".to_string(),
+        params: vec![],
+        arguments: vec![is_not_null],
+    })
 }
 
 /// Run a single join filter test case
@@ -594,6 +610,67 @@ fn test_push_down_filter_left_join() -> anyhow::Result<()> {
     for test_case in test_cases {
         run_join_filter_test(&test_case, &metadata)?;
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_single_join_is_null_filter_not_pushed_down() -> anyhow::Result<()> {
+    let metadata = MetadataRef::default();
+    let mut builder = ExprBuilder::new();
+
+    let t1_id = builder.column(
+        "t1.id",
+        0,
+        "id",
+        DataType::Nullable(Box::new(DataType::Number(NumberDataType::Int32))),
+        "t1",
+        0,
+    );
+    let t2_id = builder.column(
+        "t2.id",
+        1,
+        "id",
+        DataType::Nullable(Box::new(DataType::Number(NumberDataType::Int32))),
+        "t2",
+        1,
+    );
+    let join_condition = JoinEquiCondition::new(t1_id.clone(), t2_id.clone(), false);
+
+    let left_scan = builder.table_scan_with_columns(0, "t1", ColumnSet::from([Symbol::new(0)]));
+    let right_scan = builder.table_scan_with_columns(1, "t2", ColumnSet::from([Symbol::new(1)]));
+    let left_single = builder.join(
+        left_scan,
+        right_scan,
+        vec![join_condition.clone()],
+        JoinType::LeftSingle,
+    );
+    let left_single_filter = builder.filter(left_single, vec![is_null(t2_id.clone())]);
+
+    let rule = RulePushDownFilterJoin::new(metadata.clone());
+    let mut result = TransformResult::default();
+    rule.apply(&left_single_filter, &mut result)?;
+    assert!(
+        result.results().is_empty(),
+        "IS NULL on the null-supplying side of LeftSingle must stay above the join"
+    );
+
+    let left_scan = builder.table_scan_with_columns(0, "t1", ColumnSet::from([Symbol::new(0)]));
+    let right_scan = builder.table_scan_with_columns(1, "t2", ColumnSet::from([Symbol::new(1)]));
+    let right_single = builder.join(
+        left_scan,
+        right_scan,
+        vec![join_condition],
+        JoinType::RightSingle,
+    );
+    let right_single_filter = builder.filter(right_single, vec![is_null(t1_id)]);
+
+    let mut result = TransformResult::default();
+    rule.apply(&right_single_filter, &mut result)?;
+    assert!(
+        result.results().is_empty(),
+        "IS NULL on the null-supplying side of RightSingle must stay above the join"
+    );
 
     Ok(())
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
@@ -158,9 +158,16 @@ pub fn can_filter_null(
     join_type: &JoinType,
     metadata: MetadataRef,
 ) -> Result<bool> {
+    // Single joins are outer joins for correlated scalar subqueries: the unmatched side is
+    // null-supplying, so `IS NULL` predicates must keep their original outer-join semantics.
     if !matches!(
         join_type,
-        JoinType::Left | JoinType::Right | JoinType::Full | JoinType::FullAsof
+        JoinType::Left
+            | JoinType::LeftSingle
+            | JoinType::Right
+            | JoinType::RightSingle
+            | JoinType::Full
+            | JoinType::FullAsof
     ) {
         return Ok(true);
     }
@@ -181,10 +188,18 @@ pub fn can_filter_null(
                         .columns_can_be_replaced
                         .contains(&column_ref.column.index)
                     {
-                        *expr = ScalarExpr::ConstantExpr(ConstantExpr {
+                        let null_expr = ConstantExpr {
                             span: None,
                             value: Scalar::Null,
-                        });
+                        };
+                        *expr = if column_ref.column.data_type.is_nullable_or_null() {
+                            ScalarExpr::TypedConstantExpr(
+                                null_expr,
+                                *column_ref.column.data_type.clone(),
+                            )
+                        } else {
+                            ScalarExpr::ConstantExpr(null_expr)
+                        };
                     }
                     Ok(())
                 }

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -43,6 +43,31 @@ SELECT * FROM (SELECT 1 AS x) AS ss1 LEFT OUTER JOIN (SELECT 2 DIV 228 AS y) AS 
 1 0 0
 
 statement ok
+CREATE OR REPLACE TABLE scalar_single_filter_lhs (k INT);
+
+statement ok
+CREATE OR REPLACE TABLE scalar_single_filter_rhs (k INT, v INT);
+
+statement ok
+INSERT INTO scalar_single_filter_lhs VALUES (1), (2), (3);
+
+statement ok
+INSERT INTO scalar_single_filter_rhs VALUES (1, 5), (2, NULL);
+
+query I rowsort
+SELECT k
+FROM scalar_single_filter_lhs AS lhs
+WHERE (
+    SELECT v
+    FROM scalar_single_filter_rhs AS rhs
+    WHERE rhs.k = lhs.k
+) IS NULL
+ORDER BY k;
+----
+2
+3
+
+statement ok
 CREATE OR REPLACE TABLE c (c_id INT NULL, bill VARCHAR NULL)
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Preserve null-supplying semantics for `LeftSingle`/`RightSingle` joins when checking whether filters can reject NULL-extended rows
- Prevent scalar subquery `IS NULL` predicates from being pushed below the single join or converting the join to inner incorrectly

## Changes

- Treat `LeftSingle` and `RightSingle` like outer joins in `can_filter_null`
- Preserve nullable type information when replacing nullable column refs with NULL for constant evaluation
- Add optimizer rule coverage for nullable-side `IS NULL` filters on both single join directions
- Add a sqllogictest regression for scalar subqueries where both matched NULL and unmatched rows must satisfy `IS NULL`

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation:

```shell
cargo fmt
cargo test -p databend-query --test it push_down_filter_join_test -- --nocapture
cargo build --bin databend-query
target/debug/databend-sqllogictests --handlers mysql --run_dir query --run_file subquery.test --enable_sandbox --parallel 1
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/19999)
<!-- Reviewable:end -->
