### PR TITLE
feat: meta: add protobuf storage variants

### DIFF
--- a/src/meta/proto-conv/src/impls/config.rs
+++ b/src/meta/proto-conv/src/impls/config.rs
@@ -22,7 +22,6 @@ use databend_common_meta_app::storage::StorageGcsConfig;
 use databend_common_meta_app::storage::StorageHdfsConfig;
 use databend_common_meta_app::storage::StorageHttpConfig;
 use databend_common_meta_app::storage::StorageIpfsConfig;
-use databend_common_meta_app::storage::StorageMokaConfig;
 use databend_common_meta_app::storage::StorageObsConfig;
 use databend_common_meta_app::storage::StorageOssConfig;
 use databend_common_meta_app::storage::StorageS3Config;
@@ -90,9 +89,6 @@ impl FromToProto for mt::storage::StorageParams {
                 reader_check_msg(s.version, s.min_reader_ver)?;
                 Ok(mt::storage::StorageParams::Memory)
             }
-            Some(pb::storage_config::Storage::Moka(s)) => Ok(mt::storage::StorageParams::Moka(
-                mt::storage::StorageMokaConfig::from_pb(s)?,
-            )),
             Some(pb::storage_config::Storage::None(_)) => Ok(mt::storage::StorageParams::None),
             None => Err(Incompatible::new(
                 "StageStorage.storage cannot be None".to_string(),
@@ -149,12 +145,13 @@ impl FromToProto for mt::storage::StorageParams {
                     },
                 )),
             }),
-            mt::storage::StorageParams::Moka(v) => Ok(pb::StorageConfig {
-                storage: Some(pb::storage_config::Storage::Moka(v.to_pb()?)),
-            }),
             mt::storage::StorageParams::None => Ok(pb::StorageConfig {
                 storage: Some(pb::storage_config::Storage::None(pb::Empty {})),
             }),
+            others => Err(Incompatible::new(format!(
+                "stage type: {} not supported",
+                others
+            ))),
         }
     }
 }
@@ -594,34 +591,6 @@ impl FromToProto for StorageIpfsConfig {
             endpoint_url: self.endpoint_url.clone(),
             root: self.root.clone(),
             network_config: self.network_config.to_pb_opt()?,
-        })
-    }
-}
-
-impl FromToProto for StorageMokaConfig {
-    type PB = pb::MokaStorageConfig;
-    fn get_pb_ver(p: &Self::PB) -> u64 {
-        p.version
-    }
-
-    fn from_pb(p: pb::MokaStorageConfig) -> Result<Self, Incompatible>
-    where Self: Sized {
-        reader_check_msg(p.version, p.min_reader_ver)?;
-
-        Ok(StorageMokaConfig {
-            max_capacity: p.max_capacity,
-            time_to_live: p.time_to_live,
-            time_to_idle: p.time_to_idle,
-        })
-    }
-
-    fn to_pb(&self) -> Result<pb::MokaStorageConfig, Incompatible> {
-        Ok(pb::MokaStorageConfig {
-            version: VER,
-            min_reader_ver: MIN_READER_VER,
-            max_capacity: self.max_capacity,
-            time_to_live: self.time_to_live,
-            time_to_idle: self.time_to_idle,
         })
     }
 }

--- a/src/meta/proto-conv/src/impls/config.rs
+++ b/src/meta/proto-conv/src/impls/config.rs
@@ -89,7 +89,6 @@ impl FromToProto for mt::storage::StorageParams {
                 reader_check_msg(s.version, s.min_reader_ver)?;
                 Ok(mt::storage::StorageParams::Memory)
             }
-            Some(pb::storage_config::Storage::None(_)) => Ok(mt::storage::StorageParams::None),
             None => Err(Incompatible::new(
                 "StageStorage.storage cannot be None".to_string(),
             )),
@@ -145,13 +144,6 @@ impl FromToProto for mt::storage::StorageParams {
                     },
                 )),
             }),
-            mt::storage::StorageParams::None => Ok(pb::StorageConfig {
-                storage: Some(pb::storage_config::Storage::None(pb::Empty {})),
-            }),
-            others => Err(Incompatible::new(format!(
-                "stage type: {} not supported",
-                others
-            ))),
         }
     }
 }

--- a/src/meta/proto-conv/src/impls/config.rs
+++ b/src/meta/proto-conv/src/impls/config.rs
@@ -14,10 +14,15 @@
 
 use databend_common_meta_app as mt;
 use databend_common_meta_app::storage::S3StorageClass;
+use databend_common_meta_app::storage::StorageAzblobConfig;
 use databend_common_meta_app::storage::StorageCosConfig;
 use databend_common_meta_app::storage::StorageFsConfig;
+use databend_common_meta_app::storage::StorageFtpConfig;
 use databend_common_meta_app::storage::StorageGcsConfig;
 use databend_common_meta_app::storage::StorageHdfsConfig;
+use databend_common_meta_app::storage::StorageHttpConfig;
+use databend_common_meta_app::storage::StorageIpfsConfig;
+use databend_common_meta_app::storage::StorageMokaConfig;
 use databend_common_meta_app::storage::StorageObsConfig;
 use databend_common_meta_app::storage::StorageOssConfig;
 use databend_common_meta_app::storage::StorageS3Config;
@@ -69,6 +74,26 @@ impl FromToProto for mt::storage::StorageParams {
                     mt::storage::StorageHuggingfaceConfig::from_pb(s)?,
                 ))
             }
+            Some(pb::storage_config::Storage::Azblob(s)) => Ok(mt::storage::StorageParams::Azblob(
+                mt::storage::StorageAzblobConfig::from_pb(s)?,
+            )),
+            Some(pb::storage_config::Storage::Ftp(s)) => Ok(mt::storage::StorageParams::Ftp(
+                mt::storage::StorageFtpConfig::from_pb(s)?,
+            )),
+            Some(pb::storage_config::Storage::Http(s)) => Ok(mt::storage::StorageParams::Http(
+                mt::storage::StorageHttpConfig::from_pb(s)?,
+            )),
+            Some(pb::storage_config::Storage::Ipfs(s)) => Ok(mt::storage::StorageParams::Ipfs(
+                mt::storage::StorageIpfsConfig::from_pb(s)?,
+            )),
+            Some(pb::storage_config::Storage::Memory(s)) => {
+                reader_check_msg(s.version, s.min_reader_ver)?;
+                Ok(mt::storage::StorageParams::Memory)
+            }
+            Some(pb::storage_config::Storage::Moka(s)) => Ok(mt::storage::StorageParams::Moka(
+                mt::storage::StorageMokaConfig::from_pb(s)?,
+            )),
+            Some(pb::storage_config::Storage::None(_)) => Ok(mt::storage::StorageParams::None),
             None => Err(Incompatible::new(
                 "StageStorage.storage cannot be None".to_string(),
             )),
@@ -104,10 +129,32 @@ impl FromToProto for mt::storage::StorageParams {
             mt::storage::StorageParams::Huggingface(v) => Ok(pb::StorageConfig {
                 storage: Some(pb::storage_config::Storage::Huggingface(v.to_pb()?)),
             }),
-            others => Err(Incompatible::new(format!(
-                "stage type: {} not supported",
-                others
-            ))),
+            mt::storage::StorageParams::Azblob(v) => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Azblob(v.to_pb()?)),
+            }),
+            mt::storage::StorageParams::Ftp(v) => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Ftp(v.to_pb()?)),
+            }),
+            mt::storage::StorageParams::Http(v) => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Http(v.to_pb()?)),
+            }),
+            mt::storage::StorageParams::Ipfs(v) => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Ipfs(v.to_pb()?)),
+            }),
+            mt::storage::StorageParams::Memory => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Memory(
+                    pb::MemoryStorageConfig {
+                        version: VER,
+                        min_reader_ver: MIN_READER_VER,
+                    },
+                )),
+            }),
+            mt::storage::StorageParams::Moka(v) => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::Moka(v.to_pb()?)),
+            }),
+            mt::storage::StorageParams::None => Ok(pb::StorageConfig {
+                storage: Some(pb::storage_config::Storage::None(pb::Empty {})),
+            }),
         }
     }
 }
@@ -425,6 +472,156 @@ impl FromToProto for mt::storage::StorageHuggingfaceConfig {
             token: self.token.clone(),
             root: self.root.clone(),
             network_config: self.network_config.to_pb_opt()?,
+        })
+    }
+}
+
+impl FromToProto for StorageAzblobConfig {
+    type PB = pb::AzblobStorageConfig;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.version
+    }
+
+    fn from_pb(p: pb::AzblobStorageConfig) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.version, p.min_reader_ver)?;
+
+        Ok(StorageAzblobConfig {
+            endpoint_url: p.endpoint_url,
+            container: p.container,
+            account_name: p.account_name,
+            account_key: p.account_key,
+            root: p.root,
+            network_config: p.network_config.from_pb_opt()?,
+        })
+    }
+
+    fn to_pb(&self) -> Result<pb::AzblobStorageConfig, Incompatible> {
+        Ok(pb::AzblobStorageConfig {
+            version: VER,
+            min_reader_ver: MIN_READER_VER,
+            endpoint_url: self.endpoint_url.clone(),
+            container: self.container.clone(),
+            account_name: self.account_name.clone(),
+            account_key: self.account_key.clone(),
+            root: self.root.clone(),
+            network_config: self.network_config.to_pb_opt()?,
+        })
+    }
+}
+
+impl FromToProto for StorageFtpConfig {
+    type PB = pb::FtpStorageConfig;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.version
+    }
+
+    fn from_pb(p: pb::FtpStorageConfig) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.version, p.min_reader_ver)?;
+
+        Ok(StorageFtpConfig {
+            endpoint: p.endpoint,
+            root: p.root,
+            username: p.username,
+            password: p.password,
+            network_config: p.network_config.from_pb_opt()?,
+        })
+    }
+
+    fn to_pb(&self) -> Result<pb::FtpStorageConfig, Incompatible> {
+        Ok(pb::FtpStorageConfig {
+            version: VER,
+            min_reader_ver: MIN_READER_VER,
+            endpoint: self.endpoint.clone(),
+            root: self.root.clone(),
+            username: self.username.clone(),
+            password: self.password.clone(),
+            network_config: self.network_config.to_pb_opt()?,
+        })
+    }
+}
+
+impl FromToProto for StorageHttpConfig {
+    type PB = pb::HttpStorageConfig;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.version
+    }
+
+    fn from_pb(p: pb::HttpStorageConfig) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.version, p.min_reader_ver)?;
+
+        Ok(StorageHttpConfig {
+            endpoint_url: p.endpoint_url,
+            paths: p.paths,
+            network_config: p.network_config.from_pb_opt()?,
+        })
+    }
+
+    fn to_pb(&self) -> Result<pb::HttpStorageConfig, Incompatible> {
+        Ok(pb::HttpStorageConfig {
+            version: VER,
+            min_reader_ver: MIN_READER_VER,
+            endpoint_url: self.endpoint_url.clone(),
+            paths: self.paths.clone(),
+            network_config: self.network_config.to_pb_opt()?,
+        })
+    }
+}
+
+impl FromToProto for StorageIpfsConfig {
+    type PB = pb::IpfsStorageConfig;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.version
+    }
+
+    fn from_pb(p: pb::IpfsStorageConfig) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.version, p.min_reader_ver)?;
+
+        Ok(StorageIpfsConfig {
+            endpoint_url: p.endpoint_url,
+            root: p.root,
+            network_config: p.network_config.from_pb_opt()?,
+        })
+    }
+
+    fn to_pb(&self) -> Result<pb::IpfsStorageConfig, Incompatible> {
+        Ok(pb::IpfsStorageConfig {
+            version: VER,
+            min_reader_ver: MIN_READER_VER,
+            endpoint_url: self.endpoint_url.clone(),
+            root: self.root.clone(),
+            network_config: self.network_config.to_pb_opt()?,
+        })
+    }
+}
+
+impl FromToProto for StorageMokaConfig {
+    type PB = pb::MokaStorageConfig;
+    fn get_pb_ver(p: &Self::PB) -> u64 {
+        p.version
+    }
+
+    fn from_pb(p: pb::MokaStorageConfig) -> Result<Self, Incompatible>
+    where Self: Sized {
+        reader_check_msg(p.version, p.min_reader_ver)?;
+
+        Ok(StorageMokaConfig {
+            max_capacity: p.max_capacity,
+            time_to_live: p.time_to_live,
+            time_to_idle: p.time_to_idle,
+        })
+    }
+
+    fn to_pb(&self) -> Result<pb::MokaStorageConfig, Incompatible> {
+        Ok(pb::MokaStorageConfig {
+            version: VER,
+            min_reader_ver: MIN_READER_VER,
+            max_capacity: self.max_capacity,
+            time_to_live: self.time_to_live,
+            time_to_idle: self.time_to_idle,
         })
     }
 }

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -207,7 +207,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (175, "2026-05-08: Add: field_stats_truncate_len per-column string stats truncation in TableMeta"),
     (176, "2026-05-25: Add: task.proto/Task.script_sql"),
     (177, "2026-06-02: Add: file_format.proto Arrow and ArrowStream file formats"),
-    (178, "2026-06-22: Add: config.proto StorageConfig variants for all StorageParams"),
+    (178, "2026-06-22: Add: config.proto StorageConfig variants for additional StorageParams"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -207,7 +207,7 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (175, "2026-05-08: Add: field_stats_truncate_len per-column string stats truncation in TableMeta"),
     (176, "2026-05-25: Add: task.proto/Task.script_sql"),
     (177, "2026-06-02: Add: file_format.proto Arrow and ArrowStream file formats"),
-    (178, "2026-06-22: Add: config.proto StorageConfig variants for additional StorageParams"),
+    (178, "2026-06-22: Add: config.proto StorageConfig variants for StorageParams::{Azblob,Ftp,Http,Ipfs,Memory}"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/src/util.rs
+++ b/src/meta/proto-conv/src/util.rs
@@ -206,7 +206,8 @@ const META_CHANGE_LOG: &[(u64, &str)] = &[
     (174, "2026-04-28: Add: AuthInfo::KeyPair for key-pair authentication"),
     (175, "2026-05-08: Add: field_stats_truncate_len per-column string stats truncation in TableMeta"),
     (176, "2026-05-25: Add: task.proto/Task.script_sql"),
-    (177, "2026-06-02: Add: file_format.proto Arrow and ArrowStream file formats")
+    (177, "2026-06-02: Add: file_format.proto Arrow and ArrowStream file formats"),
+    (178, "2026-06-22: Add: config.proto StorageConfig variants for all StorageParams"),
     // Dear developer:
     //      If you're gonna add a new metadata version, you'll have to add a test for it.
     //      You could just copy an existing test file(e.g., `../tests/it/v024_table_meta.rs`)

--- a/src/meta/proto-conv/tests/it/main.rs
+++ b/src/meta/proto-conv/tests/it/main.rs
@@ -169,3 +169,4 @@ mod v174_user_key_pair;
 mod v175_field_stats_truncate_len;
 mod v176_task_script_sql;
 mod v177_arrow_file_format_params;
+mod v178_storage_config;

--- a/src/meta/proto-conv/tests/it/v178_storage_config.rs
+++ b/src/meta/proto-conv/tests/it/v178_storage_config.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_meta_app::storage::StorageAzblobConfig;
+use databend_common_meta_app::storage::StorageFtpConfig;
+use databend_common_meta_app::storage::StorageHttpConfig;
+use databend_common_meta_app::storage::StorageIpfsConfig;
+use databend_common_meta_app::storage::StorageMokaConfig;
+use databend_common_meta_app::storage::StorageNetworkParams;
+use databend_common_meta_app::storage::StorageParams;
+use fastrace::func_name;
+
+use crate::common;
+
+fn network_config() -> Option<StorageNetworkParams> {
+    Some(StorageNetworkParams {
+        retry_timeout: 1,
+        retry_io_timeout: 2,
+        tcp_keepalive: 3,
+        connect_timeout: 4,
+        pool_max_idle_per_host: 5,
+        max_concurrent_io_requests: 6,
+    })
+}
+
+// These bytes are built when a new version in introduced,
+// and are kept for backward compatibility test.
+//
+// *************************************************************
+// * These messages should never be updated,                   *
+// * only be added when a new version is added,                *
+// * or be removed when an old version is no longer supported. *
+// *************************************************************
+//
+#[test]
+fn test_decode_v178_storage_config_azblob() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![
+        82, 88, 10, 26, 104, 116, 116, 112, 115, 58, 47, 47, 97, 122, 98, 108, 111, 98, 46, 101,
+        120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 18, 9, 99, 111, 110, 116, 97, 105, 110, 101,
+        114, 26, 7, 97, 99, 99, 111, 117, 110, 116, 34, 3, 107, 101, 121, 42, 5, 47, 100, 97, 116,
+        97, 50, 19, 8, 1, 16, 2, 24, 3, 32, 4, 40, 5, 48, 6, 160, 6, 178, 1, 168, 6, 24, 160, 6,
+        178, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        StorageParams::Azblob(StorageAzblobConfig {
+            endpoint_url: "https://azblob.example.com".to_string(),
+            container: "container".to_string(),
+            account_name: "account".to_string(),
+            account_key: "key".to_string(),
+            root: "/data".to_string(),
+            network_config: network_config(),
+        })
+    };
+
+    // StorageConfig itself does not carry version fields and get_pb_ver() returns 0.
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_ftp() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![
+        90, 76, 10, 22, 102, 116, 112, 115, 58, 47, 47, 102, 116, 112, 46, 101, 120, 97, 109, 112,
+        108, 101, 46, 99, 111, 109, 18, 6, 47, 102, 105, 108, 101, 115, 26, 4, 117, 115, 101, 114,
+        34, 8, 112, 97, 115, 115, 119, 111, 114, 100, 42, 19, 8, 1, 16, 2, 24, 3, 32, 4, 40, 5, 48,
+        6, 160, 6, 178, 1, 168, 6, 24, 160, 6, 178, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        StorageParams::Ftp(StorageFtpConfig {
+            endpoint: "ftps://ftp.example.com".to_string(),
+            root: "/files".to_string(),
+            username: "user".to_string(),
+            password: "password".to_string(),
+            network_config: network_config(),
+        })
+    };
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_http() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![
+        98, 70, 10, 24, 104, 116, 116, 112, 115, 58, 47, 47, 100, 97, 116, 97, 46, 101, 120, 97,
+        109, 112, 108, 101, 46, 99, 111, 109, 18, 6, 47, 97, 46, 99, 115, 118, 18, 6, 47, 98, 46,
+        99, 115, 118, 26, 19, 8, 1, 16, 2, 24, 3, 32, 4, 40, 5, 48, 6, 160, 6, 178, 1, 168, 6, 24,
+        160, 6, 178, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        StorageParams::Http(StorageHttpConfig {
+            endpoint_url: "https://data.example.com".to_string(),
+            paths: vec!["/a.csv".to_string(), "/b.csv".to_string()],
+            network_config: network_config(),
+        })
+    };
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_ipfs() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![
+        106, 66, 10, 24, 104, 116, 116, 112, 115, 58, 47, 47, 105, 112, 102, 115, 46, 101, 120, 97,
+        109, 112, 108, 101, 46, 99, 111, 109, 18, 10, 47, 105, 112, 102, 115, 47, 114, 111, 111,
+        116, 26, 19, 8, 1, 16, 2, 24, 3, 32, 4, 40, 5, 48, 6, 160, 6, 178, 1, 168, 6, 24, 160, 6,
+        178, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        StorageParams::Ipfs(StorageIpfsConfig {
+            endpoint_url: "https://ipfs.example.com".to_string(),
+            root: "/ipfs/root".to_string(),
+            network_config: network_config(),
+        })
+    };
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_memory() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![114, 7, 160, 6, 178, 1, 168, 6, 24];
+
+    let want = || StorageParams::Memory;
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_moka() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![
+        122, 16, 8, 128, 8, 16, 144, 28, 24, 216, 4, 160, 6, 178, 1, 168, 6, 24,
+    ];
+
+    let want = || {
+        StorageParams::Moka(StorageMokaConfig {
+            max_capacity: 1024,
+            time_to_live: 3600,
+            time_to_idle: 600,
+        })
+    };
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}
+
+#[test]
+fn test_decode_v178_storage_config_none() -> anyhow::Result<()> {
+    let storage_config_v178 = vec![130, 1, 0];
+
+    let want = || StorageParams::None;
+
+    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
+    common::test_pb_from_to(func_name!(), want())?;
+    Ok(())
+}

--- a/src/meta/proto-conv/tests/it/v178_storage_config.rs
+++ b/src/meta/proto-conv/tests/it/v178_storage_config.rs
@@ -147,14 +147,3 @@ fn test_decode_v178_storage_config_memory() -> anyhow::Result<()> {
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }
-
-#[test]
-fn test_decode_v178_storage_config_none() -> anyhow::Result<()> {
-    let storage_config_v178 = vec![130, 1, 0];
-
-    let want = || StorageParams::None;
-
-    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}

--- a/src/meta/proto-conv/tests/it/v178_storage_config.rs
+++ b/src/meta/proto-conv/tests/it/v178_storage_config.rs
@@ -16,7 +16,6 @@ use databend_common_meta_app::storage::StorageAzblobConfig;
 use databend_common_meta_app::storage::StorageFtpConfig;
 use databend_common_meta_app::storage::StorageHttpConfig;
 use databend_common_meta_app::storage::StorageIpfsConfig;
-use databend_common_meta_app::storage::StorageMokaConfig;
 use databend_common_meta_app::storage::StorageNetworkParams;
 use databend_common_meta_app::storage::StorageParams;
 use fastrace::func_name;
@@ -143,25 +142,6 @@ fn test_decode_v178_storage_config_memory() -> anyhow::Result<()> {
     let storage_config_v178 = vec![114, 7, 160, 6, 178, 1, 168, 6, 24];
 
     let want = || StorageParams::Memory;
-
-    common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}
-
-#[test]
-fn test_decode_v178_storage_config_moka() -> anyhow::Result<()> {
-    let storage_config_v178 = vec![
-        122, 16, 8, 128, 8, 16, 144, 28, 24, 216, 4, 160, 6, 178, 1, 168, 6, 24,
-    ];
-
-    let want = || {
-        StorageParams::Moka(StorageMokaConfig {
-            max_capacity: 1024,
-            time_to_live: 3600,
-            time_to_idle: 600,
-        })
-    };
 
     common::test_load_old(func_name!(), storage_config_v178.as_slice(), 0, want())?;
     common::test_pb_from_to(func_name!(), want())?;

--- a/src/meta/protos/proto/config.proto
+++ b/src/meta/protos/proto/config.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package databend_proto;
 
+import "datatype.proto";
+
 message StorageConfig {
   oneof storage {
     S3StorageConfig s3 = 1;
@@ -27,6 +29,13 @@ message StorageConfig {
     CosStorageConfig cos = 7;
     HdfsStorageConfig hdfs = 8;
     HuggingfaceStorageConfig huggingface = 9;
+    AzblobStorageConfig azblob = 10;
+    FtpStorageConfig ftp = 11;
+    HttpStorageConfig http = 12;
+    IpfsStorageConfig ipfs = 13;
+    MemoryStorageConfig memory = 14;
+    MokaStorageConfig moka = 15;
+    Empty none = 16;
   }
 }
 
@@ -166,4 +175,59 @@ message HuggingfaceStorageConfig {
   string root = 4;
   string token = 5;
   NetworkConfig network_config = 6;
+}
+
+message AzblobStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+
+  string endpoint_url = 1;
+  string container = 2;
+  string account_name = 3;
+  string account_key = 4;
+  string root = 5;
+  NetworkConfig network_config = 6;
+}
+
+message FtpStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+
+  string endpoint = 1;
+  string root = 2;
+  string username = 3;
+  string password = 4;
+  NetworkConfig network_config = 5;
+}
+
+message HttpStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+
+  string endpoint_url = 1;
+  repeated string paths = 2;
+  NetworkConfig network_config = 3;
+}
+
+message IpfsStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+
+  string endpoint_url = 1;
+  string root = 2;
+  NetworkConfig network_config = 3;
+}
+
+message MemoryStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+}
+
+message MokaStorageConfig {
+  uint64 version = 100;
+  uint64 min_reader_ver = 101;
+
+  uint64 max_capacity = 1;
+  int64 time_to_live = 2;
+  int64 time_to_idle = 3;
 }

--- a/src/meta/protos/proto/config.proto
+++ b/src/meta/protos/proto/config.proto
@@ -34,7 +34,6 @@ message StorageConfig {
     HttpStorageConfig http = 12;
     IpfsStorageConfig ipfs = 13;
     MemoryStorageConfig memory = 14;
-    MokaStorageConfig moka = 15;
     Empty none = 16;
   }
 }
@@ -221,13 +220,4 @@ message IpfsStorageConfig {
 message MemoryStorageConfig {
   uint64 version = 100;
   uint64 min_reader_ver = 101;
-}
-
-message MokaStorageConfig {
-  uint64 version = 100;
-  uint64 min_reader_ver = 101;
-
-  uint64 max_capacity = 1;
-  int64 time_to_live = 2;
-  int64 time_to_idle = 3;
 }

--- a/src/meta/protos/proto/config.proto
+++ b/src/meta/protos/proto/config.proto
@@ -34,7 +34,6 @@ message StorageConfig {
     HttpStorageConfig http = 12;
     IpfsStorageConfig ipfs = 13;
     MemoryStorageConfig memory = 14;
-    Empty none = 16;
   }
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: meta: add protobuf storage variants
# Summary

Add protobuf coverage for every `StorageParams` variant so storage metadata can encode all supported backends without falling through to an encode-time incompatibility error.

# Details

The storage protobuf schema now includes the previously missing external and in-memory storage variants. `StorageParams::None` uses the existing empty protobuf message because it carries no payload.

The conversion layer now maps the new protobuf variants in both directions, preserving version checks for payload-bearing messages and keeping the empty none case payload-free.

A v178 compatibility test decodes fixed binary protobuf messages for each new storage variant and verifies current round-trip encoding.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20038)
<!-- Reviewable:end -->
