### PR TITLE
fix(query): make metadata$filename stage-relative for csv/text/ndjson/avro

### DIFF
--- a/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
+++ b/src/query/catalog/src/plan/datasource/datasource_info/stage.rs
@@ -32,7 +32,6 @@ use crate::plan::FullParquetMeta;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct StageTableInfo {
     // common
-    pub stage_root: String,
     pub stage_info: StageInfo,
 
     // copy into table only
@@ -58,7 +57,7 @@ pub struct StageTableInfo {
 
 impl PartialEq for StageTableInfo {
     fn eq(&self, other: &Self) -> bool {
-        self.stage_root == other.stage_root && self.stage_info == other.stage_info
+        self.stage_info == other.stage_info
     }
 }
 

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -126,8 +126,6 @@ use databend_common_storage::FileStatus;
 use databend_common_storage::StageFileInfo;
 use databend_common_storage::StageFilesInfo;
 use databend_common_storage::StorageMetrics;
-#[cfg(feature = "storage-stage")]
-use databend_common_storage::init_stage_operator;
 use databend_common_storages_basic::ResultScan;
 use databend_common_storages_delta::DeltaTable;
 use databend_common_storages_fuse::FuseTable;

--- a/src/query/service/src/sessions/query_ctx/table.rs
+++ b/src/query/service/src/sessions/query_ctx/table.rs
@@ -463,14 +463,6 @@ impl TableContextTableManagement for QueryContext {
             on_error: on_error_mode.unwrap_or_default(),
             ..Default::default()
         };
-        let operator = init_stage_operator(&stage_info)?;
-        let info = operator.info();
-        let stage_root = format!("{}{}", info.name(), info.root());
-        let stage_root = if stage_root.ends_with('/') {
-            stage_root
-        } else {
-            format!("{}/", stage_root)
-        };
         match &stage_info.file_format_params {
             FileFormatParams::Parquet(fmt) => {
                 if max_column_position > 1 {
@@ -518,7 +510,6 @@ impl TableContextTableManagement for QueryContext {
                         is_select: true,
                         default_exprs: None,
                         copy_into_table_options: copy_options.clone(),
-                        stage_root,
                         is_variant: true,
                         parquet_metas: None,
                     };
@@ -541,7 +532,6 @@ impl TableContextTableManagement for QueryContext {
                     stage_info,
                     files_info,
                     files_to_copy,
-                    stage_root,
                     is_variant,
                     is_select: true,
                     copy_into_table_options: copy_options.clone(),
@@ -561,7 +551,6 @@ impl TableContextTableManagement for QueryContext {
                     files_to_copy,
                     is_select: true,
                     is_variant: true,
-                    stage_root,
                     copy_into_table_options: copy_options.clone(),
                     ..Default::default()
                 };
@@ -585,7 +574,6 @@ impl TableContextTableManagement for QueryContext {
                     files_to_copy,
                     is_select: true,
                     is_variant: false,
-                    stage_root,
                     copy_into_table_options: copy_options.clone(),
                     ..Default::default()
                 };
@@ -644,7 +632,6 @@ impl TableContextTableManagement for QueryContext {
                     files_info,
                     files_to_copy,
                     is_select: true,
-                    stage_root,
                     copy_into_table_options: copy_options.clone(),
                     ..Default::default()
                 };

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -483,7 +483,6 @@ impl Binder {
                 is_select: false,
                 default_exprs: Some(default_values),
                 copy_into_table_options,
-                stage_root: "".to_string(),
                 is_variant: false,
                 ..Default::default()
             },

--- a/src/query/storages/stage/src/read/avro/block_builder_processor.rs
+++ b/src/query/storages/stage/src/read/avro/block_builder_processor.rs
@@ -54,7 +54,6 @@ impl AccumulatingTransform for BlockBuilderProcessor {
             .unwrap();
         self.state.file_path = data.path.clone();
         let num_rows = self.state.num_rows;
-        self.state.file_full_path = format!("{}{}", self.ctx.stage_root, data.path);
         self.decoder.read_file(&data.data, &mut self.state)?;
         self.state
             .add_internals_columns_batch(self.state.num_rows - num_rows);

--- a/src/query/storages/stage/src/read/block_builder_state.rs
+++ b/src/query/storages/stage/src/read/block_builder_state.rs
@@ -38,7 +38,6 @@ pub struct BlockBuilderState {
     pub num_rows: usize,
     pub file_status: FileStatus,
     pub file_path: String,
-    pub file_full_path: String,
 }
 
 impl BlockBuilderState {
@@ -75,7 +74,6 @@ impl BlockBuilderState {
             num_rows: 0,
             file_status: Default::default(),
             file_path: "".to_string(),
-            file_full_path: "".to_string(),
         }
     }
 
@@ -128,7 +126,7 @@ impl BlockBuilderState {
             match c.column_type {
                 InternalColumnType::FileName => {
                     self.internal_column_builders[i]
-                        .push_repeat(&ScalarRef::String(&self.file_full_path), n);
+                        .push_repeat(&ScalarRef::String(&self.file_path), n);
                 }
                 InternalColumnType::FileRowNumber => {}
                 _ => {

--- a/src/query/storages/stage/src/read/load_context.rs
+++ b/src/query/storages/stage/src/read/load_context.rs
@@ -39,7 +39,6 @@ pub struct LoadContext {
     pub default_exprs: Option<Vec<RemoteDefaultExpr>>,
     pub default_expr_evaluator: Option<Arc<DefaultExprEvaluator>>,
     pub pos_projection: Option<Vec<usize>>,
-    pub stage_root: String,
 
     pub is_select: bool,
     pub schema_evolution: bool,
@@ -72,7 +71,6 @@ impl LoadContext {
             pos_projection,
             block_compact_thresholds,
             internal_columns,
-            stage_table_info.stage_root.clone(),
             stage_table_info.copy_into_table_options.on_error.clone(),
         )?;
         load_context.schema_evolution = stage_table_info
@@ -90,7 +88,6 @@ impl LoadContext {
         pos_projection: Option<Vec<usize>>,
         block_compact_thresholds: BlockThresholds,
         internal_columns: Vec<InternalColumn>,
-        stage_root: String,
         on_error_mode: OnErrorMode,
     ) -> Result<Self> {
         let fields = schema
@@ -118,7 +115,6 @@ impl LoadContext {
             default_expr_evaluator,
             default_exprs,
             pos_projection,
-            stage_root,
             is_select,
             schema_evolution: false,
             settings,

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -59,14 +59,14 @@ impl NdJsonDecoder {
         buf: &[u8],
         columns: &mut [ColumnBuilder],
         null_if: &[&str],
-        file_full_path: &str,
+        file_path: &str,
     ) -> std::result::Result<(), FileParseError> {
         // Use from_slice instead of from_reader: from_reader wraps the slice
         // in an IoRead adapter that reads byte-by-byte and disables serde_json's
         // slice fast path. Benchmarks on ~890 MiB of real NDJSON show a 2.5x
         // speedup from this change alone.
         let json: serde_json::Value =
-            serde_json::from_slice(buf).map_err(|e| map_json_error(e, buf, file_full_path))?;
+            serde_json::from_slice(buf).map_err(|e| map_json_error(e, buf, file_path))?;
         // todo: this is temporary
         if self.field_decoder.is_select {
             if let ColumnBuilder::Variant(column) = &mut columns[0] {
@@ -183,7 +183,7 @@ impl NdJsonDecoder {
                         format: "NDJSON".to_string(),
                         message: format!(
                             "schema evolution sample did not include all columns for File '{}'. Extra columns: {}. Please adjust SCHEMA_EVOLUTION sample options such as SAMPLE_FILES, SAMPLE_RECORDS_PER_FILE, or SAMPLE_TOTAL_RECORDS",
-                            file_full_path,
+                            file_path,
                             extra_columns.join(", "),
                         ),
                     });
@@ -289,7 +289,7 @@ impl RowDecoder for NdJsonDecoder {
 // - add info for size and next byte
 //
 // Use test in case of changes of serde_json.
-fn map_json_error(err: serde_json::Error, data: &[u8], file_full_path: &str) -> FileParseError {
+fn map_json_error(err: serde_json::Error, data: &[u8], file_path: &str) -> FileParseError {
     let pos = if err.column() > 0 {
         err.column() - 1
     } else {
@@ -302,7 +302,7 @@ fn map_json_error(err: serde_json::Error, data: &[u8], file_full_path: &str) -> 
         message = message[..p].to_string()
     }
 
-    message = format!("{message}, position {pos} of size {len} for File '{file_full_path}'");
+    message = format!("{message}, position {pos} of size {len} for File '{file_path}'");
     if err.column() < len {
         message = format!("{message}, next byte is '{}'", data[pos] as char)
     }

--- a/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
@@ -81,7 +81,6 @@ impl AccumulatingTransform for BlockBuilder {
             .unwrap();
         if self.state.file_path != batch.start_pos.path {
             self.state.file_path = batch.start_pos.path.clone();
-            self.state.file_full_path = format!("{}{}", self.ctx.stage_root, batch.start_pos.path)
         }
         let num_rows = self.state.num_rows;
         self.decoder.add(&mut self.state, batch)?;

--- a/src/query/storages/stage/src/streaming_load.rs
+++ b/src/query/storages/stage/src/streaming_load.rs
@@ -89,7 +89,6 @@ pub fn build_streaming_load_pipeline(
         None,
         block_compact_thresholds,
         vec![],
-        "".to_string(),
         OnErrorMode::AbortNum(1),
     )?);
     match file_format_params {

--- a/tests/sqllogictests/suites/stage/formats/avro/avro_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/avro/avro_metadata.test
@@ -1,14 +1,14 @@
 query ???
 SELECT metadata$filename, metadata$file_row_number, $1 FROM '@data_s3/avro/' ( FILES => ('map.avro', 'number.avro', 'array.avro', 'nested_record.avro'), FILE_FORMAT => 'avro') order by metadata$filename, metadata$file_row_number
 ----
-testbucket/data/avro/array.avro 0 {"tags":["tall","rich","handsome"]}
-testbucket/data/avro/array.avro 1 {"tags":[]}
-testbucket/data/avro/map.avro 0 {"scores":{"math":100}}
-testbucket/data/avro/map.avro 1 {"scores":{}}
-testbucket/data/avro/nested_record.avro 0 {"id":0,"info":{"contact":{"email":"yang@m","phone":"911"},"name":"yang"}}
-testbucket/data/avro/nested_record.avro 1 {"id":1,"info":{"contact":{"email":"wang@m","phone":null},"name":"wang"}}
-testbucket/data/avro/number.avro 0 {"c_double":1.7976931348623157e+308,"c_float":3.4028234663852886e+38,"c_int":2147483647,"c_long":9223372036854775807}
-testbucket/data/avro/number.avro 1 {"c_double":-1.7976931348623157e+308,"c_float":-3.4028234663852886e+38,"c_int":-2147483648,"c_long":-9223372036854775808}
+avro/array.avro 0 {"tags":["tall","rich","handsome"]}
+avro/array.avro 1 {"tags":[]}
+avro/map.avro 0 {"scores":{"math":100}}
+avro/map.avro 1 {"scores":{}}
+avro/nested_record.avro 0 {"id":0,"info":{"contact":{"email":"yang@m","phone":"911"},"name":"yang"}}
+avro/nested_record.avro 1 {"id":1,"info":{"contact":{"email":"wang@m","phone":null},"name":"wang"}}
+avro/number.avro 0 {"c_double":1.7976931348623157e+308,"c_float":3.4028234663852886e+38,"c_int":2147483647,"c_long":9223372036854775807}
+avro/number.avro 1 {"c_double":-1.7976931348623157e+308,"c_float":-3.4028234663852886e+38,"c_int":-2147483648,"c_long":-9223372036854775808}
 
 statement ok
 create or replace table t(scores variant, filename string, file_row_number int)
@@ -19,5 +19,5 @@ copy into t from (SELECT $1, metadata$filename, metadata$file_row_number FROM '@
 query ???
 select * from t order by filename,file_row_number
 ----
-{"scores":{"math":100}} testbucket/data/avro/map.avro 0
-{"scores":{}} testbucket/data/avro/map.avro 1
+{"scores":{"math":100}} avro/map.avro 0
+{"scores":{}} avro/map.avro 1

--- a/tests/sqllogictests/suites/stage/formats/csv/csv_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/csv/csv_metadata.test
@@ -1,8 +1,8 @@
 query TTIT
 select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/csv/it.csv (file_format=>'csv')
 ----
-testbucket/data/csv/it.csv b 0 1
-testbucket/data/csv/it.csv d 1 2
+csv/it.csv b 0 1
+csv/it.csv d 1 2
 
 statement ok
 create or replace table t(file_name string, c2 string,  `row` int, c1 int)
@@ -15,5 +15,5 @@ csv/it.csv 2 0 NULL NULL
 query TTII
 select * from t
 ----
-testbucket/data/csv/it.csv b 1 1
-testbucket/data/csv/it.csv d 2 2
+csv/it.csv b 1 1
+csv/it.csv d 2 2

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_metadata.test
@@ -1,9 +1,9 @@
 query TTI
 select metadata$filename, $1, metadata$file_row_number  from @data_s3/ndjson/ts.ndjson (file_format=>'ndjson')
 ----
-testbucket/data/ndjson/ts.ndjson {"t":1736305864} 0
-testbucket/data/ndjson/ts.ndjson {"t":1736305865000} 1
-testbucket/data/ndjson/ts.ndjson {"t":1736305866000000} 2
+ndjson/ts.ndjson {"t":1736305864} 0
+ndjson/ts.ndjson {"t":1736305865000} 1
+ndjson/ts.ndjson {"t":1736305866000000} 2
 
 statement ok
 create or replace table t(file_name string, value variant,  `row` int)
@@ -16,6 +16,6 @@ ndjson/ts.ndjson 3 0 NULL NULL
 query TTI
 select * from t
 ----
-testbucket/data/ndjson/ts.ndjson {"t":1736305864} 1
-testbucket/data/ndjson/ts.ndjson {"t":1736305865000} 2
-testbucket/data/ndjson/ts.ndjson {"t":1736305866000000} 3
+ndjson/ts.ndjson {"t":1736305864} 1
+ndjson/ts.ndjson {"t":1736305865000} 2
+ndjson/ts.ndjson {"t":1736305866000000} 3

--- a/tests/sqllogictests/suites/stage/formats/text/text_metadata.test
+++ b/tests/sqllogictests/suites/stage/formats/text/text_metadata.test
@@ -1,8 +1,8 @@
 query TTIT
 select metadata$filename, $2, metadata$file_row_number, $1 from @data_s3/tsv/no_newline.tsv (file_format=>'text')
 ----
-testbucket/data/tsv/no_newline.tsv 2 0 1
-testbucket/data/tsv/no_newline.tsv 4 1 3
+tsv/no_newline.tsv 2 0 1
+tsv/no_newline.tsv 4 1 3
 
 
 statement ok
@@ -16,5 +16,5 @@ tsv/no_newline.tsv 2 0 NULL NULL
 query TTII
 select * from t
 ----
-testbucket/data/tsv/no_newline.tsv 2 1 1
-testbucket/data/tsv/no_newline.tsv 4 2 3
+tsv/no_newline.tsv 2 1 1
+tsv/no_newline.tsv 4 2 3


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Make `metadata$filename` return a stage-relative path for csv, text, ndjson, and avro, matching what columnar formats (parquet, orc, arrow) already do.

## Changes

Row-based formats (csv, text, ndjson) and avro were prepending the stage's own bucket+root to `metadata$filename`. For example, querying `@data_s3` (whose stage URL is `s3://testbucket/data/`):

```sql
select metadata$filename from @data_s3/csv/it.csv (file_format=>'csv');
-- before: testbucket/data/csv/it.csv
-- after : csv/it.csv
```

Columnar formats already returned the stage-relative path (`csv/it.csv`), so the row-based and avro paths now align with them.

## Implementation

- `BlockBuilderState`: dropped the redundant `file_full_path` field; `add_internals_columns_batch` now pushes the stage-relative `file_path` into the `FileName` internal column.
- Removed the `stage_root` prefixing in the row-based `BlockBuilder` and avro `BlockBuilderProcessor`.
- Renamed the misleading `file_full_path` parameter in the ndjson decoder to `file_path` (it now carries the stage-relative path; error messages updated accordingly).
- Removed the now-unused `stage_root` plumbing entirely:
  - `LoadContext` field/constructor argument and the `streaming_load` caller.
  - `StageTableInfo.stage_root` field plus its `PartialEq` participation (the value was derived deterministically from `stage_info`, so equality is unchanged).
  - The `stage_root` derivation in `QueryContext::create_stage_table` and the five `StageTableInfo` initializers there, plus the now-unused `init_stage_operator` import in `query_ctx.rs`.
  - The `stage_root: ""` placeholder in `binder/copy_into_table.rs`.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

Updated the affected sqllogic fixtures so the expected values reflect the corrected paths:

- `tests/sqllogictests/suites/stage/formats/csv/csv_metadata.test`
- `tests/sqllogictests/suites/stage/formats/text/text_metadata.test`
- `tests/sqllogictests/suites/stage/formats/ndjson/ndjson_metadata.test`
- `tests/sqllogictests/suites/stage/formats/avro/avro_metadata.test`

`cargo check -p databend-query` and `cargo check -p databend-common-storages-stage` both pass; `cargo test -p databend-common-storages-stage --lib` is green.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20012)
<!-- Reviewable:end -->
