### PR TITLE
refactor: udf: store UDF metadata as table types

### DIFF
--- a/src/meta/api/src/api_impl/dictionary_api.rs
+++ b/src/meta/api/src/api_impl/dictionary_api.rs
@@ -153,19 +153,19 @@ where
         MetaTxnManager::new(self, ctx)
             .run(|txn| async move {
                 // The source must exist; reading it for update arms an `eq_seq` guard.
-                let old = txn.get_for_update(&req.name_ident).await?;
-                let old = old.some_or_unknown_error(ctx).map_err(AppError::from)?;
+                let old = txn.get_for_update(req.name_ident.clone()).await?;
+                let old = old.some_or_unknown(ctx).map_err(AppError::from)?;
                 let dict_id = old.value();
 
                 // The target must be free; reading it guards it stays at seq 0 till commit.
                 let new_name_ident =
                     DictionaryNameIdent::new(req.tenant(), req.new_dict_ident.clone());
-                let new = txn.get_for_update(&new_name_ident).await?;
-                let new = new.none_or_exist_error(ctx).map_err(AppError::from)?;
+                let new = txn.get_for_update(new_name_ident).await?;
+                let new = new.none_or_exists(ctx).map_err(AppError::from)?;
 
                 // Move the id from the old name to the new one.
-                new.put(dict_id)?;
-                old.delete();
+                new.stage_put(dict_id)?;
+                old.stage_delete();
 
                 Ok(())
             })

--- a/src/meta/api/src/api_impl/ref_api.rs
+++ b/src/meta/api/src/api_impl/ref_api.rs
@@ -168,26 +168,28 @@ where
 
         let key_tag = TableIdTagName::new(req.table_id, &req.tag_name);
         let ctx = func_name!();
-        let key_tag = &key_tag;
         let req = &req;
         MetaTxnManager::new(self, ctx)
-            .run(|txn| async move {
-                let tag = txn.get_for_update(key_tag).await?;
-                let tag = tag.some_or_unknown_error(ctx).map_err(AppError::from)?;
+            .run(|txn| {
+                let key_tag = key_tag.clone();
+                async move {
+                    let tag = txn.get_for_update(key_tag).await?;
+                    let tag = tag.some_or_unknown(ctx).map_err(AppError::from)?;
 
-                let seq_tag = tag.seq();
-                if req.seq.match_seq(&seq_tag).is_err() {
-                    return Err(KVAppError::AppError(AppError::from(UnknownReference::new(
-                        format!(
-                            "Tag '{}' seq mismatched: expect {}, current {}",
-                            req.tag_name, req.seq, seq_tag
-                        ),
-                    ))));
+                    let seq_tag = tag.seq();
+                    if req.seq.match_seq(&seq_tag).is_err() {
+                        return Err(KVAppError::AppError(AppError::from(UnknownReference::new(
+                            format!(
+                                "Tag '{}' seq mismatched: expect {}, current {}",
+                                req.tag_name, req.seq, seq_tag
+                            ),
+                        ))));
+                    }
+
+                    tag.stage_delete();
+
+                    Ok(())
                 }
-
-                tag.delete();
-
-                Ok(())
             })
             .await
     }

--- a/src/meta/api/src/txn/fetched_record/absent.rs
+++ b/src/meta/api/src/txn/fetched_record/absent.rs
@@ -32,7 +32,7 @@ where
     K::ValueType: FromToProto + 'static,
 {
     /// Stage a put to the read key.
-    pub fn put(self, value: &K::ValueType) -> Result<(), KV::Error> {
-        self.target.put(value)
+    pub fn stage_put(self, value: &K::ValueType) -> Result<(), KV::Error> {
+        self.target.stage_put(value)
     }
 }

--- a/src/meta/api/src/txn/fetched_record/mod.rs
+++ b/src/meta/api/src/txn/fetched_record/mod.rs
@@ -36,10 +36,11 @@ use target::FetchedRecordTarget;
 ///
 /// It borrows the transaction and holds the key and value read. If it came from
 /// [`MetaTxn::get_for_update`], the `eq_seq` guard was installed in the
-/// transaction's read set when the key was read. Writing through it
-/// ([`put`](Self::put) / [`delete`](Self::delete)) goes back to that
-/// transaction and reuses that key, so a write cannot target a different key
-/// than the one guarded, and replaces any operation previously staged for it.
+/// transaction's read set when the key was read. Staging a write through it
+/// ([`stage_put`](Self::stage_put) / [`stage_delete`](Self::stage_delete)) goes
+/// back to that transaction and reuses that key, so a write cannot target a
+/// different key than the one guarded, and replaces any operation previously
+/// staged for it.
 ///
 /// The handle borrows the transaction shared-ly (the transaction keeps its read
 /// and write sets behind a lock), so several handles may be held at once: read a
@@ -84,7 +85,7 @@ where
     /// follow-up code can use the seq/value without re-checking the option.
     ///
     /// [`unknown_error`]: KeyUnknownBuilder::unknown_error
-    pub fn some_or_unknown_error(
+    pub fn some_or_unknown(
         self,
         ctx: impl Display,
     ) -> Result<PresentRecord<'t, 'a, KV, K>, K::UnknownError>
@@ -105,7 +106,7 @@ where
     /// follow-up code can create the value without re-checking the option.
     ///
     /// [`exist_error`]: KeyExistsBuilder::exist_error
-    pub fn none_or_exist_error(
+    pub fn none_or_exists(
         self,
         ctx: impl Display,
     ) -> Result<AbsentRecord<'t, 'a, KV, K>, K::ExistError>
@@ -127,8 +128,8 @@ where
     }
 
     /// Stage a delete of the read key.
-    pub fn delete(self) {
-        self.target.delete();
+    pub fn stage_delete(self) {
+        self.target.stage_delete();
     }
 }
 
@@ -140,7 +141,7 @@ where
     K::ValueType: FromToProto + 'static,
 {
     /// Stage a put to the read key.
-    pub fn put(self, value: &K::ValueType) -> Result<(), KV::Error> {
-        self.target.put(value)
+    pub fn stage_put(self, value: &K::ValueType) -> Result<(), KV::Error> {
+        self.target.stage_put(value)
     }
 }

--- a/src/meta/api/src/txn/fetched_record/present.rs
+++ b/src/meta/api/src/txn/fetched_record/present.rs
@@ -52,8 +52,8 @@ where
     }
 
     /// Stage a delete of the read key.
-    pub fn delete(self) {
-        self.target.delete();
+    pub fn stage_delete(self) {
+        self.target.stage_delete();
     }
 }
 
@@ -65,7 +65,7 @@ where
     K::ValueType: FromToProto + 'static,
 {
     /// Stage a put to the read key.
-    pub fn put(self, value: &K::ValueType) -> Result<(), KV::Error> {
-        self.target.put(value)
+    pub fn stage_put(self, value: &K::ValueType) -> Result<(), KV::Error> {
+        self.target.stage_put(value)
     }
 }

--- a/src/meta/api/src/txn/fetched_record/target.rs
+++ b/src/meta/api/src/txn/fetched_record/target.rs
@@ -29,8 +29,8 @@ where
     KV: ?Sized,
     K: kvapi::Key,
 {
-    pub(crate) fn delete(self) {
-        self.txn.delete(&self.key);
+    pub(crate) fn stage_delete(self) {
+        self.txn.stage_delete(&self.key);
     }
 }
 
@@ -41,7 +41,7 @@ where
     K: kvapi::Key,
     K::ValueType: FromToProto + 'static,
 {
-    pub(crate) fn put(self, value: &K::ValueType) -> Result<(), KV::Error> {
-        self.txn.put(&self.key, value)
+    pub(crate) fn stage_put(self, value: &K::ValueType) -> Result<(), KV::Error> {
+        self.txn.stage_put(&self.key, value)
     }
 }

--- a/src/meta/api/src/txn/meta_txn/manager.rs
+++ b/src/meta/api/src/txn/meta_txn/manager.rs
@@ -68,9 +68,9 @@ where KV: KVApi + ?Sized
     /// ```ignore
     /// MetaTxnManager::new(kv, ctx)
     ///     .run(|txn| async move {
-    ///         let cur = txn.get_for_update(&key).await?;
+    ///         let cur = txn.get_for_update(key.clone()).await?;
     ///         // ... inspect `cur`, then stage writes ...
-    ///         txn.put(&key, &value)?;
+    ///         txn.stage_put(&key, &value)?;
     ///         Ok(())
     ///     })
     ///     .await
@@ -85,9 +85,10 @@ where KV: KVApi + ?Sized
         loop {
             trials.next().unwrap()?.await;
 
-            // The closure gets only the staging handle. The manager keeps the
-            // commit handle so user code cannot drain state or bypass retries.
-            let (txn, commit) = MetaTxn::new(self.kv);
+            // The closure gets a cloned handle. The manager keeps one so user
+            // code cannot drain state or bypass retries.
+            let txn = MetaTxn::new(self.kv);
+            let commit = txn.clone();
             let out = build(txn).await?;
 
             // A closure that stages no write produced its result purely from the

--- a/src/meta/api/src/txn/meta_txn/mod.rs
+++ b/src/meta/api/src/txn/meta_txn/mod.rs
@@ -46,8 +46,7 @@ use read_entry::ReadEntry;
 
 /// The reads and writes staged by one transaction attempt.
 ///
-/// Held behind an [`Arc`] so the user-facing transaction handle and the private
-/// committer share one set.
+/// Held behind an [`Arc`] so cloned transaction handles share one set.
 #[derive(Default)]
 struct TxnState {
     reads: BTreeMap<String, ReadEntry>,
@@ -76,29 +75,25 @@ pub struct MetaTxn<'a, KV: ?Sized> {
     state: Arc<Mutex<TxnState>>,
 }
 
-/// Commit authority for a [`MetaTxn`].
-///
-/// This is intentionally not exposed to transaction-building closures: staging
-/// code can read and write, but only the manager can drain and commit state.
-pub(crate) struct MetaTxnCommit<'a, KV: ?Sized> {
-    kv: &'a KV,
-    state: Arc<Mutex<TxnState>>,
+impl<KV: ?Sized> Clone for MetaTxn<'_, KV> {
+    fn clone(&self) -> Self {
+        Self {
+            kv: self.kv,
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<'a, KV: ?Sized> MetaTxn<'a, KV> {
-    pub(crate) fn new(kv: &'a KV) -> (Self, MetaTxnCommit<'a, KV>) {
-        let state = Arc::new(Mutex::new(TxnState::default()));
-        (
-            Self {
-                kv,
-                state: state.clone(),
-            },
-            MetaTxnCommit { kv, state },
-        )
+    fn new(kv: &'a KV) -> Self {
+        Self {
+            kv,
+            state: Arc::new(Mutex::new(TxnState::default())),
+        }
     }
 
     /// Stage a delete. Replaces any operation previously staged for `key`.
-    pub fn delete<K>(&self, key: &K)
+    pub fn stage_delete<K>(&self, key: &K)
     where K: kvapi::Key {
         self.state
             .lock()
@@ -114,12 +109,12 @@ where
     KV::Error: From<PbDecodeError>,
 {
     /// Read a key without arming a guard.
-    pub async fn get<K>(&self, key: &K) -> Result<Option<SeqV<K::ValueType>>, KV::Error>
+    pub async fn get<K>(&self, key: K) -> Result<FetchedRecord<'_, 'a, KV, K>, KV::Error>
     where
         K: kvapi::Key,
         K::ValueType: FromToProto,
     {
-        self.read(key, false).await
+        self.fetch(key, false).await
     }
 
     /// Read a key and mark it for update, so it becomes an `eq_seq` guard at
@@ -128,18 +123,14 @@ where
     /// Re-reading the same key keeps the version first observed.
     ///
     /// The returned [`FetchedRecord`] borrows the transaction and writes back to
-    /// the same key via [`put`](FetchedRecord::put) /
-    /// [`delete`](FetchedRecord::delete).
-    pub async fn get_for_update<K>(
-        &self,
-        key: &K,
-    ) -> Result<FetchedRecord<'_, 'a, KV, K>, KV::Error>
+    /// the same key via [`stage_put`](FetchedRecord::stage_put) /
+    /// [`stage_delete`](FetchedRecord::stage_delete).
+    pub async fn get_for_update<K>(&self, key: K) -> Result<FetchedRecord<'_, 'a, KV, K>, KV::Error>
     where
-        K: kvapi::Key + Clone,
+        K: kvapi::Key,
         K::ValueType: FromToProto,
     {
-        let got = self.read(key, true).await?;
-        Ok(FetchedRecord::new(self, key.clone(), got))
+        self.fetch(key, true).await
     }
 
     /// Read a key through the snapshot cache, recording it in the read set.
@@ -147,11 +138,11 @@ where
     /// On a cache hit the backend is not touched; the version first observed and
     /// its value are reused. `for_update` is OR-ed in, so a plain read followed
     /// by a for-update read upgrades the key to a guard.
-    async fn read<K>(
+    async fn fetch<K>(
         &self,
-        key: &K,
+        key: K,
         for_update: bool,
-    ) -> Result<Option<SeqV<K::ValueType>>, KV::Error>
+    ) -> Result<FetchedRecord<'_, 'a, KV, K>, KV::Error>
     where
         K: kvapi::Key,
         K::ValueType: FromToProto,
@@ -182,7 +173,8 @@ where
             }
         };
 
-        decode_raw::<K::ValueType, KV::Error>(raw, &key_str)
+        let seq_v = decode_raw::<K::ValueType, KV::Error>(raw, &key_str)?;
+        Ok(FetchedRecord::new(self, key, seq_v))
     }
 }
 
@@ -192,7 +184,7 @@ where
     KV::Error: From<InvalidArgument>,
 {
     /// Stage a put. Replaces any operation previously staged for `key`.
-    pub fn put<K>(&self, key: &K, value: &K::ValueType) -> Result<(), KV::Error>
+    pub fn stage_put<K>(&self, key: &K, value: &K::ValueType) -> Result<(), KV::Error>
     where
         K: kvapi::Key,
         K::ValueType: FromToProto + 'static,
@@ -207,18 +199,18 @@ where
     }
 }
 
-impl<KV> MetaTxnCommit<'_, KV>
+impl<KV> MetaTxn<'_, KV>
 where KV: KVApi + ?Sized
 {
     /// Whether no write has been staged: an empty transaction has nothing to
     /// commit.
-    pub(crate) fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.state.lock().unwrap().operations.is_empty()
     }
 
-    /// Consume the transaction committer, sending its staged reads and writes as
-    /// one commit and reporting whether its guards held.
-    pub(crate) async fn execute(self) -> Result<bool, KV::Error> {
+    /// Send the staged reads and writes as one commit and report whether its
+    /// guards held.
+    async fn execute(&self) -> Result<bool, KV::Error> {
         let (reads, operations) = {
             let mut state = self.state.lock().unwrap();
             (

--- a/src/meta/api/src/txn/meta_txn/tests.rs
+++ b/src/meta/api/src/txn/meta_txn/tests.rs
@@ -73,10 +73,10 @@ async fn test_read_is_cached() -> anyhow::Result<()> {
     let k = key(1);
     mem.seed(&k.to_string_key(), 7, encoded());
 
-    let (txn, _commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
 
     // First read snapshots the key at seq 7.
-    let first = txn.get_for_update(&k).await?;
+    let first = txn.get_for_update(k.clone()).await?;
     assert_eq!(first.seq_v().map(|s| s.seq), Some(7));
     assert_eq!(first.value(), Some(&meta()));
 
@@ -89,7 +89,7 @@ async fn test_read_is_cached() -> anyhow::Result<()> {
     );
 
     // The transaction serves its cached snapshot, not the new backend record.
-    let second = txn.get_for_update(&k).await?;
+    let second = txn.get_for_update(k.clone()).await?;
     assert_eq!(second.seq(), 7, "cached snapshot, not backend seq 9");
     assert_eq!(
         second.into_value(),
@@ -110,16 +110,17 @@ async fn test_for_update_becomes_guard() -> anyhow::Result<()> {
     mem.seed(&k.to_string_key(), 7, encoded());
     mem.seed(&other.to_string_key(), 5, encoded());
 
-    let (txn, commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
+    let commit = txn.clone();
 
     // The same key read several times — plain and for update — yields one guard.
-    txn.get(&k).await?;
-    txn.get_for_update(&k).await?;
-    let fu = txn.get_for_update(&k).await?;
-    fu.put(&meta())?;
+    txn.get(k.clone()).await?;
+    txn.get_for_update(k.clone()).await?;
+    let fu = txn.get_for_update(k.clone()).await?;
+    fu.stage_put(&meta())?;
 
     // A plain get of another key arms no guard.
-    txn.get(&other).await?;
+    txn.get(other.clone()).await?;
 
     assert!(commit.execute().await?);
 
@@ -140,9 +141,10 @@ async fn test_plain_get_adds_no_guard() -> anyhow::Result<()> {
     let (k1, k2) = (key(1), key(2));
     mem.seed(&k1.to_string_key(), 7, encoded());
 
-    let (txn, commit) = MetaTxn::new(&mem);
-    txn.get(&k1).await?;
-    txn.put(&k2, &meta())?;
+    let txn = MetaTxn::new(&mem);
+    let commit = txn.clone();
+    txn.get(k1.clone()).await?;
+    txn.stage_put(&k2, &meta())?;
     commit.execute().await?;
 
     let req = mem.last_request();
@@ -159,10 +161,11 @@ async fn test_get_then_for_update_upgrades() -> anyhow::Result<()> {
     let k = key(1);
     mem.seed(&k.to_string_key(), 7, encoded());
 
-    let (txn, commit) = MetaTxn::new(&mem);
-    txn.get(&k).await?;
-    let fu = txn.get_for_update(&k).await?;
-    fu.put(&meta())?;
+    let txn = MetaTxn::new(&mem);
+    let commit = txn.clone();
+    txn.get(k.clone()).await?;
+    let fu = txn.get_for_update(k.clone()).await?;
+    fu.stage_put(&meta())?;
     commit.execute().await?;
 
     assert_eq!(mem.read_count(), 1, "no second backend read");
@@ -184,13 +187,15 @@ async fn test_run_retries_on_conflict() -> anyhow::Result<()> {
 
     let calls = AtomicUsize::new(0);
     let calls = &calls;
-    let k = &k;
     let res: Result<(), KVAppError> = MetaTxnManager::new(&mem, "test")
-        .run(|txn| async move {
-            calls.fetch_add(1, Ordering::SeqCst);
-            let fu = txn.get_for_update(k).await?;
-            fu.put(&meta())?;
-            Ok(())
+        .run(|txn| {
+            let k = k.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let fu = txn.get_for_update(k).await?;
+                fu.stage_put(&meta())?;
+                Ok(())
+            }
         })
         .await;
 
@@ -210,14 +215,15 @@ async fn test_multiple_for_update_held() -> anyhow::Result<()> {
     mem.seed(&k1.to_string_key(), 7, encoded());
     mem.seed(&k2.to_string_key(), 9, encoded());
 
-    let (txn, commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
+    let commit = txn.clone();
 
-    let a = txn.get_for_update(&k1).await?;
-    let b = txn.get_for_update(&k2).await?;
+    let a = txn.get_for_update(k1.clone()).await?;
+    let b = txn.get_for_update(k2.clone()).await?;
     assert_eq!(a.seq(), 7);
     assert_eq!(b.seq(), 9);
-    a.put(&meta())?;
-    b.delete();
+    a.stage_put(&meta())?;
+    b.stage_delete();
 
     commit.execute().await?;
 
@@ -249,10 +255,10 @@ async fn test_meta_is_cached() -> anyhow::Result<()> {
         SeqV::new_with_meta(7, Some(seeded_meta.clone()), encoded()),
     );
 
-    let (txn, _commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
 
     // First read decodes the value and carries the meta.
-    let first = txn.get_for_update(&k).await?;
+    let first = txn.get_for_update(k.clone()).await?;
     assert_eq!(
         first.seq_v().and_then(|s| s.meta.as_ref()),
         Some(&seeded_meta)
@@ -261,7 +267,7 @@ async fn test_meta_is_cached() -> anyhow::Result<()> {
     // Replace the backend record with one that has no meta; the cached snapshot
     // still carries the original meta.
     mem.seed_seqv(&k.to_string_key(), SeqV::new(9, encoded()));
-    let second = txn.get_for_update(&k).await?;
+    let second = txn.get_for_update(k.clone()).await?;
     assert_eq!(
         second.seq_v().and_then(|s| s.meta.as_ref()),
         Some(&seeded_meta),
@@ -272,15 +278,17 @@ async fn test_meta_is_cached() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `put` and `delete` each stage the matching operation, keyed by its target.
+/// `stage_put` and `stage_delete` each stage the matching operation, keyed by
+/// its target.
 #[tokio::test]
 async fn test_writes_generate_operations() -> anyhow::Result<()> {
     let mem = MemKV::new();
     let (k1, k2) = (key(1), key(2));
 
-    let (txn, commit) = MetaTxn::new(&mem);
-    txn.put(&k1, &meta())?;
-    txn.delete(&k2);
+    let txn = MetaTxn::new(&mem);
+    let commit = txn.clone();
+    txn.stage_put(&k1, &meta())?;
+    txn.stage_delete(&k2);
     commit.execute().await?;
 
     let req = mem.last_request();
@@ -304,15 +312,15 @@ async fn test_some_or_unknown() -> anyhow::Result<()> {
         encode_pb(&DatabaseMeta::default()).unwrap(),
     );
 
-    let (txn, _commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
 
-    let fu = txn.get_for_update(&present).await?;
-    let present = fu.some_or_unknown_error("ctx").unwrap();
+    let fu = txn.get_for_update(present).await?;
+    let present = fu.some_or_unknown("ctx").unwrap();
     assert_eq!(present.seq(), 3);
     assert_eq!(present.seq_v().seq, 3);
 
-    let fu = txn.get_for_update(&absent).await?;
-    let err = match fu.some_or_unknown_error("ctx") {
+    let fu = txn.get_for_update(absent).await?;
+    let err = match fu.some_or_unknown("ctx") {
         Ok(_) => panic!("expected unknown key"),
         Err(err) => err,
     };
@@ -335,14 +343,14 @@ async fn test_none_or_exist() -> anyhow::Result<()> {
         encode_pb(&TableId::new(8)).unwrap(),
     );
 
-    let (txn, _commit) = MetaTxn::new(&mem);
+    let txn = MetaTxn::new(&mem);
 
-    let fu = txn.get_for_update(&absent).await?;
-    let absent = fu.none_or_exist_error("ctx").unwrap();
-    absent.put(&TableId::new(7))?;
+    let fu = txn.get_for_update(absent.clone()).await?;
+    let absent = fu.none_or_exists("ctx").unwrap();
+    absent.stage_put(&TableId::new(7))?;
 
-    let fu = txn.get_for_update(&present).await?;
-    let err = match fu.none_or_exist_error("ctx") {
+    let fu = txn.get_for_update(present.clone()).await?;
+    let err = match fu.none_or_exists("ctx") {
         Ok(_) => panic!("expected existing key"),
         Err(err) => err,
     };

--- a/src/meta/app/src/principal/user_defined_function.rs
+++ b/src/meta/app/src/principal/user_defined_function.rs
@@ -18,8 +18,8 @@ use std::fmt::Formatter;
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::DataField;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LambdaUDF {
@@ -34,8 +34,8 @@ pub struct UDFServer {
     pub headers: BTreeMap<String, String>,
     pub language: String,
     pub arg_names: Vec<String>,
-    pub arg_types: Vec<DataType>,
-    pub return_type: DataType,
+    pub arg_types: Vec<TableDataType>,
+    pub return_type: TableDataType,
     pub immutable: Option<bool>,
 }
 
@@ -46,21 +46,21 @@ pub struct UDFScript {
     pub packages: Vec<String>,
     pub handler: String,
     pub language: String,
-    pub arg_types: Vec<DataType>,
-    pub return_type: DataType,
+    pub arg_types: Vec<TableDataType>,
+    pub return_type: TableDataType,
     pub runtime_version: String,
     pub immutable: Option<bool>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UDTFServer {
     pub address: String,
     pub handler: String,
     pub headers: BTreeMap<String, String>,
     pub language: String,
     pub arg_names: Vec<String>,
-    pub arg_types: Vec<DataType>,
-    pub return_types: Vec<(String, DataType)>,
+    pub arg_types: Vec<TableDataType>,
+    pub return_types: Vec<(String, TableDataType)>,
     pub immutable: Option<bool>,
 }
 
@@ -72,8 +72,8 @@ pub struct UDTFServer {
 /// - `sql`: SQL implementing the UDTF
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UDTF {
-    pub arg_types: Vec<(String, DataType)>,
-    pub return_types: Vec<(String, DataType)>,
+    pub arg_types: Vec<(String, TableDataType)>,
+    pub return_types: Vec<(String, TableDataType)>,
     pub sql: String,
 }
 
@@ -85,8 +85,8 @@ pub struct UDTF {
 /// - `definition`: typically including the code or expression implementing the function logic
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ScalarUDF {
-    pub arg_types: Vec<(String, DataType)>,
-    pub return_type: DataType,
+    pub arg_types: Vec<(String, TableDataType)>,
+    pub return_type: TableDataType,
     pub definition: String,
 }
 
@@ -97,10 +97,10 @@ pub struct UDAFScript {
     pub packages: Vec<String>,
     pub language: String,
     // aggregate function input types
-    pub arg_types: Vec<DataType>,
+    pub arg_types: Vec<TableDataType>,
     // aggregate function state fields
-    pub state_fields: Vec<DataField>,
-    pub return_type: DataType,
+    pub state_fields: Vec<TableField>,
+    pub return_type: TableDataType,
     pub runtime_version: String,
 }
 
@@ -189,8 +189,8 @@ impl UserDefinedFunction {
         headers: &BTreeMap<String, String>,
         language: &str,
         arg_names: Vec<String>,
-        arg_types: Vec<DataType>,
-        return_type: DataType,
+        arg_types: Vec<TableDataType>,
+        return_type: TableDataType,
         description: &str,
         immutable: Option<bool>,
     ) -> Self {
@@ -218,8 +218,8 @@ impl UserDefinedFunction {
         code: &str,
         handler: &str,
         language: &str,
-        arg_types: Vec<DataType>,
-        return_type: DataType,
+        arg_types: Vec<TableDataType>,
+        return_type: TableDataType,
         runtime_version: &str,
         description: &str,
         immutable: Option<bool>,

--- a/src/meta/proto-conv/src/impls/udf.rs
+++ b/src/meta/proto-conv/src/impls/udf.rs
@@ -14,8 +14,6 @@
 
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
-use databend_common_expression::infer_schema_type;
-use databend_common_expression::types::DataType;
 use databend_common_meta_app::principal as mt;
 use databend_common_protos::pb;
 use databend_common_protos::pb::UdtfArg;
@@ -60,12 +58,12 @@ impl FromToProto for mt::UDFServer {
 
         let mut arg_types = Vec::with_capacity(p.arg_types.len());
         for arg_type in p.arg_types {
-            let arg_type = DataType::from(&TableDataType::from_pb(arg_type)?);
+            let arg_type = TableDataType::from_pb(arg_type)?;
             arg_types.push(arg_type);
         }
-        let return_type = DataType::from(&TableDataType::from_pb(p.return_type.ok_or_else(
-            || Incompatible::new("UdfServer.return_type can not be None".to_string()),
-        )?)?);
+        let return_type = TableDataType::from_pb(p.return_type.ok_or_else(|| {
+            Incompatible::new("UdfServer.return_type can not be None".to_string())
+        })?)?;
 
         Ok(mt::UDFServer {
             address: p.address,
@@ -82,24 +80,10 @@ impl FromToProto for mt::UDFServer {
     fn to_pb(&self) -> Result<pb::UdfServer, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(arg_type);
         }
-        let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| {
-                Incompatible::new(format!(
-                    "Convert DataType to TableDataType failed: {}",
-                    e.message()
-                ))
-            })?
-            .to_pb()?;
+        let return_type = self.return_type.to_pb()?;
 
         Ok(pb::UdfServer {
             ver: VER,
@@ -126,12 +110,12 @@ impl FromToProto for mt::UDFScript {
 
         let mut arg_types = Vec::with_capacity(p.arg_types.len());
         for arg_type in p.arg_types {
-            let arg_type = DataType::from(&TableDataType::from_pb(arg_type)?);
+            let arg_type = TableDataType::from_pb(arg_type)?;
             arg_types.push(arg_type);
         }
-        let return_type = DataType::from(&TableDataType::from_pb(p.return_type.ok_or_else(
-            || Incompatible::new("UDFScript.return_type can not be None".to_string()),
-        )?)?);
+        let return_type = TableDataType::from_pb(p.return_type.ok_or_else(|| {
+            Incompatible::new("UDFScript.return_type can not be None".to_string())
+        })?)?;
 
         Ok(mt::UDFScript {
             code: p.code,
@@ -149,24 +133,10 @@ impl FromToProto for mt::UDFScript {
     fn to_pb(&self) -> Result<pb::UdfScript, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(arg_type);
         }
-        let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| {
-                Incompatible::new(format!(
-                    "Convert DataType to TableDataType failed: {}",
-                    e.message()
-                ))
-            })?
-            .to_pb()?;
+        let return_type = self.return_type.to_pb()?;
 
         Ok(pb::UdfScript {
             ver: VER,
@@ -195,19 +165,18 @@ impl FromToProto for mt::UDAFScript {
         let arg_types = p
             .arg_types
             .into_iter()
-            .map(|arg_type| Ok((&TableDataType::from_pb(arg_type)?).into()))
+            .map(TableDataType::from_pb)
             .collect::<Result<Vec<_>, _>>()?;
 
         let state_fields = p
             .state_fields
             .into_iter()
-            .map(|field| TableField::from_pb(field).map(|field| (&field).into()))
+            .map(TableField::from_pb)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let return_type = (&TableDataType::from_pb(p.return_type.ok_or_else(|| {
+        let return_type = TableDataType::from_pb(p.return_type.ok_or_else(|| {
             Incompatible::new("UDAFScript.return_type can not be None".to_string())
-        })?)?)
-            .into();
+        })?)?;
 
         Ok(mt::UDAFScript {
             code: p.code,
@@ -224,42 +193,17 @@ impl FromToProto for mt::UDAFScript {
     fn to_pb(&self) -> Result<pb::UdafScript, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(arg_type);
         }
 
         let state_fields = self
             .state_fields
             .iter()
-            .map(|field| {
-                TableField::new(
-                    field.name(),
-                    infer_schema_type(field.data_type()).map_err(|e| {
-                        Incompatible::new(format!(
-                            "Convert DataType to TableDataType failed: {}",
-                            e.message()
-                        ))
-                    })?,
-                )
-                .to_pb()
-            })
+            .map(TableField::to_pb)
             .collect::<Result<_, _>>()?;
 
-        let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| {
-                Incompatible::new(format!(
-                    "Convert DataType to TableDataType failed: {}",
-                    e.message()
-                ))
-            })?
-            .to_pb()?;
+        let return_type = self.return_type.to_pb()?;
 
         Ok(pb::UdafScript {
             ver: VER,
@@ -294,7 +238,7 @@ impl FromToProto for mt::UDTF {
             })?;
             let ty = TableDataType::from_pb(ty_pb)?;
 
-            arg_types.push((arg_ty.name, (&ty).into()));
+            arg_types.push((arg_ty.name, ty));
         }
 
         let mut return_types = Vec::new();
@@ -304,7 +248,7 @@ impl FromToProto for mt::UDTF {
             })?;
             let ty = TableDataType::from_pb(ty_pb)?;
 
-            return_types.push((return_ty.name, (&ty).into()));
+            return_types.push((return_ty.name, ty));
         }
 
         Ok(Self {
@@ -317,14 +261,7 @@ impl FromToProto for mt::UDTF {
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for (arg_name, arg_type) in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(UdtfArg {
                 name: arg_name.clone(),
                 ty: Some(arg_type),
@@ -333,14 +270,7 @@ impl FromToProto for mt::UDTF {
 
         let mut return_types = Vec::with_capacity(self.return_types.len());
         for (return_name, return_type) in self.return_types.iter() {
-            let return_type = infer_schema_type(return_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let return_type = return_type.to_pb()?;
             return_types.push(UdtfArg {
                 name: return_name.clone(),
                 ty: Some(return_type),
@@ -370,7 +300,7 @@ impl FromToProto for mt::UDTFServer {
 
         let mut arg_types = Vec::with_capacity(p.arg_types.len());
         for arg_type in p.arg_types {
-            let arg_type = DataType::from(&TableDataType::from_pb(arg_type)?);
+            let arg_type = TableDataType::from_pb(arg_type)?;
             arg_types.push(arg_type);
         }
         let mut return_types = Vec::new();
@@ -380,7 +310,7 @@ impl FromToProto for mt::UDTFServer {
             })?;
             let ty = TableDataType::from_pb(ty_pb)?;
 
-            return_types.push((return_ty.name, (&ty).into()));
+            return_types.push((return_ty.name, ty));
         }
 
         Ok(mt::UDTFServer {
@@ -398,26 +328,12 @@ impl FromToProto for mt::UDTFServer {
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for arg_type in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(arg_type);
         }
         let mut return_types = Vec::with_capacity(self.return_types.len());
         for (return_name, return_type) in self.return_types.iter() {
-            let return_type = infer_schema_type(return_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let return_type = return_type.to_pb()?;
             return_types.push(UdtfArg {
                 name: return_name.clone(),
                 ty: Some(return_type),
@@ -457,7 +373,7 @@ impl FromToProto for mt::ScalarUDF {
             })?;
             let ty = TableDataType::from_pb(ty_pb)?;
 
-            arg_types.push((arg_ty.name, (&ty).into()));
+            arg_types.push((arg_ty.name, ty));
         }
 
         let return_type_pb = p.return_type.ok_or_else(|| {
@@ -467,7 +383,7 @@ impl FromToProto for mt::ScalarUDF {
 
         Ok(Self {
             arg_types,
-            return_type: (&return_type).into(),
+            return_type,
             definition: p.definition,
         })
     }
@@ -475,28 +391,14 @@ impl FromToProto for mt::ScalarUDF {
     fn to_pb(&self) -> Result<Self::PB, Incompatible> {
         let mut arg_types = Vec::with_capacity(self.arg_types.len());
         for (arg_name, arg_type) in self.arg_types.iter() {
-            let arg_type = infer_schema_type(arg_type)
-                .map_err(|e| {
-                    Incompatible::new(format!(
-                        "Convert DataType to TableDataType failed: {}",
-                        e.message()
-                    ))
-                })?
-                .to_pb()?;
+            let arg_type = arg_type.to_pb()?;
             arg_types.push(UdtfArg {
                 name: arg_name.clone(),
                 ty: Some(arg_type),
             });
         }
 
-        let return_type = infer_schema_type(&self.return_type)
-            .map_err(|e| {
-                Incompatible::new(format!(
-                    "Convert DataType to TableDataType failed: {}",
-                    e.message()
-                ))
-            })?
-            .to_pb()?;
+        let return_type = self.return_type.to_pb()?;
 
         Ok(pb::ScalarUdf {
             ver: VER,

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -26,7 +26,6 @@ use databend_common_expression as ce;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
-use databend_common_expression::types::DataType;
 use databend_common_meta_app::schema as mt;
 use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
@@ -313,8 +312,8 @@ fn new_udf_server() -> databend_common_meta_app::principal::UDFServer {
         ]),
         language: "python".to_string(),
         arg_names: vec![],
-        arg_types: vec![DataType::String],
-        return_type: DataType::Boolean,
+        arg_types: vec![TableDataType::String],
+        return_type: TableDataType::Boolean,
         immutable: None,
     }
 }

--- a/src/meta/proto-conv/tests/it/v058_udf.rs
+++ b/src/meta/proto-conv/tests/it/v058_udf.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDFServer;

--- a/src/meta/proto-conv/tests/it/v079_udf_created_on.rs
+++ b/src/meta/proto-conv/tests/it/v079_udf_created_on.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::LambdaUDF;
 use databend_common_meta_app::principal::UDFDefinition;

--- a/src/meta/proto-conv/tests/it/v081_udf_script.rs
+++ b/src/meta/proto-conv/tests/it/v081_udf_script.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::LambdaUDF;
 use databend_common_meta_app::principal::UDFDefinition;

--- a/src/meta/proto-conv/tests/it/v115_add_udaf_script.rs
+++ b/src/meta/proto-conv/tests/it/v115_add_udaf_script.rs
@@ -14,8 +14,8 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::DataField;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
+use databend_common_expression::TableField as DataField;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::UDAFScript;
 use databend_common_meta_app::principal::UDFDefinition;

--- a/src/meta/proto-conv/tests/it/v124_udf_server_headers.rs
+++ b/src/meta/proto-conv/tests/it/v124_udf_server_headers.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_meta_app::principal::UDFServer;
 use fastrace::func_name;
 

--- a/src/meta/proto-conv/tests/it/v130_udf_imports_packages.rs
+++ b/src/meta/proto-conv/tests/it/v130_udf_imports_packages.rs
@@ -14,7 +14,7 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDFScript;

--- a/src/meta/proto-conv/tests/it/v135_udf_immutable.rs
+++ b/src/meta/proto-conv/tests/it/v135_udf_immutable.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDFScript;

--- a/src/meta/proto-conv/tests/it/v143_udtf.rs
+++ b/src/meta/proto-conv/tests/it/v143_udtf.rs
@@ -14,7 +14,7 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDTF;
 use databend_common_meta_app::principal::UserDefinedFunction;

--- a/src/meta/proto-conv/tests/it/v144_scalar_udf.rs
+++ b/src/meta/proto-conv/tests/it/v144_scalar_udf.rs
@@ -14,7 +14,7 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_meta_app::principal::ScalarUDF;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UserDefinedFunction;

--- a/src/meta/proto-conv/tests/it/v152_external_udf.rs
+++ b/src/meta/proto-conv/tests/it/v152_external_udf.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_expression::TableDataType;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDFServer;
 use databend_common_meta_app::principal::UserDefinedFunction;

--- a/src/meta/proto-conv/tests/it/v158_udtf_server.rs
+++ b/src/meta/proto-conv/tests/it/v158_udtf_server.rs
@@ -14,7 +14,7 @@
 
 use chrono::DateTime;
 use chrono::Utc;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::UDFDefinition;
 use databend_common_meta_app::principal::UDTFServer;

--- a/src/query/management/tests/it/udf.rs
+++ b/src/query/management/tests/it/udf.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use databend_common_exception::ErrorCode;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_management::udf::UdfMgr;
 use databend_common_management::*;

--- a/src/query/service/src/builtin/builtin_udfs.rs
+++ b/src/query/service/src/builtin/builtin_udfs.rs
@@ -24,7 +24,6 @@ use databend_common_ast::parser::tokenize_sql;
 use databend_common_config::UDFConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::types::DataType;
 use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_sql::NameResolutionContext;
 use databend_common_sql::normalize_identifier;
@@ -66,8 +65,7 @@ impl BuiltinUDFs {
                                         "StageLocation must have a corresponding variable name",
                                     ));
                                 }
-                                arg_datatypes
-                                    .push(DataType::from(&resolve_type_name_udf(arg_type)?));
+                                arg_datatypes.push(resolve_type_name_udf(arg_type)?);
                             }
                         }
                         UDFArgs::NameWithTypes(name_with_types) => {
@@ -79,12 +77,11 @@ impl BuiltinUDFs {
                                     )
                                     .name,
                                 );
-                                arg_datatypes
-                                    .push(DataType::from(&resolve_type_name_udf(arg_type)?));
+                                arg_datatypes.push(resolve_type_name_udf(arg_type)?);
                             }
                         }
                     }
-                    let return_type = DataType::from(&resolve_type_name_udf(&return_type)?);
+                    let return_type = resolve_type_name_udf(&return_type)?;
                     let udf = UserDefinedFunction::create_udf_server(
                         name,
                         &address,

--- a/src/query/service/src/table_functions/udf_table.rs
+++ b/src/query/service/src/table_functions/udf_table.rs
@@ -25,11 +25,11 @@ use databend_common_catalog::table_args::TableArgs;
 use databend_common_catalog::table_function::TableFunction;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRefExt;
 use databend_common_expression::cast_scalar;
-use databend_common_expression::infer_schema_type;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::principal::StageType;
@@ -78,7 +78,7 @@ impl UDTFTable {
             .zip(udtf.arg_types.iter())
             .enumerate()
         {
-            if dest_type.remove_nullable() == DataType::StageLocation {
+            if dest_type.remove_nullable() == TableDataType::StageLocation {
                 let Some(location) = argument.as_string() else {
                     return Err(ErrorCode::SemanticError(format!(
                         "invalid parameter {argument} for udf function, expected constant string",
@@ -137,6 +137,7 @@ impl UDTFTable {
             .cloned()
             .zip(udtf.arg_types)
             .map(|(scalar, ty)| {
+                let ty = DataType::from(&ty);
                 cast_scalar(Span::None, scalar, &ty, &BUILTIN_FUNCTIONS).map(|scalar| (scalar, ty))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -146,7 +147,10 @@ impl UDTFTable {
                 name: table_func_name.to_string(),
                 func_name: udtf.handler,
                 return_ty: DataType::Tuple(
-                    udtf.return_types.into_iter().map(|(_, ty)| ty).collect(),
+                    udtf.return_types
+                        .into_iter()
+                        .map(|(_, ty)| DataType::from(&ty))
+                        .collect(),
                 ),
                 args,
                 headers: udtf.headers,
@@ -160,8 +164,8 @@ impl UDTFTable {
         let fields = udtf
             .return_types
             .iter()
-            .map(|(name, ty)| infer_schema_type(ty).map(|ty| TableField::new(name.as_str(), ty)))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|(name, ty)| TableField::new(name.as_str(), ty.clone()))
+            .collect::<Vec<_>>();
 
         Ok(TableSchemaRefExt::create(fields))
     }

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_table_function.rs
@@ -34,6 +34,7 @@ use databend_common_exception::Result;
 use databend_common_expression::FunctionKind;
 use databend_common_expression::Scalar;
 use databend_common_expression::display::scalar_ref_to_string;
+use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::principal::UDFDefinition;
@@ -212,6 +213,7 @@ impl Binder {
                         .into_iter()
                         .zip(bind_context.columns.iter())
                     {
+                        let return_type = DataType::from(&return_type);
                         let input_expr = ScalarExpr::BoundColumnRef(BoundColumnRef {
                             span: None,
                             column: output_binding.clone(),

--- a/src/query/sql/src/planner/binder/udf.rs
+++ b/src/query/sql/src/planner/binder/udf.rs
@@ -24,7 +24,8 @@ use databend_common_ast::ast::UDFArgs;
 use databend_common_ast::ast::UDFDefinition;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::DataField;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
 use databend_common_expression::types::DataType;
 use databend_common_expression::udf_client::UDFFlightClient;
 use databend_common_functions::is_builtin_function;
@@ -51,6 +52,14 @@ use crate::plans::CreateUDFPlan;
 use crate::plans::DropUDFPlan;
 use crate::plans::Plan;
 use crate::plans::UDFLanguage;
+
+fn table_type_to_data_type(ty: &TableDataType) -> DataType {
+    DataType::from(ty)
+}
+
+fn table_types_to_data_types(tys: &[TableDataType]) -> Vec<DataType> {
+    tys.iter().map(table_type_to_data_type).collect()
+}
 
 impl Binder {
     pub(in crate::planner::binder) async fn bind_udf_definition(
@@ -104,7 +113,7 @@ impl Binder {
                                     "StageLocation must have a corresponding variable name",
                                 ));
                             }
-                            arg_datatypes.push(DataType::from(&resolve_type_name_udf(arg_type)?));
+                            arg_datatypes.push(resolve_type_name_udf(arg_type)?);
                         }
                     }
                     UDFArgs::NameWithTypes(name_with_types) => {
@@ -112,11 +121,11 @@ impl Binder {
                             arg_names.push(
                                 normalize_identifier(arg_name, &self.name_resolution_ctx).name,
                             );
-                            arg_datatypes.push(DataType::from(&resolve_type_name_udf(arg_type)?));
+                            arg_datatypes.push(resolve_type_name_udf(arg_type)?);
                         }
                     }
                 }
-                let return_type = DataType::from(&resolve_type_name_udf(return_type)?);
+                let return_type = resolve_type_name_udf(return_type)?;
 
                 let connect_timeout = self
                     .ctx
@@ -146,8 +155,10 @@ impl Binder {
                         .with_handler_name(handler)?
                         .with_query_id(&self.ctx.get_id())?
                         .with_headers(headers.iter())?;
+                let schema_arg_types = table_types_to_data_types(&arg_datatypes);
+                let schema_return_type = table_type_to_data_type(&return_type);
                 client
-                    .check_schema(handler, &arg_datatypes, &return_type)
+                    .check_schema(handler, &schema_arg_types, &schema_return_type)
                     .await?;
 
                 Ok(UserDefinedFunction {
@@ -240,7 +251,7 @@ impl Binder {
                     .iter()
                     .map(|(name, arg_type)| {
                         let column = normalize_identifier(name, &self.name_resolution_ctx).name;
-                        let ty = DataType::from(&resolve_type_name_udf(arg_type)?);
+                        let ty = resolve_type_name_udf(arg_type)?;
                         Ok((column, ty))
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -249,7 +260,7 @@ impl Binder {
                     .iter()
                     .map(|(name, arg_type)| {
                         let column = normalize_identifier(name, &self.name_resolution_ctx).name;
-                        let ty = DataType::from(&resolve_type_name_udf(arg_type)?);
+                        let ty = resolve_type_name_udf(arg_type)?;
                         Ok((column, ty))
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -282,14 +293,14 @@ impl Binder {
 
                 for (arg_name, arg_type) in arg_types {
                     arg_names.push(normalize_identifier(arg_name, &self.name_resolution_ctx).name);
-                    arg_datatypes.push(DataType::from(&resolve_type_name_udf(arg_type)?));
+                    arg_datatypes.push(resolve_type_name_udf(arg_type)?);
                 }
 
                 let return_types = return_types
                     .iter()
                     .map(|(name, arg_type)| {
                         let column = normalize_identifier(name, &self.name_resolution_ctx).name;
-                        let ty = DataType::from(&resolve_type_name_udf(arg_type)?);
+                        let ty = resolve_type_name_udf(arg_type)?;
                         Ok((column, ty))
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -320,11 +331,11 @@ impl Binder {
                     .iter()
                     .map(|(name, arg_type)| {
                         let column = normalize_identifier(name, &self.name_resolution_ctx).name;
-                        let ty = DataType::from(&resolve_type_name_udf(arg_type)?);
+                        let ty = resolve_type_name_udf(arg_type)?;
                         Ok((column, ty))
                     })
                     .collect::<Result<Vec<_>>>()?;
-                let return_type = DataType::from(&resolve_type_name_udf(return_type)?);
+                let return_type = resolve_type_name_udf(return_type)?;
 
                 Ok(UserDefinedFunction {
                     name,
@@ -441,10 +452,10 @@ fn create_udf_definition_script(
 
     let arg_types = arg_types
         .types_iter()
-        .map(|arg_type| Ok(DataType::from(&resolve_type_name_udf(arg_type)?)))
+        .map(resolve_type_name_udf)
         .collect::<Result<Vec<_>>>()?;
 
-    let return_type = DataType::from(&resolve_type_name_udf(return_type)?);
+    let return_type = resolve_type_name_udf(return_type)?;
 
     let mut runtime_version = runtime_version.to_string();
     if runtime_version.is_empty() && language == UDFLanguage::Python {
@@ -456,9 +467,9 @@ fn create_udf_definition_script(
             let state_fields = fields
                 .iter()
                 .map(|field| {
-                    Ok(DataField::new(
+                    Ok(TableField::new(
                         &field.name.name,
-                        DataType::from(&resolve_type_name_udf(&field.type_name)?),
+                        resolve_type_name_udf(&field.type_name)?,
                     ))
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -36,6 +36,7 @@ use databend_common_expression::BlockEntry;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::is_builtin_function;
@@ -124,7 +125,7 @@ impl<'a> CoreExprArena<'a> {
 }
 
 // UDF server expects unsigned types in UINT* form instead of SQL unsigned names.
-fn udf_type_string(data_type: &DataType) -> String {
+fn udf_type_string(data_type: &TableDataType) -> String {
     let sql_name = data_type.sql_name();
     match sql_name.as_str() {
         "TINYINT UNSIGNED" => "UINT8".to_string(),
@@ -133,6 +134,14 @@ fn udf_type_string(data_type: &DataType) -> String {
         "BIGINT UNSIGNED" => "UINT64".to_string(),
         _ => sql_name,
     }
+}
+
+fn table_type_to_data_type(ty: &TableDataType) -> DataType {
+    DataType::from(ty)
+}
+
+fn table_types_to_data_types(tys: &[TableDataType]) -> Vec<DataType> {
+    tys.iter().map(table_type_to_data_type).collect()
 }
 
 fn build_udf_cloud_script(
@@ -533,11 +542,9 @@ impl UdfAdapter for FullTypeCheckAdapter {
             udf_definition
                 .arg_types
                 .iter()
-                .filter(|ty| ty.remove_nullable() != DataType::StageLocation),
+                .filter(|ty| ty.remove_nullable() != TableDataType::StageLocation),
         ) {
-            if matches!(dest_type, DataType::StageLocation) {
-                continue;
-            }
+            let dest_type = table_type_to_data_type(dest_type);
             let entry = BlockEntry::new_const_column(dest_type.clone(), arg, 1);
             block_entries.push(entry);
         }
@@ -547,7 +554,7 @@ impl UdfAdapter for FullTypeCheckAdapter {
         let request_timeout = settings.get_external_server_request_timeout_secs()?;
 
         let handler = udf_definition.handler;
-        let return_type = udf_definition.return_type;
+        let return_type = table_type_to_data_type(&udf_definition.return_type);
         let endpoint = databend_common_expression::udf_client::UDFFlightClient::build_endpoint(
             &udf_definition.address,
             connect_timeout,
@@ -900,14 +907,18 @@ where A: UdfAdapter
             .zip(udf_definition.arg_types.iter())
             .enumerate()
         {
+            let dest_type_no_nullable = dest_type.remove_nullable();
+            let is_stage_location = dest_type_no_nullable == TableDataType::StageLocation;
+            let dest_type_data = table_type_to_data_type(dest_type);
+            let dest_type_no_nullable_data = table_type_to_data_type(&dest_type_no_nullable);
+
             // TODO: support cast constant
             if !matches!(argument.scalar, ScalarExpr::ConstantExpr(_))
-                || (argument.data_type != dest_type.remove_nullable()
-                    && dest_type.remove_nullable() != DataType::StageLocation)
+                || (argument.data_type != dest_type_no_nullable_data && !is_stage_location)
             {
                 all_args_const = false;
             }
-            if dest_type.remove_nullable() == DataType::StageLocation {
+            if is_stage_location {
                 if udf_definition.arg_names.is_empty() {
                     return Err(ErrorCode::InvalidArgument(
                         "StageLocation must have a corresponding variable name",
@@ -952,8 +963,8 @@ where A: UdfAdapter
                 });
                 continue;
             }
-            if argument.data_type != *dest_type {
-                args.push(wrap_cast(&argument.scalar, dest_type));
+            if argument.data_type != dest_type_data {
+                args.push(wrap_cast(&argument.scalar, &dest_type_data));
             } else {
                 args.push(argument.scalar.clone());
             }
@@ -983,9 +994,10 @@ where A: UdfAdapter
                 arg_scalars,
                 udf_definition.clone(),
             )?;
+            let return_type = table_type_to_data_type(&udf_definition.return_type);
             return Ok(UdfResolveResult::Expr(Box::new((
                 ConstantExpr { span, value }.into(),
-                udf_definition.return_type.clone(),
+                return_type,
             ))));
         }
 
@@ -994,6 +1006,8 @@ where A: UdfAdapter
             .map(|arg| arg.display_name.as_str())
             .join(", ");
         let display_name = format!("{}({})", udf_definition.handler, arg_names);
+        let arg_types = table_types_to_data_types(&udf_definition.arg_types);
+        let return_type = table_type_to_data_type(&udf_definition.return_type);
 
         Ok(UdfResolveResult::RuntimeServerExpr(Box::new((
             UDFCall {
@@ -1003,12 +1017,12 @@ where A: UdfAdapter
                 headers: udf_definition.headers,
                 display_name,
                 udf_type: UDFType::Server(udf_definition.address.clone()),
-                arg_types: udf_definition.arg_types,
-                return_type: Box::new(udf_definition.return_type.clone()),
+                arg_types,
+                return_type: Box::new(return_type.clone()),
                 arguments: args,
             }
             .into(),
-            udf_definition.return_type.clone(),
+            return_type,
         ))))
     }
 
@@ -1044,8 +1058,9 @@ where A: UdfAdapter
         } = udf_definition;
         let mut scalar_arguments = Vec::with_capacity(arguments.len());
         for (argument, dest_type) in arguments.iter().zip(arg_types.iter()) {
-            if argument.data_type != *dest_type {
-                scalar_arguments.push(wrap_cast(&argument.scalar, dest_type));
+            let dest_type = table_type_to_data_type(dest_type);
+            if argument.data_type != dest_type {
+                scalar_arguments.push(wrap_cast(&argument.scalar, &dest_type));
             } else {
                 scalar_arguments.push(argument.scalar.clone());
             }
@@ -1068,6 +1083,8 @@ where A: UdfAdapter
             .map(|arg| arg.display_name.as_str())
             .join(", ");
         let display_name = format!("{}({})", &handler, arg_names);
+        let arg_types = table_types_to_data_types(&arg_types);
+        let return_type = table_type_to_data_type(&return_type);
 
         Ok(UdfResolveResult::RuntimeScriptExpr(Box::new((
             UDFCall {
@@ -1120,10 +1137,11 @@ where A: UdfAdapter
             .iter()
             .zip(arg_types.iter())
             .map(|(argument, dest_type)| {
-                Ok(if argument.data_type == *dest_type {
+                let dest_type = table_type_to_data_type(dest_type);
+                Ok(if argument.data_type == dest_type {
                     argument.scalar.clone()
                 } else {
-                    wrap_cast(&argument.scalar, dest_type)
+                    wrap_cast(&argument.scalar, &dest_type)
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1132,6 +1150,8 @@ where A: UdfAdapter
             "{name}({})",
             args.iter().map(|arg| arg.display_name.as_str()).join(", ")
         );
+        let arg_types = table_types_to_data_types(&arg_types);
+        let return_type = table_type_to_data_type(&return_type);
 
         Ok(UdfResolveResult::RuntimeScriptExpr(Box::new((
             UDAFCall {
@@ -1143,7 +1163,7 @@ where A: UdfAdapter
                     .iter()
                     .map(|f| UDFField {
                         name: f.name().to_string(),
-                        data_type: f.data_type().clone(),
+                        data_type: table_type_to_data_type(f.data_type()),
                     })
                     .collect(),
                 return_type: Box::new(return_type.clone()),
@@ -1209,19 +1229,20 @@ where A: UdfAdapter
         }
         let mut parameters = Vec::with_capacity(arg_types.len());
         for ((arg_name, dest_type), argument) in arg_types.iter().zip(arguments.iter()) {
-            let arg = if argument.data_type != *dest_type {
-                wrap_cast(&argument.scalar, dest_type)
+            let dest_type = table_type_to_data_type(dest_type);
+            let arg = if argument.data_type != dest_type {
+                wrap_cast(&argument.scalar, &dest_type)
             } else {
                 argument.scalar.clone()
             };
-            parameters.push((arg_name.clone(), dest_type.clone(), arg));
+            parameters.push((arg_name.clone(), dest_type, arg));
         }
         Ok(UdfResolveResult::ScalarDefinition {
             span,
             func_name,
             definition: udf_definition.definition,
             parameters,
-            return_type: udf_definition.return_type,
+            return_type: table_type_to_data_type(&udf_definition.return_type),
         })
     }
 }

--- a/src/query/sql/src/planner/semantic/udf_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/udf_rewriter.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use databend_common_ast::ast::Expr;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::TableDataType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::convert_to_type_name;
 use derive_visitor::VisitorMut as StatementVisitorMut;
@@ -253,12 +254,12 @@ impl<'a> VisitorMut<'a> for UdfRewriter {
 #[derive(StatementVisitorMut)]
 #[visitor(Expr(exit))]
 pub struct UDFArgVisitor<'a> {
-    arg_types: &'a [(String, DataType)],
+    arg_types: &'a [(String, TableDataType)],
     args: &'a [Expr],
 }
 
 impl<'a> UDFArgVisitor<'a> {
-    pub fn new(arg_types: &'a [(String, DataType)], args: &'a [Expr]) -> Self {
+    pub fn new(arg_types: &'a [(String, TableDataType)], args: &'a [Expr]) -> Self {
         Self { arg_types, args }
     }
 
@@ -279,7 +280,7 @@ impl<'a> UDFArgVisitor<'a> {
             *expr = Expr::Cast {
                 span: *span,
                 expr: Box::new(self.args[pos].clone()),
-                target_type: convert_to_type_name(ty),
+                target_type: convert_to_type_name(&DataType::from(ty)),
                 pg_style: false,
             }
         }

--- a/src/query/sql/tests/it/semantic/type_check/udf.rs
+++ b/src/query/sql/tests/it/semantic/type_check/udf.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
-use databend_common_expression::DataField;
+use databend_common_expression::TableDataType as DataType;
+use databend_common_expression::TableField as DataField;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::ScalarUDF;
 use databend_common_meta_app::principal::UDAFScript;

--- a/src/query/users/tests/it/user_udf.rs
+++ b/src/query/users/tests/it/user_udf.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use databend_common_config::GlobalConfig;
 use databend_common_config::InnerConfig;
-use databend_common_expression::types::DataType;
+use databend_common_expression::TableDataType as DataType;
 use databend_common_meta_app::principal::UserDefinedFunction;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::tenant::Tenant;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: udf: store UDF metadata as table types
# Summary

Store persisted UDF signatures as table-schema types instead of expression types, so metadata cannot represent internal expression-only placeholders such as generic type variables.

# Details

- UDF metadata structs now carry concrete `TableDataType` and `TableField` values, while query planning converts them to `DataType` at validation, casting, and runtime UDF boundaries.
- Protobuf conversion now encodes UDF table types directly, preserving the existing wire format and old-version compatibility tests.
- UDF tests and built-in UDF setup now construct persisted signatures with table-schema types.


##### refactor: meta: simplify MetaTxn record handling
# Summary

Make MetaTxn use one cloneable transaction handle and model fetched records directly so callers can assert presence, absence, and staged writes through the same typed wrapper.

# Details

Remove the separate commit handle and let the manager retain a cloned MetaTxn for commit execution while transaction-building closures receive the same staging API.

Return FetchedRecord from both read paths, consume owned keys when a fetched record needs to retain its target, and rename the helper methods to describe their assertions and staged-write behavior clearly.

Update the refactored dictionary and table-tag flows plus transaction tests to use the new fetched-record API.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20034)
<!-- Reviewable:end -->
