### PR TITLE
refactor: meta: remove file format encode sentinels

### DIFF
--- a/src/meta/api/src/kv/pb_api/compress.rs
+++ b/src/meta/api/src/kv/pb_api/compress.rs
@@ -78,9 +78,7 @@ impl Encoder {
     /// Encode a `FromToProto` value to protobuf bytes, with optional zstd compression.
     pub fn encode_pb<T: FromToProto>(&self, value: &T) -> Result<Vec<u8>, PbEncodeError> {
         let p = value.to_pb()?;
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
-        Ok(self.encode_value(buf))
+        Ok(self.encode_value(prost::Message::encode_to_vec(&p)))
     }
 
     /// Optionally compress `buf` with zstd.

--- a/src/meta/api/src/kv/pb_api/errors/encode_error.rs
+++ b/src/meta/api/src/kv/pb_api/errors/encode_error.rs
@@ -21,24 +21,19 @@ use databend_meta_client::types::MetaNetworkError;
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
 #[error("PbEncodeError: {0}")]
 pub enum PbEncodeError {
-    EncodeError(#[from] prost::EncodeError),
     Incompatible(#[from] Incompatible),
 }
 
 impl From<PbEncodeError> for MetaError {
     fn from(value: PbEncodeError) -> Self {
-        match value {
-            PbEncodeError::EncodeError(e) => MetaError::from(InvalidArgument::new(e, "")),
-            PbEncodeError::Incompatible(e) => MetaError::from(InvalidArgument::new(e, "")),
-        }
+        let PbEncodeError::Incompatible(e) = value;
+        MetaError::from(InvalidArgument::new(e, ""))
     }
 }
 
 impl From<PbEncodeError> for MetaNetworkError {
     fn from(value: PbEncodeError) -> Self {
-        match value {
-            PbEncodeError::EncodeError(e) => MetaNetworkError::from(InvalidArgument::new(e, "")),
-            PbEncodeError::Incompatible(e) => MetaNetworkError::from(InvalidArgument::new(e, "")),
-        }
+        let PbEncodeError::Incompatible(e) = value;
+        MetaNetworkError::from(InvalidArgument::new(e, ""))
     }
 }

--- a/src/meta/app/src/data_id.rs
+++ b/src/meta/app/src/data_id.rs
@@ -227,8 +227,7 @@ mod prost_message_impl {
                 v = v.wrapping_mul(7);
 
                 let id = DataId::<Resource>::new(v);
-                let mut buf = Vec::new();
-                prost::Message::encode(&id, &mut buf).unwrap();
+                let buf = prost::Message::encode_to_vec(&id);
                 let expected = format!("{}", v);
                 assert_eq!(buf, expected.as_bytes());
 

--- a/src/meta/app/src/principal/file_format.rs
+++ b/src/meta/app/src/principal/file_format.rs
@@ -393,11 +393,6 @@ impl FileFormatParams {
                     output_header,
                 })
             }
-            _ => {
-                return Err(ErrorCode::IllegalFileFormat(format!(
-                    "Unsupported file format {typ:?}"
-                )));
-            }
         };
         if old {
             Ok(params)

--- a/src/meta/app/src/principal/user_stage.rs
+++ b/src/meta/app/src/principal/user_stage.rs
@@ -178,7 +178,6 @@ pub enum StageFileFormatType {
     Arrow,
     ArrowStream,
     Xml,
-    None,
 }
 
 impl Default for StageFileFormatType {
@@ -223,7 +222,6 @@ impl Display for StageFileFormatType {
             StageFileFormatType::Arrow => write!(f, "ARROW"),
             StageFileFormatType::ArrowStream => write!(f, "ARROW_STREAM"),
             StageFileFormatType::Xml => write!(f, "XML"),
-            StageFileFormatType::None => write!(f, "NONE"),
         }
     }
 }
@@ -262,30 +260,10 @@ impl Default for FileFormatOptions {
 }
 
 impl FileFormatOptions {
-    pub fn new() -> Self {
-        Self {
-            format: StageFileFormatType::None,
-            field_delimiter: "".to_string(),
-            record_delimiter: "".to_string(),
-            nan_display: "".to_string(),
-            skip_header: 0,
-            escape: "".to_string(),
-            compression: StageFileCompression::None,
-            row_tag: "".to_string(),
-            quote: "".to_string(),
-            name: None,
-        }
-    }
-
     pub fn from_map(opts: &BTreeMap<String, String>) -> Result<Self> {
-        let mut file_format_options = Self::new();
-        file_format_options.apply(opts, false)?;
-        if file_format_options.format == StageFileFormatType::None {
-            return Err(ErrorCode::SyntaxException(
-                "File format type must be specified",
-            ));
-        }
-        Ok(file_format_options)
+        let mut builder = FileFormatOptionsBuilder::default();
+        builder.apply(opts)?;
+        builder.build()
     }
 
     pub fn to_map(&self) -> BTreeMap<String, String> {
@@ -325,8 +303,41 @@ impl FileFormatOptions {
         }
         options
     }
+}
 
-    pub fn apply(&mut self, opts: &BTreeMap<String, String>, ignore_unknown: bool) -> Result<()> {
+#[derive(Default)]
+struct FileFormatOptionsBuilder {
+    format: Option<StageFileFormatType>,
+    skip_header: Option<u64>,
+    field_delimiter: Option<String>,
+    record_delimiter: Option<String>,
+    nan_display: Option<String>,
+    escape: Option<String>,
+    compression: Option<StageFileCompression>,
+    row_tag: Option<String>,
+    quote: Option<String>,
+    name: Option<String>,
+}
+
+impl FileFormatOptionsBuilder {
+    fn build(self) -> Result<FileFormatOptions> {
+        Ok(FileFormatOptions {
+            format: self
+                .format
+                .ok_or_else(|| ErrorCode::SyntaxException("File format type must be specified"))?,
+            skip_header: self.skip_header.unwrap_or_default(),
+            field_delimiter: self.field_delimiter.unwrap_or_default(),
+            record_delimiter: self.record_delimiter.unwrap_or_default(),
+            nan_display: self.nan_display.unwrap_or_default(),
+            escape: self.escape.unwrap_or_default(),
+            compression: self.compression.unwrap_or_default(),
+            row_tag: self.row_tag.unwrap_or_default(),
+            quote: self.quote.unwrap_or_default(),
+            name: self.name,
+        })
+    }
+
+    fn apply(&mut self, opts: &BTreeMap<String, String>) -> Result<()> {
         if opts.is_empty() {
             return Ok(());
         }
@@ -334,29 +345,28 @@ impl FileFormatOptions {
             match k.as_str() {
                 "format" | "type" => {
                     let format = StageFileFormatType::from_str(v)?;
-                    self.format = format;
+                    self.format = Some(format);
                 }
                 "skip_header" => {
                     let skip_header = u64::from_str(v)?;
-                    self.skip_header = skip_header;
+                    self.skip_header = Some(skip_header);
                 }
-                "field_delimiter" => self.field_delimiter = v.clone(),
-                "record_delimiter" => self.record_delimiter = v.clone(),
-                "nan_display" => self.nan_display = v.clone(),
-                "escape" => self.escape = v.clone(),
+                "field_delimiter" => self.field_delimiter = Some(v.clone()),
+                "record_delimiter" => self.record_delimiter = Some(v.clone()),
+                "nan_display" => self.nan_display = Some(v.clone()),
+                "escape" => self.escape = Some(v.clone()),
                 "compression" => {
                     let compression = StageFileCompression::from_str(v)?;
-                    self.compression = compression;
+                    self.compression = Some(compression);
                 }
-                "row_tag" => self.row_tag = v.clone(),
-                "quote" => self.quote = v.clone(),
+                "row_tag" => self.row_tag = Some(v.clone()),
+                "quote" => self.quote = Some(v.clone()),
+                "name" => self.name = Some(v.clone()),
                 _ => {
-                    if !ignore_unknown {
-                        return Err(ErrorCode::BadArguments(format!(
-                            "Unknown stage file format option {}",
-                            k
-                        )));
-                    }
+                    return Err(ErrorCode::BadArguments(format!(
+                        "Unknown stage file format option {}",
+                        k
+                    )));
                 }
             }
         }

--- a/src/meta/app/src/value_id.rs
+++ b/src/meta/app/src/value_id.rs
@@ -161,8 +161,7 @@ mod tests {
 
     fn assert_pb_round_trip(value: u64) {
         let id = ValueId::<Resource>::new(value);
-        let mut buf = Vec::new();
-        prost::Message::encode(&id, &mut buf).unwrap();
+        let buf = prost::Message::encode_to_vec(&id);
 
         let expected = value.to_string();
         assert_eq!(buf, expected.as_bytes());

--- a/src/meta/control/src/dump_raft_log_wal.rs
+++ b/src/meta/control/src/dump_raft_log_wal.rs
@@ -158,8 +158,7 @@ mod tests {
             gc_in_progress: false,
         };
         let pb = meta.to_pb()?;
-        let mut pb_buf = vec![];
-        pb.encode(&mut pb_buf)?;
+        let pb_buf = pb.encode_to_vec();
 
         let cmd = Cmd::UpsertKV(UpsertKV::update("__fd_database_by_id/123", &pb_buf));
         let log_entry = LogEntry::new(cmd);
@@ -210,8 +209,7 @@ mod tests {
             gc_in_progress: false,
         };
         let pb = meta.to_pb()?;
-        let mut pb_buf = vec![];
-        pb.encode(&mut pb_buf)?;
+        let pb_buf = pb.encode_to_vec();
 
         let raw_bytes_str = format!(
             "[{}]",

--- a/src/meta/proto-conv/src/impls/file_format.rs
+++ b/src/meta/proto-conv/src/impls/file_format.rs
@@ -69,9 +69,6 @@ impl FromToProtoEnum for mt::principal::StageFileFormatType {
             mt::principal::StageFileFormatType::ArrowStream => {
                 Ok(pb::StageFileFormatType::ArrowStream)
             }
-            mt::principal::StageFileFormatType::None => Err(Incompatible::new(
-                "StageFileFormatType::None cannot be converted to protobuf".to_string(),
-            )),
         }
     }
 }

--- a/src/meta/proto-conv/src/impls/id.rs
+++ b/src/meta/proto-conv/src/impls/id.rs
@@ -127,8 +127,7 @@ mod tests {
     fn assert_json_u64_round_trip<T>(value: T, id: u64)
     where T: FromToProto + Debug + PartialEq {
         let pb = value.to_pb().unwrap();
-        let mut buf = Vec::new();
-        pb.encode(&mut buf).unwrap();
+        let buf = pb.encode_to_vec();
 
         assert_eq!(buf, id.to_string().as_bytes());
 

--- a/src/meta/proto-conv/src/impls/stage.rs
+++ b/src/meta/proto-conv/src/impls/stage.rs
@@ -128,10 +128,10 @@ impl FromToProto for mt::principal::CopyOptions {
 
     fn to_pb(&self) -> Result<pb::stage_info::CopyOptions, Incompatible> {
         let on_error = mt::principal::OnErrorMode::to_pb(&self.on_error)?;
-        let size_limit: u64 = convert_field(self.size_limit, "CopyOptions.size_limit")?;
-        let max_files: u64 = convert_field(self.max_files, "CopyOptions.max_files")?;
-        let split_size: u64 = convert_field(self.split_size, "CopyOptions.split_size")?;
-        let max_file_size: u64 = convert_field(self.max_file_size, "CopyOptions.max_file_size")?;
+        let size_limit = self.size_limit as u64;
+        let max_files = self.max_files as u64;
+        let split_size = self.split_size as u64;
+        let max_file_size = self.max_file_size as u64;
         Ok(pb::stage_info::CopyOptions {
             on_error: Some(on_error),
             size_limit,

--- a/src/meta/proto-conv/tests/it/common.rs
+++ b/src/meta/proto-conv/tests/it/common.rs
@@ -28,8 +28,7 @@ where MT: FromToProto + PartialEq + Debug {
 
     let n = std::any::type_name::<MT>();
 
-    let mut buf = vec![];
-    prost::Message::encode(&p, &mut buf)?;
+    let buf = prost::Message::encode_to_vec(&p);
 
     let var_name = n.split("::").last().unwrap();
     // The encoded data should be saved for compatibility test.

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -401,8 +401,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let db_meta = new_db_meta_share();
         let p = db_meta.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("db from share:{:?}", buf);
     }
 
@@ -411,8 +410,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let db_meta = new_db_meta();
         let p = db_meta.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("db:{:?}", buf);
     }
 
@@ -422,8 +420,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
 
         let p = tbl.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("table:{:?}", buf);
     }
 
@@ -432,8 +429,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let index = new_index_meta();
         let p = index.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("index meta:{buf:?}");
     }
 
@@ -442,8 +438,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let copied_file = new_table_copied_file_info_v6();
         let p = copied_file.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("copied_file:{:?}", buf);
     }
 
@@ -452,18 +447,14 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let empty_proto = new_empty_proto();
         let p = empty_proto.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("empty_proto:{:?}", buf);
     }
 
     // LockMeta
     {
         let table_lock_meta = new_lock_meta();
-        let p = table_lock_meta.to_pb()?;
-
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        table_lock_meta.to_pb()?;
     }
 
     // schema
@@ -471,8 +462,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let schema = new_latest_schema();
         let p = schema.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("schema:{:?}", buf);
     }
 
@@ -481,8 +471,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let data_mask_meta = new_data_mask_meta();
         let p = data_mask_meta.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("data mask:{:?}", buf);
     }
 
@@ -491,8 +480,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let table_statistics = new_table_statistics();
         let p = table_statistics.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("table statistics:{:?}", buf);
     }
 
@@ -501,8 +489,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let catalog_meta = new_catalog_meta();
         let p = catalog_meta.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("catalog catalog_meta:{:?}", buf);
     }
 
@@ -511,8 +498,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let lvt = new_lvt();
         let p = lvt.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("lvt:{:?}", buf);
     }
 
@@ -521,8 +507,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let sequence_meta = new_sequence_meta();
         let p = sequence_meta.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("sequence:{:?}", buf);
     }
 
@@ -531,8 +516,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let virtual_data_schema = new_virtual_data_schema();
         let p = virtual_data_schema.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("virtual data schema:{:?}", buf);
     }
 
@@ -541,8 +525,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let udf_server = new_udf_server();
         let p = udf_server.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("udf server:{:?}", buf);
     }
 
@@ -551,8 +534,7 @@ fn test_build_pb_buf() -> anyhow::Result<()> {
         let table_index = new_table_index();
         let p = table_index.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("table index:{:?}", buf);
     }
 

--- a/src/meta/proto-conv/tests/it/user_proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/user_proto_conv.rs
@@ -613,8 +613,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
         let user_info = test_user_info();
         let p = user_info.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("user_info: {:?}", buf);
     }
 
@@ -622,8 +621,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
     {
         let stage_file = test_stage_file();
         let p = stage_file.to_pb()?;
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("stage_file: {:?}", buf);
     }
 
@@ -633,8 +631,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
 
         let p = fs_stage_info.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("fs_stage_info: {:?}", buf);
     }
 
@@ -644,8 +641,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
 
         let p = s3_stage_info.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("s3_stage_info: {:?}", buf);
     }
 
@@ -655,8 +651,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
 
         let p = s3_stage_info.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("s3_stage_info_v16: {:?}", buf);
     }
 
@@ -666,8 +661,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
 
         let p = s3_stage_info.to_pb()?;
 
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("s3_stage_info_v14: {:?}", buf);
     }
 
@@ -675,8 +669,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
     {
         let gcs_stage_info = test_gcs_stage_info();
         let p = gcs_stage_info.to_pb()?;
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("gcs_stage_info: {:?}", buf);
     }
 
@@ -684,8 +677,7 @@ fn test_build_user_pb_buf() -> anyhow::Result<()> {
     {
         let oss_stage_info = test_oss_stage_info();
         let p = oss_stage_info.to_pb()?;
-        let mut buf = vec![];
-        prost::Message::encode(&p, &mut buf)?;
+        let buf = prost::Message::encode_to_vec(&p);
         println!("oss_stage_info: {:?}", buf);
     }
 

--- a/src/query/management/src/serde/pb_serde.rs
+++ b/src/query/management/src/serde/pb_serde.rs
@@ -42,9 +42,7 @@ where
     CtxFn: FnOnce() -> D + Copy,
 {
     let p = value.to_pb().map_err_to_code(err_code_fn, context_fn)?;
-    let mut buf = vec![];
-    prost::Message::encode(&p, &mut buf).map_err_to_code(err_code_fn, context_fn)?;
-    Ok(buf)
+    Ok(prost::Message::encode_to_vec(&p))
 }
 
 pub fn deserialize_struct<T, ErrFn, CtxFn, D>(


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: remove file format encode sentinels
# Summary

Remove invalid intermediate states from file-format metadata so protobuf encoding no longer needs to report errors for values that should not exist in finalized metadata.

# Details

File-format parsing now uses an option-backed builder to represent missing input while keeping `StageFileFormatType` limited to real formats. The builder validates that the format is provided before constructing `FileFormatOptions`.

The protobuf enum conversion no longer has to reject `StageFileFormatType::None`, and the exhaustive file-format match no longer needs an unreachable fallback.

Copy option limits now encode `usize` values directly as `u64`, leaving checked conversion only on the decode path where truncation can happen on narrower targets.


##### refactor: meta: use prost encode_to_vec
# Summary

Switch protobuf serialization call sites to `encode_to_vec()`, which avoids manual buffer allocation and makes prost encode failures impossible in these paths.

# Details

- Keep encode errors scoped to `FromToProto` incompatibility by removing the dead `prost::EncodeError` variant from `PbEncodeError`.
- Update compatibility buffer builders and ID serialization checks to use direct vector encoding while preserving the generated bytes.
- Verified with targeted `cargo check --tests` for the affected meta and management crates.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20035)
<!-- Reviewable:end -->
