### PR TITLE
refactor: add MetaServiceKeyErrorBuilder for meta keys

### DIFF
--- a/src/meta/api/src/api_impl/data_mask_api_impl.rs
+++ b/src/meta/api/src/api_impl/data_mask_api_impl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::data_mask::CreateDatamaskReply;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;
 use databend_common_meta_app::data_mask::DataMaskId;

--- a/src/meta/api/src/api_impl/dictionary_api.rs
+++ b/src/meta/api/src/api_impl/dictionary_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::schema::CreateDictionaryReply;
 use databend_common_meta_app::schema::CreateDictionaryReq;

--- a/src/meta/api/src/api_impl/index_api.rs
+++ b/src/meta/api/src/api_impl/index_api.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::DuplicatedIndexColumnId;
 use databend_common_meta_app::app_error::IndexColumnIdNotFound;

--- a/src/meta/api/src/api_impl/row_access_policy_api_impl.rs
+++ b/src/meta/api/src/api_impl/row_access_policy_api_impl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::data_mask::DataMaskNameIdent;
 use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::row_access_policy::CreateRowAccessPolicyReply;

--- a/src/meta/api/src/api_impl/sequence_api_impl.rs
+++ b/src/meta/api/src/api_impl/sequence_api_impl.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::SequenceError;
 use databend_common_meta_app::app_error::UnsupportedSequenceStorageVersion;

--- a/src/meta/api/src/api_impl/tag_api.rs
+++ b/src/meta/api/src/api_impl/tag_api.rs
@@ -15,6 +15,7 @@
 use std::collections::HashSet;
 
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::principal::ProcedureIdentity;
 use databend_common_meta_app::principal::ProcedureNameIdent;

--- a/src/meta/api/src/kv/name_value_api.rs
+++ b/src/meta/api/src/kv/name_value_api.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 use std::time::Duration;
 
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant_key::errors::ExistError;
 use databend_common_meta_app::tenant_key::ident::TIdent;

--- a/src/meta/app/src/app_error.rs
+++ b/src/meta/app/src/app_error.rs
@@ -19,6 +19,7 @@ use chrono::Utc;
 use databend_common_exception::ErrorCode;
 use databend_meta_client::types::MatchSeq;
 
+use crate::MetaServiceKeyErrorBuilder;
 use crate::data_mask::data_mask_name_ident;
 use crate::principal::ProcedureIdentity;
 use crate::principal::procedure_name_ident;
@@ -30,7 +31,6 @@ use crate::schema::dictionary_name_ident;
 use crate::schema::index_name_ident;
 use crate::tenant_key::errors::ExistError;
 use crate::tenant_key::errors::UnknownError;
-use crate::tenant_key::ident::TIdent;
 
 /// Output message for end users, with sensitive info stripped.
 pub trait AppErrorMessage: Display {
@@ -1018,22 +1018,22 @@ pub enum AppError {
 }
 
 impl AppError {
-    /// Create an `unknown` TIdent error.
-    pub fn unknown<R, N>(ident: &TIdent<R, N>, ctx: impl Display) -> AppError
+    /// Create an `unknown` meta-service key error.
+    pub fn unknown<K>(key: &K, ctx: impl Display) -> AppError
     where
-        N: Clone,
-        AppError: From<UnknownError<R, N>>,
+        K: MetaServiceKeyErrorBuilder,
+        AppError: From<K::UnknownError>,
     {
-        AppError::from(ident.unknown_error(ctx))
+        AppError::from(key.unknown_error(ctx))
     }
 
-    /// Create an `exist` TIdent error.
-    pub fn exists<R, N>(ident: &TIdent<R, N>, ctx: impl Display) -> AppError
+    /// Create an `exist` meta-service key error.
+    pub fn exists<K>(key: &K, ctx: impl Display) -> AppError
     where
-        N: Clone,
-        AppError: From<ExistError<R, N>>,
+        K: MetaServiceKeyErrorBuilder,
+        AppError: From<K::ExistError>,
     {
-        AppError::from(ident.exist_error(ctx))
+        AppError::from(key.exist_error(ctx))
     }
 }
 

--- a/src/meta/app/src/lib.rs
+++ b/src/meta/app/src/lib.rs
@@ -36,6 +36,8 @@ pub mod value_id;
 pub mod id_generator;
 
 mod key_with_tenant;
+mod meta_service_key_error;
 pub mod row_access_policy;
 
 pub use key_with_tenant::KeyWithTenant;
+pub use meta_service_key_error::MetaServiceKeyErrorBuilder;

--- a/src/meta/app/src/meta_service_key_error.rs
+++ b/src/meta/app/src/meta_service_key_error.rs
@@ -1,0 +1,24 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Display;
+
+pub trait MetaServiceKeyErrorBuilder {
+    type UnknownError;
+    type ExistError;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError;
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError;
+}

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -25,6 +25,9 @@ use databend_meta_client::types::SeqV;
 
 use super::CreateOption;
 use crate::KeyWithTenant;
+use crate::MetaServiceKeyErrorBuilder;
+use crate::app_error::DatabaseAlreadyExists;
+use crate::app_error::UnknownDatabaseId;
 use crate::schema::database_id::DatabaseId;
 use crate::schema::database_name_ident::DatabaseNameIdent;
 use crate::tenant::Tenant;
@@ -53,6 +56,19 @@ impl Display for DatabaseIdToName {
 impl DatabaseIdToName {
     pub fn new(db_id: u64) -> Self {
         DatabaseIdToName { db_id }
+    }
+}
+
+impl MetaServiceKeyErrorBuilder for DatabaseIdToName {
+    type UnknownError = UnknownDatabaseId;
+    type ExistError = DatabaseAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownDatabaseId::new(self.db_id, ctx.to_string())
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        DatabaseAlreadyExists::new(self.db_id.to_string(), ctx.to_string())
     }
 }
 
@@ -367,9 +383,22 @@ mod tests {
     use databend_meta_client::kvapi::testing::assert_round_trip;
 
     use super::DatabaseIdToName;
+    use crate::MetaServiceKeyErrorBuilder;
 
     #[test]
     fn test_database_id_to_name_key_format() {
         assert_round_trip(DatabaseIdToName::new(3), "__fd_database_id_to_name/3");
+    }
+
+    #[test]
+    fn test_database_id_to_name_error_builder() {
+        assert_eq!(
+            DatabaseIdToName::new(3).unknown_error("ctx").to_string(),
+            "UnknownDatabaseId: `3` while `ctx`"
+        );
+        assert_eq!(
+            DatabaseIdToName::new(3).exist_error("ctx").to_string(),
+            "DatabaseAlreadyExists: `3` while `ctx`"
+        );
     }
 }

--- a/src/meta/app/src/schema/database_id.rs
+++ b/src/meta/app/src/schema/database_id.rs
@@ -20,6 +20,10 @@ use databend_meta_client::kvapi;
 use derive_more::Deref;
 use derive_more::DerefMut;
 
+use crate::MetaServiceKeyErrorBuilder;
+use crate::app_error::DatabaseAlreadyExists;
+use crate::app_error::UnknownDatabaseId;
+
 /// `__fd_database_by_id/<db_id>`
 #[derive(
     Clone, Debug, Copy, Default, Eq, PartialEq, PartialOrd, Ord, Deref, DerefMut, kvapi::StructKey,
@@ -47,6 +51,19 @@ impl Display for DatabaseId {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for DatabaseId {
+    type UnknownError = UnknownDatabaseId;
+    type ExistError = DatabaseAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownDatabaseId::new(self.db_id, ctx.to_string())
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        DatabaseAlreadyExists::new(self.db_id.to_string(), ctx.to_string())
+    }
+}
+
 mod kvapi_key_impl {
     use databend_meta_client::kvapi;
 
@@ -63,9 +80,22 @@ mod tests {
     use databend_meta_client::kvapi::testing::assert_round_trip;
 
     use super::DatabaseId;
+    use crate::MetaServiceKeyErrorBuilder;
 
     #[test]
     fn test_database_id_key_format() {
         assert_round_trip(DatabaseId::new(3), "__fd_database_by_id/3");
+    }
+
+    #[test]
+    fn test_database_id_error_builder() {
+        assert_eq!(
+            DatabaseId::new(3).unknown_error("ctx").to_string(),
+            "UnknownDatabaseId: `3` while `ctx`"
+        );
+        assert_eq!(
+            DatabaseId::new(3).exist_error("ctx").to_string(),
+            "DatabaseAlreadyExists: `3` while `ctx`"
+        );
     }
 }

--- a/src/meta/app/src/schema/table/ident.rs
+++ b/src/meta/app/src/schema/table/ident.rs
@@ -22,6 +22,10 @@ use databend_meta_client::kvapi;
 use derive_more::Deref;
 use derive_more::DerefMut;
 
+use crate::MetaServiceKeyErrorBuilder;
+use crate::app_error::TableAlreadyExists;
+use crate::app_error::UnknownTable;
+use crate::app_error::UnknownTableId;
 use crate::schema::database_name_ident::DatabaseNameIdent;
 use crate::tenant::Tenant;
 use crate::tenant::ToTenant;
@@ -99,6 +103,19 @@ impl Display for TableNameIdent {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for TableNameIdent {
+    type UnknownError = UnknownTable;
+    type ExistError = TableAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownTable::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        TableAlreadyExists::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+}
+
 /// `__fd_table/<db_id>/<tb_name>`
 #[derive(Clone, Debug, Eq, PartialEq, Default, kvapi::StructKey)]
 #[structkey(prefix = "__fd_table")]
@@ -125,6 +142,19 @@ impl Display for DBIdTableName {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for DBIdTableName {
+    type UnknownError = UnknownTable;
+    type ExistError = TableAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownTable::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        TableAlreadyExists::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+}
+
 /// `__fd_table_by_id/<tb_id> -> TableMeta`
 #[derive(Clone, Debug, Eq, PartialEq, Default, Deref, DerefMut, kvapi::StructKey)]
 #[structkey(prefix = "__fd_table_by_id")]
@@ -144,6 +174,19 @@ impl Display for TableId {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for TableId {
+    type UnknownError = UnknownTableId;
+    type ExistError = TableAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownTableId::new(self.table_id, ctx.to_string())
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        TableAlreadyExists::new(self.table_id.to_string(), ctx.to_string())
+    }
+}
+
 /// The meta-service key for storing table id history ever used by a table name.
 ///
 /// `__fd_table_id_list/<db_id>/<tb_name> -> id_list`
@@ -160,6 +203,19 @@ impl Display for TableIdHistoryIdent {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for TableIdHistoryIdent {
+    type UnknownError = UnknownTable;
+    type ExistError = TableAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownTable::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        TableAlreadyExists::new(&self.table_name, format!("{}: {}", ctx, self))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use databend_meta_client::kvapi::testing::assert_round_trip;
@@ -167,6 +223,9 @@ mod tests {
     use super::DBIdTableName;
     use super::TableId;
     use super::TableIdHistoryIdent;
+    use super::TableNameIdent;
+    use crate::MetaServiceKeyErrorBuilder;
+    use crate::tenant::Tenant;
 
     #[test]
     fn test_table_name_id_key_formats() {
@@ -178,6 +237,63 @@ mod tests {
                 table_name: "table/a".to_string(),
             },
             "__fd_table_id_list/7/table%2fa",
+        );
+    }
+
+    #[test]
+    fn test_table_name_ident_error_builder() {
+        let ident = TableNameIdent::new(Tenant::new_literal("tenant"), "db", "table");
+
+        assert_eq!(
+            ident.unknown_error("ctx").to_string(),
+            "UnknownTable: `table` while `ctx: 'tenant'.'db'.'table'`"
+        );
+        assert_eq!(
+            ident.exist_error("ctx").to_string(),
+            "TableAlreadyExists: table while ctx: 'tenant'.'db'.'table'"
+        );
+    }
+
+    #[test]
+    fn test_db_id_table_name_error_builder() {
+        let ident = DBIdTableName::new(7, "table");
+
+        assert_eq!(
+            ident.unknown_error("ctx").to_string(),
+            "UnknownTable: `table` while `ctx: 7.'table'`"
+        );
+        assert_eq!(
+            ident.exist_error("ctx").to_string(),
+            "TableAlreadyExists: table while ctx: 7.'table'"
+        );
+    }
+
+    #[test]
+    fn test_table_id_error_builder() {
+        assert_eq!(
+            TableId::new(9).unknown_error("ctx").to_string(),
+            "UnknownTableId: `9` while `ctx`"
+        );
+        assert_eq!(
+            TableId::new(9).exist_error("ctx").to_string(),
+            "TableAlreadyExists: 9 while ctx"
+        );
+    }
+
+    #[test]
+    fn test_table_id_history_ident_error_builder() {
+        let ident = TableIdHistoryIdent {
+            database_id: 7,
+            table_name: "table".to_string(),
+        };
+
+        assert_eq!(
+            ident.unknown_error("ctx").to_string(),
+            "UnknownTable: `table` while `ctx: 7.'table'`"
+        );
+        assert_eq!(
+            ident.exist_error("ctx").to_string(),
+            "TableAlreadyExists: table while ctx: 7.'table'"
         );
     }
 }

--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -40,6 +40,9 @@ use super::CatalogInfo;
 use super::CreateOption;
 use super::DatabaseId;
 use super::MarkedDeletedIndexMeta;
+use crate::MetaServiceKeyErrorBuilder;
+use crate::app_error::TableAlreadyExists;
+use crate::app_error::UnknownTableId;
 use crate::schema::constraint::Constraint;
 use crate::schema::database_name_ident::DatabaseNameIdent;
 use crate::schema::table_niv::TableNIV;
@@ -1129,6 +1132,19 @@ impl Display for TableIdToName {
     }
 }
 
+impl MetaServiceKeyErrorBuilder for TableIdToName {
+    type UnknownError = UnknownTableId;
+    type ExistError = TableAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownTableId::new(self.table_id, ctx.to_string())
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        TableAlreadyExists::new(self.table_id.to_string(), ctx.to_string())
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct TableCopiedFileNameIdent {
     pub table_id: u64,
@@ -1255,6 +1271,7 @@ mod tests {
     use databend_meta_client::kvapi::StructKey;
     use databend_meta_client::kvapi::testing::assert_round_trip;
 
+    use crate::MetaServiceKeyErrorBuilder;
     use crate::schema::TableCopiedFileNameIdent;
     use crate::schema::TableIdToName;
     use crate::schema::TableMeta;
@@ -1262,6 +1279,20 @@ mod tests {
     #[test]
     fn test_table_id_to_name_key_format() {
         assert_round_trip(TableIdToName { table_id: 9 }, "__fd_table_id_to_name/9");
+    }
+
+    #[test]
+    fn test_table_id_to_name_error_builder() {
+        let ident = TableIdToName { table_id: 9 };
+
+        assert_eq!(
+            ident.unknown_error("ctx").to_string(),
+            "UnknownTableId: `9` while `ctx`"
+        );
+        assert_eq!(
+            ident.exist_error("ctx").to_string(),
+            "TableAlreadyExists: 9 while ctx"
+        );
     }
 
     #[test]

--- a/src/meta/app/src/schema/table/refs.rs
+++ b/src/meta/app/src/schema/table/refs.rs
@@ -22,6 +22,9 @@ use databend_meta_client::kvapi;
 use databend_meta_client::types::MatchSeq;
 
 use super::TableLvtCheck;
+use crate::MetaServiceKeyErrorBuilder;
+use crate::app_error::ReferenceAlreadyExists;
+use crate::app_error::UnknownReference;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableTag {
@@ -55,6 +58,19 @@ impl TableIdTagName {
 impl Display for TableIdTagName {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}.'{}'", self.table_id, self.tag_name)
+    }
+}
+
+impl MetaServiceKeyErrorBuilder for TableIdTagName {
+    type UnknownError = UnknownReference;
+    type ExistError = ReferenceAlreadyExists;
+
+    fn unknown_error(&self, ctx: impl Display) -> Self::UnknownError {
+        UnknownReference::new(format!("{}: {}", ctx, self))
+    }
+
+    fn exist_error(&self, ctx: impl Display) -> Self::ExistError {
+        ReferenceAlreadyExists::new(format!("{}: {}", ctx, self))
     }
 }
 
@@ -107,9 +123,24 @@ mod tests {
     use databend_meta_client::kvapi::testing::assert_round_trip;
 
     use super::TableIdTagName;
+    use crate::MetaServiceKeyErrorBuilder;
 
     #[test]
     fn test_table_id_tag_name_key_format() {
         assert_round_trip(TableIdTagName::new(9, "tag/a"), "__fd_table_tag/9/tag%2fa");
+    }
+
+    #[test]
+    fn test_table_id_tag_name_error_builder() {
+        let ident = TableIdTagName::new(9, "tag");
+
+        assert_eq!(
+            ident.unknown_error("ctx").to_string(),
+            "UnknownReference: `ctx: 9.'tag'`"
+        );
+        assert_eq!(
+            ident.exist_error("ctx").to_string(),
+            "ReferenceAlreadyExists: ctx: 9.'tag'"
+        );
     }
 }

--- a/src/meta/app/src/schema/tag/error.rs
+++ b/src/meta/app/src/schema/tag/error.rs
@@ -14,6 +14,7 @@
 
 use databend_common_exception::ErrorCode;
 
+use crate::MetaServiceKeyErrorBuilder;
 use crate::schema::tag::TagId;
 use crate::schema::tag::TaggableObject;
 use crate::schema::tag::id_ident::Resource as TagIdResource;

--- a/src/meta/app/src/tenant_key/ident.rs
+++ b/src/meta/app/src/tenant_key/ident.rs
@@ -15,11 +15,11 @@
 use std::any::type_name;
 use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Display;
 use std::hash::Hash;
 use std::hash::Hasher;
 
 use crate::KeyWithTenant;
+use crate::MetaServiceKeyErrorBuilder;
 use crate::tenant::Tenant;
 use crate::tenant::ToTenant;
 use crate::tenant_key::errors::ExistError;
@@ -167,15 +167,20 @@ impl<R, N> TIdent<R, N> {
     where N: fmt::Display {
         format!("'{}'/'{}'", self.tenant.tenant_name(), self.name)
     }
+}
 
-    pub fn unknown_error(&self, ctx: impl Display) -> UnknownError<R, N>
-    where N: Clone {
-        UnknownError::new(self.name.clone(), ctx)
+impl<R, N> MetaServiceKeyErrorBuilder for TIdent<R, N>
+where N: Clone
+{
+    type UnknownError = UnknownError<R, N>;
+    type ExistError = ExistError<R, N>;
+
+    fn unknown_error(&self, ctx: impl fmt::Display) -> Self::UnknownError {
+        UnknownError::new(self.name().clone(), ctx)
     }
 
-    pub fn exist_error(&self, ctx: impl Display) -> ExistError<R, N>
-    where N: Clone {
-        ExistError::new(self.name.clone(), ctx)
+    fn exist_error(&self, ctx: impl fmt::Display) -> Self::ExistError {
+        ExistError::new(self.name().clone(), ctx)
     }
 }
 

--- a/src/query/catalog/src/catalog/manager.rs
+++ b/src/query/catalog/src/catalog/manager.rs
@@ -22,6 +22,7 @@ use databend_common_config::InnerConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_api::CatalogApi;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::schema::CatalogIdIdent;
 use databend_common_meta_app::schema::CatalogInfo;

--- a/src/query/ee/src/data_mask/data_mask_handler.rs
+++ b/src/query/ee/src/data_mask/data_mask_handler.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_meta_api::DatamaskApi;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::data_mask::CreateDatamaskReply;
 use databend_common_meta_app::data_mask::CreateDatamaskReq;

--- a/src/query/ee/src/row_access_policy/row_access_policy_handler.rs
+++ b/src/query/ee/src/row_access_policy/row_access_policy_handler.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
 use databend_common_meta_api::RowAccessPolicyApi;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::row_access_policy::CreateRowAccessPolicyReply;
 use databend_common_meta_app::row_access_policy::CreateRowAccessPolicyReq;

--- a/src/query/management/src/procedure/procedure_mgr.rs
+++ b/src/query/management/src/procedure/procedure_mgr.rs
@@ -21,6 +21,7 @@ use databend_common_meta_api::name_id_value_api::CreateIdValueResult;
 use databend_common_meta_api::name_id_value_api::NameIdValueApi;
 use databend_common_meta_api::serialize_struct;
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::data_id::DataId;
 use databend_common_meta_app::principal::CreateProcedureReply;
 use databend_common_meta_app::principal::CreateProcedureReq;

--- a/src/query/management/src/role/role_mgr.rs
+++ b/src/query/management/src/role/role_mgr.rs
@@ -23,6 +23,7 @@ use databend_common_meta_api::txn_cond_seq;
 use databend_common_meta_api::txn_del;
 use databend_common_meta_api::txn_put_pb;
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::TxnRetryMaxTimes;
 use databend_common_meta_app::principal::BUILTIN_ROLE_ACCOUNT_ADMIN;
 use databend_common_meta_app::principal::GrantObject;

--- a/src/query/management/src/user/user_mgr.rs
+++ b/src/query/management/src/user/user_mgr.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_meta_api::kv_pb_api::KVPbApi;
 use databend_common_meta_api::kv_pb_api::UpsertPB;
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::principal::TenantUserIdent;
 use databend_common_meta_app::principal::UserIdentity;
 use databend_common_meta_app::principal::UserInfo;

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -38,6 +38,7 @@ use databend_common_meta_api::TableApi;
 use databend_common_meta_api::kv_app_error::KVAppError;
 use databend_common_meta_api::name_id_value_api::NameIdValueApiCompat;
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::MetaServiceKeyErrorBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::principal::UDTFServer;
 use databend_common_meta_app::schema::CatalogInfo;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: add MetaServiceKeyErrorBuilder for meta keys
# Summary

Extract meta-service key error construction into `MetaServiceKeyErrorBuilder` and implement it for `TIdent` plus selected schema keys. This keeps concrete call sites explicit while giving generic key-handling paths a shared way to produce unknown/exist errors.

# Details

- Define `MetaServiceKeyErrorBuilder` in `meta_service_key_error.rs` and export it from meta-app.
- Move the `TIdent` implementation beside `TIdent`; keep the trait file definition-only.
- Implement the trait for schema keys with clear domain error pairs: `DatabaseId`, `DatabaseIdToName`, `TableNameIdent`, `DBIdTableName`, `TableId`, `TableIdToName`, `TableIdHistoryIdent`, and `TableIdTagName`.
- Generalize `AppError::unknown` and `AppError::exists` for generic paths while preserving explicit concrete constructors in source call sites.
- Add focused tests for each implementation.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20030)
<!-- Reviewable:end -->
