### PR TITLE
fix: avoid repeated stale spill meta cleanup in RECLUSTER FINAL

### DIFF
--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -275,6 +275,10 @@ impl ReclusterTableInterpreter {
                     ctx.unload_spill_meta();
                     hook_clear_m_cte_temp_table(&ctx)?;
                     hook_vacuum_temp_files(&ctx)?;
+                    // RECLUSTER FINAL runs internal pipelines under one query id.
+                    // Do not let later rounds reuse consumed spill progress and
+                    // repeatedly probe the same stale spill meta file.
+                    ctx.clear_cluster_spill_progress();
                     hook_disk_temp_dir(&ctx)?;
                     match &info.res {
                         Ok(_) => {

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -275,9 +275,10 @@ impl ReclusterTableInterpreter {
                     ctx.unload_spill_meta();
                     hook_clear_m_cte_temp_table(&ctx)?;
                     hook_vacuum_temp_files(&ctx)?;
-                    // RECLUSTER FINAL runs internal pipelines under one query id.
-                    // Do not let later rounds reuse consumed spill progress and
-                    // repeatedly probe the same stale spill meta file.
+                    // RECLUSTER FINAL runs independent pipelines under one query id.
+                    // We allow hook vacuum to be best-effort for each round, and avoid
+                    // carrying this round's spill progress into later rounds.
+                    // Leftovers beyond the hook vacuum limit are handled by normal vacuum.
                     ctx.clear_cluster_spill_progress();
                     hook_disk_temp_dir(&ctx)?;
                     match &info.res {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -554,6 +554,10 @@ impl QueryContext {
             .or_insert(p);
     }
 
+    pub fn clear_cluster_spill_progress(&self) {
+        self.shared.cluster_spill_progress.write().clear();
+    }
+
     pub fn add_spill_file(&self, location: spillers::Location, layout: spillers::Layout) {
         let mut w = self.shared.spilled_files.write();
         w.insert(location, layout);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

RECLUSTER FINAL can run multiple internal pipelines under the same query id. Each round triggers spill vacuum and removes the corresponding `_query_spill/{query_id}_{node}.list` meta files.

  Previously, cluster_spill_progress was kept after cleanup, so later rounds reused stale progress and repeatedly tried to read already-deleted spill meta, causing persistent NotFound warnings from object storage.

  This PR clears consumed spill progress after RECLUSTER pipeline spill vacuum finishes. Existing vacuum limits and temp-file cleanup behavior remain unchanged.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20037)
<!-- Reviewable:end -->
