### PR TITLE
fix(storage): adjust proxy route cost

### DIFF
--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -51,27 +51,6 @@ jobs:
             exit 1
           fi
 
-  proxy_benchmark_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      any_changed: ${{ steps.proxy.outputs.any_changed }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Check PROXY benchmark related changes
-        uses: tj-actions/changed-files@v47
-        id: proxy
-        with:
-          files: |
-            .github/workflows/reuse.linux.yml
-            scripts/benchmark/proxy_table_routing_bench.py
-            scripts/ci/ci-run-proxy-routing-benchmark.sh
-            src/query/catalog/src/table.rs
-            src/query/settings/src/**
-            src/query/storages/basic/src/proxy_table.rs
-            src/query/storages/fuse/src/**
-
   check:
     needs: info
     runs-on:
@@ -273,8 +252,7 @@ jobs:
         timeout-minutes: 20
 
   test_proxy_routing_benchmark:
-    needs: [build, check, proxy_benchmark_changes]
-    if: needs.proxy_benchmark_changes.outputs.any_changed == 'true'
+    needs: [build, check]
     runs-on:
       - self-hosted
       - "${{ inputs.runner_arch }}"

--- a/scripts/benchmark/proxy_table_routing_bench.py
+++ b/scripts/benchmark/proxy_table_routing_bench.py
@@ -62,8 +62,8 @@ class ScanStats:
     read_bytes: int
 
     @property
-    def cost(self) -> tuple[int, int, int]:
-        return (self.partitions_scanned, self.read_rows, self.read_bytes)
+    def cost(self) -> tuple[int, int]:
+        return (self.partitions_scanned, self.read_rows)
 
 
 @dataclass
@@ -719,14 +719,13 @@ def format_bytes(value: int) -> str:
 
 
 def format_cost(stats: ScanStats) -> str:
-    return f"{stats.partitions_scanned}/{stats.read_rows}/{stats.read_bytes}"
+    return f"{stats.partitions_scanned}/{stats.read_rows}"
 
 
 def format_cost_delta(stats: ScanStats, best: ScanStats) -> str:
     return (
         f"{stats.partitions_scanned - best.partitions_scanned:+d}/"
-        f"{stats.read_rows - best.read_rows:+d}/"
-        f"{stats.read_bytes - best.read_bytes:+d}"
+        f"{stats.read_rows - best.read_rows:+d}"
     )
 
 
@@ -773,7 +772,7 @@ def print_case_report(
     print(
         f"{'route':<18} {'pick':<18} {'rank':>4} {'query_ms(p50)':>13} "
         f"{'partitions':>14} {'read_rows':>12} {'read_size':>12} "
-        f"{'cost(parts/rows/bytes)':<24} {'delta_best'}"
+        f"{'route_cost(parts/rows)':<24} {'delta_best(parts/rows)'}"
     )
     print("-" * 143)
     for name in ["proxy", "trace", "chat", "user", "trace_chat", "trace_chat_user"]:
@@ -801,7 +800,7 @@ def print_summary(results: list[RouteResult]) -> None:
     print("\nsummary:")
     print(
         "case,best_by_stats,tied_best,actual_route,count,"
-        "best_cost,proxy_cost,selected_cost,selected_delta,"
+        "best_route_cost,proxy_route_cost,selected_route_cost,selected_delta,"
         "best_ms,proxy_ms,selected_ms,route_rank,top1_match,acceptable_route,passed"
     )
     for result in results:

--- a/src/query/storages/basic/src/proxy_table.rs
+++ b/src/query/storages/basic/src/proxy_table.rs
@@ -1048,12 +1048,8 @@ fn simple_cluster_key_column(expr: &ast::Expr) -> Option<String> {
     }
 }
 
-fn statistics_cost(statistics: &PartStatistics) -> (usize, usize, usize) {
-    (
-        statistics.partitions_scanned,
-        statistics.read_rows,
-        statistics.read_bytes,
-    )
+fn statistics_cost(statistics: &PartStatistics) -> (usize, usize) {
+    (statistics.partitions_scanned, statistics.read_rows)
 }
 
 fn database_from_desc(desc: &str) -> Option<String> {
@@ -1128,6 +1124,14 @@ mod tests {
             String::new(),
             id.to_string(),
         ))
+    }
+
+    #[test]
+    fn test_statistics_cost_ignores_read_bytes() {
+        let small_file = PartStatistics::new_exact(100, 10, 2, 10);
+        let large_file = PartStatistics::new_exact(100, 1000, 2, 10);
+
+        assert_eq!(statistics_cost(&small_file), statistics_cost(&large_file));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Remove the changed-files gate for the PROXY routing benchmark so the CI matrix always runs it.
- Adjust PROXY statistics routing to rank candidates by partitions and rows instead of parquet read bytes.
- Keep read size in the benchmark report as diagnostic output, but remove it from the oracle route cost.

Related to #20011.

## Motivation

#20011 introduces the new parquet writer direction where page/offset metadata is expected to be maintained outside the parquet footer. With that direction, parquet file bytes and footer/index layout are no longer a stable proxy for future point-read cost. The PROXY statistics route should prefer pruning effectiveness, represented by partitions scanned and rows read, instead of letting read_bytes dominate route choice.

## Changes

1. Deleted the proxy benchmark changed-files trigger job and made test_proxy_routing_benchmark depend only on build and check.
2. Changed statistics_cost to compare (partitions_scanned, read_rows).
3. Updated scripts/benchmark/proxy_table_routing_bench.py to use the same route cost while preserving read_size in the printed report.
4. Added a unit test to assert read_bytes does not affect statistics_cost.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20017)
<!-- Reviewable:end -->
