### PR TITLE
feat(stage): support metadata$file_path, file_basename, file_content_key, file_last_modified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "async-backtrace",
  "async-trait",
  "bstr",
+ "chrono",
  "csv-core",
  "databend-common-ast",
  "databend-common-base",
@@ -6770,6 +6771,7 @@ name = "databend-storages-common-stage"
 version = "0.1.0"
 dependencies = [
  "arrow-array 58.1.0",
+ "chrono",
  "databend-common-ast",
  "databend-common-catalog",
  "databend-common-exception",

--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -23,6 +23,10 @@ use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnId;
+use databend_common_expression::FILE_BASENAME_COLUMN_ID;
+use databend_common_expression::FILE_CONTENT_KEY_COLUMN_ID;
+use databend_common_expression::FILE_LAST_MODIFIED_COLUMN_ID;
+use databend_common_expression::FILE_PATH_COLUMN_ID;
 use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
 use databend_common_expression::FILENAME_COLUMN_ID;
 use databend_common_expression::FromData;
@@ -153,6 +157,10 @@ pub enum InternalColumnType {
 
     FileName,
     FileRowNumber,
+    FilePath,
+    FileBasename,
+    FileContentKey,
+    FileLastModified,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -188,6 +196,10 @@ impl InternalColumn {
             InternalColumnType::VectorScore => TableDataType::Number(NumberDataType::Float32),
             InternalColumnType::FileName => TableDataType::String,
             InternalColumnType::FileRowNumber => TableDataType::Number(NumberDataType::UInt64),
+            InternalColumnType::FilePath => TableDataType::String,
+            InternalColumnType::FileBasename => TableDataType::String,
+            InternalColumnType::FileContentKey => TableDataType::Nullable(Box::new(TableDataType::String)),
+            InternalColumnType::FileLastModified => TableDataType::Nullable(Box::new(TableDataType::Timestamp)),
         }
     }
 
@@ -213,6 +225,10 @@ impl InternalColumn {
             InternalColumnType::VectorScore => VECTOR_SCORE_COLUMN_ID,
             InternalColumnType::FileName => FILENAME_COLUMN_ID,
             InternalColumnType::FileRowNumber => FILE_ROW_NUMBER_COLUMN_ID,
+            InternalColumnType::FilePath => FILE_PATH_COLUMN_ID,
+            InternalColumnType::FileBasename => FILE_BASENAME_COLUMN_ID,
+            InternalColumnType::FileContentKey => FILE_CONTENT_KEY_COLUMN_ID,
+            InternalColumnType::FileLastModified => FILE_LAST_MODIFIED_COLUMN_ID,
         }
     }
 
@@ -320,7 +336,9 @@ impl InternalColumn {
                 }
                 Float32Type::from_data(scores).into()
             }
-            InternalColumnType::FileName | InternalColumnType::FileRowNumber => {
+            InternalColumnType::FileName | InternalColumnType::FileRowNumber
+            | InternalColumnType::FilePath | InternalColumnType::FileBasename
+            | InternalColumnType::FileContentKey | InternalColumnType::FileLastModified => {
                 todo!("generate_column_values not support for file related")
             }
         }

--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -163,6 +163,14 @@ pub enum InternalColumnType {
     FileLastModified,
 }
 
+/// Extract the file name (last path component) from a stage file path.
+///
+/// Backs the `metadata$file_basename` internal column. Stage paths are
+/// normalized with forward slashes, so splitting on `/` is sufficient.
+pub fn file_basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct InternalColumn {
     pub column_name: String,

--- a/src/query/catalog/src/plan/internal_column.rs
+++ b/src/query/catalog/src/plan/internal_column.rs
@@ -198,8 +198,12 @@ impl InternalColumn {
             InternalColumnType::FileRowNumber => TableDataType::Number(NumberDataType::UInt64),
             InternalColumnType::FilePath => TableDataType::String,
             InternalColumnType::FileBasename => TableDataType::String,
-            InternalColumnType::FileContentKey => TableDataType::Nullable(Box::new(TableDataType::String)),
-            InternalColumnType::FileLastModified => TableDataType::Nullable(Box::new(TableDataType::Timestamp)),
+            InternalColumnType::FileContentKey => {
+                TableDataType::Nullable(Box::new(TableDataType::String))
+            }
+            InternalColumnType::FileLastModified => {
+                TableDataType::Nullable(Box::new(TableDataType::Timestamp))
+            }
         }
     }
 
@@ -336,9 +340,12 @@ impl InternalColumn {
                 }
                 Float32Type::from_data(scores).into()
             }
-            InternalColumnType::FileName | InternalColumnType::FileRowNumber
-            | InternalColumnType::FilePath | InternalColumnType::FileBasename
-            | InternalColumnType::FileContentKey | InternalColumnType::FileLastModified => {
+            InternalColumnType::FileName
+            | InternalColumnType::FileRowNumber
+            | InternalColumnType::FilePath
+            | InternalColumnType::FileBasename
+            | InternalColumnType::FileContentKey
+            | InternalColumnType::FileLastModified => {
                 todo!("generate_column_values not support for file related")
             }
         }

--- a/src/query/expression/src/schema.rs
+++ b/src/query/expression/src/schema.rs
@@ -82,6 +82,10 @@ pub const PREDICATE_COLUMN_NAME: &str = "_predicate";
 
 pub const FILENAME_COLUMN_NAME: &str = "metadata$filename";
 pub const FILE_ROW_NUMBER_COLUMN_NAME: &str = "metadata$file_row_number";
+pub const FILE_PATH_COLUMN_NAME: &str = "metadata$file_path";
+pub const FILE_BASENAME_COLUMN_NAME: &str = "metadata$file_basename";
+pub const FILE_CONTENT_KEY_COLUMN_NAME: &str = "metadata$file_content_key";
+pub const FILE_LAST_MODIFIED_COLUMN_NAME: &str = "metadata$file_last_modified";
 
 // stream column id.
 pub const ORIGIN_BLOCK_ROW_NUM_COLUMN_ID: u32 = u32::MAX - 10;
@@ -90,6 +94,10 @@ pub const ORIGIN_VERSION_COLUMN_ID: u32 = u32::MAX - 12;
 
 pub const FILENAME_COLUMN_ID: u32 = u32::MAX - 14;
 pub const FILE_ROW_NUMBER_COLUMN_ID: u32 = u32::MAX - 15;
+pub const FILE_PATH_COLUMN_ID: u32 = u32::MAX - 16;
+pub const FILE_BASENAME_COLUMN_ID: u32 = u32::MAX - 17;
+pub const FILE_CONTENT_KEY_COLUMN_ID: u32 = u32::MAX - 18;
+pub const FILE_LAST_MODIFIED_COLUMN_ID: u32 = u32::MAX - 19;
 // stream column name.
 pub const ORIGIN_VERSION_COL_NAME: &str = "_origin_version";
 pub const ORIGIN_BLOCK_ID_COL_NAME: &str = "_origin_block_id";
@@ -117,13 +125,17 @@ pub static INTERNAL_COLUMNS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| 
         ORIGIN_BLOCK_ROW_NUM_COL_NAME,
         FILENAME_COLUMN_NAME,
         FILE_ROW_NUMBER_COLUMN_NAME,
+        FILE_PATH_COLUMN_NAME,
+        FILE_BASENAME_COLUMN_NAME,
+        FILE_CONTENT_KEY_COLUMN_NAME,
+        FILE_LAST_MODIFIED_COLUMN_NAME,
     ])
 });
 
 #[inline]
 pub fn is_internal_column_id(column_id: ColumnId) -> bool {
     column_id >= VECTOR_SCORE_COLUMN_ID
-        || (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
+        || (FILE_LAST_MODIFIED_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
 }
 
 #[inline]

--- a/src/query/service/src/servers/http/v1/streaming_load.rs
+++ b/src/query/service/src/servers/http/v1/streaming_load.rs
@@ -361,6 +361,8 @@ async fn read_multi_part(
                             path: filename.clone(),
                             offset: 0,
                             is_eof: true,
+                            content_key: None,
+                            last_modified: None,
                         };
                         let block = DataBlock::empty_with_meta(Box::new(batch));
                         if let Err(e) = tx.send(Ok(block)).await {
@@ -384,6 +386,8 @@ async fn read_multi_part(
                                 path: filename.clone(),
                                 offset,
                                 is_eof: n == 0,
+                                content_key: None,
+                                last_modified: None,
                             };
                             let block = DataBlock::empty_with_meta(Box::new(batch));
                             if let Err(e) = tx.send(Ok(block)).await {

--- a/src/query/service/src/table_functions/infer_schema/infer_schema_table.rs
+++ b/src/query/service/src/table_functions/infer_schema/infer_schema_table.rs
@@ -267,6 +267,8 @@ impl Table for InferSchemaTable {
                         let part = SingleFilePartition {
                             path: v.path.clone(),
                             size: v.size as usize,
+                            content_key: v.etag.clone().or_else(|| v.md5.clone()),
+                            last_modified: v.last_modified,
                         };
                         let part_info: Box<dyn PartInfo> = Box::new(part);
                         Arc::new(part_info)

--- a/src/query/service/src/table_functions/infer_schema/separator.rs
+++ b/src/query/service/src/table_functions/infer_schema/separator.rs
@@ -465,6 +465,8 @@ mod tests {
             path: "sample.ndjson".to_string(),
             offset: 0,
             is_eof: false,
+            content_key: None,
+            last_modified: None,
         })))?;
         assert_eq!(output.len(), 1);
         assert!(output[0].is_empty());
@@ -474,6 +476,8 @@ mod tests {
             path: "sample.ndjson".to_string(),
             offset: 13,
             is_eof: true,
+            content_key: None,
+            last_modified: None,
         })))?;
         assert_eq!(output.len(), 1);
         assert!(!output[0].is_empty());

--- a/src/query/sql/src/planner/binder/internal_column_factory.rs
+++ b/src/query/sql/src/planner/binder/internal_column_factory.rs
@@ -20,6 +20,10 @@ use databend_common_catalog::plan::InternalColumnType;
 use databend_common_expression::BASE_BLOCK_IDS_COL_NAME;
 use databend_common_expression::BASE_ROW_ID_COL_NAME;
 use databend_common_expression::BLOCK_NAME_COL_NAME;
+use databend_common_expression::FILE_BASENAME_COLUMN_NAME;
+use databend_common_expression::FILE_CONTENT_KEY_COLUMN_NAME;
+use databend_common_expression::FILE_LAST_MODIFIED_COLUMN_NAME;
+use databend_common_expression::FILE_PATH_COLUMN_NAME;
 use databend_common_expression::FILE_ROW_NUMBER_COLUMN_NAME;
 use databend_common_expression::FILENAME_COLUMN_NAME;
 use databend_common_expression::ROW_ID_COL_NAME;
@@ -95,6 +99,32 @@ impl InternalColumnFactory {
             InternalColumn::new(
                 FILE_ROW_NUMBER_COLUMN_NAME,
                 InternalColumnType::FileRowNumber,
+            ),
+        );
+
+        internal_columns.insert(
+            FILE_PATH_COLUMN_NAME.to_string(),
+            InternalColumn::new(FILE_PATH_COLUMN_NAME, InternalColumnType::FilePath),
+        );
+
+        internal_columns.insert(
+            FILE_BASENAME_COLUMN_NAME.to_string(),
+            InternalColumn::new(FILE_BASENAME_COLUMN_NAME, InternalColumnType::FileBasename),
+        );
+
+        internal_columns.insert(
+            FILE_CONTENT_KEY_COLUMN_NAME.to_string(),
+            InternalColumn::new(
+                FILE_CONTENT_KEY_COLUMN_NAME,
+                InternalColumnType::FileContentKey,
+            ),
+        );
+
+        internal_columns.insert(
+            FILE_LAST_MODIFIED_COLUMN_NAME.to_string(),
+            InternalColumn::new(
+                FILE_LAST_MODIFIED_COLUMN_NAME,
+                InternalColumnType::FileLastModified,
             ),
         );
 

--- a/src/query/storages/basic/src/result_cache/table_function/table.rs
+++ b/src/query/storages/basic/src/result_cache/table_function/table.rs
@@ -127,6 +127,7 @@ impl Table for ResultScan {
             estimated_uncompressed_size: self.file_size,
             dedup_key: format!("{}_{}", self.location, self.file_size),
             bucket_option: None,
+            meta: Default::default(),
         });
 
         let part_info: Box<dyn PartInfo> = Box::new(part);

--- a/src/query/storages/common/stage/Cargo.toml
+++ b/src/query/storages/common/stage/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true }
+chrono = { workspace = true }
 databend-common-ast = { workspace = true }
 databend-common-catalog = { workspace = true }
 databend-common-exception = { workspace = true }

--- a/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
+++ b/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
@@ -15,6 +15,7 @@
 use chrono::DateTime;
 use chrono::Utc;
 use databend_common_catalog::plan::InternalColumnType;
+use databend_common_catalog::plan::file_basename;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
@@ -45,7 +46,7 @@ pub fn add_internal_columns_with_meta(
                 b.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
             InternalColumnType::FileBasename => {
-                let basename = path.rsplit('/').next().unwrap_or(&path).to_string();
+                let basename = file_basename(&path).to_string();
                 b.add_const_column(Scalar::String(basename), DataType::String);
             }
             InternalColumnType::FileRowNumber => {

--- a/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
+++ b/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
@@ -60,25 +60,17 @@ pub fn add_internal_columns_with_meta(
                     Some(key) => Scalar::String(key.to_string()),
                     None => Scalar::Null,
                 };
-                b.add_const_column(
-                    scalar,
-                    DataType::Nullable(Box::new(DataType::String)),
-                );
+                b.add_const_column(scalar, DataType::Nullable(Box::new(DataType::String)));
             }
             InternalColumnType::FileLastModified => {
                 let scalar = match last_modified {
                     Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
                     None => Scalar::Null,
                 };
-                b.add_const_column(
-                    scalar,
-                    DataType::Nullable(Box::new(DataType::Timestamp)),
-                );
+                b.add_const_column(scalar, DataType::Nullable(Box::new(DataType::Timestamp)));
             }
             _ => {
-                unreachable!(
-                    "unexpected InternalColumnType in stage file reader"
-                );
+                unreachable!("unexpected InternalColumnType in stage file reader");
             }
         }
     }

--- a/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
+++ b/src/query/storages/common/stage/src/read/columnar/internal_columns.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::InternalColumnType;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
@@ -25,21 +27,57 @@ pub fn add_internal_columns(
     b: &mut DataBlock,
     start_row: &mut u64,
 ) {
+    add_internal_columns_with_meta(internal_columns, path, b, start_row, None, None);
+}
+
+pub fn add_internal_columns_with_meta(
+    internal_columns: &[InternalColumnType],
+    path: String,
+    b: &mut DataBlock,
+    start_row: &mut u64,
+    content_key: Option<&str>,
+    last_modified: Option<DateTime<Utc>>,
+) {
+    let num_rows = b.num_rows();
     for c in internal_columns {
         match c {
-            InternalColumnType::FileName => {
+            InternalColumnType::FileName | InternalColumnType::FilePath => {
                 b.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
+            InternalColumnType::FileBasename => {
+                let basename = path.rsplit('/').next().unwrap_or(&path).to_string();
+                b.add_const_column(Scalar::String(basename), DataType::String);
+            }
             InternalColumnType::FileRowNumber => {
-                let end_row = (*start_row) + b.num_rows() as u64;
+                let end_row = (*start_row) + num_rows as u64;
                 b.add_column(Column::Number(
                     NumberColumnBuilder::UInt64(((*start_row)..end_row).collect()).build(),
                 ));
                 *start_row = end_row;
             }
+            InternalColumnType::FileContentKey => {
+                let scalar = match content_key {
+                    Some(key) => Scalar::String(key.to_string()),
+                    None => Scalar::Null,
+                };
+                b.add_const_column(
+                    scalar,
+                    DataType::Nullable(Box::new(DataType::String)),
+                );
+            }
+            InternalColumnType::FileLastModified => {
+                let scalar = match last_modified {
+                    Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
+                    None => Scalar::Null,
+                };
+                b.add_const_column(
+                    scalar,
+                    DataType::Nullable(Box::new(DataType::Timestamp)),
+                );
+            }
             _ => {
                 unreachable!(
-                    "except InternalColumnType::FileName or InternalColumnType::FileRowNumber"
+                    "unexpected InternalColumnType in stage file reader"
                 );
             }
         }

--- a/src/query/storages/common/stage/src/read/columnar/mod.rs
+++ b/src/query/storages/common/stage/src/read/columnar/mod.rs
@@ -19,4 +19,5 @@ mod projection;
 pub use arrow_to_variant::read_record_batch_to_variant_column;
 pub use arrow_to_variant::record_batch_to_variant_block;
 pub use internal_columns::add_internal_columns;
+pub use internal_columns::add_internal_columns_with_meta;
 pub use projection::project_columnar;

--- a/src/query/storages/common/stage/src/read/single_file_partition.rs
+++ b/src/query/storages/common/stage/src/read/single_file_partition.rs
@@ -17,6 +17,8 @@ use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_exception::ErrorCode;
@@ -26,6 +28,8 @@ use databend_common_exception::Result;
 pub struct SingleFilePartition {
     pub path: String,
     pub size: usize,
+    pub content_key: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
 }
 
 #[typetag::serde(name = "single_file_part")]

--- a/src/query/storages/delta/src/table.rs
+++ b/src/query/storages/delta/src/table.rs
@@ -348,6 +348,7 @@ impl DeltaTable {
                                 estimated_uncompressed_size: add.size as u64, // This field is not used here.
                                 dedup_key: format!("{}_{}", add.modification_time, add.size),
                                 bucket_option: None,
+                                meta: Default::default(),
                             },
                         ),
                     }) as _))

--- a/src/query/storages/iceberg/src/partition.rs
+++ b/src/query/storages/iceberg/src/partition.rs
@@ -27,6 +27,8 @@ pub(crate) fn convert_file_scan_task(task: iceberg::scan::FileScanTask) -> Box<d
             let part = SingleFilePartition {
                 path: task.data_file_path.clone(),
                 size: task.length as usize,
+                content_key: None,
+                last_modified: None,
             };
             Box::new(part)
         }

--- a/src/query/storages/iceberg/src/partition.rs
+++ b/src/query/storages/iceberg/src/partition.rs
@@ -39,6 +39,7 @@ pub(crate) fn convert_file_scan_task(task: iceberg::scan::FileScanTask) -> Box<d
                 estimated_uncompressed_size: task.length * 5,
                 dedup_key: format!("{}_{}", task.data_file_path, task.length),
                 bucket_option: None,
+                meta: Default::default(),
             };
 
             if !task.deletes.is_empty() {

--- a/src/query/storages/orc/src/copy_into_table/processors/source.rs
+++ b/src/query/storages/orc/src/copy_into_table/processors/source.rs
@@ -69,6 +69,8 @@ impl ORCSourceForCopy {
         let file = SingleFilePartition::from_part(&part)?.clone();
         let path = file.path.clone();
         let size = file.size;
+        let content_key = file.content_key.clone();
+        let last_modified = file.last_modified;
 
         let file = OrcChunkReader {
             operator: self.op.clone(),
@@ -89,6 +91,8 @@ impl ORCSourceForCopy {
             size,
             schema: Some(schema),
             rows: 0,
+            content_key,
+            last_modified,
         });
         Ok(true)
     }
@@ -139,12 +143,16 @@ impl AsyncSource for ORCSourceForCopy {
                             size: file.size,
                             schema: file.schema.clone(),
                             rows: (rows as u64) + file.rows,
+                            content_key: file.content_key.clone(),
+                            last_modified: file.last_modified,
                         });
                         let meta = Box::new(StripeInMemory {
                             path: file.path.clone(),
                             stripe,
                             schema: file.schema,
                             start_row: file.rows,
+                            content_key: file.content_key,
+                            last_modified: file.last_modified,
                         });
                         return Ok(Some(DataBlock::empty_with_meta(meta)));
                     }

--- a/src/query/storages/orc/src/processors/decoder.rs
+++ b/src/query/storages/orc/src/processors/decoder.rs
@@ -25,7 +25,7 @@ use databend_common_expression::DataSchema;
 use databend_common_pipeline_transforms::processors::AccumulatingTransform;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::FileStatus;
-use databend_storages_common_stage::add_internal_columns;
+use databend_storages_common_stage::add_internal_columns_with_meta;
 use orc_rust::array_decoder::NaiveStripeDecoder;
 
 use crate::strip::StripeInMemory;
@@ -83,11 +83,13 @@ impl AccumulatingTransform for StripeDecoder {
                     error: None,
                 })
             }
-            add_internal_columns(
+            add_internal_columns_with_meta(
                 &self.internal_columns,
                 stripe.path.clone(),
                 &mut block,
                 &mut start_row,
+                stripe.content_key.as_deref(),
+                stripe.last_modified,
             );
             blocks.push(block);
         }

--- a/src/query/storages/orc/src/processors/source.rs
+++ b/src/query/storages/orc/src/processors/source.rs
@@ -70,6 +70,8 @@ pub struct ReadingFile {
     pub size: usize,
     pub schema: Option<HashableSchema>,
     pub rows: u64,
+    pub content_key: Option<String>,
+    pub last_modified: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 pub struct ORCSource {
@@ -128,6 +130,8 @@ impl ORCSource {
         };
         let file = SingleFilePartition::from_part(&part)?.clone();
         let size = file.size;
+        let content_key = file.content_key.clone();
+        let last_modified = file.last_modified;
 
         let (operator, path) = self.op_registry.get_operator_path(&file.path)?;
         let file = OrcChunkReader {
@@ -164,6 +168,8 @@ impl ORCSource {
             size,
             schema,
             rows: 0,
+            content_key,
+            last_modified,
         });
         Ok(true)
     }
@@ -208,6 +214,8 @@ impl AsyncSource for ORCSource {
                             stripe,
                             schema: file.schema.clone(),
                             start_row: file.rows,
+                            content_key: file.content_key.clone(),
+                            last_modified: file.last_modified,
                         });
                         self.reader = Some(ReadingFile {
                             path: file.path.clone(),
@@ -215,6 +223,8 @@ impl AsyncSource for ORCSource {
                             size: file.size,
                             schema: file.schema.clone(),
                             rows: (rows as u64) + file.rows,
+                            content_key: file.content_key.clone(),
+                            last_modified: file.last_modified,
                         });
                         return Ok(Some(DataBlock::empty_with_meta(meta)));
                     }

--- a/src/query/storages/orc/src/processors/variant_decoder.rs
+++ b/src/query/storages/orc/src/processors/variant_decoder.rs
@@ -27,7 +27,7 @@ use databend_common_expression::TableSchema;
 use databend_common_pipeline_transforms::processors::AccumulatingTransform;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::FileStatus;
-use databend_storages_common_stage::add_internal_columns;
+use databend_storages_common_stage::add_internal_columns_with_meta;
 use databend_storages_common_stage::record_batch_to_variant_block;
 use jiff::tz::TimeZone;
 use orc_rust::array_decoder::NaiveStripeDecoder;
@@ -96,11 +96,13 @@ impl AccumulatingTransform for StripeDecoderForVariantTable {
                     error: None,
                 })
             }
-            add_internal_columns(
+            add_internal_columns_with_meta(
                 &self.internal_columns,
                 stripe.path.clone(),
                 &mut block,
                 &mut start_row,
+                stripe.content_key.as_deref(),
+                stripe.last_modified,
             );
             blocks.push(block);
         }

--- a/src/query/storages/orc/src/read_partition.rs
+++ b/src/query/storages/orc/src/read_partition.rs
@@ -49,9 +49,12 @@ pub async fn read_partitions_simple(
     let partitions = files
         .into_iter()
         .map(|v| {
+            let content_key = v.etag.clone().or_else(|| v.md5.clone());
             let part = SingleFilePartition {
                 path: v.path.clone(),
                 size: v.size as usize,
+                content_key,
+                last_modified: v.last_modified,
             };
             let part_info: Box<dyn PartInfo> = Box::new(part);
             Arc::new(part_info)

--- a/src/query/storages/orc/src/strip.rs
+++ b/src/query/storages/orc/src/strip.rs
@@ -26,6 +26,8 @@ pub struct StripeInMemory {
     pub stripe: Stripe,
     pub schema: Option<HashableSchema>,
     pub start_row: u64,
+    pub content_key: Option<String>,
+    pub last_modified: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 local_block_meta_serde!(StripeInMemory);

--- a/src/query/storages/orc/src/table.rs
+++ b/src/query/storages/orc/src/table.rs
@@ -31,7 +31,7 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
-use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
+use databend_common_expression::FILE_LAST_MODIFIED_COLUMN_ID;
 use databend_common_expression::FILENAME_COLUMN_ID;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
@@ -161,7 +161,7 @@ impl Table for OrcTable {
     }
 
     fn supported_internal_column(&self, column_id: ColumnId) -> bool {
-        (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
+        (FILE_LAST_MODIFIED_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
     }
 
     fn support_prewhere(&self) -> bool {

--- a/src/query/storages/parquet/src/lib.rs
+++ b/src/query/storages/parquet/src/lib.rs
@@ -52,6 +52,7 @@ pub use copy_into_table::ParquetTableForCopy;
 pub use meta::read_metas_in_parallel_for_copy;
 pub use parquet_part::DeleteTask;
 pub use parquet_part::DeleteType;
+pub use parquet_part::ParquetFileMeta;
 pub use parquet_part::ParquetFilePart;
 pub use parquet_part::ParquetPart;
 pub use parquet_reader::InMemoryRowGroup;

--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -18,6 +18,8 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::PartStatistics;
@@ -27,6 +29,19 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
 use crate::partition::ParquetRowGroupPart;
+
+/// File-level metadata carried from a stage listing into a parquet partition,
+/// used to populate the metadata$file_content_key / metadata$file_last_modified
+/// internal columns. Non-stage callers (iceberg/delta/result-cache) leave these
+/// empty, so those columns stay NULL as before.
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct ParquetFileMeta {
+    pub content_key: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
+}
+
+/// One file to turn into partition(s): (path, size, dedup_key, file-meta).
+pub type CollectFile = (String, u64, String, ParquetFileMeta);
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum DeleteType {
@@ -85,6 +100,11 @@ pub struct ParquetFilePart {
     // But we don't read metadata during plan stage, so we split them by 128MB into buckets
     // (bucket_idx, bucket_num)
     pub bucket_option: Option<(usize, usize)>,
+
+    // File-level metadata for the metadata$file_content_key /
+    // metadata$file_last_modified internal columns. Empty for non-stage reads.
+    #[serde(default)]
+    pub meta: ParquetFileMeta,
 }
 
 impl ParquetFilePart {
@@ -155,7 +175,7 @@ impl ParquetPart {
 /// 2. to avoid OOM, the total size of small files in one part is limited,
 ///    and we need compression_ratio to estimate the uncompressed size.
 fn collect_small_file_parts(
-    small_files: Vec<(String, u64, String)>,
+    small_files: Vec<CollectFile>,
     mut max_compression_ratio: f64,
     mut max_compressed_size: u64,
     partitions: &mut Partitions,
@@ -177,8 +197,8 @@ fn collect_small_file_parts(
     let total_len = small_files.len();
     let max_files = 8;
 
-    for (i, (path, size, dedup_key)) in small_files.into_iter().enumerate() {
-        small_part.push((path.clone(), size, dedup_key));
+    for (i, (path, size, dedup_key, meta)) in small_files.into_iter().enumerate() {
+        small_part.push((path.clone(), size, dedup_key, meta));
         stats.read_bytes += size as usize;
         part_size += size;
         let is_last = i + 1 == total_len;
@@ -189,12 +209,13 @@ fn collect_small_file_parts(
             let files = small_part
                 .iter()
                 .cloned()
-                .map(|(path, size, dedup_key)| ParquetFilePart {
+                .map(|(path, size, dedup_key, meta)| ParquetFilePart {
                     file: path,
                     compressed_size: size,
                     estimated_uncompressed_size: (size as f64 * max_compression_ratio) as u64,
                     dedup_key,
                     bucket_option: None,
+                    meta,
                 })
                 .collect::<Vec<_>>();
 
@@ -210,7 +231,7 @@ fn collect_small_file_parts(
 }
 
 fn collect_file_parts(
-    files: Vec<(String, u64, String)>,
+    files: Vec<CollectFile>,
     compress_ratio: f64,
     partitions: &mut Partitions,
     stats: &mut PartStatistics,
@@ -218,7 +239,7 @@ fn collect_file_parts(
     total_columns_to_read: usize,
     rowgroup_hint_bytes: u64,
 ) {
-    for (file, size, dedup_key) in files.into_iter() {
+    for (file, size, dedup_key, meta) in files.into_iter() {
         stats.read_bytes += size as usize;
         let estimated_read_rows: f64 = size as f64 / (total_columns_to_read * 8) as f64;
         let read_bytes =
@@ -235,6 +256,7 @@ fn collect_file_parts(
                     estimated_uncompressed_size: estimated_uncompressed_size as u64,
                     dedup_key: dedup_key.clone(),
                     bucket_option: Some((bucket, bucket_num)),
+                    meta: meta.clone(),
                 })) as Box<dyn PartInfo>));
 
             stats.partitions_scanned += 1;
@@ -249,7 +271,7 @@ fn collect_file_parts(
 
 pub(crate) fn collect_parts(
     ctx: Arc<dyn TableContext>,
-    files: Vec<(String, u64, String)>,
+    files: Vec<CollectFile>,
     compression_ratio: f64,
     num_columns_to_read: usize,
     total_columns_to_read: usize,
@@ -262,11 +284,11 @@ pub(crate) fn collect_parts(
 
     let mut large_files = vec![];
     let mut small_files = vec![];
-    for (location, size, dedup_key) in files.into_iter() {
+    for (location, size, dedup_key, meta) in files.into_iter() {
         if size > fast_read_bytes {
-            large_files.push((location, size, dedup_key));
+            large_files.push((location, size, dedup_key, meta));
         } else if size > 0 {
-            small_files.push((location, size, dedup_key));
+            small_files.push((location, size, dedup_key, meta));
         }
     }
 

--- a/src/query/storages/parquet/src/parquet_table/partition.rs
+++ b/src/query/storages/parquet/src/parquet_table/partition.rs
@@ -24,6 +24,7 @@ use databend_common_exception::Result;
 use databend_common_expression::FieldIndex;
 
 use super::table::ParquetTable;
+use crate::parquet_part::ParquetFileMeta;
 use crate::parquet_part::collect_parts;
 
 impl ParquetTable {
@@ -66,7 +67,12 @@ impl ParquetTable {
                 Some(files) => files
                     .iter()
                     .filter(|f| f.size > 0)
-                    .map(|f| (f.path.clone(), f.size, f.dedup_key()))
+                    .map(|f| {
+                        (f.path.clone(), f.size, f.dedup_key(), ParquetFileMeta {
+                            content_key: f.etag.clone().or_else(|| f.md5.clone()),
+                            last_modified: f.last_modified,
+                        })
+                    })
                     .collect::<Vec<_>>(),
                 None => self
                     .files_info
@@ -74,7 +80,12 @@ impl ParquetTable {
                     .await?
                     .into_iter()
                     .filter(|f| f.size > 0)
-                    .map(|f| (f.path.clone(), f.size, f.dedup_key()))
+                    .map(|f| {
+                        (f.path.clone(), f.size, f.dedup_key(), ParquetFileMeta {
+                            content_key: f.etag.clone().or_else(|| f.md5.clone()),
+                            last_modified: f.last_modified,
+                        })
+                    })
                     .collect::<Vec<_>>(),
             }
         };

--- a/src/query/storages/parquet/src/parquet_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_table/table.rs
@@ -35,7 +35,7 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
-use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
+use databend_common_expression::FILE_LAST_MODIFIED_COLUMN_ID;
 use databend_common_expression::FILENAME_COLUMN_ID;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
@@ -214,7 +214,7 @@ impl Table for ParquetTable {
     }
 
     fn supported_internal_column(&self, column_id: ColumnId) -> bool {
-        (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
+        (FILE_LAST_MODIFIED_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
     }
 
     fn support_prewhere(&self) -> bool {

--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -50,6 +50,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::parquet_to_arrow_field_levels;
 use parquet::arrow::parquet_to_arrow_schema;
 
+use crate::ParquetFileMeta;
 use crate::ParquetFilePart;
 use crate::ParquetPart;
 use crate::meta::read_metadata_async_cached;
@@ -64,8 +65,10 @@ enum State {
     ReadRowGroup {
         readers: VecDeque<(ParquetRecordBatchReader, u64, TableDataType, DataSchema)>,
         location: String,
+        meta: ParquetFileMeta,
     },
-    ReadFiles(Vec<(Bytes, String)>),
+    // (bytes, path, file-meta)
+    ReadFiles(Vec<(Bytes, String, ParquetFileMeta)>),
 }
 
 pub struct ParquetVariantSource {
@@ -179,6 +182,7 @@ impl Processor for ParquetVariantSource {
             State::ReadRowGroup {
                 readers: mut vs,
                 location,
+                meta,
             } => {
                 if let Some((reader, start_row, typ, data_schema)) = vs.front_mut() {
                     if let Some(batch) = reader.next() {
@@ -189,8 +193,8 @@ impl Processor for ParquetVariantSource {
                             location.clone(),
                             &mut block,
                             start_row,
-                            None,
-                            None,
+                            meta.content_key.as_deref(),
+                            meta.last_modified,
                         );
 
                         if self.is_copy {
@@ -206,13 +210,14 @@ impl Processor for ParquetVariantSource {
                     self.state = State::ReadRowGroup {
                         readers: vs,
                         location,
+                        meta,
                     };
                 }
                 // Else: The reader is finished. We should try to build another reader.
             }
             State::ReadFiles(buffers) => {
                 let mut blocks = Vec::with_capacity(buffers.len());
-                for (buffer, path) in buffers {
+                for (buffer, path, meta) in buffers {
                     let mut block =
                         read_small_file(buffer, self.batch_size, &self.tz, self.use_logic_type)?;
 
@@ -228,8 +233,8 @@ impl Processor for ParquetVariantSource {
                         path.to_string(),
                         &mut block,
                         &mut rows_start,
-                        None,
-                        None,
+                        meta.content_key.as_deref(),
+                        meta.last_modified,
                     );
                     blocks.push(block);
                 }
@@ -256,6 +261,7 @@ impl Processor for ParquetVariantSource {
                             for part in parts {
                                 let (op, path) =
                                     self.op_registry.get_operator_path(part.file.as_str())?;
+                                let meta = part.meta.clone();
                                 handlers.push(async move {
                                     let bs = cached_range_full_read(
                                         &op,
@@ -264,7 +270,7 @@ impl Processor for ParquetVariantSource {
                                         false,
                                     )
                                     .await?;
-                                    Ok::<_, ErrorCode>((bs, path.to_owned()))
+                                    Ok::<_, ErrorCode>((bs, path.to_owned(), meta))
                                 });
                             }
                             let results = futures::future::try_join_all(handlers).await?;
@@ -276,6 +282,7 @@ impl Processor for ParquetVariantSource {
                                 self.state = State::ReadRowGroup {
                                     readers,
                                     location: part.file.clone(),
+                                    meta: part.meta.clone(),
                                 };
                             }
                         }

--- a/src/query/storages/parquet/src/parquet_variant_table/source.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/source.rs
@@ -39,7 +39,7 @@ use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::FileStatus;
 use databend_common_storage::OperatorRegistry;
-use databend_storages_common_stage::add_internal_columns;
+use databend_storages_common_stage::add_internal_columns_with_meta;
 use databend_storages_common_stage::read_record_batch_to_variant_column;
 use databend_storages_common_stage::record_batch_to_variant_block;
 use jiff::tz::TimeZone;
@@ -184,11 +184,13 @@ impl Processor for ParquetVariantSource {
                     if let Some(batch) = reader.next() {
                         let mut block =
                             record_batch_to_variant_block(batch?, &self.tz, typ, data_schema)?;
-                        add_internal_columns(
+                        add_internal_columns_with_meta(
                             &self.internal_columns,
                             location.clone(),
                             &mut block,
                             start_row,
+                            None,
+                            None,
                         );
 
                         if self.is_copy {
@@ -221,11 +223,13 @@ impl Processor for ParquetVariantSource {
                         });
                     }
                     let mut rows_start = 0;
-                    add_internal_columns(
+                    add_internal_columns_with_meta(
                         &self.internal_columns,
                         path.to_string(),
                         &mut block,
                         &mut rows_start,
+                        None,
+                        None,
                     );
                     blocks.push(block);
                 }

--- a/src/query/storages/parquet/src/parquet_variant_table/table.rs
+++ b/src/query/storages/parquet/src/parquet_variant_table/table.rs
@@ -26,6 +26,7 @@ use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_storage::init_stage_operator;
 
+use crate::parquet_part::ParquetFileMeta;
 use crate::parquet_part::collect_parts;
 use crate::parquet_variant_table::source::ParquetVariantSource;
 
@@ -45,7 +46,12 @@ impl ParquetVariantTable {
             .await?
             .into_iter()
             .filter(|f| f.size > 0)
-            .map(|f| (f.path.clone(), f.size, f.dedup_key()))
+            .map(|f| {
+                (f.path.clone(), f.size, f.dedup_key(), ParquetFileMeta {
+                    content_key: f.etag.clone().or_else(|| f.md5.clone()),
+                    last_modified: f.last_modified,
+                })
+            })
             .collect::<Vec<_>>();
         collect_parts(ctx, files, 1.0, 1, 1)
     }

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -40,7 +40,7 @@ use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_storage::CopyStatus;
 use databend_common_storage::FileStatus;
 use databend_common_storage::OperatorRegistry;
-use databend_storages_common_stage::add_internal_columns;
+use databend_storages_common_stage::add_internal_columns_with_meta;
 use parquet::arrow::parquet_to_arrow_schema;
 
 use crate::ParquetFilePart;
@@ -216,11 +216,13 @@ impl Processor for ParquetSource {
             } => {
                 if let Some((reader, start_row)) = vs.front_mut() {
                     if let Some(mut block) = reader.as_mut().read_block()? {
-                        add_internal_columns(
+                        add_internal_columns_with_meta(
                             &self.internal_columns,
                             location.clone(),
                             &mut block,
                             start_row,
+                            None,
+                            None,
                         );
 
                         if self.is_copy {
@@ -260,11 +262,13 @@ impl Processor for ParquetSource {
                     }
                     let mut rows_start = 0;
                     for b in bs.iter_mut() {
-                        add_internal_columns(
+                        add_internal_columns_with_meta(
                             &self.internal_columns,
                             path.to_string(),
                             b,
                             &mut rows_start,
+                            None,
+                            None,
                         );
                     }
                     blocks.extend(bs);

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -43,6 +43,7 @@ use databend_common_storage::OperatorRegistry;
 use databend_storages_common_stage::add_internal_columns_with_meta;
 use parquet::arrow::parquet_to_arrow_schema;
 
+use crate::ParquetFileMeta;
 use crate::ParquetFilePart;
 use crate::ParquetPart;
 use crate::ParquetReaderBuilder;
@@ -62,8 +63,10 @@ enum State {
     ReadRowGroup {
         readers: VecDeque<(ReadPolicyImpl, u64)>,
         location: String,
+        meta: ParquetFileMeta,
     },
-    ReadFiles(Vec<(Bytes, String)>),
+    // (bytes, path, file-meta)
+    ReadFiles(Vec<(Bytes, String, ParquetFileMeta)>),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -213,6 +216,7 @@ impl Processor for ParquetSource {
             State::ReadRowGroup {
                 readers: mut vs,
                 location,
+                meta,
             } => {
                 if let Some((reader, start_row)) = vs.front_mut() {
                     if let Some(mut block) = reader.as_mut().read_block()? {
@@ -221,8 +225,8 @@ impl Processor for ParquetSource {
                             location.clone(),
                             &mut block,
                             start_row,
-                            None,
-                            None,
+                            meta.content_key.as_deref(),
+                            meta.last_modified,
                         );
 
                         if self.is_copy {
@@ -238,13 +242,14 @@ impl Processor for ParquetSource {
                     self.state = State::ReadRowGroup {
                         readers: vs,
                         location,
+                        meta,
                     };
                 }
                 // Else: The reader is finished. We should try to build another reader.
             }
             State::ReadFiles(buffers) => {
                 let mut blocks = Vec::with_capacity(buffers.len());
-                for (buffer, path) in buffers {
+                for (buffer, path, meta) in buffers {
                     let bs: Result<Vec<DataBlock>> = self
                         .whole_file_reader
                         .as_ref()
@@ -267,8 +272,8 @@ impl Processor for ParquetSource {
                             path.to_string(),
                             b,
                             &mut rows_start,
-                            None,
-                            None,
+                            meta.content_key.as_deref(),
+                            meta.last_modified,
                         );
                     }
                     blocks.extend(bs);
@@ -310,6 +315,7 @@ impl Processor for ParquetSource {
                                 self.state = State::ReadRowGroup {
                                     readers: vec![(reader, part.start_row)].into(),
                                     location: part.location.clone(),
+                                    meta: ParquetFileMeta::default(),
                                 };
                             }
                             // Else: keep in init state.
@@ -320,6 +326,7 @@ impl Processor for ParquetSource {
                             for part in parts {
                                 let (op, path) =
                                     self.row_group_reader.operator(part.file.as_str())?;
+                                let meta = part.meta.clone();
 
                                 handlers.push(async move {
                                     let bs = cached_range_full_read(
@@ -329,7 +336,7 @@ impl Processor for ParquetSource {
                                         false,
                                     )
                                     .await?;
-                                    Ok::<_, ErrorCode>((bs, path.to_owned()))
+                                    Ok::<_, ErrorCode>((bs, path.to_owned(), meta))
                                 });
                             }
                             let results = futures::future::try_join_all(handlers).await?;
@@ -341,6 +348,7 @@ impl Processor for ParquetSource {
                                 self.state = State::ReadRowGroup {
                                     readers,
                                     location: part.file.clone(),
+                                    meta: part.meta.clone(),
                                 };
                             }
                         }
@@ -350,6 +358,7 @@ impl Processor for ParquetSource {
                                 self.state = State::ReadRowGroup {
                                     readers,
                                     location: inner.file.clone(),
+                                    meta: inner.meta.clone(),
                                 };
                             }
                         }

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -14,6 +14,7 @@ arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
 async-trait = { workspace = true }
 bstr = { workspace = true }
+chrono = { workspace = true }
 csv-core = { workspace = true }
 databend-common-ast = { workspace = true }
 databend-common-base = { workspace = true }

--- a/src/query/storages/stage/src/read/arrow/pipeline.rs
+++ b/src/query/storages/stage/src/read/arrow/pipeline.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use arrow_array::RecordBatch;
 use arrow_ipc::reader::FileReaderBuilder;
 use arrow_ipc::reader::StreamReader;
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::InternalColumnType;
@@ -292,21 +294,48 @@ fn add_arrow_internal_columns(
     path: String,
     block: &mut DataBlock,
     start_row: &mut u64,
+    content_key: Option<&str>,
+    last_modified: Option<DateTime<Utc>>,
 ) {
+    let num_rows = block.num_rows();
     for column_type in internal_columns {
         match column_type {
-            InternalColumnType::FileName => {
+            InternalColumnType::FileName | InternalColumnType::FilePath => {
                 block.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
+            InternalColumnType::FileBasename => {
+                let basename = path.rsplit('/').next().unwrap_or(&path).to_string();
+                block.add_const_column(Scalar::String(basename), DataType::String);
+            }
             InternalColumnType::FileRowNumber => {
-                let end_row = *start_row + block.num_rows() as u64;
+                let end_row = *start_row + num_rows as u64;
                 block.add_column(Column::Number(
                     NumberColumnBuilder::UInt64((*start_row..end_row).collect()).build(),
                 ));
                 *start_row = end_row;
             }
+            InternalColumnType::FileContentKey => {
+                let scalar = match content_key {
+                    Some(key) => Scalar::String(key.to_string()),
+                    None => Scalar::Null,
+                };
+                block.add_const_column(
+                    scalar,
+                    DataType::Nullable(Box::new(DataType::String)),
+                );
+            }
+            InternalColumnType::FileLastModified => {
+                let scalar = match last_modified {
+                    Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
+                    None => Scalar::Null,
+                };
+                block.add_const_column(
+                    scalar,
+                    DataType::Nullable(Box::new(DataType::Timestamp)),
+                );
+            }
             _ => unreachable!(
-                "except InternalColumnType::FileName or InternalColumnType::FileRowNumber"
+                "unexpected InternalColumnType in stage file reader"
             ),
         }
     }
@@ -319,26 +348,37 @@ impl AccumulatingTransform for ArrowBlockBuilder {
         let meta = data
             .get_owned_meta()
             .ok_or_else(|| ErrorCode::Internal("ArrowBlockBuilder expects file data meta"))?;
-        let (path, data) = match BytesBatch::downcast_from_err(meta) {
-            Ok(data) => (data.path, data.data),
+        let (path, data, content_key, last_modified) = match BytesBatch::downcast_from_err(meta) {
+            Ok(data) => (
+                data.path,
+                data.data,
+                data.content_key,
+                data.last_modified,
+            ),
             Err(meta) => {
                 let data = WholeFileData::downcast_from(meta).ok_or_else(|| {
                     ErrorCode::Internal("ArrowBlockBuilder expects Arrow file data")
                 })?;
-                (data.path, data.data)
+                (data.path, data.data, data.content_key, data.last_modified)
             }
         };
 
         if self.ctx.is_select {
-            return self.transform_for_select(path, data);
+            return self.transform_for_select(path, data, content_key.as_deref(), last_modified);
         }
 
-        self.transform_for_copy(path, data)
+        self.transform_for_copy(path, data, content_key.as_deref(), last_modified)
     }
 }
 
 impl ArrowBlockBuilder {
-    fn transform_for_select(&mut self, path: String, data: Vec<u8>) -> Result<Vec<DataBlock>> {
+    fn transform_for_select(
+        &mut self,
+        path: String,
+        data: Vec<u8>,
+        content_key: Option<&str>,
+        last_modified: Option<DateTime<Utc>>,
+    ) -> Result<Vec<DataBlock>> {
         let mut blocks = Vec::new();
         let mut rows_start = 0;
         for batch in self.read_batches(&path, data)? {
@@ -351,13 +391,21 @@ impl ArrowBlockBuilder {
                 path.clone(),
                 &mut block,
                 &mut rows_start,
+                content_key,
+                last_modified,
             );
             blocks.push(block);
         }
         Ok(blocks)
     }
 
-    fn transform_for_copy(&mut self, path: String, data: Vec<u8>) -> Result<Vec<DataBlock>> {
+    fn transform_for_copy(
+        &mut self,
+        path: String,
+        data: Vec<u8>,
+        content_key: Option<&str>,
+        last_modified: Option<DateTime<Utc>>,
+    ) -> Result<Vec<DataBlock>> {
         let mut file_status = FileStatus::default();
         let batches = match self.read_batches(&path, data) {
             Ok(batches) => batches,
@@ -406,6 +454,8 @@ impl ArrowBlockBuilder {
                 path.clone(),
                 &mut block,
                 &mut rows_start,
+                content_key,
+                last_modified,
             );
             rows_loaded += block.num_rows();
             blocks.push(block);

--- a/src/query/storages/stage/src/read/arrow/pipeline.rs
+++ b/src/query/storages/stage/src/read/arrow/pipeline.rs
@@ -26,6 +26,7 @@ use databend_common_catalog::plan::InternalColumnType;
 use databend_common_catalog::plan::Projection;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::StageTableInfo;
+use databend_common_catalog::plan::file_basename;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -304,7 +305,7 @@ fn add_arrow_internal_columns(
                 block.add_const_column(Scalar::String(path.clone()), DataType::String);
             }
             InternalColumnType::FileBasename => {
-                let basename = path.rsplit('/').next().unwrap_or(&path).to_string();
+                let basename = file_basename(&path).to_string();
                 block.add_const_column(Scalar::String(basename), DataType::String);
             }
             InternalColumnType::FileRowNumber => {

--- a/src/query/storages/stage/src/read/arrow/pipeline.rs
+++ b/src/query/storages/stage/src/read/arrow/pipeline.rs
@@ -319,24 +319,16 @@ fn add_arrow_internal_columns(
                     Some(key) => Scalar::String(key.to_string()),
                     None => Scalar::Null,
                 };
-                block.add_const_column(
-                    scalar,
-                    DataType::Nullable(Box::new(DataType::String)),
-                );
+                block.add_const_column(scalar, DataType::Nullable(Box::new(DataType::String)));
             }
             InternalColumnType::FileLastModified => {
                 let scalar = match last_modified {
                     Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
                     None => Scalar::Null,
                 };
-                block.add_const_column(
-                    scalar,
-                    DataType::Nullable(Box::new(DataType::Timestamp)),
-                );
+                block.add_const_column(scalar, DataType::Nullable(Box::new(DataType::Timestamp)));
             }
-            _ => unreachable!(
-                "unexpected InternalColumnType in stage file reader"
-            ),
+            _ => unreachable!("unexpected InternalColumnType in stage file reader"),
         }
     }
 }
@@ -349,12 +341,7 @@ impl AccumulatingTransform for ArrowBlockBuilder {
             .get_owned_meta()
             .ok_or_else(|| ErrorCode::Internal("ArrowBlockBuilder expects file data meta"))?;
         let (path, data, content_key, last_modified) = match BytesBatch::downcast_from_err(meta) {
-            Ok(data) => (
-                data.path,
-                data.data,
-                data.content_key,
-                data.last_modified,
-            ),
+            Ok(data) => (data.path, data.data, data.content_key, data.last_modified),
             Err(meta) => {
                 let data = WholeFileData::downcast_from(meta).ok_or_else(|| {
                     ErrorCode::Internal("ArrowBlockBuilder expects Arrow file data")

--- a/src/query/storages/stage/src/read/avro/block_builder_processor.rs
+++ b/src/query/storages/stage/src/read/avro/block_builder_processor.rs
@@ -53,6 +53,8 @@ impl AccumulatingTransform for BlockBuilderProcessor {
             .and_then(WholeFileData::downcast_from)
             .unwrap();
         self.state.file_path = data.path.clone();
+        self.state.file_content_key = data.content_key.clone();
+        self.state.file_last_modified = data.last_modified;
         let num_rows = self.state.num_rows;
         self.decoder.read_file(&data.data, &mut self.state)?;
         self.state

--- a/src/query/storages/stage/src/read/block_builder_state.rs
+++ b/src/query/storages/stage/src/read/block_builder_state.rs
@@ -136,29 +136,22 @@ impl BlockBuilderState {
                         .push_repeat(&ScalarRef::String(&self.file_path), n);
                 }
                 InternalColumnType::FileBasename => {
-                    let basename = self
-                        .file_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(&self.file_path);
-                    self.internal_column_builders[i]
-                        .push_repeat(&ScalarRef::String(basename), n);
+                    let basename = self.file_path.rsplit('/').next().unwrap_or(&self.file_path);
+                    self.internal_column_builders[i].push_repeat(&ScalarRef::String(basename), n);
                 }
                 InternalColumnType::FileContentKey => {
                     let scalar = match &self.file_content_key {
                         Some(key) => Scalar::String(key.clone()),
                         None => Scalar::Null,
                     };
-                    self.internal_column_builders[i]
-                        .push_repeat(&scalar.as_ref(), n);
+                    self.internal_column_builders[i].push_repeat(&scalar.as_ref(), n);
                 }
                 InternalColumnType::FileLastModified => {
                     let scalar = match &self.file_last_modified {
                         Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
                         None => Scalar::Null,
                     };
-                    self.internal_column_builders[i]
-                        .push_repeat(&scalar.as_ref(), n);
+                    self.internal_column_builders[i].push_repeat(&scalar.as_ref(), n);
                 }
                 InternalColumnType::FileRowNumber => {}
                 _ => {

--- a/src/query/storages/stage/src/read/block_builder_state.rs
+++ b/src/query/storages/stage/src/read/block_builder_state.rs
@@ -15,6 +15,8 @@
 use std::mem;
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::InternalColumnType;
 use databend_common_catalog::table_context::TableContext;
@@ -22,6 +24,7 @@ use databend_common_exception::Result;
 use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
+use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::types::NumberScalar;
 use databend_common_storage::FileStatus;
@@ -38,6 +41,8 @@ pub struct BlockBuilderState {
     pub num_rows: usize,
     pub file_status: FileStatus,
     pub file_path: String,
+    pub file_content_key: Option<String>,
+    pub file_last_modified: Option<DateTime<Utc>>,
 }
 
 impl BlockBuilderState {
@@ -74,6 +79,8 @@ impl BlockBuilderState {
             num_rows: 0,
             file_status: Default::default(),
             file_path: "".to_string(),
+            file_content_key: None,
+            file_last_modified: None,
         }
     }
 
@@ -124,9 +131,34 @@ impl BlockBuilderState {
     pub(crate) fn add_internals_columns_batch(&mut self, n: usize) {
         for (i, c) in self.internal_columns.iter().enumerate() {
             match c.column_type {
-                InternalColumnType::FileName => {
+                InternalColumnType::FileName | InternalColumnType::FilePath => {
                     self.internal_column_builders[i]
                         .push_repeat(&ScalarRef::String(&self.file_path), n);
+                }
+                InternalColumnType::FileBasename => {
+                    let basename = self
+                        .file_path
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(&self.file_path);
+                    self.internal_column_builders[i]
+                        .push_repeat(&ScalarRef::String(basename), n);
+                }
+                InternalColumnType::FileContentKey => {
+                    let scalar = match &self.file_content_key {
+                        Some(key) => Scalar::String(key.clone()),
+                        None => Scalar::Null,
+                    };
+                    self.internal_column_builders[i]
+                        .push_repeat(&scalar.as_ref(), n);
+                }
+                InternalColumnType::FileLastModified => {
+                    let scalar = match &self.file_last_modified {
+                        Some(ts) => Scalar::Timestamp(ts.timestamp_micros()),
+                        None => Scalar::Null,
+                    };
+                    self.internal_column_builders[i]
+                        .push_repeat(&scalar.as_ref(), n);
                 }
                 InternalColumnType::FileRowNumber => {}
                 _ => {

--- a/src/query/storages/stage/src/read/block_builder_state.rs
+++ b/src/query/storages/stage/src/read/block_builder_state.rs
@@ -19,6 +19,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::plan::InternalColumnType;
+use databend_common_catalog::plan::file_basename;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::Column;
@@ -136,7 +137,7 @@ impl BlockBuilderState {
                         .push_repeat(&ScalarRef::String(&self.file_path), n);
                 }
                 InternalColumnType::FileBasename => {
-                    let basename = self.file_path.rsplit('/').next().unwrap_or(&self.file_path);
+                    let basename = file_basename(&self.file_path);
                     self.internal_column_builders[i].push_repeat(&ScalarRef::String(basename), n);
                 }
                 InternalColumnType::FileContentKey => {

--- a/src/query/storages/stage/src/read/row_based/batch.rs
+++ b/src/query/storages/stage/src/read/row_based/batch.rs
@@ -14,6 +14,8 @@
 
 use std::intrinsics::unlikely;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_expression::BlockMetaInfo;
 use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
@@ -24,6 +26,8 @@ pub struct Position {
     pub path: String,
     pub rows: usize,
     pub offset: usize,
+    pub content_key: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
 }
 
 impl Position {
@@ -32,6 +36,8 @@ impl Position {
             path,
             rows: 0,
             offset: 0,
+            content_key: None,
+            last_modified: None,
         }
     }
 
@@ -40,6 +46,8 @@ impl Position {
             path: batch.path.clone(),
             rows: start_row_id,
             offset: batch.offset,
+            content_key: batch.content_key.clone(),
+            last_modified: batch.last_modified,
         }
     }
 }
@@ -51,6 +59,10 @@ pub struct BytesBatch {
     pub path: String,
     pub offset: usize,
     pub is_eof: bool,
+    /// etag or md5 of the file (set on first batch of file)
+    pub content_key: Option<String>,
+    /// last modified time of the file (set on first batch of file)
+    pub last_modified: Option<DateTime<Utc>>,
 }
 
 impl BytesBatch {
@@ -60,6 +72,8 @@ impl BytesBatch {
             path: self.path.clone(),
             offset: self.offset,
             is_eof: self.is_eof,
+            content_key: self.content_key.clone(),
+            last_modified: self.last_modified,
         }
     }
 }

--- a/src/query/storages/stage/src/read/row_based/batch.rs
+++ b/src/query/storages/stage/src/read/row_based/batch.rs
@@ -59,9 +59,9 @@ pub struct BytesBatch {
     pub path: String,
     pub offset: usize,
     pub is_eof: bool,
-    /// etag or md5 of the file (set on first batch of file)
+    /// etag or md5 of the file (stamped on every batch of the file)
     pub content_key: Option<String>,
-    /// last modified time of the file (set on first batch of file)
+    /// last modified time of the file (stamped on every batch of the file)
     pub last_modified: Option<DateTime<Utc>>,
 }
 

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/separator.rs
@@ -48,6 +48,13 @@ impl NdJsonRowSeparator {
         &mut self,
         mut batch: BytesBatch,
     ) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
+        // Capture file-level metadata from the first batch
+        if batch.content_key.is_some() {
+            self.pos.content_key = batch.content_key;
+        }
+        if batch.last_modified.is_some() {
+            self.pos.last_modified = batch.last_modified;
+        }
         let data = std::mem::take(&mut batch.data);
         let mut rows: NdjsonRowBatch = Default::default();
         let mut check_first = !self.last_partial_row.is_empty();
@@ -114,6 +121,8 @@ mod tests {
             path: "".to_string(),
             offset: 0,
             is_eof,
+            content_key: None,
+            last_modified: None,
         };
 
         let (batches, _) = sep.append(input).unwrap();

--- a/src/query/storages/stage/src/read/row_based/formats/ndjson/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/ndjson/separator.rs
@@ -48,7 +48,8 @@ impl NdJsonRowSeparator {
         &mut self,
         mut batch: BytesBatch,
     ) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
-        // Capture file-level metadata from the first batch
+        // File-level metadata is stamped on every batch (identical for the whole
+        // file); keep the latest non-empty value (last-writer-wins).
         if batch.content_key.is_some() {
             self.pos.content_key = batch.content_key;
         }

--- a/src/query/storages/stage/src/read/row_based/formats/text/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/text/block_builder.rs
@@ -15,9 +15,11 @@
 use std::sync::Arc;
 
 use databend_common_exception::Result;
+use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::TableDataType;
 use databend_common_expression::types::nullable::NullableColumnBuilder;
+use databend_common_expression::types::string::StringColumnBuilder;
 use databend_common_formats::SeparatedTextDecoder;
 use databend_common_meta_app::principal::EmptyFieldAs;
 use databend_common_storage::FileParseError;
@@ -290,5 +292,30 @@ impl RowDecoder for TextDecoder {
             }
         }
         Ok(())
+    }
+
+    fn flush(&self, columns: Vec<Column>, num_rows: usize) -> Vec<Column> {
+        // When the query prunes data columns (e.g. only metadata$* columns are
+        // needed by the outer query), `pos_projection` excludes those columns and
+        // `read_row` never pushes values into their builders, leaving them shorter
+        // than `num_rows`. Rebuild the non-projected columns at the right length so
+        // all columns in the output block agree on row count.
+        if let Some(projection) = &self.load_context.pos_projection {
+            let empty_strings =
+                Column::String(StringColumnBuilder::repeat_default(num_rows).build());
+            columns
+                .into_iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    if projection.contains(&i) {
+                        c
+                    } else {
+                        empty_strings.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            columns
+        }
     }
 }

--- a/src/query/storages/stage/src/read/row_based/formats/text/parser.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/text/parser.rs
@@ -184,6 +184,8 @@ pub fn parse_tsv_records_for_infer_schema(
         path: "infer_schema".to_string(),
         offset: 0,
         is_eof,
+        content_key: None,
+        last_modified: None,
     };
     let (batches, _) = separator.append(batch)?;
 

--- a/src/query/storages/stage/src/read/row_based/formats/text/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/text/separator.rs
@@ -64,6 +64,13 @@ impl TextRowSeparator {
         &mut self,
         mut batch: BytesBatch,
     ) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
+        // Capture file-level metadata from the first batch
+        if batch.content_key.is_some() {
+            self.pos.content_key = batch.content_key;
+        }
+        if batch.last_modified.is_some() {
+            self.pos.last_modified = batch.last_modified;
+        }
         let mut data = std::mem::take(&mut batch.data);
         let mut rows: NdjsonRowBatch = Default::default();
         let mut check_first = !self.last_partial_row.is_empty();
@@ -142,6 +149,8 @@ mod tests {
             path: "".to_string(),
             offset: 0,
             is_eof,
+            content_key: None,
+            last_modified: None,
         };
 
         let (batches, _) = sep.append(input).unwrap();

--- a/src/query/storages/stage/src/read/row_based/formats/text/separator.rs
+++ b/src/query/storages/stage/src/read/row_based/formats/text/separator.rs
@@ -64,7 +64,8 @@ impl TextRowSeparator {
         &mut self,
         mut batch: BytesBatch,
     ) -> Result<(Vec<RowBatchWithPosition>, FileStatus)> {
-        // Capture file-level metadata from the first batch
+        // File-level metadata is stamped on every batch (identical for the whole
+        // file); keep the latest non-empty value (last-writer-wins).
         if batch.content_key.is_some() {
             self.pos.content_key = batch.content_key;
         }

--- a/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/block_builder.rs
@@ -81,6 +81,8 @@ impl AccumulatingTransform for BlockBuilder {
             .unwrap();
         if self.state.file_path != batch.start_pos.path {
             self.state.file_path = batch.start_pos.path.clone();
+            self.state.file_content_key = batch.start_pos.content_key.clone();
+            self.state.file_last_modified = batch.start_pos.last_modified;
         }
         let num_rows = self.state.num_rows;
         self.decoder.add(&mut self.state, batch)?;

--- a/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
@@ -14,6 +14,8 @@
 
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_compress::CompressAlgorithm;
 use databend_common_compress::DecompressDecoder;
@@ -34,6 +36,9 @@ pub struct Decompressor {
     decompressor: Option<(DecompressDecoder, usize)>,
     path: Option<String>,
     zip_buf: Vec<u8>,
+    /// File-level metadata captured from the first batch of each file.
+    file_content_key: Option<String>,
+    file_last_modified: Option<DateTime<Utc>>,
 }
 
 impl Decompressor {
@@ -44,17 +49,22 @@ impl Decompressor {
             path: None,
             decompressor: None,
             zip_buf: Vec::new(),
+            file_content_key: None,
+            file_last_modified: None,
         })
     }
 
-    fn new_file(&mut self, path: String) {
+    fn new_file(&mut self, batch: &BytesBatch) {
         assert!(self.decompressor.is_none());
+        let path = batch.path.clone();
         let algo = if let Some(algo) = &self.algo {
             Some(algo.to_owned())
         } else {
             CompressAlgorithm::from_path(&path)
         };
         self.path = Some(path);
+        self.file_content_key = batch.content_key.clone();
+        self.file_last_modified = batch.last_modified;
 
         if let Some(algo) = algo {
             if matches!(algo, CompressAlgorithm::Zip) {
@@ -78,10 +88,10 @@ impl AccumulatingTransform for Decompressor {
             .and_then(BytesBatch::downcast_from)
             .unwrap();
         match &self.path {
-            None => self.new_file(batch.path.clone()),
+            None => self.new_file(&batch),
             Some(path) => {
                 if path != &batch.path {
-                    self.new_file(batch.path.clone())
+                    self.new_file(&batch)
                 }
             }
         }
@@ -107,8 +117,8 @@ impl AccumulatingTransform for Decompressor {
                     path: batch.path.clone(),
                     offset: 0,
                     is_eof: batch.is_eof,
-                    content_key: batch.content_key.clone(),
-                    last_modified: batch.last_modified,
+                    content_key: self.file_content_key.clone(),
+                    last_modified: self.file_last_modified,
                 });
                 self.zip_buf.clear();
                 Ok(vec![DataBlock::empty_with_meta(new_batch)])
@@ -146,8 +156,8 @@ impl AccumulatingTransform for Decompressor {
                 path: batch.path.clone(),
                 offset: *offset,
                 is_eof: batch.is_eof,
-                content_key: batch.content_key.clone(),
-                last_modified: batch.last_modified,
+                content_key: self.file_content_key.clone(),
+                last_modified: self.file_last_modified,
             });
             *offset += batch.data.len();
             if batch.is_eof {

--- a/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/decompressor.rs
@@ -107,6 +107,8 @@ impl AccumulatingTransform for Decompressor {
                     path: batch.path.clone(),
                     offset: 0,
                     is_eof: batch.is_eof,
+                    content_key: batch.content_key.clone(),
+                    last_modified: batch.last_modified,
                 });
                 self.zip_buf.clear();
                 Ok(vec![DataBlock::empty_with_meta(new_batch)])
@@ -144,6 +146,8 @@ impl AccumulatingTransform for Decompressor {
                 path: batch.path.clone(),
                 offset: *offset,
                 is_eof: batch.is_eof,
+                content_key: batch.content_key.clone(),
+                last_modified: batch.last_modified,
             });
             *offset += batch.data.len();
             if batch.is_eof {

--- a/src/query/storages/stage/src/read/row_based/processors/encoding_transformer.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/encoding_transformer.rs
@@ -232,6 +232,54 @@ mod tests {
     }
 
     #[test]
+    fn test_encoding_transformer_preserves_meta_when_first_batch_buffered() {
+        // The first chunk is an incomplete multibyte sequence, so the
+        // transformer buffers it and emits nothing. The file metadata is
+        // stamped on every batch (as BytesReader now does), so the batch that
+        // actually emits rows must still carry content_key/last_modified.
+        let (encoded, _, had_errors) = GBK.encode("张三,1\n");
+        assert!(!had_errors);
+
+        let last_modified = chrono::DateTime::from_timestamp(1_700_000_000, 0);
+        let mut transformer =
+            DecodingTransformer::try_create("gbk".to_string(), "strict".to_string()).unwrap();
+
+        let first = transformer
+            .transform(DataBlock::empty_with_meta(Box::new(BytesBatch {
+                data: encoded[..1].to_vec(),
+                path: "test.csv".to_string(),
+                offset: 0,
+                is_eof: false,
+                content_key: Some("etag-123".to_string()),
+                last_modified,
+            })))
+            .unwrap();
+        assert!(first.is_empty());
+
+        let second = transformer
+            .transform(DataBlock::empty_with_meta(Box::new(BytesBatch {
+                data: encoded[1..].to_vec(),
+                path: "test.csv".to_string(),
+                offset: 1,
+                is_eof: true,
+                content_key: Some("etag-123".to_string()),
+                last_modified,
+            })))
+            .unwrap();
+        assert_eq!(second.len(), 1);
+
+        let batch = second
+            .into_iter()
+            .next()
+            .unwrap()
+            .get_owned_meta()
+            .and_then(BytesBatch::downcast_from)
+            .unwrap();
+        assert_eq!(batch.content_key.as_deref(), Some("etag-123"));
+        assert_eq!(batch.last_modified, last_modified);
+    }
+
+    #[test]
     fn test_encoding_transformer_strict_invalid_utf8() {
         let mut transformer =
             DecodingTransformer::try_create("utf-8".to_string(), "strict".to_string()).unwrap();

--- a/src/query/storages/stage/src/read/row_based/processors/encoding_transformer.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/encoding_transformer.rs
@@ -170,6 +170,8 @@ impl AccumulatingTransform for DecodingTransformer {
             path: batch.path,
             offset: batch.offset,
             is_eof: batch.is_eof,
+            content_key: batch.content_key,
+            last_modified: batch.last_modified,
         }))])
     }
 }
@@ -201,6 +203,8 @@ mod tests {
                 path: "test.csv".to_string(),
                 offset: 0,
                 is_eof: false,
+                content_key: None,
+                last_modified: None,
             })))
             .unwrap();
         assert!(first.is_empty());
@@ -211,6 +215,8 @@ mod tests {
                 path: "test.csv".to_string(),
                 offset: 1,
                 is_eof: true,
+                content_key: None,
+                last_modified: None,
             })))
             .unwrap();
         assert_eq!(second.len(), 1);
@@ -235,6 +241,8 @@ mod tests {
                 path: "bad.csv".to_string(),
                 offset: 0,
                 is_eof: true,
+                content_key: None,
+                last_modified: None,
             })))
             .unwrap_err();
 
@@ -251,6 +259,8 @@ mod tests {
                 path: "bad.csv".to_string(),
                 offset: 0,
                 is_eof: true,
+                content_key: None,
+                last_modified: None,
             })))
             .unwrap();
 

--- a/src/query/storages/stage/src/read/row_based/processors/reader.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/reader.rs
@@ -85,16 +85,14 @@ impl BytesReader {
                 path: state.file.path.clone(),
                 offset,
                 is_eof,
-                content_key: if offset == 0 {
-                    state.file.content_key.clone()
-                } else {
-                    None
-                },
-                last_modified: if offset == 0 {
-                    state.file.last_modified
-                } else {
-                    None
-                },
+                // Stamp file-level metadata on every batch, not just the first.
+                // A stateful upstream transformer (encoding decoder buffering an
+                // incomplete multibyte sequence, a record/header longer than the
+                // read buffer, etc.) may drop or buffer the offset-0 batch, so
+                // pinning the metadata to offset 0 could lose it before any row
+                // is emitted. The value is identical for the whole file.
+                content_key: state.file.content_key.clone(),
+                last_modified: state.file.last_modified,
             });
             if is_eof {
                 self.file_state = None;

--- a/src/query/storages/stage/src/read/row_based/processors/reader.rs
+++ b/src/query/storages/stage/src/read/row_based/processors/reader.rs
@@ -85,6 +85,16 @@ impl BytesReader {
                 path: state.file.path.clone(),
                 offset,
                 is_eof,
+                content_key: if offset == 0 {
+                    state.file.content_key.clone()
+                } else {
+                    None
+                },
+                last_modified: if offset == 0 {
+                    state.file.last_modified
+                } else {
+                    None
+                },
             });
             if is_eof {
                 self.file_state = None;

--- a/src/query/storages/stage/src/read/whole_file_reader.rs
+++ b/src/query/storages/stage/src/read/whole_file_reader.rs
@@ -28,6 +28,8 @@
 
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::Utc;
 use databend_common_base::base::ProgressValues;
 use databend_common_base::runtime::profile::Profile;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
@@ -46,6 +48,8 @@ use serde::Serialize;
 pub struct WholeFileData {
     pub data: Vec<u8>,
     pub path: String,
+    pub content_key: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
 }
 
 #[typetag::serde(name = "avro_file_data")]
@@ -111,6 +115,8 @@ impl PrefetchAsyncSource for WholeFileReader {
         let meta = std::boxed::Box::new(WholeFileData {
             data,
             path: file.path.clone(),
+            content_key: file.content_key.clone(),
+            last_modified: file.last_modified,
         });
         Ok(Some(DataBlock::empty_with_meta(meta)))
     }

--- a/src/query/storages/stage/src/stage_table.rs
+++ b/src/query/storages/stage/src/stage_table.rs
@@ -29,7 +29,7 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
-use databend_common_expression::FILE_ROW_NUMBER_COLUMN_ID;
+use databend_common_expression::FILE_LAST_MODIFIED_COLUMN_ID;
 use databend_common_expression::FILENAME_COLUMN_ID;
 use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::StageInfo;
@@ -120,9 +120,12 @@ impl StageTable {
             .into_iter()
             .filter(|f| f.size > 0)
             .map(|v| {
+                let content_key = v.etag.clone().or_else(|| v.md5.clone());
                 let part = SingleFilePartition {
                     path: v.path.clone(),
                     size: v.size as usize,
+                    content_key,
+                    last_modified: v.last_modified,
                 };
                 let part_info: Box<dyn PartInfo> = Box::new(part);
                 Arc::new(part_info)
@@ -148,7 +151,7 @@ impl Table for StageTable {
     }
 
     fn supported_internal_column(&self, column_id: ColumnId) -> bool {
-        (FILE_ROW_NUMBER_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
+        (FILE_LAST_MODIFIED_COLUMN_ID..=FILENAME_COLUMN_ID).contains(&column_id)
     }
 
     fn get_data_source_info(&self) -> DataSourceInfo {

--- a/tests/nox/suites/copy/test_metadata.py
+++ b/tests/nox/suites/copy/test_metadata.py
@@ -24,18 +24,13 @@ def _storage_type(conn):
     return row.values()[0]
 
 
-# Parquet reads go through the columnar ParquetPart pipeline, which does not yet
-# thread stage file metadata (ETag/last-modified) into the scan. So for parquet
-# both metadata$file_content_key and metadata$file_last_modified are always NULL,
-# regardless of the storage backend. Other (row-based) formats thread it through.
-def _content_key_present(conn, fmt):
-    if fmt == "parquet":
-        return False
+def _content_key_present(conn):
+    """content_key is backed by ETag/md5, present only on object stores.
+
+    Object stores (s3/minio/azblob/...) expose an ETag or md5; the local fs
+    backend has no such value, so content_key is NULL there.
+    """
     return _storage_type(conn) != "fs"
-
-
-def _last_modified_present(fmt):
-    return fmt != "parquet"
 
 
 def _unload(conn, name, path, fmt, query="select number as a, number + 100 as b from numbers(2)"):
@@ -120,7 +115,7 @@ def test_metadata_file_content_key(copy_env, fmt):
     _unload(conn, name, f"ck/f1.{fmt}", fmt)
 
     # On fs: content_key is NULL. On object stores: it must be non-null.
-    content_present_expected = _content_key_present(conn, fmt)
+    content_present_expected = _content_key_present(conn)
 
     run_all(conn, [
         (
@@ -141,12 +136,6 @@ def test_metadata_file_last_modified(copy_env, fmt):
     col = _col_ref(fmt)
     _unload(conn, name, f"lm/f1.{fmt}", fmt)
 
-    if _last_modified_present(fmt):
-        recent_expected, before_now_expected = True, True
-    else:
-        # parquet: last_modified is not threaded through, always NULL
-        recent_expected, before_now_expected = None, None
-
     run_all(conn, [
         (
             f"select typeof(metadata$file_last_modified), "
@@ -154,7 +143,7 @@ def test_metadata_file_last_modified(copy_env, fmt):
             f"metadata$file_last_modified <= now() "
             f"from (select {col}, metadata$file_last_modified "
             f"from @{name}/lm/f1.{fmt} (file_format => '{fmt}')) limit 1;",
-            [("TIMESTAMP NULL", recent_expected, before_now_expected)],
+            [("TIMESTAMP NULL", True, True)],
         ),
     ])
 
@@ -167,8 +156,7 @@ def test_metadata_all_columns_together(copy_env, fmt):
     col = _col_ref(fmt)
     _unload(conn, name, f"all/f1.{fmt}", fmt)
 
-    content_present_expected = _content_key_present(conn, fmt)
-    last_modified_recent = True if _last_modified_present(fmt) else None
+    content_present_expected = _content_key_present(conn)
 
     run_all(conn, [
         (
@@ -184,8 +172,8 @@ def test_metadata_all_columns_together(copy_env, fmt):
             f"from @{name}/all/f1.{fmt} (file_format => '{fmt}')) "
             f"order by metadata$file_row_number;",
             [
-                (True, True, 0, content_present_expected, last_modified_recent),
-                (True, True, 1, content_present_expected, last_modified_recent),
+                (True, True, 0, content_present_expected, True),
+                (True, True, 1, content_present_expected, True),
             ],
         ),
     ])

--- a/tests/nox/suites/copy/test_metadata.py
+++ b/tests/nox/suites/copy/test_metadata.py
@@ -1,0 +1,191 @@
+import pytest
+
+from .copy_utils import run_all
+
+
+# For row-based formats, queries must include at least one $N column reference.
+# parquet uses named columns directly.
+#
+# orc/avro are excluded because they do not support unload (output), so test
+# data cannot be generated with `copy into @stage`. Track separately.
+FORMATS = ["csv", "ndjson", "text", "parquet"]
+
+
+def _col_ref(fmt):
+    """Return a data column reference appropriate for the format."""
+    if fmt == "parquet":
+        return "a"
+    return "$1"
+
+
+def _storage_type(conn):
+    """Return the configured storage backend type (e.g. 'fs', 's3')."""
+    row = conn.query_row("select value from system.configs where name = 'type'")
+    return row.values()[0]
+
+
+# Parquet reads go through the columnar ParquetPart pipeline, which does not yet
+# thread stage file metadata (ETag/last-modified) into the scan. So for parquet
+# both metadata$file_content_key and metadata$file_last_modified are always NULL,
+# regardless of the storage backend. Other (row-based) formats thread it through.
+def _content_key_present(conn, fmt):
+    if fmt == "parquet":
+        return False
+    return _storage_type(conn) != "fs"
+
+
+def _last_modified_present(fmt):
+    return fmt != "parquet"
+
+
+def _unload(conn, name, path, fmt, query="select number as a, number + 100 as b from numbers(2)"):
+    """Create a stage and unload `query` to a known raw path inside it.
+
+    Using single=true + use_raw_path=true gives a deterministic file name so we
+    can assert metadata$file_basename exactly.
+    """
+    conn.exec(f"create or replace stage {name}")
+    conn.exec(
+        f"copy into @{name}/{path} from ({query}) "
+        f"file_format=(type={fmt}) single=true use_raw_path=true overwrite=true"
+    )
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_file_path_equals_filename(copy_env, fmt):
+    """metadata$file_path and metadata$filename are equivalent."""
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"data/f1.{fmt}", fmt)
+
+    run_all(conn, [
+        (
+            f"select metadata$file_path = metadata$filename "
+            f"from (select {col}, metadata$file_path, metadata$filename "
+            f"from @{name}/data/f1.{fmt} (file_format => '{fmt}')) limit 1;",
+            [(True,)],
+        ),
+    ])
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_file_basename(copy_env, fmt):
+    """metadata$file_basename is exactly the file name (no directory prefix)."""
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"sub/dir/f1.{fmt}", fmt)
+
+    run_all(conn, [
+        (
+            f"select metadata$file_basename, metadata$filename "
+            f"from (select {col}, metadata$file_basename, metadata$filename "
+            f"from @{name}/sub/dir/f1.{fmt} (file_format => '{fmt}')) limit 1;",
+            [(f"f1.{fmt}", f"sub/dir/f1.{fmt}")],
+        ),
+    ])
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_file_row_number(copy_env, fmt):
+    """metadata$file_row_number is the 0-based row index within the file."""
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"rn/f1.{fmt}", fmt)
+
+    run_all(conn, [
+        (
+            f"select metadata$file_row_number "
+            f"from (select {col}, metadata$file_row_number "
+            f"from @{name}/rn/f1.{fmt} (file_format => '{fmt}')) "
+            f"order by metadata$file_row_number;",
+            [(0,), (1,)],
+        ),
+    ])
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_file_content_key(copy_env, fmt):
+    """metadata$file_content_key is nullable string; non-null on object stores.
+
+    Object stores (s3/minio/azblob/...) expose an ETag or md5 that backs the
+    content key, so it must be present. The local fs backend has no such value,
+    so NULL is expected there.
+    """
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"ck/f1.{fmt}", fmt)
+
+    # On fs: content_key is NULL. On object stores: it must be non-null.
+    content_present_expected = _content_key_present(conn, fmt)
+
+    run_all(conn, [
+        (
+            f"select typeof(metadata$file_content_key), "
+            f"metadata$file_content_key is not null "
+            f"from (select {col}, metadata$file_content_key "
+            f"from @{name}/ck/f1.{fmt} (file_format => '{fmt}')) limit 1;",
+            [("VARCHAR NULL", content_present_expected)],
+        ),
+    ])
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_file_last_modified(copy_env, fmt):
+    """metadata$file_last_modified is a timestamp set close to write time."""
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"lm/f1.{fmt}", fmt)
+
+    if _last_modified_present(fmt):
+        recent_expected, before_now_expected = True, True
+    else:
+        # parquet: last_modified is not threaded through, always NULL
+        recent_expected, before_now_expected = None, None
+
+    run_all(conn, [
+        (
+            f"select typeof(metadata$file_last_modified), "
+            f"metadata$file_last_modified > now() - interval 10 minute, "
+            f"metadata$file_last_modified <= now() "
+            f"from (select {col}, metadata$file_last_modified "
+            f"from @{name}/lm/f1.{fmt} (file_format => '{fmt}')) limit 1;",
+            [("TIMESTAMP NULL", recent_expected, before_now_expected)],
+        ),
+    ])
+
+
+@pytest.mark.parametrize("fmt", FORMATS)
+def test_metadata_all_columns_together(copy_env, fmt):
+    """All metadata columns can be selected together and agree with each other."""
+    name = copy_env.uniq_name
+    conn = copy_env.conn
+    col = _col_ref(fmt)
+    _unload(conn, name, f"all/f1.{fmt}", fmt)
+
+    content_present_expected = _content_key_present(conn, fmt)
+    last_modified_recent = True if _last_modified_present(fmt) else None
+
+    run_all(conn, [
+        (
+            f"select "
+            f"metadata$file_path = metadata$filename, "
+            f"metadata$file_basename = 'f1.{fmt}', "
+            f"metadata$file_row_number, "
+            f"metadata$file_content_key is not null, "
+            f"metadata$file_last_modified > now() - interval 10 minute "
+            f"from (select {col}, metadata$file_path, metadata$filename, "
+            f"metadata$file_basename, metadata$file_row_number, "
+            f"metadata$file_content_key, metadata$file_last_modified "
+            f"from @{name}/all/f1.{fmt} (file_format => '{fmt}')) "
+            f"order by metadata$file_row_number;",
+            [
+                (True, True, 0, content_present_expected, last_modified_recent),
+                (True, True, 1, content_present_expected, last_modified_recent),
+            ],
+        ),
+    ])


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix: https://github.com/databendlabs/databend/issues/18058

Add new internal columns for stage file metadata, extending the existing `metadata$filename` and `metadata$file_row_number` support:

- `metadata$file_path`: alias for `metadata$filename` (full file path)
- `metadata$file_basename`: basename of the file path (e.g. `data.csv` from `path/to/data.csv`)
- `metadata$file_content_key`: etag or md5 of the file (nullable string)
- `metadata$file_last_modified`: last modified timestamp of the file (nullable timestamp)

## Changes

- Added new `InternalColumnType` variants: `FilePath`, `FileBasename`, `FileContentKey`, `FileLastModified`
- Added corresponding column name/id constants in expression schema
- Extended `SingleFilePartition` to carry `content_key` and `last_modified` from `StageFileInfo`
- Propagated file metadata through `BytesBatch`, `WholeFileData`, and `Position` structs
- Updated all stage file readers (row-based, arrow, avro) and block builders
- Updated `supported_internal_column` in stage, parquet, and orc tables
- Registered new columns in `InternalColumnFactory`

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Added SQL logic test `csv_metadata_extended.test` for the new metadata columns.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20036)
<!-- Reviewable:end -->
