### PR TITLE
feat(query): use cluster ordering for top-k sort

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -103,6 +103,9 @@ pub type PartInfoPtr = Arc<Box<dyn PartInfo>>;
 pub enum PartitionsShuffleKind {
     // Bind the Partition to executor one by one with order.
     Seq,
+    // Bind partitions in sequence and keep the ordered contract through local scan streams.
+    // Consumers may merge those streams as already-sorted subsequences.
+    PreserveOrder,
     // Bind the Partition to executor by partition.hash()%executor_nums order.
     Mod,
     // Bind the Partition to executor by ConsistentHash(partition.hash()) order.
@@ -124,6 +127,13 @@ pub struct Partitions {
 impl Partitions {
     pub fn create(kind: PartitionsShuffleKind, partitions: Vec<PartInfoPtr>) -> Self {
         Partitions { kind, partitions }
+    }
+
+    fn executor_partition_kind(&self) -> PartitionsShuffleKind {
+        match self.kind {
+            PartitionsShuffleKind::PreserveOrder => PartitionsShuffleKind::PreserveOrder,
+            _ => PartitionsShuffleKind::Seq,
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -164,7 +174,7 @@ impl Partitions {
             .collect::<Vec<_>>();
 
         let partitions = match self.kind {
-            PartitionsShuffleKind::Seq => regular_partitions,
+            PartitionsShuffleKind::Seq | PartitionsShuffleKind::PreserveOrder => regular_partitions,
             PartitionsShuffleKind::Mod => {
                 // Sort by hash%executor_nums.
                 let mut parts = regular_partitions
@@ -264,7 +274,7 @@ impl Partitions {
 
                 executor_part.insert(
                     executor.id.clone(),
-                    Partitions::create(PartitionsShuffleKind::Seq, parts),
+                    Partitions::create(self.executor_partition_kind(), parts),
                 );
             }
 
@@ -287,7 +297,7 @@ impl Partitions {
 
                 executor_part.insert(
                     executor.id.clone(),
-                    Partitions::create(PartitionsShuffleKind::Seq, parts),
+                    Partitions::create(self.executor_partition_kind(), parts),
                 );
             }
 
@@ -319,7 +329,7 @@ impl Partitions {
 
             executor_part.insert(
                 executor.id.clone(),
-                Partitions::create(PartitionsShuffleKind::Seq, parts),
+                Partitions::create(self.executor_partition_kind(), parts),
             );
         }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/core/merger.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/core/merger.rs
@@ -122,6 +122,7 @@ where A: SortAlgorithm
 {
     batch_rows: usize,
     limit: Option<usize>,
+    row_by_row: bool,
     unsorted_streams: Vec<S>,
 
     pending_streams: VecDeque<usize>,
@@ -133,6 +134,14 @@ impl<A, S> Merger<A, S>
 where A: SortAlgorithm
 {
     pub fn new(streams: Vec<S>, batch_rows: usize, limit: Option<usize>) -> Self {
+        Self::create(streams, batch_rows, limit, false)
+    }
+
+    pub fn new_row_by_row(streams: Vec<S>, batch_rows: usize, limit: Option<usize>) -> Self {
+        Self::create(streams, batch_rows, limit, true)
+    }
+
+    fn create(streams: Vec<S>, batch_rows: usize, limit: Option<usize>, row_by_row: bool) -> Self {
         // We only create a merger when there are at least two streams.
         debug_assert!(streams.len() > 1, "streams.len() = {}", streams.len());
 
@@ -145,6 +154,7 @@ where A: SortAlgorithm
             sorted_cursors,
             batch_rows,
             limit,
+            row_by_row,
             pending_streams,
             buffers,
         }
@@ -181,16 +191,22 @@ where A: SortAlgorithm
 
         self.buffers.record_output_range(buffer_index, start, count);
 
-        // `self.sorted_cursors.peek_mut` will return a `PeekMut` object which allows us to modify the top element of the sorted_cursors.
-        // The sorted_cursors will adjust itself automatically when the `PeekMut` object is dropped (RAII).
-        let mut peek_mut = self.sorted_cursors.peek_mut();
-        let cursor = &mut peek_mut.0;
-        cursor.row_index += count;
+        {
+            // `peek_mut` adjusts the sorted cursor container when it is
+            // dropped. Keep the guard scoped to this update so the next
+            // iteration compares the advanced cursor with the other streams.
+            let mut peek_mut = self.sorted_cursors.peek_mut();
+            let cursor = &mut peek_mut.0;
+            cursor.row_index += count;
 
-        if cursor.is_finished() {
-            // Pop the current `cursor`.
-            A::pop_mut(peek_mut);
-            self.buffers.detach(buffer_index, stream_index);
+            if cursor.is_finished() {
+                // Pop the current `cursor`.
+                A::pop_mut(peek_mut);
+                self.buffers.detach(buffer_index, stream_index);
+            }
+        }
+
+        if self.buffers.stream_to_buffer[stream_index].is_none() {
             self.pending_streams.push_back(stream_index);
         }
 
@@ -207,6 +223,10 @@ where A: SortAlgorithm
         let row_index_limit = cursor
             .num_rows()
             .min(start + max_rows - self.buffers.output_len());
+
+        if self.row_by_row {
+            return 1;
+        }
 
         if self.sorted_cursors.len() == 1 || cursor.current() == cursor.last() {
             return row_index_limit - start;
@@ -382,3 +402,105 @@ where
 pub type HeapMerger<R, S> = Merger<HeapSort<R>, S>;
 
 pub type LoserTreeMerger<R, S> = Merger<LoserTreeSort<R>, S>;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use databend_common_expression::Column;
+    use databend_common_expression::DataBlock;
+    use databend_common_expression::DataField;
+    use databend_common_expression::DataSchemaRefExt;
+    use databend_common_expression::FromData;
+    use databend_common_expression::SortColumnDescription;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::Int32Type;
+    use databend_common_expression::types::NumberDataType;
+
+    use super::super::FixedRows;
+    use super::super::convert_rows;
+    use super::*;
+
+    struct TestStream {
+        blocks: VecDeque<(DataBlock, Column)>,
+    }
+
+    impl SortedStream for TestStream {
+        fn next(&mut self) -> Result<(Option<(DataBlock, Column)>, bool)> {
+            Ok((self.blocks.pop_front(), false))
+        }
+    }
+
+    fn make_compound_streams() -> Result<Vec<TestStream>> {
+        let schema = DataSchemaRefExt::create(vec![
+            DataField::new("a", DataType::Number(NumberDataType::Int32)),
+            DataField::new("b", DataType::Number(NumberDataType::Int32)),
+        ]);
+        let sort_desc: Arc<[SortColumnDescription]> = vec![
+            SortColumnDescription {
+                offset: 0,
+                asc: true,
+                nulls_first: false,
+            },
+            SortColumnDescription {
+                offset: 1,
+                asc: false,
+                nulls_first: false,
+            },
+        ]
+        .into();
+
+        let make_stream = |b_values: Vec<i32>| -> Result<TestStream> {
+            let rows = b_values.len();
+            let block = DataBlock::new_from_columns(vec![
+                Int32Type::from_data(vec![1; rows]),
+                Int32Type::from_data(b_values),
+            ]);
+            let order_col = convert_rows(schema.clone(), &sort_desc, block.clone(), true)?;
+            Ok(TestStream {
+                blocks: VecDeque::from([(block, order_col)]),
+            })
+        };
+
+        Ok(vec![
+            make_stream(vec![10, 1])?,
+            make_stream(vec![9, 2])?,
+            make_stream(vec![8, 3])?,
+        ])
+    }
+
+    fn collect_b_values<A>(mut merger: Merger<A, TestStream>) -> Result<Vec<i32>>
+    where A: SortAlgorithm {
+        let mut outputs = Vec::new();
+        while let Some(block) = merger.next_block()? {
+            outputs.push(block.get_by_offset(1).to_column());
+        }
+
+        assert_eq!(outputs.len(), 1);
+        let Some(databend_common_expression::Column::Number(
+            databend_common_expression::types::NumberColumn::Int32(values),
+        )) = outputs.pop()
+        else {
+            unreachable!("expected Int32 b column")
+        };
+        Ok(values.into_iter().collect())
+    }
+
+    #[test]
+    fn test_row_by_row_heap_merge_keeps_compound_desc_order_for_overlaps() -> Result<()> {
+        let streams = make_compound_streams()?;
+        let merger = Merger::<HeapSort<FixedRows<2>>, _>::new_row_by_row(streams, 1024, Some(4));
+        assert_eq!(collect_b_values(merger)?, vec![10, 9, 8, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_row_by_row_loser_tree_merge_keeps_compound_desc_order_for_overlaps() -> Result<()> {
+        let streams = make_compound_streams()?;
+        let merger =
+            Merger::<LoserTreeSort<FixedRows<2>>, _>::new_row_by_row(streams, 1024, Some(4));
+        assert_eq!(collect_b_values(merger)?, vec![10, 9, 8, 3]);
+        Ok(())
+    }
+}

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_multi_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_multi_merge.rs
@@ -47,6 +47,50 @@ pub fn try_add_multi_sort_merge(
     enable_loser_tree: bool,
     enable_fixed_rows_sort: bool,
 ) -> Result<()> {
+    add_multi_sort_merge(
+        pipeline,
+        key_desc,
+        block_size,
+        limit,
+        remove_order_col,
+        enable_loser_tree,
+        enable_fixed_rows_sort,
+        false,
+    )
+}
+
+pub fn add_row_by_row_multi_sort_merge(
+    pipeline: &mut Pipeline,
+    key_desc: SortKeyDescription,
+    block_size: usize,
+    limit: Option<usize>,
+    remove_order_col: bool,
+    enable_loser_tree: bool,
+    enable_fixed_rows_sort: bool,
+) -> Result<()> {
+    add_multi_sort_merge(
+        pipeline,
+        key_desc,
+        block_size,
+        limit,
+        remove_order_col,
+        enable_loser_tree,
+        enable_fixed_rows_sort,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_multi_sort_merge(
+    pipeline: &mut Pipeline,
+    key_desc: SortKeyDescription,
+    block_size: usize,
+    limit: Option<usize>,
+    remove_order_col: bool,
+    enable_loser_tree: bool,
+    enable_fixed_rows_sort: bool,
+    row_by_row: bool,
+) -> Result<()> {
     match pipeline.output_len() {
         0 => panic!("Cannot resize empty pipe."),
         1 => Ok(()),
@@ -65,6 +109,7 @@ pub fn try_add_multi_sort_merge(
                 limit,
                 remove_order_col,
                 enable_loser_tree,
+                row_by_row,
             };
             pipeline.add_pipe(Pipe::create(inputs_port.len(), 1, vec![PipeItem::create(
                 ProcessorPtr::create(select_row_type(&mut builder, enable_fixed_rows_sort)?),
@@ -84,6 +129,7 @@ struct MultiSortMergeBuilder {
     limit: Option<usize>,
     remove_order_col: bool,
     enable_loser_tree: bool,
+    row_by_row: bool,
 }
 
 impl RowsTypeVisitor for MultiSortMergeBuilder {
@@ -116,10 +162,15 @@ impl MultiSortMergeBuilder {
             .iter()
             .map(|i| InputBlockStream::new(i.clone(), remove_order_col, sort_row_offset))
             .collect::<Vec<_>>();
-        let merger = Merger::<A, _>::new(streams, self.block_size, self.limit);
+        let merger = if self.row_by_row {
+            Merger::<A, _>::new_row_by_row(streams, self.block_size, self.limit)
+        } else {
+            Merger::<A, _>::new(streams, self.block_size, self.limit)
+        };
 
         Ok(Box::new(MultiSortMergeProcessor {
             merger,
+            row_by_row: self.row_by_row,
             inputs: self.inputs.clone(),
             output: self.output.clone(),
             output_data: VecDeque::new(),
@@ -167,6 +218,7 @@ pub struct MultiSortMergeProcessor<A>
 where A: SortAlgorithm
 {
     merger: Merger<A, InputBlockStream>,
+    row_by_row: bool,
 
     /// This field is used to drive the processor's state.
     ///
@@ -181,7 +233,11 @@ impl<A> Processor for MultiSortMergeProcessor<A>
 where A: SortAlgorithm + 'static
 {
     fn name(&self) -> String {
-        "MultiSortMerge".to_string()
+        if self.row_by_row {
+            "RowByRowMultiSortMerge".to_string()
+        } else {
+            "MultiSortMerge".to_string()
+        }
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/query/service/src/physical_plans/physical_limit.rs
+++ b/src/query/service/src/physical_plans/physical_limit.rs
@@ -153,8 +153,11 @@ impl PhysicalPlanBuilder {
 
         // 2. Build physical plan.
         let mut input_plan = self.build(s_expr.child(0)?, required).await?;
-        if let Some(count) = limit.limit {
-            self.try_apply_presorted_merge_for_limit(&mut input_plan, count + limit.offset)
+        if let Some(limit_rows) = limit
+            .limit
+            .and_then(|count| count.checked_add(limit.offset))
+        {
+            self.try_apply_presorted_merge_for_limit(&mut input_plan, limit_rows)
                 .await?;
         }
         if limit.before_exchange || limit.lazy_columns.is_empty() || !support_lazy_materialize {

--- a/src/query/service/src/physical_plans/physical_limit.rs
+++ b/src/query/service/src/physical_plans/physical_limit.rs
@@ -152,7 +152,11 @@ impl PhysicalPlanBuilder {
         }
 
         // 2. Build physical plan.
-        let input_plan = self.build(s_expr.child(0)?, required).await?;
+        let mut input_plan = self.build(s_expr.child(0)?, required).await?;
+        if let Some(count) = limit.limit {
+            self.try_apply_presorted_merge_for_limit(&mut input_plan, count + limit.offset)
+                .await?;
+        }
         if limit.before_exchange || limit.lazy_columns.is_empty() || !support_lazy_materialize {
             return Ok(PhysicalPlan::new(Limit {
                 input: input_plan,

--- a/src/query/service/src/physical_plans/physical_sort.rs
+++ b/src/query/service/src/physical_plans/physical_sort.rs
@@ -14,17 +14,36 @@
 
 use std::any::Any;
 use std::assert_matches::debug_assert_matches;
+use std::cmp;
+use std::cmp::Ordering;
 use std::fmt::Display;
+use std::sync::Arc;
 
 use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::Filters;
+use databend_common_catalog::plan::PartInfo;
+use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PartInfoType;
+use databend_common_catalog::plan::PartStatistics;
+use databend_common_catalog::plan::PartitionsShuffleKind;
+use databend_common_catalog::plan::ReadPartitionsPruningMode;
+use databend_common_catalog::table::Table;
+use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
+use databend_common_expression::RemoteExpr;
+use databend_common_expression::Scalar;
 use databend_common_expression::SortColumnDescription;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::NumberScalar;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_common_pipeline_transforms::blocks::CompoundBlockOperator;
 use databend_common_pipeline_transforms::sorts::core::SortKeyDescription;
+use databend_common_sql::BaseTableColumn;
+use databend_common_sql::ColumnEntry;
 use databend_common_sql::ColumnSet;
 use databend_common_sql::IndexType;
 use databend_common_sql::evaluator::BlockOperator;
@@ -32,11 +51,21 @@ use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::SortDesc;
 use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::WindowFuncType;
+use databend_common_storages_fuse::FuseBlockPartInfo;
+use databend_common_storages_fuse::FuseLazyPartInfo;
+use databend_common_storages_fuse::FuseStorageFormat;
+use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::SegmentLocation;
+use databend_storages_common_table_meta::meta::ClusterStatistics;
+use databend_storages_common_table_meta::table::ClusterType;
 use itertools::Itertools;
 
+use crate::physical_plans::EvalScalar;
 use crate::physical_plans::Exchange;
+use crate::physical_plans::Filter;
 use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::PhysicalPlanCast;
+use crate::physical_plans::TableScan;
 use crate::physical_plans::WindowPartition;
 use crate::physical_plans::WindowPartitionTopN;
 use crate::physical_plans::WindowPartitionTopNFunc;
@@ -82,6 +111,9 @@ pub enum SortStep {
     Sample,
     Shuffled,
     Route,
+
+    // Input streams are already sorted by the required keys.
+    PresortedMerge,
 }
 
 impl Display for SortStep {
@@ -93,6 +125,7 @@ impl Display for SortStep {
             SortStep::Sample => write!(f, "Sample"),
             SortStep::Shuffled => write!(f, "Shuffled"),
             SortStep::Route => write!(f, "Route"),
+            SortStep::PresortedMerge => write!(f, "PresortedMerge"),
         }
     }
 }
@@ -119,10 +152,10 @@ impl IPhysicalPlan for Sort {
                 input_schema,
                 self.enable_fixed_rows,
             ),
-            SortStep::Single | SortStep::Partial | SortStep::Sample => {
+            SortStep::Single | SortStep::Partial | SortStep::Sample | SortStep::PresortedMerge => {
                 let projected_schema =
                     DataSchema::new_ref(self.fields_after_projection(&input_schema));
-                if self.step == SortStep::Single {
+                if matches!(self.step, SortStep::Single | SortStep::PresortedMerge) {
                     return Ok(projected_schema);
                 }
                 let key_desc = SortKeyDescription::new(
@@ -195,7 +228,7 @@ impl IPhysicalPlan for Sort {
         if let Some(proj) = &self.pre_projection {
             debug_assert_matches!(
                 self.step,
-                SortStep::Single | SortStep::Partial | SortStep::Sample
+                SortStep::Single | SortStep::Partial | SortStep::Sample | SortStep::PresortedMerge
             );
 
             let input_schema = self.input.output_schema()?;
@@ -301,6 +334,9 @@ impl IPhysicalPlan for Sort {
                     TransformSortBuilder::add_route(&mut builder.main_pipeline)
                 }
             }
+            SortStep::PresortedMerge => {
+                sort_builder.build_presorted_merge_pipeline(&mut builder.main_pipeline)
+            }
         }
     }
 }
@@ -309,9 +345,11 @@ impl Sort {
     fn sort_pipeline_schema(&self) -> Result<DataSchemaRef> {
         let input_schema = self.input.output_schema()?;
         match self.step {
-            SortStep::Single | SortStep::Partial | SortStep::Sample => Ok(DataSchema::new_ref(
-                self.fields_after_projection(&input_schema),
-            )),
+            SortStep::Single | SortStep::Partial | SortStep::Sample | SortStep::PresortedMerge => {
+                Ok(DataSchema::new_ref(
+                    self.fields_after_projection(&input_schema),
+                ))
+            }
             SortStep::Final | SortStep::Shuffled => SortKeyDescription::strip_order_col_schema(
                 self.sort_desc(&input_schema)?.into(),
                 input_schema,
@@ -324,7 +362,7 @@ impl Sort {
     fn fields_after_projection(&self, input_schema: &DataSchema) -> Vec<DataField> {
         debug_assert_matches!(
             self.step,
-            SortStep::Single | SortStep::Partial | SortStep::Sample
+            SortStep::Single | SortStep::Partial | SortStep::Sample | SortStep::PresortedMerge
         );
         self.pre_projection
             .as_ref()
@@ -431,7 +469,24 @@ impl PhysicalPlanBuilder {
         let enable_fixed_rows = settings.get_enable_fixed_rows_sort()?;
 
         let Some(after_exchange) = sort.after_exchange else {
-            let input_plan = self.build(s_expr.unary_child(), required).await?;
+            let mut input_plan = self.build(s_expr.unary_child(), required).await?;
+            if sort.limit.is_some()
+                && self
+                    .prove_cluster_key_ordering(&mut input_plan, &order_by)
+                    .await?
+            {
+                return Ok(PhysicalPlan::new(Sort {
+                    input: input_plan,
+                    order_by,
+                    limit: sort.limit,
+                    step: SortStep::PresortedMerge,
+                    pre_projection,
+                    broadcast_id: None,
+                    enable_fixed_rows,
+                    stat_info: Some(stat_info),
+                    meta: PhysicalPlanMeta::new("Sort"),
+                }));
+            }
             return Ok(PhysicalPlan::new(Sort {
                 input: input_plan,
                 order_by,
@@ -521,5 +576,749 @@ impl PhysicalPlanBuilder {
             stat_info: Some(stat_info),
             meta: PhysicalPlanMeta::new("Sort"),
         }))
+    }
+}
+
+impl PhysicalPlanBuilder {
+    pub(super) async fn try_apply_presorted_merge_for_limit(
+        &self,
+        plan: &mut PhysicalPlan,
+        limit: usize,
+    ) -> Result<()> {
+        let Some(sort) = Sort::from_mut_physical_plan(plan) else {
+            return Ok(());
+        };
+        if sort.step != SortStep::Single {
+            return Ok(());
+        }
+
+        let order_by = sort.order_by.clone();
+        if self
+            .prove_cluster_key_ordering(&mut sort.input, &order_by)
+            .await?
+        {
+            sort.limit = Some(sort.limit.map_or(limit, |v| cmp::max(v, limit)));
+            sort.step = SortStep::PresortedMerge;
+        }
+        Ok(())
+    }
+
+    async fn prove_cluster_key_ordering(
+        &self,
+        input_plan: &mut PhysicalPlan,
+        order_by: &[SortDesc],
+    ) -> Result<bool> {
+        if order_by.is_empty() {
+            return Ok(false);
+        }
+        if !self.ctx.get_cluster().is_empty() {
+            // Preserve-order streams are assigned before source fragments are
+            // redistributed. Until the scheduler can remap stream ids per
+            // executor, keep the optimization local to single-node plans.
+            return Ok(false);
+        }
+
+        let Some(sort_exprs) = self.sort_exprs(order_by) else {
+            return Ok(false);
+        };
+
+        let Some((fuse_table, max_overlap, max_streams_limit)) = (|| {
+            let settings = self.ctx.get_settings();
+            if !settings.get_enable_cluster_key_ordered_topk().ok()? {
+                return None;
+            }
+
+            let scan = ordered_table_scan(input_plan)?;
+            let table_index = scan.table_index?;
+            let table = self.metadata.read().table(table_index).table().clone();
+            let fuse_table = table.as_any().downcast_ref::<FuseTable>()?;
+            if !matches!(fuse_table.get_storage_format(), FuseStorageFormat::Parquet)
+                || fuse_table
+                    .cluster_type()
+                    .is_none_or(|v| v != ClusterType::Linear)
+            {
+                return None;
+            }
+
+            let cluster_keys = fuse_table.linear_cluster_keys(self.ctx.clone());
+            if !cluster_keys_cover_ordering(&cluster_keys, scan, &sort_exprs) {
+                return None;
+            }
+
+            let max_overlap = settings.get_max_cluster_key_ordered_topk_overlap().ok()?;
+            let max_streams = cmp::min(
+                settings.get_max_threads().ok()? as usize,
+                settings.get_max_storage_io_requests().ok()? as usize,
+            );
+            Some((fuse_table.clone(), max_overlap, max_streams))
+        })() else {
+            return Ok(false);
+        };
+
+        let Some(scan) = ordered_table_scan(input_plan) else {
+            return Ok(false);
+        };
+        let (statistics, partitions) =
+            match cluster_order_partitions(self.ctx.clone(), scan, &fuse_table).await {
+                Ok(partitions) => partitions,
+                Err(error) => {
+                    log::debug!(
+                        "skip cluster key ordered top-k: failed to expand lazy partitions: {:?}",
+                        error
+                    );
+                    return Ok(false);
+                }
+            };
+        if !ordering_minus_safe(&sort_exprs, scan, &partitions) {
+            return Ok(false);
+        }
+        let max_streams = cmp::min(max_streams_limit, partitions.len());
+        let Some(ordered_partitions) = ordered_cluster_partitions(
+            &partitions,
+            fuse_table.cluster_key_id(),
+            max_overlap,
+            max_streams,
+        ) else {
+            return Ok(false);
+        };
+
+        if let Some(scan) = ordered_table_scan_mut(input_plan) {
+            scan.source.parts.kind = PartitionsShuffleKind::PreserveOrder;
+            scan.source.parts.partitions = ordered_partitions;
+            scan.source.statistics = statistics;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn sort_exprs(&self, order_by: &[SortDesc]) -> Option<Vec<(RemoteExpr<String>, bool, bool)>> {
+        let metadata = self.metadata.read();
+        order_by
+            .iter()
+            .map(|item| {
+                let column = metadata.column(item.order_by);
+                let ColumnEntry::BaseTableColumn(BaseTableColumn {
+                    column_name,
+                    data_type,
+                    ..
+                }) = column
+                else {
+                    return None;
+                };
+                Some((
+                    RemoteExpr::ColumnRef {
+                        span: None,
+                        id: column_name.clone(),
+                        data_type: DataType::from(data_type),
+                        display_name: column_name.clone(),
+                    },
+                    item.asc,
+                    item.nulls_first,
+                ))
+            })
+            .collect()
+    }
+}
+
+fn cluster_keys_cover_ordering(
+    cluster_keys: &[RemoteExpr<String>],
+    scan: &TableScan,
+    sort_exprs: &[(RemoteExpr<String>, bool, bool)],
+) -> bool {
+    let sort_exprs = sort_exprs
+        .iter()
+        .filter(|(sort_expr, _, _)| !scan_cluster_key_fixed_by_filters(sort_expr, scan))
+        .collect::<Vec<_>>();
+    if sort_exprs.is_empty() {
+        return false;
+    }
+
+    let mut sort_index = 0;
+    for cluster_key in cluster_keys {
+        if scan_cluster_key_fixed_by_filters(cluster_key, scan) {
+            continue;
+        }
+
+        let Some((sort_expr, asc, nulls_first)) = sort_exprs.get(sort_index) else {
+            return true;
+        };
+        if !cluster_key_matches_order_by(cluster_key, sort_expr, *asc, *nulls_first) {
+            return false;
+        }
+
+        sort_index += 1;
+        if sort_index == sort_exprs.len() {
+            return true;
+        }
+    }
+
+    false
+}
+
+async fn cluster_order_partitions(
+    ctx: Arc<dyn TableContext>,
+    scan: &TableScan,
+    fuse_table: &FuseTable,
+) -> Result<(PartStatistics, Vec<PartInfoPtr>)> {
+    if scan.source.parts.partitions_type() != PartInfoType::LazyLevel {
+        return Ok((
+            scan.source.statistics.clone(),
+            scan.source.parts.partitions.clone(),
+        ));
+    }
+
+    let snapshot = scan.source.statistics.snapshot.clone();
+    let snapshot_block_count = fuse_table
+        .read_table_snapshot_with_location(snapshot.clone())
+        .await?
+        .map(|snapshot| snapshot.summary.block_count as usize)
+        .unwrap_or(scan.source.statistics.partitions_total);
+    let mut segments = Vec::with_capacity(scan.source.parts.len());
+    for part in &scan.source.parts.partitions {
+        let Some(lazy_part) = part.as_any().downcast_ref::<FuseLazyPartInfo>() else {
+            return Ok((scan.source.statistics.clone(), vec![]));
+        };
+        segments.push(SegmentLocation {
+            segment_idx: lazy_part.segment_index,
+            location: lazy_part.segment_location.clone(),
+            snapshot_loc: snapshot.clone(),
+        });
+    }
+
+    let (statistics, partitions, _) = fuse_table
+        .prune_snapshot_blocks(
+            ctx,
+            scan.source.push_downs.clone(),
+            fuse_table.schema_with_stream(),
+            segments,
+            snapshot_block_count,
+            ReadPartitionsPruningMode::Normal,
+            None,
+        )
+        .await?;
+    Ok((statistics, partitions.partitions))
+}
+
+fn ordered_cluster_partitions(
+    partitions: &[PartInfoPtr],
+    cluster_key_id: Option<u32>,
+    max_overlap: u64,
+    max_streams_limit: usize,
+) -> Option<Vec<PartInfoPtr>> {
+    if partitions.is_empty() || max_streams_limit == 0 {
+        return None;
+    }
+    let cluster_key_id = cluster_key_id?;
+    if partitions.len() == 1 {
+        let mut fuse_part = FuseBlockPartInfo::from_part(&partitions[0]).ok()?.clone();
+        valid_cluster_stats(&fuse_part, cluster_key_id)?;
+        fuse_part.preserve_order_stream = Some(0);
+        return Some(vec![Arc::new(Box::new(fuse_part) as Box<dyn PartInfo>)]);
+    }
+
+    let mut partitions = partitions
+        .iter()
+        .map(|part| {
+            let fuse_part = FuseBlockPartInfo::from_part(part).ok()?;
+            let stats = valid_cluster_stats(fuse_part, cluster_key_id)?;
+            Some((stats.min().clone(), stats.max().clone(), part.clone()))
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    partitions.sort_by(|left, right| {
+        compare_cluster_values(&left.0, &right.0)
+            .then_with(|| compare_cluster_values(&left.1, &right.1))
+    });
+
+    // `max_overlap` is the number of extra simultaneously-overlapping ranges.
+    // The active range count therefore includes the current range itself.
+    let max_allowed_active_ranges = match max_overlap {
+        v if v >= usize::MAX as u64 => usize::MAX,
+        v => v as usize + 1,
+    };
+    let max_allowed_active_ranges = cmp::min(max_allowed_active_ranges, max_streams_limit);
+    let mut active_ranges: Vec<Vec<Scalar>> = Vec::new();
+    let mut max_observed_active_ranges = 0;
+    for (min, max, _) in &partitions {
+        if compare_cluster_values(min, max) == Ordering::Greater {
+            return None;
+        }
+
+        active_ranges
+            .retain(|active_max| compare_cluster_values(active_max, min) == Ordering::Greater);
+        active_ranges.push(max.clone());
+        if active_ranges.len() > max_allowed_active_ranges {
+            return None;
+        }
+        max_observed_active_ranges = cmp::max(max_observed_active_ranges, active_ranges.len());
+    }
+
+    // Non-overlapping ranges can stay in one stream. That lets LIMIT over a
+    // clustered scan consume blocks sequentially and stop without waiting for
+    // unrelated source streams to produce their first block.
+    let max_streams = cmp::max(1, cmp::min(max_observed_active_ranges, max_streams_limit));
+    let mut stream_ranges: Vec<Option<Vec<Scalar>>> = vec![None; max_streams];
+    let mut next_stream = 0;
+    let mut ordered_partitions: Vec<PartInfoPtr> = Vec::with_capacity(partitions.len());
+    for (min, max, part) in partitions {
+        let stream_index = (0..max_streams).find_map(|offset| {
+            let stream_index = (next_stream + offset) % max_streams;
+            stream_ranges[stream_index]
+                .as_ref()
+                .is_none_or(|stream_max| {
+                    compare_cluster_values(stream_max, &min) != Ordering::Greater
+                })
+                .then_some(stream_index)
+        })?;
+        stream_ranges[stream_index] = Some(max.clone());
+        next_stream = (stream_index + 1) % max_streams;
+
+        let mut part = FuseBlockPartInfo::from_part(&part).ok()?.clone();
+        part.preserve_order_stream = Some(stream_index);
+        ordered_partitions.push(Arc::new(Box::new(part) as Box<dyn PartInfo>));
+    }
+
+    Some(ordered_partitions)
+}
+
+fn valid_cluster_stats(
+    part: &FuseBlockPartInfo,
+    cluster_key_id: u32,
+) -> Option<&ClusterStatistics> {
+    part.cluster_stats
+        .as_ref()
+        .filter(|stats| stats.cluster_key_id == cluster_key_id)
+        .filter(|stats| !stats.min().is_empty() && stats.min().len() == stats.max().len())
+}
+
+fn compare_cluster_values(
+    left: &[databend_common_expression::Scalar],
+    right: &[databend_common_expression::Scalar],
+) -> Ordering {
+    left.iter()
+        .map(databend_common_expression::Scalar::as_ref)
+        .cmp(right.iter().map(databend_common_expression::Scalar::as_ref))
+}
+
+fn ordered_table_scan(plan: &PhysicalPlan) -> Option<&TableScan> {
+    if let Some(scan) = TableScan::from_physical_plan(plan) {
+        return Some(scan);
+    }
+    if let Some(filter) = Filter::from_physical_plan(plan) {
+        return ordered_table_scan(&filter.input);
+    }
+    if let Some(eval_scalar) = EvalScalar::from_physical_plan(plan) {
+        return ordered_table_scan(&eval_scalar.input);
+    }
+    None
+}
+
+fn ordered_table_scan_mut(plan: &mut PhysicalPlan) -> Option<&mut TableScan> {
+    if TableScan::check_physical_plan(plan) {
+        return TableScan::from_mut_physical_plan(plan);
+    }
+    if Filter::check_physical_plan(plan) {
+        let filter = Filter::from_mut_physical_plan(plan).unwrap();
+        return ordered_table_scan_mut(&mut filter.input);
+    }
+    if EvalScalar::check_physical_plan(plan) {
+        let eval_scalar = EvalScalar::from_mut_physical_plan(plan).unwrap();
+        return ordered_table_scan_mut(&mut eval_scalar.input);
+    }
+    None
+}
+
+fn scan_cluster_key_fixed_by_filters(cluster_key: &RemoteExpr<String>, scan: &TableScan) -> bool {
+    scan.source.push_downs.as_ref().is_some_and(|push_downs| {
+        push_downs
+            .filters
+            .as_ref()
+            .is_some_and(|filters| expr_fixed_by_filters(cluster_key, filters))
+            || push_downs
+                .secure_filters
+                .as_ref()
+                .is_some_and(|filters| expr_fixed_by_filters(cluster_key, filters))
+            || push_downs
+                .prewhere
+                .as_ref()
+                .is_some_and(|prewhere| expr_fixed_by_filter_expr(cluster_key, &prewhere.filter))
+    })
+}
+
+fn expr_fixed_by_filters(expr: &RemoteExpr<String>, filters: &Filters) -> bool {
+    expr_fixed_by_filter_expr(expr, &filters.filter)
+}
+
+fn expr_fixed_by_filter_expr(expr: &RemoteExpr<String>, filter: &RemoteExpr<String>) -> bool {
+    let RemoteExpr::FunctionCall { id, args, .. } = filter else {
+        return false;
+    };
+    match id.name().as_ref() {
+        "and" | "and_filters" => args.iter().any(|arg| expr_fixed_by_filter_expr(expr, arg)),
+        "is_true" if args.len() == 1 => expr_fixed_by_filter_expr(expr, &args[0]),
+        "eq" if args.len() == 2 => {
+            expr_eq_constant(expr, &args[0], &args[1]) || expr_eq_constant(expr, &args[1], &args[0])
+        }
+        _ => false,
+    }
+}
+
+fn expr_eq_constant(
+    expr: &RemoteExpr<String>,
+    maybe_expr: &RemoteExpr<String>,
+    maybe_constant: &RemoteExpr<String>,
+) -> bool {
+    expr_is_constant(maybe_constant) && expr_matches_filter_arg(expr, maybe_expr)
+}
+
+fn expr_is_constant(expr: &RemoteExpr<String>) -> bool {
+    match expr {
+        RemoteExpr::Constant { .. } => true,
+        RemoteExpr::Cast { is_try, expr, .. } if !*is_try => expr_is_constant(expr),
+        _ => false,
+    }
+}
+
+fn expr_matches_filter_arg(expr: &RemoteExpr<String>, maybe_expr: &RemoteExpr<String>) -> bool {
+    remote_expr_semantic_eq(maybe_expr, expr)
+        || cast_expr_matches_expr(maybe_expr, expr)
+        || negated_column_matches_expr(expr, maybe_expr)
+        || string_prefix_cluster_key_matches_expr(expr, maybe_expr)
+}
+
+fn cast_expr_matches_expr(maybe_cast: &RemoteExpr<String>, expr: &RemoteExpr<String>) -> bool {
+    let RemoteExpr::Cast {
+        is_try,
+        expr: inner,
+        dest_type,
+        ..
+    } = maybe_cast
+    else {
+        return false;
+    };
+    !*is_try
+        && cast_preserves_ordering_type(dest_type, expr)
+        && expr_matches_filter_arg(expr, inner)
+}
+
+fn cast_preserves_ordering_type(dest_type: &DataType, expr: &RemoteExpr<String>) -> bool {
+    let source_type = remote_expr_data_type(expr);
+    source_type.remove_nullable() == dest_type.remove_nullable()
+}
+
+fn remote_expr_data_type(expr: &RemoteExpr<String>) -> &DataType {
+    match expr {
+        RemoteExpr::Constant { data_type, .. } => data_type,
+        RemoteExpr::ColumnRef { data_type, .. } => data_type,
+        RemoteExpr::Cast { dest_type, .. } => dest_type,
+        RemoteExpr::FunctionCall { return_type, .. } => return_type,
+        RemoteExpr::LambdaFunctionCall { return_type, .. } => return_type,
+    }
+}
+
+fn string_prefix_cluster_key_matches_expr(
+    cluster_key: &RemoteExpr<String>,
+    filter_expr: &RemoteExpr<String>,
+) -> bool {
+    let RemoteExpr::FunctionCall { id, args, .. } = cluster_key else {
+        return false;
+    };
+    if id.name().as_ref() != "substr" || args.len() != 3 {
+        return false;
+    }
+
+    expr_matches_filter_arg(&args[0], filter_expr)
+        && is_number_constant(&args[1], 1)
+        && is_number_constant(&args[2], 8)
+}
+
+fn is_number_constant(expr: &RemoteExpr<String>, expected: i128) -> bool {
+    match expr {
+        RemoteExpr::Constant {
+            scalar: Scalar::Number(number),
+            ..
+        } => number.integer_to_i128().is_some_and(|v| v == expected),
+        RemoteExpr::Cast { is_try, expr, .. } if !*is_try => is_number_constant(expr, expected),
+        _ => false,
+    }
+}
+
+fn ordering_minus_safe(
+    sort_exprs: &[(RemoteExpr<String>, bool, bool)],
+    scan: &TableScan,
+    partitions: &[PartInfoPtr],
+) -> bool {
+    sort_exprs
+        .iter()
+        .filter(|(_, asc, nulls_first)| !*asc && !*nulls_first)
+        .all(|(sort_expr, _, _)| ordering_minus_safe_for_expr(sort_expr, scan, partitions))
+}
+
+fn ordering_minus_safe_for_expr(
+    sort_expr: &RemoteExpr<String>,
+    scan: &TableScan,
+    partitions: &[PartInfoPtr],
+) -> bool {
+    let RemoteExpr::ColumnRef { id, data_type, .. } = sort_expr else {
+        return false;
+    };
+
+    match data_type.remove_nullable() {
+        DataType::Number(NumberDataType::Int64) => {
+            let Ok(column_id) = scan.source.schema().column_id_of(id) else {
+                return false;
+            };
+            partitions.iter().all(|part| {
+                let Ok(fuse_part) = FuseBlockPartInfo::from_part(part) else {
+                    return false;
+                };
+                fuse_part
+                    .columns_stat
+                    .as_ref()
+                    .and_then(|stats| stats.get(&column_id))
+                    .is_some_and(|stat| {
+                        !matches!(
+                            stat.min(),
+                            Scalar::Number(NumberScalar::Int64(v)) if *v == i64::MIN
+                        )
+                    })
+            })
+        }
+        _ => true,
+    }
+}
+
+fn cluster_key_matches_order_by(
+    cluster_key: &RemoteExpr<String>,
+    sort_expr: &RemoteExpr<String>,
+    asc: bool,
+    nulls_first: bool,
+) -> bool {
+    if asc && !nulls_first && remote_expr_semantic_eq(cluster_key, sort_expr) {
+        return true;
+    }
+
+    !asc && !nulls_first && matches_negated_column(cluster_key, sort_expr)
+}
+
+fn matches_negated_column(
+    cluster_key: &RemoteExpr<String>,
+    sort_expr: &RemoteExpr<String>,
+) -> bool {
+    let RemoteExpr::ColumnRef { data_type, .. } = sort_expr else {
+        return false;
+    };
+    supports_order_reversing_minus(data_type) && negated_column_matches_expr(cluster_key, sort_expr)
+}
+
+fn negated_column_matches_expr(
+    cluster_key: &RemoteExpr<String>,
+    sort_expr: &RemoteExpr<String>,
+) -> bool {
+    let RemoteExpr::FunctionCall { id, args, .. } = cluster_key else {
+        return false;
+    };
+    if id.name().as_ref() != "minus" || args.len() != 1 {
+        return false;
+    }
+
+    let RemoteExpr::ColumnRef {
+        id: sort_column, ..
+    } = sort_expr
+    else {
+        return false;
+    };
+
+    matches!(
+        &args[0],
+        RemoteExpr::ColumnRef {
+            id: cluster_column,
+            ..
+        } if cluster_column == sort_column
+    )
+}
+
+fn remote_expr_semantic_eq(left: &RemoteExpr<String>, right: &RemoteExpr<String>) -> bool {
+    match (left, right) {
+        (
+            RemoteExpr::Constant {
+                scalar: left_scalar,
+                data_type: left_type,
+                ..
+            },
+            RemoteExpr::Constant {
+                scalar: right_scalar,
+                data_type: right_type,
+                ..
+            },
+        ) => left_scalar == right_scalar && left_type == right_type,
+        (
+            RemoteExpr::ColumnRef {
+                id: left_id,
+                data_type: left_type,
+                ..
+            },
+            RemoteExpr::ColumnRef {
+                id: right_id,
+                data_type: right_type,
+                ..
+            },
+        ) => left_id == right_id && left_type == right_type,
+        (
+            RemoteExpr::Cast {
+                is_try: left_is_try,
+                expr: left_expr,
+                dest_type: left_dest_type,
+                ..
+            },
+            RemoteExpr::Cast {
+                is_try: right_is_try,
+                expr: right_expr,
+                dest_type: right_dest_type,
+                ..
+            },
+        ) => {
+            left_is_try == right_is_try
+                && left_dest_type == right_dest_type
+                && remote_expr_semantic_eq(left_expr, right_expr)
+        }
+        (
+            RemoteExpr::FunctionCall {
+                id: left_id,
+                generics: left_generics,
+                args: left_args,
+                return_type: left_return_type,
+                ..
+            },
+            RemoteExpr::FunctionCall {
+                id: right_id,
+                generics: right_generics,
+                args: right_args,
+                return_type: right_return_type,
+                ..
+            },
+        ) => {
+            left_id.name() == right_id.name()
+                && left_generics == right_generics
+                && left_return_type == right_return_type
+                && left_args.len() == right_args.len()
+                && left_args
+                    .iter()
+                    .zip(right_args)
+                    .all(|(left_arg, right_arg)| remote_expr_semantic_eq(left_arg, right_arg))
+        }
+        (RemoteExpr::LambdaFunctionCall { .. }, RemoteExpr::LambdaFunctionCall { .. }) => false,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use databend_common_expression::types::NumberScalar;
+    use databend_storages_common_table_meta::meta::Compression;
+
+    use super::*;
+
+    fn scalar(value: i64) -> Scalar {
+        Scalar::Number(NumberScalar::Int64(value))
+    }
+
+    fn part(location: &str, min: i64, max: i64) -> PartInfoPtr {
+        FuseBlockPartInfo::create(
+            location.to_string(),
+            None,
+            0,
+            None,
+            0,
+            1,
+            HashMap::new(),
+            None,
+            None,
+            Compression::legacy(),
+            None,
+            Some(ClusterStatistics::new(
+                7,
+                vec![scalar(min)],
+                vec![scalar(max)],
+                0,
+                None,
+            )),
+            None,
+            None,
+        )
+    }
+
+    fn stream_ids(parts: &[PartInfoPtr]) -> Vec<usize> {
+        parts
+            .iter()
+            .map(|part| {
+                FuseBlockPartInfo::from_part(part)
+                    .unwrap()
+                    .preserve_order_stream
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_ordered_cluster_partitions_uses_single_stream_for_non_overlap() {
+        let parts = vec![part("b", 10, 19), part("a", 0, 9), part("c", 20, 29)];
+
+        let ordered = ordered_cluster_partitions(&parts, Some(7), 10, 8).unwrap();
+
+        assert_eq!(stream_ids(&ordered), vec![0, 0, 0]);
+        let locations = ordered
+            .iter()
+            .map(|part| {
+                FuseBlockPartInfo::from_part(part)
+                    .unwrap()
+                    .location
+                    .as_str()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(locations, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_ordered_cluster_partitions_uses_overlap_width_streams() {
+        let parts = vec![part("a", 0, 10), part("b", 5, 15), part("c", 12, 20)];
+
+        let ordered = ordered_cluster_partitions(&parts, Some(7), 10, 8).unwrap();
+        let stream_ids = stream_ids(&ordered);
+
+        assert_eq!(stream_ids, vec![0, 1, 0]);
+        assert_eq!(stream_ids.iter().max().copied().unwrap() + 1, 2);
+    }
+
+    #[test]
+    fn test_ordered_cluster_partitions_rejects_excess_overlap() {
+        let parts = vec![part("a", 0, 10), part("b", 5, 15), part("c", 7, 20)];
+
+        assert!(ordered_cluster_partitions(&parts, Some(7), 1, 8).is_none());
+    }
+}
+
+fn supports_order_reversing_minus(data_type: &DataType) -> bool {
+    match data_type.remove_nullable() {
+        DataType::Number(
+            NumberDataType::UInt8
+            | NumberDataType::UInt16
+            | NumberDataType::UInt32
+            | NumberDataType::Int8
+            | NumberDataType::Int16
+            | NumberDataType::Int32,
+        ) => true,
+        DataType::Number(NumberDataType::Int64) => true,
+        // Decimal negation has a type-dependent lower-bound overflow case that
+        // is not proven safe here.
+        DataType::Decimal(_) => false,
+        // UInt64/Float boundary ordering is not proven here.
+        DataType::Number(
+            NumberDataType::UInt64 | NumberDataType::Float32 | NumberDataType::Float64,
+        ) => false,
+        _ => false,
     }
 }

--- a/src/query/service/src/physical_plans/physical_sort.rs
+++ b/src/query/service/src/physical_plans/physical_sort.rs
@@ -1084,7 +1084,7 @@ fn string_prefix_cluster_key_matches_expr(
 
     expr_matches_filter_arg(&args[0], filter_expr)
         && is_number_constant(&args[1], 1)
-        && is_number_constant(&args[2], 8)
+        && positive_number_constant(&args[2])
 }
 
 fn is_number_constant(expr: &RemoteExpr<String>, expected: i128) -> bool {
@@ -1094,6 +1094,17 @@ fn is_number_constant(expr: &RemoteExpr<String>, expected: i128) -> bool {
             ..
         } => number.integer_to_i128().is_some_and(|v| v == expected),
         RemoteExpr::Cast { is_try, expr, .. } if !*is_try => is_number_constant(expr, expected),
+        _ => false,
+    }
+}
+
+fn positive_number_constant(expr: &RemoteExpr<String>) -> bool {
+    match expr {
+        RemoteExpr::Constant {
+            scalar: Scalar::Number(number),
+            ..
+        } => number.integer_to_i128().is_some_and(|v| v > 0),
+        RemoteExpr::Cast { is_try, expr, .. } if !*is_try => positive_number_constant(expr),
         _ => false,
     }
 }
@@ -1370,6 +1381,14 @@ mod tests {
         function("contains", vec![array, expr], DataType::Boolean)
     }
 
+    fn substr(expr: RemoteExpr<String>, start: i32, len: i32) -> RemoteExpr<String> {
+        function(
+            "substr",
+            vec![expr, int_constant(start), int_constant(len)],
+            DataType::String,
+        )
+    }
+
     fn array(args: Vec<RemoteExpr<String>>) -> RemoteExpr<String> {
         function(
             "array",
@@ -1493,6 +1512,26 @@ mod tests {
                 int_column("b")
             )
         ));
+    }
+
+    #[test]
+    fn test_filter_fixed_prefix_expr_matches_any_positive_substr_len() {
+        let address = column("wallet_address", DataType::String);
+        let filter = eq(address.clone(), RemoteExpr::Constant {
+            span: None,
+            scalar: Scalar::String("0x1234567890abcdef".to_string()),
+            data_type: DataType::String,
+        });
+
+        assert!(expr_fixed_by_filter_expr(
+            &substr(address.clone(), 1, 8),
+            &filter
+        ));
+        assert!(expr_fixed_by_filter_expr(
+            &substr(address.clone(), 1, 16),
+            &filter
+        ));
+        assert!(!expr_fixed_by_filter_expr(&substr(address, 1, 0), &filter));
     }
 
     #[test]

--- a/src/query/service/src/physical_plans/physical_sort.rs
+++ b/src/query/service/src/physical_plans/physical_sort.rs
@@ -849,7 +849,7 @@ fn ordered_cluster_partitions(
         }
 
         active_ranges
-            .retain(|active_max| compare_cluster_values(active_max, min) == Ordering::Greater);
+            .retain(|active_max| compare_cluster_values(active_max, min) != Ordering::Less);
         active_ranges.push(max.clone());
         if active_ranges.len() > max_allowed_active_ranges {
             return None;
@@ -869,9 +869,7 @@ fn ordered_cluster_partitions(
             let stream_index = (next_stream + offset) % max_streams;
             stream_ranges[stream_index]
                 .as_ref()
-                .is_none_or(|stream_max| {
-                    compare_cluster_values(stream_max, &min) != Ordering::Greater
-                })
+                .is_none_or(|stream_max| compare_cluster_values(stream_max, &min) == Ordering::Less)
                 .then_some(stream_index)
         })?;
         stream_ranges[stream_index] = Some(max.clone());
@@ -960,11 +958,47 @@ fn expr_fixed_by_filter_expr(expr: &RemoteExpr<String>, filter: &RemoteExpr<Stri
     match id.name().as_ref() {
         "and" | "and_filters" => args.iter().any(|arg| expr_fixed_by_filter_expr(expr, arg)),
         "is_true" if args.len() == 1 => expr_fixed_by_filter_expr(expr, &args[0]),
+        "is_null" if args.len() == 1 => {
+            remote_expr_semantic_eq(expr, filter) || expr_matches_filter_arg(expr, &args[0])
+        }
+        "not" if args.len() == 1 => {
+            remote_expr_semantic_eq(expr, filter)
+                || expr_fixed_by_is_not_null_negation(expr, &args[0])
+        }
+        "contains" if args.len() == 2 => {
+            single_constant_array_expr(&args[0]) && expr_matches_filter_arg(expr, &args[1])
+        }
         "eq" if args.len() == 2 => {
             expr_eq_constant(expr, &args[0], &args[1]) || expr_eq_constant(expr, &args[1], &args[0])
         }
         _ => false,
     }
+}
+
+fn expr_fixed_by_is_not_null_negation(
+    expr: &RemoteExpr<String>,
+    maybe_is_not_null: &RemoteExpr<String>,
+) -> bool {
+    let RemoteExpr::FunctionCall { id, args, .. } = maybe_is_not_null else {
+        return false;
+    };
+    if id.name().as_ref() != "is_not_null" || args.len() != 1 {
+        return false;
+    }
+
+    is_null_cluster_key_matches_expr(expr, &args[0]) || expr_matches_filter_arg(expr, &args[0])
+}
+
+fn is_null_cluster_key_matches_expr(
+    cluster_key: &RemoteExpr<String>,
+    filter_expr: &RemoteExpr<String>,
+) -> bool {
+    let RemoteExpr::FunctionCall { id, args, .. } = cluster_key else {
+        return false;
+    };
+    id.name().as_ref() == "is_null"
+        && args.len() == 1
+        && expr_matches_filter_arg(&args[0], filter_expr)
 }
 
 fn expr_eq_constant(
@@ -979,6 +1013,23 @@ fn expr_is_constant(expr: &RemoteExpr<String>) -> bool {
     match expr {
         RemoteExpr::Constant { .. } => true,
         RemoteExpr::Cast { is_try, expr, .. } if !*is_try => expr_is_constant(expr),
+        _ => false,
+    }
+}
+
+fn single_constant_array_expr(expr: &RemoteExpr<String>) -> bool {
+    match expr {
+        RemoteExpr::Constant {
+            scalar: Scalar::Array(array),
+            ..
+        } => array.len() == 1,
+        RemoteExpr::FunctionCall { id, args, .. } if id.name().as_ref() == "array" => {
+            matches!(args.as_slice(), [arg] if expr_is_constant(arg))
+        }
+        RemoteExpr::FunctionCall { id, args, .. } if id.name().as_ref() == "array_distinct" => {
+            matches!(args.as_slice(), [arg] if single_constant_array_expr(arg))
+        }
+        RemoteExpr::Cast { is_try, expr, .. } if !*is_try => single_constant_array_expr(expr),
         _ => false,
     }
 }
@@ -1247,6 +1298,7 @@ fn remote_expr_semantic_eq(left: &RemoteExpr<String>, right: &RemoteExpr<String>
 mod tests {
     use std::collections::HashMap;
 
+    use databend_common_expression::FunctionID;
     use databend_common_expression::types::NumberScalar;
     use databend_storages_common_table_meta::meta::Compression;
 
@@ -1254,6 +1306,80 @@ mod tests {
 
     fn scalar(value: i64) -> Scalar {
         Scalar::Number(NumberScalar::Int64(value))
+    }
+
+    fn builtin(name: &str) -> Box<FunctionID> {
+        Box::new(FunctionID::Builtin {
+            name: name.to_string(),
+            id: 0,
+        })
+    }
+
+    fn column(name: &str, data_type: DataType) -> RemoteExpr<String> {
+        RemoteExpr::ColumnRef {
+            span: None,
+            id: name.to_string(),
+            data_type,
+            display_name: name.to_string(),
+        }
+    }
+
+    fn int_column(name: &str) -> RemoteExpr<String> {
+        column(name, DataType::Number(NumberDataType::Int32))
+    }
+
+    fn int_constant(value: i32) -> RemoteExpr<String> {
+        RemoteExpr::Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int32(value)),
+            data_type: DataType::Number(NumberDataType::Int32),
+        }
+    }
+
+    fn function(
+        name: &str,
+        args: Vec<RemoteExpr<String>>,
+        return_type: DataType,
+    ) -> RemoteExpr<String> {
+        RemoteExpr::FunctionCall {
+            span: None,
+            id: builtin(name),
+            generics: vec![],
+            args,
+            return_type,
+        }
+    }
+
+    fn eq(left: RemoteExpr<String>, right: RemoteExpr<String>) -> RemoteExpr<String> {
+        function("eq", vec![left, right], DataType::Boolean)
+    }
+
+    fn is_null(expr: RemoteExpr<String>) -> RemoteExpr<String> {
+        function("is_null", vec![expr], DataType::Boolean)
+    }
+
+    fn is_not_null(expr: RemoteExpr<String>) -> RemoteExpr<String> {
+        function("is_not_null", vec![expr], DataType::Boolean)
+    }
+
+    fn not(expr: RemoteExpr<String>) -> RemoteExpr<String> {
+        function("not", vec![expr], DataType::Boolean)
+    }
+
+    fn contains(array: RemoteExpr<String>, expr: RemoteExpr<String>) -> RemoteExpr<String> {
+        function("contains", vec![array, expr], DataType::Boolean)
+    }
+
+    fn array(args: Vec<RemoteExpr<String>>) -> RemoteExpr<String> {
+        function(
+            "array",
+            args,
+            DataType::Array(Box::new(DataType::Number(NumberDataType::Int32))),
+        )
+    }
+
+    fn and(args: Vec<RemoteExpr<String>>) -> RemoteExpr<String> {
+        function("and", args, DataType::Boolean)
     }
 
     fn part(location: &str, min: i64, max: i64) -> PartInfoPtr {
@@ -1295,7 +1421,7 @@ mod tests {
 
     #[test]
     fn test_ordered_cluster_partitions_uses_single_stream_for_non_overlap() {
-        let parts = vec![part("b", 10, 19), part("a", 0, 9), part("c", 20, 29)];
+        let parts = vec![part("b", 10, 19), part("a", 0, 8), part("c", 21, 29)];
 
         let ordered = ordered_cluster_partitions(&parts, Some(7), 10, 8).unwrap();
 
@@ -1324,23 +1450,90 @@ mod tests {
     }
 
     #[test]
+    fn test_ordered_cluster_partitions_treats_touching_ranges_as_overlap() {
+        let parts = vec![part("a", 0, 10), part("b", 10, 20), part("c", 21, 30)];
+
+        let ordered = ordered_cluster_partitions(&parts, Some(7), 10, 8).unwrap();
+        let stream_ids = stream_ids(&ordered);
+
+        assert_eq!(stream_ids, vec![0, 1, 0]);
+        assert_eq!(stream_ids.iter().max().copied().unwrap() + 1, 2);
+    }
+
+    #[test]
     fn test_ordered_cluster_partitions_rejects_excess_overlap() {
         let parts = vec![part("a", 0, 10), part("b", 5, 15), part("c", 7, 20)];
 
         assert!(ordered_cluster_partitions(&parts, Some(7), 1, 8).is_none());
     }
+
+    #[test]
+    fn test_filter_fixed_expr_matches_single_value_in_and_is_null_rewrite() {
+        let tag = column("tag", DataType::Nullable(Box::new(DataType::String)));
+        let filter = and(vec![
+            eq(int_column("a"), int_constant(1)),
+            contains(array(vec![int_constant(2)]), int_column("b")),
+            not(is_not_null(tag.clone())),
+            eq(int_column("e"), int_constant(3)),
+        ]);
+
+        assert!(expr_fixed_by_filter_expr(&int_column("a"), &filter));
+        assert!(expr_fixed_by_filter_expr(&int_column("b"), &filter));
+        assert!(expr_fixed_by_filter_expr(&is_null(tag.clone()), &filter));
+        assert!(expr_fixed_by_filter_expr(
+            &not(is_not_null(tag.clone())),
+            &filter
+        ));
+        assert!(expr_fixed_by_filter_expr(&int_column("e"), &filter));
+        assert!(!expr_fixed_by_filter_expr(&int_column("c"), &filter));
+        assert!(!expr_fixed_by_filter_expr(
+            &int_column("b"),
+            &contains(
+                array(vec![int_constant(2), int_constant(3)]),
+                int_column("b")
+            )
+        ));
+    }
+
+    #[test]
+    fn test_supports_order_reversing_minus_for_safe_integer_widths() {
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::UInt8
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::UInt16
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::UInt32
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::Int8
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::Int16
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::Int32
+        )));
+        assert!(supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::Int64
+        )));
+        assert!(!supports_order_reversing_minus(&DataType::Number(
+            NumberDataType::UInt64
+        )));
+    }
 }
 
 fn supports_order_reversing_minus(data_type: &DataType) -> bool {
     match data_type.remove_nullable() {
+        // Unary minus widens these integer types, so their minimum values do
+        // not overflow the cluster-key expression.
         DataType::Number(
-            NumberDataType::UInt8
-            | NumberDataType::UInt16
-            | NumberDataType::UInt32
-            | NumberDataType::Int8
-            | NumberDataType::Int16
-            | NumberDataType::Int32,
+            NumberDataType::UInt8 | NumberDataType::UInt16 | NumberDataType::UInt32,
         ) => true,
+        DataType::Number(NumberDataType::Int8 | NumberDataType::Int16 | NumberDataType::Int32) => {
+            true
+        }
         DataType::Number(NumberDataType::Int64) => true,
         DataType::Decimal(_) => true,
         // UInt64/Float boundary ordering is not proven here.

--- a/src/query/service/src/physical_plans/physical_sort.rs
+++ b/src/query/service/src/physical_plans/physical_sort.rs
@@ -37,8 +37,11 @@ use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::SortColumnDescription;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalScalar;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::decimal::Decimal;
+use databend_common_expression::types::i256;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_common_pipeline_transforms::blocks::CompoundBlockOperator;
 use databend_common_pipeline_transforms::sorts::core::SortKeyDescription;
@@ -1069,24 +1072,51 @@ fn ordering_minus_safe_for_expr(
             let Ok(column_id) = scan.source.schema().column_id_of(id) else {
                 return false;
             };
-            partitions.iter().all(|part| {
-                let Ok(fuse_part) = FuseBlockPartInfo::from_part(part) else {
-                    return false;
-                };
-                fuse_part
-                    .columns_stat
-                    .as_ref()
-                    .and_then(|stats| stats.get(&column_id))
-                    .is_some_and(|stat| {
-                        !matches!(
-                            stat.min(),
-                            Scalar::Number(NumberScalar::Int64(v)) if *v == i64::MIN
-                        )
-                    })
-            })
+            partitions
+                .iter()
+                .all(|part| partition_column_stats(part, column_id).is_some_and(i64_min_safe))
+        }
+        DataType::Decimal(_) => {
+            let Ok(column_id) = scan.source.schema().column_id_of(id) else {
+                return false;
+            };
+            partitions
+                .iter()
+                .all(|part| partition_column_stats(part, column_id).is_some_and(decimal_min_safe))
         }
         _ => true,
     }
+}
+
+fn partition_column_stats(
+    part: &PartInfoPtr,
+    column_id: u32,
+) -> Option<&databend_storages_common_table_meta::meta::ColumnStatistics> {
+    let fuse_part = FuseBlockPartInfo::from_part(part).ok()?;
+    fuse_part
+        .columns_stat
+        .as_ref()
+        .and_then(|stats| stats.get(&column_id))
+}
+
+fn i64_min_safe(stat: &databend_storages_common_table_meta::meta::ColumnStatistics) -> bool {
+    !matches!(
+        stat.min(),
+        Scalar::Number(NumberScalar::Int64(v)) if *v == i64::MIN
+    )
+}
+
+fn decimal_min_safe(stat: &databend_storages_common_table_meta::meta::ColumnStatistics) -> bool {
+    !matches!(
+        stat.min(),
+        Scalar::Decimal(DecimalScalar::Decimal64(v, _)) if *v == <i64 as Decimal>::DECIMAL_MIN
+    ) && !matches!(
+        stat.min(),
+        Scalar::Decimal(DecimalScalar::Decimal128(v, _)) if *v == <i128 as Decimal>::DECIMAL_MIN
+    ) && !matches!(
+        stat.min(),
+        Scalar::Decimal(DecimalScalar::Decimal256(v, _)) if *v == <i256 as Decimal>::DECIMAL_MIN
+    )
 }
 
 fn cluster_key_matches_order_by(
@@ -1312,9 +1342,7 @@ fn supports_order_reversing_minus(data_type: &DataType) -> bool {
             | NumberDataType::Int32,
         ) => true,
         DataType::Number(NumberDataType::Int64) => true,
-        // Decimal negation has a type-dependent lower-bound overflow case that
-        // is not proven safe here.
-        DataType::Decimal(_) => false,
+        DataType::Decimal(_) => true,
         // UInt64/Float boundary ordering is not proven here.
         DataType::Number(
             NumberDataType::UInt64 | NumberDataType::Float32 | NumberDataType::Float64,

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -188,7 +188,9 @@ impl IPhysicalPlan for TableScan {
         let table = builder.ctx.build_table_from_source_plan(&self.source)?;
         builder.ctx.set_partitions(self.source.parts.clone())?;
 
-        if builder.ctx.get_settings().get_enable_prune_pipeline()? {
+        if self.source.parts.kind != PartitionsShuffleKind::PreserveOrder
+            && builder.ctx.get_settings().get_enable_prune_pipeline()?
+        {
             if let Some(prune_pipeline) = table.build_prune_pipeline(
                 builder.ctx.clone(),
                 &self.source,

--- a/src/query/service/src/pipelines/builders/builder_sort.rs
+++ b/src/query/service/src/pipelines/builders/builder_sort.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 
 use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
+use databend_common_expression::Column;
+use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::LimitType;
 use databend_common_expression::SortColumnDescription;
@@ -26,9 +28,13 @@ use databend_common_pipeline::core::PipeItem;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
+use databend_common_pipeline_transforms::filters::TransformLimit;
+use databend_common_pipeline_transforms::processors::Transform;
 use databend_common_pipeline_transforms::sorts::TransformSortPartial;
 use databend_common_pipeline_transforms::sorts::add_k_way_merge_sort;
+use databend_common_pipeline_transforms::sorts::add_row_by_row_multi_sort_merge;
 use databend_common_pipeline_transforms::sorts::core::SortKeyDescription;
+use databend_common_pipeline_transforms::sorts::core::convert_rows;
 use databend_common_pipeline_transforms::sorts::try_add_multi_sort_merge;
 use databend_common_storage::DataOperator;
 use databend_storages_common_cache::TempDirManager;
@@ -209,6 +215,52 @@ impl SortPipelineBuilder {
         }
     }
 
+    pub fn build_presorted_merge_pipeline(self, pipeline: &mut Pipeline) -> Result<()> {
+        // The scan streams are ordered by cluster-key ranges, but individual
+        // blocks are not guaranteed to be internally sorted by the query's
+        // ORDER BY expression after filters are applied.
+        pipeline.add_transformer(|| {
+            TransformSortPartial::new(
+                LimitType::from_limit_rows(self.limit),
+                self.key_desc.sort_column_desc(),
+            )
+        });
+
+        if pipeline.output_len() == 1 {
+            if self.limit.is_some() {
+                pipeline.add_transform(|input, output| {
+                    Ok(ProcessorPtr::create(TransformLimit::try_create(
+                        self.limit, 0, input, output,
+                    )?))
+                })?;
+            }
+            return Ok(());
+        }
+
+        if !self.key_desc.uses_source_sort_col() {
+            let schema = self.key_desc.schema();
+            let sort_desc = self.key_desc.sort_column_desc();
+            let enable_fixed_rows = self.enable_fixed_rows;
+            pipeline.try_add_transformer(|| {
+                Ok(TransformAddOrderColumn::new(
+                    schema.clone(),
+                    sort_desc.clone(),
+                    enable_fixed_rows,
+                ))
+            })?;
+        }
+
+        add_row_by_row_multi_sort_merge(
+            pipeline,
+            self.key_desc.clone(),
+            self.block_size,
+            self.limit,
+            true,
+            self.enable_loser_tree,
+            self.enable_fixed_rows,
+        )
+    }
+
     pub fn build_sample(self, pipeline: &mut Pipeline) -> Result<()> {
         let settings = self.ctx.get_settings();
         let max_block_size = settings.get_max_block_size()? as usize;
@@ -306,5 +358,42 @@ impl SortPipelineBuilder {
             vec![output_port],
         )]));
         Ok(())
+    }
+}
+
+struct TransformAddOrderColumn {
+    schema: DataSchemaRef,
+    sort_desc: Arc<[SortColumnDescription]>,
+    enable_fixed_rows: bool,
+}
+
+impl TransformAddOrderColumn {
+    fn new(
+        schema: DataSchemaRef,
+        sort_desc: Arc<[SortColumnDescription]>,
+        enable_fixed_rows: bool,
+    ) -> Self {
+        Self {
+            schema,
+            sort_desc,
+            enable_fixed_rows,
+        }
+    }
+}
+
+impl Transform for TransformAddOrderColumn {
+    const NAME: &'static str = "TransformAddOrderColumn";
+
+    const SKIP_EMPTY_DATA_BLOCK: bool = true;
+
+    fn transform(&mut self, mut data_block: DataBlock) -> Result<DataBlock> {
+        let order_column: Column = convert_rows(
+            self.schema.clone(),
+            &self.sort_desc,
+            data_block.clone(),
+            self.enable_fixed_rows,
+        )?;
+        data_block.add_column(order_column);
+        Ok(data_block)
     }
 }

--- a/src/query/service/tests/it/indexes/spatial_index/runtime_filter.rs
+++ b/src/query/service/tests/it/indexes/spatial_index/runtime_filter.rs
@@ -179,6 +179,7 @@ async fn test_spatial_runtime_filter_pruner() -> anyhow::Result<()> {
         None,
         None,
         None,
+        None,
     );
 
     let pruned_by_stats = prune_with_bounds(schema.clone(), operator.clone(), settings, &part, [
@@ -225,6 +226,7 @@ async fn test_spatial_runtime_filter_pruner_distance_within_bounds() -> anyhow::
         None,
         Some(spatial_stats),
         Compression::Lz4Raw,
+        None,
         None,
         None,
         None,

--- a/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
@@ -71,6 +71,138 @@ async fn test_prewhere_with_single_reader() -> Result<()> {
     run_prewhere_test_with_threshold(0, true).await
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_prewhere_split_deserialize() -> Result<()> {
+    let PrewhereTestSetup {
+        _fixture,
+        ctx,
+        prewhere_info,
+        block_reader,
+        column_chunks,
+        part,
+        ..
+    } = prepare_prewhere_data().await?;
+    let _ = _fixture;
+
+    ctx.set_runtime_filter(HashMap::new());
+    ctx.get_settings().set_setting(
+        "prewhere_selectivity_threshold".to_string(),
+        "50".to_string(),
+    )?;
+
+    let read_state = ReadState::create(ctx, 1000, Some(&prewhere_info), block_reader)?;
+    assert!(!read_state.use_single_prewhere_reader);
+
+    let pre_columns_chunks = filter_chunks(&column_chunks, &read_state.pre_column_ids);
+    let remain_columns_chunks = filter_chunks(&column_chunks, &read_state.remain_column_ids);
+
+    let prewhere_result = read_state.deserialize_prewhere(pre_columns_chunks, &part)?;
+    assert_eq!(prewhere_result.preread_block.num_rows(), 1);
+    assert!(prewhere_result.row_selection.is_some());
+    assert!(prewhere_result.bitmap_selection.is_some());
+    assert!(prewhere_result.push_down_row_selection);
+
+    let data_block = read_state.deserialize_remaining(
+        prewhere_result.preread_block,
+        remain_columns_chunks,
+        &part,
+        prewhere_result.row_selection.as_ref(),
+        prewhere_result.bitmap_selection.as_ref(),
+        prewhere_result.push_down_row_selection,
+    )?;
+
+    assert_result_row(&data_block, 3, 30, 300, 3000, 7);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_prewhere_split_deserialize_empty_selection() -> Result<()> {
+    let PrewhereTestSetup {
+        _fixture,
+        ctx,
+        mut prewhere_info,
+        block_reader,
+        column_chunks,
+        part,
+        ..
+    } = prepare_prewhere_data().await?;
+    let _ = _fixture;
+
+    ctx.set_runtime_filter(HashMap::new());
+    ctx.get_settings().set_setting(
+        "prewhere_selectivity_threshold".to_string(),
+        "50".to_string(),
+    )?;
+
+    prewhere_info.filter = build_filter_eq("z", 999)?.as_remote_expr();
+    let read_state = ReadState::create(ctx, 1001, Some(&prewhere_info), block_reader)?;
+
+    let pre_columns_chunks = filter_chunks(&column_chunks, &read_state.pre_column_ids);
+    let prewhere_result = read_state.deserialize_prewhere(pre_columns_chunks, &part)?;
+    let row_selection = prewhere_result.row_selection.as_ref().unwrap();
+    assert_eq!(row_selection.selected_rows, 0);
+    assert!(prewhere_result.push_down_row_selection);
+
+    let data_block = read_state.deserialize_remaining(
+        prewhere_result.preread_block,
+        HashMap::new(),
+        &part,
+        prewhere_result.row_selection.as_ref(),
+        prewhere_result.bitmap_selection.as_ref(),
+        prewhere_result.push_down_row_selection,
+    )?;
+
+    assert_eq!(data_block.num_rows(), 0);
+    assert_eq!(data_block.num_columns(), 5);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_runtime_filter_only_split_deserialize() -> Result<()> {
+    let PrewhereTestSetup {
+        _fixture,
+        ctx,
+        block_reader,
+        column_chunks,
+        part,
+        ..
+    } = prepare_prewhere_data().await?;
+    let _ = _fixture;
+
+    ctx.get_settings().set_setting(
+        "prewhere_selectivity_threshold".to_string(),
+        "50".to_string(),
+    )?;
+
+    let read_state = ReadState::create(ctx, 999, None, block_reader)?;
+    assert!(!read_state.use_single_prewhere_reader);
+    assert!(read_state.filters.is_none());
+    assert_eq!(read_state.runtime_filters.len(), 2);
+
+    let pre_columns_chunks = filter_chunks(&column_chunks, &read_state.pre_column_ids);
+    let remain_columns_chunks = filter_chunks(&column_chunks, &read_state.remain_column_ids);
+    assert_eq!(pre_columns_chunks.len(), 2);
+    assert_eq!(remain_columns_chunks.len(), 3);
+
+    let prewhere_result = read_state.deserialize_prewhere(pre_columns_chunks, &part)?;
+    assert_eq!(prewhere_result.preread_block.num_rows(), 1);
+    assert!(prewhere_result.row_selection.is_some());
+    assert!(prewhere_result.bitmap_selection.is_some());
+    assert!(prewhere_result.push_down_row_selection);
+
+    let data_block = read_state.deserialize_remaining(
+        prewhere_result.preread_block,
+        remain_columns_chunks,
+        &part,
+        prewhere_result.row_selection.as_ref(),
+        prewhere_result.bitmap_selection.as_ref(),
+        prewhere_result.push_down_row_selection,
+    )?;
+
+    assert_result_row(&data_block, 3, 30, 300, 3000, 7);
+    Ok(())
+}
+
 async fn run_prewhere_test_with_threshold(
     selectivity_threshold: u64,
     expect_single_reader: bool,
@@ -108,49 +240,7 @@ async fn run_prewhere_test_with_threshold(
     // Verify the final data_block (all columns in order: x, y, z, d, e)
     // The new API internally handles all filter stages (prewhere + runtime filters)
     {
-        assert_eq!(data_block.num_rows(), 1); // Only 1 row should pass all filters
-        assert_eq!(data_block.num_columns(), 5); // All 5 columns
-
-        // Verify column order matches src_schema: x, y, z, d, e
-        let col_x: Vec<i32> =
-            Int32Type::try_downcast_column(&data_block.get_by_offset(0).to_column())
-                .unwrap()
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(col_x, vec![3]);
-
-        let col_y: Vec<i32> =
-            Int32Type::try_downcast_column(&data_block.get_by_offset(1).to_column())
-                .unwrap()
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(col_y, vec![30]);
-
-        let col_z: Vec<i32> =
-            Int32Type::try_downcast_column(&data_block.get_by_offset(2).to_column())
-                .unwrap()
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(col_z, vec![300]);
-
-        let col_d: Vec<i32> =
-            Int32Type::try_downcast_column(&data_block.get_by_offset(3).to_column())
-                .unwrap()
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(col_d, vec![3000]);
-
-        let col_e: Vec<i32> =
-            Int32Type::try_downcast_column(&data_block.get_by_offset(4).to_column())
-                .unwrap()
-                .iter()
-                .copied()
-                .collect();
-        assert_eq!(col_e, vec![7]);
+        assert_result_row(&data_block, 3, 30, 300, 3000, 7);
     }
 
     // Verify the bitmap_selection is present and has the correct format
@@ -165,6 +255,67 @@ async fn run_prewhere_test_with_threshold(
     }
 
     Ok(())
+}
+
+fn assert_result_row(
+    data_block: &DataBlock,
+    expected_x: i32,
+    expected_y: i32,
+    expected_z: i32,
+    expected_d: i32,
+    expected_e: i32,
+) {
+    assert_eq!(data_block.num_rows(), 1);
+    assert_eq!(data_block.num_columns(), 5);
+
+    assert_i32_column(data_block, 0, &[expected_x]);
+    assert_i32_column(data_block, 1, &[expected_y]);
+    assert_i32_column(data_block, 2, &[expected_z]);
+    assert_i32_column(data_block, 3, &[expected_d]);
+    assert_i32_column(data_block, 4, &[expected_e]);
+}
+
+fn assert_i32_column(data_block: &DataBlock, offset: usize, expected: &[i32]) {
+    let values: Vec<i32> =
+        Int32Type::try_downcast_column(&data_block.get_by_offset(offset).to_column())
+            .unwrap()
+            .iter()
+            .copied()
+            .collect();
+    assert_eq!(values, expected);
+}
+
+fn filter_chunks(
+    column_chunks: &HashMap<ColumnId, DataItem<'static>>,
+    column_ids: &std::collections::HashSet<ColumnId>,
+) -> HashMap<ColumnId, DataItem<'static>> {
+    column_chunks
+        .iter()
+        .filter(|(column_id, _)| column_ids.contains(column_id))
+        .map(|(column_id, data_item)| (*column_id, data_item.clone()))
+        .collect()
+}
+
+fn build_filter_eq(column_name: &str, value: i32) -> Result<Expr<String>> {
+    let column_expr: Expr<String> = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: column_name.to_string(),
+        data_type: DataType::Number(NumberDataType::Int32),
+        display_name: column_name.to_string(),
+    });
+    let const_expr: Expr<String> = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::Number(NumberScalar::Int32(value)),
+        data_type: DataType::Number(NumberDataType::Int32),
+    });
+
+    check_function(
+        None,
+        "eq",
+        &[],
+        &[column_expr, const_expr],
+        &BUILTIN_FUNCTIONS,
+    )
 }
 
 fn create_bloom_filter_for_int32(values: &[i32]) -> Sbbf {
@@ -340,6 +491,8 @@ async fn prepare_prewhere_data() -> Result<PrewhereTestSetup> {
         spatial_stats: None,
         compression,
         sort_min_max: None,
+        cluster_stats: None,
+        preserve_order_stream: None,
         block_meta_index: None,
     };
 

--- a/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
@@ -52,6 +52,7 @@ use databend_common_storages_fuse::operations::ReadState;
 use databend_query::sessions::TableContext;
 use databend_query::sessions::TableContextRuntimeFilter;
 use databend_query::test_kits::TestFixture;
+use databend_storages_common_pruner::BlockMetaIndex;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::Compression;
 use opendal::Buffer;
@@ -203,6 +204,84 @@ async fn test_runtime_filter_only_split_deserialize() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_page_range_without_prewhere() -> Result<()> {
+    let PrewhereTestSetup {
+        _fixture,
+        ctx,
+        block_reader,
+        column_chunks,
+        part,
+        ..
+    } = prepare_prewhere_data().await?;
+    let _ = _fixture;
+
+    ctx.set_runtime_filter(HashMap::new());
+    let read_state = ReadState::create(ctx, 1002, None, block_reader)?;
+    let part = with_page_range(part, 1..4, 1);
+
+    let (data_block, row_selection, bitmap_selection) =
+        read_state.deserialize_and_filter(column_chunks, &part)?;
+
+    assert_eq!(row_selection.as_ref().unwrap().selected_rows, 3);
+    assert_eq!(bitmap_selection.as_ref().unwrap().len(), 5);
+    assert_eq!(bitmap_selection.as_ref().unwrap().null_count(), 2);
+    assert_i32_column(&data_block, 0, &[2, 3, 4]);
+    assert_i32_column(&data_block, 1, &[20, 30, 40]);
+    assert_i32_column(&data_block, 2, &[200, 300, 400]);
+    assert_i32_column(&data_block, 3, &[2000, 3000, 4000]);
+    assert_i32_column(&data_block, 4, &[7, 7, 7]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_page_range_prewhere_forces_remaining_pushdown() -> Result<()> {
+    let PrewhereTestSetup {
+        _fixture,
+        ctx,
+        prewhere_info,
+        block_reader,
+        column_chunks,
+        part,
+        ..
+    } = prepare_prewhere_data().await?;
+    let _ = _fixture;
+
+    ctx.set_runtime_filter(HashMap::new());
+    ctx.get_settings().set_setting(
+        "prewhere_selectivity_threshold".to_string(),
+        "10".to_string(),
+    )?;
+
+    let read_state = ReadState::create(ctx, 1003, Some(&prewhere_info), block_reader)?;
+    let part = with_page_range(part, 1..4, 1);
+    let pre_columns_chunks = filter_chunks(&column_chunks, &read_state.pre_column_ids);
+    let remain_columns_chunks = filter_chunks(&column_chunks, &read_state.remain_column_ids);
+
+    let prewhere_result = read_state.deserialize_prewhere(pre_columns_chunks, &part)?;
+    assert!(prewhere_result.push_down_row_selection);
+    assert_eq!(
+        prewhere_result
+            .row_selection
+            .as_ref()
+            .unwrap()
+            .selected_rows,
+        1
+    );
+
+    let data_block = read_state.deserialize_remaining(
+        prewhere_result.preread_block,
+        remain_columns_chunks,
+        &part,
+        prewhere_result.row_selection.as_ref(),
+        prewhere_result.bitmap_selection.as_ref(),
+        prewhere_result.push_down_row_selection,
+    )?;
+
+    assert_result_row(&data_block, 3, 30, 300, 3000, 7);
+    Ok(())
+}
+
 async fn run_prewhere_test_with_threshold(
     selectivity_threshold: u64,
     expect_single_reader: bool,
@@ -283,6 +362,20 @@ fn assert_i32_column(data_block: &DataBlock, offset: usize, expected: &[i32]) {
             .copied()
             .collect();
     assert_eq!(values, expected);
+}
+
+fn with_page_range(
+    mut part: FuseBlockPartInfo,
+    range: std::ops::Range<usize>,
+    page_size: usize,
+) -> FuseBlockPartInfo {
+    part.block_meta_index = Some(BlockMetaIndex {
+        range: Some(range),
+        page_size,
+        block_location: part.location.clone(),
+        ..Default::default()
+    });
+    part
 }
 
 fn filter_chunks(

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1361,6 +1361,20 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),
                 }),
+                ("enable_cluster_key_ordered_topk", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Enables ORDER BY LIMIT optimization when Fuse cluster keys prove the input order",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
+                ("max_cluster_key_ordered_topk_overlap", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(10),
+                    desc: "Maximum number of extra simultaneously-overlapping cluster-key block ranges allowed for ordered top-k; 0 disallows overlaps",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=u64::MAX)),
+                }),
                 ("enable_fixed_rows_sort", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
                     desc: "Enable fixed rows sort serialize",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -1020,6 +1020,14 @@ impl Settings {
         Ok(self.try_get_u64("enable_parallel_multi_merge_sort")? == 1)
     }
 
+    pub fn get_enable_cluster_key_ordered_topk(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_cluster_key_ordered_topk")? == 1)
+    }
+
+    pub fn get_max_cluster_key_ordered_topk_overlap(&self) -> Result<u64> {
+        self.try_get_u64("max_cluster_key_ordered_topk_overlap")
+    }
+
     pub fn get_enable_fixed_rows_sort(&self) -> Result<bool> {
         Ok(self.try_get_u64("enable_fixed_rows_sort")? == 1)
     }

--- a/src/query/storages/common/index/src/page_index.rs
+++ b/src/query/storages/common/index/src/page_index.rs
@@ -25,10 +25,19 @@ use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::Domain;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::FunctionID;
+use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::expr::*;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::Decimal;
+use databend_common_expression::types::DecimalDomain;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::NumberDomain;
+use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::SimpleDomain;
+use databend_common_expression::types::i256;
 use databend_common_expression::visit_expr;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
@@ -46,6 +55,14 @@ pub struct PageIndex {
 
     // index of the cluster key inside the schema
     cluster_key_fields: Vec<DataField>,
+    cluster_key_sources: Vec<ClusterKeyDomainSource>,
+}
+
+#[derive(Clone)]
+enum ClusterKeyDomainSource {
+    None,
+    Column(String),
+    NegatedColumn { column: String, data_type: DataType },
 }
 
 impl PageIndex {
@@ -61,11 +78,60 @@ impl PageIndex {
             .iter()
             .map(|name| data_schema.field_with_name(name.as_str()).unwrap().clone())
             .collect::<Vec<_>>();
+        let cluster_key_sources = cluster_keys
+            .into_iter()
+            .map(ClusterKeyDomainSource::Column)
+            .collect::<Vec<_>>();
 
+        Self::try_create_with_fields(
+            func_ctx,
+            cluster_key_id,
+            cluster_key_fields,
+            cluster_key_sources,
+            expr,
+        )
+    }
+
+    pub fn try_create_with_exprs(
+        func_ctx: FunctionContext,
+        cluster_key_id: u32,
+        cluster_keys: &[RemoteExpr<String>],
+        expr: &Expr<String>,
+    ) -> Result<Self> {
+        let (cluster_key_fields, cluster_key_sources): (Vec<_>, Vec<_>) = cluster_keys
+            .iter()
+            .map(|expr| {
+                (
+                    DataField::new(
+                        &cluster_key_field_name(expr),
+                        remote_expr_data_type(expr).clone(),
+                    ),
+                    cluster_key_domain_source(expr),
+                )
+            })
+            .unzip();
+
+        Self::try_create_with_fields(
+            func_ctx,
+            cluster_key_id,
+            cluster_key_fields,
+            cluster_key_sources,
+            expr,
+        )
+    }
+
+    fn try_create_with_fields(
+        func_ctx: FunctionContext,
+        cluster_key_id: u32,
+        cluster_key_fields: Vec<DataField>,
+        cluster_key_sources: Vec<ClusterKeyDomainSource>,
+        expr: &Expr<String>,
+    ) -> Result<Self> {
         Ok(Self {
             column_refs: expr.column_refs(),
             expr: expr.clone(),
             cluster_key_fields,
+            cluster_key_sources,
             cluster_key_id,
             func_ctx,
         })
@@ -74,10 +140,12 @@ impl PageIndex {
     pub fn try_apply_const(&self) -> Result<bool> {
         // if the exprs did not contains the first cluster key, we should return true
         if self.cluster_key_fields.is_empty()
-            || !self
-                .column_refs
-                .iter()
-                .any(|c| self.cluster_key_fields.iter().any(|f| f.name() == c.0))
+            || !self.column_refs.iter().any(|c| {
+                self.cluster_key_sources
+                    .iter()
+                    .filter_map(ClusterKeyDomainSource::column)
+                    .any(|f| f == c.0)
+            })
         {
             return Ok(true);
         }
@@ -109,6 +177,10 @@ impl PageIndex {
         }
 
         let pages = min_values.len();
+        if pages == 0 {
+            return Ok((true, None));
+        }
+
         let mut start = 0;
         let mut end = pages - 1;
 
@@ -163,10 +235,11 @@ impl PageIndex {
         let mut input_domains = HashMap::with_capacity(self.cluster_key_fields.len());
         for (idx, (min, max)) in min_value.iter().zip(max_value.iter()).enumerate() {
             let f = &self.cluster_key_fields[idx];
-            if self.column_refs.contains_key(f.name()) {
-                let stat = ColumnStatistics::new(min.clone(), max.clone(), 1, 0, None);
-                let domain = statistics_to_domain(vec![&stat], f.data_type());
-                input_domains.insert(f.name().clone(), domain);
+            if let Some((column_ref, domain)) =
+                self.cluster_key_sources[idx].domain(min, max, f.data_type())
+                && self.column_refs.contains_key(&column_ref)
+            {
+                input_domains.insert(column_ref, domain);
             }
 
             // For Tuple scalars, if the first element is not equal, then the monotonically increasing property is broken.
@@ -212,5 +285,205 @@ impl PageIndex {
                 ..
             })
         ))
+    }
+}
+
+fn cluster_key_field_name(expr: &RemoteExpr<String>) -> String {
+    match expr {
+        RemoteExpr::ColumnRef { id, .. } => id.clone(),
+        _ => expr.as_expr(&BUILTIN_FUNCTIONS).sql_display(),
+    }
+}
+
+impl ClusterKeyDomainSource {
+    fn column(&self) -> Option<&String> {
+        match self {
+            ClusterKeyDomainSource::None => None,
+            ClusterKeyDomainSource::Column(column) => Some(column),
+            ClusterKeyDomainSource::NegatedColumn { column, .. } => Some(column),
+        }
+    }
+
+    fn domain(
+        &self,
+        min: &Scalar,
+        max: &Scalar,
+        cluster_key_data_type: &DataType,
+    ) -> Option<(String, Domain)> {
+        match self {
+            ClusterKeyDomainSource::None => None,
+            ClusterKeyDomainSource::Column(column) => {
+                let stat = ColumnStatistics::new(min.clone(), max.clone(), 1, 0, None);
+                let domain = statistics_to_domain(vec![&stat], cluster_key_data_type);
+                Some((column.clone(), domain))
+            }
+            ClusterKeyDomainSource::NegatedColumn { column, data_type } => {
+                negated_domain(min, max, cluster_key_data_type, data_type)
+                    .map(|domain| (column.clone(), domain))
+            }
+        }
+    }
+}
+
+fn cluster_key_domain_source(expr: &RemoteExpr<String>) -> ClusterKeyDomainSource {
+    match expr {
+        RemoteExpr::ColumnRef { id, .. } => ClusterKeyDomainSource::Column(id.clone()),
+        RemoteExpr::FunctionCall { id, args, .. } if function_name(id) == "minus" => {
+            match args.as_slice() {
+                [RemoteExpr::ColumnRef { id, data_type, .. }] => {
+                    ClusterKeyDomainSource::NegatedColumn {
+                        column: id.clone(),
+                        data_type: data_type.clone(),
+                    }
+                }
+                _ => ClusterKeyDomainSource::None,
+            }
+        }
+        _ => ClusterKeyDomainSource::None,
+    }
+}
+
+fn function_name(id: &FunctionID) -> &str {
+    match id {
+        FunctionID::Builtin { name, .. } | FunctionID::Factory { name, .. } => name,
+    }
+}
+
+fn remote_expr_data_type(expr: &RemoteExpr<String>) -> &DataType {
+    match expr {
+        RemoteExpr::Constant { data_type, .. } => data_type,
+        RemoteExpr::ColumnRef { data_type, .. } => data_type,
+        RemoteExpr::Cast { dest_type, .. } => dest_type,
+        RemoteExpr::FunctionCall { return_type, .. } => return_type,
+        RemoteExpr::LambdaFunctionCall { return_type, .. } => return_type,
+    }
+}
+
+fn negated_domain(
+    min: &Scalar,
+    max: &Scalar,
+    cluster_key_data_type: &DataType,
+    source_data_type: &DataType,
+) -> Option<Domain> {
+    if let Some(domain) = negated_decimal_domain(min, max, cluster_key_data_type, source_data_type)
+    {
+        return Some(domain);
+    }
+
+    let min = min.as_number()?;
+    let max = max.as_number()?;
+    match (min, max, cluster_key_data_type, source_data_type) {
+        (
+            NumberScalar::Int16(min),
+            NumberScalar::Int16(max),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int16),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int8),
+        ) => Some(Domain::Number(NumberDomain::Int8(SimpleDomain {
+            min: i8::try_from(max.checked_neg()?).ok()?,
+            max: i8::try_from(min.checked_neg()?).ok()?,
+        }))),
+        (
+            NumberScalar::Int32(min),
+            NumberScalar::Int32(max),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int32),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int16),
+        ) => Some(Domain::Number(NumberDomain::Int16(SimpleDomain {
+            min: i16::try_from(max.checked_neg()?).ok()?,
+            max: i16::try_from(min.checked_neg()?).ok()?,
+        }))),
+        (
+            NumberScalar::Int64(min),
+            NumberScalar::Int64(max),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int64),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int32),
+        ) => Some(Domain::Number(NumberDomain::Int32(SimpleDomain {
+            min: i32::try_from(max.checked_neg()?).ok()?,
+            max: i32::try_from(min.checked_neg()?).ok()?,
+        }))),
+        (
+            NumberScalar::Int64(min),
+            NumberScalar::Int64(max),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int64),
+            DataType::Number(databend_common_expression::types::NumberDataType::Int64),
+        ) => {
+            let source_min = max.checked_neg()?;
+            let source_max = min.checked_neg()?;
+            Some(Domain::Number(NumberDomain::Int64(SimpleDomain {
+                min: source_min,
+                max: source_max,
+            })))
+        }
+        _ => None,
+    }
+}
+
+fn negated_decimal_domain(
+    min: &Scalar,
+    max: &Scalar,
+    cluster_key_data_type: &DataType,
+    source_data_type: &DataType,
+) -> Option<Domain> {
+    let source_size = source_data_type.as_decimal()?;
+    let cluster_key_size = cluster_key_data_type.as_decimal()?;
+    if source_size != cluster_key_size {
+        return None;
+    }
+
+    match (min.as_decimal()?, max.as_decimal()?) {
+        (DecimalScalar::Decimal64(min, min_size), DecimalScalar::Decimal64(max, max_size))
+            if min_size == source_size && max_size == source_size =>
+        {
+            let source_min = max.checked_neg()?;
+            let source_max = min.checked_neg()?;
+            if !(i64::DECIMAL_MIN..=i64::DECIMAL_MAX).contains(&source_min)
+                || !(i64::DECIMAL_MIN..=i64::DECIMAL_MAX).contains(&source_max)
+            {
+                return None;
+            }
+            Some(Domain::Decimal(DecimalDomain::Decimal64(
+                SimpleDomain {
+                    min: source_min,
+                    max: source_max,
+                },
+                *source_size,
+            )))
+        }
+        (DecimalScalar::Decimal128(min, min_size), DecimalScalar::Decimal128(max, max_size))
+            if min_size == source_size && max_size == source_size =>
+        {
+            let source_min = max.checked_neg()?;
+            let source_max = min.checked_neg()?;
+            if !(i128::DECIMAL_MIN..=i128::DECIMAL_MAX).contains(&source_min)
+                || !(i128::DECIMAL_MIN..=i128::DECIMAL_MAX).contains(&source_max)
+            {
+                return None;
+            }
+            Some(Domain::Decimal(DecimalDomain::Decimal128(
+                SimpleDomain {
+                    min: source_min,
+                    max: source_max,
+                },
+                *source_size,
+            )))
+        }
+        (DecimalScalar::Decimal256(min, min_size), DecimalScalar::Decimal256(max, max_size))
+            if min_size == source_size && max_size == source_size =>
+        {
+            let source_min = max.checked_neg()?;
+            let source_max = min.checked_neg()?;
+            if !(i256::DECIMAL_MIN..=i256::DECIMAL_MAX).contains(&source_min)
+                || !(i256::DECIMAL_MIN..=i256::DECIMAL_MAX).contains(&source_max)
+            {
+                return None;
+            }
+            Some(Domain::Decimal(DecimalDomain::Decimal256(
+                SimpleDomain {
+                    min: source_min,
+                    max: source_max,
+                },
+                *source_size,
+            )))
+        }
+        _ => None,
     }
 }

--- a/src/query/storages/common/index/tests/it/page_pruner.rs
+++ b/src/query/storages/common/index/tests/it/page_pruner.rs
@@ -16,13 +16,18 @@ use std::io::Write;
 use std::sync::Arc;
 
 use databend_common_expression::FunctionContext;
+use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::types::ArgType;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::NumberDataType;
+use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_index::PageIndex;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
 use goldenfile::Mint;
@@ -62,6 +67,14 @@ fn test_page_index() -> anyhow::Result<()> {
     run_text(file, "to_int8(a) = 2", stats);
     run_text(file, "to_uint8(a) = 2::int64", stats);
     run_text(file, "to_int16(a::int8) = 1+2", stats);
+    run_empty_pages_text(file, "a = 2");
+    run_expr_text(file, "a = 2", stats);
+    run_expr_text(file, "a = 2 and b = -40", stats);
+    run_negated_expr_text(file, "a = 2 and b > 55");
+    run_negated_expr_text(file, "a = 2 and b >= 35 and b <= 55");
+    run_negated_expr_text(file, "a = 2 and b < 5");
+    run_decimal_negated_expr_text(file, "a = 2 and balance > 55::decimal(18,2)");
+    run_decimal_negated_expr_text(file, "a = 2 and balance < 5::decimal(18,2)");
 
     Ok(())
 }
@@ -96,4 +109,224 @@ fn run_text(file: &mut impl Write, text: &str, stats: &Option<ClusterStatistics>
         }
     };
     writeln!(file).unwrap();
+}
+
+fn run_empty_pages_text(file: &mut impl Write, text: &str) {
+    fn n(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let stats = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![n(1), n(10)],
+        max: vec![n(3), n(30)],
+        level: 0,
+        pages: Some(vec![]),
+    });
+
+    writeln!(file, "text      : {text}").unwrap();
+    writeln!(file, "pages     : []").unwrap();
+
+    match create_column_page_index(text).apply(&stats) {
+        Err(err) => {
+            writeln!(file, "err       : {err}").unwrap();
+        }
+
+        Ok((keep, range)) => {
+            writeln!(file, "keep      : {keep}").unwrap();
+            writeln!(file, "range     : {range:?}").unwrap();
+        }
+    };
+    writeln!(file).unwrap();
+}
+
+fn run_expr_text(file: &mut impl Write, text: &str, stats: &Option<ClusterStatistics>) {
+    let func_ctx = FunctionContext::default();
+    let cluster_key_id = 0;
+    let int32_type = Int32Type::data_type();
+    let cluster_keys = vec![
+        RemoteExpr::ColumnRef {
+            span: None,
+            id: "a".to_string(),
+            data_type: int32_type.clone(),
+            display_name: "a".to_string(),
+        },
+        parse_expr("-b", &[("b", int32_type.clone())]).as_remote_expr(),
+    ];
+
+    let columns = [("a", int32_type.clone()), ("b", int32_type)];
+    let expr = parse_expr(text, &columns);
+
+    let index =
+        PageIndex::try_create_with_exprs(func_ctx, cluster_key_id, &cluster_keys, &expr).unwrap();
+
+    writeln!(file, "text      : {text}").unwrap();
+    writeln!(file, "expr      : {expr}").unwrap();
+    writeln!(
+        file,
+        "cluster   : {:?}",
+        cluster_key_displays(&cluster_keys)
+    )
+    .unwrap();
+
+    match index.apply(stats) {
+        Err(err) => {
+            writeln!(file, "err       : {err}").unwrap();
+        }
+
+        Ok((keep, range)) => {
+            writeln!(file, "keep      : {keep}").unwrap();
+            writeln!(file, "range     : {range:?}").unwrap();
+        }
+    };
+    writeln!(file).unwrap();
+}
+
+fn create_column_page_index(text: &str) -> PageIndex {
+    let func_ctx = FunctionContext::default();
+    let cluster_key_id = 0;
+    let cluster_keys = vec!["a".to_string(), "b".to_string()];
+
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::Int32)),
+        TableField::new("b", TableDataType::Number(NumberDataType::Int32)),
+    ]));
+
+    let columns = [("a", Int32Type::data_type()), ("b", Int32Type::data_type())];
+    let expr = parse_expr(text, &columns);
+
+    PageIndex::try_create(func_ctx, cluster_key_id, cluster_keys, &expr, schema).unwrap()
+}
+
+fn run_negated_expr_text(file: &mut impl Write, text: &str) {
+    fn n32(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+    fn n64(n: i64) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let stats = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![n32(2), n64(-70)],
+        max: vec![n32(2), n64(-10)],
+        level: 0,
+        pages: Some(vec![
+            Scalar::Tuple(vec![n32(2), n64(-70)]), // b in [50, 70]
+            Scalar::Tuple(vec![n32(2), n64(-50)]), // b in [30, 50]
+            Scalar::Tuple(vec![n32(2), n64(-30)]), // b in [10, 30]
+            Scalar::Tuple(vec![n32(2), n64(-10)]), // b in [10, 10]
+        ]),
+    });
+
+    let func_ctx = FunctionContext::default();
+    let cluster_key_id = 0;
+    let int32_type = Int32Type::data_type();
+    let cluster_keys = vec![
+        RemoteExpr::ColumnRef {
+            span: None,
+            id: "a".to_string(),
+            data_type: int32_type.clone(),
+            display_name: "a".to_string(),
+        },
+        parse_expr("-b", &[("b", int32_type.clone())]).as_remote_expr(),
+    ];
+
+    let columns = [("a", int32_type.clone()), ("b", int32_type)];
+    let expr = parse_expr(text, &columns);
+
+    let index =
+        PageIndex::try_create_with_exprs(func_ctx, cluster_key_id, &cluster_keys, &expr).unwrap();
+
+    writeln!(file, "text      : {text}").unwrap();
+    writeln!(file, "expr      : {expr}").unwrap();
+    writeln!(
+        file,
+        "cluster   : {:?}",
+        cluster_key_displays(&cluster_keys)
+    )
+    .unwrap();
+
+    match index.apply(&stats) {
+        Err(err) => {
+            writeln!(file, "err       : {err}").unwrap();
+        }
+
+        Ok((keep, range)) => {
+            writeln!(file, "keep      : {keep}").unwrap();
+            writeln!(file, "range     : {range:?}").unwrap();
+        }
+    };
+    writeln!(file).unwrap();
+}
+
+fn run_decimal_negated_expr_text(file: &mut impl Write, text: &str) {
+    fn n32(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+    fn d(n: i64, size: DecimalSize) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(n, size))
+    }
+
+    let decimal_size = DecimalSize::new_unchecked(18, 2);
+    let decimal_type = DataType::Decimal(decimal_size);
+    let stats = Some(ClusterStatistics {
+        cluster_key_id: 0,
+        min: vec![n32(2), d(-7000, decimal_size)],
+        max: vec![n32(2), d(-1000, decimal_size)],
+        level: 0,
+        pages: Some(vec![
+            Scalar::Tuple(vec![n32(2), d(-7000, decimal_size)]), // balance in [50, 70]
+            Scalar::Tuple(vec![n32(2), d(-5000, decimal_size)]), // balance in [30, 50]
+            Scalar::Tuple(vec![n32(2), d(-3000, decimal_size)]), // balance in [10, 30]
+            Scalar::Tuple(vec![n32(2), d(-1000, decimal_size)]), // balance in [10, 10]
+        ]),
+    });
+
+    let func_ctx = FunctionContext::default();
+    let cluster_key_id = 0;
+    let int32_type = Int32Type::data_type();
+    let cluster_keys = vec![
+        RemoteExpr::ColumnRef {
+            span: None,
+            id: "a".to_string(),
+            data_type: int32_type.clone(),
+            display_name: "a".to_string(),
+        },
+        parse_expr("-balance", &[("balance", decimal_type.clone())]).as_remote_expr(),
+    ];
+
+    let columns = [("a", int32_type.clone()), ("balance", decimal_type)];
+    let expr = parse_expr(text, &columns);
+
+    let index =
+        PageIndex::try_create_with_exprs(func_ctx, cluster_key_id, &cluster_keys, &expr).unwrap();
+
+    writeln!(file, "text      : {text}").unwrap();
+    writeln!(file, "expr      : {expr}").unwrap();
+    writeln!(
+        file,
+        "cluster   : {:?}",
+        cluster_key_displays(&cluster_keys)
+    )
+    .unwrap();
+
+    match index.apply(&stats) {
+        Err(err) => {
+            writeln!(file, "err       : {err}").unwrap();
+        }
+
+        Ok((keep, range)) => {
+            writeln!(file, "keep      : {keep}").unwrap();
+            writeln!(file, "range     : {range:?}").unwrap();
+        }
+    };
+    writeln!(file).unwrap();
+}
+
+fn cluster_key_displays(cluster_keys: &[RemoteExpr<String>]) -> Vec<String> {
+    cluster_keys
+        .iter()
+        .map(|expr| expr.as_expr(&BUILTIN_FUNCTIONS).sql_display())
+        .collect()
 }

--- a/src/query/storages/common/index/tests/it/testdata/test_page_indies.txt
+++ b/src/query/storages/common/index/tests/it/testdata/test_page_indies.txt
@@ -38,3 +38,50 @@ expr      : eq<Int32, Int32>(CAST<Int16>(CAST<Int8>(CAST<Int32>(a AS Int8) AS In
 keep      : true
 range     : Some(3..5)
 
+text      : a = 2
+pages     : []
+keep      : true
+range     : None
+
+text      : a = 2
+expr      : eq<Int32, Int32>(a, 2_i32)
+cluster   : ["a", "- b"]
+keep      : true
+range     : Some(1..4)
+
+text      : a = 2 and b = -40
+expr      : and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), eq<Int32, Int32>(b, -40_i32))
+cluster   : ["a", "- b"]
+keep      : true
+range     : Some(1..4)
+
+text      : a = 2 and b > 55
+expr      : and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), gt<Int32, Int32>(b, CAST<UInt8>(55_u8 AS Int32)))
+cluster   : ["a", "- b"]
+keep      : true
+range     : Some(0..1)
+
+text      : a = 2 and b >= 35 and b <= 55
+expr      : and<Boolean, Boolean>(and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), gte<Int32, Int32>(b, CAST<UInt8>(35_u8 AS Int32))), lte<Int32, Int32>(b, CAST<UInt8>(55_u8 AS Int32)))
+cluster   : ["a", "- b"]
+keep      : true
+range     : Some(0..2)
+
+text      : a = 2 and b < 5
+expr      : and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), lt<Int32, Int32>(b, CAST<UInt8>(5_u8 AS Int32)))
+cluster   : ["a", "- b"]
+keep      : false
+range     : None
+
+text      : a = 2 and balance > 55::decimal(18,2)
+expr      : and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), gt<Decimal(18, 2), Decimal(18, 2)>(balance, CAST<UInt8>(55_u8 AS Decimal(18, 2))))
+cluster   : ["a", "- balance"]
+keep      : true
+range     : Some(0..1)
+
+text      : a = 2 and balance < 5::decimal(18,2)
+expr      : and<Boolean, Boolean>(eq<Int32, Int32>(a, 2_i32), lt<Decimal(18, 2), Decimal(18, 2)>(balance, CAST<UInt8>(5_u8 AS Decimal(18, 2))))
+cluster   : ["a", "- balance"]
+keep      : false
+range     : None
+

--- a/src/query/storages/common/pruner/src/page_pruner.rs
+++ b/src/query/storages/common/pruner/src/page_pruner.rs
@@ -67,17 +67,12 @@ impl PagePrunerCreator {
     /// Note: the schema should be the schema of the table, not the schema of the input.
     pub fn try_create<'a>(
         func_ctx: FunctionContext,
-        schema: &'a TableSchemaRef,
+        _schema: &'a TableSchemaRef,
         filter_expr: Option<&'a Expr<String>>,
         cluster_key_meta: Option<ClusterKey>,
         cluster_keys: Vec<RemoteExpr<String>>,
     ) -> Result<Arc<dyn PagePruner + Send + Sync>> {
-        if cluster_key_meta.is_none()
-            || cluster_keys.is_empty()
-            || cluster_keys
-                .iter()
-                .any(|expr| !matches!(expr, RemoteExpr::ColumnRef { .. }))
-        {
+        if cluster_key_meta.is_none() || cluster_keys.is_empty() {
             return Ok(Arc::new(KeepTrue));
         }
 
@@ -85,20 +80,11 @@ impl PagePrunerCreator {
 
         Ok(match filter_expr {
             Some(expr) => {
-                let cluster_keys = cluster_keys
-                    .iter()
-                    .map(|expr| match expr {
-                        RemoteExpr::ColumnRef { id, .. } => id.to_string(),
-                        _ => unreachable!(),
-                    })
-                    .collect::<Vec<_>>();
-
-                let page_filter = PageIndex::try_create(
+                let page_filter = PageIndex::try_create_with_exprs(
                     func_ctx,
                     cluster_key_meta.0,
-                    cluster_keys,
+                    &cluster_keys,
                     expr,
-                    schema.clone(),
                 )?;
                 match page_filter.try_apply_const() {
                     Ok(v) => {

--- a/src/query/storages/fuse/src/fuse_part.rs
+++ b/src/query/storages/fuse/src/fuse_part.rs
@@ -30,6 +30,7 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_storages_common_pruner::BlockMetaIndex;
+use databend_storages_common_table_meta::meta::ClusterStatistics;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::Compression;
@@ -37,7 +38,7 @@ use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::SpatialStatistics;
 
 /// Fuse table partition information.
-#[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug, Clone)]
 pub struct FuseBlockPartInfo {
     pub location: String,
 
@@ -54,6 +55,10 @@ pub struct FuseBlockPartInfo {
     pub compression: Compression,
 
     pub sort_min_max: Option<(Scalar, Scalar)>,
+    #[serde(default)]
+    pub cluster_stats: Option<ClusterStatistics>,
+    #[serde(default)]
+    pub preserve_order_stream: Option<usize>,
     pub block_meta_index: Option<BlockMetaIndex>,
 }
 
@@ -94,6 +99,7 @@ impl FuseBlockPartInfo {
         spatial_stats: Option<HashMap<ColumnId, SpatialStatistics>>,
         compression: Compression,
         sort_min_max: Option<(Scalar, Scalar)>,
+        cluster_stats: Option<ClusterStatistics>,
         block_meta_index: Option<BlockMetaIndex>,
         create_on: Option<DateTime<Utc>>,
     ) -> Arc<Box<dyn PartInfo>> {
@@ -108,6 +114,8 @@ impl FuseBlockPartInfo {
             nums_rows: rows_count as usize,
             compression,
             sort_min_max,
+            cluster_stats,
+            preserve_order_stream: None,
             block_meta_index,
             columns_stat,
             spatial_stats,

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -62,6 +62,34 @@ impl BlockReader {
         )
     }
 
+    pub fn deserialize_part_with_page_range(
+        &self,
+        part: &FuseBlockPartInfo,
+        column_chunks: HashMap<ColumnId, DataItem>,
+        selection: Option<&RowSelection>,
+    ) -> databend_common_exception::Result<DataBlock> {
+        let page_selection = page_range_selection(part);
+        let selection = merge_row_selection(page_selection.as_ref(), selection);
+        self.deserialize_part(part, column_chunks, selection.as_ref())
+    }
+
+    pub fn page_range_selection(part: &FuseBlockPartInfo) -> Option<RowSelection> {
+        page_range_selection(part)
+    }
+
+    pub fn merge_row_selection(
+        page_selection: Option<&RowSelection>,
+        row_selection: Option<&RowSelection>,
+    ) -> Option<RowSelection> {
+        merge_row_selection(page_selection, row_selection)
+    }
+
+    pub fn page_range_bitmap(
+        part: &FuseBlockPartInfo,
+    ) -> Option<databend_common_expression::types::Bitmap> {
+        page_range_selection(part).map(|selection| selection.bitmap)
+    }
+
     pub fn deserialize_parquet_chunks(
         &self,
         num_rows: usize,
@@ -161,6 +189,36 @@ impl BlockReader {
     }
 }
 
+fn page_range_selection(part: &FuseBlockPartInfo) -> Option<RowSelection> {
+    let page_size = part.page_size();
+    if page_size == 0 || page_size >= part.nums_rows {
+        return None;
+    }
+
+    part.range().map(|range| {
+        RowSelection::from_range(
+            part.nums_rows,
+            range.start.saturating_mul(page_size),
+            range.end.saturating_mul(page_size),
+        )
+    })
+}
+
+fn merge_row_selection(
+    page_selection: Option<&RowSelection>,
+    row_selection: Option<&RowSelection>,
+) -> Option<RowSelection> {
+    match (page_selection, row_selection) {
+        (None, None) => None,
+        (Some(page_selection), None) => Some(page_selection.clone()),
+        (None, Some(row_selection)) => Some(row_selection.clone()),
+        (Some(page_selection), Some(row_selection)) => {
+            let bitmap = &page_selection.bitmap & &row_selection.bitmap;
+            Some(RowSelection::from(&bitmap))
+        }
+    }
+}
+
 fn column_by_name(record_batch: &RecordBatch, names: &[String]) -> ArrayRef {
     let mut array = record_batch.column_by_name(&names[0]).unwrap().clone();
     if names.len() > 1 {
@@ -204,6 +262,59 @@ fn column_name_paths(projection: &Projection, schema: &TableSchema) -> Vec<Vec<S
                 name_paths.push(name_path);
             }
             name_paths
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use databend_storages_common_pruner::BlockMetaIndex;
+
+    use super::*;
+
+    fn part(nums_rows: usize, page_size: usize) -> FuseBlockPartInfo {
+        FuseBlockPartInfo {
+            location: "test.parquet".to_string(),
+            bloom_filter_index_location: None,
+            bloom_filter_index_size: 0,
+            spatial_index_location: None,
+            spatial_index_size: 0,
+            create_on: None,
+            nums_rows,
+            columns_meta: HashMap::new(),
+            columns_stat: None,
+            spatial_stats: None,
+            compression: Compression::Lz4,
+            sort_min_max: None,
+            cluster_stats: None,
+            preserve_order_stream: None,
+            block_meta_index: Some(BlockMetaIndex {
+                range: Some(1..2),
+                page_size,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn test_page_range_selection_ignores_parquet_full_block_page_size() {
+        let part = part(10, 10);
+
+        assert!(BlockReader::page_range_selection(&part).is_none());
+    }
+
+    #[test]
+    fn test_page_range_selection_uses_native_page_size() {
+        let part = part(10, 3);
+
+        let selection = BlockReader::page_range_selection(&part).unwrap();
+
+        assert_eq!(selection.selected_rows, 3);
+        assert_eq!(selection.bitmap.len(), 10);
+        for row in 0..10 {
+            assert_eq!(selection.bitmap.get_bit(row), (3..6).contains(&row));
         }
     }
 }

--- a/src/query/storages/fuse/src/io/read/block/parquet/row_selection.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/row_selection.rs
@@ -14,6 +14,7 @@
 
 use databend_common_column::bitmap::utils::SlicesIterator;
 use databend_common_expression::types::Bitmap;
+use databend_common_expression::types::MutableBitmap;
 use parquet::arrow::arrow_reader::RowSelector;
 
 /// A wrapper around parquet's `RowSelection` that also tracks the number of selected rows (bits set to 1 in the bitmap).
@@ -37,6 +38,18 @@ impl RowSelection {
             selected_rows,
             bitmap,
         }
+    }
+
+    pub fn from_range(total_rows: usize, start: usize, end: usize) -> Self {
+        let start = start.min(total_rows);
+        let end = end.min(total_rows).max(start);
+
+        let mut bitmap = MutableBitmap::from_len_zeroed(total_rows);
+        for row in start..end {
+            bitmap.set(row, true);
+        }
+        let bitmap: Bitmap = bitmap.into();
+        Self::from(&bitmap)
     }
 }
 
@@ -132,6 +145,26 @@ mod tests {
         // No bits are set to 1
         assert_eq!(row_selection.selected_rows, 0);
         assert_eq!(row_selection.bitmap.len(), bitmap.len());
+        assert_eq!(selectors.len(), 1);
+        assert_eq!(selectors[0].row_count, 5);
+        assert!(selectors[0].skip);
+    }
+
+    #[test]
+    fn test_row_selection_from_range() {
+        let row_selection = RowSelection::from_range(5, 2, 10);
+        let selectors: Vec<_> = row_selection.selection.iter().collect();
+
+        assert_eq!(row_selection.selected_rows, 3);
+        assert_eq!(selectors.len(), 2);
+        assert_eq!(selectors[0].row_count, 2);
+        assert!(selectors[0].skip);
+        assert_eq!(selectors[1].row_count, 3);
+        assert!(!selectors[1].skip);
+
+        let empty_selection = RowSelection::from_range(5, 6, 1);
+        let selectors: Vec<_> = empty_selection.selection.iter().collect();
+        assert_eq!(empty_selection.selected_rows, 0);
         assert_eq!(selectors.len(), 1);
         assert_eq!(selectors[0].row_count, 5);
         assert!(selectors[0].skip);

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -19,6 +19,7 @@ use async_channel::Receiver;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::PartInfoType;
+use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_common_catalog::plan::StealablePartitions;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
@@ -31,6 +32,7 @@ use log::info;
 use super::block_format::FuseParquetBlockFormat;
 use super::read_block_context::ReadBlockContext;
 use super::read_data_transform::ReadDataTransform;
+use crate::FuseBlockPartInfo;
 use crate::FuseStorageFormat;
 use crate::io::AggIndexReader;
 use crate::io::BlockReader;
@@ -57,13 +59,42 @@ pub fn build_fuse_source_pipeline(
 ) -> Result<()> {
     (max_threads, max_io_requests) = adjust_threads_and_request(max_threads, max_io_requests, plan);
 
+    let preserve_order = plan.parts.kind == PartitionsShuffleKind::PreserveOrder;
+    if preserve_order {
+        // Keep the planner-proven scan-stream count. Each stream reads its
+        // assigned subsequence in order; downstream PresortedMerge performs the
+        // only inter-stream merge.
+        let preserve_order_streams = plan
+            .parts
+            .partitions
+            .iter()
+            .filter_map(|part| {
+                FuseBlockPartInfo::from_part(part)
+                    .ok()
+                    .and_then(|part| part.preserve_order_stream)
+            })
+            .max()
+            .map_or(1, |stream| stream + 1);
+        max_io_requests = max_io_requests.min(max_threads).min(preserve_order_streams);
+        max_threads = max_threads.min(max_io_requests);
+    }
+
     let waker = pipeline.get_waker();
-    let batch_size = ctx.get_settings().get_storage_fetch_part_num()? as usize;
+    // DeserializeDataTransform emits the parts in a batch with pop(), so an
+    // ordered scan must fetch one part at a time to preserve per-stream order.
+    let batch_size = match preserve_order {
+        true => 1,
+        false => ctx.get_settings().get_storage_fetch_part_num()? as usize,
+    };
     let stream: Arc<dyn PartitionStream> = match receiver {
         Some(rx) => Arc::new(ReceiverPartitionStream::new(rx)),
         None => {
             let partitions = dispatch_partitions(ctx.clone(), plan, max_io_requests);
-            let partitions = StealablePartitions::new(partitions, ctx.clone());
+            let mut partitions = StealablePartitions::new(partitions, ctx.clone());
+
+            if preserve_order {
+                partitions.disable_steal();
+            }
 
             Arc::new(StealPartitionStream::new(partitions.clone(), batch_size))
         }
@@ -109,6 +140,9 @@ pub fn build_fuse_source_pipeline(
             table_schema.clone(),
             block_reader.clone(),
             read_block_context.clone(),
+            plan.push_downs
+                .as_ref()
+                .and_then(|push_downs| push_downs.prewhere.clone()),
             input,
             output,
         )
@@ -119,7 +153,9 @@ pub fn build_fuse_source_pipeline(
         max_io_requests
     );
 
-    pipeline.try_resize(std::cmp::min(max_threads, max_io_requests))?;
+    if !preserve_order {
+        pipeline.try_resize(std::cmp::min(max_threads, max_io_requests))?;
+    }
 
     info!(
         "[FUSE-SOURCE] Block read pipeline resized from {} to {} threads",
@@ -176,8 +212,18 @@ pub fn dispatch_partitions(
         return results;
     }
 
+    let preserve_order = plan.parts.kind == PartitionsShuffleKind::PreserveOrder;
     for (i, part) in partitions.iter().enumerate() {
-        results[i % max_streams].push_back(part.clone());
+        let index = if preserve_order {
+            FuseBlockPartInfo::from_part(part)
+                .ok()
+                .and_then(|part| part.preserve_order_stream)
+                .filter(|stream| *stream < max_streams)
+                .unwrap_or(i % max_streams)
+        } else {
+            i % max_streams
+        };
+        results[index].push_back(part.clone());
     }
     results
 }

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -80,8 +80,8 @@ pub fn build_fuse_source_pipeline(
     }
 
     let waker = pipeline.get_waker();
-    // DeserializeDataTransform emits the parts in a batch with pop(), so an
-    // ordered scan must fetch one part at a time to preserve per-stream order.
+    // Keep ordered streams at one block per fetch so LIMIT can stop before a
+    // stream reads blocks beyond the current merge frontier.
     let batch_size = match preserve_order {
         true => 1,
         false => ctx.get_settings().get_storage_fetch_part_num()? as usize,
@@ -170,6 +170,7 @@ pub fn build_fuse_source_pipeline(
                     ctx.clone(),
                     block_reader.clone(),
                     plan,
+                    preserve_order,
                     transform_input,
                     transform_output,
                     index_reader.clone(),

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source.rs
@@ -14,6 +14,8 @@
 
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_expression::BlockMetaInfo;
+use databend_common_expression::DataBlock;
+use databend_common_expression::types::Bitmap;
 
 use crate::io::BlockReadResult;
 use crate::io::VirtualBlockReadResult;
@@ -22,6 +24,11 @@ use crate::operations::read::data_source_with_meta::DataSourceWithMeta;
 pub enum ParquetDataSource {
     AggIndex((PartInfoPtr, BlockReadResult)),
     Normal((BlockReadResult, Option<VirtualBlockReadResult>)),
+    Decoded {
+        block: DataBlock,
+        bitmap_selection: Option<Bitmap>,
+        deserialize_milliseconds: u64,
+    },
 }
 
 #[typetag::serde(name = "fuse_data_source")]

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -61,8 +62,9 @@ pub struct DeserializeDataTransform {
     output_data: Option<DataBlock>,
     src_schema: DataSchema,
     output_schema: DataSchema,
-    parts: Vec<PartInfoPtr>,
-    chunks: Vec<ParquetDataSource>,
+    parts: VecDeque<PartInfoPtr>,
+    chunks: VecDeque<ParquetDataSource>,
+    preserve_order: bool,
 
     index_reader: Arc<Option<AggIndexReader>>,
     virtual_reader: Arc<Option<VirtualColumnReader>>,
@@ -81,6 +83,7 @@ impl DeserializeDataTransform {
         ctx: Arc<dyn TableContext>,
         block_reader: Arc<BlockReader>,
         plan: &DataSourcePlan,
+        preserve_order: bool,
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
         index_reader: Arc<Option<AggIndexReader>>,
@@ -121,8 +124,9 @@ impl DeserializeDataTransform {
             output_data: None,
             src_schema,
             output_schema,
-            parts: vec![],
-            chunks: vec![],
+            parts: VecDeque::new(),
+            chunks: VecDeque::new(),
+            preserve_order,
             index_reader,
             virtual_reader,
             base_block_ids: plan.base_block_ids.clone(),
@@ -173,8 +177,8 @@ impl Processor for DeserializeDataTransform {
                 if let Some(source_meta) =
                     DataSourceWithMeta::<ParquetDataSource>::downcast_from(source_meta)
                 {
-                    self.parts = source_meta.meta;
-                    self.chunks = source_meta.data;
+                    self.parts = source_meta.meta.into();
+                    self.chunks = source_meta.data.into();
                     return Ok(Event::Sync);
                 }
             }
@@ -192,8 +196,11 @@ impl Processor for DeserializeDataTransform {
     }
 
     fn process(&mut self) -> Result<()> {
-        let part = self.parts.pop();
-        let chunks = self.chunks.pop();
+        let (part, chunks) = if self.preserve_order {
+            (self.parts.pop_front(), self.chunks.pop_front())
+        } else {
+            (self.parts.pop_back(), self.chunks.pop_back())
+        };
         if let Some((part, read_res)) = part.zip(chunks) {
             match read_res {
                 ParquetDataSource::AggIndex((actual_part, data)) => {

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_deserializer.rs
@@ -31,6 +31,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::Scalar;
+use databend_common_expression::types::Bitmap;
 use databend_common_expression::types::DataType;
 use databend_common_metrics::storage::*;
 use databend_common_pipeline::core::Event;
@@ -246,47 +247,67 @@ impl Processor for DeserializeDataTransform {
                         );
                     }
 
-                    let progress_values = ProgressValues {
-                        rows: data_block.num_rows(),
-                        bytes: data_block.memory_size(),
-                    };
-                    self.scan_progress.incr(&progress_values);
-                    Profile::record_usize_profile(
-                        ProfileStatisticsName::ScanBytes,
-                        data_block.memory_size(),
-                    );
-
-                    let mut data_block =
-                        data_block.resort(&self.src_schema, &self.output_schema)?;
-
-                    // Fill `BlockMetaIndex` as `DataBlock.meta` if query internal columns,
-                    // `TransformAddInternalColumns` will generate internal columns using `BlockMetaIndex` in next pipeline.
-                    let offsets = if self.block_meta_options.query_internal_columns {
-                        bitmap_selection.as_ref().map(|bitmap| {
-                            RoaringTreemap::from_sorted_iter(
-                                (0..bitmap.len())
-                                    .filter(|i| unsafe { bitmap.get_bit_unchecked(*i) })
-                                    .map(|i| i as u64),
-                            )
-                            .unwrap()
-                        })
-                    } else {
-                        None
-                    };
-
-                    data_block = add_data_block_meta(
-                        data_block,
-                        part,
-                        offsets,
-                        self.base_block_ids.clone(),
-                        &self.block_meta_options,
-                    )?;
-
-                    self.output_data = Some(data_block);
+                    self.set_output_block(data_block, Some(part), bitmap_selection.as_ref(), None)?;
+                }
+                ParquetDataSource::Decoded {
+                    block,
+                    bitmap_selection,
+                    deserialize_milliseconds,
+                } => {
+                    let part = FuseBlockPartInfo::from_part(&part)?;
+                    metrics_inc_remote_io_deserialize_milliseconds(deserialize_milliseconds);
+                    self.set_output_block(block, Some(part), bitmap_selection.as_ref(), None)?;
                 }
             }
         }
 
+        Ok(())
+    }
+}
+
+impl DeserializeDataTransform {
+    fn set_output_block(
+        &mut self,
+        mut data_block: DataBlock,
+        part: Option<&FuseBlockPartInfo>,
+        bitmap_selection: Option<&Bitmap>,
+        offsets: Option<RoaringTreemap>,
+    ) -> Result<()> {
+        let progress_values = ProgressValues {
+            rows: data_block.num_rows(),
+            bytes: data_block.memory_size(),
+        };
+        self.scan_progress.incr(&progress_values);
+        Profile::record_usize_profile(ProfileStatisticsName::ScanBytes, data_block.memory_size());
+
+        data_block = data_block.resort(&self.src_schema, &self.output_schema)?;
+
+        if let Some(part) = part {
+            let offsets = offsets.or_else(|| {
+                if self.block_meta_options.query_internal_columns {
+                    bitmap_selection.map(|bitmap| {
+                        RoaringTreemap::from_sorted_iter(
+                            (0..bitmap.len())
+                                .filter(|i| unsafe { bitmap.get_bit_unchecked(*i) })
+                                .map(|i| i as u64),
+                        )
+                        .unwrap()
+                    })
+                } else {
+                    None
+                }
+            });
+
+            data_block = add_data_block_meta(
+                data_block,
+                part,
+                offsets,
+                self.base_block_ids.clone(),
+                &self.block_meta_options,
+            )?;
+        }
+
+        self.output_data = Some(data_block);
         Ok(())
     }
 }

--- a/src/query/storages/fuse/src/operations/read/read_block_context.rs
+++ b/src/query/storages/fuse/src/operations/read/read_block_context.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::table_context::TableContext;
@@ -26,9 +27,12 @@ use crate::FuseBlockPartInfo;
 use crate::FuseStorageFormat;
 use crate::io::AggIndexReader;
 use crate::io::BlockReadContext;
+use crate::io::BlockReadResult;
+use crate::io::BlockReader;
 use crate::io::TableMetaLocationGenerator;
 use crate::io::VirtualBlockReadResult;
 use crate::io::VirtualColumnReader;
+use crate::operations::read::ReadState;
 
 pub struct ReadBlockContext {
     read_settings: ReadSettings,
@@ -63,6 +67,11 @@ impl ReadBlockContext {
         self.read_settings
     }
 
+    #[inline]
+    pub fn can_split_prewhere(&self) -> bool {
+        self.virtual_reader.as_ref().is_none()
+    }
+
     #[async_backtrace::framed]
     pub async fn read_data(&self, part: PartInfoPtr) -> Result<ParquetDataSource> {
         let fuse_part = FuseBlockPartInfo::from_part(&part)?;
@@ -88,6 +97,81 @@ impl ReadBlockContext {
             .await?;
 
         Ok(ParquetDataSource::Normal((data, virtual_source)))
+    }
+
+    pub async fn read_data_with_prewhere(
+        &self,
+        part: PartInfoPtr,
+        read_state: ReadState,
+    ) -> Result<ParquetDataSource> {
+        let fuse_part = FuseBlockPartInfo::from_part(&part)?;
+
+        if read_state.use_single_prewhere_reader
+            || (read_state.filters.is_none() && read_state.runtime_filters.is_empty())
+            || self.virtual_reader.as_ref().is_some()
+        {
+            return self.read_data(part).await;
+        }
+
+        if let Some(data_source) = self.read_agg_index_data(fuse_part).await? {
+            return Ok(data_source);
+        }
+
+        let pre_data = self
+            .read_block_with_reader(&read_state.pre_reader, fuse_part)
+            .await?;
+        let deserialize_start = Instant::now();
+        let pre_columns_chunks = pre_data.columns_chunks()?;
+        let prewhere_result = read_state.deserialize_prewhere(pre_columns_chunks, fuse_part)?;
+
+        let no_rows_selected = prewhere_result
+            .row_selection
+            .as_ref()
+            .is_some_and(|row_selection| row_selection.selected_rows == 0);
+        let block = if no_rows_selected {
+            read_state.deserialize_remaining(
+                prewhere_result.preread_block,
+                Default::default(),
+                fuse_part,
+                prewhere_result.row_selection.as_ref(),
+                prewhere_result.bitmap_selection.as_ref(),
+                prewhere_result.push_down_row_selection,
+            )?
+        } else {
+            let remain_data = self
+                .read_block_with_reader(&read_state.remain_reader, fuse_part)
+                .await?;
+            read_state.deserialize_remaining(
+                prewhere_result.preread_block,
+                remain_data.columns_chunks()?,
+                fuse_part,
+                prewhere_result.row_selection.as_ref(),
+                prewhere_result.bitmap_selection.as_ref(),
+                prewhere_result.push_down_row_selection,
+            )?
+        };
+
+        Ok(ParquetDataSource::Decoded {
+            block,
+            bitmap_selection: prewhere_result.bitmap_selection,
+            deserialize_milliseconds: deserialize_start.elapsed().as_millis() as u64,
+        })
+    }
+
+    pub async fn read_block_with_reader(
+        &self,
+        reader: &BlockReader,
+        fuse_part: &FuseBlockPartInfo,
+    ) -> Result<BlockReadResult> {
+        self.block_format
+            .read_data_by_merge_io(
+                &reader.read_context(),
+                &self.read_settings,
+                &fuse_part.location,
+                &fuse_part.columns_meta,
+                &None,
+            )
+            .await
     }
 
     async fn read_agg_index_data(
@@ -141,6 +225,7 @@ impl ReadBlockContext {
             None,
             None,
             index_reader.compression().into(),
+            None,
             None,
             None,
             None,

--- a/src/query/storages/fuse/src/operations/read/read_data_transform.rs
+++ b/src/query/storages/fuse/src/operations/read/read_data_transform.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PrewhereInfo;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -31,6 +32,7 @@ use databend_common_sql::IndexType;
 
 use super::read_block_context::ReadBlockContext;
 use crate::io::BlockReader;
+use crate::operations::read::ReadState;
 use crate::operations::read::block_partition_meta::BlockPartitionMeta;
 use crate::operations::read::data_source_with_meta::DataSourceWithMeta;
 use crate::pruning::ExprRuntimePruner;
@@ -44,6 +46,7 @@ pub struct ReadDataTransform {
     table_schema: Arc<TableSchema>,
     scan_id: IndexType,
     context: Arc<dyn TableContext>,
+    prewhere_info: Option<PrewhereInfo>,
 }
 
 impl ReadDataTransform {
@@ -54,6 +57,7 @@ impl ReadDataTransform {
         table_schema: Arc<TableSchema>,
         block_reader: Arc<BlockReader>,
         read_block_context: Arc<ReadBlockContext>,
+        prewhere_info: Option<PrewhereInfo>,
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
     ) -> Result<ProcessorPtr> {
@@ -67,6 +71,7 @@ impl ReadDataTransform {
                 read_block_context,
                 table_schema,
                 scan_id,
+                prewhere_info,
                 context: ctx,
             },
         )))
@@ -105,6 +110,25 @@ impl ReadDataTransform {
         let mut read_tasks = Vec::with_capacity(parts.len());
         let mut parts_to_read = Vec::with_capacity(parts.len());
         let (expr_runtime_pruner, spatial_runtime_pruner) = self.create_runtime_pruners()?;
+        let has_prewhere = self.prewhere_info.is_some();
+        let should_split_prewhere = (has_prewhere
+            || self.context.has_bloom_runtime_filters(self.scan_id))
+            && self
+                .context
+                .get_settings()
+                .get_prewhere_selectivity_threshold()?
+                != 0
+            && self.read_block_context.can_split_prewhere();
+        let read_state = if should_split_prewhere {
+            Some(ReadState::create(
+                self.context.clone(),
+                self.scan_id,
+                self.prewhere_info.as_ref(),
+                self.block_reader.clone(),
+            )?)
+        } else {
+            None
+        };
 
         for part in parts {
             if expr_runtime_pruner.prune(&part).await? {
@@ -119,10 +143,17 @@ impl ReadDataTransform {
 
             parts_to_read.push(part.clone());
             let read_block_context = self.read_block_context.clone();
+            let read_state = read_state.clone();
 
             read_tasks.push(async move {
                 databend_common_base::runtime::spawn(async move {
-                    read_block_context.read_data(part).await
+                    if let Some(read_state) = read_state {
+                        read_block_context
+                            .read_data_with_prewhere(part, read_state)
+                            .await
+                    } else {
+                        read_block_context.read_data(part).await
+                    }
                 })
                 .await
                 .unwrap()

--- a/src/query/storages/fuse/src/operations/read/read_state.rs
+++ b/src/query/storages/fuse/src/operations/read/read_state.rs
@@ -51,6 +51,7 @@ pub struct BloomRuntimeFilterRef {
     pub stats: Arc<RuntimeFilterStats>,
 }
 
+#[derive(Clone)]
 pub struct ReadState {
     pub pre_reader: Arc<BlockReader>,
     pub remain_reader: Arc<BlockReader>,
@@ -62,6 +63,13 @@ pub struct ReadState {
     pub output_schema: DataSchema,
     pub prewhere_selectivity_threshold: u64,
     pub use_single_prewhere_reader: bool,
+}
+
+pub struct PrewhereFilterResult {
+    pub preread_block: DataBlock,
+    pub row_selection: Option<RowSelection>,
+    pub bitmap_selection: Option<Bitmap>,
+    pub push_down_row_selection: bool,
 }
 
 impl ReadState {
@@ -190,11 +198,11 @@ impl ReadState {
         Ok(result_bitmap)
     }
 
-    pub fn deserialize_and_filter(
+    pub fn deserialize_prewhere(
         &self,
         columns_chunks: HashMap<ColumnId, DataItem>,
         part: &FuseBlockPartInfo,
-    ) -> Result<(DataBlock, Option<RowSelection>, Option<Bitmap>)> {
+    ) -> Result<PrewhereFilterResult> {
         let pre_columns_chunks = Self::filter_column_chunks(&columns_chunks, &self.pre_column_ids)?;
         let mut preread_block = self
             .pre_reader
@@ -220,24 +228,48 @@ impl ReadState {
         }
 
         if self.use_single_prewhere_reader {
-            return Ok((preread_block, row_selection, bitmap_selection));
+            return Ok(PrewhereFilterResult {
+                preread_block,
+                row_selection,
+                bitmap_selection,
+                push_down_row_selection: false,
+            });
         }
 
-        let remain_columns_chunks =
-            Self::filter_column_chunks(&columns_chunks, &self.remain_column_ids)?;
         let push_down_row_selection = row_selection.as_ref().is_some_and(|row_selection| {
             should_push_down_row_selection(row_selection, self.prewhere_selectivity_threshold)
         });
 
+        Ok(PrewhereFilterResult {
+            preread_block,
+            row_selection,
+            bitmap_selection,
+            push_down_row_selection,
+        })
+    }
+
+    pub fn deserialize_remaining(
+        &self,
+        mut preread_block: DataBlock,
+        columns_chunks: HashMap<ColumnId, DataItem>,
+        part: &FuseBlockPartInfo,
+        row_selection: Option<&RowSelection>,
+        bitmap_selection: Option<&Bitmap>,
+        push_down_row_selection: bool,
+    ) -> Result<DataBlock> {
+        if self.use_single_prewhere_reader {
+            return Ok(preread_block);
+        }
+
+        let remain_columns_chunks =
+            Self::filter_column_chunks(&columns_chunks, &self.remain_column_ids)?;
         let mut remain_block = self.remain_reader.deserialize_part(
             part,
             remain_columns_chunks,
-            push_down_row_selection
-                .then_some(row_selection.as_ref())
-                .flatten(),
+            push_down_row_selection.then_some(row_selection).flatten(),
         )?;
         if !push_down_row_selection {
-            if let Some(bitmap) = bitmap_selection.as_ref() {
+            if let Some(bitmap) = bitmap_selection {
                 remain_block = remain_block.filter_with_bitmap(bitmap)?;
             }
         }
@@ -250,7 +282,29 @@ impl ReadState {
 
         let data_block = preread_block.resort(&merged_schema, &self.output_schema)?;
 
-        Ok((data_block, row_selection, bitmap_selection))
+        Ok(data_block)
+    }
+
+    pub fn deserialize_and_filter(
+        &self,
+        columns_chunks: HashMap<ColumnId, DataItem>,
+        part: &FuseBlockPartInfo,
+    ) -> Result<(DataBlock, Option<RowSelection>, Option<Bitmap>)> {
+        let prewhere_result = self.deserialize_prewhere(columns_chunks.clone(), part)?;
+        let data_block = self.deserialize_remaining(
+            prewhere_result.preread_block,
+            columns_chunks,
+            part,
+            prewhere_result.row_selection.as_ref(),
+            prewhere_result.bitmap_selection.as_ref(),
+            prewhere_result.push_down_row_selection,
+        )?;
+
+        Ok((
+            data_block,
+            prewhere_result.row_selection,
+            prewhere_result.bitmap_selection,
+        ))
     }
 
     fn filter_column_chunks<'a>(

--- a/src/query/storages/fuse/src/operations/read/read_state.rs
+++ b/src/query/storages/fuse/src/operations/read/read_state.rs
@@ -220,6 +220,7 @@ impl ReadState {
             (None, Some(runtime_filter_bitmap)) => Some(runtime_filter_bitmap.into()),
             (None, None) => None,
         };
+        let bitmap_selection = Self::merge_page_range_bitmap(bitmap_selection, part);
 
         let row_selection = bitmap_selection.as_ref().map(RowSelection::from);
 
@@ -237,7 +238,11 @@ impl ReadState {
         }
 
         let push_down_row_selection = row_selection.as_ref().is_some_and(|row_selection| {
-            should_push_down_row_selection(row_selection, self.prewhere_selectivity_threshold)
+            part.range().is_some()
+                || should_push_down_row_selection(
+                    row_selection,
+                    self.prewhere_selectivity_threshold,
+                )
         });
 
         Ok(PrewhereFilterResult {
@@ -285,11 +290,31 @@ impl ReadState {
         Ok(data_block)
     }
 
+    pub fn deserialize_no_prewhere(
+        &self,
+        columns_chunks: HashMap<ColumnId, DataItem>,
+        part: &FuseBlockPartInfo,
+    ) -> Result<(DataBlock, Option<RowSelection>, Option<Bitmap>)> {
+        let page_selection = BlockReader::page_range_selection(part);
+        let page_bitmap = page_selection
+            .as_ref()
+            .map(|selection| selection.bitmap.clone());
+        let data_block =
+            self.remain_reader
+                .deserialize_part(part, columns_chunks, page_selection.as_ref())?;
+
+        Ok((data_block, page_selection, page_bitmap))
+    }
+
     pub fn deserialize_and_filter(
         &self,
         columns_chunks: HashMap<ColumnId, DataItem>,
         part: &FuseBlockPartInfo,
     ) -> Result<(DataBlock, Option<RowSelection>, Option<Bitmap>)> {
+        if self.filters.is_none() && self.runtime_filters.is_empty() {
+            return self.deserialize_no_prewhere(columns_chunks, part);
+        }
+
         let prewhere_result = self.deserialize_prewhere(columns_chunks.clone(), part)?;
         let data_block = self.deserialize_remaining(
             prewhere_result.preread_block,
@@ -318,6 +343,20 @@ impl ReadState {
             }
         }
         Ok(filtered_columns_chunks)
+    }
+
+    fn merge_page_range_bitmap(
+        bitmap_selection: Option<Bitmap>,
+        part: &FuseBlockPartInfo,
+    ) -> Option<Bitmap> {
+        let Some(page_bitmap) = BlockReader::page_range_bitmap(part) else {
+            return bitmap_selection;
+        };
+
+        Some(match bitmap_selection {
+            Some(bitmap_selection) => (&bitmap_selection & &page_bitmap).into(),
+            None => page_bitmap,
+        })
     }
 }
 

--- a/src/query/storages/fuse/src/operations/read_data.rs
+++ b/src/query/storages/fuse/src/operations/read_data.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_base::runtime::Runtime;
 use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::ReadPartitionsPruningMode;
@@ -131,7 +132,15 @@ impl FuseTable {
         );
 
         let enable_prune_pipeline = ctx.get_settings().get_enable_prune_pipeline()?;
-        let rx = if !enable_prune_pipeline && !lazy_init_segments.is_empty() {
+        let preserve_order = plan.parts.kind == PartitionsShuffleKind::PreserveOrder;
+        let rx = if preserve_order {
+            // PreserveOrder scans rely on the part list already being sorted and
+            // annotated with planner-selected streams. Do not consume async
+            // pruning receivers here because channel delivery cannot preserve
+            // that per-stream assignment.
+            let _ = self.pruned_result_receiver.lock().take();
+            None
+        } else if !enable_prune_pipeline && !lazy_init_segments.is_empty() {
             // If the prune pipeline is disabled and is lazy init segments, we need to fallback
             let table = self.clone();
             let table_schema = self.schema_with_stream();

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -1417,6 +1417,7 @@ impl FuseTable {
             },
             meta.compression(),
             sort_min_max,
+            meta.cluster_stats.clone(),
             block_meta_index.to_owned(),
             create_on,
         )
@@ -1482,6 +1483,7 @@ impl FuseTable {
             },
             meta.compression(),
             sort_min_max,
+            meta.cluster_stats.clone(),
             block_meta_index.to_owned(),
             create_on,
         )

--- a/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
@@ -546,6 +546,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -736,6 +737,7 @@ mod tests {
             Some(column_stats),
             None,
             Compression::Lz4Raw,
+            None,
             None,
             None,
             None,

--- a/src/query/storages/fuse/src/pruning_pipeline/column_oriented_block_prune.rs
+++ b/src/query/storages/fuse/src/pruning_pipeline/column_oriented_block_prune.rs
@@ -32,11 +32,14 @@ use databend_common_pipeline::sinks::AsyncSink;
 use databend_common_pipeline::sinks::AsyncSinker;
 use databend_storages_common_pruner::BlockMetaIndex;
 use databend_storages_common_pruner::RangeIndexInput;
+use databend_storages_common_table_meta::meta::ClusterStatistics;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::ColumnMetaV0;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::Compression;
+use databend_storages_common_table_meta::meta::MetaEncoding;
 use databend_storages_common_table_meta::meta::column_oriented_segment::*;
+use databend_storages_common_table_meta::meta::decode;
 use futures_util::future;
 use tokio::sync::OwnedSemaphorePermit;
 
@@ -106,6 +109,7 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
         let bloom_index_size_col = segment.bloom_filter_index_size_col();
         let block_size_col = segment.block_size_col();
         let row_count_col = segment.row_count_col();
+        let cluster_stats_col = segment.col_by_name(&[CLUSTER_STATS]);
 
         let pruning_runtime = &self.block_pruner.pruning_ctx.pruning_runtime;
         let pruning_semaphore = &self.block_pruner.pruning_ctx.pruning_semaphore;
@@ -140,6 +144,7 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
             let create_on_col = create_on_col.clone();
             let bloom_index_location_col = bloom_index_location_col.clone();
             let bloom_index_size_col = bloom_index_size_col.clone();
+            let cluster_stats_col = cluster_stats_col.clone();
             let runtime_stats_pruner = runtime_stats_pruner.clone();
 
             pruning_tasks.push(move |permit: OwnedSemaphorePermit| {
@@ -180,7 +185,7 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
                     let row_count = row_count_col[block_idx];
                     let range_input = RangeIndexInput::from_columns(&columns_stat);
                     if !range_pruner.should_keep(&range_input, None) {
-                        return Ok::<_, ()>(());
+                        return Ok::<_, ErrorCode>(());
                     }
 
                     if runtime_stats_pruner.as_ref().is_some_and(|pruner| {
@@ -206,6 +211,17 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
                         _ => unreachable!(),
                     };
                     let bloom_filter_index_size = bloom_index_size_col[block_idx];
+                    let cluster_stats = match cluster_stats_col
+                        .as_ref()
+                        .and_then(|col| col.index(block_idx))
+                    {
+                        Some(ScalarRef::Binary(bytes)) => Some(decode::<ClusterStatistics>(
+                            &MetaEncoding::MessagePack,
+                            bytes,
+                        )?),
+                        Some(ScalarRef::Null) | None => None,
+                        _ => unreachable!(),
+                    };
 
                     // Bloom filter pruning
                     if let Some(bloom_pruner) = bloom_pruner {
@@ -289,6 +305,7 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
                         None,
                         compression,
                         None, // TODO(Sky): sort_min_max
+                        cluster_stats,
                         Some(block_meta_index),
                         create_on,
                     );
@@ -307,9 +324,12 @@ impl AsyncSink for ColumnOrientedBlockPruneSink {
                 .map_err(|e| ErrorCode::StorageOther(format!("block pruning failure, {}", e)))?;
 
             // Wait for all tasks to complete
-            let _ = future::try_join_all(join_handlers)
+            let joint = future::try_join_all(join_handlers)
                 .await
                 .map_err(|e| ErrorCode::StorageOther(format!("block pruning failure, {}", e)))?;
+            for result in joint {
+                result?;
+            }
         }
         Ok(false)
     }

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
@@ -1,0 +1,1033 @@
+statement ok
+set max_threads = 4
+
+statement ok
+set enable_parallel_multi_merge_sort = 0
+
+statement ok
+set enable_cluster_key_ordered_topk = 1
+
+statement ok
+set max_cluster_key_ordered_topk_overlap = 10
+
+statement ok
+set lazy_read_threshold = 0
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_i64 ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_decimal ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_string ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_prefix ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_column_segment ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_single ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_mixed ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_overlap ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_cross_prefix ALL
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_pruned_multi ALL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide(
+    a int not null,
+    b int not null,
+    c int not null,
+    d int not null,
+    e int not null,
+    f int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, b, -c, d) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide VALUES
+    (1, 2, 90, 4, 0, 8),
+    (1, 2, 80, 3, 3, 8),
+    (1, 2, 80, 4, 3, 8),
+    (1, 2, 80, 5, 3, 8),
+    (1, 2, 70, 4, 3, 7),
+    (1, 2, 60, 4, 0, 8),
+    (1, 2, 50, 4, 3, 8),
+    (1, 2, 40, 4, 3, 8),
+    (1, 2, 30, 5, 3, 8),
+    (1, 3, 95, 4, 3, 8),
+    (2, 2, 99, 4, 3, 8)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_single(
+    a int not null,
+    b int not null,
+    payload int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 100 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_single VALUES
+    (1, 10, 1),
+    (1, 30, 2),
+    (1, 20, 3),
+    (2, 5, 4)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_single RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_mixed(
+    a int not null,
+    b int not null,
+    payload int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_mixed VALUES
+    (1, 10, 1),
+    (1, 30, 2),
+    (1, 20, 3),
+    (2, 5, 4),
+    (0, 100, 5),
+    (2, 7, 6),
+    (0, 90, 7)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_mixed RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_overlap(
+    a int not null,
+    b int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_overlap VALUES
+    (1, 10),
+    (1, 1),
+    (1, 9),
+    (1, 2),
+    (1, 8),
+    (1, 3)
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_cross_prefix(
+    a int not null,
+    b int not null,
+    payload int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 3 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_cross_prefix VALUES
+    (0, 100, 0),
+    (1, 90, 1),
+    (1, 70, 2),
+    (2, 99, 3),
+    (1, 80, 4),
+    (1, 60, 5)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_cross_prefix RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_pruned_multi(
+    a int not null,
+    b int not null,
+    c int not null,
+    d int not null,
+    e int not null,
+    f int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, b, -c, d) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_pruned_multi VALUES
+    (0, 1, 200, 1, 3, 8),
+    (0, 1, 100, 1, 3, 8),
+    (1, 2, 100, 1, 3, 8),
+    (1, 2, 90, 1, 3, 7),
+    (1, 2, 80, 1, 4, 8),
+    (1, 2, 70, 1, 3, 8),
+    (1, 2, 60, 1, 3, 8),
+    (1, 2, 50, 2, 3, 8),
+    (1, 2, 40, 2, 3, 7),
+    (1, 2, 30, 2, 3, 8),
+    (1, 2, 20, 3, 3, 8),
+    (2, 2, 200, 1, 3, 8),
+    (2, 2, 100, 1, 3, 8)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_pruned_multi RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_string(
+    platform_id int not null,
+    wallet_address string not null,
+    last_active_time bigint not null,
+    balance int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(platform_id, wallet_address, -last_active_time) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_string VALUES
+    (14, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 300, 1),
+    (14, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 200, 2),
+    (14, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 100, 3),
+    (14, '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 400, 4),
+    (15, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 500, 5)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_string RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_prefix(
+    platform_id int not null,
+    wallet_address string not null,
+    last_active_time bigint not null,
+    balance int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(platform_id, substr(wallet_address, 1, 8), -last_active_time) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_prefix VALUES
+    (14, '0xaaaaaa0000000000000000000000000000000000', 400, 1),
+    (14, '0xaaaaaa1111111111111111111111111111111111', 350, 2),
+    (14, '0xaaaaaa0000000000000000000000000000000000', 300, 3),
+    (14, '0xaaaaaa1111111111111111111111111111111111', 250, 4),
+    (14, '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 500, 5),
+    (15, '0xaaaaaa0000000000000000000000000000000000', 450, 6)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_prefix RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_column_segment(
+    a int not null,
+    b int not null,
+    c int not null,
+    d int not null,
+    e int not null,
+    f int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, b, -c, d) ROW_PER_BLOCK = 2 BLOCK_PER_SEGMENT = 2 SEGMENT_FORMAT = 'column_oriented' STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_column_segment VALUES
+    (0, 1, 200, 1, 3, 8),
+    (0, 1, 100, 1, 3, 8),
+    (1, 2, 100, 1, 3, 8),
+    (1, 2, 90, 1, 3, 7),
+    (1, 2, 80, 1, 4, 8),
+    (1, 2, 70, 1, 3, 8),
+    (1, 2, 60, 1, 3, 8),
+    (1, 2, 50, 2, 3, 8),
+    (1, 2, 40, 2, 3, 7),
+    (1, 2, 30, 2, 3, 8),
+    (1, 2, 20, 3, 3, 8),
+    (2, 2, 200, 1, 3, 8),
+    (2, 2, 100, 1, 3, 8)
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8 AND d = 4
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+1 2 80 4
+1 2 50 4
+1 2 40 4
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND d = 4
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+1 2 80 4
+1 2 70 4
+1 2 50 4
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 4
+----
+1 2 80 3
+1 2 80 4
+1 2 80 5
+1 2 50 4
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 2 OFFSET 1
+----
+1 2 80 4
+1 2 80 5
+
+query III
+SELECT a, b, payload
+FROM test_cluster_sort_elide_mixed
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 5
+----
+0 100 5
+0 90 7
+1 30 2
+1 20 3
+1 10 1
+
+query III
+SELECT a, b, payload
+FROM test_cluster_sort_elide_single
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+1 30 2
+1 20 3
+
+query II
+SELECT a, b
+FROM test_cluster_sort_elide_overlap
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 4
+----
+1 10
+1 9
+1 8
+1 3
+
+query III
+SELECT a, b, payload
+FROM test_cluster_sort_elide_cross_prefix
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 4
+----
+1 90 1
+1 80 4
+1 70 2
+1 60 5
+
+query III
+settings(lazy_read_threshold = 100) SELECT a, b, payload
+FROM test_cluster_sort_elide_cross_prefix
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 4
+----
+1 90 1
+1 80 4
+1 70 2
+1 60 5
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide_pruned_multi
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 5
+----
+1 2 100 1
+1 2 70 1
+1 2 60 1
+1 2 50 2
+1 2 30 2
+
+statement ok
+set enable_cluster_key_ordered_topk = 0
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 4
+----
+1 2 80 3
+1 2 80 4
+1 2 80 5
+1 2 50 4
+
+query III
+SELECT a, b, payload
+FROM test_cluster_sort_elide_single
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+1 30 2
+1 20 3
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 4
+----
+Limit
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── limit: 4
+├── offset: 0
+├── estimated rows: 4.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 5.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 5
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8], limit: 4]
+        └── estimated rows: 5.50
+
+statement ok
+set enable_cluster_key_ordered_topk = 1
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8 AND d = 4
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 3.67
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 5
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8 and test_cluster_sort_elide.d (#3) = 4], limit: 3]
+        └── estimated rows: 3.67
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 4
+----
+Limit
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── limit: 4
+├── offset: 0
+├── estimated rows: 4.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 5.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 5
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8], limit: 4]
+        └── estimated rows: 5.50
+
+query T
+EXPLAIN SELECT a, b, payload
+FROM test_cluster_sort_elide_mixed
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 5
+----
+Limit
+├── output columns: [test_cluster_sort_elide_mixed.a (#0), test_cluster_sort_elide_mixed.b (#1), test_cluster_sort_elide_mixed.payload (#2)]
+├── limit: 5
+├── offset: 0
+├── estimated rows: 5.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_mixed.a (#0), test_cluster_sort_elide_mixed.b (#1), test_cluster_sort_elide_mixed.payload (#2)]
+    ├── sort keys: [a ASC NULLS LAST, b DESC NULLS LAST]
+    ├── estimated rows: 7.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_mixed
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), payload (#2)]
+        ├── read rows: 7
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [], limit: 5]
+        └── estimated rows: 7.00
+
+query T
+EXPLAIN SELECT a, b, payload
+FROM test_cluster_sort_elide_single
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_single.a (#0), test_cluster_sort_elide_single.b (#1), test_cluster_sort_elide_single.payload (#2)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_single.a (#0), test_cluster_sort_elide_single.b (#1), test_cluster_sort_elide_single.payload (#2)]
+    ├── sort keys: [b DESC NULLS LAST]
+    ├── estimated rows: 2.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_single
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), payload (#2)]
+        ├── read rows: 4
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_single.a (#0) = 1], limit: 2]
+        └── estimated rows: 2.00
+
+query T
+EXPLAIN SELECT a, b, payload
+FROM test_cluster_sort_elide_cross_prefix
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 4
+----
+Limit
+├── output columns: [test_cluster_sort_elide_cross_prefix.a (#0), test_cluster_sort_elide_cross_prefix.b (#1), test_cluster_sort_elide_cross_prefix.payload (#2)]
+├── limit: 4
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_cross_prefix.a (#0), test_cluster_sort_elide_cross_prefix.b (#1), test_cluster_sort_elide_cross_prefix.payload (#2)]
+    ├── sort keys: [b DESC NULLS LAST]
+    ├── estimated rows: 2.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_cross_prefix
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), payload (#2)]
+        ├── read rows: 6
+        ├── read size: < 1 KiB
+        ├── partitions total: 2
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_cross_prefix.a (#0) = 1], limit: 4]
+        └── estimated rows: 2.00
+
+query T
+settings(lazy_read_threshold = 100) EXPLAIN SELECT a, b, payload
+FROM test_cluster_sort_elide_cross_prefix
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 4
+----
+RowFetch
+├── output columns: [test_cluster_sort_elide_cross_prefix.a (#0), test_cluster_sort_elide_cross_prefix.b (#1), test_cluster_sort_elide_cross_prefix._row_id (#3), test_cluster_sort_elide_cross_prefix.payload (#2)]
+├── columns to fetch: [payload]
+├── estimated rows: 2.00
+└── Limit
+    ├── output columns: [test_cluster_sort_elide_cross_prefix.a (#0), test_cluster_sort_elide_cross_prefix.b (#1), test_cluster_sort_elide_cross_prefix._row_id (#3)]
+    ├── limit: 4
+    ├── offset: 0
+    ├── estimated rows: 2.00
+    └── Sort(PresortedMerge)
+        ├── output columns: [test_cluster_sort_elide_cross_prefix.a (#0), test_cluster_sort_elide_cross_prefix.b (#1), test_cluster_sort_elide_cross_prefix._row_id (#3)]
+        ├── sort keys: [b DESC NULLS LAST]
+        ├── estimated rows: 2.00
+        └── TableScan
+            ├── table: default.default.test_cluster_sort_elide_cross_prefix
+            ├── scan id: 0
+            ├── output columns: [a (#0), b (#1), _row_id (#3)]
+            ├── read rows: 6
+            ├── read size: < 1 KiB
+            ├── partitions total: 2
+            ├── partitions scanned: 2
+            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+            ├── push downs: [filters: [test_cluster_sort_elide_cross_prefix.a (#0) = 1], limit: 4]
+            └── estimated rows: 2.00
+
+query T
+EXPLAIN SELECT a, b
+FROM test_cluster_sort_elide_overlap
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide_overlap.a (#0), test_cluster_sort_elide_overlap.b (#1)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_overlap.a (#0), test_cluster_sort_elide_overlap.b (#1)]
+    ├── sort keys: [a ASC NULLS LAST, b DESC NULLS LAST]
+    ├── estimated rows: 6.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_overlap
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 6
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [], limit: 3]
+        └── estimated rows: 6.00
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide_pruned_multi
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 5
+----
+Limit
+├── output columns: [test_cluster_sort_elide_pruned_multi.a (#0), test_cluster_sort_elide_pruned_multi.b (#1), test_cluster_sort_elide_pruned_multi.c (#2), test_cluster_sort_elide_pruned_multi.d (#3)]
+├── limit: 5
+├── offset: 0
+├── estimated rows: 4.33
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_pruned_multi.a (#0), test_cluster_sort_elide_pruned_multi.b (#1), test_cluster_sort_elide_pruned_multi.c (#2), test_cluster_sort_elide_pruned_multi.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 4.33
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_pruned_multi
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 6
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 6 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_pruned_multi.a (#0) = 1 and test_cluster_sort_elide_pruned_multi.b (#1) = 2 and test_cluster_sort_elide_pruned_multi.e (#4) = 3 and test_cluster_sort_elide_pruned_multi.f (#5) = 8], limit: 5]
+        └── estimated rows: 4.33
+
+statement ok
+set max_cluster_key_ordered_topk_overlap = 0
+
+query II
+SELECT a, b
+FROM test_cluster_sort_elide_overlap
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 4
+----
+1 10
+1 9
+1 8
+1 3
+
+query T
+EXPLAIN SELECT a, b
+FROM test_cluster_sort_elide_overlap
+ORDER BY a ASC NULLS LAST, b DESC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide_overlap.a (#0), test_cluster_sort_elide_overlap.b (#1)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_overlap.a (#0), test_cluster_sort_elide_overlap.b (#1)]
+    ├── sort keys: [a ASC NULLS LAST, b DESC NULLS LAST]
+    ├── estimated rows: 6.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_overlap
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 6
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [], limit: 3]
+        └── estimated rows: 6.00
+
+statement ok
+set max_cluster_key_ordered_topk_overlap = 10
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 5.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 5
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8], limit: 3]
+        └── estimated rows: 5.50
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS FIRST, d ASC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+    ├── sort keys: [c DESC NULLS FIRST, d ASC NULLS LAST]
+    ├── estimated rows: 5.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 11
+        ├── read size: < 1 KiB
+        ├── partitions total: 5
+        ├── partitions scanned: 5
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8], limit: 3]
+        └── estimated rows: 5.50
+
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8 AND d = 4
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+----
+Sort(Single)
+├── output columns: [test_cluster_sort_elide.a (#0), test_cluster_sort_elide.b (#1), test_cluster_sort_elide.c (#2), test_cluster_sort_elide.d (#3)]
+├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+├── estimated rows: 3.67
+└── TableScan
+    ├── table: default.default.test_cluster_sort_elide
+    ├── scan id: 0
+    ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+    ├── read rows: 11
+    ├── read size: < 1 KiB
+    ├── partitions total: 5
+    ├── partitions scanned: 5
+    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
+    ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8 and test_cluster_sort_elide.d (#3) = 4], limit: NONE]
+    └── estimated rows: 3.67
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_i64(
+    a int not null,
+    b bigint not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 100 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_i64 VALUES
+    (1, 1),
+    (1, 3),
+    (1, 2)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_i64 RECLUSTER FINAL
+
+query T
+EXPLAIN SELECT a, b
+FROM test_cluster_sort_elide_i64
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_i64.a (#0), test_cluster_sort_elide_i64.b (#1)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_i64.a (#0), test_cluster_sort_elide_i64.b (#1)]
+    ├── sort keys: [b DESC NULLS LAST]
+    ├── estimated rows: 3.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_i64
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 3
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_i64.a (#0) = 1], limit: 2]
+        └── estimated rows: 3.00
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_i64_min ALL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_i64_min(
+    a int not null,
+    b bigint not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 100 STORAGE_FORMAT = 'parquet'
+
+statement error number overflowed
+INSERT INTO test_cluster_sort_elide_i64_min VALUES
+    (1, CAST('-9223372036854775808' AS BIGINT)),
+    (1, 10)
+
+statement ok
+DROP TABLE test_cluster_sort_elide_i64_min ALL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_decimal(
+    a int not null,
+    b decimal(20, 4) not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 100 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_decimal VALUES
+    (1, 1.0000),
+    (1, 3.0000),
+    (1, 2.0000)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_decimal RECLUSTER FINAL
+
+query T
+EXPLAIN SELECT a, b
+FROM test_cluster_sort_elide_decimal
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_decimal.a (#0), test_cluster_sort_elide_decimal.b (#1)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_decimal.a (#0), test_cluster_sort_elide_decimal.b (#1)]
+    ├── sort keys: [b DESC NULLS LAST]
+    ├── estimated rows: 3.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_decimal
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 3
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_decimal.a (#0) = 1], limit: 2]
+        └── estimated rows: 3.00
+
+query T
+EXPLAIN SELECT platform_id, wallet_address, last_active_time
+FROM test_cluster_sort_elide_string
+WHERE platform_id = 14 AND wallet_address = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AND balance > 0
+ORDER BY last_active_time DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_string.platform_id (#0), test_cluster_sort_elide_string.wallet_address (#1), test_cluster_sort_elide_string.last_active_time (#2)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_string.platform_id (#0), test_cluster_sort_elide_string.wallet_address (#1), test_cluster_sort_elide_string.last_active_time (#2)]
+    ├── sort keys: [last_active_time DESC NULLS LAST]
+    ├── estimated rows: 2.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_string
+        ├── scan id: 0
+        ├── output columns: [platform_id (#0), wallet_address (#1), last_active_time (#2)]
+        ├── read rows: 5
+        ├── read size: < 1 KiB
+        ├── partitions total: 2
+        ├── partitions scanned: 2
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_string.platform_id (#0) = 14 and test_cluster_sort_elide_string.balance (#3) > 0 and test_cluster_sort_elide_string.wallet_address (#1) = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], limit: 2]
+        └── estimated rows: 2.50
+
+query T
+EXPLAIN SELECT platform_id, wallet_address, last_active_time
+FROM test_cluster_sort_elide_prefix
+WHERE platform_id = 14 AND wallet_address = '0xaaaaaa0000000000000000000000000000000000'
+ORDER BY last_active_time DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_prefix.platform_id (#0), test_cluster_sort_elide_prefix.wallet_address (#1), test_cluster_sort_elide_prefix.last_active_time (#2)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_prefix.platform_id (#0), test_cluster_sort_elide_prefix.wallet_address (#1), test_cluster_sort_elide_prefix.last_active_time (#2)]
+    ├── sort keys: [last_active_time DESC NULLS LAST]
+    ├── estimated rows: 2.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_prefix
+        ├── scan id: 0
+        ├── output columns: [platform_id (#0), wallet_address (#1), last_active_time (#2)]
+        ├── read rows: 6
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_prefix.platform_id (#0) = 14 and test_cluster_sort_elide_prefix.wallet_address (#1) = '0xaaaaaa0000000000000000000000000000000000'], limit: 2]
+        └── estimated rows: 2.00
+
+query T
+EXPLAIN SELECT platform_id, wallet_address, last_active_time
+FROM test_cluster_sort_elide_prefix
+WHERE platform_id = 14 AND substr(wallet_address, 1, 6) = '0xaaaa'
+ORDER BY last_active_time DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_prefix.platform_id (#0), test_cluster_sort_elide_prefix.wallet_address (#1), test_cluster_sort_elide_prefix.last_active_time (#2)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 1.20
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_prefix.platform_id (#0), test_cluster_sort_elide_prefix.wallet_address (#1), test_cluster_sort_elide_prefix.last_active_time (#2)]
+    ├── sort keys: [last_active_time DESC NULLS LAST]
+    ├── estimated rows: 1.20
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_prefix
+        ├── scan id: 0
+        ├── output columns: [platform_id (#0), wallet_address (#1), last_active_time (#2)]
+        ├── read rows: 6
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_prefix.platform_id (#0) = 14 and substr(test_cluster_sort_elide_prefix.wallet_address (#1), 1, 6) = '0xaaaa'], limit: 2]
+        └── estimated rows: 1.20
+
+query IIII
+SELECT a, b, c, d
+FROM test_cluster_sort_elide_column_segment
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 5
+----
+1 2 100 1
+1 2 70 1
+1 2 60 1
+1 2 50 2
+1 2 30 2
+
+# Column-oriented segments currently keep the conservative Sort(Single) path.
+query T
+EXPLAIN SELECT a, b, c, d
+FROM test_cluster_sort_elide_column_segment
+WHERE a = 1 AND b = 2 AND e = 3 AND f = 8
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 5
+----
+Limit
+├── output columns: [test_cluster_sort_elide_column_segment.a (#0), test_cluster_sort_elide_column_segment.b (#1), test_cluster_sort_elide_column_segment.c (#2), test_cluster_sort_elide_column_segment.d (#3)]
+├── limit: 5
+├── offset: 0
+├── estimated rows: 4.33
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_column_segment.a (#0), test_cluster_sort_elide_column_segment.b (#1), test_cluster_sort_elide_column_segment.c (#2), test_cluster_sort_elide_column_segment.d (#3)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 4.33
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_column_segment
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), c (#2), d (#3)]
+        ├── read rows: 13
+        ├── read size: 6.71 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── push downs: [filters: [test_cluster_sort_elide_column_segment.a (#0) = 1 and test_cluster_sort_elide_column_segment.b (#1) = 2 and test_cluster_sort_elide_column_segment.e (#4) = 3 and test_cluster_sort_elide_column_segment.f (#5) = 8], limit: 5]
+        └── estimated rows: 4.33
+
+statement ok
+DROP TABLE test_cluster_sort_elide ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_i64 ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_decimal ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_string ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_prefix ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_column_segment ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_single ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_mixed ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_overlap ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_cross_prefix ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_pruned_multi ALL
+
+statement ok
+unset max_threads
+
+statement ok
+unset enable_parallel_multi_merge_sort
+
+statement ok
+unset enable_cluster_key_ordered_topk
+
+statement ok
+unset max_cluster_key_ordered_topk_overlap
+
+statement ok
+unset lazy_read_threshold

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
@@ -50,6 +50,9 @@ statement ok
 DROP TABLE IF EXISTS test_cluster_sort_elide_pruned_multi ALL
 
 statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_nullable_prefix ALL
+
+statement ok
 CREATE TABLE test_cluster_sort_elide(
     a int not null,
     b int not null,
@@ -175,6 +178,29 @@ INSERT INTO test_cluster_sort_elide_pruned_multi VALUES
 
 statement ok
 ALTER TABLE test_cluster_sort_elide_pruned_multi RECLUSTER FINAL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_nullable_prefix(
+    a int not null,
+    b int not null,
+    tag string null,
+    c int not null,
+    d int not null,
+    e int not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, b, is_null(tag), -c, d, e) ROW_PER_BLOCK = 2 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_nullable_prefix VALUES
+    (1, 2, NULL, 90, 4, 3),
+    (1, 2, 'tagged', 95, 4, 3),
+    (1, 2, NULL, 80, 3, 3),
+    (1, 2, NULL, 80, 4, 1),
+    (1, 2, NULL, 70, 5, 3),
+    (1, 3, NULL, 99, 4, 3),
+    (2, 2, NULL, 100, 4, 3)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_nullable_prefix RECLUSTER FINAL
 
 statement ok
 CREATE TABLE test_cluster_sort_elide_string(
@@ -355,6 +381,17 @@ LIMIT 5
 1 2 50 2
 1 2 30 2
 
+query IITIII
+SELECT a, b, tag, c, d, e
+FROM test_cluster_sort_elide_nullable_prefix
+WHERE a = 1 AND b IN (2) AND tag IS NULL AND e = 3
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+1 2 NULL 90 4 3
+1 2 NULL 80 3 3
+1 2 NULL 70 5 3
+
 statement ok
 set enable_cluster_key_ordered_topk = 0
 
@@ -407,6 +444,34 @@ Limit
         ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
         ├── push downs: [filters: [test_cluster_sort_elide.a (#0) = 1 and test_cluster_sort_elide.b (#1) = 2 and test_cluster_sort_elide.e (#4) = 3 and test_cluster_sort_elide.f (#5) = 8], limit: 4]
         └── estimated rows: 5.50
+
+query T
+EXPLAIN SELECT a, b, tag, c, d, e
+FROM test_cluster_sort_elide_nullable_prefix
+WHERE a = 1 AND b IN (2) AND tag IS NULL AND e = 3
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide_nullable_prefix.a (#0), test_cluster_sort_elide_nullable_prefix.b (#1), test_cluster_sort_elide_nullable_prefix.tag (#2), test_cluster_sort_elide_nullable_prefix.c (#3), test_cluster_sort_elide_nullable_prefix.d (#4), test_cluster_sort_elide_nullable_prefix.e (#5)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_nullable_prefix.a (#0), test_cluster_sort_elide_nullable_prefix.b (#1), test_cluster_sort_elide_nullable_prefix.tag (#2), test_cluster_sort_elide_nullable_prefix.c (#3), test_cluster_sort_elide_nullable_prefix.d (#4), test_cluster_sort_elide_nullable_prefix.e (#5)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 3.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_nullable_prefix
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), tag (#2), c (#3), d (#4), e (#5)]
+        ├── read rows: 7
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_nullable_prefix.a (#0) = 1 and test_cluster_sort_elide_nullable_prefix.b (#1) = 2 and test_cluster_sort_elide_nullable_prefix.e (#5) = 3 and NOT is_not_null(test_cluster_sort_elide_nullable_prefix.tag (#2))], limit: 3]
+        └── estimated rows: 3.50
 
 statement ok
 set enable_cluster_key_ordered_topk = 1
@@ -636,6 +701,34 @@ Limit
         ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 6 to 5 cost: <slt:ignore>, bloom pruning: 5 to 5 cost: <slt:ignore>>]
         ├── push downs: [filters: [test_cluster_sort_elide_pruned_multi.a (#0) = 1 and test_cluster_sort_elide_pruned_multi.b (#1) = 2 and test_cluster_sort_elide_pruned_multi.e (#4) = 3 and test_cluster_sort_elide_pruned_multi.f (#5) = 8], limit: 5]
         └── estimated rows: 4.33
+
+query T
+EXPLAIN SELECT a, b, tag, c, d, e
+FROM test_cluster_sort_elide_nullable_prefix
+WHERE a = 1 AND b IN (2) AND tag IS NULL AND e = 3
+ORDER BY c DESC NULLS LAST, d ASC NULLS LAST
+LIMIT 3
+----
+Limit
+├── output columns: [test_cluster_sort_elide_nullable_prefix.a (#0), test_cluster_sort_elide_nullable_prefix.b (#1), test_cluster_sort_elide_nullable_prefix.tag (#2), test_cluster_sort_elide_nullable_prefix.c (#3), test_cluster_sort_elide_nullable_prefix.d (#4), test_cluster_sort_elide_nullable_prefix.e (#5)]
+├── limit: 3
+├── offset: 0
+├── estimated rows: 3.00
+└── Sort(PresortedMerge)
+    ├── output columns: [test_cluster_sort_elide_nullable_prefix.a (#0), test_cluster_sort_elide_nullable_prefix.b (#1), test_cluster_sort_elide_nullable_prefix.tag (#2), test_cluster_sort_elide_nullable_prefix.c (#3), test_cluster_sort_elide_nullable_prefix.d (#4), test_cluster_sort_elide_nullable_prefix.e (#5)]
+    ├── sort keys: [c DESC NULLS LAST, d ASC NULLS LAST]
+    ├── estimated rows: 3.50
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_nullable_prefix
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1), tag (#2), c (#3), d (#4), e (#5)]
+        ├── read rows: 7
+        ├── read size: < 1 KiB
+        ├── partitions total: 3
+        ├── partitions scanned: 3
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_nullable_prefix.a (#0) = 1 and test_cluster_sort_elide_nullable_prefix.b (#1) = 2 and test_cluster_sort_elide_nullable_prefix.e (#5) = 3 and NOT is_not_null(test_cluster_sort_elide_nullable_prefix.tag (#2))], limit: 3]
+        └── estimated rows: 3.50
 
 statement ok
 set max_cluster_key_ordered_topk_overlap = 0
@@ -1064,6 +1157,9 @@ DROP TABLE test_cluster_sort_elide_cross_prefix ALL
 
 statement ok
 DROP TABLE test_cluster_sort_elide_pruned_multi ALL
+
+statement ok
+DROP TABLE test_cluster_sort_elide_nullable_prefix ALL
 
 statement ok
 unset max_threads

--- a/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain_native/eliminate_sort_cluster_key.test
@@ -23,6 +23,9 @@ statement ok
 DROP TABLE IF EXISTS test_cluster_sort_elide_decimal ALL
 
 statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_decimal_min ALL
+
+statement ok
 DROP TABLE IF EXISTS test_cluster_sort_elide_string ALL
 
 statement ok
@@ -843,7 +846,7 @@ Limit
 ├── limit: 2
 ├── offset: 0
 ├── estimated rows: 2.00
-└── Sort(Single)
+└── Sort(PresortedMerge)
     ├── output columns: [test_cluster_sort_elide_decimal.a (#0), test_cluster_sort_elide_decimal.b (#1)]
     ├── sort keys: [b DESC NULLS LAST]
     ├── estimated rows: 3.00
@@ -858,6 +861,51 @@ Limit
         ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [test_cluster_sort_elide_decimal.a (#0) = 1], limit: 2]
         └── estimated rows: 3.00
+
+statement ok
+DROP TABLE IF EXISTS test_cluster_sort_elide_decimal_min ALL
+
+statement ok
+CREATE TABLE test_cluster_sort_elide_decimal_min(
+    a int not null,
+    b decimal(38, 0) not null
+) ENGINE = FUSE CLUSTER BY LINEAR(a, -b) ROW_PER_BLOCK = 100 STORAGE_FORMAT = 'parquet'
+
+statement ok
+INSERT INTO test_cluster_sort_elide_decimal_min VALUES
+    (1, -99999999999999999999999999999999999999),
+    (1, 10)
+
+statement ok
+ALTER TABLE test_cluster_sort_elide_decimal_min RECLUSTER FINAL
+
+query T
+EXPLAIN SELECT a, b
+FROM test_cluster_sort_elide_decimal_min
+WHERE a = 1
+ORDER BY b DESC NULLS LAST
+LIMIT 2
+----
+Limit
+├── output columns: [test_cluster_sort_elide_decimal_min.a (#0), test_cluster_sort_elide_decimal_min.b (#1)]
+├── limit: 2
+├── offset: 0
+├── estimated rows: 2.00
+└── Sort(Single)
+    ├── output columns: [test_cluster_sort_elide_decimal_min.a (#0), test_cluster_sort_elide_decimal_min.b (#1)]
+    ├── sort keys: [b DESC NULLS LAST]
+    ├── estimated rows: 2.00
+    └── TableScan
+        ├── table: default.default.test_cluster_sort_elide_decimal_min
+        ├── scan id: 0
+        ├── output columns: [a (#0), b (#1)]
+        ├── read rows: 2
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── push downs: [filters: [test_cluster_sort_elide_decimal_min.a (#0) = 1], limit: 2]
+        └── estimated rows: 2.00
 
 query T
 EXPLAIN SELECT platform_id, wallet_address, last_active_time


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add a guarded physical `Sort(PresortedMerge)` path for `ORDER BY ... LIMIT` when a Fuse Parquet scan can prove linear cluster-key ordering matches the requested sort order.
- Support equality/IS NULL/single-value fixed cluster-key prefixes followed by sort keys and extra filters, including Web3 shapes such as `CLUSTER BY linear(a, b, is_null(e), -c, d, f)` with `a/b/e` fixed and `ORDER BY c DESC, d ASC`.
- Preserve ordered scan streams after block pruning, including bounded overlapping block ranges controlled by `max_cluster_key_ordered_topk_overlap`.
- Keep the feature default-off through `enable_cluster_key_ordered_topk`.
- Keep Web3 benchmark code and artifacts out of this Databend PR; they live in `dbsid/hbx-web3`.

## Implementation

1. Proves cluster-key/order-by compatibility in physical sort planning for Fuse Parquet linear cluster keys.
2. Skips cluster-key expressions fixed by equality, single-value `IN`, and `IS NULL` predicates while leaving unrelated filters as row predicates.
3. Reorders pruned block partitions by block cluster statistics and assigns ordered per-stream sequences for `PartitionsShuffleKind::PreserveOrder`.
4. Allows bounded overlap by using row-by-row multi-stream merge after per-block partial sort.
5. Expands LazyLevel Fuse partitions before ordered proof and updates scan statistics with expanded part statistics.
6. Adds page-index pruning support for negated numeric/decimal cluster-key expressions such as `-balance`.
7. Merges page-range and prewhere/runtime-filter row selections when deserializing Parquet, with a regression guard for Parquet full-block `page_size` metadata.
8. Keeps the optimization local to single-node plans until stream-id remapping across executor fragments is available.
9. Treats `substr(col, 1, N)` cluster-key prefixes as fixed when `col` itself is fixed by filters, for any positive constant `N`.

## Benchmark

Benchmark scripts, schemas, reports, and retained artifacts were moved out of this PR and pushed to:

- Report: https://github.com/dbsid/hbx-web3/blob/main/report_pr20031_ordered_topk.md
- Artifacts: https://github.com/dbsid/hbx-web3/tree/main/results/pr20031
- Driver: https://github.com/dbsid/hbx-web3/tree/main/cmd/web3lake

Environment: us-west-2 `m5.4xlarge` EC2, single-node Databend built from this PR, S3 storage, c8/120s, fixed seed `2026062101`. Q1/Q2 were run separately; `-query both` runs Q1 and then Q2 serially, not as a mixed concurrent workload.

Final v3 serving schemas follow the requested cluster-key guideline: equality/single-value/IS NULL prefix first, sort keys next, extra filters after the sorted prefix.

| Query | Top-K | QPS | OK | Errors | p50 ms | p95 ms | p99 ms | max ms |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| Q1 | off | 2.39 | 290 | 0 | 3810.73 | 5794.88 | 6289.21 | 6910.82 |
| Q1 | on | 2.51 | 303 | 0 | 3299.90 | 5352.96 | 5634.55 | 6199.23 |
| Q2 | off | 4.33 | 528 | 0 | 1024.18 | 4057.12 | 4480.58 | 5297.97 |
| Q2 | on | 4.75 | 578 | 0 | 986.37 | 3741.61 | 4206.50 | 4351.25 |
| flex tag-filter | off | 4.33 | 526 | 0 | 1056.64 | 3961.27 | 4404.58 | 4843.02 |
| flex tag-filter | on | 4.54 | 557 | 0 | 1002.23 | 3828.41 | 4214.05 | 4599.95 |

Compare-mode full-row result equivalence, same seed and off/on session SQL:

| Query | Table | Iterations | Matches | Mismatches | Errors |
|---|---|---:|---:|---:|---:|
| Q1 | `web3_test_01_q1_wallet_ck_v3` | 20 | 20 | 0 | 0 |
| Q2 | `web3_test_01_q2_token_ck_v3` | 20 | 20 | 0 | 0 |
| flex tag-filter | `web3_test_01_flex_token_ck_v3` | 20 | 20 | 0 | 0 |
| swap flex-filter | `web3_swap_flex_ck` | 20 | 20 | 0 | 0 |

Overlap coverage:

- Non-overlap production tables use `Sort(PresortedMerge)` with the switch on.
- Controlled low-overlap tables use `Sort(PresortedMerge)` with `max_cluster_key_ordered_topk_overlap=10` and fall back to `Sort(Single)` with overlap `0`.
- Heavy-overlap shuffled tables fall back to `Sort(Single)` with overlap `10`, proving the guard prevents unsafe ordering.

Conclusion: the ordered path is correct and consistently trims Q1/Q2/flex latency, but the full Web3 `SELECT * LIMIT 100` workload is still dominated by reading 4-8 wide Parquet blocks from S3. It does not reach the aspirational 5x throughput or sub-200ms max-latency target without a deeper scan/page-level early-stop design. Deep review of the current branch did not find a safe small patch that would turn the current 5-10% gain into 5x; the next design should persist/load FUSE Parquet page locations or add a real ordered top-k source that reads order/filter columns first and stops by range frontier.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation run after the latest deep-review fix:

```bash
cargo fmt --check
git diff --check
cargo test -p databend-query --lib physical_plans::physical_sort::tests -- --nocapture
cargo test -p databend-common-storages-fuse test_page_range_selection -- --nocapture
cargo test -p databend-storages-common-index --test it page_pruner::test_page_index -- --nocapture
target/debug/databend-sqllogictests --handlers mysql --run_file eliminate_sort_cluster_key.test
```

Latest targeted sqllogic result: 119 tests passed.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20031)
<!-- Reviewable:end -->
