### PR TITLE
ci: simplify shell_env.sh with BENDSQL_ERROR_NO_VERSION

### DIFF
--- a/tests/shell_env.sh
+++ b/tests/shell_env.sh
@@ -11,53 +11,40 @@ export QUERY_MYSQL_HANDLER_HOST=${QUERY_MYSQL_HANDLER_HOST:="127.0.0.1"}
 export QUERY_MYSQL_HANDLER_PORT=${QUERY_MYSQL_HANDLER_PORT:="3307"}
 export QUERY_HTTP_HANDLER_PORT=${QUERY_HTTP_HANDLER_PORT:="8000"}
 
-bendsql_client() {
-	local stderr_file status
+export BENDSQL_ERROR_NO_VERSION=1
 
-	stderr_file=$(mktemp) || return 1
-	bendsql "$@" 2>"$stderr_file"
-	status=$?
-	sed -E 's/ \[v[0-9][^]]*\]$//' "$stderr_file" >&2
-	rm -f "$stderr_file"
-	return "$status"
-}
-
-bendsql_query_http_connect() {
-	bendsql_client \
+bendsql_connect() {
+	bendsql \
 		--host "${QUERY_MYSQL_HANDLER_HOST}" \
 		--port "${QUERY_HTTP_HANDLER_PORT}" \
 		"$@"
 }
 
-bendsql_query_http_user_connect() {
+bendsql_connect_user() {
 	local user="$1"
 	local password="$2"
 	shift 2
 
-	bendsql_query_http_connect \
+	bendsql_connect \
 		--user "${user}" \
 		--password "${password}" \
 		"$@"
 }
 
-bendsql_client_connect() {
-	bendsql_query_http_connect -uroot --quote-style=never "$@"
+bendsql_connect_root() {
+	bendsql_connect -uroot --quote-style=never "$@"
 }
 
-bendsql_client_output_null() {
-	bendsql_client_connect --output null "$@"
+bendsql_connect_root_null() {
+	bendsql_connect_root --output null "$@"
 }
-
-export BENDSQL_CLIENT_CONNECT="bendsql_client_connect"
-export BENDSQL_CLIENT_OUTPUT_NULL="bendsql_client_output_null"
-
 
 # share client
 export QUERY_MYSQL_HANDLER_SHARE_PROVIDER_PORT="18000"
 export QUERY_MYSQL_HANDLER_SHARE_CONSUMER_PORT="28000"
 
-bendsql_client_share_provider_connect() {
-	bendsql_client \
+bendsql_connect_share_provider() {
+	bendsql \
 		-uroot \
 		--host "${QUERY_MYSQL_HANDLER_HOST}" \
 		--port "${QUERY_MYSQL_HANDLER_SHARE_PROVIDER_PORT}" \
@@ -65,8 +52,8 @@ bendsql_client_share_provider_connect() {
 		"$@"
 }
 
-bendsql_client_share_consumer_connect() {
-	bendsql_client \
+bendsql_connect_share_consumer() {
+	bendsql \
 		-uroot \
 		--host "${QUERY_MYSQL_HANDLER_HOST}" \
 		--port "${QUERY_MYSQL_HANDLER_SHARE_CONSUMER_PORT}" \
@@ -74,19 +61,16 @@ bendsql_client_share_consumer_connect() {
 		"$@"
 }
 
-export BENDSQL_CLIENT_PROVIDER_CONNECT="bendsql_client_share_provider_connect"
-export BENDSQL_CLIENT_CONSUMER_CONNECT="bendsql_client_share_consumer_connect"
-
 
 query() {
 	echo ">>>> $1"
-	echo "$1" | $BENDSQL_CLIENT_CONNECT
+	echo "$1" | bendsql_connect_root
 	echo "<<<<"
 }
 
 stmt() {
 	echo ">>>> $1"
-	echo "$1" | $BENDSQL_CLIENT_CONNECT
+	echo "$1" | bendsql_connect_root
 	if [ $? -ne 0 ]; then
 		echo "<<<<"
 	fi
@@ -95,7 +79,7 @@ stmt() {
 
 stmt_fail() {
 	echo ">>>> $1"
-	echo "$1" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+	echo "$1" | bendsql_connect_root > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		return 1
 	fi
@@ -109,7 +93,7 @@ comment() {
 
 # Execute SQL as root user, useful for setup/teardown blocks
 run_root_sql() {
-	cat <<SQL | $BENDSQL_CLIENT_CONNECT
+	cat <<SQL | bendsql_connect_root
 $1
 SQL
 }

--- a/tests/sqllogictests/scripts/prepare_stage.sh
+++ b/tests/sqllogictests/scripts/prepare_stage.sh
@@ -7,21 +7,21 @@
 # most of the time, the tests will succeed with with "s3" too.
 # todo: add storage "http"?
 DATADIR="fs://${PWD}/tests/data/"
-echo "drop stage if exists data" | $BENDSQL_CLIENT_CONNECT
-echo "create or replace connection my_conn_s3 storage_type = 's3' access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900'" | $BENDSQL_CLIENT_CONNECT
-echo "create or replace stage data_s3 url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
-echo "create or replace stage data_fs url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists data" | bendsql_connect_root
+echo "create or replace connection my_conn_s3 storage_type = 's3' access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900'" | bendsql_connect_root
+echo "create or replace stage data_s3 url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
+echo "create or replace stage data_fs url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
 if [ -z "$TEST_STAGE_STORAGE" ] || [ "$TEST_STAGE_STORAGE" == "fs" ]; then
-	echo "create or replace stage data url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+	echo "create or replace stage data url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
 elif [ "$TEST_STAGE_STORAGE" == "s3" ]; then
-	echo "create or replace stage data url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
+	echo "create or replace stage data url='s3://testbucket/data/' connection=(connection_name='my_conn_s3') FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
 else
 	echo "unknown TEST_STAGE_STORAGE value: ${TEST_STAGE_STORAGE}"
 	exit 1
 fi
 
-echo "drop table if exists ontime" | $BENDSQL_CLIENT_CONNECT
-cat tests/data/ddl/ontime.sql | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists ontime" | bendsql_connect_root
+cat tests/data/ddl/ontime.sql | bendsql_connect_root
 
 if [ -z "$TEST_STAGE_DEDUP" ] || [ "$TEST_STAGE_DEDUP" = "full_path" ]; then
     FULL_PATH=1
@@ -32,12 +32,12 @@ else
     exit 1
 fi
 
-echo "set global copy_dedup_full_path_by_default = ${FULL_PATH}" | $BENDSQL_CLIENT_CONNECT
+echo "set global copy_dedup_full_path_by_default = ${FULL_PATH}" | bendsql_connect_root
 
 if [ -z "$TEST_STAGE_SIZE" ] || [ "$TEST_STAGE_SIZE" = "small" ]; then
-		echo "set global parquet_fast_read_bytes = 1048576" | $BENDSQL_CLIENT_CONNECT
+		echo "set global parquet_fast_read_bytes = 1048576" | bendsql_connect_root
 elif [ "$TEST_STAGE_SIZE" = "large" ]; then
-		echo "set global parquet_fast_read_bytes = 0" | $BENDSQL_CLIENT_CONNECT
+		echo "set global parquet_fast_read_bytes = 0" | bendsql_connect_root
 else
     echo "TEST_STAGE_DEDUP must be 'small' or 'large'" >&2
     exit 1

--- a/tests/sqllogictests/scripts/prepare_tpcds_data.sh
+++ b/tests/sqllogictests/scripts/prepare_tpcds_data.sh
@@ -36,10 +36,10 @@ tables=(
 
 force=${2:-"1"}
 if [ "$force" == "0" ]; then
-	table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'call_center'" | $BENDSQL_CLIENT_CONNECT --output tsv)
+	table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'call_center'" | bendsql_connect_root --output tsv)
 	table_exists=$(echo "$table_exists" | tr -d '\r\n[:space:]')
 	if [ -n "$table_exists" ] && [ "$table_exists" -gt 0 ]; then
-		res=$(echo "SELECT COUNT() from ${db}.call_center" | $BENDSQL_CLIENT_CONNECT --output tsv)
+		res=$(echo "SELECT COUNT() from ${db}.call_center" | bendsql_connect_root --output tsv)
 		res=$(echo "$res" | tr -d '\r\n[:space:]')
 		if [ -n "$res" ] && [ "$res" -gt 0 ]; then
 			echo "Table $db.call_center already exists and is not empty, size: ${res}. Use force=1 to override it."
@@ -48,11 +48,11 @@ if [ "$force" == "0" ]; then
 	fi
 fi
 
-echo "CREATE OR REPLACE DATABASE tpcds" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE OR REPLACE DATABASE tpcds" | bendsql_connect_root
 
 # Create Tables;
 # shellcheck disable=SC2002
-cat ${target_dir}/scripts/tpcds.sql | $BENDSQL_CLIENT_CONNECT
+cat ${target_dir}/scripts/tpcds.sql | bendsql_connect_root
 python ${target_dir}/scripts/prepare_duckdb_tpcds_data.py 1
 
 stmt "drop stage if exists s1"

--- a/tests/sqllogictests/scripts/prepare_tpch_data.sh
+++ b/tests/sqllogictests/scripts/prepare_tpch_data.sh
@@ -9,10 +9,10 @@ db=${1:-"tpch_test"}
 force=${2:-"1"}
 
 if [ "$force" == "0" ]; then
-	table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'nation'" | $BENDSQL_CLIENT_CONNECT --output tsv)
+	table_exists=$(echo "SELECT COUNT() FROM system.tables WHERE database = '${db}' AND name = 'nation'" | bendsql_connect_root --output tsv)
 	table_exists=$(echo "$table_exists" | tr -d '\r\n[:space:]')
 	if [ -n "$table_exists" ] && [ "$table_exists" -gt 0 ]; then
-		res=$(echo "SELECT COUNT() from ${db}.nation" | $BENDSQL_CLIENT_CONNECT --output tsv)
+		res=$(echo "SELECT COUNT() from ${db}.nation" | bendsql_connect_root --output tsv)
 		res=$(echo "$res" | tr -d '\r\n[:space:]')
 		if [ -n "$res" ] && [ "$res" -gt 0 ]; then
 			echo "Table $db.nation already exists and is not empty, size: ${res}. Use force=1 to override it."
@@ -21,11 +21,11 @@ if [ "$force" == "0" ]; then
 	fi
 fi
 
-echo "DROP DATABASE if EXISTS ${db}" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE DATABASE ${db}" | $BENDSQL_CLIENT_CONNECT
+echo "DROP DATABASE if EXISTS ${db}" | bendsql_connect_root
+echo "CREATE DATABASE ${db}" | bendsql_connect_root
 
 for t in customer lineitem nation orders partsupp part region supplier; do
-	echo "DROP TABLE IF EXISTS ${db}.$t" | $BENDSQL_CLIENT_CONNECT
+	echo "DROP TABLE IF EXISTS ${db}.$t" | bendsql_connect_root
 done
 
 # create tpch tables
@@ -35,14 +35,14 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.nation
     n_name       STRING not null,
     n_regionkey  INTEGER not null,
     n_comment    STRING
-) CLUSTER BY (n_nationkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (n_nationkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.region
 (
     r_regionkey  INTEGER not null,
     r_name       STRING not null,
     r_comment    STRING
-) CLUSTER BY (r_regionkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (r_regionkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.part
 (
@@ -55,7 +55,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.part
     p_container   STRING not null,
     p_retailprice DECIMAL(15, 2) not null,
     p_comment     STRING not null
-) CLUSTER BY (p_partkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (p_partkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.supplier
 (
@@ -66,7 +66,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.supplier
     s_phone       STRING not null,
     s_acctbal     DECIMAL(15, 2) not null,
     s_comment     STRING not null
-) CLUSTER BY (s_suppkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (s_suppkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.partsupp
 (
@@ -75,7 +75,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.partsupp
     ps_availqty    BIGINT not null,
     ps_supplycost  DECIMAL(15, 2)  not null,
     ps_comment     STRING not null
-) CLUSTER BY (ps_partkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (ps_partkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.customer
 (
@@ -87,7 +87,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.customer
     c_acctbal     DECIMAL(15, 2)   not null,
     c_mktsegment  STRING not null,
     c_comment     STRING not null
-) CLUSTER BY (c_custkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (c_custkey)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.orders
 (
@@ -100,7 +100,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.orders
     o_clerk          STRING not null,
     o_shippriority   INTEGER not null,
     o_comment        STRING not null
-) CLUSTER BY (o_orderkey, o_orderdate)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY (o_orderkey, o_orderdate)" | bendsql_connect_root
 
 echo "CREATE TABLE IF NOT EXISTS ${db}.lineitem
 (
@@ -120,7 +120,7 @@ echo "CREATE TABLE IF NOT EXISTS ${db}.lineitem
     l_shipinstruct STRING not null,
     l_shipmode     STRING not null,
     l_comment      STRING not null
-) CLUSTER BY(l_shipdate, l_orderkey)" | $BENDSQL_CLIENT_CONNECT
+) CLUSTER BY(l_shipdate, l_orderkey)" | bendsql_connect_root
 
 #import data
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/suites/0_stateless/00_dummy/00_0003_dummy_select_sh.sh
+++ b/tests/suites/0_stateless/00_dummy/00_0003_dummy_select_sh.sh
@@ -4,8 +4,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "SELECT 1;select 2;select 3;" | $BENDSQL_CLIENT_CONNECT
+echo "SELECT 1;select 2;select 3;" | bendsql_connect_root
 
-echo "SELECT 1" | $BENDSQL_CLIENT_CONNECT
-echo "SELECT 2" | $BENDSQL_CLIENT_CONNECT
-echo "SELECT 3" | $BENDSQL_CLIENT_CONNECT
+echo "SELECT 1" | bendsql_connect_root
+echo "SELECT 2" | bendsql_connect_root
+echo "SELECT 3" | bendsql_connect_root

--- a/tests/suites/0_stateless/02_ddl/02_0001_autoincrement.sh
+++ b/tests/suites/0_stateless/02_ddl/02_0001_autoincrement.sh
@@ -3,7 +3,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace database test" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace database test" | bendsql_connect_root
 
 
 stmt """

--- a/tests/suites/0_stateless/02_ddl/02_0001_show_create_table.sh
+++ b/tests/suites/0_stateless/02_ddl/02_0001_show_create_table.sh
@@ -3,7 +3,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace database test" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace database test" | bendsql_connect_root
 
 
 stmt """
@@ -37,7 +37,7 @@ and t.name = 'b'
 echo """
 set hide_options_in_show_create_table=0;
 SHOW CREATE TABLE test.b;
-""" | $BENDSQL_CLIENT_CONNECT
+""" | bendsql_connect_root
 
 stmt "create or replace view test.v_b as select * from test.b"
 
@@ -60,7 +60,7 @@ query "SHOW CREATE TABLE test.c"
 echo """
 create or replace table test.t(c1 int, c2 int);
 create or replace table test.t1(c1 int, c2 string);
-""" | $BENDSQL_CLIENT_CONNECT
+""" | bendsql_connect_root
 
 stmt "create or replace view test.v_union as select c1 from test.t union all select c1 from test.t1;"
 
@@ -87,7 +87,7 @@ show create table test.tc;
 set quoted_ident_case_sensitive=1;
 set sql_dialect='MySQL';
 show create table test.tc;
-""" | $BENDSQL_CLIENT_CONNECT
+""" | bendsql_connect_root
 
 stmt """
 create or replace table test.auto_increment(c1 int, c2 int autoincrement, c3 int identity (2, 3) order);

--- a/tests/suites/0_stateless/03_dml/03_0016_update_with_lock.sh
+++ b/tests/suites/0_stateless/03_dml/03_0016_update_with_lock.sh
@@ -3,32 +3,32 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop database if exists test_update" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists test_update" | bendsql_connect_root
 
-echo "CREATE DATABASE test_update" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_update.t(a int, b int)" | $BENDSQL_CLIENT_CONNECT
-echo "set global enable_table_lock = 1" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE test_update" | bendsql_connect_root
+echo "create table test_update.t(a int, b int)" | bendsql_connect_root
+echo "set global enable_table_lock = 1" | bendsql_connect_root
 
 for i in $(seq 1 10);do
 	(
 		j=$(($i+1))
-		echo "insert into test_update.t values($i, $j)" | $BENDSQL_CLIENT_OUTPUT_NULL
+		echo "insert into test_update.t values($i, $j)" | bendsql_connect_root_null
 	)&
 done
 wait
 
-echo "optimize table test_update.t compact" | $BENDSQL_CLIENT_CONNECT
-echo "select count() from test_update.t where a + 1 = b" | $BENDSQL_CLIENT_CONNECT
+echo "optimize table test_update.t compact" | bendsql_connect_root
+echo "select count() from test_update.t where a + 1 = b" | bendsql_connect_root
 
 echo "Test table lock for update"
 for i in $(seq 1 10);do
 	(
-		echo "update test_update.t set b = $i where a = $i" | $BENDSQL_CLIENT_OUTPUT_NULL
+		echo "update test_update.t set b = $i where a = $i" | bendsql_connect_root_null
 	)&
 done
 wait
 
-echo "select count() from test_update.t where a = b" | $BENDSQL_CLIENT_CONNECT
+echo "select count() from test_update.t where a = b" | bendsql_connect_root
 
-echo "drop table test_update.t all" | $BENDSQL_CLIENT_CONNECT
-echo "drop database test_update" | $BENDSQL_CLIENT_CONNECT
+echo "drop table test_update.t all" | bendsql_connect_root
+echo "drop database test_update" | bendsql_connect_root

--- a/tests/suites/0_stateless/05_hints/05_0001_set_var.sh
+++ b/tests/suites/0_stateless/05_hints/05_0001_set_var.sh
@@ -6,35 +6,35 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # mariadb mysql client has some bug, please use mysql official client
 # mysql --version
 # mysql  Ver 8.0.32-0ubuntu0.20.04.2 for Linux on x86_64 ((Ubuntu))
-echo "select * from (select /*+SET_VAR(timezone='Asia/Shanghai')*/ name, value value from system.settings where name in ('timezone') union all (select /*+SET_VAR(timezone='America/Los_Angeles')*/ 'x','x')) order by name desc;" |  $BENDSQL_CLIENT_CONNECT
-echo "select * from (select /*+SET_VAR(timezone='America/Los_Angeles')*/ name, value value from system.settings where name in ('timezone') union all (select /*+SET_VAR(timezone='Asia/Shanghai')*/ 'x','x')) order by name desc;" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+SET_VAR(timezone='Asia/Shanghai') */ * from system.settings where name = 'timezone';" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+SET_VAR(timezone='Asia') SET_VAR(storage_read_buffer_size=200)*/ name, value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ /*+SET_VAR(storage_read_buffer_size=100)*/name, /*+xx*/ value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+SET_VA(timezone='Asia/Shanghai') storage_read_buffer_size=200 SET_VAR(storage_read_buffer_size=100)*/name, /*+xx*/ value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+ SET_VAR(timezone=x) SET_VAR(timezone=select 1) */ name, value from system.settings where name='timezone';" |  $BENDSQL_CLIENT_CONNECT
-echo "select /*+ SET_VAR(storage_read_buffer_size=200) SET_VAR(timezone=x) */ name, value from system.settings where name='timezone' or name = 'storage_read_buffer_size';" |  $BENDSQL_CLIENT_CONNECT
+echo "select * from (select /*+SET_VAR(timezone='Asia/Shanghai')*/ name, value value from system.settings where name in ('timezone') union all (select /*+SET_VAR(timezone='America/Los_Angeles')*/ 'x','x')) order by name desc;" |  bendsql_connect_root
+echo "select * from (select /*+SET_VAR(timezone='America/Los_Angeles')*/ name, value value from system.settings where name in ('timezone') union all (select /*+SET_VAR(timezone='Asia/Shanghai')*/ 'x','x')) order by name desc;" |  bendsql_connect_root
+echo "select /*+SET_VAR(timezone='Asia/Shanghai') */ * from system.settings where name = 'timezone';" |  bendsql_connect_root
+echo "select /*+SET_VAR(timezone='Asia') SET_VAR(storage_read_buffer_size=200)*/ name, value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  bendsql_connect_root
+echo "select /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ /*+SET_VAR(storage_read_buffer_size=100)*/name, /*+xx*/ value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  bendsql_connect_root
+echo "select /*+SET_VA(timezone='Asia/Shanghai') storage_read_buffer_size=200 SET_VAR(storage_read_buffer_size=100)*/name, /*+xx*/ value from system.settings where name in ('timezone', 'storage_read_buffer_size')" |  bendsql_connect_root
+echo "select /*+ SET_VAR(timezone=x) SET_VAR(timezone=select 1) */ name, value from system.settings where name='timezone';" |  bendsql_connect_root
+echo "select /*+ SET_VAR(storage_read_buffer_size=200) SET_VAR(timezone=x) */ name, value from system.settings where name='timezone' or name = 'storage_read_buffer_size';" |  bendsql_connect_root
 
-echo "drop database if exists set_var;" | $BENDSQL_CLIENT_CONNECT
-echo "create database set_var;" | $BENDSQL_CLIENT_CONNECT
-echo "create table set_var.test(id int);" | $BENDSQL_CLIENT_CONNECT
-echo "insert /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ into set_var.test values(1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "insert /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ into set_var.test values(3)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ * from set_var.test order by id" | $BENDSQL_CLIENT_CONNECT
-echo "select /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ id from set_var.test order by id" | $BENDSQL_CLIENT_CONNECT
-echo "update /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ set_var.test set id=2 where id=1" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "update /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ set_var.test set id=4 where id=3" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from set_var.test order by id" | $BENDSQL_CLIENT_CONNECT
-echo "delete /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ from set_var.test where id=2" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "delete /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ from set_var.test where id=4" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from set_var.test" | $BENDSQL_CLIENT_CONNECT
-echo "set timezone='America/Toronto'; select /*+SET_VAR(timezone='Asia/Shanghai') */ timezone(); select timezone();" | $BENDSQL_CLIENT_CONNECT
-echo "create table set_var.t(c1 timestamp)" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists set_var;" | bendsql_connect_root
+echo "create database set_var;" | bendsql_connect_root
+echo "create table set_var.test(id int);" | bendsql_connect_root
+echo "insert /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ into set_var.test values(1)" | bendsql_connect_root_null
+echo "insert /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ into set_var.test values(3)" | bendsql_connect_root_null
+echo "select /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ * from set_var.test order by id" | bendsql_connect_root
+echo "select /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ id from set_var.test order by id" | bendsql_connect_root
+echo "update /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ set_var.test set id=2 where id=1" | bendsql_connect_root_null
+echo "update /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ set_var.test set id=4 where id=3" | bendsql_connect_root_null
+echo "select * from set_var.test order by id" | bendsql_connect_root
+echo "delete /*+SET_VAR(timezone='Asia/Shanghai') SET_VAR(storage_read_buffer_size=200)*/ from set_var.test where id=2" | bendsql_connect_root_null
+echo "delete /*+SET_VAR(timezone='Asia/Shanghai') (storage_read_buffer_size=200)*/ from set_var.test where id=4" | bendsql_connect_root_null
+echo "select * from set_var.test" | bendsql_connect_root
+echo "set timezone='America/Toronto'; select /*+SET_VAR(timezone='Asia/Shanghai') */ timezone(); select timezone();" | bendsql_connect_root
+echo "create table set_var.t(c1 timestamp)" | bendsql_connect_root
 # Toronto and Shanghai time diff is 13 hours.
-echo "set timezone='America/Toronto'; insert /*+SET_VAR(timezone='Asia/Shanghai') */ into set_var.t values('2022-02-02 03:00:00'); select /*+SET_VAR(timezone='Asia/Shanghai') */ * from set_var.t; select * from set_var.t;" | $BENDSQL_CLIENT_CONNECT
-echo "drop database set_var;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s2" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s2" | $BENDSQL_CLIENT_CONNECT
-echo "copy  /*+SET_VAR(timezone='Asia/Shanghai') */ into @s2 from (select timezone()); " | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
-echo "select * from @s2 " | $BENDSQL_CLIENT_CONNECT
-echo "drop stage s2" | $BENDSQL_CLIENT_CONNECT
+echo "set timezone='America/Toronto'; insert /*+SET_VAR(timezone='Asia/Shanghai') */ into set_var.t values('2022-02-02 03:00:00'); select /*+SET_VAR(timezone='Asia/Shanghai') */ * from set_var.t; select * from set_var.t;" | bendsql_connect_root
+echo "drop database set_var;" | bendsql_connect_root
+echo "drop stage if exists s2" | bendsql_connect_root
+echo "create stage s2" | bendsql_connect_root
+echo "copy  /*+SET_VAR(timezone='Asia/Shanghai') */ into @s2 from (select timezone()); " | bendsql_connect_root | cut -d$'\t' -f1,2
+echo "select * from @s2 " | bendsql_connect_root
+echo "drop stage s2" | bendsql_connect_root

--- a/tests/suites/0_stateless/05_hints/05_0002_deduplicate_label.sh
+++ b/tests/suites/0_stateless/05_hints/05_0002_deduplicate_label.sh
@@ -6,31 +6,31 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # mariadb mysql client has some bug, please use mysql official client
 # mysql --version
 # mysql  Ver 8.0.32-0ubuntu0.20.04.2 for Linux on x86_64 ((Ubuntu))
-echo "drop table if exists t5;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s5;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s5_1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t5;" | bendsql_connect_root
+echo "drop stage if exists s5;" | bendsql_connect_root
+echo "drop stage if exists s5_1;" | bendsql_connect_root
 
-echo "CREATE TABLE t5(a Int, b bool) Engine = Fuse;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE TABLE t5(a Int, b bool) Engine = Fuse;" | bendsql_connect_root
 
-echo "INSERT /*+ SET_VAR(deduplicate_label='insert-test') */ INTO t5 (a, b) VALUES(1, false)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "INSERT /*+ SET_VAR(deduplicate_label='insert-test') */ INTO t5 (a, b) VALUES(1, false)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from t5" | $BENDSQL_CLIENT_CONNECT
+echo "INSERT /*+ SET_VAR(deduplicate_label='insert-test') */ INTO t5 (a, b) VALUES(1, false)" | bendsql_connect_root_null
+echo "INSERT /*+ SET_VAR(deduplicate_label='insert-test') */ INTO t5 (a, b) VALUES(1, false)" | bendsql_connect_root_null
+echo "select * from t5" | bendsql_connect_root
 
-echo "CREATE STAGE s5_1;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE s5_1;" | bendsql_connect_root
 echo "copy /*+SET_VAR(deduplicate_label='copy-test')*/ into @s5_1 from (select * from t5);" | $MYSQL_CLINEENRT_CONNECT
 echo "select * from @s5_1;" | $MYSQL_CLINEENRT_CONNECT
 echo "CREATE STAGE s5;" | $MYSQL_CLINEENRT_CONNECT
 echo "copy /*+SET_VAR(deduplicate_label='copy-test')*/ into @s5 from (select * from t5);" | $MYSQL_CLINEENRT_CONNECT
 echo "select * from @s5;" | $MYSQL_CLINEENRT_CONNECT
 
-echo "UPDATE /*+ SET_VAR(deduplicate_label='update-test') */ t5 SET a = 20 WHERE b = false;" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "UPDATE /*+ SET_VAR(deduplicate_label='update-test') */ t5 SET a = 30 WHERE b = false;" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from t5" | $BENDSQL_CLIENT_CONNECT
+echo "UPDATE /*+ SET_VAR(deduplicate_label='update-test') */ t5 SET a = 20 WHERE b = false;" | bendsql_connect_root_null
+echo "UPDATE /*+ SET_VAR(deduplicate_label='update-test') */ t5 SET a = 30 WHERE b = false;" | bendsql_connect_root_null
+echo "select * from t5" | bendsql_connect_root
 
-echo "replace /*+ SET_VAR(deduplicate_label='replace-test') */ into t5 on(a,b) values(40,false);" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "replace /*+ SET_VAR(deduplicate_label='replace-test') */ into t5 on(a,b) values(50,false);" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from t5 order by a" | $BENDSQL_CLIENT_CONNECT
+echo "replace /*+ SET_VAR(deduplicate_label='replace-test') */ into t5 on(a,b) values(40,false);" | bendsql_connect_root_null
+echo "replace /*+ SET_VAR(deduplicate_label='replace-test') */ into t5 on(a,b) values(50,false);" | bendsql_connect_root_null
+echo "select * from t5 order by a" | bendsql_connect_root
 
-echo "drop table if exists t5;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s5;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s5_1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t5;" | bendsql_connect_root
+echo "drop stage if exists s5;" | bendsql_connect_root
+echo "drop stage if exists s5_1;" | bendsql_connect_root

--- a/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
+++ b/tests/suites/0_stateless/12_time_travel/12_0004_time_travel_select_at.sh
@@ -5,35 +5,35 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 ## Create table t12_0004
-echo "create table t12_0004(c int)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t12_0004(c int)" | bendsql_connect_root
 echo "two insertions"
-echo "insert into t12_0004 values(1),(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into t12_0004 values(1),(2)" | bendsql_connect_root_null
 
 # for at offset.
 sleep 2
 
-echo "insert into t12_0004 values(3)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into t12_0004 values(3)" | bendsql_connect_root_null
 echo "latest snapshot should contain 3 rows"
-echo "select count(*)  from t12_0004" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)  from t12_0004" | bendsql_connect_root
 
 ## Get the previous snapshot id of the latest snapshot
-SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0004') where row_count=3 " | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0004') where row_count=3 " | bendsql_connect_root)
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(*) from t12_0004 at (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t12_0004 at (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(t.c) from t12_0004 at (snapshot => '$SNAPSHOT_ID') as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0004 at (snapshot => '$SNAPSHOT_ID') as t" | bendsql_connect_root
 
 # Get a time point at/after the first insertion.
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0004') where row_count=2" | $BENDSQL_CLIENT_CONNECT)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0004') where row_count=2" | bendsql_connect_root)
 
 echo "counting the data set of first insertion by timestamp, which should contains 2 rows"
-echo "select count(t.c) from t12_0004 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0004 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | bendsql_connect_root
 
 offset=$(( $(date -u +%s) - $(date -u -d "$TIMEPOINT" +%s) - 1 ))
 echo "counting the data set of first insertion by offset, which should contains 2 rows"
-echo "select count(t.c) from t12_0004 at (OFFSET => -$offset) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0004 at (OFFSET => -$offset) as t" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t12_0004" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t12_0004" | bendsql_connect_root

--- a/tests/suites/0_stateless/12_time_travel/12_0005_changes_select.sh
+++ b/tests/suites/0_stateless/12_time_travel/12_0005_changes_select.sh
@@ -5,56 +5,56 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 ## Create or replace table t12_0005
-echo "create or replace table t12_0005(a int, b int) change_tracking=true enable_auto_analyze=0" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t12_0005 values(1, 1),(2, 1)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "create or replace table t12_0005(a int, b int) change_tracking=true enable_auto_analyze=0" | bendsql_connect_root
+echo "insert into t12_0005 values(1, 1),(2, 1)" | bendsql_connect_root_null
 
-echo "update t12_0005 set b = 2 where a = 2" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "delete from t12_0005 where a = 1" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "insert into t12_0005 values(3, 3)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "update t12_0005 set b = 2 where a = 2" | bendsql_connect_root_null
+echo "delete from t12_0005 where a = 1" | bendsql_connect_root_null
+echo "insert into t12_0005 values(3, 3)" | bendsql_connect_root_null
 
 echo "latest snapshot should contain 2 rows"
-echo "select count(*) from t12_0005" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t12_0005" | bendsql_connect_root
 
 ## Get the snapshot id of the oldest snapshot.
-AT_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') where previous_snapshot_id is null" | $BENDSQL_CLIENT_CONNECT)
+AT_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') where previous_snapshot_id is null" | bendsql_connect_root)
 
 ## Get end the snapshot id after delete.
-END_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') where row_count=1" | $BENDSQL_CLIENT_CONNECT)
+END_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') where row_count=1" | bendsql_connect_root)
 
 echo "changes default snapshot at the first insertion"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 echo "changes default snapshot at the first insertion end the deletion"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$AT_SNAPSHOT_ID') end(snapshot => '$END_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$AT_SNAPSHOT_ID') end(snapshot => '$END_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 echo "changes append_only snapshot at the first insertion"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 # Not find end point.
 echo "not find end point"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$END_SNAPSHOT_ID') end(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(snapshot => '$END_SNAPSHOT_ID') end(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 # Get a time point at/after the first insertion.
-AT_TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default','t12_0005') where previous_snapshot_id is null" | $BENDSQL_CLIENT_CONNECT)
+AT_TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default','t12_0005') where previous_snapshot_id is null" | bendsql_connect_root)
 
 ## Get a time point after delete.
-END_TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default','t12_0005') where row_count=1" | $BENDSQL_CLIENT_CONNECT)
+END_TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default','t12_0005') where row_count=1" | bendsql_connect_root)
 
 echo "changes default timestamp at the first insertion end the deletion"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(timestamp => '$AT_TIMEPOINT'::TIMESTAMP) end(timestamp => '$END_TIMEPOINT'::TIMESTAMP) order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => default) at(timestamp => '$AT_TIMEPOINT'::TIMESTAMP) end(timestamp => '$END_TIMEPOINT'::TIMESTAMP) order by a, b" | bendsql_connect_root
 
 echo "changes append_only timestamp at the first insertion"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(timestamp => '$AT_TIMEPOINT'::TIMESTAMP) order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(timestamp => '$AT_TIMEPOINT'::TIMESTAMP) order by a, b" | bendsql_connect_root
 
 # Change tracking is disabled.
-echo "alter table t12_0005 set options(change_tracking=false)" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t12_0005 set options(change_tracking=false)" | bendsql_connect_root
 echo "change tracking is disabled"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 # Change tracking has been missing for the time range requested.
-echo "alter table t12_0005 set options(change_tracking=true)" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t12_0005 set options(change_tracking=true)" | bendsql_connect_root
 echo "change tracking has been missing for the time range requested"
-echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b, change\$action, change\$is_update from t12_0005 changes(information => append_only) at(snapshot => '$AT_SNAPSHOT_ID') order by a, b" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t12_0005 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t12_0005 all" | bendsql_connect_root

--- a/tests/suites/0_stateless/16_flashback/16_0001_flashback.sh
+++ b/tests/suites/0_stateless/16_flashback/16_0001_flashback.sh
@@ -4,53 +4,53 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "create table t16(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t16(c int not null)" | bendsql_connect_root
 # the first snapshot contains 2 rows
-echo "insert into t16 values(1),(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into t16 values(1),(2)" | bendsql_connect_root_null
 
 # the second(last) snapshot should contain 3 rows
-echo "insert into t16 values(3)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into t16 values(3)" | bendsql_connect_root_null
 
 # flash back to the second(last) snapshot should be ok, and have no effects
-SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t16') where row_count=3" | $BENDSQL_CLIENT_CONNECT)
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't16') where row_count=3" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t16') where row_count=3" | bendsql_connect_root)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't16') where row_count=3" | bendsql_connect_root)
 
-echo "alter table t16 flashback to (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t16 flashback to (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 echo "checking that after flashback to snapshot, there should be 3 rows"
-echo "select count(*)=3  from t16" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from t16" | bendsql_connect_root
 echo "checking that after flashback to the same snapshot, no new snapshots shall be generated"
-echo "select count(*)=2  from fuse_snapshot('default', 't16')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=2  from fuse_snapshot('default', 't16')" | bendsql_connect_root
 
-echo "alter table t16 flashback to (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t16 flashback to (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | bendsql_connect_root
 echo "checking that after flashback to timestamp, there should be 3 rows"
-echo "select count(*)=3  from t16" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from t16" | bendsql_connect_root
 
 echo "checking that after flashback to the same timestamp, number of snapshots shall be the same"
-echo "select count(*)=2  from fuse_snapshot('default', 't16')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=2  from fuse_snapshot('default', 't16')" | bendsql_connect_root
 
 # flash back to the first snapshot
-FST_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t16') where row_count=2" | $BENDSQL_CLIENT_CONNECT)
-echo "alter table t16 flashback to (snapshot => '$FST_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+FST_SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t16') where row_count=2" | bendsql_connect_root)
+echo "alter table t16 flashback to (snapshot => '$FST_SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "checking that after flashback to the first snapshot, there should be 2 rows"
-echo "select count(*)=2  from t16" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=2  from t16" | bendsql_connect_root
 
 echo "checking that after flashback to the first snapshot, there should be only 1 snapshot visible"
-echo "select count(*)=1  from fuse_snapshot('default', 't16')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=1  from fuse_snapshot('default', 't16')" | bendsql_connect_root
 
 # flash back to point that not exist should fail
 echo "flash back to snapshot id that not exist should report error 1105"
-echo "alter table t16 flashback to (snapshot => 'NOTE_EXIST')" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t16 flashback to (snapshot => 'NOTE_EXIST')" | bendsql_connect_root
 
 echo "flash back to timestamp that not exist should report error 1105"
-echo "alter table t16 flashback to (TIMESTAMP => '2000-12-06 04:35:17.856848'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT;
+echo "alter table t16 flashback to (TIMESTAMP => '2000-12-06 04:35:17.856848'::TIMESTAMP)" | bendsql_connect_root;
 
 # flash back to point that does not visible to the current snapshot will also fail
 #  although $SNAPSHOT_ID has been in the history of table `t16`, but
 #  after reverted to the $FST_SNAPSHOT_ID, it no longer visible to the table `t16`
 echo "flash back to point that does not visible to the current snapshot should report error 1105"
-echo "alter table t16 flashback to (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t16 flashback to (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 
 ## Drop table.
-echo "drop table t16" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t16" | bendsql_connect_root

--- a/tests/suites/0_stateless/16_flashback/16_0002_flashback_metadata.sh
+++ b/tests/suites/0_stateless/16_flashback/16_0002_flashback_metadata.sh
@@ -6,12 +6,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 DB="db_16_0002"
 
 snapshot_id() {
-    echo "select snapshot_id from fuse_snapshot('$1', '$2') where row_count=$3 limit 1" | $BENDSQL_CLIENT_CONNECT
+    echo "select snapshot_id from fuse_snapshot('$1', '$2') where row_count=$3 limit 1" | bendsql_connect_root
 }
 
 insert_stmt() {
     echo ">>>> $1"
-    echo "$1" | $BENDSQL_CLIENT_OUTPUT_NULL
+    echo "$1" | bendsql_connect_root_null
 }
 
 comment "prepare flashback metadata regression environment"
@@ -26,7 +26,7 @@ stmt "ALTER TABLE ${DB}.t_bloom ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_bloom SET OPTIONS(bloom_index_columns = 'a, c')"
 insert_stmt "INSERT INTO ${DB}.t_bloom VALUES (2, 2, 2)"
 comment "flashback bloom table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_bloom FLASHBACK TO (SNAPSHOT => '$BLOOM_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_bloom FLASHBACK TO (SNAPSHOT => '$BLOOM_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option NOT LIKE '%BLOOM_INDEX_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_bloom'"
 insert_stmt "INSERT INTO ${DB}.t_bloom VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_bloom"
@@ -39,7 +39,7 @@ stmt "ALTER TABLE ${DB}.t_bloom_keep ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_bloom_keep SET OPTIONS(bloom_index_columns = 'a')"
 insert_stmt "INSERT INTO ${DB}.t_bloom_keep VALUES (2, 2, 2)"
 comment "flashback compatible bloom table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_bloom_keep FLASHBACK TO (SNAPSHOT => '$BLOOM_KEEP_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_bloom_keep FLASHBACK TO (SNAPSHOT => '$BLOOM_KEEP_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option LIKE '%BLOOM_INDEX_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_bloom_keep'"
 insert_stmt "INSERT INTO ${DB}.t_bloom_keep VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_bloom_keep"
@@ -52,7 +52,7 @@ stmt "ALTER TABLE ${DB}.t_hll_keep ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_hll_keep SET OPTIONS(approx_distinct_columns = 'a')"
 insert_stmt "INSERT INTO ${DB}.t_hll_keep VALUES (2, 2, 2)"
 comment "flashback compatible approx distinct table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_hll_keep FLASHBACK TO (SNAPSHOT => '$HLL_KEEP_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_hll_keep FLASHBACK TO (SNAPSHOT => '$HLL_KEEP_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option LIKE '%APPROX_DISTINCT_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_hll_keep'"
 insert_stmt "INSERT INTO ${DB}.t_hll_keep VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_hll_keep"
@@ -65,7 +65,7 @@ stmt "ALTER TABLE ${DB}.t_bloom_none ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_bloom_none SET OPTIONS(bloom_index_columns = '')"
 insert_stmt "INSERT INTO ${DB}.t_bloom_none VALUES (2, 2, 2)"
 comment "flashback bloom none table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_bloom_none FLASHBACK TO (SNAPSHOT => '$BLOOM_NONE_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_bloom_none FLASHBACK TO (SNAPSHOT => '$BLOOM_NONE_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option LIKE '%BLOOM_INDEX_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_bloom_none'"
 insert_stmt "INSERT INTO ${DB}.t_bloom_none VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_bloom_none"
@@ -78,7 +78,7 @@ stmt "ALTER TABLE ${DB}.t_hll_none ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_hll_none SET OPTIONS(approx_distinct_columns = '')"
 insert_stmt "INSERT INTO ${DB}.t_hll_none VALUES (2, 2, 2)"
 comment "flashback approx distinct none table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_hll_none FLASHBACK TO (SNAPSHOT => '$HLL_NONE_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_hll_none FLASHBACK TO (SNAPSHOT => '$HLL_NONE_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option LIKE '%APPROX_DISTINCT_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_hll_none'"
 insert_stmt "INSERT INTO ${DB}.t_hll_none VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_hll_none"
@@ -91,7 +91,7 @@ stmt "ALTER TABLE ${DB}.t_hll ADD COLUMN c INT"
 stmt "ALTER TABLE ${DB}.t_hll SET OPTIONS(approx_distinct_columns = 'a, c')"
 insert_stmt "INSERT INTO ${DB}.t_hll VALUES (2, 2, 2)"
 comment "flashback approx distinct table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_hll FLASHBACK TO (SNAPSHOT => '$HLL_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_hll FLASHBACK TO (SNAPSHOT => '$HLL_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option NOT LIKE '%APPROX_DISTINCT_COLUMNS=%' FROM system.tables WHERE database = '${DB}' AND name = 't_hll'"
 insert_stmt "INSERT INTO ${DB}.t_hll VALUES (3, 3)"
 query "SELECT count(*)=2 FROM ${DB}.t_hll"
@@ -104,7 +104,7 @@ stmt "ALTER TABLE ${DB}.t_ck ADD COLUMN c INT"
 insert_stmt "INSERT INTO ${DB}.t_ck VALUES (2, 2, 2)"
 stmt "ALTER TABLE ${DB}.t_ck CLUSTER BY (c, a)"
 comment "flashback cluster table to saved snapshot"
-echo "ALTER TABLE ${DB}.t_ck FLASHBACK TO (SNAPSHOT => '$CK_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+echo "ALTER TABLE ${DB}.t_ck FLASHBACK TO (SNAPSHOT => '$CK_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null || exit 1
 query "SELECT table_option NOT LIKE '%CLUSTER_TYPE=%' FROM system.tables WHERE database = '${DB}' AND name = 't_ck'"
 
 comment "flashback should reject constraints tied to dropped columns"
@@ -117,7 +117,7 @@ insert_stmt "INSERT INTO ${DB}.t_constraint VALUES (2, 2, 2)"
 stmt_fail "INSERT INTO ${DB}.t_constraint VALUES (3, 3, -1)"
 comment "flashback constrained table to saved snapshot should fail"
 echo ">>>> ALTER TABLE ${DB}.t_constraint FLASHBACK TO (SNAPSHOT => '<saved_snapshot>')"
-echo "ALTER TABLE ${DB}.t_constraint FLASHBACK TO (SNAPSHOT => '$CONSTRAINT_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+echo "ALTER TABLE ${DB}.t_constraint FLASHBACK TO (SNAPSHOT => '$CONSTRAINT_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     exit 1
 fi

--- a/tests/suites/0_stateless/17_altertable/17_0001_time_travel_alter_add_drop_column_select_at.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0001_time_travel_alter_add_drop_column_select_at.sh
@@ -5,70 +5,70 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 ## Create table t12_0005
-echo "drop table if exists t12_0005" | $BENDSQL_CLIENT_CONNECT
-echo "create table t12_0005(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t12_0005" | bendsql_connect_root
+echo "create table t12_0005(c int not null)" | bendsql_connect_root
 echo "two insertions"
 # the first snapshot contains 2 rows, 1 block
-echo "insert into t12_0005 values(1),(2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t12_0005 values(1),(2)" | bendsql_connect_root
 
 # the second snapshot contains 3 rows, 2 blocks
-echo "insert into t12_0005 values(3)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t12_0005 values(3)" | bendsql_connect_root
 echo "latest snapshot should contain 3 rows"
-echo "select count(*)  from t12_0005" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)  from t12_0005" | bendsql_connect_root
 
 # alter table add a column
 echo "alter table add a column"
 # alter table add a column will create a new snapshot (the latest snapshot)
-echo "alter table t12_0005 add column a float default 1.01" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t12_0005 add column a float default 1.01" | bendsql_connect_root
 
 ## Get the 3rd latest snapshot id of the latest snapshot
-SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') limit 1 offset 2" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t12_0005') limit 1 offset 2" | bendsql_connect_root)
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(*) from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "select the data set of first insertion, which should contain 2 rows"
-echo "select * from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "select * from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(t.c) from t12_0005 at (snapshot => '$SNAPSHOT_ID') as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0005 at (snapshot => '$SNAPSHOT_ID') as t" | bendsql_connect_root
 
 
 # Get a time point at/after the first insertion.
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0005') where row_count=2" | $BENDSQL_CLIENT_CONNECT)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0005') where row_count=2" | bendsql_connect_root)
 
 echo "counting the data set of first insertion by timestamp, which should contains 2 rows"
-echo "select count(t.c) from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | bendsql_connect_root
 
 echo "select the data set of first insertion by timestamp, which should contains 2 rows"
-echo "select * from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select * from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | bendsql_connect_root
 
 # alter table drop a column
 echo "alter table drop a column"
-echo "alter table t12_0005 drop column c" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t12_0005 drop column c" | bendsql_connect_root
 
 ## Get the previous snapshot id of the latest snapshot
-S1=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0005') where row_count=3 limit 1 offset 1" | $BENDSQL_CLIENT_CONNECT)
-SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0005') where snapshot_id='${S1}'" | $BENDSQL_CLIENT_CONNECT)
+S1=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0005') where row_count=3 limit 1 offset 1" | bendsql_connect_root)
+SNAPSHOT_ID=$(echo "select previous_snapshot_id from fuse_snapshot('default','t12_0005') where snapshot_id='${S1}'" | bendsql_connect_root)
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(*) from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "select the data set of first insertion, which should contain 2 rows"
-echo "select * from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "select * from t12_0005 at (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 
 echo "counting the data set of first insertion, which should contain 2 rows"
-echo "select count(t.c) from t12_0005 at (snapshot => '$SNAPSHOT_ID') as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0005 at (snapshot => '$SNAPSHOT_ID') as t" | bendsql_connect_root
 
 
 # Get a time point at/after the first insertion.
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0005') where row_count=2 limit 1" | $BENDSQL_CLIENT_CONNECT)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't12_0005') where row_count=2 limit 1" | bendsql_connect_root)
 
 echo "counting the data set of first insertion by timestamp, which should contains 2 rows"
-echo "select count(t.c) from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select count(t.c) from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | bendsql_connect_root
 
 echo "select the data set of first insertion by timestamp, which should contains 2 rows"
-echo "select * from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | $BENDSQL_CLIENT_CONNECT
+echo "select * from t12_0005 at (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP) as t" | bendsql_connect_root
 
 ## Drop table.
-#echo "drop table t12_0005" | $BENDSQL_CLIENT_CONNECT
+#echo "drop table t12_0005" | bendsql_connect_root

--- a/tests/suites/0_stateless/17_altertable/17_0002_alter_table_purge_before.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0002_alter_table_purge_before.sh
@@ -8,88 +8,88 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # PURGE BEFORE SNAPSHOT
 
 ## Setup
-echo "create table t17_0002(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t17_0002(c int not null)" | bendsql_connect_root
 ## - 1st snapshot contains 2 rows, 1 block, 1 segment
-echo "insert into t17_0002 values(1),(2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(1),(2)" | bendsql_connect_root
 ## - 2nd snapshot contains 3 rows, 2 blocks, 2 segments
-echo "insert into t17_0002 values(3)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(3)" | bendsql_connect_root
 ## - 3rd snapshot contains 4 rows, 3 blocks, 3 segments
-echo "insert into t17_0002 values(4)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(4)" | bendsql_connect_root
 
 echo "checking that there should are 3 snapshots before purge"
-echo "select count(*)=3  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 
 ## location the id of 2nd snapshot
-SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t17_0002') where row_count=3 limit 1" | $BENDSQL_CLIENT_CONNECT)
-#TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't17_0002') where row_count=3" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t17_0002') where row_count=3 limit 1" | bendsql_connect_root)
+#TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't17_0002') where row_count=3" | bendsql_connect_root)
 
 # alter table add a column
 echo "alter table add a column"
 # alter table will generate a new snapshot
-echo "alter table t17_0002 add column a float default 1.01" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0002 add column a float default 1.01" | bendsql_connect_root
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 3 snapshots left"
-echo "select count(*)=3  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 4 rows left"
-echo "select count(*)=4  from t17_0002" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from t17_0002" | bendsql_connect_root
 
 # alter table drop a column
 echo "alter table drop a column"
 # alter table will generate a new snapshot
-echo "alter table t17_0002 drop column c" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0002 drop column c" | bendsql_connect_root
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 4 snapshots left"
-echo "select count(*)=4  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 4 rows left"
-echo "select count(*)=4  from t17_0002" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from t17_0002" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t17_0002 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t17_0002 all" | bendsql_connect_root
 
 # PURGE BEFORE TIMESTAMP
 
 ## Setup
-echo "create table t17_0002(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t17_0002(c int not null)" | bendsql_connect_root
 ## - 1st snapshot contains 2 rows, 1 block, 1 segment
-echo "insert into t17_0002 values(1),(2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(1),(2)" | bendsql_connect_root
 ## - 2nd snapshot contains 3 rows, 2 blocks, 2 segments
-echo "insert into t17_0002 values(3)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(3)" | bendsql_connect_root
 ## - 3rd snapshot contains 4 rows, 3 blocks, 3 segments
-echo "insert into t17_0002 values(4)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(4)" | bendsql_connect_root
 ## - 4rd snapshot contains 5 rows, 4 blocks, 4 segments
-echo "insert into t17_0002 values(5)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0002 values(5)" | bendsql_connect_root
 
 echo "checking that there should are 4 snapshots before purge"
-echo "select count(*)=4  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 
 ## location the timestamp of latest snapshot
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't17_0002') where row_count=5 limit 1" | $BENDSQL_CLIENT_CONNECT)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't17_0002') where row_count=5 limit 1" | bendsql_connect_root)
 
 # alter table add a column
 echo "alter table add a column"
-echo "alter table t17_0002 add column a float default 1.01" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0002 add column a float default 1.01" | bendsql_connect_root
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be at least 2 snapshots left"
-echo "select count(*)>=2  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)>=2  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be 5 rows left"
-echo "select count(*)=5  from t17_0002" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=5  from t17_0002" | bendsql_connect_root
 
 # alter table drop a column
 echo "alter table drop a column"
-echo "alter table t17_0002 drop column a" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0002 drop column a" | bendsql_connect_root
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t17_0002 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be at least 2 snapshots left"
-echo "select count(*)>=2  from fuse_snapshot('default', 't17_0002')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)>=2  from fuse_snapshot('default', 't17_0002')" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be 5 rows left"
-echo "select count(*)=5  from t17_0002" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=5  from t17_0002" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t17_0002 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t17_0002 all" | bendsql_connect_root

--- a/tests/suites/0_stateless/17_altertable/17_0003_alter_table_update.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0003_alter_table_update.sh
@@ -3,51 +3,51 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create table t17_0003(a int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t17_0003 values(1)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t17_0003(a int not null)" | bendsql_connect_root
+echo "insert into t17_0003 values(1)" | bendsql_connect_root
 
 # alter table add a column
 echo "alter table add a column"
-echo "alter table t17_0003 add column c int default 100" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0003 add column c int default 100" | bendsql_connect_root
 
-echo "insert into t17_0003 values(3,2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0003 values(3,2)" | bendsql_connect_root
 
 # update should return error, if fix this error, please change the case
 echo "update table column"
-echo "update t17_0003 set a=3 where a=1" | $BENDSQL_CLIENT_CONNECT
+echo "update t17_0003 set a=3 where a=1" | bendsql_connect_root
 
 # alter table drop a column
 echo "alter table drop a column"
-echo "alter table t17_0003 drop column a" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0003 drop column a" | bendsql_connect_root
 
 # update should return error, if fix this error, please change the case
 echo "update table column"
-echo "update t17_0003 set c=2 where c=1" | $BENDSQL_CLIENT_CONNECT
+echo "update t17_0003 set c=2 where c=1" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t17_0003 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t17_0003 all" | bendsql_connect_root
 
 ## create two column table
-echo "create table t17_0003(a int not null, b int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t17_0003 values(1, 2)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t17_0003(a int not null, b int not null)" | bendsql_connect_root
+echo "insert into t17_0003 values(1, 2)" | bendsql_connect_root
 
 # alter table add a column
 echo "alter table add a column"
-echo "alter table t17_0003 add column c int default 100" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0003 add column c int default 100" | bendsql_connect_root
 
-echo "insert into t17_0003 values(3,2,2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t17_0003 values(3,2,2)" | bendsql_connect_root
 
 # two column table update success
 echo "update table column"
-echo "update t17_0003 set a=3 where a=1" | $BENDSQL_CLIENT_CONNECT
+echo "update t17_0003 set a=3 where a=1" | bendsql_connect_root
 
 # alter table drop a column
 echo "alter table drop a column"
-echo "alter table t17_0003 drop column b" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t17_0003 drop column b" | bendsql_connect_root
 
 # two column table update success
 echo "update table column"
-echo "update t17_0003 set a=3 where a=1" | $BENDSQL_CLIENT_CONNECT
+echo "update t17_0003 set a=3 where a=1" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t17_0003 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t17_0003 all" | bendsql_connect_root

--- a/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0004_alter_table_set_options.sh
@@ -3,33 +3,33 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace table t(a int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t values(1)" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table t(a int not null)" | bendsql_connect_root
+echo "insert into t values(1)" | bendsql_connect_root
 
 # get snapshot location
-SNAPSHOT_LOCATION=$(echo "select _snapshot_name from t;" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select _snapshot_name from t;" | bendsql_connect_root)
 
-echo "create or replace table t2(a int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(snapshot_location = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(snapshot_loc = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(extrenal_location = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(block_per_segment = 500)" | $BENDSQL_CLIENT_CONNECT
-echo "select * from t2;" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table t2(a int not null)" | bendsql_connect_root
+echo "alter table t2 set options(snapshot_location = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | bendsql_connect_root
+echo "alter table t2 set options(snapshot_loc = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | bendsql_connect_root
+echo "alter table t2 set options(extrenal_location = '$SNAPSHOT_LOCATION',block_per_segment = 500)" | bendsql_connect_root
+echo "alter table t2 set options(block_per_segment = 500)" | bendsql_connect_root
+echo "select * from t2;" | bendsql_connect_root
 # valid key check
-echo "alter table t2 set options(abc = '1')" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(block_per_segment = 2000)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(storage_format = 'memory')" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(bloom_index_columns = 'b')" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(bloom_index_type = 'binary_fuse32')" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t2 set options(bloom_index_type = 'nope')" | $BENDSQL_CLIENT_CONNECT
+echo "alter table t2 set options(abc = '1')" | bendsql_connect_root
+echo "alter table t2 set options(block_per_segment = 2000)" | bendsql_connect_root
+echo "alter table t2 set options(storage_format = 'memory')" | bendsql_connect_root
+echo "alter table t2 set options(bloom_index_columns = 'b')" | bendsql_connect_root
+echo "alter table t2 set options(bloom_index_type = 'binary_fuse32')" | bendsql_connect_root
+echo "alter table t2 set options(bloom_index_type = 'nope')" | bendsql_connect_root
 
 # valid bloom index column data type.
-echo "create or replace table t3(a decimal(4,2) not null)" | $BENDSQL_CLIENT_CONNECT
-echo "alter table t3 set options(bloom_index_columns = 'a')" | $BENDSQL_CLIENT_CONNECT
-echo "create or replace table t4(a int not null) bloom_index_type = 'binary_fuse32'" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table t3(a decimal(4,2) not null)" | bendsql_connect_root
+echo "alter table t3 set options(bloom_index_columns = 'a')" | bendsql_connect_root
+echo "create or replace table t4(a int not null) bloom_index_type = 'binary_fuse32'" | bendsql_connect_root
 
 #drop table
-echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t2" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t3" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t4" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t" | bendsql_connect_root
+echo "drop table if exists t2" | bendsql_connect_root
+echo "drop table if exists t3" | bendsql_connect_root
+echo "drop table if exists t4" | bendsql_connect_root

--- a/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
+++ b/tests/suites/0_stateless/17_altertable/17_0005_alter_table_modify_column_type.sh
@@ -3,62 +3,62 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "DROP DATABASE IF EXISTS test_modify_column_type" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE DATABASE test_modify_column_type" | $BENDSQL_CLIENT_CONNECT
+echo "DROP DATABASE IF EXISTS test_modify_column_type" | bendsql_connect_root
+echo "CREATE DATABASE test_modify_column_type" | bendsql_connect_root
 
-echo "CREATE table test_modify_column_type.a(a String not null, b int not null, c int not null)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.a values('1', 2, 3)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b,c from test_modify_column_type.a"  | $BENDSQL_CLIENT_CONNECT
-echo "DESC test_modify_column_type.a"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.a(a String not null, b int not null, c int not null)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.a values('1', 2, 3)"  | bendsql_connect_root
+echo "SELECT a,b,c from test_modify_column_type.a"  | bendsql_connect_root
+echo "DESC test_modify_column_type.a"  | bendsql_connect_root
 
-echo "alter table test_modify_column_type.a modify column a float not null, column b String not null"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.a"  | $BENDSQL_CLIENT_CONNECT
-echo "DESC test_modify_column_type.a"  | $BENDSQL_CLIENT_CONNECT
+echo "alter table test_modify_column_type.a modify column a float not null, column b String not null"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.a"  | bendsql_connect_root
+echo "DESC test_modify_column_type.a"  | bendsql_connect_root
 
-echo "CREATE table test_modify_column_type.b(a String not null)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.b values('a')"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.b modify column a float not null"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.b modify column b float not null"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.b(a String not null)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.b values('a')"  | bendsql_connect_root
+echo "alter table test_modify_column_type.b modify column a float not null"  | bendsql_connect_root
+echo "alter table test_modify_column_type.b modify column b float not null"  | bendsql_connect_root
 
-echo "CREATE table test_modify_column_type.c(a int not null, b int not null)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.c (b) values(1)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.c (a,b) values(0,1)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.c"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.c modify column a float not null default 'a'"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.c modify column a float not null default 1.2"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.c"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.c (b) values(2)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.c order by a"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.c(a int not null, b int not null)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.c (b) values(1)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.c (a,b) values(0,1)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.c"  | bendsql_connect_root
+echo "alter table test_modify_column_type.c modify column a float not null default 'a'"  | bendsql_connect_root
+echo "alter table test_modify_column_type.c modify column a float not null default 1.2"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.c"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.c (b) values(2)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.c order by a"  | bendsql_connect_root
 
-echo "CREATE table test_modify_column_type.d(a int not null, b int not null default 10)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.d (a) values(1)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.d"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.d modify column b int not null default 2"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.d"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.d add column c float not null default 1.01" | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b,c from test_modify_column_type.d"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.d modify column c float not null default 2.2"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.d (a) values(10)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b,c from test_modify_column_type.d order by a"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.d(a int not null, b int not null default 10)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.d (a) values(1)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.d"  | bendsql_connect_root
+echo "alter table test_modify_column_type.d modify column b int not null default 2"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.d"  | bendsql_connect_root
+echo "alter table test_modify_column_type.d add column c float not null default 1.01" | bendsql_connect_root
+echo "SELECT a,b,c from test_modify_column_type.d"  | bendsql_connect_root
+echo "alter table test_modify_column_type.d modify column c float not null default 2.2"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.d (a) values(10)"  | bendsql_connect_root
+echo "SELECT a,b,c from test_modify_column_type.d order by a"  | bendsql_connect_root
 
 echo "begin test default column"
-echo "CREATE table test_modify_column_type.e(a int not null, b int not null)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.e values(1,1)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.e order by b"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.e modify column a VARCHAR(10) not null DEFAULT 'not'"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.e (b) values(2)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.e order by b"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.e(a int not null, b int not null)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.e values(1,1)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.e order by b"  | bendsql_connect_root
+echo "alter table test_modify_column_type.e modify column a VARCHAR(10) not null DEFAULT 'not'"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.e (b) values(2)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.e order by b"  | bendsql_connect_root
 
 echo "begin test not NULL column"
-echo "CREATE table test_modify_column_type.f(a int not null, b int not null)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.f values(1,1)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.f order by b"  | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.f modify column a VARCHAR(10) NOT NULL" | $BENDSQL_CLIENT_CONNECT
-echo "alter table test_modify_column_type.f modify column a COMMENT 'new column'"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.f (b) values(2)"  | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_modify_column_type.f (a,b) values('',2)"  | $BENDSQL_CLIENT_CONNECT
-echo "SELECT a,b from test_modify_column_type.f order by b"  | $BENDSQL_CLIENT_CONNECT
-echo "DESC test_modify_column_type.f"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE table test_modify_column_type.f(a int not null, b int not null)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.f values(1,1)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.f order by b"  | bendsql_connect_root
+echo "alter table test_modify_column_type.f modify column a VARCHAR(10) NOT NULL" | bendsql_connect_root
+echo "alter table test_modify_column_type.f modify column a COMMENT 'new column'"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.f (b) values(2)"  | bendsql_connect_root
+echo "INSERT INTO test_modify_column_type.f (a,b) values('',2)"  | bendsql_connect_root
+echo "SELECT a,b from test_modify_column_type.f order by b"  | bendsql_connect_root
+echo "DESC test_modify_column_type.f"  | bendsql_connect_root
 
 echo "begin test modify column NULL to not NULL"
 stmt "CREATE TABLE test_modify_column_type.g(a STRING NULL, b INT NULL, c string not null)"
@@ -70,4 +70,4 @@ stmt "ALTER TABLE test_modify_column_type.g MODIFY COLUMN c STRING NOT NULL"
 stmt "SELECT a,b,c from test_modify_column_type.g"
 stmt "DESC test_modify_column_type.g"
 
-echo "DROP DATABASE IF EXISTS test_modify_column_type" | $BENDSQL_CLIENT_CONNECT
+echo "DROP DATABASE IF EXISTS test_modify_column_type" | bendsql_connect_root

--- a/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0001_udf_priv.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "=== test UDF priv"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect test-user password -A"
+export TEST_USER_CONNECT="bendsql_connect_user test-user password -A"
 
 run_root_sql "
 drop user if exists 'test-user';
@@ -26,8 +26,8 @@ SYSTEM FLUSH PRIVILEGES;
 
 # error test need privielge f1
 echo "=== Only Has Privilege on f2 ==="
-echo "grant usage on udf f2 to 'test-user';" |  $BENDSQL_CLIENT_CONNECT
-echo "SYSTEM FLUSH PRIVILEGES" | $BENDSQL_CLIENT_CONNECT
+echo "grant usage on udf f2 to 'test-user';" |  bendsql_connect_root
+echo "SYSTEM FLUSH PRIVILEGES" | bendsql_connect_root
 echo "select f2(f1(1));" | $TEST_USER_CONNECT
 # bug need error
 echo "select add(1, f2(f1(1)));" | $TEST_USER_CONNECT
@@ -60,9 +60,9 @@ echo "delete from t;" | $TEST_USER_CONNECT
 
 # error test need privielge f1
 echo "=== Only Has Privilege on f1 ==="
-echo "grant usage on udf f1 to 'test-user';" |  $BENDSQL_CLIENT_CONNECT
-echo "revoke usage on udf f2 from 'test-user';" |  $BENDSQL_CLIENT_CONNECT
-echo "SYSTEM FLUSH PRIVILEGES" | $BENDSQL_CLIENT_CONNECT
+echo "grant usage on udf f1 to 'test-user';" |  bendsql_connect_root
+echo "revoke usage on udf f2 from 'test-user';" |  bendsql_connect_root
+echo "SYSTEM FLUSH PRIVILEGES" | bendsql_connect_root
 echo "select f2(f1(1))" | $TEST_USER_CONNECT
 echo "select add(1, f1(1))" | $TEST_USER_CONNECT
 echo "select max(f2(f1(1)));" | $TEST_USER_CONNECT
@@ -91,8 +91,8 @@ echo "select case when i > 100 then f2(f1(200)) else 100 end as c1 from t;" | $T
 echo "delete from t;" | $TEST_USER_CONNECT
 
 echo "=== Has Privilege on f1, f2 ==="
-echo "grant usage on udf f1 to 'test-user';" |  $BENDSQL_CLIENT_CONNECT
-echo "grant all on udf f2 to 'test-user';" |  $BENDSQL_CLIENT_CONNECT
+echo "grant usage on udf f1 to 'test-user';" |  bendsql_connect_root
+echo "grant all on udf f2 to 'test-user';" |  bendsql_connect_root
 echo "select f2(f1(1))" | $TEST_USER_CONNECT
 echo "select add(1, f1(1))" | $TEST_USER_CONNECT
 echo "select max(f2(f1(1)));" | $TEST_USER_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0002_ownership_cover.sh
@@ -5,9 +5,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 export TEST_USER_NAME="owner"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect owner password -A"
+export TEST_USER_CONNECT="bendsql_connect_user owner password -A"
 
-export TEST_TRANSFER_USER_CONNECT="bendsql_query_http_user_connect owner1 password -A"
+export TEST_TRANSFER_USER_CONNECT="bendsql_connect_user owner1 password -A"
 
 run_root_sql "
 drop database if exists d_0002;
@@ -48,10 +48,10 @@ echo "select a(1);" | $TEST_USER_CONNECT
 
 # ownership transfer
 echo "=== test ownership r_0002 transfer to r_0002_1 ==="
-echo "GRANT OWNERSHIP on d_0002.* to role 'r_0002_1'" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT OWNERSHIP on d_0002.t to role 'r_0002_1'" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT OWNERSHIP on stage hello to role 'r_0002_1'" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT OWNERSHIP on udf a to role 'r_0002_1'" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT OWNERSHIP on d_0002.* to role 'r_0002_1'" | bendsql_connect_root
+echo "GRANT OWNERSHIP on d_0002.t to role 'r_0002_1'" | bendsql_connect_root
+echo "GRANT OWNERSHIP on stage hello to role 'r_0002_1'" | bendsql_connect_root
+echo "GRANT OWNERSHIP on udf a to role 'r_0002_1'" | bendsql_connect_root
 echo "set default role 'r_0002_1'" | $TEST_TRANSFER_USER_CONNECT
 echo "=== test role r_0002_1 ==="
 echo "create table d_0002.t1(id int)" | $TEST_TRANSFER_USER_CONNECT
@@ -93,8 +93,8 @@ grant role role1 to a;
 create user b identified by '123';
 "
 
-export USER_A_CONNECT="bendsql_query_http_user_connect a 123 -A"
-export USER_B_CONNECT="bendsql_query_http_user_connect b 123 -A"
+export USER_A_CONNECT="bendsql_connect_user a 123 -A"
+export USER_B_CONNECT="bendsql_connect_user b 123 -A"
 
 echo "set default role role1;" | $USER_A_CONNECT
 echo "show roles;" | $USER_A_CONNECT
@@ -103,18 +103,18 @@ echo "create table db_a.t1(id int);" | $USER_A_CONNECT
 echo "show tables from db_a" | $USER_A_CONNECT
 echo "show databases" | $USER_A_CONNECT
 
-echo "show grants for role role1;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role role1;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
-echo "grant role role1 to b;" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for b;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
-echo "show grants for a;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "grant role role1 to b;" | bendsql_connect_root
+echo "show grants for b;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for a;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 
 echo "show tables from db_a;" | $USER_A_CONNECT
 echo "show tables from db_a;" | $USER_B_CONNECT
 
-echo "revoke role role1 from a;" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for a ;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "revoke role role1 from a;" | bendsql_connect_root
+echo "show grants for a ;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "show tables from db_a;" | $USER_A_CONNECT
 echo "show tables from db_a;" | $USER_B_CONNECT
@@ -139,22 +139,22 @@ create user u1 identified by '123' with DEFAULT_ROLE='drop_role';
 grant role drop_role to u1;
 grant create database on *.* to role drop_role;
 "
-export USER_U1_CONNECT="bendsql_query_http_user_connect u1 123 -A"
+export USER_U1_CONNECT="bendsql_connect_user u1 123 -A"
 
 echo "create database a" | $USER_U1_CONNECT
 echo "create table a.t(id int)" | $USER_U1_CONNECT
 echo "select name, owner from system.databases where name='a'" | $USER_U1_CONNECT
 echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
-echo "drop role drop_role;" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where database='a'" | $BENDSQL_CLIENT_CONNECT
+echo "drop role drop_role;" | bendsql_connect_root
+echo "select name, owner from system.databases where name='a'" | bendsql_connect_root
+echo "select name, owner from system.tables where database='a'" | bendsql_connect_root
 echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
-echo "grant ownership on a.* to role drop_role1;" | $BENDSQL_CLIENT_CONNECT
-echo "grant ownership on a.t to role drop_role1;" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.databases where name='a'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where database='a'" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on a.* to role drop_role1;" | bendsql_connect_root
+echo "grant ownership on a.t to role drop_role1;" | bendsql_connect_root
+echo "select name, owner from system.databases where name='a'" | bendsql_connect_root
+echo "select name, owner from system.tables where database='a'" | bendsql_connect_root
 echo "select name, owner from system.tables where database='a'" | $USER_U1_CONNECT
-echo "show grants for role drop_role1" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role drop_role1" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 run_root_sql "
 drop role drop_role1;
 drop user u1;
@@ -170,7 +170,7 @@ create user a identified by '123' with DEFAULT_ROLE='role1';
 grant role role1 to a;
 "
 
-echo "drop database if exists c" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists c" | bendsql_connect_root
 echo "create database c" | $USER_A_CONNECT
 echo "drop database c" | $USER_A_CONNECT
 echo "show tables from c" | $USER_A_CONNECT
@@ -205,13 +205,13 @@ echo "set role role1;insert into db1.t1 values(1);" | $USER_U1_CONNECT
 echo "set role role1;insert into db1.t2 values(2);" | $USER_U1_CONNECT
 echo "set role role1;select * from db1.t1;" | $USER_U1_CONNECT
 echo "set role role1;select * from db1.t2;" | $USER_U1_CONNECT
-export USER_U2_CONNECT="bendsql_query_http_user_connect u2 123 -A"
+export USER_U2_CONNECT="bendsql_connect_user u2 123 -A"
 echo "set role role2;select * from db1.t1;" | $USER_U2_CONNECT
 echo "set role role2;select * from db1.t2;" | $USER_U2_CONNECT
 
-echo "show grants for role role2;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role role2;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 echo "set role role1;drop table db1.t2;" | $USER_U1_CONNECT
-echo "show grants for role role2;" | $BENDSQL_CLIENT_CONNECT
+echo "show grants for role role2;" | bendsql_connect_root
 
 run_root_sql "
 drop database if exists db1;

--- a/tests/suites/0_stateless/18_rbac/18_0003_db_visibility.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0003_db_visibility.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 export TEST_USER_NAME="owner"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect owner password -A"
+export TEST_USER_CONNECT="bendsql_connect_user owner password -A"
 
 
 run_root_sql "
@@ -31,13 +31,13 @@ create user u3 identified by '123' with DEFAULT_ROLE='role2';
 "
 
 echo "=== test u1 with role1 ==="
-echo "grant role role1 to u1;" | $BENDSQL_CLIENT_CONNECT
-export TEST_U1_CONNECT="bendsql_query_http_user_connect u1 123 -A"
+echo "grant role role1 to u1;" | bendsql_connect_root
+export TEST_U1_CONNECT="bendsql_connect_user u1 123 -A"
 echo "show databases" | $TEST_U1_CONNECT
 echo "create database db1;" | $TEST_U1_CONNECT
-echo "grant delete on db1.* to u1" | $BENDSQL_CLIENT_CONNECT
+echo "grant delete on db1.* to u1" | bendsql_connect_root
 echo "drop database db1;" | $TEST_U1_CONNECT
-echo "select count(name)>0, count(dropped_on is not null)>0 from system.databases_with_history where name='db1'" | $BENDSQL_CLIENT_CONNECT
+echo "select count(name)>0, count(dropped_on is not null)>0 from system.databases_with_history where name='db1'" | bendsql_connect_root
 echo "select name, dropped_on is not null from system.databases_with_history where name='db1'" | $TEST_U1_CONNECT
 echo "select name from system.databases_with_history where name!='db1'" | $TEST_U1_CONNECT
 echo "create database db1;" | $TEST_U1_CONNECT
@@ -48,8 +48,8 @@ echo "select * from db_root.t1;" | $TEST_U1_CONNECT
 echo "show databases" | $TEST_U1_CONNECT
 
 echo "=== test u2 with role1 ==="
-echo "grant role role1 to u2;" | $BENDSQL_CLIENT_CONNECT
-export TEST_U2_CONNECT="bendsql_query_http_user_connect u2 123 -A"
+echo "grant role role1 to u2;" | bendsql_connect_root
+export TEST_U2_CONNECT="bendsql_connect_user u2 123 -A"
 echo "show databases" | $TEST_U2_CONNECT
 echo "create database db2" | $TEST_U2_CONNECT
 echo "create table db2.t2(id int);" | $TEST_U2_CONNECT
@@ -60,8 +60,8 @@ echo "select * from db1.t1;" | $TEST_U2_CONNECT
 echo "select * from db2.t2;" | $TEST_U1_CONNECT
 
 echo "=== test u3 with role2 ==="
-echo "grant role role2 to u3;" | $BENDSQL_CLIENT_CONNECT
-export TEST_U3_CONNECT="bendsql_query_http_user_connect u3 123 -A"
+echo "grant role role2 to u3;" | bendsql_connect_root
+export TEST_U3_CONNECT="bendsql_connect_user u3 123 -A"
 
 echo "show databases" | $TEST_U3_CONNECT
 echo "create database db_u3" | $TEST_U3_CONNECT
@@ -74,7 +74,7 @@ echo "select * from db_root.t1" | $TEST_U3_CONNECT
 echo "select * from db_u3.t3" | $TEST_U3_CONNECT
 
 echo "=== test u3 with role2 and role1 secondary roles all ==="
-echo "grant role role1 to u3" | $BENDSQL_CLIENT_CONNECT
+echo "grant role role1 to u3" | bendsql_connect_root
 echo "SET SECONDARY ROLES ALL; show databases" | $TEST_U3_CONNECT
 echo "SET SECONDARY ROLES ALL; select * from db1.t1" | $TEST_U3_CONNECT
 echo "SET SECONDARY ROLES ALL; select * from db2.t2" | $TEST_U3_CONNECT
@@ -89,11 +89,11 @@ echo "set role role1; SET SECONDARY ROLES NONE; select * from db_root.t1" | $TES
 echo "set role role1; SET SECONDARY ROLES NONE; select * from db_u3.t3" | $TEST_U3_CONNECT
 
 echo "=== test root user ==="
-echo "show databases" | $BENDSQL_CLIENT_CONNECT
-echo "select * from db1.t1" | $BENDSQL_CLIENT_CONNECT
-echo "select * from db2.t2" | $BENDSQL_CLIENT_CONNECT
-echo "select * from db_u3.t3" | $BENDSQL_CLIENT_CONNECT
-echo "select * from db_root.t1" | $BENDSQL_CLIENT_CONNECT
+echo "show databases" | bendsql_connect_root
+echo "select * from db1.t1" | bendsql_connect_root
+echo "select * from db2.t2" | bendsql_connect_root
+echo "select * from db_u3.t3" | bendsql_connect_root
+echo "select * from db_root.t1" | bendsql_connect_root
 
 echo "=== test system.tables ==="
 run_root_sql "
@@ -111,7 +111,7 @@ create table a.b(id int);
 create role b;
 grant ownership on a.b to role b;
 "
-export TEST_A_CONNECT="bendsql_query_http_user_connect a 123 -A"
+export TEST_A_CONNECT="bendsql_connect_user a 123 -A"
 echo "select name, owner from system.tables where database = 'a'and name = 'b'" | $TEST_A_CONNECT
 run_root_sql "
 drop user if exists a;

--- a/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0004_view_privilege.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 export TEST_USER_NAME="owner"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect owner password -A"
+export TEST_USER_CONNECT="bendsql_connect_user owner password -A"
 
 run_root_sql "
 drop user if exists 'owner';

--- a/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0005_show_grants_with_dropped.sh
@@ -28,59 +28,59 @@ grant update, delete on c_r2.t2 to role role3;
 "
 
 echo "=== review init role3 grants ==="
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== drop table c_r2.t2 ==="
-echo "drop table c_r2.t2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table c_r2.t2;" | bendsql_connect_root
 echo "=== drop c_r2.t2 once ==="
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== create same name table c_r2.t2 ==="
-echo "create table c_r2.t2(id int);" | $BENDSQL_CLIENT_CONNECT
-echo "grant select on c_r2.t2 to role role3;" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
-echo "drop table c_r2.t2;" | $BENDSQL_CLIENT_CONNECT
+echo "create table c_r2.t2(id int);" | bendsql_connect_root
+echo "grant select on c_r2.t2 to role role3;" | bendsql_connect_root
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
+echo "drop table c_r2.t2;" | bendsql_connect_root
 echo "=== drop c_r2.t2 twice ==="
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
-echo "create table c_r2.t2(id int);" | $BENDSQL_CLIENT_CONNECT
-echo "grant update, delete on c_r2.t2 to role role3;" | $BENDSQL_CLIENT_CONNECT
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
+echo "create table c_r2.t2(id int);" | bendsql_connect_root
+echo "grant update, delete on c_r2.t2 to role role3;" | bendsql_connect_root
 
 echo "=== test database drop ==="
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
-echo "drop database c_r;" | $BENDSQL_CLIENT_CONNECT
-echo "drop database c_r2;" | $BENDSQL_CLIENT_CONNECT
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
+echo "drop database c_r;" | bendsql_connect_root
+echo "drop database c_r2;" | bendsql_connect_root
 
 echo "=== drop database c_r , c_r2 ==="
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== undrop database c_r2 ==="
-echo "undrop database c_r2" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "undrop database c_r2" | bendsql_connect_root
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== undrop database c_r, contain table c_r.t's ownership ==="
-echo "undrop database c_r" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "undrop database c_r" | bendsql_connect_root
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== drop database c_r, c_r2, re-create c_r, c_r2 ==="
-echo "drop database c_r" | $BENDSQL_CLIENT_CONNECT
-echo "drop database c_r2" | $BENDSQL_CLIENT_CONNECT
-echo "create database c_r" | $BENDSQL_CLIENT_CONNECT
-echo "create database c_r2" | $BENDSQL_CLIENT_CONNECT
-echo "show grants for role role3;" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "drop database c_r" | bendsql_connect_root
+echo "drop database c_r2" | bendsql_connect_root
+echo "create database c_r" | bendsql_connect_root
+echo "create database c_r2" | bendsql_connect_root
+echo "show grants for role role3;" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 
 echo "=== show grants test ==="
-echo "drop user if exists u1" | $BENDSQL_CLIENT_CONNECT
-echo "drop role if exists role1" | $BENDSQL_CLIENT_CONNECT
-echo "drop role if exists role2" | $BENDSQL_CLIENT_CONNECT
-echo "create user u1 identified by '123' with DEFAULT_ROLE='role1'" | $BENDSQL_CLIENT_CONNECT
-echo "create role role1" | $BENDSQL_CLIENT_CONNECT
-echo "create role role2" | $BENDSQL_CLIENT_CONNECT
-echo "grant select on *.* to role role1;" | $BENDSQL_CLIENT_CONNECT
-echo "grant insert on *.* to role role1;" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role1 to u1" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role2 to u1" | $BENDSQL_CLIENT_CONNECT
+echo "drop user if exists u1" | bendsql_connect_root
+echo "drop role if exists role1" | bendsql_connect_root
+echo "drop role if exists role2" | bendsql_connect_root
+echo "create user u1 identified by '123' with DEFAULT_ROLE='role1'" | bendsql_connect_root
+echo "create role role1" | bendsql_connect_root
+echo "create role role2" | bendsql_connect_root
+echo "grant select on *.* to role role1;" | bendsql_connect_root
+echo "grant insert on *.* to role role1;" | bendsql_connect_root
+echo "grant role role1 to u1" | bendsql_connect_root
+echo "grant role role2 to u1" | bendsql_connect_root
 
-export USER_U1_CONNECT="bendsql_query_http_user_connect u1 123 -A"
+export USER_U1_CONNECT="bendsql_connect_user u1 123 -A"
 
 echo "show grants for role role1" | $USER_U1_CONNECT
 echo "show grants for role role2" | $USER_U1_CONNECT
@@ -93,7 +93,7 @@ echo "Need Err:"
 echo "show grants for user root" | $USER_U1_CONNECT
 echo "show grants for role account_admin" | $USER_U1_CONNECT
 
-echo "grant grant on *.* to role role1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant grant on *.* to role role1;" | bendsql_connect_root
 echo "show grants for role role3;" | $USER_U1_CONNECT | awk -F ' ' '{$3=""; print $0}'
 echo "show grants for user 'role3@test';" | $USER_U1_CONNECT
 

--- a/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0007_privilege_access.sh
@@ -4,13 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_root_sql() {
-  cat <<SQL | $BENDSQL_CLIENT_CONNECT
+  cat <<SQL | bendsql_connect_root
 $1
 SQL
 }
 
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect test-user password -A"
+export TEST_USER_CONNECT="bendsql_connect_user test-user password -A"
 export RM_UUID="sed -E ""s/[-a-z0-9]{32,36}/UUID/g"""
 
 run_test_user() {
@@ -26,8 +26,8 @@ drop database if exists dbnotexists;
 "
 
 # These need separate execution to show individual errors
-echo "GRANT SELECT ON db01.tbnotexists TO 'test-user'" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT SELECT ON dbnotexists.* TO 'test-user'" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT SELECT ON db01.tbnotexists TO 'test-user'" | bendsql_connect_root
+echo "GRANT SELECT ON dbnotexists.* TO 'test-user'" | bendsql_connect_root
 
 run_root_sql "
 drop user if exists 'test-user';
@@ -185,7 +185,7 @@ rm -rf password.out
 
 ## Show grants test
 export TEST_USER_PASSWORD="password"
-export USER_A_CONNECT="bendsql_query_http_user_connect a password -A"
+export USER_A_CONNECT="bendsql_connect_user a password -A"
 
 run_user_a() {
   cat <<SQL | $USER_A_CONNECT
@@ -208,16 +208,16 @@ drop table if exists default.test_t;
 create table default.test_t(id int not null);
 "
 
-echo "show grants for a" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for a" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 echo "show databases" | $USER_A_CONNECT
 
-echo "select 'test -- show tables from system'" | $BENDSQL_CLIENT_CONNECT
+echo "select 'test -- show tables from system'" | bendsql_connect_root
 echo "show tables from system" | $USER_A_CONNECT
-echo "select 'test -- show tables from grant_db'" | $BENDSQL_CLIENT_CONNECT
+echo "select 'test -- show tables from grant_db'" | bendsql_connect_root
 echo "show tables from grant_db" | $USER_A_CONNECT
 echo "use system" | $USER_A_CONNECT
 echo "use grant_db" | $USER_A_CONNECT
-echo "select 'test -- show columns from one from system'" | $BENDSQL_CLIENT_CONNECT
+echo "select 'test -- show columns from one from system'" | bendsql_connect_root
 run_user_a "
 show columns from one from system;
 show columns from t from grant_db;
@@ -236,11 +236,11 @@ select count(1) from information_schema.columns where table_schema in ('grant_db
 select count(1) from information_schema.columns where table_schema in ('nogrant');
 "
 
-echo "show columns from clusters from system" | $BENDSQL_CLIENT_CONNECT | echo $?
-echo "show columns from tasks from system" | $BENDSQL_CLIENT_CONNECT | echo $?
+echo "show columns from clusters from system" | bendsql_connect_root | echo $?
+echo "show columns from tasks from system" | bendsql_connect_root | echo $?
 
 #DML privilege check
-export USER_B_CONNECT="bendsql_query_http_user_connect b password -A"
+export USER_B_CONNECT="bendsql_connect_user b password -A"
 
 run_user_b() {
   cat <<SQL | $USER_B_CONNECT
@@ -300,7 +300,7 @@ grant select on system.* to b;
 create stage s3;
 "
 
-echo "copy into '@s3/a b' from (select 2);" | $BENDSQL_CLIENT_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
+echo "copy into '@s3/a b' from (select 2);" | bendsql_connect_root | $RM_UUID | cut -d$'\t' -f1,2
 
 # need err - these must be separate to show individual errors
 echo "insert into t select * from t1" | $USER_B_CONNECT
@@ -338,21 +338,21 @@ create table c.t (id int);
 grant insert, select on c.t to b;
 "
 
-echo "show grants for b" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for b" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 run_user_b "
 insert into c.t values(1);
 select * from c.t;
 "
 
 run_root_sql "alter table c.t rename to t1;"
-echo "show grants for b" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for b" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 run_user_b "
 insert into c.t1 values(2);
 select * from c.t1 order by id;
 "
 
 run_root_sql "alter database c rename to d;"
-echo "show grants for b" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for b" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 run_user_b "
 insert into d.t1 values(3);
 select * from d.t1 order by id;
@@ -374,7 +374,7 @@ create user c identified by '123';
 grant drop on default.t to c;
 "
 
-export USER_C_CONNECT="bendsql_query_http_user_connect c 123 -A"
+export USER_C_CONNECT="bendsql_connect_user c 123 -A"
 
 run_user_c() {
   cat <<SQL | $USER_C_CONNECT
@@ -399,13 +399,13 @@ run_root_sql "
 drop user if exists c;
 create user c identified by '123';
 "
-export USER_C_CONNECT="bendsql_query_http_user_connect c 123 -A"
+export USER_C_CONNECT="bendsql_connect_user c 123 -A"
 
 run_root_sql "
 set session max_threads=1000;
 unset session max_threads;
 "
-echo "settings (ddl_column_type_nullable=0) select 100" | $BENDSQL_CLIENT_CONNECT
+echo "settings (ddl_column_type_nullable=0) select 100" | bendsql_connect_root
 run_root_sql "
 SET variable a = 'a';
 set global max_threads=1000;

--- a/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0008_privilege_ownership.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 export TEST_USER_NAME="owner"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect owner password -A"
+export TEST_USER_CONNECT="bendsql_connect_user owner password -A"
 
 run_root_sql "
 drop table if exists d20_0014.table2;
@@ -27,14 +27,14 @@ echo "insert into d20_0014.table1 values(1),(2),(3);" | $TEST_USER_CONNECT
 echo "select * from d20_0014.table1;" | $TEST_USER_CONNECT
 
 echo "=== test drop role ==="
-echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
-echo "drop role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
-echo "create role 'd20_0014_owner'" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | $BENDSQL_CLIENT_CONNECT
-echo "select name, owner from system.databases where name='d20_0014'" | $BENDSQL_CLIENT_CONNECT
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | bendsql_connect_root
+echo "select name, owner from system.databases where name='d20_0014'" | bendsql_connect_root
+echo "drop role 'd20_0014_owner'" | bendsql_connect_root
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | bendsql_connect_root
+echo "select name, owner from system.databases where name='d20_0014'" | bendsql_connect_root
+echo "create role 'd20_0014_owner'" | bendsql_connect_root
+echo "select name, owner from system.tables where name in ('table1', 'table2') and database='d20_0014' order by name" | bendsql_connect_root
+echo "select name, owner from system.databases where name='d20_0014'" | bendsql_connect_root
 
 run_root_sql "
 drop role 'd20_0014_owner';

--- a/tests/suites/0_stateless/18_rbac/18_0009_set_role.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0009_set_role.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect testuser1 password -A"
+export TEST_USER_CONNECT="bendsql_connect_user testuser1 password -A"
 
 echo '-- reset user, roles, and tables'
 run_root_sql "
@@ -98,7 +98,7 @@ GRANT ALL ON *.* TO ROLE \`role_c\`;
 GRANT ROLE \`role_c\` to test_c;
 "
 
-export TEST_C_CONNECT="bendsql_query_http_user_connect test_c 123 -A"
+export TEST_C_CONNECT="bendsql_connect_user test_c 123 -A"
 run_root_sql "
 drop database if exists db_c;
 drop database if exists db_d;

--- a/tests/suites/0_stateless/18_rbac/18_0010_rewrite_statements.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0010_rewrite_statements.sh
@@ -4,15 +4,15 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect testuser1 password -A"
+export TEST_USER_CONNECT="bendsql_connect_user testuser1 password -A"
 
 echo '-- reset users'
-echo "DROP USER IF EXISTS 'testuser1'" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS 'testuser1'" | bendsql_connect_root
 
 echo '-- prepare user and tables for tests'
-echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE IF NOT EXISTS t20_0016_table1(c int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT SELECT ON default.t20_0016_table1 TO testuser1" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | bendsql_connect_root
+echo "CREATE TABLE IF NOT EXISTS t20_0016_table1(c int not null)" | bendsql_connect_root
+echo "GRANT SELECT ON default.t20_0016_table1 TO testuser1" | bendsql_connect_root
 
 echo '-- ensure the statements not break with PUBLIC role'
 echo "SHOW TABLES;" | $TEST_USER_CONNECT > /dev/null

--- a/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0011_alter_own_username.sh
@@ -4,16 +4,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect testuser1 password -A"
-export TEST_USER2_CONNECT="bendsql_query_http_user_connect testuser2 password -A"
+export TEST_USER_CONNECT="bendsql_connect_user testuser1 password -A"
+export TEST_USER2_CONNECT="bendsql_connect_user testuser2 password -A"
 
 echo '-- reset users'
-echo "DROP USER IF EXISTS 'testuser1'" | $BENDSQL_CLIENT_CONNECT
-echo "DROP USER IF EXISTS 'testuser2'" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS 'testuser1'" | bendsql_connect_root
+echo "DROP USER IF EXISTS 'testuser2'" | bendsql_connect_root
 
 echo '-- prepare user and tables for tests'
-echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE USER 'testuser2' IDENTIFIED BY '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE USER 'testuser1' IDENTIFIED BY '$TEST_USER_PASSWORD'" | bendsql_connect_root
+echo "CREATE USER 'testuser2' IDENTIFIED BY '$TEST_USER_PASSWORD'" | bendsql_connect_root
 echo "alter user 'testuser2' identified by '123'" | $TEST_USER_CONNECT 2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
 echo "alter user 'testuser1' identified by '123' with default_role='role1'" | $TEST_USER_CONNECT  2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
 echo "alter user 'testuser1' identified by '123' with disabled=true" | $TEST_USER_CONNECT  2>&1 | grep 'Permission denied: privilege \[Alter\]' |wc -l
@@ -23,12 +23,12 @@ echo "alter user 'testuser1' identified by '123' with disabled=true" | $TEST_USE
 # error: APIError: RequestError: Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"... incorrect password ..."}}
 echo "alter user 'testuser1' identified by '123'" | $TEST_USER_CONNECT 2>&1 | grep 'incorrect password' | wc -l
 
-export TEST_USER_MODIFY_CONNECT="bendsql_query_http_user_connect testuser1 123 -A"
+export TEST_USER_MODIFY_CONNECT="bendsql_connect_user testuser1 123 -A"
 
 echo "select 1" | $TEST_USER_CONNECT  2>&1 | grep 'incorrect password' | wc -l
 echo "select 'testuser1 password is 123'" | $TEST_USER_MODIFY_CONNECT
 echo "select 'testuser2 password not modify'" | $TEST_USER2_CONNECT
 
 echo '-- reset users'
-echo "DROP USER IF EXISTS 'testuser1'" | $BENDSQL_CLIENT_CONNECT
-echo "DROP USER IF EXISTS 'testuser2'" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS 'testuser1'" | bendsql_connect_root
+echo "DROP USER IF EXISTS 'testuser2'" | bendsql_connect_root

--- a/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0013_column_privilege.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 export TEST_USER_PASSWORD="password"
-export USER_A_CONNECT="bendsql_query_http_user_connect a password -A"
+export USER_A_CONNECT="bendsql_connect_user a password -A"
 
 run_root_sql "
 drop user if exists a;
@@ -20,7 +20,7 @@ create or replace table default.test_t(id int not null);
 "
 
 echo "=== show grants for a ==="
-echo "show grants for a" | $BENDSQL_CLIENT_CONNECT | awk -F ' ' '{$3=""; print $0}'
+echo "show grants for a" | bendsql_connect_root | awk -F ' ' '{$3=""; print $0}'
 echo "=== show databases ==="
 echo "show databases" | $USER_A_CONNECT
 
@@ -40,7 +40,7 @@ echo "show tables from nogrant" | $USER_A_CONNECT
 echo "show columns from t from nogrant" | $USER_A_CONNECT
 
 echo "=== grant system to a ==="
-echo "grant select on system.* to a" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on system.* to a" | bendsql_connect_root
 echo "show tables from system" | $USER_A_CONNECT | echo $?
 echo "use system" | $USER_A_CONNECT | echo $?
 

--- a/tests/suites/0_stateless/18_rbac/18_0014_use_db_priv_check.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0014_use_db_priv_check.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 export TEST_USER_PASSWORD="password"
-export USER_TEST_CONNECT="bendsql_query_http_user_connect test password -A"
+export USER_TEST_CONNECT="bendsql_connect_user test password -A"
 
 run_root_sql "
 drop user if exists test;

--- a/tests/suites/0_stateless/18_rbac/18_0015_connection_rbac.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0015_connection_rbac.sh
@@ -4,9 +4,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-export USER_A_CONNECT="bendsql_query_http_user_connect a 123 -A"
-export USER_B_CONNECT="bendsql_query_http_user_connect b 123 -A"
-export USER_C_CONNECT="bendsql_query_http_user_connect c 123 -A"
+export USER_A_CONNECT="bendsql_connect_user a 123 -A"
+export USER_B_CONNECT="bendsql_connect_user b 123 -A"
+export USER_C_CONNECT="bendsql_connect_user c 123 -A"
 
 echo "=== OLD LOGIC: user has super privileges can operator all connections with enable_experimental_connection_privilege_check=0 ==="
 echo "=== TEST USER A WITH SUPER PRIVILEGES ==="
@@ -70,7 +70,7 @@ grant role role1 to b;
 echo "--- USER b failed to create conn c1 because current role is public, can not create ---"
 echo "CREATE CONNECTION c1 STORAGE_TYPE='azblob' ENDPOINT_URL='http://s3.amazonaws.com';" | $USER_B_CONNECT
 
-echo "alter user b with default_role='role1';" | $BENDSQL_CLIENT_CONNECT
+echo "alter user b with default_role='role1';" | bendsql_connect_root
 
 echo "--- success, c1,c2,c3 owner role is role1 ---";
 echo "CREATE CONNECTION c1 STORAGE_TYPE='azblob' ENDPOINT_URL='http://s3.amazonaws.com';" | $USER_B_CONNECT
@@ -82,22 +82,22 @@ echo "DESC CONNECTION c3;" | $USER_B_CONNECT
 echo "show connections;" | $USER_B_CONNECT
 
 echo "--- transform c2'ownership from role1 to role2 ---"
-echo "grant ownership on connection c2 to role role2;" | $BENDSQL_CLIENT_CONNECT
+echo "grant ownership on connection c2 to role role2;" | bendsql_connect_root
 echo "--- USER failed to desc conn c2, c2 role is role2 ---"
 echo "DESC CONNECTION c2;" | $USER_B_CONNECT
 echo "show connections;" | $USER_B_CONNECT
 
-echo "create user c identified by '123';" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role2 to c;" | $BENDSQL_CLIENT_CONNECT
+echo "create user c identified by '123';" | bendsql_connect_root
+echo "grant role role2 to c;" | bendsql_connect_root
 echo "--- only return one row c2 ---"
 echo "DESC CONNECTION c2;" | $USER_C_CONNECT
 echo "show connections;" | $USER_C_CONNECT
 echo "--- grant access connection c1 to role3 ---"
-echo "grant access connection on connection c1 to role role3;" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role3 to c;" | $BENDSQL_CLIENT_CONNECT
+echo "grant access connection on connection c1 to role role3;" | bendsql_connect_root
+echo "grant role role3 to c;" | bendsql_connect_root
 echo "DESC CONNECTION c1;" | $USER_C_CONNECT
 echo "--- grant access connection c3 to role3 ---"
-echo "grant access connection on connection c3 to role role3;" | $BENDSQL_CLIENT_CONNECT
+echo "grant access connection on connection c3 to role role3;" | bendsql_connect_root
 echo "DESC CONNECTION c3;" | $USER_C_CONNECT
 echo "--- return three rows c1,2,3 ---"
 echo "show connections;" | $USER_C_CONNECT
@@ -108,8 +108,8 @@ curl -s -u "b:123" -XPOST "http://$QUERY_MYSQL_HANDLER_HOST:$QUERY_HTTP_HANDLER_
 echo "show grants on connection c2;" | $USER_B_CONNECT
 
 echo "--- revoke access connection from role3 , thne user c can not drop/use connection c1,3 ---"
-echo "revoke access connection on connection c1 from role role3;" | $BENDSQL_CLIENT_CONNECT
-echo "revoke access connection on connection c3 from role role3;" | $BENDSQL_CLIENT_CONNECT
+echo "revoke access connection on connection c1 from role role3;" | bendsql_connect_root
+echo "revoke access connection on connection c3 from role role3;" | bendsql_connect_root
 curl -s -u "c:123" -XPOST "http://$QUERY_MYSQL_HANDLER_HOST:$QUERY_HTTP_HANDLER_PORT/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE STAGE my_s3_stage URL = 's3://databend-toronto' CONNECTION = (CONNECTION_NAME = 'c1');\"}" | jq -r '.error.message' |grep 'Permission denied: privilege AccessConnection' |wc -l
 curl -s -u "c:123" -XPOST "http://$QUERY_MYSQL_HANDLER_HOST:$QUERY_HTTP_HANDLER_PORT/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE STAGE my_s3_stage URL = 's3://databend-toronto' CONNECTION = (CONNECTION_NAME = 'c3')\"}" | jq -r '.error.message' |grep 'Permission denied: privilege AccessConnection' |wc -l
 echo "show grants on connection c1;" | $USER_C_CONNECT

--- a/tests/suites/0_stateless/18_rbac/18_0016_seq_rbac.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0016_seq_rbac.sh
@@ -4,14 +4,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_root_sql() {
-  cat <<SQL | $BENDSQL_CLIENT_CONNECT
+  cat <<SQL | bendsql_connect_root
 $1
 SQL
 }
 
-export USER_A_CONNECT="bendsql_query_http_user_connect a 123 -A"
-export USER_B_CONNECT="bendsql_query_http_user_connect b 123 -A"
-export USER_C_CONNECT="bendsql_query_http_user_connect c 123 -A"
+export USER_A_CONNECT="bendsql_connect_user a 123 -A"
+export USER_B_CONNECT="bendsql_connect_user b 123 -A"
+export USER_C_CONNECT="bendsql_connect_user c 123 -A"
 
 run_user_a() {
   cat <<SQL | $USER_A_CONNECT
@@ -31,8 +31,8 @@ $1
 SQL
 }
 
-for seq in $(echo "select name from show_sequences();" | $BENDSQL_CLIENT_CONNECT); do
-  echo "drop sequence if exists \`$seq\`;" | $BENDSQL_CLIENT_CONNECT
+for seq in $(echo "select name from show_sequences();" | bendsql_connect_root); do
+  echo "drop sequence if exists \`$seq\`;" | bendsql_connect_root
 done
 
 echo "=== OLD LOGIC: user has super privileges can operator all sequences with enable_experimental_sequence_privilege_check=0 ==="

--- a/tests/suites/0_stateless/18_rbac/18_0017_procedure_rbac.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0017_procedure_rbac.sh
@@ -4,62 +4,37 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR/../../../shell_env.sh"
 
-# Use a synchronous stderr filter for this script so expected bendsql errors are
-# emitted before the next numbered step is printed.
-bendsql_client_sync() {
-	local stderr_file status
-
-	stderr_file=$(mktemp) || return 1
-	bendsql "$@" 2>"$stderr_file"
-	status=$?
-	sed -E 's/ \[v[0-9][^]]*\]$//' "$stderr_file" >&2
-	rm -f "$stderr_file"
-	return "$status"
-}
-
-bendsql_query_http_user_connect_sync() {
-	local user="$1"
-	local password="$2"
-	shift 2
-
-	bendsql_client_sync \
-		--host "${QUERY_MYSQL_HANDLER_HOST}" \
-		--port "${QUERY_HTTP_HANDLER_PORT}" \
-		--user "${user}" \
-		--password "${password}" \
-		"$@"
-}
 
 # Define connection strings for each user
 echo "=== Setting up user connection strings ==="
-export USER_ADMIN_USER_CONNECT="bendsql_query_http_user_connect_sync admin_user 123 -A"
-export USER_DEV_USER_CONNECT="bendsql_query_http_user_connect_sync dev_user 123 -A"
-export USER_TEST_USER_CONNECT="bendsql_query_http_user_connect_sync test_user 123 -A"
+export USER_ADMIN_USER_CONNECT="bendsql_connect_user admin_user 123 -A"
+export USER_DEV_USER_CONNECT="bendsql_connect_user dev_user 123 -A"
+export USER_TEST_USER_CONNECT="bendsql_connect_user test_user 123 -A"
 
 # Create roles
 echo "=== Creating roles ==="
-echo "DROP ROLE IF EXISTS admin_role;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP ROLE IF EXISTS dev_role;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP ROLE IF EXISTS test_role;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE ROLE admin_role;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE ROLE dev_role;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE ROLE test_role;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP ROLE IF EXISTS admin_role;" | bendsql_connect_root
+echo "DROP ROLE IF EXISTS dev_role;" | bendsql_connect_root
+echo "DROP ROLE IF EXISTS test_role;" | bendsql_connect_root
+echo "CREATE ROLE admin_role;" | bendsql_connect_root
+echo "CREATE ROLE dev_role;" | bendsql_connect_root
+echo "CREATE ROLE test_role;" | bendsql_connect_root
 
 # Create users
 echo "=== Creating users ==="
-echo "CREATE OR REPLACE USER admin_user IDENTIFIED BY '123' with default_role='admin_role';" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE OR REPLACE USER dev_user IDENTIFIED BY '123' with default_role='dev_role';" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE OR REPLACE USER test_user IDENTIFIED BY '123' with default_role='test_role';" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE OR REPLACE USER admin_user IDENTIFIED BY '123' with default_role='admin_role';" | bendsql_connect_root
+echo "CREATE OR REPLACE USER dev_user IDENTIFIED BY '123' with default_role='dev_role';" | bendsql_connect_root
+echo "CREATE OR REPLACE USER test_user IDENTIFIED BY '123' with default_role='test_role';" | bendsql_connect_root
 
 # Grant roles to users
 echo "=== Granting roles to users ==="
-echo "GRANT role admin_role TO USER admin_user;" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT role dev_role TO USER dev_user;" | $BENDSQL_CLIENT_CONNECT
-echo "GRANT role test_role TO USER test_user;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT role admin_role TO USER admin_user;" | bendsql_connect_root
+echo "GRANT role dev_role TO USER dev_user;" | bendsql_connect_root
+echo "GRANT role test_role TO USER test_user;" | bendsql_connect_root
 
 # Test global CREATE PROCEDURE permission
 echo "=== Testing global CREATE PROCEDURE permission ==="
-echo "GRANT CREATE PROCEDURE ON *.* TO ROLE admin_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT CREATE PROCEDURE ON *.* TO ROLE admin_role;" | bendsql_connect_root
 
 # admin_user creates procedures
 echo "=== admin_user: Creating procedures ==="
@@ -96,7 +71,7 @@ END;
 # Test ACCESS PROCEDURE permission
 echo "=== Testing ACCESS PROCEDURE permission ==="
 echo "5. Granting dev_role access to add_numbers..."
-echo "GRANT ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) TO ROLE dev_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) TO ROLE dev_role;" | bendsql_connect_root
 
 echo "6. dev_user calls add_numbers (should succeed)..."
 echo "CALL procedure add_numbers(3::int32, 4::int32);" | $USER_DEV_USER_CONNECT
@@ -105,7 +80,7 @@ echo "7. test_user calls add_numbers (should fail)..."
 echo "CALL procedure add_numbers(3::int32, 4::int32);" | $USER_TEST_USER_CONNECT
 
 echo "8. Granting test_role access to get_current_time..."
-echo "GRANT ACCESS PROCEDURE ON PROCEDURE get_current_time() TO ROLE test_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT ACCESS PROCEDURE ON PROCEDURE get_current_time() TO ROLE test_role;" | bendsql_connect_root
 
 echo "9. test_user calls get_current_time (should succeed)..."
 echo "CALL procedure get_current_time();" | $USER_TEST_USER_CONNECT | echo $?
@@ -117,10 +92,10 @@ echo "CREATE PROCEDURE multiply_numbers(a INT, b INT) RETURNS INT NOT NULL LANGU
 BEGIN
     RETURN a * b;
 END;
-\$\$;" | $BENDSQL_CLIENT_CONNECT
+\$\$;" | bendsql_connect_root
 
 echo "11. Transferring ownership of multiply_numbers to dev_role..."
-echo "GRANT OWNERSHIP ON PROCEDURE multiply_numbers(INT, INT) TO ROLE dev_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT OWNERSHIP ON PROCEDURE multiply_numbers(INT, INT) TO ROLE dev_role;" | bendsql_connect_root
 
 echo "12. dev_user describes multiply_numbers (should succeed)..."
 echo "DESC PROCEDURE multiply_numbers(INT32, INT32);" | $USER_DEV_USER_CONNECT
@@ -131,7 +106,7 @@ echo "DESC PROCEDURE multiply_numbers(INT32, INT32);" | $USER_TEST_USER_CONNECT
 # Test ownership chaining
 echo "=== Testing ownership chaining ==="
 echo "14. Transferring ownership of multiply_numbers to test_role..."
-echo "GRANT OWNERSHIP ON PROCEDURE multiply_numbers(INT, INT) TO ROLE test_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT OWNERSHIP ON PROCEDURE multiply_numbers(INT, INT) TO ROLE test_role;" | bendsql_connect_root
 
 echo "15. dev_user describes multiply_numbers (should fail)..."
 echo "DESC PROCEDURE multiply_numbers(INT32, INT32);" | $USER_DEV_USER_CONNECT
@@ -148,16 +123,16 @@ echo "CALL procedure multiply_numbers(1::int32, 2::int32);" | $USER_TEST_USER_CO
 # Test permission inheritance
 echo "=== Testing permission inheritance ==="
 echo "19. Creating test_with_access role..."
-echo "CREATE ROLE test_with_access;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE ROLE test_with_access;" | bendsql_connect_root
 
 echo "20. Granting test_with_access access to add_numbers..."
-echo "GRANT ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) TO ROLE test_with_access;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) TO ROLE test_with_access;" | bendsql_connect_root
 
 echo "21. test_user calls add_numbers (should fail, not yet granted role)..."
 echo "CALL procedure add_numbers(5::int32, 6::int32);" | $USER_TEST_USER_CONNECT
 
 echo "22. Granting test_with_access to test_user..."
-echo "GRANT role test_with_access TO USER test_user;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT role test_with_access TO USER test_user;" | bendsql_connect_root
 
 echo "23. test_user calls add_numbers (should succeed)..."
 echo "CALL procedure add_numbers(5::int32, 6::int32);" | $USER_TEST_USER_CONNECT
@@ -165,7 +140,7 @@ echo "CALL procedure add_numbers(5::int32, 6::int32);" | $USER_TEST_USER_CONNECT
 # Test permission revocation
 echo "=== Testing permission revocation ==="
 echo "24. Revoking test_with_access's access to add_numbers..."
-echo "REVOKE ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) FROM ROLE test_with_access;" | $BENDSQL_CLIENT_CONNECT
+echo "REVOKE ACCESS PROCEDURE ON PROCEDURE add_numbers(int, int) FROM ROLE test_with_access;" | bendsql_connect_root
 
 echo "25. test_user calls add_numbers (should fail)..."
 echo "CALL procedure add_numbers(5::int32, 6::int32);" | $USER_TEST_USER_CONNECT
@@ -180,10 +155,10 @@ echo "CREATE PROCEDURE greet() RETURNS STRING NOT NULL LANGUAGE SQL AS \$\$
 BEGIN
     RETURN 'Hello, Databend!';
 END;
-\$\$;" | $BENDSQL_CLIENT_CONNECT
+\$\$;" | bendsql_connect_root
 
 echo "28. Granting dev_role access to greet..."
-echo "GRANT ACCESS PROCEDURE ON PROCEDURE greet() TO ROLE dev_role;" | $BENDSQL_CLIENT_CONNECT
+echo "GRANT ACCESS PROCEDURE ON PROCEDURE greet() TO ROLE dev_role;" | bendsql_connect_root
 
 echo "29. dev_user calls greet (should succeed)..."
 echo "CALL procedure greet();" | $USER_DEV_USER_CONNECT
@@ -193,11 +168,11 @@ echo "CALL procedure greet();" | $USER_TEST_USER_CONNECT
 
 # Test system.procedures visibility
 echo "=== Testing system.procedures visibility ==="
-echo "SET GLOBAL enable_experimental_rbac_check = 1;" | $BENDSQL_CLIENT_CONNECT
+echo "SET GLOBAL enable_experimental_rbac_check = 1;" | bendsql_connect_root
 
 echo "31. admin_user queries system.procedures (should see add_numbers, get_current_time via ownership)..."
 echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_current_time', 'multiply_numbers', 'greet') ORDER BY name;" | $USER_ADMIN_USER_CONNECT
-echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_current_time', 'multiply_numbers', 'greet') ORDER BY name;" | $BENDSQL_CLIENT_CONNECT
+echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_current_time', 'multiply_numbers', 'greet') ORDER BY name;" | bendsql_connect_root
 
 echo "32. dev_user queries system.procedures (should see add_numbers and greet via grant)..."
 echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_current_time', 'multiply_numbers', 'greet') ORDER BY name;" | $USER_DEV_USER_CONNECT
@@ -205,26 +180,26 @@ echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_curr
 echo "33. test_user queries system.procedures (should see get_current_time via grant, multiply_numbers via ownership)..."
 echo "SELECT name FROM system.procedures WHERE name IN ('add_numbers', 'get_current_time', 'multiply_numbers', 'greet') ORDER BY name;" | $USER_TEST_USER_CONNECT
 
-echo "SET GLOBAL enable_experimental_rbac_check = 0;" | $BENDSQL_CLIENT_CONNECT
+echo "SET GLOBAL enable_experimental_rbac_check = 0;" | bendsql_connect_root
 
 # Cleanup
 echo "=== Cleaning up test environment ==="
 echo "34. Dropping users..."
-echo "DROP USER IF EXISTS admin_user;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP USER IF EXISTS dev_user;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP USER IF EXISTS test_user;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP USER IF EXISTS admin_user;" | bendsql_connect_root
+echo "DROP USER IF EXISTS dev_user;" | bendsql_connect_root
+echo "DROP USER IF EXISTS test_user;" | bendsql_connect_root
 
 echo "35. Dropping roles..."
-echo "DROP ROLE IF EXISTS admin_role;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP ROLE IF EXISTS dev_role;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP ROLE IF EXISTS test_role;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP ROLE IF EXISTS test_with_access;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP ROLE IF EXISTS admin_role;" | bendsql_connect_root
+echo "DROP ROLE IF EXISTS dev_role;" | bendsql_connect_root
+echo "DROP ROLE IF EXISTS test_role;" | bendsql_connect_root
+echo "DROP ROLE IF EXISTS test_with_access;" | bendsql_connect_root
 
 echo "36. Dropping procedures..."
-echo "DROP PROCEDURE IF EXISTS add_numbers(int, int);" | $BENDSQL_CLIENT_CONNECT
-echo "DROP PROCEDURE IF EXISTS get_current_time();" | $BENDSQL_CLIENT_CONNECT
-echo "DROP PROCEDURE IF EXISTS multiply_numbers(int, int);" | $BENDSQL_CLIENT_CONNECT
-echo "DROP PROCEDURE IF EXISTS greet();" | $BENDSQL_CLIENT_CONNECT
+echo "DROP PROCEDURE IF EXISTS add_numbers(int, int);" | bendsql_connect_root
+echo "DROP PROCEDURE IF EXISTS get_current_time();" | bendsql_connect_root
+echo "DROP PROCEDURE IF EXISTS multiply_numbers(int, int);" | bendsql_connect_root
+echo "DROP PROCEDURE IF EXISTS greet();" | bendsql_connect_root
 
-echo "unset global enable_experimental_procedure;" | $BENDSQL_CLIENT_CONNECT
+echo "unset global enable_experimental_procedure;" | bendsql_connect_root
 echo "=== Test script completed ==="

--- a/tests/suites/0_stateless/18_rbac/18_0018_db_table_visibility_regression.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0018_db_table_visibility_regression.sh
@@ -5,11 +5,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 API_BASE="http://${QUERY_MYSQL_HANDLER_HOST}:${QUERY_HTTP_HANDLER_PORT}/v1/catalog"
 
-export USER_DROPPED_DB_CONNECT="bendsql_query_http_user_connect u_dropped_db_0018 123 -A --quote-style=never"
+export USER_DROPPED_DB_CONNECT="bendsql_connect_user u_dropped_db_0018 123 -A --quote-style=never"
 
 # Prepare data for table ownership, database ownership, role grants, direct user
 # grants, inherited roles, and ownership cleanup after a role is dropped.
-$BENDSQL_CLIENT_OUTPUT_NULL <<SQL
+bendsql_connect_root_null <<SQL
 drop user if exists u_table_0018;
 drop user if exists u_db_0018;
 drop user if exists u_grant_0018;
@@ -247,7 +247,7 @@ echo "select name from system.tables where database = 'db_dropped_db_0018' order
 echo "-- system.tables exact table"
 echo "select name from system.tables where database = 'db_dropped_db_0018' and name = 'dropped_case_0018'" | $USER_DROPPED_DB_CONNECT
 
-echo "drop role role_dropped_db_owner_0018;" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "drop role role_dropped_db_owner_0018;" | bendsql_connect_root_null
 
 echo "=== dropped db owner after role drop ==="
 echo "-- catalog databases"
@@ -276,7 +276,7 @@ echo "select count() from system.databases where name = 'db_dropped_db_0018'" | 
 echo "-- system.tables count"
 echo "select count() from system.tables where database = 'db_dropped_db_0018'" | $USER_DROPPED_DB_CONNECT
 
-$BENDSQL_CLIENT_OUTPUT_NULL <<SQL
+bendsql_connect_root_null <<SQL
 drop user if exists u_table_0018;
 drop user if exists u_db_0018;
 drop user if exists u_grant_0018;

--- a/tests/suites/0_stateless/19_fuzz/19_0001_fuzz_aggregate.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0001_fuzz_aggregate.sh
@@ -10,7 +10,7 @@ rows=50000
 echo """
 create or replace table agg_fuzz(a int, b string, c bool, d variant, e int, f Decimal(15, 2), g Decimal(39,2));
 create or replace table agg_fuzz_r like agg_fuzz Engine = Random max_string_len = 3 max_array_len = 2;
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 
 echo """
@@ -19,7 +19,7 @@ insert into agg_fuzz select * from agg_fuzz_r limit ${rows};
 insert into agg_fuzz select * from agg_fuzz_r limit ${rows};
 insert into agg_fuzz select * from agg_fuzz_r limit ${rows};
 insert into agg_fuzz select * from agg_fuzz_r limit ${rows};
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 for m in `seq 1 6 19`; do
 	echo """create or replace table agg_fuzz_result1 as select a, sum(e) e, sum(f) f, sum(g) g from (
@@ -29,7 +29,7 @@ select a % ${m} a, b, c, d, sum(e) e, sum(f) f, sum(g) g  from agg_fuzz where b 
 ) group by all
 ) group by all
 ) group by all;
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 	echo """create or replace table agg_fuzz_result2 as select a, sum(e) e, sum(f) f, sum(g) g from (
 	select a, d, sum(e) e, sum(f) f, sum(g) g from (
@@ -38,7 +38,7 @@ select a % ${m} a, b, c, d, sum(e) e, sum(f) f, sum(g) g  from agg_fuzz where b 
 ) group by all
 ) group by all
 ) group by all;
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 	echo """
 	select count() + 1 from (
@@ -50,7 +50,7 @@ select a % ${m} a, b, c, d, sum(e) e, sum(f) f, sum(g) g  from agg_fuzz where b 
 		EXCEPT
 		SELECT * FROM agg_fuzz_result1
 	);
-	""" | $BENDSQL_CLIENT_CONNECT
+	""" | bendsql_connect_root
 
 	echo """
 	select count() + 1 from (
@@ -62,5 +62,5 @@ select a % ${m} a, b, c, d, sum(e) e, sum(f) f, sum(g) g  from agg_fuzz where b 
 		EXCEPT
 		SELECT * FROM agg_fuzz_result1)
 	);
-	""" | $BENDSQL_CLIENT_CONNECT
+	""" | bendsql_connect_root
 done

--- a/tests/suites/0_stateless/19_fuzz/19_0002_fuzz_join.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0002_fuzz_join.sh
@@ -4,13 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_bendsql() {
-  cat <<SQL | $BENDSQL_CLIENT_CONNECT
+  cat <<SQL | bendsql_connect_root
 $1
 SQL
 }
 
 run_bendsql_null() {
-  cat <<SQL | $BENDSQL_CLIENT_OUTPUT_NULL
+  cat <<SQL | bendsql_connect_root_null
 $1
 SQL
 }

--- a/tests/suites/0_stateless/19_fuzz/19_0003_fuzz_union.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0003_fuzz_union.sh
@@ -11,7 +11,7 @@ echo """
 create or replace table union_fuzz(a int, b string, c bool, d variant, e int64, f Decimal(15, 2), g Decimal(39,2), h Array(String), i Array(Decimal(15, 2)));
 create or replace table union_fuzz2(a int, b string, c bool, d variant, e int64, f Decimal(15, 2), g Decimal(39,2), h Array(String), i Array(Decimal(15, 2)));
 create or replace table union_fuzz_r like union_fuzz Engine = Random max_string_len = 5 max_array_len = 2;
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 
 echo """
@@ -19,7 +19,7 @@ insert into union_fuzz select * from union_fuzz_r limit ${rows};
 insert into union_fuzz select * from union_fuzz_r limit ${rows};
 insert into union_fuzz2 select * from union_fuzz_r limit ${rows};
 insert into union_fuzz2 select * from union_fuzz_r limit ${rows};
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 fields=(a b e f)
 length=${#fields[@]}
@@ -32,11 +32,11 @@ for ((i=0; i<$length; i++)); do
 	# x,y
 	echo """create or replace table union_fuzz_result1 as
 	select $x, $y from union_fuzz union all select $x, $y from union_fuzz2;
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 	echo """create or replace table union_fuzz_result2 as
 	select $y, $x from (select $x, $y from union_fuzz2 union all select $x, $y from union_fuzz);
-""" | $BENDSQL_CLIENT_OUTPUT_NULL
+""" | bendsql_connect_root_null
 
 echo """
 	select count() + 1 from (
@@ -48,7 +48,7 @@ echo """
 		EXCEPT
 		SELECT $x, $y FROM union_fuzz_result1)
 	);
-	""" | $BENDSQL_CLIENT_CONNECT
+	""" | bendsql_connect_root
 
     done
 done

--- a/tests/suites/0_stateless/19_fuzz/19_0005_fuzz_cte.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0005_fuzz_cte.sh
@@ -20,12 +20,12 @@ order by 1, 2;
 SQL
 
 for i in `seq 1 ${times}`;do
-	echo "$FUZZ_QUERY" | $BENDSQL_CLIENT_CONNECT >> /tmp/fuzz_a.txt
+	echo "$FUZZ_QUERY" | bendsql_connect_root >> /tmp/fuzz_a.txt
 done
 
 
 for i in `seq 1 ${times}`;do
-	echo "$FUZZ_QUERY" | $BENDSQL_CLIENT_CONNECT >> /tmp/fuzz_b.txt
+	echo "$FUZZ_QUERY" | bendsql_connect_root >> /tmp/fuzz_b.txt
 done
 
 diff /tmp/fuzz_a.txt /tmp/fuzz_b.txt && echo "OK"

--- a/tests/suites/0_stateless/19_fuzz/19_0006_fuzz_random_join.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0006_fuzz_random_join.sh
@@ -4,13 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_bendsql() {
-  cat <<SQL | $BENDSQL_CLIENT_CONNECT
+  cat <<SQL | bendsql_connect_root
 $1
 SQL
 }
 
 run_bendsql_null() {
-  cat <<SQL | $BENDSQL_CLIENT_OUTPUT_NULL
+  cat <<SQL | bendsql_connect_root_null
 $1
 SQL
 }
@@ -64,7 +64,7 @@ function run_test() {
   local expected="$2"
   local test_name="$3"
 
-  result=$(echo "$query" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}')
+  result=$(echo "$query" | bendsql_connect_root | awk '{print $1}')
 
   if [ "$result" != "$expected" ]; then
     echo "FAIL: $test_name (Expected $expected, got $result)"
@@ -170,7 +170,7 @@ for ((i=1; i<=$iterations; i++)); do
 
   run_test """
     SELECT COUNT(*) FROM join_fuzz1 LEFT JOIN empty_table as join_fuzz2  ON $condition;
-  """ "$(echo "SELECT COUNT(*) FROM join_fuzz1;" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}')" "LEFT JOIN with empty table preserves left table"
+  """ "$(echo "SELECT COUNT(*) FROM join_fuzz1;" | bendsql_connect_root | awk '{print $1}')" "LEFT JOIN with empty table preserves left table"
 
   # Test type compatibility
   run_test """
@@ -188,4 +188,4 @@ done
 # DROP TABLE if exists join_fuzz2;
 # DROP TABLE if exists join_fuzz_r;
 # DROP TABLE if exists empty_table;
-# """ | $BENDSQL_CLIENT_CONNECT
+# """ | bendsql_connect_root

--- a/tests/suites/0_stateless/19_fuzz/19_0007_fuzz_decimal.sh
+++ b/tests/suites/0_stateless/19_fuzz/19_0007_fuzz_decimal.sh
@@ -19,5 +19,5 @@ for scale in `seq 0 ${MAX_SCALE}`;do
 	done
 done >> /tmp/decimal.sql
 
-cat /tmp/decimal.sql | $BENDSQL_CLIENT_OUTPUT_NULL
+cat /tmp/decimal.sql | bendsql_connect_root_null
 echo "1"

--- a/tests/suites/0_stateless/20+_others/20_0010_distinct_aggr.sh
+++ b/tests/suites/0_stateless/20+_others/20_0010_distinct_aggr.sh
@@ -4,13 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "drop table if exists s_distinct;" | $BENDSQL_CLIENT_CONNECT
-echo "create table s_distinct (a String not null);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists s_distinct;" | bendsql_connect_root
+echo "create table s_distinct (a String not null);" | bendsql_connect_root
 
 for i in `seq 1 20`;do
-	echo "insert into s_distinct values ('$i'), ('$[i+1]'), ('$[i+2]')" | $BENDSQL_CLIENT_CONNECT
+	echo "insert into s_distinct values ('$i'), ('$[i+1]'), ('$[i+2]')" | bendsql_connect_root
 done
 
-echo "select count(distinct a) from s_distinct" |  $BENDSQL_CLIENT_CONNECT
+echo "select count(distinct a) from s_distinct" |  bendsql_connect_root
 
-echo "drop table s_distinct;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table s_distinct;" | bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0011_purge_before.sh
+++ b/tests/suites/0_stateless/20+_others/20_0011_purge_before.sh
@@ -8,54 +8,54 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # PURGE BEFORE SNAPSHOT
 
 ## Setup
-echo "create table t20_0011(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t20_0011(c int not null)" | bendsql_connect_root
 ## - 1st snapshot contains 2 rows, 1 block, 1 segment
-echo "insert into t20_0011 values(1),(2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(1),(2)" | bendsql_connect_root
 ## - 2nd snapshot contains 3 rows, 2 blocks, 2 segments
-echo "insert into t20_0011 values(3)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(3)" | bendsql_connect_root
 ## - 3rd snapshot contains 4 rows, 3 blocks, 3 segments
-echo "insert into t20_0011 values(4)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(4)" | bendsql_connect_root
 
 echo "checking that there should are 3 snapshots before purge"
-echo "select count(*)=3  from fuse_snapshot('default', 't20_0011')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from fuse_snapshot('default', 't20_0011')" | bendsql_connect_root
 
 ## location the id of 2nd snapshot
-SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t20_0011') where row_count=3" | $BENDSQL_CLIENT_CONNECT)
-#TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't20_0011') where row_count=3" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_ID=$(echo "select snapshot_id from fuse_snapshot('default','t20_0011') where row_count=3" | bendsql_connect_root)
+#TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't20_0011') where row_count=3" | bendsql_connect_root)
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t20_0011 purge before (snapshot => '$SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t20_0011 purge before (snapshot => '$SNAPSHOT_ID')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 2 snapshots left"
-echo "select count(*)=2  from fuse_snapshot('default', 't20_0011')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=2  from fuse_snapshot('default', 't20_0011')" | bendsql_connect_root
 echo "checking that after purge (by snapshot id) there should be 4 rows left"
-echo "select count(*)=4  from t20_0011" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from t20_0011" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t20_0011 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t20_0011 all" | bendsql_connect_root
 
 # PURGE BEFORE TIMESTAMP
 
 ## Setup
-echo "create table t20_0011(c int not null)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t20_0011(c int not null)" | bendsql_connect_root
 ## - 1st snapshot contains 2 rows, 1 block, 1 segment
-echo "insert into t20_0011 values(1),(2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(1),(2)" | bendsql_connect_root
 ## - 2nd snapshot contains 3 rows, 2 blocks, 2 segments
-echo "insert into t20_0011 values(3)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(3)" | bendsql_connect_root
 ## - 3rd snapshot contains 4 rows, 3 blocks, 3 segments
-echo "insert into t20_0011 values(4)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into t20_0011 values(4)" | bendsql_connect_root
 
 echo "checking that there should are 3 snapshots before purge"
-echo "select count(*)=3  from fuse_snapshot('default', 't20_0011')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=3  from fuse_snapshot('default', 't20_0011')" | bendsql_connect_root
 
 ## location the timestamp of latest snapshot
-TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't20_0011') where row_count=4" | $BENDSQL_CLIENT_CONNECT)
+TIMEPOINT=$(echo "select timestamp from fuse_snapshot('default', 't20_0011') where row_count=4" | bendsql_connect_root)
 
 ## verify
-echo "set data_retention_time_in_days=0; optimize table t20_0011 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
+echo "set data_retention_time_in_days=0; optimize table t20_0011 purge before (TIMESTAMP => '$TIMEPOINT'::TIMESTAMP)" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be 1 snapshot left"
-echo "select count(*)=1  from fuse_snapshot('default', 't20_0011')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=1  from fuse_snapshot('default', 't20_0011')" | bendsql_connect_root
 echo "checking that after purge (by timestamp) there should be 4 rows left"
-echo "select count(*)=4  from t20_0011" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*)=4  from t20_0011" | bendsql_connect_root
 
 ## Drop table.
-echo "drop table t20_0011 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table t20_0011 all" | bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0013_pretty_error.sh
+++ b/tests/suites/0_stateless/20+_others/20_0013_pretty_error.sh
@@ -3,27 +3,27 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "DROP TABLE IF EXISTS t;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE IF EXISTS t1;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE IF EXISTS t2;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE IF EXISTS t3;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP TABLE IF EXISTS t;" | bendsql_connect_root
+echo "DROP TABLE IF EXISTS t1;" | bendsql_connect_root
+echo "DROP TABLE IF EXISTS t2;" | bendsql_connect_root
+echo "DROP TABLE IF EXISTS t3;" | bendsql_connect_root
 
-echo "select *;" |  $BENDSQL_CLIENT_CONNECT
-echo "select * from t;" |  $BENDSQL_CLIENT_CONNECT
-echo "select base64(1);" |  $BENDSQL_CLIENT_CONNECT
-echo "select to_base64(1);" | $BENDSQL_CLIENT_CONNECT
-echo "select truncate('xx', -1);" | $BENDSQL_CLIENT_CONNECT
-echo "select 1 + 'a';" | $BENDSQL_CLIENT_CONNECT
-echo "select cast((1::int null,'a') as tuple(string,int not null)).1 +3;" | $BENDSQL_CLIENT_CONNECT
+echo "select *;" |  bendsql_connect_root
+echo "select * from t;" |  bendsql_connect_root
+echo "select base64(1);" |  bendsql_connect_root
+echo "select to_base64(1);" | bendsql_connect_root
+echo "select truncate('xx', -1);" | bendsql_connect_root
+echo "select 1 + 'a';" | bendsql_connect_root
+echo "select cast((1::int null,'a') as tuple(string,int not null)).1 +3;" | bendsql_connect_root
 
-echo "create table t1 (a tuple(b int, c int) not null)" | $BENDSQL_CLIENT_CONNECT
-echo "select t1.a:z from t" | $BENDSQL_CLIENT_CONNECT
+echo "create table t1 (a tuple(b int, c int) not null)" | bendsql_connect_root
+echo "select t1.a:z from t" | bendsql_connect_root
 
-echo "create table t2 (a int not null, b int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "create table t3 (c int not null, d int not null)" | $BENDSQL_CLIENT_CONNECT
-echo "select * from t2 join t3 using (c)" | $BENDSQL_CLIENT_CONNECT
+echo "create table t2 (a int not null, b int not null)" | bendsql_connect_root
+echo "create table t3 (c int not null, d int not null)" | bendsql_connect_root
+echo "select * from t2 join t3 using (c)" | bendsql_connect_root
 
-echo "DROP TABLE t;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE t1;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE t2;" | $BENDSQL_CLIENT_CONNECT
-echo "DROP TABLE t3;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP TABLE t;" | bendsql_connect_root
+echo "DROP TABLE t1;" | bendsql_connect_root
+echo "DROP TABLE t2;" | bendsql_connect_root
+echo "DROP TABLE t3;" | bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0015_compact_hook_stas_issue_13947.sh
+++ b/tests/suites/0_stateless/20+_others/20_0015_compact_hook_stas_issue_13947.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 # set up
-cat <<EOF |  $BENDSQL_CLIENT_CONNECT > /dev/null
+cat <<EOF |  bendsql_connect_root > /dev/null
 create or replace database i13947;
 use i13947;
 create or replace stage test_stage;
@@ -27,4 +27,4 @@ curl -s -u root: -XPOST "http://localhost:8000/v1/query" \
   -d '{"sql": "copy into i13947.tmp from (select * from @test_stage)", "pagination": { "wait_time_secs": 6}}'  \
   | jq -r '.stats.write_progress.rows, .error'
 
-echo "DROP database i13947;" | $BENDSQL_CLIENT_CONNECT
+echo "DROP database i13947;" | bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0017_stackoverflow.sh
+++ b/tests/suites/0_stateless/20+_others/20_0017_stackoverflow.sh
@@ -9,4 +9,4 @@ for i in $(seq 1 200); do
 	SQL="$SQL UNION ALL SELECT COUNT(1), 'numbers(10)' FROM numbers(10)"
 done
 
-echo "SELECT * FROM ($SQL) LIMIT 200" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "SELECT * FROM ($SQL) LIMIT 200" | bendsql_connect_root | wc -l

--- a/tests/suites/0_stateless/20+_others/20_0018_stackoverflow.sh
+++ b/tests/suites/0_stateless/20+_others/20_0018_stackoverflow.sh
@@ -3,8 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "DROP TABLE IF EXISTS t1"|$BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE t1(id VARCHAR NULL, timestamp TIMESTAMP NULL, type VARCHAR NULL)" |$BENDSQL_CLIENT_CONNECT
+echo "DROP TABLE IF EXISTS t1"|bendsql_connect_root
+echo "CREATE TABLE t1(id VARCHAR NULL, timestamp TIMESTAMP NULL, type VARCHAR NULL)" |bendsql_connect_root
 
 SQL="SELECT * FROM t1 WHERE 1 = 1 AND((timestamp = '2024-05-05 18:05:20' AND type = '1' AND id = 'xx')"
 
@@ -14,7 +14,7 @@ done
 
 SQL="$SQL)"
 
-echo "$SQL"|$BENDSQL_CLIENT_CONNECT
+echo "$SQL"|bendsql_connect_root
 
 
 SQL="a > 0 "
@@ -25,6 +25,6 @@ done
 
 SQL="$SQL OR (a / 0 > 0)"
 
-echo "SELECT $SQL from numbers(1) t(a)" | $BENDSQL_CLIENT_CONNECT
+echo "SELECT $SQL from numbers(1) t(a)" | bendsql_connect_root
 
-echo "DROP TABLE IF EXISTS t1"|$BENDSQL_CLIENT_CONNECT
+echo "DROP TABLE IF EXISTS t1"|bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0019_set_cache_capacity_privilege_check.sh
+++ b/tests/suites/0_stateless/20+_others/20_0019_set_cache_capacity_privilege_check.sh
@@ -3,9 +3,9 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create user if not exists test identified by 'test'"|$BENDSQL_CLIENT_CONNECT
+echo "create user if not exists test identified by 'test'"|bendsql_connect_root
 
-export TEST_NON_PRIVILEGED_USER_CONNECT="bendsql_query_http_user_connect test test -A"
+export TEST_NON_PRIVILEGED_USER_CONNECT="bendsql_connect_user test test -A"
 
 
 echo "call system\$fuse_amend('db', 't')" | $TEST_NON_PRIVILEGED_USER_CONNECT

--- a/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
+++ b/tests/suites/0_stateless/20+_others/20_0020_fuse_time_travel_size.sh
@@ -15,7 +15,7 @@ stmt "create table test_fuse_time_travel_size.t(c int) 'fs:///tmp/test_fuse_time
 
 stmt "insert into test_fuse_time_travel_size.t values (1),(2)" 
 
-result_size=$(echo "select time_travel_size from fuse_time_travel_size('test_fuse_time_travel_size')" | $BENDSQL_CLIENT_CONNECT)
+result_size=$(echo "select time_travel_size from fuse_time_travel_size('test_fuse_time_travel_size')" | bendsql_connect_root)
 
 expected_size=$(find /tmp/test_fuse_time_travel_size/ -type f -exec du -b  {} + | awk '{sum += $1} END {print sum}')
 

--- a/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.sh
+++ b/tests/suites/0_stateless/20+_others/20_0021_set_cache_capacity_privilege_check.sh
@@ -3,9 +3,9 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create user if not exists test identified by 'test'"|$BENDSQL_CLIENT_CONNECT
+echo "create user if not exists test identified by 'test'"|bendsql_connect_root
 
-export TEST_NON_PRIVILEGED_USER_CONNECT="bendsql_query_http_user_connect test test -A"
+export TEST_NON_PRIVILEGED_USER_CONNECT="bendsql_connect_user test test -A"
 
 echo "call system\$set_cache_capacity('memory_cache_block_meta', 100)" | $TEST_NON_PRIVILEGED_USER_CONNECT
 

--- a/tests/suites/0_stateless/20+_others/20_0022_agg_memory.sh
+++ b/tests/suites/0_stateless/20+_others/20_0022_agg_memory.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ## warmup
 for i in `seq 1 2`;do
-	$BENDSQL_CLIENT_CONNECT --query="""
+	bendsql_connect_root --query="""
 	select number::string , max(number::string), min(number::string), count(distinct number) from numbers(10000000) group by 1 ignore_result;
 	"""
 done
@@ -21,7 +21,7 @@ done
 
 for i in `seq 1 5`;do
 	echo "executing $i"
-	$BENDSQL_CLIENT_CONNECT --query="""
+	bendsql_connect_root --query="""
 	select number::string , max(number::string), min(number::string), count(distinct number) from numbers(10000000) group by 1 ignore_result;
 	"""
 done

--- a/tests/suites/0_stateless/20+_others/20_0023_udf_script_parallelism.sh
+++ b/tests/suites/0_stateless/20+_others/20_0023_udf_script_parallelism.sh
@@ -2,7 +2,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-$BENDSQL_CLIENT_CONNECT --query="""
+bendsql_connect_root --query="""
 CREATE OR REPLACE FUNCTION js_wait_test ( INT64 ) RETURNS INT64 LANGUAGE javascript HANDLER = 'wait' AS \$\$
 export function wait(n) {
     let i = 0;
@@ -12,8 +12,8 @@ export function wait(n) {
 \$\$;
 """
 
-$BENDSQL_CLIENT_CONNECT --query='select js_wait_test(50)' &
+bendsql_connect_root --query='select js_wait_test(50)' &
 job_pid=$!
-$BENDSQL_CLIENT_CONNECT --query='select js_wait_test(1)'
-$BENDSQL_CLIENT_CONNECT --query='select js_wait_test(2)'
+bendsql_connect_root --query='select js_wait_test(1)'
+bendsql_connect_root --query='select js_wait_test(2)'
 wait $job_pid

--- a/tests/suites/0_stateless/20+_others/20_0024_session_query_tag.sh
+++ b/tests/suites/0_stateless/20+_others/20_0024_session_query_tag.sh
@@ -2,7 +2,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-$BENDSQL_CLIENT_CONNECT --query="set query_tag = 'test-query_tag'; select 1; create database if not exists c;"
-$BENDSQL_CLIENT_CONNECT --query="set query_tag = 'test-query_tag-2'; select 2; create database if not exists b;"
+bendsql_connect_root --query="set query_tag = 'test-query_tag'; select 1; create database if not exists c;"
+bendsql_connect_root --query="set query_tag = 'test-query_tag-2'; select 2; create database if not exists b;"
 
-$BENDSQL_CLIENT_CONNECT --query="drop database if exists b;drop database if exists c;"
+bendsql_connect_root --query="drop database if exists b;drop database if exists c;"

--- a/tests/suites/0_stateless/20+_others/20_0025_stackoverflow.sh
+++ b/tests/suites/0_stateless/20+_others/20_0025_stackoverflow.sh
@@ -3,8 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "DROP STAGE IF EXISTS test_stackoverflow_stage" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE test_stackoverflow_stage" | $BENDSQL_CLIENT_CONNECT
+echo "DROP STAGE IF EXISTS test_stackoverflow_stage" | bendsql_connect_root
+echo "CREATE STAGE test_stackoverflow_stage" | bendsql_connect_root
 cp $CURDIR/books.parquet $CURDIR/test.parquet
 
 FILE_NAME="$CURDIR/test.parquet"
@@ -12,12 +12,12 @@ FILE_NAME="$CURDIR/test.parquet"
 for i in `seq 1 50`;do
   mv $FILE_NAME "$CURDIR/test_$i.parquet"
   FILE_NAME="$CURDIR/test_$i.parquet"
-  echo "PUT fs://$FILE_NAME @test_stackoverflow_stage"|$BENDSQL_CLIENT_CONNECT >/dev/null
+  echo "PUT fs://$FILE_NAME @test_stackoverflow_stage"|bendsql_connect_root >/dev/null
 done
 
 rm $FILE_NAME
 
-echo "CREATE OR REPLACE TABLE test_files_multiprocessing(file_name varchar, title varchar)"|$BENDSQL_CLIENT_CONNECT
+echo "CREATE OR REPLACE TABLE test_files_multiprocessing(file_name varchar, title varchar)"|bendsql_connect_root
 
 SQL="SELECT 'working/demo/test_1.parquet', \$1 FROM @test_stackoverflow_stage/test_1.parquet"
 
@@ -25,4 +25,4 @@ for i in `seq 2 50`;do
   SQL="$SQL UNION ALL SELECT 'working/demo/test_$i.parquet', \$1 FROM @test_stackoverflow_stage/test_$i.parquet"
 done
 
-echo "insert into test_files_multiprocessing(file_name, title) $SQL"|$BENDSQL_CLIENT_CONNECT
+echo "insert into test_files_multiprocessing(file_name, title) $SQL"|bendsql_connect_root

--- a/tests/suites/0_stateless/20+_others/20_0026_report_issue.sh
+++ b/tests/suites/0_stateless/20+_others/20_0026_report_issue.sh
@@ -2,10 +2,10 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-$BENDSQL_CLIENT_CONNECT --query="CREATE DATABASE test_report;" > /dev/null 2>&1
-$BENDSQL_CLIENT_CONNECT --query="CREATE TABLE test_report.test_report_1(text String);" > /dev/null 2>&1
-$BENDSQL_CLIENT_CONNECT --query="INSERT INTO test_report.test_report_1 VALUES('1234');" > /dev/null 2>&1
-output=$(echo "REPORT ISSUE SELECT text FROM test_report.test_report_1" | $BENDSQL_CLIENT_CONNECT)
+bendsql_connect_root --query="CREATE DATABASE test_report;" > /dev/null 2>&1
+bendsql_connect_root --query="CREATE TABLE test_report.test_report_1(text String);" > /dev/null 2>&1
+bendsql_connect_root --query="INSERT INTO test_report.test_report_1 VALUES('1234');" > /dev/null 2>&1
+output=$(echo "REPORT ISSUE SELECT text FROM test_report.test_report_1" | bendsql_connect_root)
 
 if echo "$output" | grep -q "Obfuscated Databases"; then
     echo "Obfuscated Databases"

--- a/tests/suites/0_stateless/20+_others/20_0028_issues_19543.sh
+++ b/tests/suites/0_stateless/20+_others/20_0028_issues_19543.sh
@@ -30,7 +30,7 @@ IGNORE_RESULT;
 
 # Warm up the aggregate path to reduce noise from one-time allocations.
 for i in `seq 1 2`; do
-    $BENDSQL_CLIENT_CONNECT --query="$QUERY"
+    bendsql_connect_root --query="$QUERY"
 done
 
 PIDS=($(pgrep databend-query))
@@ -42,7 +42,7 @@ done
 
 for i in `seq 1 3`; do
     echo "executing $i"
-    $BENDSQL_CLIENT_CONNECT --query="$QUERY"
+    bendsql_connect_root --query="$QUERY"
 done
 
 sleep 15

--- a/tests/suites/0_stateless/20+_others/20_0029_lance_copy_string_literal_utf8view.sh
+++ b/tests/suites/0_stateless/20+_others/20_0029_lance_copy_string_literal_utf8view.sh
@@ -3,7 +3,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-cat <<'EOF' | $BENDSQL_CLIENT_CONNECT > /dev/null
+cat <<'EOF' | bendsql_connect_root > /dev/null
 create or replace stage test_lance_utf8view;
 copy into @test_lance_utf8view/t_wubx/
 from (
@@ -17,12 +17,12 @@ detailed_output=true;
 EOF
 
 echo "list @test_lance_utf8view/t_wubx PATTERN = '.*[.]lance';" \
-    | $BENDSQL_CLIENT_CONNECT \
+    | bendsql_connect_root \
     | grep -q '[.]lance' \
     && echo 1 || echo 0
 echo "list @test_lance_utf8view/t_wubx PATTERN = '.*/_versions/.*manifest';" \
-    | $BENDSQL_CLIENT_CONNECT \
+    | bendsql_connect_root \
     | grep -q 'manifest' \
     && echo 1 || echo 0
 
-echo "drop stage if exists test_lance_utf8view" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "drop stage if exists test_lance_utf8view" | bendsql_connect_root > /dev/null

--- a/tests/suites/1_stateful/00_stage/00_0000_copy_from_internal_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0000_copy_from_internal_stage.sh
@@ -5,28 +5,28 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists iti" | $BENDSQL_CLIENT_CONNECT
-echo "create table iti (a int, b string, c int)" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists iti" | bendsql_connect_root
+echo "create table iti (a int, b string, c int)" | bendsql_connect_root
 
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE s1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s1" | bendsql_connect_root
+echo "CREATE STAGE s1;" | bendsql_connect_root
 
 for STAGE in "s1" "~"
 do
 	echo "---- testing @$STAGE;"
-	echo "remove @$STAGE;" | $BENDSQL_CLIENT_CONNECT
-	echo "truncate table iti;" | $BENDSQL_CLIENT_CONNECT
+	echo "remove @$STAGE;" | bendsql_connect_root
+	echo "truncate table iti;" | bendsql_connect_root
 
 	curl -s -u root: -XPUT -H "x-databend-stage-name:${STAGE}" -F "upload=@${TESTS_DATA_DIR}/csv/sample.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" | jq -r '.state'
-	echo "list @$STAGE" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+	echo "list @$STAGE" | bendsql_connect_root | awk '{print $1}' | sort
 	echo "-- testing copy;"
-  echo "copy into iti from @$STAGE FILE_FORMAT = (type = CSV skip_header = 1) force=true;" | $BENDSQL_CLIENT_CONNECT
-  echo "select count(*) from iti;" | $BENDSQL_CLIENT_CONNECT
+  echo "copy into iti from @$STAGE FILE_FORMAT = (type = CSV skip_header = 1) force=true;" | bendsql_connect_root
+  echo "select count(*) from iti;" | bendsql_connect_root
 
 	echo "-- testing copy with purge;"
-	echo "truncate table iti;" | $BENDSQL_CLIENT_CONNECT
-  echo "copy into iti from @$STAGE FILE_FORMAT = (type = CSV skip_header = 1) purge=true;" | $BENDSQL_CLIENT_CONNECT
-  echo "select count(*) from iti;" | $BENDSQL_CLIENT_CONNECT
+	echo "truncate table iti;" | bendsql_connect_root
+  echo "copy into iti from @$STAGE FILE_FORMAT = (type = CSV skip_header = 1) purge=true;" | bendsql_connect_root
+  echo "select count(*) from iti;" | bendsql_connect_root
 done
 
 echo "---- check files are purged;"
@@ -34,5 +34,5 @@ echo "---- check files are purged;"
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 ls s3://testbucket/admin/stage/internal/s1/ | grep -o sample.csv  | wc -l | sed 's/ //g'
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 ls s3://testbucket/admin/stage/user/root/ | grep -o sample.csv  | wc -l | sed 's/ //g'
 
-echo "drop table if exists iti" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists iti" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root

--- a/tests/suites/1_stateful/00_stage/00_0001_copy_into_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0001_copy_into_stage.sh
@@ -3,34 +3,34 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists test_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE if exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE s2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_table;" | bendsql_connect_root
+echo "drop STAGE if exists s2;" | bendsql_connect_root
+echo "CREATE STAGE s2;" | bendsql_connect_root
 
 echo "CREATE TABLE test_table (
     id INTEGER,
     name VARCHAR,
     age INT
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 for i in `seq 1 10`;do
-    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | $BENDSQL_CLIENT_CONNECT
+    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | bendsql_connect_root
 done
 
 # The last column `output_bytes` is excluded to avoid flakiness
-echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV);" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
-echo "copy into @s2 from (select name, age, id from test_table limit 100) FILE_FORMAT = (type = 'PARQUET');" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
-echo "list @s2;" | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
+echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV);" | bendsql_connect_root | cut -d$'\t' -f1,2
+echo "copy into @s2 from (select name, age, id from test_table limit 100) FILE_FORMAT = (type = 'PARQUET');" | bendsql_connect_root | cut -d$'\t' -f1,2
+echo "list @s2;" | bendsql_connect_root | wc -l | sed 's/ //g'
 
 
 # The last column `output_bytes` is excluded to avoid flakiness
-echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 10;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
+echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 10;" | bendsql_connect_root | cut -d$'\t' -f1,2
 
-lines=`echo "list @s2;" | $BENDSQL_CLIENT_CONNECT | wc -l`
+lines=`echo "list @s2;" | bendsql_connect_root | wc -l`
 
 if [ $lines -eq 1 ];then
     echo "More than one line"
 fi
 
-echo "drop STAGE s2;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table test_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop STAGE s2;" | bendsql_connect_root
+echo "drop table test_table;" | bendsql_connect_root

--- a/tests/suites/1_stateful/00_stage/00_0003_copy_with_max_files_parquet.sh
+++ b/tests/suites/1_stateful/00_stage/00_0003_copy_with_max_files_parquet.sh
@@ -12,11 +12,11 @@ do
 	for purge in 'false'  'true'
 	do
 		table="test_max_files_force_${force}_purge_${purge}"
-		echo "drop table if exists ${table}" | $BENDSQL_CLIENT_CONNECT
+		echo "drop table if exists ${table}" | bendsql_connect_root
 		echo "CREATE TABLE ${table} (
       id INT,
       c1 INT
-    ) ENGINE=FUSE;" | $BENDSQL_CLIENT_CONNECT
+    ) ENGINE=FUSE;" | bendsql_connect_root
 	done
 done
 
@@ -26,8 +26,8 @@ gen_files() {
   cp  "$TESTS_DATA_DIR"/parquet/ii/* $TMP
 }
 
-echo "drop stage if exists s5;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s5 url = 'fs://$TMP/' FILE_FORMAT = (type = PARQUET)" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s5;" | bendsql_connect_root
+echo "create stage s5 url = 'fs://$TMP/' FILE_FORMAT = (type = PARQUET)" | bendsql_connect_root
 
 
 for force in 'false'  'true'
@@ -40,11 +40,11 @@ do
 		do
 			echo "--- --- 'copy max_files=2' ${i}"
 			table="test_max_files_force_${force}_purge_${purge}"
-			copied=$(echo "copy into ${table} from (select * from @s5 t) max_files=2 force=${force} purge=${purge}" | $BENDSQL_CLIENT_CONNECT | wc -l  |  sed 's/ //g')
+			copied=$(echo "copy into ${table} from (select * from @s5 t) max_files=2 force=${force} purge=${purge}" | bendsql_connect_root | wc -l  |  sed 's/ //g')
 			echo "copied ${copied} files"
 		  remain=$(ls -1 $TMP | wc -l |  sed 's/ //g')
 			echo "remain ${remain} files"
-			remain=$(echo "select count(*) from ${table}" | $BENDSQL_CLIENT_CONNECT)
+			remain=$(echo "select count(*) from ${table}" | bendsql_connect_root)
 			echo "remain ${remain} rows"
 		done
 	done
@@ -54,6 +54,6 @@ for force in 'false'  'true'
 do
 	for purge in 'false'  'true'
 	do
-		echo "drop table if exists test_max_files_force_${force}_purge_${purge}" | $BENDSQL_CLIENT_CONNECT
+		echo "drop table if exists test_max_files_force_${force}_purge_${purge}" | bendsql_connect_root
 	done
 done

--- a/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
+++ b/tests/suites/1_stateful/00_stage/00_0004_copy_with_max_files.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_bendsql() {
-  $BENDSQL_CLIENT_CONNECT <<SQL
+  bendsql_connect_root <<SQL
 $1
 SQL
 }
@@ -61,11 +61,11 @@ do
 			do
 				table="test_max_files_force_${force}_purge_${purge}_transform_${transform}"
 				if [ "$transform" = true ]; then
-					copied=$(echo "copy into ${table} from 'fs:///tmp/00_0004/' FILE_FORMAT = (type = CSV) max_files=2 force=${force} purge=${purge}" | $BENDSQL_CLIENT_CONNECT | wc -l |  sed 's/ //g')
+					copied=$(echo "copy into ${table} from 'fs:///tmp/00_0004/' FILE_FORMAT = (type = CSV) max_files=2 force=${force} purge=${purge}" | bendsql_connect_root | wc -l |  sed 's/ //g')
         else
-					copied=$(echo "copy into ${table} from (select \$1, \$2 from 'fs:///tmp/00_0004/') FILE_FORMAT = (type = CSV) max_files=2 force=${force} purge=${purge}" | $BENDSQL_CLIENT_CONNECT | wc -l |  sed 's/ //g')
+					copied=$(echo "copy into ${table} from (select \$1, \$2 from 'fs:///tmp/00_0004/') FILE_FORMAT = (type = CSV) max_files=2 force=${force} purge=${purge}" | bendsql_connect_root | wc -l |  sed 's/ //g')
         fi
-				copied_rows=$(echo "select count(*) from ${table}" | $BENDSQL_CLIENT_CONNECT)
+				copied_rows=$(echo "select count(*) from ${table}" | bendsql_connect_root)
 				remain=$(ls -1 /tmp/00_0004/ | wc -l |  sed 's/ //g')
 				echo "copied ${copied} files with ${copied_rows} rows, remain ${remain} files"
 			done

--- a/tests/suites/1_stateful/00_stage/00_0006_upload_to_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0006_upload_to_stage.sh
@@ -4,18 +4,18 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "drop stage if exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE if not exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "list @s2" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s2;" | bendsql_connect_root
+echo "CREATE STAGE if not exists s2;" | bendsql_connect_root
+echo "list @s2" | bendsql_connect_root
 
 # both stage_name and x-databend-stage-name is allowed
 curl -u root: -XPUT -H "stage_name:s2" -F "upload=@${TESTS_DATA_DIR}/csv/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 curl -u root: -XPUT -H "x-databend-stage-name:s2" -H "relative_path:test" -F "upload=@${TESTS_DATA_DIR}/csv/books.csv" "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/upload_to_stage" > /dev/null 2>&1
 
-echo "list @s2" | $BENDSQL_CLIENT_CONNECT | awk '{print $1,$2,$3}'
-echo "drop stage s2;" | $BENDSQL_CLIENT_CONNECT
+echo "list @s2" | bendsql_connect_root | awk '{print $1,$2,$3}'
+echo "drop stage s2;" | bendsql_connect_root
 
 # test drop stage
-echo "CREATE STAGE if not exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "list @s2" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage s2;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE if not exists s2;" | bendsql_connect_root
+echo "list @s2" | bendsql_connect_root
+echo "drop stage s2;" | bendsql_connect_root

--- a/tests/suites/1_stateful/00_stage/00_0007_copy_into_stage2.sh
+++ b/tests/suites/1_stateful/00_stage/00_0007_copy_into_stage2.sh
@@ -3,26 +3,26 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists test_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE if exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE s2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_table;" | bendsql_connect_root
+echo "drop STAGE if exists s2;" | bendsql_connect_root
+echo "CREATE STAGE s2;" | bendsql_connect_root
 
 STAGE_DIR=/tmp/copy_into_stage2
 
 rm -rf "$STAGE_DIR"
 
-echo "drop stage if exists s1;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s1 url = 'fs:///$STAGE_DIR/' FILE_FORMAT = (type = PARQUET)" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s1;" | bendsql_connect_root
+echo "create stage s1 url = 'fs:///$STAGE_DIR/' FILE_FORMAT = (type = PARQUET)" | bendsql_connect_root
 
 echo "CREATE TABLE test_table (
     id INTEGER,
     name VARCHAR,
     age INT
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 # each insert create a block
 for i in `seq 1 10`;do
-    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | $BENDSQL_CLIENT_CONNECT
+    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | bendsql_connect_root
 done
 
 check_csv() {
@@ -32,22 +32,22 @@ check_csv() {
 }
 
 # each block create a CSV chunk of size 16
-echo "copy into @s1/csv from test_table FILE_FORMAT = (type = CSV);" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s1/csv from test_table FILE_FORMAT = (type = CSV);" | bendsql_connect_root
 check_csv "csv"
-echo "copy into @s1/csv_single from test_table FILE_FORMAT = (type = CSV) single=true;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s1/csv_single from test_table FILE_FORMAT = (type = CSV) single=true;" | bendsql_connect_root
 check_csv "csv_single"
-echo "copy into @s1/csv_10 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 10;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s1/csv_10 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 10;" | bendsql_connect_root
 check_csv "csv_10"
-echo "copy into @s1/csv_20 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 20;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s1/csv_20 from test_table FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 20;" | bendsql_connect_root
 check_csv "csv_20"
 
-echo "drop table if exists t1;" | $BENDSQL_CLIENT_CONNECT
-echo "create table t1 (a int);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1;" | bendsql_connect_root
+echo "create table t1 (a int);" | bendsql_connect_root
 
 ## CSV slice block by 1024, so we should get 2 CSV files but one parquet file.
 for i in $(seq 1 2000);do
   echo "$i" >> "$STAGE_DIR"/big.csv
 done
-echo "copy into t1 from @s1/big.csv FILE_FORMAT = (type = CSV);" | $BENDSQL_CLIENT_CONNECT
-echo "copy into @s1/csv_big_20 from t1 FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 20;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into t1 from @s1/big.csv FILE_FORMAT = (type = CSV);" | bendsql_connect_root
+echo "copy into @s1/csv_big_20 from t1 FILE_FORMAT = (type = CSV) MAX_FILE_SIZE = 20;" | bendsql_connect_root
 check_csv "csv_big_20"

--- a/tests/suites/1_stateful/00_stage/00_0008_remove_external_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0008_remove_external_stage.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "drop stage if exists named_external_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists named_external_stage" | bendsql_connect_root
 
 ## tempdate/
 aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/ontime_200.csv s3://testbucket/tempdata/ontime_200.csv >/dev/null 2>&1
@@ -17,32 +17,32 @@ aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/ontime
 aws --endpoint-url  ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/ontime_200.csv.zst s3://testbucket/tempdata/dir/ontime_200.csv.zst >/dev/null 2>&1
 
 ## Copy from named external stage
-echo "CREATE STAGE named_external_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE named_external_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 ## List files in internal stage
 echo "=== List files in external stage ==="
-echo "list @named_external_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "list @named_external_stage" | bendsql_connect_root | awk '{print $1}' | sort
 
 ## Remove external stage file
 echo "=== Test remove external stage file ==="
-echo "remove @named_external_stage/ontime_200.csv.gz" | $BENDSQL_CLIENT_CONNECT
-echo "list @named_external_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
-echo "remove @named_external_stage/dir/ontime_200.csv.gz" | $BENDSQL_CLIENT_CONNECT
-echo "list @named_external_stage/dir/" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "remove @named_external_stage/ontime_200.csv.gz" | bendsql_connect_root
+echo "list @named_external_stage" | bendsql_connect_root | awk '{print $1}' | sort
+echo "remove @named_external_stage/dir/ontime_200.csv.gz" | bendsql_connect_root
+echo "list @named_external_stage/dir/" | bendsql_connect_root | awk '{print $1}' | sort
 
 ## Remove external stage file with pattern
 echo "=== Test remove external stage file with pattern ==="
-echo "remove @named_external_stage/dir/ PATTERN = '.*zst'" | $BENDSQL_CLIENT_CONNECT
-echo "list @named_external_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
-echo "remove @named_external_stage PATTERN = '.*zst'" | $BENDSQL_CLIENT_CONNECT
-echo "list @named_external_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "remove @named_external_stage/dir/ PATTERN = '.*zst'" | bendsql_connect_root
+echo "list @named_external_stage" | bendsql_connect_root | awk '{print $1}' | sort
+echo "remove @named_external_stage PATTERN = '.*zst'" | bendsql_connect_root
+echo "list @named_external_stage" | bendsql_connect_root | awk '{print $1}' | sort
 
-echo "drop stage named_external_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage named_external_stage" | bendsql_connect_root
 
 echo "=== Test create or replace external stage ==="
-echo "CREATE STAGE replace_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE replace_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 echo "=== List files in external stage ==="
-echo "list @replace_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
-echo "CREATE OR REPLACE STAGE replace_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "list @replace_stage" | bendsql_connect_root | awk '{print $1}' | sort
+echo "CREATE OR REPLACE STAGE replace_stage url = 's3://testbucket/tempdata/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin'  endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 echo "=== After create or replace List files in external stage again ==="
-echo "list @replace_stage" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "list @replace_stage" | bendsql_connect_root | awk '{print $1}' | sort

--- a/tests/suites/1_stateful/00_stage/00_0009_remove_internal_stage.sh
+++ b/tests/suites/1_stateful/00_stage/00_0009_remove_internal_stage.sh
@@ -4,10 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s1" | bendsql_connect_root
 
 ## Copy from internal stage
-echo "CREATE STAGE s1;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE s1;" | bendsql_connect_root
 
 aws --endpoint-url http://127.0.0.1:9900/ s3 cp s3://testbucket/data/ontime_200.csv s3://testbucket/admin/stage/internal/s1/ontime_200.csv >/dev/null 2>&1
 aws --endpoint-url http://127.0.0.1:9900/ s3 cp s3://testbucket/data/ontime_200.csv.gz s3://testbucket/admin/stage/internal/s1/ontime_200.csv.gz >/dev/null 2>&1
@@ -19,20 +19,20 @@ aws --endpoint-url http://127.0.0.1:9900/ s3 cp s3://testbucket/data/ontime_200.
 
 ## List files in internal stage
 echo "=== List files in internal stage ==="
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "list @s1" | bendsql_connect_root | awk '{print $1}' | sort
 
 ## Remove internal stage file
 echo "=== Test remove internal stage file ==="
-echo "remove @s1/ontime_200.csv.gz" | $BENDSQL_CLIENT_CONNECT
-echo "remove @s1/dir/ontime_200.csv.gz" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1/dir/" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}'| sort
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "remove @s1/ontime_200.csv.gz" | bendsql_connect_root
+echo "remove @s1/dir/ontime_200.csv.gz" | bendsql_connect_root
+echo "list @s1/dir/" | bendsql_connect_root | awk '{print $1}'| sort
+echo "list @s1" | bendsql_connect_root | awk '{print $1}' | sort
 
 ## Remove internal stage file with pattern
 echo "=== Test remove internal stage file with pattern ==="
-echo "remove @s1/dir/ PATTERN = '.*zst'" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
-echo "remove @s1 PATTERN = 'ontime.*'" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}' | sort
+echo "remove @s1/dir/ PATTERN = '.*zst'" | bendsql_connect_root
+echo "list @s1" | bendsql_connect_root | awk '{print $1}' | sort
+echo "remove @s1 PATTERN = 'ontime.*'" | bendsql_connect_root
+echo "list @s1" | bendsql_connect_root | awk '{print $1}' | sort
 
-echo "drop stage s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage s1" | bendsql_connect_root

--- a/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table.sh
+++ b/tests/suites/1_stateful/00_stage/00_0011_distributed_copy_into_table.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "set global max_threads = 1" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists products;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s0011;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE s0011 FILE_FORMAT = (TYPE = CSV);" | $BENDSQL_CLIENT_CONNECT
-echo "create table products (id int, name string, description string);" | $BENDSQL_CLIENT_CONNECT
+echo "set global max_threads = 1" | bendsql_connect_root
+echo "drop table if exists products;" | bendsql_connect_root
+echo "drop stage if exists s0011;" | bendsql_connect_root
+echo "CREATE STAGE s0011 FILE_FORMAT = (TYPE = CSV);" | bendsql_connect_root
+echo "create table products (id int, name string, description string);" | bendsql_connect_root
 
 #multi files to trigger distributed test
 curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/csv/itt.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
@@ -15,14 +15,14 @@ curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../..
 curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/csv/sample_3_replace.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/csv/sample_3_duplicate.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
 
-echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv';" | $BENDSQL_CLIENT_CONNECT
-echo "select * from products order by id,name,description;" | $BENDSQL_CLIENT_CONNECT
-echo "select count(*) from products;" | $BENDSQL_CLIENT_CONNECT
+echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv';" | bendsql_connect_root
+echo "select * from products order by id,name,description;" | bendsql_connect_root
+echo "select count(*) from products;" | bendsql_connect_root
 ## error test!!!
 curl -s -u root: -H "x-databend-stage-name:s0011" -F "upload=@${CURDIR}/../../../data/csv/sample_2_columns.csv" -XPUT "http://localhost:8000/v1/upload_to_stage" -u root: | jq ".data"
-echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | $BENDSQL_CLIENT_CONNECT 2>&1
-echo "select count(*) from products;" | $BENDSQL_CLIENT_CONNECT
-echo "list @s0011;" | $BENDSQL_CLIENT_CONNECT | grep -o 'csv' | wc -l | sed 's/ //g'
-echo "set enable_distributed_copy_into = 1;copy into products from (select \$1,\$2,\$3 from @s0011 as t2) force = true purge = true;"  | $BENDSQL_CLIENT_CONNECT
-echo "select count(*) from products;" | $BENDSQL_CLIENT_CONNECT
-echo "list @s0011;" | $BENDSQL_CLIENT_CONNECT | grep -o 'csv' | wc -l | sed 's/ //g'
+echo "set enable_distributed_copy_into = 1;copy into products from @s0011 pattern = '.*[.]csv' purge = true;"  | bendsql_connect_root 2>&1
+echo "select count(*) from products;" | bendsql_connect_root
+echo "list @s0011;" | bendsql_connect_root | grep -o 'csv' | wc -l | sed 's/ //g'
+echo "set enable_distributed_copy_into = 1;copy into products from (select \$1,\$2,\$3 from @s0011 as t2) force = true purge = true;"  | bendsql_connect_root
+echo "select count(*) from products;" | bendsql_connect_root
+echo "list @s0011;" | bendsql_connect_root | grep -o 'csv' | wc -l | sed 's/ //g'

--- a/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
+++ b/tests/suites/1_stateful/00_stage/00_0012_stage_priv.sh
@@ -5,114 +5,114 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 export TEST_USER_NAME="u1"
 export TEST_USER_PASSWORD="password"
-export TEST_USER_CONNECT="bendsql_query_http_user_connect u1 password -A"
-export USER_B_CONNECT="bendsql_query_http_user_connect b password -A"
+export TEST_USER_CONNECT="bendsql_connect_user u1 password -A"
+export USER_B_CONNECT="bendsql_connect_user b password -A"
 export RM_UUID="sed -E ""s/[-a-z0-9]{32,36}/UUID/g"""
 
-echo "drop table if exists test_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop user if exists u1;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE if exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE if exists s1;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE STAGE s2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_table;" | bendsql_connect_root
+echo "drop user if exists u1;" | bendsql_connect_root
+echo "drop STAGE if exists s2;" | bendsql_connect_root
+echo "drop STAGE if exists s1;" | bendsql_connect_root
+echo "CREATE STAGE s2;" | bendsql_connect_root
 
 echo "CREATE TABLE test_table (
     id INTEGER,
     name VARCHAR,
     age INT
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 for i in $(seq 1 10); do
-    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | $BENDSQL_CLIENT_CONNECT
+    echo "insert into test_table (id,name,age) values(1,'2',3), (4, '5', 6);" | bendsql_connect_root
 done
 
 STAGE_DIR=/tmp/copy_into_stage2
 
 rm -rf "$STAGE_DIR"
-echo "create stage s1 url = 'fs:///$STAGE_DIR/' FILE_FORMAT = (type = CSV)" | $BENDSQL_CLIENT_CONNECT
+echo "create stage s1 url = 'fs:///$STAGE_DIR/' FILE_FORMAT = (type = CSV)" | bendsql_connect_root
 
-echo "create user u1 identified by 'password';" | $BENDSQL_CLIENT_CONNECT
-echo "grant insert on default.test_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "create user u1 identified by 'password';" | bendsql_connect_root
+echo "grant insert on default.test_table to u1;" | bendsql_connect_root
 echo "==== check internal stage write priv ==="
 echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
-echo "grant Write on stage s2 to 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "grant Write on stage s2 to 'u1'" | bendsql_connect_root
 echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
-echo "grant select on default.test_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on default.test_table to u1;" | bendsql_connect_root
 echo "copy into @s2 from test_table FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
-echo "list @s2;" | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
+echo "list @s2;" | bendsql_connect_root | wc -l | sed 's/ //g'
 
 echo "==== check external stage priv ==="
 echo "copy into @s1/csv/ from test_table FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
-echo "grant write on stage s1 to 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "grant write on stage s1 to 'u1'" | bendsql_connect_root
 echo "copy into @s1/csv/ from test_table FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
 echo "copy into test_table from @s1/csv/ FILE_FORMAT = (type = CSV skip_header = 0) force=true;" | $TEST_USER_CONNECT | $RM_UUID
-echo "grant read on stage s1 to 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "grant read on stage s1 to 'u1'" | bendsql_connect_root
 echo "copy into test_table from @s1/csv/ FILE_FORMAT = (type = CSV skip_header = 0) force=true;" | $TEST_USER_CONNECT | $RM_UUID
 
 echo "==== check internal stage read priv ==="
-echo "truncate table test_table;" | $BENDSQL_CLIENT_CONNECT
+echo "truncate table test_table;" | bendsql_connect_root
 echo "copy into test_table from @s2 FILE_FORMAT = (type = CSV skip_header = 0) force=true;" | $TEST_USER_CONNECT | $RM_UUID
-echo "grant Read on stage s2 to 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "grant Read on stage s2 to 'u1'" | bendsql_connect_root
 echo "copy into test_table from @s2 FILE_FORMAT = (type = CSV skip_header = 0) force=true;" | $TEST_USER_CONNECT | $RM_UUID
 
 echo "==== check schema evolution alter priv ==="
-echo "drop table if exists se_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists se_query_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
-echo "create table se_table(a int);" | $BENDSQL_CLIENT_CONNECT
-echo "alter table se_table set options(enable_schema_evolution = true);" | $BENDSQL_CLIENT_CONNECT
-echo "create table se_query_table(a int);" | $BENDSQL_CLIENT_CONNECT
-echo "alter table se_query_table set options(enable_schema_evolution = true);" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
-echo "copy into @s_schema_evolution from (select 1 as a, 2 as b) file_format=(type=ndjson);" | $BENDSQL_CLIENT_CONNECT >/dev/null
-echo "grant read on stage s_schema_evolution to u1;" | $BENDSQL_CLIENT_CONNECT
-echo "grant insert on default.se_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists se_table;" | bendsql_connect_root
+echo "drop table if exists se_query_table;" | bendsql_connect_root
+echo "drop stage if exists s_schema_evolution;" | bendsql_connect_root
+echo "create table se_table(a int);" | bendsql_connect_root
+echo "alter table se_table set options(enable_schema_evolution = true);" | bendsql_connect_root
+echo "create table se_query_table(a int);" | bendsql_connect_root
+echo "alter table se_query_table set options(enable_schema_evolution = true);" | bendsql_connect_root
+echo "create stage s_schema_evolution;" | bendsql_connect_root
+echo "copy into @s_schema_evolution from (select 1 as a, 2 as b) file_format=(type=ndjson);" | bendsql_connect_root >/dev/null
+echo "grant read on stage s_schema_evolution to u1;" | bendsql_connect_root
+echo "grant insert on default.se_table to u1;" | bendsql_connect_root
 echo "copy into se_table from @s_schema_evolution/ file_format=(type=ndjson missing_field_as=field_default) force=true;" | $TEST_USER_CONNECT | $RM_UUID
-echo "grant alter on default.se_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "grant alter on default.se_table to u1;" | bendsql_connect_root
 echo "copy into se_table from @s_schema_evolution/ file_format=(type=ndjson missing_field_as=field_default) force=true;" | $TEST_USER_CONNECT | $RM_UUID
-echo "select a, b from se_table;" | $BENDSQL_CLIENT_CONNECT
-echo "grant insert on default.se_query_table to u1;" | $BENDSQL_CLIENT_CONNECT
+echo "select a, b from se_table;" | bendsql_connect_root
+echo "grant insert on default.se_query_table to u1;" | bendsql_connect_root
 echo "copy into se_query_table from (select to_int32(\$1:a) from @s_schema_evolution) file_format=(type=ndjson) force=true;" | $TEST_USER_CONNECT | $RM_UUID
-echo "select * from se_query_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table se_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table se_query_table;" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage s_schema_evolution;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from se_query_table;" | bendsql_connect_root
+echo "drop table se_table;" | bendsql_connect_root
+echo "drop table se_query_table;" | bendsql_connect_root
+echo "drop stage s_schema_evolution;" | bendsql_connect_root
 
 echo "remove @s2;" | $TEST_USER_CONNECT
-echo "remove @s1;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE s2;" | $BENDSQL_CLIENT_CONNECT
-echo "drop STAGE s1;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table test_table;" | $BENDSQL_CLIENT_CONNECT
+echo "remove @s1;" | bendsql_connect_root
+echo "drop STAGE s2;" | bendsql_connect_root
+echo "drop STAGE s1;" | bendsql_connect_root
+echo "drop table test_table;" | bendsql_connect_root
 
 echo "=== check presign ==="
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root
 
-echo "CREATE STAGE presign_stage;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE presign_stage;" | bendsql_connect_root
 
 # Most arguments is the same with previous, except:
 # -X PUT: Specify the http method
-echo "grant Write, Read on stage presign_stage to 'u1'" | $BENDSQL_CLIENT_CONNECT
-echo "revoke Write on stage presign_stage from 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "grant Write, Read on stage presign_stage to 'u1'" | bendsql_connect_root
+echo "revoke Write on stage presign_stage from 'u1'" | bendsql_connect_root
 curl -s -w "%{http_code}\n" -X PUT -o /dev/null -H Content-Type:application/octet-stream "$(echo "PRESIGN UPLOAD @presign_stage/hello_world.txt CONTENT_TYPE='application/octet-stream'" | $TEST_USER_CONNECT)"
 
-echo "revoke Read on stage presign_stage from 'u1'" | $BENDSQL_CLIENT_CONNECT
+echo "revoke Read on stage presign_stage from 'u1'" | bendsql_connect_root
 curl -s -w "%{http_code}\n" -o /dev/null "$(echo "PRESIGN @presign_stage/hello_word.txt" | $TEST_USER_CONNECT)"
 
-echo "drop stage if exists s3" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s3" | bendsql_connect_root
 
-echo "create stage s3;" | $BENDSQL_CLIENT_CONNECT
+echo "create stage s3;" | bendsql_connect_root
 echo "remove @s3;" | $TEST_USER_CONNECT
-echo "grant write on stage s3 to u1" | $BENDSQL_CLIENT_CONNECT
+echo "grant write on stage s3 to u1" | bendsql_connect_root
 echo "remove @s3;" | $TEST_USER_CONNECT
 echo "copy into '@s3/a b' from (select 2);" | $TEST_USER_CONNECT | $RM_UUID | cut -d$'\t' -f1,2
 
-echo "grant select on system.* to u1" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on system.* to u1" | bendsql_connect_root
 
 echo "select * from @s3" | $TEST_USER_CONNECT
 echo "select * from infer_schema(location => '@s3')" | $TEST_USER_CONNECT
 echo "select * from list_stage(location => '@s3')" | $TEST_USER_CONNECT
 echo "select * from inspect_parquet('@s3')" | $TEST_USER_CONNECT
 
-echo "grant read on stage s3 to u1" | $BENDSQL_CLIENT_CONNECT
+echo "grant read on stage s3 to u1" | bendsql_connect_root
 
 echo "select * from @s3" | $TEST_USER_CONNECT
 echo "select 1 from infer_schema(location => '@s3')" | $TEST_USER_CONNECT
@@ -127,29 +127,29 @@ cat <<EOF >/tmp/00_0012/i0.csv
 2,2
 EOF
 
-echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t" | bendsql_connect_root
 echo "select \$1, \$2 from 'fs:///tmp/00_0012/' (FILE_FORMAT => 'CSV')" | $TEST_USER_CONNECT
-echo "create table t(c1 int, c2 int)" | $BENDSQL_CLIENT_CONNECT
-echo "grant select, insert on default.t to u1" | $BENDSQL_CLIENT_CONNECT
+echo "create table t(c1 int, c2 int)" | bendsql_connect_root
+echo "grant select, insert on default.t to u1" | bendsql_connect_root
 echo "copy into t from 'fs:///tmp/00_0012/' FILE_FORMAT = (type = CSV);" | $TEST_USER_CONNECT
-echo "select * from t" | $BENDSQL_CLIENT_CONNECT
+echo "select * from t" | bendsql_connect_root
 
 echo "=== check access user's local stage ==="
 # file no need to check privileges
 curl -s -w "%{http_code}\n" -X PUT -o /dev/null -H Content-Type:application/octet-stream "$(echo "PRESIGN UPLOAD @~/hello_world.txt CONTENT_TYPE='application/octet-stream'" | $TEST_USER_CONNECT)"
 
 ## clean ups
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s3" | $BENDSQL_CLIENT_CONNECT
-echo "drop user u1" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root
+echo "drop stage if exists s3" | bendsql_connect_root
+echo "drop user u1" | bendsql_connect_root
+echo "drop table if exists t" | bendsql_connect_root
 
-echo "drop user if exists b" | $BENDSQL_CLIENT_CONNECT
-echo "create user b identified by '$TEST_USER_PASSWORD'" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
-echo "create table t(id int)" | $BENDSQL_CLIENT_CONNECT
+echo "drop user if exists b" | bendsql_connect_root
+echo "create user b identified by '$TEST_USER_PASSWORD'" | bendsql_connect_root
+echo "drop table if exists t" | bendsql_connect_root
+echo "create table t(id int)" | bendsql_connect_root
 
-echo "grant insert, delete on default.t to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant insert, delete on default.t to b" | bendsql_connect_root
 
 cat <<EOF >/tmp/00_0012/i1.csv
 1
@@ -158,10 +158,10 @@ EOF
 
 echo "insert into t select \$1 from 'fs:///tmp/00_0020/' (FILE_FORMAT => 'CSV');" | $USER_B_CONNECT
 
-echo "grant select on system.* to b" | $BENDSQL_CLIENT_CONNECT
+echo "grant select on system.* to b" | bendsql_connect_root
 
 echo "insert into t select \$1 from 'fs:///tmp/00_0020/' (FILE_FORMAT => 'CSV');" | $USER_B_CONNECT
 
-echo "drop table if exists t" | $BENDSQL_CLIENT_CONNECT
-echo "drop user if exists b" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t" | bendsql_connect_root
+echo "drop user if exists b" | bendsql_connect_root
 rm -rf /tmp/00_0012

--- a/tests/suites/1_stateful/00_stage/00_0014_parquet_missing_field.sh
+++ b/tests/suites/1_stateful/00_stage/00_0014_parquet_missing_field.sh
@@ -9,11 +9,11 @@ stmt "DROP TABLE IF EXISTS ontime"
 stmt "DROP STAGE IF EXISTS data"
 
 comment "create table ontime ..."
-cat $TESTS_DATA_DIR/ddl/ontime.sql |  $BENDSQL_CLIENT_CONNECT
+cat $TESTS_DATA_DIR/ddl/ontime.sql |  bendsql_connect_root
 stmt "ALTER TABLE ontime ADD COLUMN new_col int NOT NULL DEFAULT 3;"
 
 comment "create stage data..."
-echo "create stage data url='fs://$TESTS_DATA_DIR/';" |  $BENDSQL_CLIENT_CONNECT
+echo "create stage data url='fs://$TESTS_DATA_DIR/';" |  bendsql_connect_root
 
 query "copy into ontime from @data/ontime_200.parquet FILE_FORMAT = (type = parquet  missing_field_as = field_default);"
 query " select tail_number, new_col from ontime where dayofmonth=1 order by new_col"

--- a/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
+++ b/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 run_copy_count() {
-  echo "$1" | $BENDSQL_CLIENT_CONNECT | wc -l | sed 's/ //g'
+  echo "$1" | bendsql_connect_root | wc -l | sed 's/ //g'
 }
 
 SINGLE_ROW_COUNT=${COPY_PARQUET_SINGLE_ROW_COUNT:-600000}
@@ -37,7 +37,7 @@ run_copy_count "copy /*+ set_var(max_threads=4) set_var(max_memory_usage=${MEMOR
 stmt "remove @s1;"
 
 for i in `seq 1 ${COPY_ITERATIONS}`;do
-	echo "copy into @s1/ from (select number a, number + 1 b from numbers(20))" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+	echo "copy into @s1/ from (select number a, number + 1 b from numbers(20))" | bendsql_connect_root > /dev/null 2>&1
 done
 
 stmt "select count() from @s1 where a >= 0 and b <= 1000;"

--- a/tests/suites/1_stateful/01_streaming_load/01_0001_streaming_load_ontime.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0001_streaming_load_ontime.sh
@@ -4,16 +4,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 
-echo "drop table if exists ontime_streaming_load;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists ontime_streaming_load;" | bendsql_connect_root
 ## create ontime table
-cat $TESTS_DATA_DIR/ddl/ontime.sql | sed 's/ontime/ontime_streaming_load/g' | $BENDSQL_CLIENT_CONNECT
+cat $TESTS_DATA_DIR/ddl/ontime.sql | sed 's/ontime/ontime_streaming_load/g' | bendsql_connect_root
 
 function run() {
   echo "--$2"
   curl -sS -H "x-databend-query-id:$2" -H "X-Databend-SQL:insert into ontime_streaming_load  from @_databend_load  file_format = ($1)" -F "upload=@/${TESTS_DATA_DIR}/$2" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load" | jq -r '.id, .stats.rows'
   echo
-  echo "select count(1), avg(Year), sum(DayOfWeek)  from ontime_streaming_load;" | $BENDSQL_CLIENT_CONNECT
-  echo "truncate table ontime_streaming_load" | $BENDSQL_CLIENT_CONNECT
+  echo "select count(1), avg(Year), sum(DayOfWeek)  from ontime_streaming_load;" | bendsql_connect_root
+  echo "truncate table ontime_streaming_load" | bendsql_connect_root
 }
 
 run "type = CSV skip_header = 1" "ontime_200.csv"

--- a/tests/suites/1_stateful/01_streaming_load/01_0002_streaming_load_variant.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0002_streaming_load_variant.sh
@@ -3,10 +3,10 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists variant_test;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists variant_test2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists variant_test;" | bendsql_connect_root
+echo "drop table if exists variant_test2;" | bendsql_connect_root
 ## create variant_test and variant_test2 table
-cat ${TESTS_DATA_DIR}/ddl/variant_test.sql | $BENDSQL_CLIENT_CONNECT
+cat ${TESTS_DATA_DIR}/ddl/variant_test.sql | bendsql_connect_root
 
 # run format path table
 function run() {
@@ -18,11 +18,11 @@ function run() {
 run "type = CSV field_delimiter = ',' quote = '\''" "csv/json_sample1.csv" "variant_test"
 run "type = CSV field_delimiter = '|' quote = '\''" "csv/json_sample2.csv" "variant_test"
 
-echo "select * from variant_test order by Id asc;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from variant_test order by Id asc;" | bendsql_connect_root
 
 # load ndjson
 run "type = ndjson" "ndjson/json_sample.ndjson" "variant_test2"
-echo "select * from variant_test2 order by b asc;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from variant_test2 order by b asc;" | bendsql_connect_root
 
-echo "drop table variant_test;" | $BENDSQL_CLIENT_CONNECT
-echo "drop table variant_test2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table variant_test;" | bendsql_connect_root
+echo "drop table variant_test2;" | bendsql_connect_root

--- a/tests/suites/1_stateful/02_query/02_0001_create_table_with_external_location.sh
+++ b/tests/suites/1_stateful/02_query/02_0001_create_table_with_external_location.sh
@@ -3,10 +3,10 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists table_external_location;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_external_location;" | bendsql_connect_root
 
 ## Create table
-echo "create table table_external_location(a int) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "create table table_external_location(a int) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 table_inserts=(
   "insert into table_external_location(a) values(888)"
@@ -14,13 +14,13 @@ table_inserts=(
 )
 
 for i in "${table_inserts[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_CONNECT
+  echo "$i" | bendsql_connect_root
 done
 
 ## Select table
-echo "select * from table_external_location order by a;" | $BENDSQL_CLIENT_CONNECT
-echo "select is_external, storage_param from system.tables where name='table_external_location';" | $BENDSQL_CLIENT_CONNECT
+echo "select * from table_external_location order by a;" | bendsql_connect_root
+echo "select is_external, storage_param from system.tables where name='table_external_location';" | bendsql_connect_root
 
 ## Drop table
-echo "drop table if exists table_external_location;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_external_location;" | bendsql_connect_root
 

--- a/tests/suites/1_stateful/02_query/02_0003_create_table_with_block_per_segment.sh
+++ b/tests/suites/1_stateful/02_query/02_0003_create_table_with_block_per_segment.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists table_block_per_segment;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_block_per_segment;" | bendsql_connect_root
 
 ## Create table
-echo "create table table_block_per_segment(a int) block_per_segment = 2000;" | $BENDSQL_CLIENT_CONNECT
-echo "create table table_block_per_segment(a int) block_per_segment = 500;" | $BENDSQL_CLIENT_CONNECT
+echo "create table table_block_per_segment(a int) block_per_segment = 2000;" | bendsql_connect_root
+echo "create table table_block_per_segment(a int) block_per_segment = 500;" | bendsql_connect_root
 
 ## Drop table
-echo "drop table if exists table_block_per_segment;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_block_per_segment;" | bendsql_connect_root

--- a/tests/suites/1_stateful/02_query/02_0010_issue_17523.sh
+++ b/tests/suites/1_stateful/02_query/02_0010_issue_17523.sh
@@ -10,9 +10,9 @@ if [ -z "$port_check" ]; then
     exit 0
 fi
 
-echo "drop table if exists table_test_02_0010;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_test_02_0010;" | bendsql_connect_root
 
-echo "create table table_test_02_0010(TEXT String);" | $BENDSQL_CLIENT_CONNECT
+echo "create table table_test_02_0010(TEXT String);" | bendsql_connect_root
 
 
 table_inserts=(
@@ -23,24 +23,24 @@ table_inserts=(
 )
 
 for i in "${table_inserts[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_CONNECT
+  echo "$i" | bendsql_connect_root
 done
 
 
-echo "select * from table_test_02_0010 order by text;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from table_test_02_0010 order by text;" | bendsql_connect_root
 
 # kill a node
 sudo lsof -i :9093 -t | xargs -r sudo kill -9
 # wait for the node to be killed
 sleep 5
 
-echo "select count(*) from system.clusters;" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from system.clusters;" | bendsql_connect_root
 
-echo "select * from table_test_02_0010 order by text;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from table_test_02_0010 order by text;" | bendsql_connect_root
 
 # restart the node
 ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../../ && pwd)"
 env "RUST_BACKTRACE=1" nohup "$ROOTDIR"/target/${BUILD_PROFILE}/databend-query -c "$ROOTDIR"/scripts/ci/deploy/config/databend-query-node-3.toml --internal-enable-sandbox-tenant > "$ROOTDIR"/.databend/query-3.out 2>&1 &
 python3 "$ROOTDIR"/scripts/ci/wait_tcp.py --timeout 30 --port 9093 > /dev/null 2>&1
 
-echo "select count(*) from system.clusters;" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from system.clusters;" | bendsql_connect_root

--- a/tests/suites/1_stateful/03_presign/03_0000_presign_download.sh
+++ b/tests/suites/1_stateful/03_presign/03_0000_presign_download.sh
@@ -3,18 +3,18 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root
 
 aws --endpoint-url http://127.0.0.1:9900/ s3 cp s3://testbucket/data/ontime_200.csv s3://testbucket/admin/stage/internal/presign_stage/ontime_200.csv >/dev/null 2>&1
 
-echo "CREATE STAGE presign_stage;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE presign_stage;" | bendsql_connect_root
 
 # Here is the a magic of curl.
 # -s: make curl silent to avoid pollute our result.
 # -w "%{http_code}": only print http code so that we can use this for test.
 # -o /dev/null: redirect content to /dev/null to avoid pollute our result.
 # cut -f 3: get the third value of output - the url.
-curl -s -w "%{http_code}\n" -o /dev/null "`echo "PRESIGN @presign_stage/ontime_200.csv" | $BENDSQL_CLIENT_CONNECT | cut -f 3`"
+curl -s -w "%{http_code}\n" -o /dev/null "`echo "PRESIGN @presign_stage/ontime_200.csv" | bendsql_connect_root | cut -f 3`"
 
 ## Drop table.
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root

--- a/tests/suites/1_stateful/03_presign/03_0001_presign_upload.sh
+++ b/tests/suites/1_stateful/03_presign/03_0001_presign_upload.sh
@@ -3,17 +3,17 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root
 
-echo "CREATE STAGE presign_stage;" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE STAGE presign_stage;" | bendsql_connect_root
 
 # Most arguments is the same with previous, except:
 # -X PUT: Specify the http method
-curl -s -w "%{http_code}\n" -X PUT -o /dev/null -H Content-Type:application/octet-stream "`echo "PRESIGN UPLOAD @presign_stage/hello_world.txt CONTENT_TYPE='application/octet-stream'" | $BENDSQL_CLIENT_CONNECT | cut -f 3`" -d "Hello, World!"
+curl -s -w "%{http_code}\n" -X PUT -o /dev/null -H Content-Type:application/octet-stream "`echo "PRESIGN UPLOAD @presign_stage/hello_world.txt CONTENT_TYPE='application/octet-stream'" | bendsql_connect_root | cut -f 3`" -d "Hello, World!"
 
 # LIST will output file's updated time, so we only take first three of output:
 # file_name, file_size, file_md5
-echo "LIST @presign_stage/" | $BENDSQL_CLIENT_CONNECT | awk '{print $1,$2,$3}';
+echo "LIST @presign_stage/" | bendsql_connect_root | awk '{print $1,$2,$3}';
 
 ## Drop table.
-echo "drop stage if exists presign_stage" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists presign_stage" | bendsql_connect_root

--- a/tests/suites/1_stateful/04_mini_dataset/04_0000_mini_ontime.sh
+++ b/tests/suites/1_stateful/04_mini_dataset/04_0000_mini_ontime.sh
@@ -3,9 +3,9 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists ontime_mini;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists ontime_mini;" | bendsql_connect_root
 ## Create table
-cat $TESTS_DATA_DIR/ddl/ontime.sql | sed 's/ontime/ontime_mini/g' | $BENDSQL_CLIENT_CONNECT
+cat $TESTS_DATA_DIR/ddl/ontime.sql | sed 's/ontime/ontime_mini/g' | bendsql_connect_root
 
 ontime_statements=(
   ## Load data
@@ -25,8 +25,8 @@ ontime_statements=(
 )
 
 for i in "${ontime_statements[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_CONNECT
+  echo "$i" | bendsql_connect_root
 done
 
 ## Clean table
-echo "drop table if exists ontime_mini all;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists ontime_mini all;" | bendsql_connect_root

--- a/tests/suites/1_stateful/04_mini_dataset/04_0001_mini_hits.sh
+++ b/tests/suites/1_stateful/04_mini_dataset/04_0001_mini_hits.sh
@@ -3,9 +3,9 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists hits;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists hits;" | bendsql_connect_root
 ## Create table
-cat $TESTS_DATA_DIR/ddl/hits.sql | $BENDSQL_CLIENT_CONNECT
+cat $TESTS_DATA_DIR/ddl/hits.sql | bendsql_connect_root
 
 hits_statements=(
   ## load data
@@ -101,8 +101,8 @@ hits_statements=(
 )
 
 for i in "${hits_statements[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_CONNECT
+  echo "$i" | bendsql_connect_root
 done
 
 ## Clean up
-echo "drop table if exists hits all;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists hits all;" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_00_01_load_unload_all.sh
+++ b/tests/suites/1_stateful/05_formats/05_00_01_load_unload_all.sh
@@ -3,7 +3,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists test_load_unload" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_load_unload" | bendsql_connect_root
 
 # todo(youngsofun): add more types
 echo "CREATE TABLE test_load_unload
@@ -17,37 +17,37 @@ echo "CREATE TABLE test_load_unload
     g map(string,int),
     h tuple(string,int),
     i array(variant)
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 insert_data() {
 	echo "insert into test_load_unload values
 	('a\"b', 1, ['a\"b'], parse_json('{\"k\":\"v\"}'), '2044-05-06T03:25:02.868894-07:00', 010.011, {'k1':10,'k2':20}, ('a', 5), ['{\"k\":\"v\"}','[1,2,3]']),
 	(null, 2, ['a\'b'], parse_json('[1]'), '2044-05-06T03:25:02.868894-07:00', -010.011, {}, ('b',10), ['{\"ab\":\"c\'d\"}'])
-	" | $BENDSQL_CLIENT_CONNECT
+	" | bendsql_connect_root
 }
 
 test_format() {
 	echo "---${1}"
 	rm -rf /tmp/test_load_unload
 	mkdir /tmp/test_load_unload
-	echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
-	echo "create stage s1 url='fs:///tmp/test_load_unload/'" | $BENDSQL_CLIENT_CONNECT
-	echo "truncate table test_load_unload" | $BENDSQL_CLIENT_CONNECT
+	echo "drop stage if exists s1" | bendsql_connect_root
+	echo "create stage s1 url='fs:///tmp/test_load_unload/'" | bendsql_connect_root
+	echo "truncate table test_load_unload" | bendsql_connect_root
 
 	# insert
 	insert_data
 
 	# unload1
-	echo "copy into @s1/unload1/ from test_load_unload file_format=(type=${1})" | $BENDSQL_CLIENT_CONNECT
+	echo "copy into @s1/unload1/ from test_load_unload file_format=(type=${1})" | bendsql_connect_root
 	mv `ls /tmp/test_load_unload/unload1/*` /tmp/test_load_unload/unload1.txt
 	cat /tmp/test_load_unload/unload1.txt
 
 	# load unload1
-	echo "truncate table test_load_unload" | $BENDSQL_CLIENT_CONNECT
-	echo "copy into test_load_unload from @s1/unload1.txt file_format=(type=${1}) force=true" | $BENDSQL_CLIENT_CONNECT
+	echo "truncate table test_load_unload" | bendsql_connect_root
+	echo "copy into test_load_unload from @s1/unload1.txt file_format=(type=${1}) force=true" | bendsql_connect_root
 
 	# unload2
-	echo "copy into @s1/unload2/ from test_load_unload file_format=(type=${1})" | $BENDSQL_CLIENT_CONNECT
+	echo "copy into @s1/unload2/ from test_load_unload file_format=(type=${1})" | bendsql_connect_root
   mv `ls /tmp/test_load_unload/unload2/*` /tmp/test_load_unload/unload2.txt
   diff /tmp/test_load_unload/unload1.txt /tmp/test_load_unload/unload2.txt
 }
@@ -58,4 +58,4 @@ test_format "TEXT"
 
 test_format "NDJSON"
 
-echo "drop table if exists test_load_unload" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_load_unload" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_00_load_compact_copy.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_00_load_compact_copy.sh
@@ -10,25 +10,25 @@ for j in $(seq 1 1000);do
 	printf "0123456789\n" >> "$DATA"
 done
 
-echo "drop table if exists t1 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1 all" | bendsql_connect_root
 echo "CREATE TABLE t1
 (
     c0 string
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 echo "---s3 cp"
 aws --endpoint-url http://127.0.0.1:9900/ s3 cp $DATA s3://testbucket/$DATA > /dev/null 2>&1
 
 echo "---copy into"
 # let input data dispatch to multi threads
-echo "set global input_read_buffer_size = 100" | $BENDSQL_CLIENT_CONNECT
-echo "copy into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $BENDSQL_CLIENT_CONNECT
-echo "set global input_read_buffer_size = 4194304" | $BENDSQL_CLIENT_CONNECT
+echo "set global input_read_buffer_size = 100" | bendsql_connect_root
+echo "copy into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | bendsql_connect_root
+echo "set global input_read_buffer_size = 4194304" | bendsql_connect_root
 
 echo "---row_count"
-echo "select count(*) from t1" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t1" | bendsql_connect_root
 
 echo "---block_count"
-echo "select block_count from fuse_snapshot('default','t1')" | $BENDSQL_CLIENT_CONNECT
+echo "select block_count from fuse_snapshot('default','t1')" | bendsql_connect_root
 
-echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_max_size.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_max_size.sh
@@ -11,12 +11,12 @@ for j in $(seq 1 1000);do
 	printf "0123456789\n" >> "$DATA"
 done
 
-echo "drop table if exists t1 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1 all" | bendsql_connect_root
 echo "CREATE TABLE t1
 (
     c0 string
 ) engine=fuse block_size_threshold=5000;
-" | $BENDSQL_CLIENT_CONNECT
+" | bendsql_connect_root
 
 
 echo "---s3 cp"
@@ -24,14 +24,14 @@ aws --endpoint-url http://127.0.0.1:9900/ s3 cp $DATA s3://testbucket/$DATA > /d
 
 echo "---copy into"
 # let input data dispatch to multi threads
-# echo "set global max_threads = 1" | $BENDSQL_CLIENT_CONNECT # for debug
-echo "set global input_read_buffer_size = 100" | $BENDSQL_CLIENT_CONNECT
-echo "copy   /*+ set_var(input_read_buffer_size=100) */  into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $BENDSQL_CLIENT_CONNECT
+# echo "set global max_threads = 1" | bendsql_connect_root # for debug
+echo "set global input_read_buffer_size = 100" | bendsql_connect_root
+echo "copy   /*+ set_var(input_read_buffer_size=100) */  into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | bendsql_connect_root
 
 echo "---row_count"
-echo "select count(*) from t1" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t1" | bendsql_connect_root
 
 echo "---block_count"
-#echo "select block_count from fuse_snapshot('default','t1')" | $BENDSQL_CLIENT_CONNECT
+#echo "select block_count from fuse_snapshot('default','t1')" | bendsql_connect_root
 
-echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_row_per_block.sh
+++ b/tests/suites/1_stateful/05_formats/05_01_compact/05_01_02_load_compact_copy_row_per_block.sh
@@ -11,12 +11,12 @@ for j in $(seq 1 1000);do
 	printf "0123456789\n" >> "$DATA"
 done
 
-echo "drop table if exists t1 all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1 all" | bendsql_connect_root
 echo "CREATE TABLE t1
 (
     c0 string
 ) engine=fuse row_per_block=500;
-" | $BENDSQL_CLIENT_CONNECT
+" | bendsql_connect_root
 
 
 echo "---s3 cp"
@@ -24,12 +24,12 @@ aws --endpoint-url http://127.0.0.1:9900/ s3 cp $DATA s3://testbucket/$DATA > /d
 
 echo "---copy into"
 # let input data dispatch to multi threads
-echo "copy  /*+ set_var(input_read_buffer_size=100) set_var(max_threads=1) */ into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | $BENDSQL_CLIENT_CONNECT
+echo "copy  /*+ set_var(input_read_buffer_size=100) set_var(max_threads=1) */ into t1 from 's3://testbucket/${DATA}' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') FILE_FORMAT = (type = CSV) force=true" | bendsql_connect_root
 
 echo "---row_count"
-echo "select count(*) from t1" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from t1" | bendsql_connect_root
 
 echo "---block_count"
-echo "select block_count from fuse_snapshot('default','t1') limit 1" | $BENDSQL_CLIENT_CONNECT
+echo "select block_count from fuse_snapshot('default','t1') limit 1" | bendsql_connect_root
 
-echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_04_tsv/05_04_01_tsv_multi_file.sh
+++ b/tests/suites/1_stateful/05_formats/05_04_tsv/05_04_01_tsv_multi_file.sh
@@ -15,7 +15,7 @@ done
 aws --endpoint-url http://127.0.0.1:9900/ s3 cp /tmp/multi_tsv s3://testbucket/tmp/multi_tsv --recursive > /dev/null 2>&1
 
 ## prepare table
-echo "drop table if exists test_tsv" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists test_tsv" | bendsql_connect_root
 echo "CREATE TABLE test_tsv
 (
     c0 int,
@@ -28,14 +28,14 @@ echo "CREATE TABLE test_tsv
     c7 int,
     c8 int,
     c9 int
-);" | $BENDSQL_CLIENT_CONNECT
+);" | bendsql_connect_root
 
 # do copy
-echo "SET GLOBAL input_read_buffer_size = 111;" | $BENDSQL_CLIENT_CONNECT
+echo "SET GLOBAL input_read_buffer_size = 111;" | bendsql_connect_root
 COPY_SQL="copy into test_tsv from 's3://testbucket/tmp/multi_tsv/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900/') PATTERN = '.*' FILE_FORMAT = (type = TEXT) force=true"
-echo "${COPY_SQL}" |  $BENDSQL_CLIENT_CONNECT
-echo "SET GLOBAL input_read_buffer_size = 1048576;" | $BENDSQL_CLIENT_CONNECT
+echo "${COPY_SQL}" |  bendsql_connect_root
+echo "SET GLOBAL input_read_buffer_size = 1048576;" | bendsql_connect_root
 
 # check
-echo "select count(*) from test_tsv" |  $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists test_tsv" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from test_tsv" |  bendsql_connect_root
+echo "drop table if exists test_tsv" | bendsql_connect_root

--- a/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.sh
+++ b/tests/suites/1_stateful/05_formats/05_05_parquet/05_05_01_parquet_load_unload.sh
@@ -69,4 +69,4 @@
 
  test_format "PARQUET"
 
- echo "drop table if exists test_load_unload" | $BENDSQL_CLIENT_CONNECT
+ echo "drop table if exists test_load_unload" | bendsql_connect_root

--- a/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0000_insert_with_stage.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root
 
 ## Create table
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE TABLE sample_table
 (
     Id      INT NOT NULL,
@@ -20,8 +20,8 @@ EOF
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample.csv s3://testbucket/admin/stage/internal/s1/sample.csv >/dev/null
 
 ## Copy from internal stage
-echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}'
+echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | bendsql_connect_root
+echo "list @s1" | bendsql_connect_root | awk '{print $1}'
 
 ## Insert with stage use http API
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into sample_table (Id, City, Score) values", "stage_attachment": {"location": "@s1/sample.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.state, .stats.scan_progress.bytes, .error'
@@ -29,22 +29,22 @@ curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" -
 ## list stage has metacache, so we just we aws client to ensure the data are purged
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 ls s3://testbucket/admin/stage/internal/s1/sample.csv
 
-echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table" | bendsql_connect_root
 
 
 # use placeholder (?, ?, ?)
-echo "truncate table sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "truncate table sample_table" | bendsql_connect_root
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample.csv s3://testbucket/admin/stage/internal/s1/sample1.csv >/dev/null
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into sample_table (Id, City, Score) values (?,?,?)", "stage_attachment": {"location": "@s1/sample1.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.state, .stats.scan_progress.bytes, .error'
-echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table" | bendsql_connect_root
 
 # use placeholder (?, ?, 1+1)
-echo "truncate table sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "truncate table sample_table" | bendsql_connect_root
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample_2_columns.csv s3://testbucket/admin/stage/internal/s1/sample2.csv  >/dev/null
 
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "insert into sample_table (Id, City, Score) values (?,?,1+1)", "stage_attachment": {"location": "@s1/sample2.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.state, .stats.scan_progress.bytes, .error'
-echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table" | bendsql_connect_root
 #
 ### Drop table.
-echo "drop table sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root

--- a/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0001_replace_with_stage.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root
 
 ## Create table
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE TABLE sample_table
 (
     Id      INT NOT NULL,
@@ -20,8 +20,8 @@ EOF
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample.csv s3://testbucket/admin/stage/internal/s1/sample.csv >/dev/null
 
 ## Copy from internal stage
-echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}'
+echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | bendsql_connect_root
+echo "list @s1" | bendsql_connect_root | awk '{print $1}'
 
 ## Insert with stage use http API
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "replace into sample_table (Id, City, Score) ON(Id) VALUES", "stage_attachment": {"location": "@s1/sample.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.stats.scan_progress.bytes,.error'
@@ -29,29 +29,29 @@ curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" -
 ## list stage has metacache, so we just we aws client to ensure the data are purged
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 ls s3://testbucket/admin/stage/internal/s1/sample.csv
 
-echo "select * from sample_table order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table order by id" | bendsql_connect_root
 
 
 # use placeholder (?, ?, ?)
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample.csv s3://testbucket/admin/stage/internal/s1/sample1.csv >/dev/null
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "replace into sample_table (Id, City, Score) ON(Id) values (?,?,?)", "stage_attachment": {"location": "@s1/sample1.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.stats.scan_progress.bytes, .error'
-echo "select * from sample_table order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table order by id" | bendsql_connect_root
 
 # use placeholder (?, ?, 1+1)
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample_2_columns.csv s3://testbucket/admin/stage/internal/s1/sample2.csv  >/dev/null
 
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "replace into sample_table (Id, City, Score) ON(Id) values (?,?,1+1)", "stage_attachment": {"location": "@s1/sample2.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.stats.scan_progress.bytes, .error'
-echo "select * from sample_table order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table order by id" | bendsql_connect_root
 
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample_3_replace.csv s3://testbucket/admin/stage/internal/s1/sample3.csv >/dev/null
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "replace into sample_table (Id, City, Score) ON(Id) values (?,?,?)", "stage_attachment": {"location": "@s1/sample3.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.stats.scan_progress.bytes, .error'
-echo "select * from sample_table order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table order by id" | bendsql_connect_root
 
 # duplicate value would show error and would not take effect
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample_3_duplicate.csv s3://testbucket/admin/stage/internal/s1/sample4.csv >/dev/null
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" --header 'Content-Type: application/json' -d '{"sql": "replace into sample_table (Id, City, Score) ON(Id) values (?,?,?)", "stage_attachment": {"location": "@s1/sample4.csv", "copy_options": {"purge": "true"}}, "pagination": { "wait_time_secs": 3}}' | jq -r '.error'
-echo "select * from sample_table order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table order by id" | bendsql_connect_root
 
 ### Drop table.
-echo "drop table sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root

--- a/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.sh
+++ b/tests/suites/1_stateful/07_stage_attachment/07_0002_insert_with_stage_deduplicate.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root
 
 ## Create table
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE TABLE sample_table
 (
     Id      INT NOT NULL,
@@ -20,8 +20,8 @@ EOF
 aws --endpoint-url ${STORAGE_S3_ENDPOINT_URL} s3 cp s3://testbucket/data/csv/sample.csv s3://testbucket/admin/stage/internal/s1/sample.csv >/dev/null
 
 ## Copy from internal stage
-echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | $BENDSQL_CLIENT_CONNECT
-echo "list @s1" | $BENDSQL_CLIENT_CONNECT | awk '{print $1}'
+echo "CREATE STAGE s1 FILE_FORMAT = (TYPE = CSV)" | bendsql_connect_root
+echo "list @s1" | bendsql_connect_root | awk '{print $1}'
 
 ## Insert with stage use http API
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
@@ -37,7 +37,7 @@ curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
     }
   }' | jq -r '.stats.scan_progress.bytes, .error'
 
-echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table" | bendsql_connect_root
 
 ## Insert again with the same deduplicate_label will have no effect
 curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
@@ -54,8 +54,8 @@ curl -s -u root: -XPOST "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/query" \
   }' | jq -r '.stats.scan_progress.bytes, .error'
 
 
-echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "select * from sample_table" | bendsql_connect_root
 
 ### Drop table.
-echo "drop table sample_table" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table sample_table" | bendsql_connect_root
+echo "drop stage if exists s1" | bendsql_connect_root

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -3,60 +3,60 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../../shell_env.sh
 
-echo "drop table if exists t1;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE t1 (id INT, name VARCHAR, age INT);" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t1 (id,name,age) values(1,'2',3), (4, '5', 6);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1;" | bendsql_connect_root
+echo "CREATE TABLE t1 (id INT, name VARCHAR, age INT);" | bendsql_connect_root
+echo "insert into t1 (id,name,age) values(1,'2',3), (4, '5', 6);" | bendsql_connect_root
 
 echo '--- named internal stage'
-echo "drop stage if exists s1;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s1 FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
-echo "copy into @s1 from t1;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
-echo "select * from @s1;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s1;" | bendsql_connect_root
+echo "create stage s1 FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
+echo "copy into @s1 from t1;" | bendsql_connect_root | cut -d$'\t' -f1,2
+echo "select * from @s1;" | bendsql_connect_root
 
 DATADIR_PATH="/tmp/08_00_00"
 rm -rf ${DATADIR_PATH}
 DATADIR="fs://$DATADIR_PATH/"
-echo "copy into '${DATADIR}' from t1 FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
+echo "copy into '${DATADIR}' from t1 FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root | cut -d$'\t' -f1,2
 
 #echo '--- uri'
-#echo "select * from '${DATADIR}';" | $BENDSQL_CLIENT_CONNECT
+#echo "select * from '${DATADIR}';" | bendsql_connect_root
 
 echo '--- external stage'
-echo "drop stage if exists s2;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s2 url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);"  | $BENDSQL_CLIENT_CONNECT
-echo "select * from @s2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s2;" | bendsql_connect_root
+echo "create stage s2 url = '${DATADIR}' FILE_FORMAT = (type = PARQUET);"  | bendsql_connect_root
+echo "select * from @s2;" | bendsql_connect_root
 
 echo '--- file_format'
-echo "drop stage if exists s3;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s3 url = '${DATADIR}' FILE_FORMAT = (type = CSV);"  | $BENDSQL_CLIENT_CONNECT
-echo "select * from @s3 (FILE_FORMAT => 'PARQUET');" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s3;" | bendsql_connect_root
+echo "create stage s3 url = '${DATADIR}' FILE_FORMAT = (type = CSV);"  | bendsql_connect_root
+echo "select * from @s3 (FILE_FORMAT => 'PARQUET');" | bendsql_connect_root
 
-echo "drop table if exists t2;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE t2 (id INT, data VARIANT);" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t2 (id,data) values(1,'[1,2,3]'),(2,'{\"k\":\"v\"}');" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t2;" | bendsql_connect_root
+echo "CREATE TABLE t2 (id INT, data VARIANT);" | bendsql_connect_root
+echo "insert into t2 (id,data) values(1,'[1,2,3]'),(2,'{\"k\":\"v\"}');" | bendsql_connect_root
 
 echo '--- variant named internal stage'
-echo "drop stage if exists s4;" | $BENDSQL_CLIENT_CONNECT
-echo "create stage s4 FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT
-echo "copy into @s4 from t2;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
-echo "select * from @s4;" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists s4;" | bendsql_connect_root
+echo "create stage s4 FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
+echo "copy into @s4 from t2;" | bendsql_connect_root | cut -d$'\t' -f1,2
+echo "select * from @s4;" | bendsql_connect_root
 
 ## generate large parquet files will cause timeout, we comment it now
 echo '--- large parquet file should be worked on parallel by rowgroups'
-echo 'remove @s4;' | $BENDSQL_CLIENT_CONNECT
-echo 'remove @s1;' | $BENDSQL_CLIENT_CONNECT
-echo "copy into @s4 from (select number a, number::string b, number::decimal(15,2) c from numbers(5000000)) file_format=(type=parquet) single=true;" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1
+echo 'remove @s4;' | bendsql_connect_root
+echo 'remove @s1;' | bendsql_connect_root
+echo "copy into @s4 from (select number a, number::string b, number::decimal(15,2) c from numbers(5000000)) file_format=(type=parquet) single=true;" | bendsql_connect_root | cut -d$'\t' -f1
 
 ## 12MB divide by 2MB = 6, so we will read 6 partitions
 echo """
 set parquet_rowgroup_hint_bytes = 2 * 1024 * 1024;
 explain select * from @s4;
-""" | $BENDSQL_CLIENT_CONNECT | grep 'partitions ' | sed  's/^[[:space:]]*//g'
+""" | bendsql_connect_root | grep 'partitions ' | sed  's/^[[:space:]]*//g'
 
-echo "copy into @s1 from (select * from @s4) file_format=(type=parquet)" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1
-echo "select * from @s1 order by a except (select * from @s4 order by a)" | $BENDSQL_CLIENT_CONNECT
+echo "copy into @s1 from (select * from @s4) file_format=(type=parquet)" | bendsql_connect_root | cut -d$'\t' -f1
+echo "select * from @s1 order by a except (select * from @s4 order by a)" | bendsql_connect_root
 
-echo 'remove @s4;' | $BENDSQL_CLIENT_CONNECT
-echo 'remove @s1;' | $BENDSQL_CLIENT_CONNECT
+echo 'remove @s4;' | bendsql_connect_root
+echo 'remove @s1;' | bendsql_connect_root
 
 rm -rf ${DATADIR_PATH}

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_05_query_uri.sh
@@ -4,7 +4,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../../shell_env.sh
 
 # TODO(andylokandy/everpcpc): skipping this test until https://github.com/datafuselabs/bendsql/pull/330 is released
-# echo  "select * from 's3://testbucket/data/parquet/tuple.parquet' (connection => (access_key_id  = 'minioadmin', secret_access_key  = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/'), file_format => 'parquet')"  | $BENDSQL_CLIENT_CONNECT
+# echo  "select * from 's3://testbucket/data/parquet/tuple.parquet' (connection => (access_key_id  = 'minioadmin', secret_access_key  = 'minioadmin', endpoint_url = 'http://127.0.0.1:9900/'), file_format => 'parquet')"  | bendsql_connect_root
 
 # expected result:
 # 1	(1,'a')

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_06_transform.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_06_transform.sh
@@ -3,22 +3,22 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../../shell_env.sh
 
-echo "drop table if exists t1;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE t1 (id INT, age INT);" | $BENDSQL_CLIENT_CONNECT
-echo "insert into t1 (id, age) values(1,3), (4, 6);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1;" | bendsql_connect_root
+echo "CREATE TABLE t1 (id INT, age INT);" | bendsql_connect_root
+echo "insert into t1 (id, age) values(1,3), (4, 6);" | bendsql_connect_root
 
 DATADIR_PATH="/tmp/08_00_06"
 rm -rf ${DATADIR_PATH}
 DATADIR="fs://$DATADIR_PATH/"
-echo "copy into '${DATADIR}' from t1 FILE_FORMAT = (type = PARQUET);" | $BENDSQL_CLIENT_CONNECT | cut -d$'\t' -f1,2
+echo "copy into '${DATADIR}' from t1 FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root | cut -d$'\t' -f1,2
 touch ${DATADIR_PATH}/transform.csv
 
 
 echo '--- copy from uri with transform'
-echo "drop table if exists t2;" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE TABLE t2 (a INT32);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t2;" | bendsql_connect_root
+echo "CREATE TABLE t2 (a INT32);" | bendsql_connect_root
 
-echo "copy into t2 from (select (t.id+1) from '${DATADIR}' t)  PATTERN='.*parquet';" | $BENDSQL_CLIENT_CONNECT > /dev/null
-echo "select * from t2 order by a;" | $BENDSQL_CLIENT_CONNECT
+echo "copy into t2 from (select (t.id+1) from '${DATADIR}' t)  PATTERN='.*parquet';" | bendsql_connect_root > /dev/null
+echo "select * from t2 order by a;" | bendsql_connect_root
 
 rm -rf ${DATADIR_PATH}

--- a/tests/suites/1_stateful/12_delta/11_0000_delta_engine.sh
+++ b/tests/suites/1_stateful/12_delta/11_0000_delta_engine.sh
@@ -8,7 +8,7 @@ ROOT=$(realpath "$CURDIR"/../../../data/delta/simple/)
 stmt "drop table if exists test_delta;"
 
 echo ">>>> create table test_delta engine = delta location = 'fs://\${ROOT}/';"
-echo "create table test_delta engine = delta location = 'fs://${ROOT}/';" | $BENDSQL_CLIENT_CONNECT
+echo "create table test_delta engine = delta location = 'fs://${ROOT}/';" | bendsql_connect_root
 # stmt "create table test_delta engine = delta location = 'fs://${ROOT}/';"
 query "select * from test_delta order by id;"
 stmt "drop table test_delta;"

--- a/tests/suites/1_stateful/12_delta/11_0000_delta_engine_partitioned.sh
+++ b/tests/suites/1_stateful/12_delta/11_0000_delta_engine_partitioned.sh
@@ -8,7 +8,7 @@ ROOT=$(realpath "$CURDIR"/../../../data/delta/partitioned/)
 stmt "drop table if exists test_delta;"
 
 echo ">>>> create table test_delta engine = delta location = 'fs://\${ROOT}/';"
-echo "create table test_delta engine = delta location = 'fs://${ROOT}/';" | $BENDSQL_CLIENT_CONNECT
+echo "create table test_delta engine = delta location = 'fs://${ROOT}/';" | bendsql_connect_root
 # stmt "create table test_delta engine = delta location = 'fs://${ROOT}/';"
 query "select * from test_delta order by c5;"
 # p* is partition column, c* is normal column

--- a/tests/suites/1_stateful/13_fuse_external_table/13_0001_external_table.sh
+++ b/tests/suites/1_stateful/13_fuse_external_table/13_0001_external_table.sh
@@ -3,9 +3,9 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists external_table_test;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists external_table_test;" | bendsql_connect_root
 
-echo "drop connection if exists external_table_conn;" | $BENDSQL_CLIENT_CONNECT
+echo "drop connection if exists external_table_conn;" | bendsql_connect_root
 
 stmt "create or replace connection external_table_conn storage_type='s3' access_key_id = 'minioadmin'  endpoint_url = 'http://127.0.0.1:9900' secret_access_key = 'minioadmin';"
 

--- a/tests/suites/3_stateful_iceberg/00_rest/00_0000_create_and_show.sh
+++ b/tests/suites/3_stateful_iceberg/00_rest/00_0000_create_and_show.sh
@@ -3,27 +3,27 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "DROP CATALOG IF EXISTS iceberg_rest" | $BENDSQL_CLIENT_CONNECT
-# echo "DROP CATALOG IF EXISTS iceberg_hms" | $BENDSQL_CLIENT_CONNECT
-echo "DROP CATALOG IF EXISTS iceberg_glue" | $BENDSQL_CLIENT_CONNECT
+echo "DROP CATALOG IF EXISTS iceberg_rest" | bendsql_connect_root
+# echo "DROP CATALOG IF EXISTS iceberg_hms" | bendsql_connect_root
+echo "DROP CATALOG IF EXISTS iceberg_glue" | bendsql_connect_root
 
 ## hms
 # hms_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -aq --filter "name=hive-metastore"))
 
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE CATALOG iceberg_rest TYPE = ICEBERG CONNECTION = (
     TYPE = 'rest' ADDRESS = 'http://localhost:8181' warehouse = 's3://warehouse/demo/' "s3.endpoint" = 'http://localhost:9000' "s3.access-key-id" = 'admin' "s3.secret-access-key" = 'password' "s3.region" = 'us-east-1'
 );
 EOF
 
 ## disable hms tests cause ci failed
-# cat <<EOF | $BENDSQL_CLIENT_CONNECT
+# cat <<EOF | bendsql_connect_root
 # CREATE CATALOG iceberg_hms TYPE = ICEBERG CONNECTION = (
 #     TYPE = 'hive' ADDRESS = '${hms_ip}:9083' warehouse = 's3a://warehouse/hive/' "s3.endpoint" = 'http://localhost:9000' "s3.access-key-id" = 'admin' "s3.secret-access-key" = 'password' "s3.region" = 'us-east-1'
 # );
 # EOF
 
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE CATALOG iceberg_glue TYPE = ICEBERG CONNECTION = (
     TYPE = 'glue' ADDRESS = 'http://localhost:5000'  warehouse = 's3a://warehouse/glue/' "aws_access_key_id" = 'my_access_id'  "aws_secret_access_key" = 'my_secret_key' "aws_session_token" = 'glue_token' "region_name" = 'us-east-1'  "s3.endpoint" = 'http://localhost:9000' "s3.access-key-id" = 'admin' "s3.secret-access-key" = 'password' "s3.region" = 'us-east-1'
 );
@@ -33,7 +33,7 @@ catalogs=(iceberg_rest iceberg_glue)
 database="db_${RANDOM}"
 for catalog in "${catalogs[@]}"; do
 	echo "===== Testing ${catalog} ====="
-	echo "SHOW CREATE CATALOG $catalog;" | $BENDSQL_CLIENT_CONNECT
+	echo "SHOW CREATE CATALOG $catalog;" | bendsql_connect_root
 	echo """
     SELECT CURRENT_CATALOG();
     USE CATALOG $catalog;
@@ -61,7 +61,7 @@ for catalog in "${catalogs[@]}"; do
     drop database if exists ${database};
 
     SELECT CURRENT_CATALOG();
-    """ | $BENDSQL_CLIENT_CONNECT
+    """ | bendsql_connect_root
 
 	echo ""
 	echo ""

--- a/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
+++ b/tests/suites/5_ee/01_vacuum/01_0002_ee_vacuum_drop_table.sh
@@ -4,82 +4,82 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 ## test vacuum drop table dry run output
-echo "drop database if exists test_vacuum_drop_dry_run" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE DATABASE test_vacuum_drop_dry_run" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop_dry_run.a(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_dry_run.a VALUES (1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "drop table test_vacuum_drop_dry_run.a" | $BENDSQL_CLIENT_CONNECT
-count=$(echo "set data_retention_time_in_days=0; vacuum drop table dry run" | $BENDSQL_CLIENT_CONNECT | wc -l)
+echo "drop database if exists test_vacuum_drop_dry_run" | bendsql_connect_root
+echo "CREATE DATABASE test_vacuum_drop_dry_run" | bendsql_connect_root
+echo "create table test_vacuum_drop_dry_run.a(c int)" | bendsql_connect_root
+echo "INSERT INTO test_vacuum_drop_dry_run.a VALUES (1)" | bendsql_connect_root_null
+echo "drop table test_vacuum_drop_dry_run.a" | bendsql_connect_root
+count=$(echo "set data_retention_time_in_days=0; vacuum drop table dry run" | bendsql_connect_root | wc -l)
 if [[ ! "$count" ]]; then
   echo "vacuum drop table dry run, count:$count"
   exit 1
 fi
-count=$(echo "set data_retention_time_in_days=0; vacuum drop table dry run summary" | $BENDSQL_CLIENT_CONNECT | wc -l)
+count=$(echo "set data_retention_time_in_days=0; vacuum drop table dry run summary" | bendsql_connect_root | wc -l)
 if [[ ! "$count" ]]; then
   echo "vacuum drop table dry run summary, count:$count"
   exit 1
 fi
-echo "drop database if exists test_vacuum_drop_dry_run" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists test_vacuum_drop_dry_run" | bendsql_connect_root
 
 ## Setup
-echo "drop database if exists test_vacuum_drop" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_2" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_3" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_4" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists test_vacuum_drop" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_2" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_3" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_4" | bendsql_connect_root
 
-echo "CREATE DATABASE test_vacuum_drop" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop.a(c int)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE test_vacuum_drop" | bendsql_connect_root
+echo "create table test_vacuum_drop.a(c int)" | bendsql_connect_root
 
-echo "INSERT INTO test_vacuum_drop.a VALUES (1)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "INSERT INTO test_vacuum_drop.a VALUES (1)" | bendsql_connect_root_null
 
-echo "select * from test_vacuum_drop.a" | $BENDSQL_CLIENT_CONNECT
+echo "select * from test_vacuum_drop.a" | bendsql_connect_root
 
-echo "drop table test_vacuum_drop.a" | $BENDSQL_CLIENT_CONNECT
+echo "drop table test_vacuum_drop.a" | bendsql_connect_root
 
-echo "set data_retention_time_in_days=0;vacuum drop table from test_vacuum_drop" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "set data_retention_time_in_days=0;vacuum drop table from test_vacuum_drop" | bendsql_connect_root > /dev/null
 
-echo "create table test_vacuum_drop.b(c int)" | $BENDSQL_CLIENT_CONNECT
+echo "create table test_vacuum_drop.b(c int)" | bendsql_connect_root
 
-echo "INSERT INTO test_vacuum_drop.b VALUES (2)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "INSERT INTO test_vacuum_drop.b VALUES (2)" | bendsql_connect_root_null
 
-echo "drop table test_vacuum_drop.b" | $BENDSQL_CLIENT_CONNECT
+echo "drop table test_vacuum_drop.b" | bendsql_connect_root
 
-echo "vacuum drop table from test_vacuum_drop" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "vacuum drop table from test_vacuum_drop" | bendsql_connect_root > /dev/null
 
-echo "undrop table test_vacuum_drop.b" | $BENDSQL_CLIENT_CONNECT
+echo "undrop table test_vacuum_drop.b" | bendsql_connect_root
 
 # test_vacuum_drop.b has not been vacuum, MUST return [2]
-echo "select * from test_vacuum_drop.b" | $BENDSQL_CLIENT_CONNECT
+echo "select * from test_vacuum_drop.b" | bendsql_connect_root
 
-echo "CREATE DATABASE test_vacuum_drop_2" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop_2.a(c int)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE test_vacuum_drop_2" | bendsql_connect_root
+echo "create table test_vacuum_drop_2.a(c int)" | bendsql_connect_root
 
-echo "INSERT INTO test_vacuum_drop_2.a VALUES (3)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "INSERT INTO test_vacuum_drop_2.a VALUES (3)" | bendsql_connect_root_null
 
-echo "CREATE DATABASE test_vacuum_drop_3" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop_3.a(c int)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE test_vacuum_drop_3" | bendsql_connect_root
+echo "create table test_vacuum_drop_3.a(c int)" | bendsql_connect_root
 
-echo "INSERT INTO test_vacuum_drop_3.a VALUES (4)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "INSERT INTO test_vacuum_drop_3.a VALUES (4)" | bendsql_connect_root_null
 
-echo "select * from test_vacuum_drop_2.a" | $BENDSQL_CLIENT_CONNECT
-echo "select * from test_vacuum_drop_3.a" | $BENDSQL_CLIENT_CONNECT
+echo "select * from test_vacuum_drop_2.a" | bendsql_connect_root
+echo "select * from test_vacuum_drop_3.a" | bendsql_connect_root
 
-echo "drop database test_vacuum_drop_2" | $BENDSQL_CLIENT_CONNECT
-echo "drop table test_vacuum_drop_3.a" | $BENDSQL_CLIENT_CONNECT
+echo "drop database test_vacuum_drop_2" | bendsql_connect_root
+echo "drop table test_vacuum_drop_3.a" | bendsql_connect_root
 
 # vacuum without [from db] will vacuum all tables, including tables in drop db
-echo "set data_retention_time_in_days=0;vacuum drop table" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "set data_retention_time_in_days=0;vacuum drop table" | bendsql_connect_root > /dev/null
 
-echo "drop database if exists test_vacuum_drop" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_2" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_3" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists test_vacuum_drop_4" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists test_vacuum_drop" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_2" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_3" | bendsql_connect_root
+echo "drop database if exists test_vacuum_drop_4" | bendsql_connect_root
 
 # test external table
-echo "drop table if exists table_drop_external_location;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_drop_external_location;" | bendsql_connect_root
 
 ## Create table
-echo "create table table_drop_external_location(a int) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "create table table_drop_external_location(a int) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 table_inserts=(
   "insert into table_drop_external_location(a) values(888)"
@@ -87,53 +87,53 @@ table_inserts=(
 )
 
 for i in "${table_inserts[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_OUTPUT_NULL
+  echo "$i" | bendsql_connect_root_null
 done
 
 ## Select table
-echo "select * from table_drop_external_location order by a;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from table_drop_external_location order by a;" | bendsql_connect_root
 
-echo "drop table table_drop_external_location;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table table_drop_external_location;" | bendsql_connect_root
 
-echo "set data_retention_time_in_days=0;vacuum drop table" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "set data_retention_time_in_days=0;vacuum drop table" | bendsql_connect_root > /dev/null
 
 ## dry run
-echo "CREATE DATABASE test_vacuum_drop_4" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop_4.a(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_4.a VALUES (1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from test_vacuum_drop_4.a"  | $BENDSQL_CLIENT_CONNECT
-echo "drop table test_vacuum_drop_4.a" | $BENDSQL_CLIENT_CONNECT
-echo "set data_retention_time_in_days=0;vacuum drop table dry run" | $BENDSQL_CLIENT_CONNECT > /dev/null
-echo "undrop table test_vacuum_drop_4.a" | $BENDSQL_CLIENT_CONNECT
-echo "select * from test_vacuum_drop_4.a"  | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE test_vacuum_drop_4" | bendsql_connect_root
+echo "create table test_vacuum_drop_4.a(c int)" | bendsql_connect_root
+echo "INSERT INTO test_vacuum_drop_4.a VALUES (1)" | bendsql_connect_root_null
+echo "select * from test_vacuum_drop_4.a"  | bendsql_connect_root
+echo "drop table test_vacuum_drop_4.a" | bendsql_connect_root
+echo "set data_retention_time_in_days=0;vacuum drop table dry run" | bendsql_connect_root > /dev/null
+echo "undrop table test_vacuum_drop_4.a" | bendsql_connect_root
+echo "select * from test_vacuum_drop_4.a"  | bendsql_connect_root
 
 # check vacuum drop table with the same name
-echo "create table test_vacuum_drop_4.b(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_4.b VALUES (1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "drop table test_vacuum_drop_4.b" | $BENDSQL_CLIENT_CONNECT
-echo "create table test_vacuum_drop_4.b(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_4.b VALUES (2)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "select * from test_vacuum_drop_4.b"  | $BENDSQL_CLIENT_CONNECT
-echo "set data_retention_time_in_days=0; vacuum drop table" | $BENDSQL_CLIENT_CONNECT > /dev/null
-echo "select * from test_vacuum_drop_4.b"  | $BENDSQL_CLIENT_CONNECT
+echo "create table test_vacuum_drop_4.b(c int)" | bendsql_connect_root
+echo "INSERT INTO test_vacuum_drop_4.b VALUES (1)" | bendsql_connect_root_null
+echo "drop table test_vacuum_drop_4.b" | bendsql_connect_root
+echo "create table test_vacuum_drop_4.b(c int)" | bendsql_connect_root
+echo "INSERT INTO test_vacuum_drop_4.b VALUES (2)" | bendsql_connect_root_null
+echo "select * from test_vacuum_drop_4.b"  | bendsql_connect_root
+echo "set data_retention_time_in_days=0; vacuum drop table" | bendsql_connect_root > /dev/null
+echo "select * from test_vacuum_drop_4.b"  | bendsql_connect_root
 
 ## test vacuum table output
-echo "create table test_vacuum_drop_4.c(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "INSERT INTO test_vacuum_drop_4.c VALUES (1),(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
-count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c" | $BENDSQL_CLIENT_CONNECT | awk '{print $9}')
+echo "create table test_vacuum_drop_4.c(c int)" | bendsql_connect_root
+echo "INSERT INTO test_vacuum_drop_4.c VALUES (1),(2)" | bendsql_connect_root_null
+count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c" | bendsql_connect_root | awk '{print $9}')
 if [[ "$count" != "4" ]]; then
   echo "vacuum table, count:$count"
   exit 1
 fi
-count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c dry run summary" | $BENDSQL_CLIENT_CONNECT | wc -l)
+count=$(echo "set data_retention_time_in_days=0; vacuum table test_vacuum_drop_4.c dry run summary" | bendsql_connect_root | wc -l)
 if [[ "$count" != "1" ]]; then
   echo "vacuum table dry run summary, count:$count"
   exit 1
 fi
 
-echo "drop database if exists test_vacuum_drop_4" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists test_vacuum_drop_4" | bendsql_connect_root
 
 ## Drop table
-echo "drop table if exists table_drop_external_location;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists table_drop_external_location;" | bendsql_connect_root
 
 

--- a/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
+++ b/tests/suites/5_ee/01_vacuum/01_003_vacuum_table_only_orphans.sh
@@ -14,7 +14,7 @@ stmt "insert into test_vacuum_table_only_orphans.a values (1),(2)"
 stmt "insert into test_vacuum_table_only_orphans.a values (2),(3)"
 stmt "insert into test_vacuum_table_only_orphans.a values (3),(4)"
 
-SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_table_only_orphans','a') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_table_only_orphans','a') limit 1" | bendsql_connect_root)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
 
 echo "before purge"

--- a/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
+++ b/tests/suites/5_ee/01_vacuum/01_004_vacuum_drop_aggregating_index.sh
@@ -21,7 +21,7 @@ stmt "insert into test_vacuum_drop_aggregating_index.agg values (2,2,5)"
 
 stmt "REFRESH AGGREGATING INDEX index;"
 
-SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg') limit 1" | bendsql_connect_root)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
 
 echo "before vacuum, should be 1 index dir"
@@ -51,7 +51,7 @@ stmt "insert into test_vacuum_drop_aggregating_index.agg_1 values (2,2,5)"
 stmt "REFRESH AGGREGATING INDEX index_1;"
 stmt "REFRESH AGGREGATING INDEX index_2;"
 
-SNAPSHOT_LOCATION_1=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg_1') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION_1=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg_1') limit 1" | bendsql_connect_root)
 PREFIX_1=$(echo "$SNAPSHOT_LOCATION_1" | cut -d'/' -f1-2)
 
 echo "before vacuum, should be 2 index dir"
@@ -69,7 +69,7 @@ stmt "insert into test_vacuum_drop_aggregating_index.agg_2 values (2,2,5)"
 
 stmt "REFRESH AGGREGATING INDEX index_3;"
 
-SNAPSHOT_LOCATION_2=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg_2') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION_2=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg_2') limit 1" | bendsql_connect_root)
 PREFIX_2=$(echo "$SNAPSHOT_LOCATION_2" | cut -d'/' -f1-2)
 
 stmt "drop aggregating index index_1"
@@ -105,7 +105,7 @@ stmt "insert into test_vacuum_drop_aggregating_index.agg values (2,2,5)"
 
 stmt "REFRESH AGGREGATING INDEX index;"
 
-SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_aggregating_index','agg') limit 1" | bendsql_connect_root)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
 
 echo "before vacuum, should be 1 index dir"

--- a/tests/suites/5_ee/01_vacuum/01_005_vacuum_drop_inverted_index.sh
+++ b/tests/suites/5_ee/01_vacuum/01_005_vacuum_drop_inverted_index.sh
@@ -18,7 +18,7 @@ stmt "INSERT INTO test_vacuum_drop_inverted_index.books VALUES
 (1, '这就是ChatGPT', '[美]斯蒂芬·沃尔弗拉姆（Stephen Wolfram）', 'ChatGPT是OpenAI开发的人工智能聊天机器人程序，于2022年11月推出。它能够自动生成一些表面上看起来像人类写的文字，这是一件很厉害且出乎大家意料的事。那么，它是如何做到的呢？又为何能做到呢？本书会大致介绍ChatGPT的内部机制，然后探讨一下为什么它能很好地生成我们认为有意义的文本。')"
 
 
-SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','books') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','books') limit 1" | bendsql_connect_root)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
 
 echo "before vacuum, should be 1 index dir"
@@ -44,7 +44,7 @@ stmt "CREATE OR REPLACE INVERTED INDEX idx4 ON test_vacuum_drop_inverted_index.b
 
 stmt "insert into test_vacuum_drop_inverted_index.book_1 values (1, '这就是ChatGPT', '[美]斯蒂芬·沃尔弗拉姆（Stephen Wolfram）', 'ChatGPT是OpenAI开发的人工智能聊天机器人程序，于2022年11月推出。它能够自动生成一些表面上看起来像人类写的文字，这是一件很厉害且出乎大家意料的事。那么，它是如何做到的呢？又为何能做到呢？本书会大致介绍ChatGPT的内部机制，然后探讨一下为什么它能很好地生成我们认为有意义的文本。')"
 
-SNAPSHOT_LOCATION_1=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','book_1') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION_1=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','book_1') limit 1" | bendsql_connect_root)
 PREFIX_1=$(echo "$SNAPSHOT_LOCATION_1" | cut -d'/' -f1-2)
 
 echo "before vacuum, should be 2 index dir"
@@ -58,7 +58,7 @@ stmt "CREATE OR REPLACE INVERTED INDEX idx5 ON test_vacuum_drop_inverted_index.b
 stmt "insert into test_vacuum_drop_inverted_index.book_2 values (1, '这就是ChatGPT', '[美]斯蒂芬·沃尔弗拉姆（Stephen Wolfram）', 'ChatGPT是OpenAI开发的人工智能聊天机器人程序，于2022年11月推出。它能够自动生成一些表面上看起来像人类写的文字，这是一件很厉害且出乎大家意料的事。那么，它是如何做到的呢？又为何能做到呢？本书会大致介绍ChatGPT的内部机制，然后探讨一下为什么它能很好地生成我们认为有意义的文本。')"
 
 
-SNAPSHOT_LOCATION_2=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','book_2') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION_2=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','book_2') limit 1" | bendsql_connect_root)
 PREFIX_2=$(echo "$SNAPSHOT_LOCATION_2" | cut -d'/' -f1-2)
 
 stmt "drop inverted index idx3 on test_vacuum_drop_inverted_index.book_1"
@@ -92,7 +92,7 @@ stmt "INSERT INTO test_vacuum_drop_inverted_index.books VALUES
 (1, '这就是ChatGPT', '[美]斯蒂芬·沃尔弗拉姆（Stephen Wolfram）', 'ChatGPT是OpenAI开发的人工智能聊天机器人程序，于2022年11月推出。它能够自动生成一些表面上看起来像人类写的文字，这是一件很厉害且出乎大家意料的事。那么，它是如何做到的呢？又为何能做到呢？本书会大致介绍ChatGPT的内部机制，然后探讨一下为什么它能很好地生成我们认为有意义的文本。')"
 
 
-SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','books') limit 1" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOT_LOCATION=$(echo "select snapshot_location from fuse_snapshot('test_vacuum_drop_inverted_index','books') limit 1" | bendsql_connect_root)
 PREFIX=$(echo "$SNAPSHOT_LOCATION" | cut -d'/' -f1-2)
 
 echo "before create or replace index, should be 1 index dir"

--- a/tests/suites/5_ee/02_data_mask/02_0001_flashback.sh
+++ b/tests/suites/5_ee/02_data_mask/02_0001_flashback.sh
@@ -10,11 +10,11 @@ MASK_POLICY="mask_c_${RUN_ID}"
 AGG_INDEX="testi_${RUN_ID}"
 
 snapshot_id() {
-    echo "select snapshot_id from fuse_snapshot('$1', '$2') where row_count=$3 limit 1" | $BENDSQL_CLIENT_CONNECT
+    echo "select snapshot_id from fuse_snapshot('$1', '$2') where row_count=$3 limit 1" | bendsql_connect_root
 }
 
 quiet_stmt() {
-    echo "$1" | $BENDSQL_CLIENT_CONNECT > /dev/null || exit 1
+    echo "$1" | bendsql_connect_root > /dev/null || exit 1
 }
 
 comment "prepare ee flashback metadata regression environment"
@@ -36,10 +36,10 @@ comment "create and attach row access policy"
 quiet_stmt "CREATE ROW ACCESS POLICY ${ROW_POLICY} AS (val INT) RETURNS BOOLEAN -> val > 100"
 quiet_stmt "ALTER TABLE ${DB}.t_row ADD ROW ACCESS POLICY ${ROW_POLICY} ON (c)"
 comment "time travel row policy table at saved snapshot"
-echo "SELECT count(*)=2 FROM ${DB}.t_row AT (SNAPSHOT => '$ROW_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT || exit 1
+echo "SELECT count(*)=2 FROM ${DB}.t_row AT (SNAPSHOT => '$ROW_SNAPSHOT_ID')" | bendsql_connect_root || exit 1
 comment "flashback row policy table to saved snapshot should fail"
 echo ">>>> ALTER TABLE ${DB}.t_row FLASHBACK TO (SNAPSHOT => '<saved_snapshot>')"
-echo "ALTER TABLE ${DB}.t_row FLASHBACK TO (SNAPSHOT => '$ROW_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+echo "ALTER TABLE ${DB}.t_row FLASHBACK TO (SNAPSHOT => '$ROW_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     exit 1
 fi
@@ -54,10 +54,10 @@ comment "create and attach masking policy"
 quiet_stmt "CREATE MASKING POLICY ${MASK_POLICY} AS (val STRING) RETURNS STRING -> '***'"
 quiet_stmt "ALTER TABLE ${DB}.t_mask MODIFY COLUMN c SET MASKING POLICY ${MASK_POLICY}"
 comment "time travel masking table at saved snapshot"
-echo "SELECT count(*)=1 FROM ${DB}.t_mask AT (SNAPSHOT => '$MASK_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT || exit 1
+echo "SELECT count(*)=1 FROM ${DB}.t_mask AT (SNAPSHOT => '$MASK_SNAPSHOT_ID')" | bendsql_connect_root || exit 1
 comment "flashback masking table to saved snapshot should fail"
 echo ">>>> ALTER TABLE ${DB}.t_mask FLASHBACK TO (SNAPSHOT => '<saved_snapshot>')"
-echo "ALTER TABLE ${DB}.t_mask FLASHBACK TO (SNAPSHOT => '$MASK_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+echo "ALTER TABLE ${DB}.t_mask FLASHBACK TO (SNAPSHOT => '$MASK_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     exit 1
 fi
@@ -74,7 +74,7 @@ quiet_stmt "REFRESH AGGREGATING INDEX ${AGG_INDEX}"
 comment "flashback should reject aggregating indexes bound to dropped columns"
 comment "flashback indexed table to saved snapshot should fail"
 echo ">>>> ALTER TABLE ${DB}.t_idx FLASHBACK TO (SNAPSHOT => '<saved_snapshot>')"
-echo "ALTER TABLE ${DB}.t_idx FLASHBACK TO (SNAPSHOT => '$IDX_SNAPSHOT_ID')" | $BENDSQL_CLIENT_CONNECT > /dev/null 2>&1
+echo "ALTER TABLE ${DB}.t_idx FLASHBACK TO (SNAPSHOT => '$IDX_SNAPSHOT_ID')" | bendsql_connect_root > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     exit 1
 fi

--- a/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.sh
+++ b/tests/suites/5_ee/02_data_mask/02_0002_data_mask_where_and_folding.sh
@@ -29,8 +29,8 @@ stmt "ALTER TABLE default.mask_test MODIFY COLUMN data SET MASKING POLICY mask_v
 stmt "GRANT SELECT ON default.mask_test TO ROLE mask_admin"
 stmt "GRANT SELECT ON default.mask_test TO ROLE mask_reader"
 
-ADMIN_CONNECT="bendsql_query_http_user_connect mask_admin_user 123 --quote-style=never"
-READER_CONNECT="bendsql_query_http_user_connect mask_reader_user 123 --quote-style=never"
+ADMIN_CONNECT="bendsql_connect_user mask_admin_user 123 --quote-style=never"
+READER_CONNECT="bendsql_connect_user mask_reader_user 123 --quote-style=never"
 
 comment "=== Constant folding verification ==="
 

--- a/tests/suites/5_ee/03_computed_column/03_0000_copy_csv_with_computed_column.sh
+++ b/tests/suites/5_ee/03_computed_column/03_0000_copy_csv_with_computed_column.sh
@@ -3,10 +3,10 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists sample_table" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists sample_table" | bendsql_connect_root
 
 ## Create table
-cat <<EOF | $BENDSQL_CLIENT_CONNECT
+cat <<EOF | bendsql_connect_root
 CREATE TABLE sample_table
 (
     Id     INT,
@@ -23,10 +23,10 @@ copy_from_test_csv=(
 
 echo "---test csv field with computed columns"
 for i in "${copy_from_test_csv[@]}"; do
-  echo "$i" | $BENDSQL_CLIENT_CONNECT
-  echo "select * from sample_table" | $BENDSQL_CLIENT_CONNECT
-  echo "truncate table sample_table" | $BENDSQL_CLIENT_CONNECT
+  echo "$i" | bendsql_connect_root
+  echo "select * from sample_table" | bendsql_connect_root
+  echo "truncate table sample_table" | bendsql_connect_root
 done
 
 ## Drop table
-echo "drop table if exists sample_table;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists sample_table;" | bendsql_connect_root

--- a/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0004_attach_table.sh
@@ -29,10 +29,10 @@ done
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table table_from" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
 comment "attaching table"
-echo "attach table table_to 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "attach table table_to 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 # If failed will return err msg. Expect it success.
-echo "select * from system.columns where table='table_to' ignore_result;" | $BENDSQL_CLIENT_CONNECT
-echo "attach table table_to2 's3://testbucket/data/$storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+echo "select * from system.columns where table='table_to' ignore_result;" | bendsql_connect_root
+echo "attach table table_to2 's3://testbucket/data/$storage_prefix' connection=(connection_name ='my_conn')" | bendsql_connect_root
 
 
 # ## Select table
@@ -68,7 +68,7 @@ base_storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_optio
 stmt "drop table if exists attach_tbl"
 
 echo "attaching base table"
-echo "attach table attach_tbl (c2, c4) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+echo "attach table attach_tbl (c2, c4) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | bendsql_connect_root
 
 query "select * from attach_tbl"
 
@@ -80,7 +80,7 @@ stmt "drop table if exists attach_tbl"
 
 # include non-exist column should fail
 echo "attaching non-exists column"
-echo "attach table attach_tbl (c2, c_not_exist) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+echo "attach table attach_tbl (c2, c_not_exist) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | bendsql_connect_root
 
 
 
@@ -90,13 +90,13 @@ echo "## access renamed columns ###"
 echo "#############################"
 
 stmt "drop table if exists attach_tbl"
-echo "attach table attach_tbl (c2, c4) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+echo "attach table attach_tbl (c2, c4) 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | bendsql_connect_root
 
 stmt "alter table base RENAME COLUMN c2 to c2_new"
 
 echo "'ATTACH' after 'ALTER TABLE RENAME COLUMN' should see the new name of column"
 stmt "drop table if exists attach_tbl2"
-echo "attach table attach_tbl2 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | $BENDSQL_CLIENT_CONNECT
+echo "attach table attach_tbl2 's3://testbucket/data/$base_storage_prefix' connection=(connection_name ='my_conn')" | bendsql_connect_root
 query "desc attach_tbl2"
 
 stmt "insert into base values('c1', 'c2_new', 'c3', 'c4')"

--- a/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0005_attach_table_read_only.sh
@@ -4,123 +4,123 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 # base table
-echo "drop table if exists base" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists attach_read_only" | $BENDSQL_CLIENT_CONNECT
-echo "create table base as select * from numbers(100)" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists base" | bendsql_connect_root
+echo "drop table if exists attach_read_only" | bendsql_connect_root
+echo "create table base as select * from numbers(100)" | bendsql_connect_root
 
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table base" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
 # attach table
-echo "attach table attach_read_only 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "attach table attach_read_only 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 
 #  1. content of two tables should be same
 echo "sum of base table"
-echo "select sum(number) from base;" | $BENDSQL_CLIENT_CONNECT
+echo "select sum(number) from base;" | bendsql_connect_root
 echo "sum of attach_read_only table"
-echo "select sum(number) from attach_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "select sum(number) from attach_read_only;" | bendsql_connect_root
 
 #  2. data should be in-sync
 echo "attach table should reflects the mutation of table being attached"
-echo "delete from base where number > 0;" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "delete from base where number > 0;" | bendsql_connect_root_null
 echo "content of base table after deletion"
-echo "select * from attach_read_only order by number;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from attach_read_only order by number;" | bendsql_connect_root
 echo "content of test attach only table after deletion"
-echo "select * from attach_read_only order by number;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from attach_read_only order by number;" | bendsql_connect_root
 
 echo "count() of base table after deletion"
-echo "select count() from base;" | $BENDSQL_CLIENT_CONNECT
+echo "select count() from base;" | bendsql_connect_root
 echo "count() of test attach only table"
-echo "select count() from attach_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "select count() from attach_read_only;" | bendsql_connect_root
 
 # 3. READ_ONLY attach table should aware of the schema evolution of table being attached
 echo "alter table modify column"
-echo "alter table base modify column number varchar;" | $BENDSQL_CLIENT_CONNECT
+echo "alter table base modify column number varchar;" | bendsql_connect_root
 echo "expects column number as varchar"
-echo "desc attach_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "desc attach_read_only;" | bendsql_connect_root
 echo "expects one row"
-echo "select * from attach_read_only order by number;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from attach_read_only order by number;" | bendsql_connect_root
 
 echo "alter table add column"
-echo "alter table base add column c1 varchar NOT NULL DEFAULT 'c1';" | $BENDSQL_CLIENT_CONNECT
-echo "alter table base add column c2 varchar NOT NULL DEFAULT 'c2';" | $BENDSQL_CLIENT_CONNECT
+echo "alter table base add column c1 varchar NOT NULL DEFAULT 'c1';" | bendsql_connect_root
+echo "alter table base add column c2 varchar NOT NULL DEFAULT 'c2';" | bendsql_connect_root
 echo "expects 3 columns: number, c1, c2"
-echo "desc attach_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "desc attach_read_only;" | bendsql_connect_root
 echo "expects one row, 3 columns"
-echo "select * from attach_read_only order by number;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from attach_read_only order by number;" | bendsql_connect_root
 
 
 echo "alter table drop column"
-echo "alter table base drop column c1;" | $BENDSQL_CLIENT_CONNECT
+echo "alter table base drop column c1;" | bendsql_connect_root
 echo "expects new columns: number, c2"
-echo "desc attach_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "desc attach_read_only;" | bendsql_connect_root
 echo "expects one row, 2 columns"
-echo "select * from attach_read_only order by number;" | $BENDSQL_CLIENT_CONNECT
+echo "select * from attach_read_only order by number;" | bendsql_connect_root
 
 # 4. READ_ONLY attach table is not allowed to be mutated
 
 # 4.0 basic cases
 
 echo "delete not allowed"
-echo "DELETE from attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "DELETE from attach_read_only" | bendsql_connect_root
 
 echo "update not allowed"
-echo "UPDATE attach_read_only set number = 1" | $BENDSQL_CLIENT_CONNECT
+echo "UPDATE attach_read_only set number = 1" | bendsql_connect_root
 
 echo "column not exists"
-echo "UPDATE attach_read_only set a = 1" | $BENDSQL_CLIENT_CONNECT
+echo "UPDATE attach_read_only set a = 1" | bendsql_connect_root
 
 echo "truncate not allowed"
-echo "TRUNCATE table attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "TRUNCATE table attach_read_only" | bendsql_connect_root
 
 echo "alter table column not allowed"
-echo "ALTER table attach_read_only ADD COLUMN brand_new_col varchar" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER table attach_read_only ADD COLUMN brand_new_col varchar" | bendsql_connect_root
 
 echo "alter table set options not allowed"
-echo "ALTER table attach_read_only SET OPTIONS(bloom_index_columns='a');" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER table attach_read_only SET OPTIONS(bloom_index_columns='a');" | bendsql_connect_root
 
 echo "alter table flashback not allowed"
-echo "ALTER TABLE attach_read_only FLASHBACK TO (SNAPSHOT => 'c5c538d6b8bc42f483eefbddd000af7d')" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER TABLE attach_read_only FLASHBACK TO (SNAPSHOT => 'c5c538d6b8bc42f483eefbddd000af7d')" | bendsql_connect_root
 
 echo "alter table recluster not allowed"
-echo "ALTER TABLE attach_read_only recluster" | $BENDSQL_CLIENT_CONNECT
+echo "ALTER TABLE attach_read_only recluster" | bendsql_connect_root
 
 
 echo "analyze table not allowed"
-echo "ANALYZE TABLE attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "ANALYZE TABLE attach_read_only" | bendsql_connect_root
 
 echo "optimize table"
 echo "optimize table compact not allowed"
-echo "OPTIMIZE TABLE attach_read_only compact" | $BENDSQL_CLIENT_CONNECT
+echo "OPTIMIZE TABLE attach_read_only compact" | bendsql_connect_root
 echo "optimize table compact segment not allowed"
-echo "OPTIMIZE TABLE attach_read_only compact segment" | $BENDSQL_CLIENT_CONNECT
+echo "OPTIMIZE TABLE attach_read_only compact segment" | bendsql_connect_root
 echo "optimize table purge not allowed"
-echo "OPTIMIZE TABLE attach_read_only purge" | $BENDSQL_CLIENT_CONNECT
+echo "OPTIMIZE TABLE attach_read_only purge" | bendsql_connect_root
 
 # 4.1 drop table
 
 echo "drop table ALL not allowed"
-echo "drop table attach_read_only all" | $BENDSQL_CLIENT_CONNECT
+echo "drop table attach_read_only all" | bendsql_connect_root
 
 echo "drop table IS allowed"
-echo "drop table attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "drop table attach_read_only" | bendsql_connect_root
 
 echo "undrop table should work"
-echo "undrop table attach_read_only" | $BENDSQL_CLIENT_CONNECT
-echo "select * from attach_read_only order by number" | $BENDSQL_CLIENT_CONNECT
+echo "undrop table attach_read_only" | bendsql_connect_root
+echo "select * from attach_read_only order by number" | bendsql_connect_root
 
 
 # 4.2 show create table
 echo "show create attach table"
 # since db_id and table_id varies between executions, replace them with PLACE_HOLDER
 # e.g. s3://testbucket/data/1/401/ to s3://testbucket/data/PLACE_HOLDER/PLACE_HOLDER/
-echo "show create table attach_read_only" | $BENDSQL_CLIENT_CONNECT | sed -E 's/[0-9]+/PLACE_HOLDER/g'
+echo "show create table attach_read_only" | bendsql_connect_root | sed -E 's/[0-9]+/PLACE_HOLDER/g'
 
 # 4.2 copy into
 echo "copy into attached table should fail"
-echo "CREATE OR REPLACE STAGE test_attach_source;" | $BENDSQL_CLIENT_CONNECT
-echo "copy into attach_read_only from @test_attach_source" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE OR REPLACE STAGE test_attach_source;" | bendsql_connect_root
+echo "copy into attach_read_only from @test_attach_source" | bendsql_connect_root
 
 
-echo "drop table if exists base" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists base" | bendsql_connect_root
+echo "drop table if exists attach_read_only" | bendsql_connect_root

--- a/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
+++ b/tests/suites/5_ee/04_attach_read_only/02_0006_attach_table_ro_issue_16121.sh
@@ -3,21 +3,21 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace database issue_16121" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace database issue_16121" | bendsql_connect_root
 
-echo "create or replace table issue_16121.base as select * from numbers(100)" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace table issue_16121.base as select * from numbers(100)" | bendsql_connect_root
 
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set hide_options_in_show_create_table=0;show create table issue_16121.base" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
-echo "attach table issue_16121.attach_read_only 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "attach table issue_16121.attach_read_only 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
-echo "drop table issue_16121.base;" | $BENDSQL_CLIENT_CONNECT
+echo "drop table issue_16121.base;" | bendsql_connect_root
 
 # purge base table data
-echo "set data_retention_time_in_days=0;vacuum drop table from issue_16121;" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "set data_retention_time_in_days=0;vacuum drop table from issue_16121;" | bendsql_connect_root > /dev/null
 
 echo "expects no error(nothing outputs)"
-echo "drop table issue_16121.attach_read_only" | $BENDSQL_CLIENT_CONNECT
+echo "drop table issue_16121.attach_read_only" | bendsql_connect_root
 
 # AI configurations (provider url, ak/sk) are not ready for CI, thus the following test case is commented out
 #echo "expects ai_to_sql works"
-#echo "SELECT* FROM  ai_to_sql ('current time') IGNORE_RESULT" | $BENDSQL_CLIENT_CONNECT
+#echo "SELECT* FROM  ai_to_sql ('current time') IGNORE_RESULT" | bendsql_connect_root

--- a/tests/suites/5_ee/04_attach_read_only/04_0001_check_mutations.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0001_check_mutations.sh
@@ -3,32 +3,32 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace database test_attach_only;" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace database test_attach_only;" | bendsql_connect_root
 
 # mutation related enterprise features
 
-echo "create or replace table test_attach_only.test_json(id int, val json) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "insert into test_attach_only.test_json values(1, '{\"a\":33,\"b\":44}'),(2, '{\"a\":55,\"b\":66}')" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "create or replace table test_attach_only.test_json(id int, val json) 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "insert into test_attach_only.test_json values(1, '{\"a\":33,\"b\":44}'),(2, '{\"a\":55,\"b\":66}')" | bendsql_connect_root_null
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table test_attach_only.test_json" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
-echo "attach table test_attach_only.test_json_read_only 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "attach table test_attach_only.test_json_read_only 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 
 echo "create index should fail"
-echo "CREATE INVERTED INDEX IF NOT EXISTS idx1 ON test_attach_only.test_json_read_only(val)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE INVERTED INDEX IF NOT EXISTS idx1 ON test_attach_only.test_json_read_only(val)" | bendsql_connect_root
 
 # vacuum
 echo "vacuum table"
 
 echo "vacuum table should fail"
-echo "VACUUM TABLE test_attach_only.test_json_read_only;" | $BENDSQL_CLIENT_CONNECT
+echo "VACUUM TABLE test_attach_only.test_json_read_only;" | bendsql_connect_root
 
 echo "vacuum drop table from db should not include the read_only attach table"
 # drop & vacuum
-echo "drop table test_attach_only.test_json_read_only" | $BENDSQL_CLIENT_CONNECT
-echo "vacuum drop table from test_attach_only" | $BENDSQL_CLIENT_CONNECT > /dev/null
+echo "drop table test_attach_only.test_json_read_only" | bendsql_connect_root
+echo "vacuum drop table from test_attach_only" | bendsql_connect_root > /dev/null
 # attach it back
-echo "attach table test_attach_only.test_json_read_only 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}')" | $BENDSQL_CLIENT_CONNECT
+echo "attach table test_attach_only.test_json_read_only 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}')" | bendsql_connect_root
 echo "expect table data still there"
-echo "select * from test_attach_only.test_json_read_only order by id" | $BENDSQL_CLIENT_CONNECT
+echo "select * from test_attach_only.test_json_read_only order by id" | bendsql_connect_root
 
 

--- a/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0007_attach_table_entity_comment.sh
@@ -4,44 +4,44 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
 # base table
-echo "drop table if exists comment_base" | $BENDSQL_CLIENT_CONNECT
-echo "create table comment_base (c1 int comment 'c1 comment', c2 int comment 'c2 comment') comment = 'tbl comment'" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists comment_base" | bendsql_connect_root
+echo "create table comment_base (c1 int comment 'c1 comment', c2 int comment 'c2 comment') comment = 'tbl comment'" | bendsql_connect_root
 
 # empty table is not attachable currently, thus we need to insert some data
 echo "init table"
-echo "insert into comment_base values(1, 2)" | $BENDSQL_CLIENT_CONNECT
+echo "insert into comment_base values(1, 2)" | bendsql_connect_root
 
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table comment_base" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
 # attach table
-echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_comment" | bendsql_connect_root
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 
 echo "check table comment"
-echo "select comment from system.tables where name = 'att_comment'" | $BENDSQL_CLIENT_CONNECT
+echo "select comment from system.tables where name = 'att_comment'" | bendsql_connect_root
 
 echo "check column comment"
-echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | bendsql_connect_root
 
 
 # alter table rename column should generate new hint file
 stmt "alter table comment_base rename column c1 to c1_new"
-echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_comment" | bendsql_connect_root
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | bendsql_connect_root
 
 # alter table rename comment should generate new hint file
 stmt "alter table comment_base comment = 'new tbl comment'"
-echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_comment" | bendsql_connect_root
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 stmt "select comment from system.tables where name = 'att_comment'"
 
 # alter table modify column comment should generate new hint file
 stmt "ALTER TABLE comment_base MODIFY COLUMN c1_new comment 'new comment of c1_new'"
-echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, comment from system.columns where table = 'att_comment' order by name" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_comment" | bendsql_connect_root
+echo "attach table att_comment 's3://testbucket/admin/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, comment from system.columns where table = 'att_comment' order by name" | bendsql_connect_root
 
-echo "drop table if exists comment_base" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists att_comment" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists comment_base" | bendsql_connect_root
+echo "drop table if exists att_comment" | bendsql_connect_root

--- a/tests/suites/5_ee/04_attach_read_only/04_0008_attach_table_index.sh
+++ b/tests/suites/5_ee/04_attach_read_only/04_0008_attach_table_index.sh
@@ -3,52 +3,52 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists phrases" | $BENDSQL_CLIENT_CONNECT
-echo "create table phrases (id INT, text STRING,  text_0 STRING, embedding Vector(8), NGRAM INDEX idx_text (text), VECTOR INDEX idx_vector (embedding) m=10 ef_construct=40 distance='cosine') 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}')" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE INVERTED INDEX idx_inverted ON phrases(text_0);" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists phrases" | bendsql_connect_root
+echo "create table phrases (id INT, text STRING,  text_0 STRING, embedding Vector(8), NGRAM INDEX idx_text (text), VECTOR INDEX idx_vector (embedding) m=10 ef_construct=40 distance='cosine') 's3://testbucket/data/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}')" | bendsql_connect_root
+echo "CREATE INVERTED INDEX idx_inverted ON phrases(text_0);" | bendsql_connect_root
 
 echo "init table"
-echo "INSERT INTO phrases VALUES(1, 'apple banana cherry', 'apple banana cherry', [0.61418788, 0.34545306, 0.14638622, 0.53249639, 0.09139293, 0.84940919, 0.105433, 0.4156201]),(2, 'banana date fig', 'banana date fig', [0.21828953, 0.87852734, 0.64221122, 0.24536394, 0.81689593, 0.86341877, 0.7218334, 0.45028494]),(3, 'cherry elderberry fig', 'cherry elderberry fig', [0.43279006, 0.45523681, 0.76060274, 0.66284758, 0.19131476, 0.13564463, 0.88712212, 0.93279565]),(4, 'date grape kiwi', 'date grape kiwi', [0.79671359, 0.86079789, 0.94477631, 0.5116732, 0.29733205, 0.33645561, 0.41380333, 0.75909903])" | $BENDSQL_CLIENT_CONNECT
+echo "INSERT INTO phrases VALUES(1, 'apple banana cherry', 'apple banana cherry', [0.61418788, 0.34545306, 0.14638622, 0.53249639, 0.09139293, 0.84940919, 0.105433, 0.4156201]),(2, 'banana date fig', 'banana date fig', [0.21828953, 0.87852734, 0.64221122, 0.24536394, 0.81689593, 0.86341877, 0.7218334, 0.45028494]),(3, 'cherry elderberry fig', 'cherry elderberry fig', [0.43279006, 0.45523681, 0.76060274, 0.66284758, 0.19131476, 0.13564463, 0.88712212, 0.93279565]),(4, 'date grape kiwi', 'date grape kiwi', [0.79671359, 0.86079789, 0.94477631, 0.5116732, 0.29733205, 0.33645561, 0.41380333, 0.75909903])" | bendsql_connect_root
 
 storage_prefix=$(mysql -uroot -h127.0.0.1 -P3307  -e "set global hide_options_in_show_create_table=0;show create table phrases" | grep -i snapshot_location | awk -F'SNAPSHOT_LOCATION='"'"'|_ss' '{print $2}')
 
 # attach table
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
 
 # check index
 echo "check index"
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
 # refresh ngram index
 stmt "REFRESH NGRAM INDEX idx_text ON phrases;"
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
 # drop ngram index
 stmt "DROP NGRAM INDEX idx_text ON phrases;"
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
 # refresh inverted index
 stmt "REFRESH INVERTED INDEX idx_inverted ON phrases;"
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
 # drop inverted index
 stmt "DROP INVERTED INDEX idx_inverted ON phrases;"
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
 # drop vector index
 stmt "DROP VECTOR INDEX idx_vector ON phrases;"
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
-echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | $BENDSQL_CLIENT_CONNECT
-echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists att_phrases" | bendsql_connect_root
+echo "attach table att_phrases 's3://testbucket/data/$storage_prefix' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='${STORAGE_S3_ENDPOINT_URL}');" | bendsql_connect_root
+echo "select name, type, database, table from system.indexes where database = 'default' and table = 'att_phrases';" | bendsql_connect_root
 
-echo "drop table if exists phrases" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists att_phrases" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists phrases" | bendsql_connect_root
+echo "drop table if exists att_phrases" | bendsql_connect_root

--- a/tests/suites/5_ee/05_stream/05_0000_ee_stream.sh
+++ b/tests/suites/5_ee/05_stream/05_0000_ee_stream.sh
@@ -3,25 +3,25 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists db_stream" | bendsql_connect_root
 
-echo "CREATE DATABASE db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.t(a int) change_tracking = true" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db_stream.t values(1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "create stream default.test_s on table db_stream.t comment = 'test'" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db_stream.t values(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "CREATE DATABASE db_stream" | bendsql_connect_root
+echo "create table db_stream.t(a int) change_tracking = true" | bendsql_connect_root
+echo "insert into db_stream.t values(1)" | bendsql_connect_root_null
+echo "create stream default.test_s on table db_stream.t comment = 'test'" | bendsql_connect_root
+echo "insert into db_stream.t values(2)" | bendsql_connect_root_null
 
-BASE_ROW_ID=$(echo "select _base_row_id from default.test_s" | $BENDSQL_CLIENT_CONNECT)
-echo "select change\$row_id='$BASE_ROW_ID' from default.test_s" | $BENDSQL_CLIENT_CONNECT
-echo "optimize table db_stream.t compact" | $BENDSQL_CLIENT_CONNECT
-echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from default.test_s" | $BENDSQL_CLIENT_CONNECT
+BASE_ROW_ID=$(echo "select _base_row_id from default.test_s" | bendsql_connect_root)
+echo "select change\$row_id='$BASE_ROW_ID' from default.test_s" | bendsql_connect_root
+echo "optimize table db_stream.t compact" | bendsql_connect_root
+echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from default.test_s" | bendsql_connect_root
 
-echo "create stream test_s1 on table db_stream.t at(stream => default.test_s) append_only=false comment = 'standard'" | $BENDSQL_CLIENT_CONNECT
-echo "show streams like 'test_s%'" | $BENDSQL_CLIENT_CONNECT
-echo "show full streams like 'test_s%'" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
-echo "desc stream default.test_s" | $BENDSQL_CLIENT_CONNECT | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
+echo "create stream test_s1 on table db_stream.t at(stream => default.test_s) append_only=false comment = 'standard'" | bendsql_connect_root
+echo "show streams like 'test_s%'" | bendsql_connect_root
+echo "show full streams like 'test_s%'" | bendsql_connect_root | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
+echo "desc stream default.test_s" | bendsql_connect_root | awk '{print $(NF-7), $(NF-6), $(NF-5), $(NF-4), $(NF-3), $(NF-2), $(NF-1), $NF}'
 
-echo "drop stream if exists default.test_s" | $BENDSQL_CLIENT_CONNECT
-echo "drop stream if exists default.test_s1" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.t" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop stream if exists default.test_s" | bendsql_connect_root
+echo "drop stream if exists default.test_s1" | bendsql_connect_root
+echo "drop table if exists db_stream.t" | bendsql_connect_root
+echo "drop database if exists db_stream" | bendsql_connect_root

--- a/tests/suites/5_ee/05_stream/05_0001_ee_stream_consume.sh
+++ b/tests/suites/5_ee/05_stream/05_0001_ee_stream_consume.sh
@@ -3,20 +3,20 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create database db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.base(a int) change_tracking = true" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.rand like db_stream.base Engine = Random" | $BENDSQL_CLIENT_CONNECT
-echo "create stream db_stream.s on table db_stream.base" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.sink(a int)" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists db_stream" | bendsql_connect_root
+echo "create database db_stream" | bendsql_connect_root
+echo "create table db_stream.base(a int) change_tracking = true" | bendsql_connect_root
+echo "create table db_stream.rand like db_stream.base Engine = Random" | bendsql_connect_root
+echo "create stream db_stream.s on table db_stream.base" | bendsql_connect_root
+echo "create table db_stream.sink(a int)" | bendsql_connect_root
 
 # Define function to write data into the base table.
 write_to_base() {
   for i in {1..20}; do
-    echo "insert into db_stream.base select * from db_stream.rand limit 10" | $BENDSQL_CLIENT_OUTPUT_NULL
+    echo "insert into db_stream.base select * from db_stream.rand limit 10" | bendsql_connect_root_null
 
     if (( i % 5 == 0 )); then
-      echo "optimize table db_stream.base compact" | $BENDSQL_CLIENT_CONNECT
+      echo "optimize table db_stream.base compact" | bendsql_connect_root
     fi
   done
 }
@@ -24,7 +24,7 @@ write_to_base() {
 # Define function to consume data from the stream into the sink table.
 consume_from_stream() {
   for i in {1..10}; do
-    echo "insert into db_stream.sink select a from db_stream.s" | $BENDSQL_CLIENT_OUTPUT_NULL
+    echo "insert into db_stream.sink select a from db_stream.s" | bendsql_connect_root_null
   done
 }
 
@@ -40,21 +40,21 @@ wait $write_pid
 wait $consume_pid
 
 # Perform a final consume operation from the stream to ensure all data is consumed
-echo "insert into db_stream.sink select a from db_stream.s" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into db_stream.sink select a from db_stream.s" | bendsql_connect_root_null
 
 # Fetch the counts and sums from both base and sink tables
-base_count=$(echo "SELECT COUNT(*) FROM db_stream.base;" | $BENDSQL_CLIENT_CONNECT)
-sink_count=$(echo "SELECT COUNT(*) FROM db_stream.sink;" | $BENDSQL_CLIENT_CONNECT)
-base_sum=$(echo "SELECT SUM(a) FROM db_stream.base;" | $BENDSQL_CLIENT_CONNECT)
-sink_sum=$(echo "SELECT SUM(a) FROM db_stream.sink;" | $BENDSQL_CLIENT_CONNECT)
+base_count=$(echo "SELECT COUNT(*) FROM db_stream.base;" | bendsql_connect_root)
+sink_count=$(echo "SELECT COUNT(*) FROM db_stream.sink;" | bendsql_connect_root)
+base_sum=$(echo "SELECT SUM(a) FROM db_stream.base;" | bendsql_connect_root)
+sink_sum=$(echo "SELECT SUM(a) FROM db_stream.sink;" | bendsql_connect_root)
 
 # Compare the counts and sums to verify consistency between the base and sink tables
 if [ "$base_count" -eq "$sink_count" ] && [ "$base_sum" -eq "$sink_sum" ]; then
   echo "test stream success"
 fi
 
-echo "drop stream if exists db_stream.s" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.base all" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.rand all" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.sink all" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop stream if exists db_stream.s" | bendsql_connect_root
+echo "drop table if exists db_stream.base all" | bendsql_connect_root
+echo "drop table if exists db_stream.rand all" | bendsql_connect_root
+echo "drop table if exists db_stream.sink all" | bendsql_connect_root
+echo "drop database if exists db_stream" | bendsql_connect_root

--- a/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.sh
+++ b/tests/suites/5_ee/05_stream/05_0002_ee_stream_create.sh
@@ -3,43 +3,43 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create database db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.base(a int)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db_stream.base values(1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "alter table db_stream.base set options(change_tracking = true)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db_stream.base values(2)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "insert into db_stream.base values(3)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "drop database if exists db_stream" | bendsql_connect_root
+echo "create database db_stream" | bendsql_connect_root
+echo "create table db_stream.base(a int)" | bendsql_connect_root
+echo "insert into db_stream.base values(1)" | bendsql_connect_root_null
+echo "alter table db_stream.base set options(change_tracking = true)" | bendsql_connect_root
+echo "insert into db_stream.base values(2)" | bendsql_connect_root_null
+echo "insert into db_stream.base values(3)" | bendsql_connect_root_null
 
-BASE_ROW_ID=$(echo "select _base_row_id from db_stream.base where a = 3" | $BENDSQL_CLIENT_CONNECT)
+BASE_ROW_ID=$(echo "select _base_row_id from db_stream.base where a = 3" | bendsql_connect_root)
 
-SNAPSHOT_ID_1=$(echo "select snapshot_id from fuse_snapshot('db_stream','base') where row_count=1 limit 1" | $BENDSQL_CLIENT_CONNECT)
-echo "create stream db_stream.s1 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_1')" | $BENDSQL_CLIENT_CONNECT
+SNAPSHOT_ID_1=$(echo "select snapshot_id from fuse_snapshot('db_stream','base') where row_count=1 limit 1" | bendsql_connect_root)
+echo "create stream db_stream.s1 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_1')" | bendsql_connect_root
 
-SNAPSHOT_ID_2=$(echo "select snapshot_id from fuse_snapshot('db_stream','base') where row_count=2 limit 1" | $BENDSQL_CLIENT_CONNECT)
-echo "create stream db_stream.s2 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_2')" | $BENDSQL_CLIENT_CONNECT
-echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from db_stream.s2" | $BENDSQL_CLIENT_CONNECT
-echo "select a from db_stream.base at (stream => db_stream.s2) order by a" | $BENDSQL_CLIENT_CONNECT
+SNAPSHOT_ID_2=$(echo "select snapshot_id from fuse_snapshot('db_stream','base') where row_count=2 limit 1" | bendsql_connect_root)
+echo "create stream db_stream.s2 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_2')" | bendsql_connect_root
+echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from db_stream.s2" | bendsql_connect_root
+echo "select a from db_stream.base at (stream => db_stream.s2) order by a" | bendsql_connect_root
 
-TIMEPOINT_1=$(echo "select timestamp from fuse_snapshot('db_stream','base') where row_count=1 limit 1" | $BENDSQL_CLIENT_CONNECT)
-echo "create stream db_stream.t1 on table db_stream.base at (timestamp => '$TIMEPOINT_1'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
+TIMEPOINT_1=$(echo "select timestamp from fuse_snapshot('db_stream','base') where row_count=1 limit 1" | bendsql_connect_root)
+echo "create stream db_stream.t1 on table db_stream.base at (timestamp => '$TIMEPOINT_1'::TIMESTAMP)" | bendsql_connect_root
 
-echo "alter table db_stream.base set options(change_tracking = true)" | $BENDSQL_CLIENT_CONNECT
-TIMEPOINT_2=$(echo "select timestamp from fuse_snapshot('db_stream','base') where row_count=2 limit 1" | $BENDSQL_CLIENT_CONNECT)
-echo "create stream db_stream.t2 on table db_stream.base at (timestamp => '$TIMEPOINT_2'::TIMESTAMP)" | $BENDSQL_CLIENT_CONNECT
-echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from db_stream.t2" | $BENDSQL_CLIENT_CONNECT
+echo "alter table db_stream.base set options(change_tracking = true)" | bendsql_connect_root
+TIMEPOINT_2=$(echo "select timestamp from fuse_snapshot('db_stream','base') where row_count=2 limit 1" | bendsql_connect_root)
+echo "create stream db_stream.t2 on table db_stream.base at (timestamp => '$TIMEPOINT_2'::TIMESTAMP)" | bendsql_connect_root
+echo "select a, change\$action, change\$is_update, change\$row_id='$BASE_ROW_ID' from db_stream.t2" | bendsql_connect_root
 
-echo "alter table db_stream.base set options(change_tracking = false)" | $BENDSQL_CLIENT_CONNECT
-echo "create stream db_stream.s3 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_2')" | $BENDSQL_CLIENT_CONNECT
-echo "alter table db_stream.base set options(change_tracking = true)" | $BENDSQL_CLIENT_CONNECT
-echo "create stream db_stream.s4 on table db_stream.base at (stream => db_stream.s2)" | $BENDSQL_CLIENT_CONNECT
-echo "select a from db_stream.s2" | $BENDSQL_CLIENT_CONNECT
+echo "alter table db_stream.base set options(change_tracking = false)" | bendsql_connect_root
+echo "create stream db_stream.s3 on table db_stream.base at (snapshot => '$SNAPSHOT_ID_2')" | bendsql_connect_root
+echo "alter table db_stream.base set options(change_tracking = true)" | bendsql_connect_root
+echo "create stream db_stream.s4 on table db_stream.base at (stream => db_stream.s2)" | bendsql_connect_root
+echo "select a from db_stream.s2" | bendsql_connect_root
 
-echo "select count(*) from fuse_snapshot('db_stream', 'base')" | $BENDSQL_CLIENT_CONNECT
-echo "set data_retention_time_in_days=0; optimize table db_stream.base purge before (stream => db_stream.s2)" | $BENDSQL_CLIENT_CONNECT
-echo "select count(*) from fuse_snapshot('db_stream', 'base')" | $BENDSQL_CLIENT_CONNECT
+echo "select count(*) from fuse_snapshot('db_stream', 'base')" | bendsql_connect_root
+echo "set data_retention_time_in_days=0; optimize table db_stream.base purge before (stream => db_stream.s2)" | bendsql_connect_root
+echo "select count(*) from fuse_snapshot('db_stream', 'base')" | bendsql_connect_root
 
-echo "drop stream if exists db_stream.s2" | $BENDSQL_CLIENT_CONNECT
-echo "drop stream if exists db_stream.t2" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.base all" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop stream if exists db_stream.s2" | bendsql_connect_root
+echo "drop stream if exists db_stream.t2" | bendsql_connect_root
+echo "drop table if exists db_stream.base all" | bendsql_connect_root
+echo "drop database if exists db_stream" | bendsql_connect_root

--- a/tests/suites/5_ee/05_stream/05_0003_ee_stream_copy_into_location.sh
+++ b/tests/suites/5_ee/05_stream/05_0003_ee_stream_copy_into_location.sh
@@ -3,17 +3,17 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace database db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.t(c int)" | $BENDSQL_CLIENT_CONNECT
-echo "create stream db_stream.s on table db_stream.t" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db_stream.t values(1)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "create or replace database db_stream" | bendsql_connect_root
+echo "create table db_stream.t(c int)" | bendsql_connect_root
+echo "create stream db_stream.s on table db_stream.t" | bendsql_connect_root
+echo "insert into db_stream.t values(1)" | bendsql_connect_root_null
 
-echo "create or replace stage stage_05_0003" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace stage stage_05_0003" | bendsql_connect_root
 
 echo "expects one row that outputs the file unloaded"
-echo "copy into @stage_05_0003 from (select c from db_stream.s) DETAILED_OUTPUT = true" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "copy into @stage_05_0003 from (select c from db_stream.s) DETAILED_OUTPUT = true" | bendsql_connect_root | wc -l
 echo "expects that the stream s is empty"
-echo "select count() from db_stream.s" | $BENDSQL_CLIENT_CONNECT
+echo "select count() from db_stream.s" | bendsql_connect_root
 
-echo "drop stage if exists stage_05_0003" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop stage if exists stage_05_0003" | bendsql_connect_root
+echo "drop database if exists db_stream" | bendsql_connect_root

--- a/tests/suites/5_ee/05_stream/05_0004_ee_stream_http_api.sh
+++ b/tests/suites/5_ee/05_stream/05_0004_ee_stream_http_api.sh
@@ -3,11 +3,11 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
-echo "drop stream if exists s1" | $BENDSQL_CLIENT_CONNECT
+echo "drop table if exists t1" | bendsql_connect_root
+echo "drop stream if exists s1" | bendsql_connect_root
 
-echo "create table t1(a int)" | $BENDSQL_CLIENT_CONNECT
-echo "create stream s1 on table t1" | $BENDSQL_CLIENT_CONNECT
+echo "create table t1(a int)" | bendsql_connect_root
+echo "create stream s1 on table t1" | bendsql_connect_root
 
 echo "# Test catalog streams API - existing database"
 curl -s -u root: -XGET "http://localhost:8000/v1/catalog/databases/default/streams" | jq 'del(.streams[].created_on, .streams[].updated_on, .streams[].stream_id, .streams[].table_id, .streams[].table_version)'
@@ -15,5 +15,5 @@ curl -s -u root: -XGET "http://localhost:8000/v1/catalog/databases/default/strea
 echo "# Test catalog streams API - non-existent database"
 curl -s -u root: -XGET "http://localhost:8000/v1/catalog/databases/nonexistent/streams" -w "%{http_code}\n"
 
-echo "drop stream if exists s1" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists t1" | $BENDSQL_CLIENT_CONNECT
+echo "drop stream if exists s1" | bendsql_connect_root
+echo "drop table if exists t1" | bendsql_connect_root

--- a/tests/suites/5_ee/06_inverted_index/06_0000_purge_inverted_index.sh
+++ b/tests/suites/5_ee/06_inverted_index/06_0000_purge_inverted_index.sh
@@ -6,21 +6,21 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ### test for purging inverted index files, using transient table ###
 
-echo "drop database if exists db_purge_inverted_index" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists db_purge_inverted_index" | bendsql_connect_root
 
-echo "CREATE DATABASE db_purge_inverted_index" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE db_purge_inverted_index" | bendsql_connect_root
 
 TEST_DB="db_purge_inverted_index"
 
-echo "create or replace stage test_purge_ii url='fs:///tmp/purge_inverted_index/'" | $BENDSQL_CLIENT_CONNECT
+echo "create or replace stage test_purge_ii url='fs:///tmp/purge_inverted_index/'" | bendsql_connect_root
 
 # uncomment this line to clean up the stage (for local diagnostic only)
 # rm -rf /tmp/purge_inverted_index/*
 
 # create transient table with 2 inverted index, at the location of @test_purge_ii
-echo "CREATE or replace transient TABLE  ${TEST_DB}.customer_feedback ( comment_title VARCHAR NULL, comment_body VARCHAR NULL ) 'fs:///tmp/purge_inverted_index/'" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE INVERTED INDEX idx1 ON ${TEST_DB}.customer_feedback(comment_title)" | $BENDSQL_CLIENT_CONNECT
-echo "CREATE INVERTED INDEX idx2 ON ${TEST_DB}.customer_feedback(comment_body)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE or replace transient TABLE  ${TEST_DB}.customer_feedback ( comment_title VARCHAR NULL, comment_body VARCHAR NULL ) 'fs:///tmp/purge_inverted_index/'" | bendsql_connect_root
+echo "CREATE INVERTED INDEX idx1 ON ${TEST_DB}.customer_feedback(comment_title)" | bendsql_connect_root
+echo "CREATE INVERTED INDEX idx2 ON ${TEST_DB}.customer_feedback(comment_body)" | bendsql_connect_root
 
 
 
@@ -28,89 +28,89 @@ echo "###################"
 echo "###1st insertion###"
 echo "###################"
 
-echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | bendsql_connect_root_null
 echo "== number of snapshots (expects 1)=="
 # 1 snapshot for the init insertion
-echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
-#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT
+#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root
 
 echo "== number of invert index files (expects 2) =="
 # NOTE: since there are 1 block, 2 inverted indexes.
-echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
-#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT
+#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root
 
 
 echo "###################"
 echo "###2nd insertion###"
 echo "###################"
 
-echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | bendsql_connect_root_null
 echo "== number of snapshots (expects 1)=="
 # NOTE:
 # - since previous snapshots should be purged,
 # - and 1 snapshot created for this new insertion
-echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
 #   it will shows that the oldest snapshot is the previous_snapshot of the latest snapshot before 2nd insertion
-#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT
+#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root
 
 echo "== number of invert index files (expects 4) =="
 # NOTE: since there are 2 blocks now, each of them will have 2 inverted indexes.
-echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
-#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT
+#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root
 
 
 echo "###################"
 echo "###3nd insertion###"
 echo "###################"
 
-echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | bendsql_connect_root_null
 
 echo "== number of snapshots (expects 1)=="
-echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
 #   it will shows that the oldest snapshot is the previous_snapshot of the latest snapshot before 3nd insertion
-#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT
+#echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root
 
 echo "== number of invert index files (expects 6) =="
 # NOTE: since there are 3 blocks now, each of them will have 2 inverted indexes.
-echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
-#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT
+#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root
 
 
 echo "###################"
 echo "####compaction#####"
 echo "###################"
 
-echo "optimize table ${TEST_DB}.customer_feedback compact" | $BENDSQL_CLIENT_CONNECT
+echo "optimize table ${TEST_DB}.customer_feedback compact" | bendsql_connect_root
 echo "== number of snapshots (expects 1)=="
 # NOTE: since previous snapshot will be purged(transient table), and inverted index is refreshed after compaction
-echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root | wc -l
 
 echo "== number of invert index files (expects 2) =="
 # NOTE: inverted index is refreshed after compaction
-echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root | wc -l
 # uncomment this line to show the details (for local diagnostic only)
-#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT
+#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root
 
 echo "###################"
 echo "####new insertion##"
 echo "###################"
 
-echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into ${TEST_DB}.customer_feedback values('a', 'b')" | bendsql_connect_root_null
 echo "== number of snapshots (expects 1) =="
-echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "select snapshot_id, previous_snapshot_id from fuse_snapshot('db_purge_inverted_index', 'customer_feedback') limit 100" | bendsql_connect_root | wc -l
 echo "== number of invert index files (expects 4) =="
 # NOTE: the inverted index refreshment will create new indexes for the new blocks, and there is one new block and 2 indexes
-echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT | wc -l
+echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root | wc -l
 # for local diagnostic only
-#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | $BENDSQL_CLIENT_CONNECT
+#echo "list @test_purge_ii PATTERN = '.*/_i_i/.*.index';" | bendsql_connect_root
 
 
-echo "drop table ${TEST_DB}.customer_feedback" | $BENDSQL_CLIENT_CONNECT
-echo "drop stage test_purge_ii" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists ${TEST_DB}" | $BENDSQL_CLIENT_CONNECT
+echo "drop table ${TEST_DB}.customer_feedback" | bendsql_connect_root
+echo "drop stage test_purge_ii" | bendsql_connect_root
+echo "drop database if exists ${TEST_DB}" | bendsql_connect_root

--- a/tests/suites/5_ee/06_inverted_index/06_0001_index_visibility.sh
+++ b/tests/suites/5_ee/06_inverted_index/06_0001_index_visibility.sh
@@ -3,26 +3,26 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop role if exists role1" | $BENDSQL_CLIENT_CONNECT
-echo "drop role if exists role2" | $BENDSQL_CLIENT_CONNECT
-echo "drop user if exists u1" | $BENDSQL_CLIENT_CONNECT
-echo "drop user if exists u2" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db1" | $BENDSQL_CLIENT_CONNECT
-echo "create database db1" | $BENDSQL_CLIENT_CONNECT
-echo "create table db1.t1(id int, title string, inverted index idx1(title))" | $BENDSQL_CLIENT_CONNECT
-echo "insert into db1.t1 values(1, 'hello world')" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "create role role1;" | $BENDSQL_CLIENT_CONNECT
-echo "create role role2;" | $BENDSQL_CLIENT_CONNECT
-echo "grant select on db1.t1 to role role1;" | $BENDSQL_CLIENT_CONNECT
-echo "create user u1 identified by '123' with DEFAULT_ROLE='role1';" | $BENDSQL_CLIENT_CONNECT
-echo "create user u2 identified by '123' with DEFAULT_ROLE='role2';" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role1 to u1;" | $BENDSQL_CLIENT_CONNECT
-echo "grant role role2 to u2;" | $BENDSQL_CLIENT_CONNECT
+echo "drop role if exists role1" | bendsql_connect_root
+echo "drop role if exists role2" | bendsql_connect_root
+echo "drop user if exists u1" | bendsql_connect_root
+echo "drop user if exists u2" | bendsql_connect_root
+echo "drop database if exists db1" | bendsql_connect_root
+echo "create database db1" | bendsql_connect_root
+echo "create table db1.t1(id int, title string, inverted index idx1(title))" | bendsql_connect_root
+echo "insert into db1.t1 values(1, 'hello world')" | bendsql_connect_root_null
+echo "create role role1;" | bendsql_connect_root
+echo "create role role2;" | bendsql_connect_root
+echo "grant select on db1.t1 to role role1;" | bendsql_connect_root
+echo "create user u1 identified by '123' with DEFAULT_ROLE='role1';" | bendsql_connect_root
+echo "create user u2 identified by '123' with DEFAULT_ROLE='role2';" | bendsql_connect_root
+echo "grant role role1 to u1;" | bendsql_connect_root
+echo "grant role role2 to u2;" | bendsql_connect_root
 
 echo "=== test u1 with role1 ==="
-export TEST_U1_CONNECT="bendsql_query_http_user_connect u1 123"
+export TEST_U1_CONNECT="bendsql_connect_user u1 123"
 echo "select name, type, definition from system.indexes where database = 'db1' order by name" | $TEST_U1_CONNECT
 
 echo "=== test u2 with role2 ==="
-export TEST_U2_CONNECT="bendsql_query_http_user_connect u2 123"
+export TEST_U2_CONNECT="bendsql_connect_user u2 123"
 echo "select name, type, definition from system.indexes where database = 'db1' order by name" | $TEST_U2_CONNECT

--- a/tests/suites/5_ee/07_failsafe/07_0000_amend_table.sh
+++ b/tests/suites/5_ee/07_failsafe/07_0000_amend_table.sh
@@ -3,29 +3,29 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace DATABASE test_failsafe" |  $BENDSQL_CLIENT_CONNECT
+echo "create or replace DATABASE test_failsafe" |  bendsql_connect_root
 
-echo "create table test_failsafe.t(a int) 's3://testbucket/test_amend/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900')" | $BENDSQL_CLIENT_CONNECT
+echo "create table test_failsafe.t(a int) 's3://testbucket/test_amend/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900')" | bendsql_connect_root
 
-echo "CREATE or replace stage test_amend_stage URL='s3://testbucket/test_amend/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900')" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE or replace stage test_amend_stage URL='s3://testbucket/test_amend/' connection=(access_key_id ='minioadmin' secret_access_key ='minioadmin' endpoint_url='http://127.0.0.1:9900')" | bendsql_connect_root
 
 
 # generate multiple blocks & segments
 
-echo "insert into test_failsafe.t select * from numbers(11)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "insert into test_failsafe.t select * from numbers(11)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "insert into test_failsafe.t select * from numbers(11)" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "insert into test_failsafe.t select * from numbers(11)" | bendsql_connect_root_null
+echo "insert into test_failsafe.t select * from numbers(11)" | bendsql_connect_root_null
+echo "insert into test_failsafe.t select * from numbers(11)" | bendsql_connect_root_null
 
-echo "remove @test_amend_stage" | $BENDSQL_CLIENT_CONNECT
+echo "remove @test_amend_stage" | bendsql_connect_root
 
 
 echo "check table is corrupted"
-echo "select * from test_failsafe.t" | $BENDSQL_CLIENT_CONNECT 2>&1 | grep "NotFound" | wc -l
+echo "select * from test_failsafe.t" | bendsql_connect_root 2>&1 | grep "NotFound" | wc -l
 
-echo "call system\$fuse_amend('test_failsafe', 't')" | $BENDSQL_CLIENT_CONNECT
+echo "call system\$fuse_amend('test_failsafe', 't')" | bendsql_connect_root
 
 
 echo "verify that table restored"
-echo "select sum(a) from  test_failsafe.t" | $BENDSQL_CLIENT_CONNECT
+echo "select sum(a) from  test_failsafe.t" | bendsql_connect_root
 
-echo "DROP DATABASE IF EXISTS test_failsafe" | $BENDSQL_CLIENT_CONNECT
+echo "DROP DATABASE IF EXISTS test_failsafe" | bendsql_connect_root

--- a/tests/suites/5_ee/08_udf_python/08_0000_parallelism.sh
+++ b/tests/suites/5_ee/08_udf_python/08_0000_parallelism.sh
@@ -2,7 +2,7 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-$BENDSQL_CLIENT_CONNECT --query="""
+bendsql_connect_root --query="""
 CREATE OR REPLACE FUNCTION python_sleep ( INT64 ) RETURNS INT64 LANGUAGE python HANDLER = 'sleep' AS \$\$
 import time
 
@@ -12,8 +12,8 @@ def sleep(n):
 \$\$;
 """
 
-$BENDSQL_CLIENT_CONNECT --query='select python_sleep(100)' &
+bendsql_connect_root --query='select python_sleep(100)' &
 job_pid=$!
-$BENDSQL_CLIENT_CONNECT --query='select python_sleep(1)'
-$BENDSQL_CLIENT_CONNECT --query='select python_sleep(2)'
+bendsql_connect_root --query='select python_sleep(1)'
+bendsql_connect_root --query='select python_sleep(2)'
 wait $job_pid

--- a/tests/suites/5_ee/09_workload_group/09_0000_workload_group.sh
+++ b/tests/suites/5_ee/09_workload_group/09_0000_workload_group.sh
@@ -3,19 +3,19 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace DATABASE workloadgroup" |  $BENDSQL_CLIENT_CONNECT
-echo "create table workloadgroup.t(a int)" | $BENDSQL_CLIENT_CONNECT
-echo "insert into workloadgroup.t values(1)" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "DROP USER IF EXISTS test_user_workload_group2;" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "DROP WORKLOAD GROUP IF EXISTS valid_mem;" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "CREATE WORKLOAD GROUP valid_mem WITH memory_quota = '4GB';" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "create user test_user_workload_group2 identified by '123' with SET WORKLOAD GROUP='valid_mem'" | $BENDSQL_CLIENT_OUTPUT_NULL
-echo "grant select on workloadgroup.t to test_user_workload_group2" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "create or replace DATABASE workloadgroup" |  bendsql_connect_root
+echo "create table workloadgroup.t(a int)" | bendsql_connect_root
+echo "insert into workloadgroup.t values(1)" | bendsql_connect_root_null
+echo "DROP USER IF EXISTS test_user_workload_group2;" | bendsql_connect_root_null
+echo "DROP WORKLOAD GROUP IF EXISTS valid_mem;" | bendsql_connect_root_null
+echo "CREATE WORKLOAD GROUP valid_mem WITH memory_quota = '4GB';" | bendsql_connect_root_null
+echo "create user test_user_workload_group2 identified by '123' with SET WORKLOAD GROUP='valid_mem'" | bendsql_connect_root_null
+echo "grant select on workloadgroup.t to test_user_workload_group2" | bendsql_connect_root_null
 
-export TEST_USER_CONNECT="bendsql_query_http_user_connect test_user_workload_group2 123"
+export TEST_USER_CONNECT="bendsql_connect_user test_user_workload_group2 123"
 
 echo "select * from workloadgroup.t" | $TEST_USER_CONNECT
-echo "drop workload group valid_mem;" | $BENDSQL_CLIENT_OUTPUT_NULL
+echo "drop workload group valid_mem;" | bendsql_connect_root_null
 
 output=$(echo "select * from workloadgroup.t" | $TEST_USER_CONNECT 2>&1)
 
@@ -23,5 +23,5 @@ if [[ "$output" != *"[3142]Unknown workload id"* ]]; then
     exit 1
 fi
 
-echo "DROP DATABASE IF EXISTS workloadgroup" | $BENDSQL_CLIENT_CONNECT
-echo "DROP USER IF EXISTS test_user_workload_group2" | $BENDSQL_CLIENT_CONNECT
+echo "DROP DATABASE IF EXISTS workloadgroup" | bendsql_connect_root
+echo "DROP USER IF EXISTS test_user_workload_group2" | bendsql_connect_root

--- a/tests/suites/5_ee/10_rbac/10_0001_masking_policy_rbac.sh
+++ b/tests/suites/5_ee/10_rbac/10_0001_masking_policy_rbac.sh
@@ -22,10 +22,10 @@ stmt "CREATE ROLE role_mask_create"
 stmt "GRANT ROLE role_mask_create TO mask_create"
 stmt "CREATE USER mask_desc IDENTIFIED BY '123' with default_role='mask_desc'"
 
-export USER_MASK_DESC="bendsql_query_http_user_connect mask_desc 123 -A --quote-style=never"
+export USER_MASK_DESC="bendsql_connect_user mask_desc 123 -A --quote-style=never"
 
-export USER_MASK_CREATE="bendsql_query_http_user_connect mask_create 123 -A --quote-style=never"
-export USER_MASK_APPLY="bendsql_query_http_user_connect mask_apply 123 -A --quote-style=never"
+export USER_MASK_CREATE="bendsql_connect_user mask_create 123 -A --quote-style=never"
+export USER_MASK_APPLY="bendsql_connect_user mask_apply 123 -A --quote-style=never"
 
 comment "create privilege requires CREATE MASKING POLICY"
 echo "CREATE MASKING POLICY mask_phone AS (val STRING) RETURNS STRING -> concat('***', right(val, 2));" | $USER_MASK_CREATE

--- a/tests/suites/5_ee/10_rbac/10_0002_row_access_policy_rbac.sh
+++ b/tests/suites/5_ee/10_rbac/10_0002_row_access_policy_rbac.sh
@@ -21,8 +21,8 @@ stmt "GRANT ROLE role_rap_apply TO rap_apply"
 stmt "CREATE ROLE role_rap_create"
 stmt "GRANT ROLE role_rap_create TO rap_create"
 
-export USER_RAP_CREATE="bendsql_query_http_user_connect rap_create 123 -A --quote-style=never"
-export USER_RAP_APPLY="bendsql_query_http_user_connect rap_apply 123 -A --quote-style=never"
+export USER_RAP_CREATE="bendsql_connect_user rap_create 123 -A --quote-style=never"
+export USER_RAP_APPLY="bendsql_connect_user rap_apply 123 -A --quote-style=never"
 
 echo "SET enable_experimental_row_access_policy = 1;" | $USER_RAP_CREATE
 echo "SET enable_experimental_row_access_policy = 1;" | $USER_RAP_APPLY

--- a/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.sh
+++ b/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.sh
@@ -18,29 +18,29 @@ stmt "CREATE ROW ACCESS POLICY rap_pushdown_policy AS (region STRING) RETURNS bo
 stmt "ALTER TABLE rap_pushdown_test ADD ROW ACCESS POLICY rap_pushdown_policy ON (region)"
 
 comment "test 1: filter pushdown with RAP - user predicate is displayed, secure predicate is hidden"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "filters: \[\]" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | bendsql_connect_root | grep "push downs:" | grep -v "filters: \[\]" | sed 's/^[[:space:]]*//g'
 
 comment "test 2: limit pushdown with RAP and user WHERE after RAP enters prewhere"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0 LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0 LIMIT 1;" | bendsql_connect_root | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
 
 comment "test 3: verify Filter [SECURE] is skipped when prewhere covers all secure predicates"
 comment "Filter [SECURE] should NOT appear because secure predicates are fully applied by prewhere"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -c "Filter \[SECURE\]" || true
+echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | bendsql_connect_root | grep -c "Filter \[SECURE\]" || true
 
 comment "test 4: limit pushdown with RAP and no user WHERE after RAP enters prewhere"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_pushdown_test LIMIT 1;" | bendsql_connect_root | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
 
 comment "test 5: sort (ORDER BY + LIMIT) pushdown with RAP after RAP enters prewhere"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test ORDER BY id LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_pushdown_test ORDER BY id LIMIT 1;" | bendsql_connect_root | grep "push downs:" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
 
 comment "test 6: sort + filter pushdown with RAP"
-echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0 ORDER BY id LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | grep -v "filters: \\[\\]" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0 ORDER BY id LIMIT 1;" | bendsql_connect_root | grep "push downs:" | grep -v "filters: \\[\\]" | grep -v "limit: NONE" | sed 's/^[[:space:]]*//g'
 
 comment "test 7: ORDER BY + LIMIT semantics should apply RAP before TopK result selection"
 query "SELECT id, region FROM rap_pushdown_test ORDER BY id LIMIT 1"
 
 comment "test 8: EXPLAIN output should not leak the raw RAP expression"
-if echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -F "region = 'APAC'"; then
+if echo "EXPLAIN SELECT * FROM rap_pushdown_test WHERE id > 0;" | bendsql_connect_root | grep -F "region = 'APAC'"; then
     echo "raw RAP expression leaked in EXPLAIN"
     exit 1
 else
@@ -48,7 +48,7 @@ else
 fi
 
 comment "test 9: EXPLAIN ANALYZE output should not leak the raw RAP expression"
-if echo "EXPLAIN ANALYZE SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -F "region = 'APAC'"; then
+if echo "EXPLAIN ANALYZE SELECT * FROM rap_pushdown_test WHERE id > 0;" | bendsql_connect_root | grep -F "region = 'APAC'"; then
     echo "raw RAP expression leaked in EXPLAIN ANALYZE"
     exit 1
 else
@@ -56,7 +56,7 @@ else
 fi
 
 comment "test 10: EXPLAIN PERF output should not leak the raw RAP expression"
-if echo "EXPLAIN PERF SELECT * FROM rap_pushdown_test WHERE id > 0;" | $BENDSQL_CLIENT_CONNECT | grep -F "region = 'APAC'"; then
+if echo "EXPLAIN PERF SELECT * FROM rap_pushdown_test WHERE id > 0;" | bendsql_connect_root | grep -F "region = 'APAC'"; then
     echo "raw RAP expression leaked in EXPLAIN PERF"
     exit 1
 else
@@ -72,7 +72,7 @@ stmt "CREATE ROW ACCESS POLICY rap_vcol_policy AS (val VARIANT) RETURNS boolean 
 stmt "ALTER TABLE rap_vcol_test ADD ROW ACCESS POLICY rap_vcol_policy ON (val)"
 
 comment "verify limit IS pushed because RAP enters prewhere"
-echo "EXPLAIN SELECT * FROM rap_vcol_test LIMIT 1;" | $BENDSQL_CLIENT_CONNECT | grep "push downs:" | sed 's/^[[:space:]]*//g'
+echo "EXPLAIN SELECT * FROM rap_vcol_test LIMIT 1;" | bendsql_connect_root | grep "push downs:" | sed 's/^[[:space:]]*//g'
 
 comment "verify query still returns correct results with RAP enforced"
 query "SELECT id FROM rap_vcol_test ORDER BY id"
@@ -116,7 +116,7 @@ stmt "CREATE ROW ACCESS POLICY rap_pruning_policy AS (region STRING) RETURNS boo
 stmt "ALTER TABLE rap_pruning_test ADD ROW ACCESS POLICY rap_pruning_policy ON (region)"
 
 comment "EXPLAIN ANALYZE should show blocks range pruning: 4 to 2 (2 EMEA blocks pruned by RAP)"
-echo "EXPLAIN ANALYZE SELECT * FROM rap_pruning_test;" | $BENDSQL_CLIENT_CONNECT | grep "pruning stats:" | sed 's/^[[:space:]]*//g' | sed 's/ cost: [0-9]* ms//g'
+echo "EXPLAIN ANALYZE SELECT * FROM rap_pruning_test;" | bendsql_connect_root | grep "pruning stats:" | sed 's/^[[:space:]]*//g' | sed 's/ cost: [0-9]* ms//g'
 
 stmt "ALTER TABLE rap_pruning_test DROP ROW ACCESS POLICY rap_pruning_policy"
 stmt "DROP TABLE IF EXISTS rap_pruning_test"

--- a/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.sh
+++ b/tests/suites/5_ee/11_security/11_0002_planner_cache_secure_policy.sh
@@ -13,7 +13,7 @@ USER_B="pc_user_b"
 PASSWORD="123"
 
 quiet_root_sql() {
-	echo "$1" | $BENDSQL_CLIENT_OUTPUT_NULL
+	echo "$1" | bendsql_connect_root_null
 }
 
 cleanup() {
@@ -27,7 +27,7 @@ cleanup() {
 run_user_query() {
 	local user="$1"
 	local sql="$2"
-	bendsql_query_http_user_connect "${user}" "${PASSWORD}" -A --quote-style=never <<<"${sql}"
+	bendsql_connect_user "${user}" "${PASSWORD}" -A --quote-style=never <<<"${sql}"
 }
 
 expect_user_query() {

--- a/tests/suites/7_management/00_stream_status/00_0000_stream_status.sh
+++ b/tests/suites/7_management/00_stream_status/00_0000_stream_status.sh
@@ -3,17 +3,17 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop database if exists db_stream" | bendsql_connect_root
 
-echo "CREATE DATABASE db_stream" | $BENDSQL_CLIENT_CONNECT
-echo "create table db_stream.t(a int)" | $BENDSQL_CLIENT_CONNECT
-echo "create stream default.s1 on table db_stream.t comment = 'test'" | $BENDSQL_CLIENT_CONNECT
-echo "create stream db_stream.s2 on table db_stream.t at(stream => default.s1)" | $BENDSQL_CLIENT_CONNECT
+echo "CREATE DATABASE db_stream" | bendsql_connect_root
+echo "create table db_stream.t(a int)" | bendsql_connect_root
+echo "create stream default.s1 on table db_stream.t comment = 'test'" | bendsql_connect_root
+echo "create stream db_stream.s2 on table db_stream.t at(stream => default.s1)" | bendsql_connect_root
 
 curl -X GET -s http://localhost:8081/v1/tenants/system/stream_status\?stream_name=s1 | jq .has_data
 curl -X GET -s http://localhost:8081/v1/tenants/system/stream_status\?stream_name\=s2\&database\=db_stream | jq .has_data
 
-echo "drop stream if exists default.s1" | $BENDSQL_CLIENT_CONNECT
-echo "drop stream if exists db_stream.s2" | $BENDSQL_CLIENT_CONNECT
-echo "drop table if exists db_stream.t all" | $BENDSQL_CLIENT_CONNECT
-echo "drop database if exists db_stream" | $BENDSQL_CLIENT_CONNECT
+echo "drop stream if exists default.s1" | bendsql_connect_root
+echo "drop stream if exists db_stream.s2" | bendsql_connect_root
+echo "drop table if exists db_stream.t all" | bendsql_connect_root
+echo "drop database if exists db_stream" | bendsql_connect_root

--- a/tests/suites/8_faked_time_prepare/00_prepare/00_0000_dummy_prepare.sh
+++ b/tests/suites/8_faked_time_prepare/00_prepare/00_0000_dummy_prepare.sh
@@ -3,8 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-echo "create or replace DATABASE test_faketime" |  $BENDSQL_CLIENT_CONNECT
+echo "create or replace DATABASE test_faketime" |  bendsql_connect_root
 
-echo "create table test_faketime.t(c timestamp)" |  $BENDSQL_CLIENT_CONNECT
+echo "create table test_faketime.t(c timestamp)" |  bendsql_connect_root
 
-echo "insert into table test_faketime.t values(now())" | $BENDSQL_CLIENT_CONNECT
+echo "insert into table test_faketime.t values(now())" | bendsql_connect_root

--- a/tests/suites/9_faked_time/00_dummy_cases/00_0001_dummy.sh
+++ b/tests/suites/9_faked_time/00_dummy_cases/00_0001_dummy.sh
@@ -10,8 +10,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #############################################################
 
 # format of `faked` is "2024-05-22 03:00:35.977589"
-c=$(echo "select c from test_faketime.t" | $BENDSQL_CLIENT_CONNECT)
-now=$(echo "select now()" | $BENDSQL_CLIENT_CONNECT)
+c=$(echo "select c from test_faketime.t" | bendsql_connect_root)
+now=$(echo "select now()" | bendsql_connect_root)
 
 # manually "time diff"
 faked=$(date -d "$c" +%s)

--- a/tests/suites/9_faked_time/00_dummy_cases/00_0002_vacuum2.sh
+++ b/tests/suites/9_faked_time/00_dummy_cases/00_0002_vacuum2.sh
@@ -3,8 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-SEGMENTS=$(echo "select file_location from fuse_segment('default','test_vacuum2');" | $BENDSQL_CLIENT_CONNECT)
-BLOCKS=$(echo "select block_location from fuse_block('default','test_vacuum2');" | $BENDSQL_CLIENT_CONNECT)
+SEGMENTS=$(echo "select file_location from fuse_segment('default','test_vacuum2');" | bendsql_connect_root)
+BLOCKS=$(echo "select block_location from fuse_block('default','test_vacuum2');" | bendsql_connect_root)
 
 stmt "insert into test_vacuum2 values(2);"
 
@@ -18,7 +18,7 @@ done
 
 stmt "set data_retention_time_in_days = 2;truncate table test_vacuum2;"
 
-SNAPSHOTS=$(echo "select snapshot_location from fuse_snapshot('default','test_vacuum2');" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOTS=$(echo "select snapshot_location from fuse_snapshot('default','test_vacuum2');" | bendsql_connect_root)
 IFS=$'\n' read -d '' -r -a snapshots <<< "$SNAPSHOTS"
 to_be_vacuumed=("${snapshots[@]}" "${segments[@]}" "${blocks[@]}" "${blooms[@]}")
 
@@ -29,7 +29,7 @@ stmt "insert into test_vacuum2 values(3);"
 # should have 4 snapshots
 query "select count(*) from fuse_snapshot('default','test_vacuum2')"
 
-RESULTS=$(echo "set data_retention_time_in_days = 0;select * from fuse_vacuum2('default','test_vacuum2');" | $BENDSQL_CLIENT_CONNECT)
+RESULTS=$(echo "set data_retention_time_in_days = 0;select * from fuse_vacuum2('default','test_vacuum2');" | bendsql_connect_root)
 IFS=$'\n' read -d '' -r -a results <<< "$RESULTS"
 
 # verify the vacuum result

--- a/tests/suites/9_faked_time/00_dummy_cases/00_0003_vacuum2_respect_time_travel.sh
+++ b/tests/suites/9_faked_time/00_dummy_cases/00_0003_vacuum2_respect_time_travel.sh
@@ -3,8 +3,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../../../shell_env.sh
 
-SEGMENTS=$(echo "select file_location from fuse_segment('default','test_vacuum2_respect_time_travel');" | $BENDSQL_CLIENT_CONNECT)
-BLOCKS=$(echo "select block_location from fuse_block('default','test_vacuum2_respect_time_travel');" | $BENDSQL_CLIENT_CONNECT)
+SEGMENTS=$(echo "select file_location from fuse_segment('default','test_vacuum2_respect_time_travel');" | bendsql_connect_root)
+BLOCKS=$(echo "select block_location from fuse_block('default','test_vacuum2_respect_time_travel');" | bendsql_connect_root)
 
 stmt "insert into test_vacuum2_respect_time_travel values(2);"
 
@@ -18,7 +18,7 @@ done
 
 stmt "set data_retention_time_in_days = 2;truncate table test_vacuum2_respect_time_travel;"
 
-SNAPSHOTS=$(echo "select snapshot_location from fuse_snapshot('default','test_vacuum2_respect_time_travel');" | $BENDSQL_CLIENT_CONNECT)
+SNAPSHOTS=$(echo "select snapshot_location from fuse_snapshot('default','test_vacuum2_respect_time_travel');" | bendsql_connect_root)
 IFS=$'\n' read -d '' -r -a snapshots <<< "$SNAPSHOTS"
 to_be_vacuumed=("${snapshots[@]}" "${segments[@]}" "${blocks[@]}" "${blooms[@]}")
 
@@ -29,7 +29,7 @@ stmt "insert into test_vacuum2_respect_time_travel values(3);"
 # should have 4 snapshots
 query "select count(*) from fuse_snapshot('default','test_vacuum2_respect_time_travel')"
 
-RESULTS=$(echo "set data_retention_time_in_days = 0;select * from fuse_vacuum2('default','test_vacuum2_respect_time_travel',true);" | $BENDSQL_CLIENT_CONNECT)
+RESULTS=$(echo "set data_retention_time_in_days = 0;select * from fuse_vacuum2('default','test_vacuum2_respect_time_travel',true);" | bendsql_connect_root)
 IFS=$'\n' read -d '' -r -a results <<< "$RESULTS"
 
 # verify the vacuum result


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Use the new `BENDSQL_ERROR_NO_VERSION=1` env var from bendsql to suppress the `[vX.Y.Z]` version suffix in error messages, replacing the previous sed/tempfile workarounds.

Also unifies the shell helper naming convention:

| Old | New |
|-----|-----|
| `bendsql_query_http_connect` | `bendsql_connect` |
| `bendsql_query_http_user_connect` | `bendsql_connect_user` |
| `bendsql_client_connect` / `$BENDSQL_CLIENT_CONNECT` | `bendsql_connect_root` |
| `bendsql_client_output_null` / `$BENDSQL_CLIENT_OUTPUT_NULL` | `bendsql_connect_root_null` |
| `bendsql_client_share_provider_connect` | `bendsql_connect_share_provider` |
| `bendsql_client_share_consumer_connect` | `bendsql_connect_share_consumer` |

Exported env vars (`BENDSQL_CLIENT_CONNECT`, etc.) are removed in favor of direct function calls.

Depends on: https://github.com/databendlabs/bendsql/commit/6a4e8c3e5068745e80fbafdcb8a42e390d30df2c

## Tests

- [x] No Test - Mechanical renames only; shell syntax validated with `bash -n`

## Type of change

- [x] Other (please describe): ci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20018)
<!-- Reviewable:end -->
