### PR TITLE
fix(storage): refine proxy statistics routing

### DIFF
--- a/src/query/storages/basic/src/proxy_table.rs
+++ b/src/query/storages/basic/src/proxy_table.rs
@@ -1071,10 +1071,21 @@ fn statistics_route_score(
     table: &dyn Table,
     predicate_columns: &PredicateColumns,
 ) -> StatisticsRouteScore {
-    let cluster_key_columns = cluster_key_columns(table);
+    statistics_route_score_for_columns(&cluster_key_columns(table), predicate_columns)
+}
+
+fn statistics_route_score_for_columns<S: AsRef<str>>(
+    cluster_key_columns: &[S],
+    predicate_columns: &PredicateColumns,
+) -> StatisticsRouteScore {
+    let prefix = cluster_prefix_score_for_columns(cluster_key_columns, predicate_columns);
     StatisticsRouteScore {
-        prefix: cluster_prefix_score_for_columns(&cluster_key_columns, predicate_columns),
-        cluster_key_len: cluster_key_columns.len(),
+        prefix,
+        cluster_key_len: if prefix.matched_prefix > 0 {
+            cluster_key_columns.len()
+        } else {
+            0
+        },
     }
 }
 
@@ -1247,6 +1258,29 @@ mod tests {
             trace_chat,
             &cost,
             trace_chat_user
+        ));
+    }
+
+    #[test]
+    fn test_statistics_route_ignores_cluster_len_without_prefix_match() {
+        let mut columns = PredicateColumns::default();
+        columns.equality.insert("span_id".to_string());
+        let trace = statistics_route_score_for_columns(&["trace_id"], &columns);
+        let trace_chat_user =
+            statistics_route_score_for_columns(&["trace_id", "chat_id", "user_id"], &columns);
+
+        assert_eq!(trace.prefix, PrefixRouteScore::default());
+        assert_eq!(trace_chat_user.prefix, PrefixRouteScore::default());
+        assert_eq!(trace.cluster_key_len, 0);
+        assert_eq!(trace_chat_user.cluster_key_len, 0);
+        assert_eq!(trace, trace_chat_user);
+
+        let cost = PartStatistics::new_exact(100, 10, 2, 10);
+        assert!(!is_better_statistics_route(
+            &cost,
+            trace_chat_user,
+            &cost,
+            trace
         ));
     }
 

--- a/src/query/storages/basic/src/proxy_table.rs
+++ b/src/query/storages/basic/src/proxy_table.rs
@@ -93,6 +93,7 @@ struct RoutingCandidate {
     target: String,
     table: Arc<dyn Table>,
     statistics: PartStatistics,
+    route_score: StatisticsRouteScore,
     reusable_pruned_metas: Option<ReusablePrunedMetas>,
 }
 
@@ -106,6 +107,12 @@ struct PrefixRoutingCandidate {
 struct PrefixRouteScore {
     matched_prefix: usize,
     equality_prefix: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+struct StatisticsRouteScore {
+    prefix: PrefixRouteScore,
+    cluster_key_len: usize,
 }
 
 #[derive(Default)]
@@ -193,10 +200,11 @@ impl ProxyTable {
 
         let mut selected: Option<RoutingCandidate> = None;
         let mut default_candidate: Option<RoutingCandidate> = None;
+        let predicate_columns = predicate_columns(&push_downs);
 
         for target in &self.targets {
             let Some(candidate) = self
-                .estimate_target(ctx.clone(), target, push_downs.clone())
+                .estimate_target(ctx.clone(), target, push_downs.clone(), &predicate_columns)
                 .await?
             else {
                 continue;
@@ -207,13 +215,15 @@ impl ProxyTable {
                     target: candidate.target.clone(),
                     table: candidate.table.clone(),
                     statistics: candidate.statistics.clone(),
+                    route_score: candidate.route_score,
                     reusable_pruned_metas: candidate.reusable_pruned_metas.clone(),
                 });
             }
 
-            if selected.as_ref().is_none_or(|selected| {
-                statistics_cost(&candidate.statistics) < statistics_cost(&selected.statistics)
-            }) {
+            if selected
+                .as_ref()
+                .is_none_or(|selected| is_better_statistics_candidate(&candidate, selected))
+            {
                 selected = Some(candidate);
             }
         }
@@ -223,6 +233,7 @@ impl ProxyTable {
         if let Some(default_candidate) = default_candidate {
             if statistics_cost(&default_candidate.statistics)
                 == statistics_cost(&selected.statistics)
+                && default_candidate.route_score == selected.route_score
             {
                 return self
                     .read_target_partitions_from_table(
@@ -349,10 +360,12 @@ impl ProxyTable {
         ctx: Arc<dyn TableContext>,
         target: &str,
         push_downs: Option<PushDownInfo>,
+        predicate_columns: &PredicateColumns,
     ) -> Result<Option<RoutingCandidate>> {
         let Some(table) = self.get_target_table(ctx.clone(), target).await? else {
             return Ok(None);
         };
+        let route_score = statistics_route_score(table.as_ref(), predicate_columns);
         let candidate = self
             .read_target_partitions_from_table(
                 ctx,
@@ -367,6 +380,7 @@ impl ProxyTable {
             target: candidate.target,
             table: candidate.table,
             statistics: candidate.statistics,
+            route_score,
             reusable_pruned_metas: candidate.reusable_pruned_metas,
         }))
     }
@@ -1007,21 +1021,22 @@ fn cluster_prefix_score(
     table: &dyn Table,
     predicate_columns: &PredicateColumns,
 ) -> PrefixRouteScore {
-    cluster_prefix_score_for_columns(cluster_key_columns(table), predicate_columns)
+    cluster_prefix_score_for_columns(&cluster_key_columns(table), predicate_columns)
 }
 
-fn cluster_prefix_score_for_columns(
-    cluster_key_columns: Vec<String>,
+fn cluster_prefix_score_for_columns<S: AsRef<str>>(
+    cluster_key_columns: &[S],
     predicate_columns: &PredicateColumns,
 ) -> PrefixRouteScore {
     let mut score = PrefixRouteScore::default();
     for column in cluster_key_columns {
-        if predicate_columns.equality.contains(&column) {
+        let column = column.as_ref();
+        if predicate_columns.equality.contains(column) {
             score.matched_prefix += 1;
             score.equality_prefix += 1;
             continue;
         }
-        if predicate_columns.range.contains(&column) {
+        if predicate_columns.range.contains(column) {
             score.matched_prefix += 1;
         }
         break;
@@ -1050,6 +1065,42 @@ fn simple_cluster_key_column(expr: &ast::Expr) -> Option<String> {
 
 fn statistics_cost(statistics: &PartStatistics) -> (usize, usize) {
     (statistics.partitions_scanned, statistics.read_rows)
+}
+
+fn statistics_route_score(
+    table: &dyn Table,
+    predicate_columns: &PredicateColumns,
+) -> StatisticsRouteScore {
+    let cluster_key_columns = cluster_key_columns(table);
+    StatisticsRouteScore {
+        prefix: cluster_prefix_score_for_columns(&cluster_key_columns, predicate_columns),
+        cluster_key_len: cluster_key_columns.len(),
+    }
+}
+
+fn is_better_statistics_candidate(
+    candidate: &RoutingCandidate,
+    selected: &RoutingCandidate,
+) -> bool {
+    is_better_statistics_route(
+        &candidate.statistics,
+        candidate.route_score,
+        &selected.statistics,
+        selected.route_score,
+    )
+}
+
+#[inline]
+fn is_better_statistics_route(
+    candidate_statistics: &PartStatistics,
+    candidate_score: StatisticsRouteScore,
+    selected_statistics: &PartStatistics,
+    selected_score: StatisticsRouteScore,
+) -> bool {
+    let candidate_cost = statistics_cost(candidate_statistics);
+    let selected_cost = statistics_cost(selected_statistics);
+    candidate_cost < selected_cost
+        || (candidate_cost == selected_cost && candidate_score > selected_score)
 }
 
 fn database_from_desc(desc: &str) -> Option<String> {
@@ -1132,6 +1183,71 @@ mod tests {
         let large_file = PartStatistics::new_exact(100, 1000, 2, 10);
 
         assert_eq!(statistics_cost(&small_file), statistics_cost(&large_file));
+    }
+
+    #[test]
+    fn test_statistics_route_prefers_lower_cost_before_cluster_score() {
+        let lower_cost = PartStatistics::new_exact(100, 10, 2, 10);
+        let higher_cost = PartStatistics::new_exact(90, 10, 3, 10);
+        let weak_score = StatisticsRouteScore {
+            prefix: PrefixRouteScore {
+                matched_prefix: 1,
+                equality_prefix: 1,
+            },
+            cluster_key_len: 1,
+        };
+        let strong_score = StatisticsRouteScore {
+            prefix: PrefixRouteScore {
+                matched_prefix: 3,
+                equality_prefix: 3,
+            },
+            cluster_key_len: 3,
+        };
+
+        assert!(is_better_statistics_route(
+            &lower_cost,
+            weak_score,
+            &higher_cost,
+            strong_score
+        ));
+        assert!(!is_better_statistics_route(
+            &higher_cost,
+            strong_score,
+            &lower_cost,
+            weak_score
+        ));
+    }
+
+    #[test]
+    fn test_statistics_route_breaks_cost_ties_with_cluster_score() {
+        let cost = PartStatistics::new_exact(100, 10, 2, 10);
+        let trace_chat = StatisticsRouteScore {
+            prefix: PrefixRouteScore {
+                matched_prefix: 2,
+                equality_prefix: 2,
+            },
+            cluster_key_len: 2,
+        };
+        let trace_chat_user = StatisticsRouteScore {
+            prefix: PrefixRouteScore {
+                matched_prefix: 2,
+                equality_prefix: 2,
+            },
+            cluster_key_len: 3,
+        };
+
+        assert!(is_better_statistics_route(
+            &cost,
+            trace_chat_user,
+            &cost,
+            trace_chat
+        ));
+        assert!(!is_better_statistics_route(
+            &cost,
+            trace_chat,
+            &cost,
+            trace_chat_user
+        ));
     }
 
     #[test]
@@ -1248,28 +1364,16 @@ mod tests {
         columns.range.insert("chat_id".to_string());
         columns.equality.insert("user_id".to_string());
 
-        let trace_chat_user = cluster_prefix_score_for_columns(
-            vec![
-                "trace_id".to_string(),
-                "chat_id".to_string(),
-                "user_id".to_string(),
-            ],
-            &columns,
-        );
+        let trace_chat_user =
+            cluster_prefix_score_for_columns(&["trace_id", "chat_id", "user_id"], &columns);
         assert_eq!(trace_chat_user.matched_prefix, 2);
         assert_eq!(trace_chat_user.equality_prefix, 1);
 
-        let chat_trace = cluster_prefix_score_for_columns(
-            vec!["chat_id".to_string(), "trace_id".to_string()],
-            &columns,
-        );
+        let chat_trace = cluster_prefix_score_for_columns(&["chat_id", "trace_id"], &columns);
         assert_eq!(chat_trace.matched_prefix, 1);
         assert_eq!(chat_trace.equality_prefix, 0);
 
-        let user_trace = cluster_prefix_score_for_columns(
-            vec!["user_id".to_string(), "trace_id".to_string()],
-            &columns,
-        );
+        let user_trace = cluster_prefix_score_for_columns(&["user_id", "trace_id"], &columns);
         assert_eq!(user_trace.matched_prefix, 2);
         assert_eq!(user_trace.equality_prefix, 2);
         assert!(user_trace > trace_chat_user);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR refines PROXY table routing when `proxy_routing_model='statistics'` sees multiple targets with the same lightweight scan cost.

The statistics model still prefers the target with the lower lightweight pruning cost, ordered by `partitions_scanned` and `read_rows`. When that cost ties, it now uses the predicate columns and target cluster key prefix as a deterministic tie-breaker, and then prefers the longer matching cluster key. This keeps statistics routing aligned with physical pruning while making it more stable for layouts produced by the new parquet writer.

Related context: #20011

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

```bash
cargo fmt --check
cargo test -p databend-common-storages-basic proxy_table --lib
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20024)
<!-- Reviewable:end -->
