### PR TITLE
fix(query): preserve null-safe join keys in null filter rule

### DIFF
--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/filter_nulls_test.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/filter_nulls_test.rs
@@ -1,0 +1,156 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_common_expression::stat_distribution::NdvEstimate;
+use databend_common_expression::stat_distribution::StatCount;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
+use databend_common_sql::ColumnSet;
+use databend_common_sql::ScalarExpr;
+use databend_common_sql::Symbol;
+use databend_common_sql::optimizer::ir::ColumnStat;
+use databend_common_sql::optimizer::ir::SExpr;
+use databend_common_sql::optimizer::ir::StatInfo;
+use databend_common_sql::optimizer::ir::Statistics;
+use databend_common_sql::optimizer::optimizers::rule::Rule;
+use databend_common_sql::optimizer::optimizers::rule::RuleFilterNulls;
+use databend_common_sql::optimizer::optimizers::rule::TransformResult;
+use databend_common_sql::plans::JoinType;
+use databend_common_sql::plans::RelOperator;
+use databend_common_sql::plans::Scan;
+use databend_common_statistics::Datum;
+
+use crate::sql::planner::optimizer::test_utils::ExprBuilder;
+
+const CARDINALITY: f64 = 100.0;
+
+#[test]
+fn filter_nulls_skips_null_safe_join_keys() -> anyhow::Result<()> {
+    let join = join_with_null_ratio(true);
+
+    let transformed = apply_filter_nulls(&join)?;
+
+    assert!(
+        matches!(transformed.child(0)?.plan(), RelOperator::Scan(_)),
+        "left side of a null-safe join must not get an is_not_null filter"
+    );
+    assert!(
+        matches!(transformed.child(1)?.plan(), RelOperator::Scan(_)),
+        "right side of a null-safe join must not get an is_not_null filter"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn filter_nulls_still_pushes_for_regular_join_keys() -> anyhow::Result<()> {
+    let join = join_with_null_ratio(false);
+
+    let transformed = apply_filter_nulls(&join)?;
+
+    assert!(
+        has_is_not_null_filter(transformed.child(0)?, Symbol::new(0)),
+        "left side of a regular join should get an is_not_null filter"
+    );
+    assert!(
+        has_is_not_null_filter(transformed.child(1)?, Symbol::new(1)),
+        "right side of a regular join should get an is_not_null filter"
+    );
+
+    Ok(())
+}
+
+fn join_with_null_ratio(is_null_equal: bool) -> SExpr {
+    let mut builder = ExprBuilder::new();
+    let left_key = builder.column("t1.k", 0, "k", nullable_int64(), "t1", 0);
+    let right_key = builder.column("t2.k", 1, "k", nullable_int64(), "t2", 1);
+
+    let left_scan = scan_with_stats(0, Symbol::new(0), 25);
+    let right_scan = scan_with_stats(1, Symbol::new(1), 25);
+    let condition = builder.join_condition(left_key, right_key, is_null_equal);
+
+    builder.join(left_scan, right_scan, vec![condition], JoinType::Inner)
+}
+
+fn apply_filter_nulls(s_expr: &SExpr) -> Result<SExpr> {
+    let rule = RuleFilterNulls::new(true);
+    let mut result = TransformResult::default();
+    rule.apply(s_expr, &mut result)?;
+
+    Ok(result.results()[0].clone())
+}
+
+fn nullable_int64() -> DataType {
+    DataType::Nullable(Box::new(DataType::Number(NumberDataType::Int64)))
+}
+
+fn scan_with_stats(table_index: usize, column: Symbol, null_count: u64) -> SExpr {
+    SExpr::create(
+        RelOperator::Scan(Scan {
+            table_index,
+            columns: ColumnSet::from([column]),
+            ..Default::default()
+        }),
+        vec![],
+        None,
+        None,
+        Some(Arc::new(StatInfo {
+            cardinality: CARDINALITY,
+            statistics: Statistics {
+                precise_cardinality: None,
+                column_stats: HashMap::from([(column, column_stat(null_count))]),
+            },
+        })),
+    )
+}
+
+fn column_stat(null_count: u64) -> ColumnStat {
+    ColumnStat {
+        min: Datum::Int(0),
+        max: Datum::Int(99),
+        ndv: NdvEstimate::exact(10.0),
+        null_count: StatCount::exact(null_count),
+        histogram: None,
+    }
+}
+
+fn has_is_not_null_filter(s_expr: &SExpr, column: Symbol) -> bool {
+    let RelOperator::Filter(filter) = s_expr.plan() else {
+        return false;
+    };
+
+    filter
+        .predicates
+        .iter()
+        .any(|predicate| is_is_not_null_on_column(predicate, column))
+}
+
+fn is_is_not_null_on_column(predicate: &ScalarExpr, column: Symbol) -> bool {
+    let ScalarExpr::FunctionCall(func) = predicate else {
+        return false;
+    };
+
+    if func.func_name != "is_not_null" || func.arguments.len() != 1 {
+        return false;
+    }
+
+    matches!(
+        &func.arguments[0],
+        ScalarExpr::BoundColumnRef(column_ref) if column_ref.column.index == column
+    )
+}

--- a/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/mod.rs
+++ b/src/query/service/tests/it/sql/planner/optimizer/optimizers/rule/filter_rules/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod filter_nulls_test;
 mod push_down_filter_join_test;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
@@ -116,6 +116,10 @@ impl Rule for RuleFilterNulls {
         let mut left_null_predicates = vec![];
         let mut right_null_predicates = vec![];
         for join_key in join.equi_conditions.iter() {
+            if join_key.is_null_equal {
+                continue;
+            }
+
             let left_key = &join_key.left;
             let right_key = &join_key.right;
             if single_plan(&left_child) {

--- a/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
@@ -216,6 +216,35 @@ statement ok
 drop table t2
 
 statement ok
+drop table if exists filter_nulls_ndf_l
+
+statement ok
+drop table if exists filter_nulls_ndf_r
+
+statement ok
+create or replace table filter_nulls_ndf_l(k int null, v int)
+
+statement ok
+create or replace table filter_nulls_ndf_r(k int null, v int)
+
+statement ok
+insert into filter_nulls_ndf_l values (null, 1), (null, 2), (1, 3), (2, 4), (3, 5)
+
+statement ok
+insert into filter_nulls_ndf_r values (null, 10), (null, 11), (null, 12), (1, 13), (3, 14)
+
+query I
+select count(*) from filter_nulls_ndf_l l join filter_nulls_ndf_r r on l.k is not distinct from r.k
+----
+8
+
+statement ok
+drop table filter_nulls_ndf_l
+
+statement ok
+drop table filter_nulls_ndf_r
+
+statement ok
 drop table if exists t
 
 statement ok

--- a/tests/sqllogictests/suites/mode/cluster/subquery.test
+++ b/tests/sqllogictests/suites/mode/cluster/subquery.test
@@ -16,6 +16,25 @@ INSERT INTO t1 VALUES (1), (2), (NULL);
 statement ok
 INSERT INTO t2 VALUES (2), (NULL);
 
+query IBB rowsort
+SELECT t1.a, EXISTS(SELECT 1 FROM t2 WHERE t2.a = t1.a), not EXISTS(SELECT 1 FROM t2 WHERE t2.a = t1.a) AS has_match
+FROM t1;
+----
+1 0 1
+2 1 0
+NULL 0 1
+
+query IBB rowsort
+SELECT
+      t1.a,
+      t1.a IN (SELECT a FROM t2) AS in_match,
+      t1.a NOT IN (SELECT a FROM t2) AS not_in_match
+FROM t1;
+----
+1 NULL NULL
+2 1 0
+NULL 1 0
+
 
 query T
 explain SELECT t1.a, EXISTS(SELECT 1 FROM t2 WHERE t2.a = t1.a), not EXISTS(SELECT 1 FROM t2 WHERE t2.a = t1.a)  AS has_match

--- a/tests/sqllogictests/suites/query/set_operator.test
+++ b/tests/sqllogictests/suites/query/set_operator.test
@@ -23,6 +23,34 @@ select * from a except select * from b union all select * from b intersect selec
 NULL 3
 
 statement ok
+create or replace table set_null_l(k int null)
+
+statement ok
+create or replace table set_null_r(k int null)
+
+statement ok
+insert into set_null_l values (null), (null), (1), (2), (3)
+
+statement ok
+insert into set_null_r values (null), (1), (3), (3)
+
+query I
+select count(*) from (select k from set_null_l intersect select k from set_null_r)
+----
+3
+
+query I
+select count(*) from (select k from set_null_l except select k from set_null_r)
+----
+1
+
+statement ok
+drop table set_null_l
+
+statement ok
+drop table set_null_r
+
+statement ok
 create or replace table a as select null, 3 , '343', 1.2, 3.4, true, 4+5, 5-2;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`RuleFilterNulls` can push `is_not_null` predicates onto join keys when column statistics show a high null ratio. This is not valid for null-safe equi conditions, because `NULL` keys are part of the join semantics for `IS NOT DISTINCT FROM`, set operators, and mark joins generated from subqueries.

This PR skips null filtering for `JoinEquiCondition::is_null_equal` and adds coverage for the main SQL paths that produce null-equal join keys.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added sqllogictest coverage in existing nearby files:

- `mode/cluster/shuffle_join.test` for `IS NOT DISTINCT FROM`
- `query/set_operator.test` for `INTERSECT` / `EXCEPT`
- `mode/cluster/subquery.test` for `EXISTS` / `IN` mark-join semantics

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20000)
<!-- Reviewable:end -->
