### PR TITLE
fix: avoid invalid semi join rewrite for partial group keys

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_semi_to_inner_join.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -62,25 +61,23 @@ impl Rule for RuleSemiToInnerJoin {
             return Ok(());
         }
 
-        let conditions = if join.join_type == JoinType::LeftSemi {
-            join.equi_conditions
-                .iter()
-                .map(|condition| condition.right.clone())
-                .collect::<Vec<_>>()
-        } else {
-            join.equi_conditions
-                .iter()
-                .map(|condition| condition.left.clone())
-                .collect::<Vec<_>>()
-        };
-
-        if conditions.is_empty() {
+        if join.equi_conditions.is_empty() {
             return Ok(());
         }
 
-        let mut condition_cols = HashSet::with_capacity(conditions.len());
-        for condition in conditions.iter() {
-            add_column_idx(condition, &mut condition_cols);
+        let build_join_keys = join.equi_conditions.iter().map(|condition| {
+            if join.join_type == JoinType::LeftSemi {
+                &condition.right
+            } else {
+                &condition.left
+            }
+        });
+
+        let mut build_join_key_cols = HashSet::with_capacity(join.equi_conditions.len());
+        for key in build_join_keys {
+            if let Some(column) = join_key_column(key) {
+                build_join_key_cols.insert(column);
+            }
         }
 
         let child = if join.join_type == JoinType::LeftSemi {
@@ -89,21 +86,20 @@ impl Rule for RuleSemiToInnerJoin {
             s_expr.child(0)?
         };
 
-        // Traverse child to find join keys in group by keys
-        let mut group_by_keys = HashMap::new();
-        find_group_by_keys(child, &mut group_by_keys)?;
-
-        // If condition are all group by keys and not nullable
+        // If group by keys are all condition keys and not nullable
         // we can rewrite semi join to inner join
         // inner join will ignore null values but semi join will keep them
         // this happens in Q38
-        if condition_cols.iter().all(|condition| {
-            if let Some(t) = group_by_keys.get(condition) {
-                !t.is_nullable_or_null()
-            } else {
-                false
+        let mut has_group_by_keys = false;
+        let mut can_rewrite = true;
+        visit_group_by_keys(child, &mut |key, data_type| {
+            has_group_by_keys = true;
+            if !build_join_key_cols.contains(&key) || data_type.is_nullable_or_null() {
+                can_rewrite = false;
             }
-        }) {
+        })?;
+
+        if has_group_by_keys && can_rewrite {
             join.join_type = JoinType::Inner;
             let mut join_expr = SExpr::create_binary(
                 Arc::new(join.into()),
@@ -121,22 +117,17 @@ impl Rule for RuleSemiToInnerJoin {
     }
 }
 
-fn find_group_by_keys(
-    child: &SExpr,
-    group_by_keys: &mut HashMap<Symbol, Box<DataType>>,
-) -> Result<()> {
+fn visit_group_by_keys(child: &SExpr, visitor: &mut impl FnMut(Symbol, DataType)) -> Result<()> {
     match child.plan() {
         RelOperator::EvalScalar(_)
         | RelOperator::Filter(_)
         | RelOperator::Window(_)
         | RelOperator::WindowGroup(_) => {
-            find_group_by_keys(child.child(0)?, group_by_keys)?;
+            visit_group_by_keys(child.child(0)?, visitor)?;
         }
         RelOperator::Aggregate(agg) => {
             for item in agg.group_items.iter() {
-                if let ScalarExpr::BoundColumnRef(c) = &item.scalar {
-                    group_by_keys.insert(c.column.index, c.column.data_type.clone());
-                }
+                visitor(item.index, item.scalar.data_type()?);
             }
         }
         RelOperator::Sort(_)
@@ -163,15 +154,11 @@ fn find_group_by_keys(
     Ok(())
 }
 
-fn add_column_idx(condition: &ScalarExpr, condition_cols: &mut HashSet<Symbol>) {
+fn join_key_column(condition: &ScalarExpr) -> Option<Symbol> {
     match condition {
-        ScalarExpr::BoundColumnRef(c) => {
-            condition_cols.insert(c.column.index);
-        }
-        ScalarExpr::CastExpr(expr) => {
-            add_column_idx(&expr.argument, condition_cols);
-        }
-        _ => {}
+        ScalarExpr::BoundColumnRef(c) => Some(c.column.index),
+        ScalarExpr::CastExpr(expr) if !expr.is_try => join_key_column(&expr.argument),
+        _ => None,
     }
 }
 

--- a/tests/sqllogictests/suites/query/join/join.test
+++ b/tests/sqllogictests/suites/query/join/join.test
@@ -29,6 +29,32 @@ query I
 select * from (select * from numbers(100)) n left semi join t1 on n.number = t1.a;
 ----
 
+# Regression: grouping by b does not make the expression b % 2 unique.
+query I
+select a
+from (values (0)) as t1(a)
+left semi join (
+    select b
+    from (values (0), (2)) as t2(b)
+    group by b
+) as g on g.b % 2 = t1.a;
+----
+0
+
+# Regression: the join keys must cover the full GROUP BY key. Grouping by
+# (b, c) does not make b unique, so rewriting this semi join to an inner join
+# would duplicate the probe row.
+query I
+select a
+from (values (0)) as t1(a)
+left semi join (
+    select b, c
+    from (values (0, 1), (0, 2)) as t2(b, c)
+    group by b, c
+) as g on g.b = t1.a;
+----
+0
+
 # left anti join with empty build side
 query I
 select * from (select * from numbers(10)) n left anti join t1 on n.number = t1.a order by number;
@@ -309,4 +335,3 @@ drop table if exists t1;
 
 statement ok
 with v2 as (SELECT 'xx' || cast(number as string) AS invoice_nr FROM numbers(135) group by invoice_nr order by invoice_nr) select v2.invoice_nr from v2 where EXISTS (SELECT cast(number as string) AS invoice_nr FROM numbers(800) where v2.invoice_nr = cast(number as string)) ignore_result;
-


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix `RuleSemiToInnerJoin` so it only rewrites semi joins to inner joins when the build-side join keys cover the full non-null GROUP BY key.

Previously the rule collected underlying columns from join-key expressions. That could incorrectly prove uniqueness for cases like `GROUP BY b` with `JOIN ON b % 2`, or `GROUP BY b, c` with `JOIN ON b`, causing semi joins to duplicate probe rows after being rewritten to inner joins.

This PR matches build-side join keys against aggregate group-key output columns instead, and adds sqllogictest regressions for both cases.

## Tests

- [x] Unit Test
  - `cargo test -p databend-common-sql rule_semi_to_inner_join --lib`
- [x] Logic Test
  - `target/debug/databend-sqllogictests --handlers http --run 'tests/sqllogictests/suites/query/join/join.test' --enable_sandbox --port 8000 --parallel 1`
  - Result: `Summary: ✅ Passed, 84 test(s) across 1 file(s)`
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20006)
<!-- Reviewable:end -->
