### PR TITLE
feat(copy): improve ColumnMissingError with contextual advice

### DIFF
--- a/src/common/storage/src/copy.rs
+++ b/src/common/storage/src/copy.rs
@@ -118,11 +118,13 @@ pub enum FileParseError {
         decode_error: String,
         column_data: String,
     },
-    #[error("Missing value for column {column_index} ({column_name} {column_type})")]
+    #[error("Missing value for column {column_index} ({column_name} {column_type}). {advice}")]
     ColumnMissingError {
         column_index: usize,
         column_name: String,
         column_type: String,
+        #[serde(default)]
+        advice: String,
     },
     #[error(
         "Encountered an empty value for column {column_index} (`{column_name}` of type {column_type}), with the FILE_FORMAT option `EMPTY_FIELD_AS={empty_field_as}`. To resolve this, please consider {remedy}"

--- a/src/query/storages/common/stage/src/read/columnar/projection.rs
+++ b/src/query/storages/common/stage/src/read/columnar/projection.rs
@@ -156,9 +156,17 @@ pub fn project_columnar(
                 match missing_as {
                     // default
                     NullAs::Error => {
+                        let advice = build_columnar_missing_advice(
+                            input_schema,
+                            output_schema,
+                            field_name,
+                            case_sensitive,
+                            "MISSING_FIELD_AS=ERROR",
+                            None,
+                        );
                         return Err(ErrorCode::BadDataValueType(format!(
-                            "file {} missing column `{}`",
-                            location, field_name,
+                            "file {} missing column `{}`. {}",
+                            location, field_name, advice,
                         )));
                     }
                     NullAs::Null => {
@@ -169,9 +177,17 @@ pub fn project_columnar(
                                 scalar: Scalar::Null,
                             })
                         } else {
+                            let advice = build_columnar_missing_advice(
+                                input_schema,
+                                output_schema,
+                                field_name,
+                                case_sensitive,
+                                "MISSING_FIELD_AS=NULL",
+                                Some("the column is not nullable"),
+                            );
                             return Err(ErrorCode::BadDataValueType(format!(
-                                "{} missing column `{}`",
-                                location, field_name,
+                                "file {} missing column `{}`. {}",
+                                location, field_name, advice,
                             )));
                         }
                     }
@@ -205,6 +221,56 @@ pub fn project_columnar(
         )));
     }
     Ok((output_projection, pushdown_columns))
+}
+
+fn build_columnar_missing_advice(
+    input_schema: &TableSchemaRef,
+    output_schema: &TableSchemaRef,
+    field_name: &str,
+    case_sensitive: bool,
+    current_setting: &str,
+    extra_reason: Option<&str>,
+) -> String {
+    let mut hints = Vec::new();
+
+    // Hint 1: current MISSING_FIELD_AS setting
+    hints.push(format!("current FILE_FORMAT option: {current_setting}"));
+
+    // Hint 2: if there's an extra reason (e.g., column not nullable)
+    if let Some(reason) = extra_reason {
+        hints.push(reason.to_string());
+    }
+
+    // Hint 3: if case_sensitive, check if there's a case-insensitive match in the file
+    if case_sensitive {
+        let lower_field = field_name.to_lowercase();
+        let matched = input_schema
+            .fields()
+            .iter()
+            .find(|f| f.name().to_lowercase() == lower_field && f.name() != field_name);
+        if let Some(f) = matched {
+            hints.push(format!(
+                "found column '{}' with different case in file; consider using `COLUMN_MATCH_MODE=CASE_INSENSITIVE`",
+                f.name()
+            ));
+        }
+    }
+
+    // Hint 4: if target table has a single Variant column, suggest select $1
+    let fields = output_schema.fields();
+    if fields.len() == 1
+        && matches!(
+            fields[0].data_type.remove_nullable(),
+            TableDataType::Variant
+        )
+    {
+        hints.push(
+            "the target table has a single VARIANT column; consider using `COPY INTO <table> FROM (SELECT $1 FROM @<stage>)` to load raw data"
+                .to_string(),
+        );
+    }
+
+    hints.join(". ")
 }
 
 fn project_array_tuple(

--- a/src/query/storages/stage/src/read/default_expr_evaluator.rs
+++ b/src/query/storages/stage/src/read/default_expr_evaluator.rs
@@ -96,6 +96,8 @@ impl DefaultExprEvaluator {
                     column_index,
                     column_name: field.name().to_string(),
                     column_type: field.data_type().to_string(),
+                    advice: "column has a SEQUENCE default which cannot be filled from file data"
+                        .to_string(),
                 });
             }
         }

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/block_builder.rs
@@ -110,20 +110,34 @@ impl NdJsonDecoder {
                 match value {
                     None => match self.fmt.params.missing_field_as {
                         NullAs::Error => {
+                            let advice = self.build_column_missing_advice(
+                                field.name(),
+                                &json,
+                                "MISSING_FIELD_AS=ERROR",
+                                None,
+                            );
                             return Err(FileParseError::ColumnMissingError {
                                 column_index,
                                 column_name: field.name().to_owned(),
                                 column_type: field.data_type.to_string(),
+                                advice,
                             });
                         }
                         NullAs::Null => {
                             if field.is_nullable_or_null() {
                                 column.push_default();
                             } else {
+                                let advice = self.build_column_missing_advice(
+                                    field.name(),
+                                    &json,
+                                    "MISSING_FIELD_AS=NULL",
+                                    Some("the column is not nullable"),
+                                );
                                 return Err(FileParseError::ColumnMissingError {
                                     column_index,
                                     column_name: field.name().to_owned(),
                                     column_type: field.data_type.to_string(),
+                                    advice,
                                 });
                             }
                         }
@@ -191,6 +205,54 @@ impl NdJsonDecoder {
             }
         }
         Ok(())
+    }
+
+    fn build_column_missing_advice(
+        &self,
+        column_name: &str,
+        json: &serde_json::Value,
+        current_setting: &str,
+        extra_reason: Option<&str>,
+    ) -> String {
+        let mut hints = Vec::new();
+
+        // Hint 1: current MISSING_FIELD_AS setting
+        hints.push(format!("current FILE_FORMAT option: {current_setting}"));
+
+        // Hint 2: if there's an extra reason (e.g., column not nullable)
+        if let Some(reason) = extra_reason {
+            hints.push(reason.to_string());
+        }
+
+        // Hint 3: if case_sensitive, try case-insensitive match
+        if self.field_decoder.ident_case_sensitive {
+            if let Some(object) = json.as_object() {
+                let lower_column = column_name.to_lowercase();
+                let matched_key = object.keys().find(|k| k.to_lowercase() == lower_column);
+                if let Some(key) = matched_key {
+                    hints.push(format!(
+                        "found field '{}' with different case; consider using COPY with `COLUMN_MATCH_MODE=CASE_INSENSITIVE`",
+                        key
+                    ));
+                }
+            }
+        }
+
+        // Hint 4: if target table has a single Variant column, suggest select $1
+        let fields = self.load_context.schema.fields();
+        if fields.len() == 1
+            && matches!(
+                fields[0].data_type.remove_nullable(),
+                databend_common_expression::TableDataType::Variant
+            )
+        {
+            hints.push(
+                "the target table has a single VARIANT column; consider using `COPY INTO <table> FROM (SELECT $1 FROM @<stage>)` to load raw JSON"
+                    .to_string(),
+            );
+        }
+
+        hints.join(". ")
     }
 }
 

--- a/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing.test
+++ b/tests/sqllogictests/suites/stage/formats/ndjson/ndjson_null_and_missing.test
@@ -11,8 +11,8 @@ copy into t from @data/ndjson/null.ndjson file_format = (type = NDJSON, null_fie
 query ?????
 copy into t from @data/ndjson/null_and_missing/ file_format = (type = NDJSON) on_error = continue force=true
 ----
-ndjson/null_and_missing/missing_a.ndjson 0 1 Missing value for column 1 (a Int32 NULL) 1
-ndjson/null_and_missing/missing_b.ndjson 0 1 Missing value for column 2 (b Int32) 1
+ndjson/null_and_missing/missing_a.ndjson 0 1 Missing value for column 1 (a Int32 NULL). current FILE_FORMAT option: MISSING_FIELD_AS=ERROR 1
+ndjson/null_and_missing/missing_b.ndjson 0 1 Missing value for column 2 (b Int32). current FILE_FORMAT option: MISSING_FIELD_AS=ERROR 1
 ndjson/null_and_missing/normal.ndjson 1 0 NULL NULL
 ndjson/null_and_missing/null_a.ndjson 1 0 NULL NULL
 ndjson/null_and_missing/null_b.ndjson 0 1 Invalid value 'null' for column 2 (b Int32): null value is not allowed for non-nullable field, when NULL_FIELDS_AS=NULL 1
@@ -30,7 +30,7 @@ query ?????
 copy into t from @data/ndjson/null_and_missing/ file_format = (type = NDJSON, null_field_as = NULL, missing_field_as = NULL) on_error = continue force=true
 ----
 ndjson/null_and_missing/missing_a.ndjson 1 0 NULL NULL
-ndjson/null_and_missing/missing_b.ndjson 0 1 Missing value for column 2 (b Int32) 1
+ndjson/null_and_missing/missing_b.ndjson 0 1 Missing value for column 2 (b Int32). current FILE_FORMAT option: MISSING_FIELD_AS=NULL. the column is not nullable 1
 ndjson/null_and_missing/normal.ndjson 1 0 NULL NULL
 ndjson/null_and_missing/null_a.ndjson 1 0 NULL NULL
 ndjson/null_and_missing/null_b.ndjson 0 1 Invalid value 'null' for column 2 (b Int32): null value is not allowed for non-nullable field, when NULL_FIELDS_AS=NULL 1

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
@@ -16,7 +16,7 @@ ok	1	2021-01-01
 q2.parquet	431	1
 >>>> streaming load: q2.parquet error :
 + curl -sS -H x-databend-query-id:load-q2 -H 'X-Databend-SQL:insert into streaming_load_parquet(c2,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q2.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
-{"error":{"code":400,"message":"Query execution failed: file q2.parquet missing column `c2`"}}
+{"error":{"code":400,"message":"Query execution failed: file q2.parquet missing column `c2`. current FILE_FORMAT option: MISSING_FIELD_AS=ERROR"}}
 <<<<
 >>>> select * from streaming_load_parquet;
 <<<<


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: https://github.com/databendlabs/databend/issues/18834

Enhance error messages for missing columns during COPY INTO to help users diagnose and resolve issues faster.

When a column is missing, the error now includes contextual advice:
- Shows the current `MISSING_FIELD_AS` setting
- Indicates when the column is not nullable (for `MISSING_FIELD_AS=NULL` case)
- Suggests `COLUMN_MATCH_MODE=CASE_INSENSITIVE` when a case-different match exists in the source data
- Suggests `COPY INTO <table> FROM (SELECT $1 FROM @<stage>)` when the target table has a single VARIANT column

Applied consistently across NDJSON, Parquet, and ORC formats.

Example before:
```
Missing value for column 2 (b Int32)
```

Example after:
```
Missing value for column 2 (b Int32). current FILE_FORMAT option: MISSING_FIELD_AS=NULL. the column is not nullable
```

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20029)
<!-- Reviewable:end -->
