### PR TITLE
fix(query): recluster infinite loop caused by inconsistent block size estimation

### DIFF
--- a/src/query/expression/src/block.rs
+++ b/src/query/expression/src/block.rs
@@ -960,10 +960,15 @@ impl DataBlock {
 
     /// Calculates the memory size of a `DataBlock` for writing purposes.
     /// This function is used to estimate the memory footprint of a `DataBlock` when writing it to storage.
-    pub fn estimate_block_size(&self) -> usize {
+    /// `num_columns` is the number of leading columns to include in the estimate.
+    /// Temporary columns appended for sorting/statistics, such as extra cluster key columns,
+    /// should not be included when they are not written.
+    pub fn estimate_block_size(&self, num_columns: usize) -> usize {
+        debug_assert!(num_columns <= self.entries.len());
         let num_rows = self.num_rows();
         self.columns()
             .iter()
+            .take(num_columns)
             .map(|entry| match entry {
                 BlockEntry::Column(Column::Nullable(col)) if col.validity().true_count() == 0 => {
                     // For `Nullable` columns with no valid values,

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
@@ -63,7 +63,7 @@ impl AccumulatingTransform for BlockCompactBuilder {
 
     fn transform(&mut self, data: DataBlock) -> Result<Vec<DataBlock>> {
         let num_rows = data.num_rows();
-        let num_bytes = data.estimate_block_size();
+        let num_bytes = data.estimate_block_size(data.num_columns());
 
         if !self.thresholds.check_for_compact(num_rows, num_bytes) {
             // holding slices of blocks to merge later may lead to oom, so

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_ordered_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_ordered_compact_builder.rs
@@ -26,9 +26,12 @@ pub fn build_ordered_compact_pipeline(
     pipeline: &mut Pipeline,
     thresholds: BlockThresholds,
     max_threads: usize,
+    extra_key_num: usize,
 ) -> Result<()> {
     pipeline.try_resize(1)?;
-    pipeline.add_accumulating_transformer(|| OrderedBlockCompactBuilder::new(thresholds));
+    pipeline.add_accumulating_transformer(move || {
+        OrderedBlockCompactBuilder::new(thresholds, extra_key_num)
+    });
     pipeline.try_resize(max_threads)?;
     pipeline.add_block_meta_transformer(TransformCompactBlock::default);
     Ok(())
@@ -36,6 +39,7 @@ pub fn build_ordered_compact_pipeline(
 
 pub struct OrderedBlockCompactBuilder {
     thresholds: BlockThresholds,
+    extra_key_num: usize,
     // Holds blocks that exceeded the threshold and are waiting to be compacted.
     staged_blocks: BlockGroup,
     // Holds blocks that are partially accumulated but haven't reached the threshold.
@@ -43,9 +47,10 @@ pub struct OrderedBlockCompactBuilder {
 }
 
 impl OrderedBlockCompactBuilder {
-    pub fn new(thresholds: BlockThresholds) -> Self {
+    pub fn new(thresholds: BlockThresholds, extra_key_num: usize) -> Self {
         Self {
             thresholds,
+            extra_key_num,
             staged_blocks: BlockGroup::default(),
             pending_blocks: BlockGroup::default(),
         }
@@ -78,8 +83,9 @@ impl AccumulatingTransform for OrderedBlockCompactBuilder {
     const NAME: &'static str = "OrderedBlockCompactBuilder";
 
     fn transform(&mut self, data: DataBlock) -> Result<Vec<DataBlock>> {
+        debug_assert!(self.extra_key_num <= data.num_columns());
         let num_rows = data.num_rows();
-        let num_bytes = data.estimate_block_size();
+        let num_bytes = data.estimate_block_size(data.num_columns() - self.extra_key_num);
 
         // pending_blocks accumulates the current ordered run; once it reaches N we either
         // stage it as the next output candidate or materialize it immediately if it grows past 2N.
@@ -161,6 +167,7 @@ mod tests {
     use databend_common_expression::BlockMetaInfoDowncast;
     use databend_common_expression::FromData;
     use databend_common_expression::types::Int32Type;
+    use databend_common_expression::types::StringType;
 
     use super::*;
     use crate::processors::BlockMetaTransform;
@@ -171,10 +178,41 @@ mod tests {
         )])
     }
 
+    fn block_with_extra_key(rows: usize, extra_value: &str) -> DataBlock {
+        DataBlock::new_from_columns(vec![
+            Int32Type::from_data((0..rows).map(|v| v as i32).collect::<Vec<_>>()),
+            StringType::from_data(vec![extra_value.to_string(); rows]),
+        ])
+    }
+
     fn row_focused_thresholds() -> BlockThresholds {
         BlockThresholds::default()
             .set_rows_per_block(1000)
             .set_bytes_per_block(1 << 20)
+    }
+
+    #[test]
+    fn test_ordered_compact_ignores_tail_extra_key_size() -> Result<()> {
+        let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+        let mut builder = OrderedBlockCompactBuilder::new(thresholds, 1);
+        let block = block_with_extra_key(10, "extra-cluster-key-value");
+
+        assert!(thresholds.check_large_enough(
+            block.num_rows(),
+            block.estimate_block_size(block.num_columns())
+        ));
+        assert!(builder.transform(block)?.is_empty());
+
+        let block = block_with_extra_key(10, "extra-cluster-key-value");
+        assert!(builder.transform(block)?.is_empty());
+        let output = builder.on_finish(true)?;
+        let meta_block = output.into_iter().next().unwrap();
+        let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
+        let output = TransformCompactBlock::default().transform(meta)?;
+
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].num_rows(), 20);
+        Ok(())
     }
 
     #[test]
@@ -183,7 +221,11 @@ mod tests {
         let mut group = BlockGroup::default();
         for rows in [300, 300, 1000] {
             let block = block_with_rows(rows);
-            group.push(block.clone(), block.num_rows(), block.estimate_block_size());
+            group.push(
+                block.clone(),
+                block.num_rows(),
+                block.estimate_block_size(block.num_columns()),
+            );
         }
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
@@ -200,7 +242,11 @@ mod tests {
         let thresholds = row_focused_thresholds();
         let block = block_with_rows(2001);
         let mut group = BlockGroup::default();
-        group.push(block.clone(), block.num_rows(), block.estimate_block_size());
+        group.push(
+            block.clone(),
+            block.num_rows(),
+            block.estimate_block_size(block.num_columns()),
+        );
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
@@ -221,7 +267,11 @@ mod tests {
         let mut group = BlockGroup::default();
         for rows in [2, 6, 6, 2, 2] {
             let block = block_with_rows(rows);
-            group.push(block.clone(), block.num_rows(), block.estimate_block_size());
+            group.push(
+                block.clone(),
+                block.num_rows(),
+                block.estimate_block_size(block.num_columns()),
+            );
         }
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
@@ -239,7 +289,11 @@ mod tests {
     fn test_ordered_compact_split_does_not_exceed_target_block_count() -> Result<()> {
         let block = block_with_rows(1000);
         let mut group = BlockGroup::default();
-        group.push(block.clone(), block.num_rows(), block.estimate_block_size());
+        group.push(
+            block.clone(),
+            block.num_rows(),
+            block.estimate_block_size(block.num_columns()),
+        );
 
         let target_block_count = 500;
         let thresholds = BlockThresholds::default()

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -246,6 +246,7 @@ impl IPhysicalPlan for Recluster {
                     &mut builder.main_pipeline,
                     compact_thresholds,
                     max_threads,
+                    cluster_stats_gen.extra_key_num,
                 )?;
 
                 builder.main_pipeline.add_transform(

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/data_processor_strategy.rs
@@ -62,7 +62,7 @@ impl DataProcessorStrategy for CompactStrategy {
         let mut result = Vec::with_capacity(blocks_num);
         for block in data_blocks {
             accumulated_rows += block.num_rows();
-            accumulated_bytes += block.estimate_block_size();
+            accumulated_bytes += block.estimate_block_size(block.num_columns());
             pending_blocks.push(block);
             if !self.check_large_enough(accumulated_rows, accumulated_bytes) {
                 continue;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -804,6 +804,19 @@ async fn test_final_recluster_skips_high_level_two_block_batch() -> anyhow::Resu
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_recluster_mutator_skips_max_level_blocks() -> anyhow::Result<()> {
+    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+    let (block_num, parts) =
+        target_select_segments_by_level_with_mode(&[(32, 3)], thresholds, 1, ReclusterMode::Final)
+            .await?;
+
+    assert_eq!(block_num, 0);
+    assert!(parts.tasks.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_safety_for_recluster() -> anyhow::Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;

--- a/src/query/storages/fuse/src/io/write/block_writer.rs
+++ b/src/query/storages/fuse/src/io/write/block_writer.rs
@@ -240,7 +240,7 @@ impl BlockBuilder {
         )?;
 
         let mut buffer = Vec::with_capacity(DEFAULT_BLOCK_BUFFER_SIZE);
-        let block_size = data_block.estimate_block_size() as u64;
+        let block_size = data_block.estimate_block_size(data_block.num_columns()) as u64;
         let col_metas = serialize_block_with_column_stats(
             &self.write_settings,
             &self.source_schema,

--- a/src/query/storages/fuse/src/io/write/stream/block_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/block_builder.rs
@@ -288,7 +288,7 @@ impl StreamBlockBuilder {
             spatial_index_builder.add_block(&block)?;
         }
         self.row_count += block.num_rows();
-        self.block_size += block.estimate_block_size();
+        self.block_size += block.estimate_block_size(block.num_columns());
 
         if !had_existing_rows {
             // Writer properties must be fixed before the ArrowWriter starts, so we rely on the first

--- a/src/query/storages/fuse/src/operations/common/processors/transform_block_writer.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_block_writer.rs
@@ -97,7 +97,7 @@ impl TransformBlockBuilder {
     }
 
     fn split_input(&self, input: DataBlock) -> Vec<DataBlock> {
-        let block_size = input.estimate_block_size();
+        let block_size = input.estimate_block_size(input.num_columns());
         let num_rows = input.num_rows();
         let average_row_size = block_size.div_ceil(num_rows);
         let max_rows = self
@@ -184,7 +184,7 @@ impl Processor for TransformBlockBuilder {
                 block.check_valid()?;
                 self.input_num_rows += block.num_rows();
                 for block in self.split_input(block) {
-                    let block_size = block.estimate_block_size();
+                    let block_size = block.estimate_block_size(block.num_columns());
                     self.input_data_size += block_size;
                     self.input_data.push_back((block_size, block));
                 }

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -71,6 +71,10 @@ use crate::statistics::reducers::merge_statistics_mut;
 /// For two-block layouts, repeated reclustering beyond this level
 /// rarely improves data locality and may cause task churn.
 const MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS: i32 = 2;
+/// Maximum recluster level allowed for candidate selection.
+/// Blocks that reach this level have already been rewritten many times, so
+/// keep them out of future recluster tasks to avoid unbounded level growth.
+const MAX_RECLUSTER_LEVEL: i32 = 32;
 const SMALL_TABLE_RECLUSTER_BLOCK_COUNT: u64 = 1000;
 
 struct LevelReclusterTasks {
@@ -283,6 +287,13 @@ impl ReclusterMutator {
         let mut blocks_map: BTreeMap<ReclusterGroup, Vec<usize>> = BTreeMap::new();
         for (idx, block) in blocks.iter().enumerate() {
             if block.stats.level < 0 {
+                continue;
+            }
+            if block.stats.level >= MAX_RECLUSTER_LEVEL {
+                debug!(
+                    "recluster: skip block segment_idx={} block_idx={} level={} skip_reason=max_recluster_level",
+                    block.index.segment_idx, block.index.block_idx, block.stats.level,
+                );
                 continue;
             }
 

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -38,12 +38,12 @@ use log::warn;
 #[derive(Clone, Default)]
 pub struct ClusterStatsGenerator {
     cluster_key_id: u32,
-    extra_key_num: usize,
     max_page_size: Option<usize>,
 
     level: i32,
     block_thresholds: BlockThresholds,
 
+    pub extra_key_num: usize,
     pub cluster_key_index: Vec<usize>,
     pub operators: Vec<BlockOperator>,
     pub out_fields: Vec<DataField>,
@@ -149,10 +149,10 @@ impl ClusterStatsGenerator {
         );
 
         let level = if min == max
-            && self
-                .block_thresholds
-                .check_large_enough(data_block.num_rows(), data_block.memory_size())
-        {
+            && self.block_thresholds.check_large_enough(
+                data_block.num_rows(),
+                data_block.estimate_block_size(data_block.num_columns() - self.extra_key_num),
+            ) {
             -1
         } else {
             level


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  - Fixed a recluster infinite-loop case where the same overlapped blocks could be selected repeatedly. **The root cause** was inconsistent block size estimation: ordered compact and cluster statistics included extra cluster key columnsthat are appended only for sorting/statistics, while the final written block removes those columns.

  - Updated `DataBlock::estimate_block_size` to estimate only the first num_columns columns, so recluster can ignore trailing extra key columns when evaluating write-size thresholds.
  - Updated ordered compact and cluster statistics to use the final write-block size view.
  - Added a max recluster level guard to prevent unbounded level growth in non-converging cases.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20002)
<!-- Reviewable:end -->
