### PR TITLE
fix(query): preserve spilled result page across restore cancellation

### DIFF
--- a/src/query/service/src/servers/http/v1/query/sized_spsc.rs
+++ b/src/query/service/src/servers/http/v1/query/sized_spsc.rs
@@ -21,6 +21,7 @@ use std::sync::Mutex;
 use std::time::Instant;
 
 use databend_common_base::base::WatchNotify;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
@@ -48,6 +49,13 @@ where
 }
 
 enum Page {
+    Memory(Vec<DataBlock>),
+    Spilled(Location),
+}
+
+// Spilled pages stay in the queue until restore succeeds so a cancelled
+// restore future can be retried by the same page request.
+enum PageRead {
     Memory(Vec<DataBlock>),
     Spilled(Location),
 }
@@ -159,11 +167,30 @@ impl SizedChannelBuffer {
         self.is_recv_stopped = true
     }
 
-    fn take_page(&mut self) -> Option<Page> {
-        self.pages.pop_front()
+    fn prepare_page_read(&mut self) -> Option<PageRead> {
+        match self.pages.front() {
+            None => None,
+            Some(Page::Memory(_)) => match self.pages.pop_front() {
+                Some(Page::Memory(page)) => Some(PageRead::Memory(page)),
+                _ => unreachable!("front page changed while holding buffer lock"),
+            },
+            Some(Page::Spilled(location)) => Some(PageRead::Spilled(location.clone())),
+        }
     }
 
-    fn take_current_page(&mut self) -> Option<Page> {
+    fn commit_spilled_page(&mut self, location: &Location) -> Result<()> {
+        match self.pages.front() {
+            Some(Page::Spilled(front)) if front == location => {
+                self.pages.pop_front();
+                Ok(())
+            }
+            _ => Err(ErrorCode::Internal(
+                "Failed to commit restored spilled page: page queue changed unexpectedly",
+            )),
+        }
+    }
+
+    fn take_current_page(&mut self) -> Option<PageRead> {
         if self
             .current_page
             .as_ref()
@@ -172,7 +199,7 @@ impl SizedChannelBuffer {
             return None;
         }
 
-        Some(Page::Memory(
+        Some(PageRead::Memory(
             self.current_page
                 .replace(PageBuilder::new(self.page_rows))
                 .expect("current_page has taken")
@@ -422,7 +449,7 @@ where S: DataBlockSpill
 
     #[fastrace::trace(name = "SizedChannelReceiver::try_take_page")]
     async fn try_take_page(&mut self) -> Result<Option<BlocksSerializer>> {
-        let page = self.chan.buffer.lock().unwrap().take_page();
+        let page = self.chan.buffer.lock().unwrap().prepare_page_read();
         self.deserialize_page(page).await
     }
 
@@ -432,17 +459,20 @@ where S: DataBlockSpill
         self.deserialize_page(page).await
     }
 
-    async fn deserialize_page(&mut self, page: Option<Page>) -> Result<Option<BlocksSerializer>> {
+    async fn deserialize_page(
+        &mut self,
+        page: Option<PageRead>,
+    ) -> Result<Option<BlocksSerializer>> {
         let collector = match page {
             None => return Ok(None),
-            Some(Page::Memory(page)) => {
+            Some(PageRead::Memory(page)) => {
                 let mut collector = BlocksCollector::new();
                 for block in page {
                     collector.append_block(block);
                 }
                 collector
             }
-            Some(Page::Spilled(location)) => {
+            Some(PageRead::Spilled(location)) => {
                 let start_time = std::time::Instant::now();
 
                 log::info!(
@@ -453,6 +483,11 @@ where S: DataBlockSpill
 
                 let spiller = self.chan.spiller.lock().unwrap().clone().unwrap();
                 let block = spiller.restore(&location).await?;
+                self.chan
+                    .buffer
+                    .lock()
+                    .unwrap()
+                    .commit_spilled_page(&location)?;
                 let rows_count = block.num_rows();
                 let memory_bytes = block.memory_size();
                 let duration_ms = start_time.elapsed().as_millis();
@@ -586,6 +621,8 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use databend_common_exception::ErrorCode;
@@ -620,6 +657,61 @@ mod tests {
         }
 
         async fn restore(&self, location: &Location) -> Result<DataBlock> {
+            match location {
+                Location::Remote(key) => {
+                    let storage = self.storage.lock().unwrap();
+                    storage
+                        .get(key)
+                        .cloned()
+                        .ok_or_else(|| ErrorCode::Internal("Block not found in mock spiller"))
+                }
+                _ => Err(ErrorCode::Internal("Unsupported location type")),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct BlockingRestoreSpiller {
+        storage: Arc<Mutex<HashMap<String, DataBlock>>>,
+        restore_started: Arc<Notify>,
+        allow_first_restore: Arc<Notify>,
+        block_first_restore: Arc<AtomicBool>,
+    }
+
+    impl BlockingRestoreSpiller {
+        fn with_page(key: &str, block: DataBlock) -> (Self, Location) {
+            let storage = Arc::new(Mutex::new(HashMap::new()));
+            storage.lock().unwrap().insert(key.to_string(), block);
+            (
+                BlockingRestoreSpiller {
+                    storage,
+                    restore_started: Arc::new(Notify::new()),
+                    allow_first_restore: Arc::new(Notify::new()),
+                    block_first_restore: Arc::new(AtomicBool::new(true)),
+                },
+                Location::Remote(key.to_string()),
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DataBlockSpill for BlockingRestoreSpiller {
+        async fn spill(&self, data_block: DataBlock) -> Result<Location> {
+            let key = format!("block_{}", rand::random::<u64>());
+            self.storage.lock().unwrap().insert(key.clone(), data_block);
+            Ok(Location::Remote(key))
+        }
+
+        async fn merge_and_spill(&self, data_block: Vec<DataBlock>) -> Result<Location> {
+            self.spill(DataBlock::concat(&data_block)?).await
+        }
+
+        async fn restore(&self, location: &Location) -> Result<DataBlock> {
+            if self.block_first_restore.swap(false, Ordering::SeqCst) {
+                self.restore_started.notify_one();
+                self.allow_first_restore.notified().await;
+            }
+
             match location {
                 Location::Remote(key) => {
                     let storage = self.storage.lock().unwrap();
@@ -754,6 +846,35 @@ mod tests {
 
         assert!(receiver.close().is_none());
         send_task.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_spilled_page_survives_cancelled_restore() {
+        let (_sender, mut receiver) = sized_spsc::<BlockingRestoreSpiller>(1, 1);
+        let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![42])]);
+        let (spiller, location) = BlockingRestoreSpiller::with_page("spilled_page", block);
+        let restore_started = spiller.restore_started.clone();
+
+        {
+            let mut buffer = receiver.chan.buffer.lock().unwrap();
+            buffer.pages.push_back(Page::Spilled(location));
+            buffer.stop_send();
+        }
+        *receiver.chan.format_settings.lock().unwrap() = Some(OutputFormatSettings::default());
+        *receiver.chan.spiller.lock().unwrap() = Some(spiller);
+
+        let mut cancelled_restore = Box::pin(receiver.next_page(&Wait::Async));
+        tokio::select! {
+            result = &mut cancelled_restore => {
+                panic!("restore completed before it could be cancelled: {}", result.is_ok());
+            }
+            _ = restore_started.notified() => {}
+        }
+        drop(cancelled_restore);
+
+        let (serializer, is_end) = receiver.next_page(&Wait::Async).await.unwrap();
+        assert_eq!(serializer.num_rows(), 1);
+        assert!(is_end);
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20015.

This PR fixes a cancellation-safety issue in the HTTP query result paging path when a result page has been spilled to storage.

Previously, a spilled page could be removed from the internal queue before `spiller.restore(...)` completed. If the request future was cancelled while restore was pending, the page was no longer queued and had not been committed as the current page. A later page request could then observe an inconsistent result stream.

This change keeps spilled pages queued while restore is pending, and only removes them from the queue after restore succeeds. Memory-page behavior is unchanged.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Targeted unit tests passed:

```text
cargo test -p databend-query --lib test_spilled_page_survives_cancelled_restore
cargo test -p databend-query --lib test_spsc_channel
cargo test -p databend-query --lib test_spsc_slow
cargo test -p databend-query --lib test_spsc_returns_partial_page_before_finish
cargo test -p databend-query --lib test_spsc_abort
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20016)
<!-- Reviewable:end -->
