### PR TITLE
fix: avoid abort on allocation failure in concat and spill paths

### DIFF
--- a/src/common/base/src/mem_allocator/jemalloc.rs
+++ b/src/common/base/src/mem_allocator/jemalloc.rs
@@ -136,7 +136,7 @@ pub mod linux {
                     unsafe { ffi::rallocx(ptr.cast().as_ptr(), new_layout.size(), flags) }
                         as *mut (),
                 )
-                .unwrap()
+                .ok_or(AllocError)?
             };
 
             Ok(NonNull::<[u8]>::from_raw_parts(

--- a/src/common/base/src/runtime/memory/alloc_error_hook.rs
+++ b/src/common/base/src/runtime/memory/alloc_error_hook.rs
@@ -12,14 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::Cell;
+
 use crate::runtime::LimitMemGuard;
 use crate::runtime::ThreadTracker;
+
+thread_local! {
+    static ALLOC_ERROR_PANIC: Cell<bool> = const { Cell::new(false) };
+}
+
+fn mark_alloc_error_panic() {
+    ALLOC_ERROR_PANIC.with(|flag| flag.set(true));
+}
+
+pub fn take_alloc_error_panic() -> bool {
+    ALLOC_ERROR_PANIC.with(|flag| flag.replace(false))
+}
 
 pub fn set_alloc_error_hook() {
     std::alloc::set_alloc_error_hook(|layout| {
         let _guard = LimitMemGuard::enter_unlimited();
 
         let out_of_limit_desc = ThreadTracker::replace_error_message(None);
+        mark_alloc_error_panic();
 
         panic!(
             "{}",

--- a/src/common/base/src/runtime/memory/mod.rs
+++ b/src/common/base/src/runtime/memory/mod.rs
@@ -19,6 +19,7 @@ mod stat_buffer_global;
 mod stat_buffer_mem_stat;
 
 pub use alloc_error_hook::set_alloc_error_hook;
+pub use alloc_error_hook::take_alloc_error_panic;
 pub use mem_stat::GLOBAL_MEM_STAT;
 pub use mem_stat::MemStat;
 pub use mem_stat::OutOfLimit;

--- a/src/common/base/src/runtime/mod.rs
+++ b/src/common/base/src/runtime/mod.rs
@@ -51,6 +51,7 @@ pub use memory::MemStatBuffer;
 pub use memory::OutOfLimit;
 pub use memory::ParentMemStat;
 pub use memory::set_alloc_error_hook;
+pub use memory::take_alloc_error_panic;
 pub use perf::PerfConfig;
 pub use perf::PerfCounters;
 pub use perf::PerfEvent;

--- a/src/common/tracing/src/panic_hook.rs
+++ b/src/common/tracing/src/panic_hook.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::panic::PanicHookInfo;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -21,6 +22,9 @@ use backtrace::BacktraceFrame;
 use databend_common_base::runtime::LimitMemGuard;
 use databend_common_exception::USER_SET_ENABLE_BACKTRACE;
 use log::error;
+
+const MEMORY_BACKTRACE_SKIPPED: &str =
+    "Backtrace skipped because the panic was caused by memory allocation failure";
 
 pub fn set_panic_hook(version: String) {
     // Set a panic hook that records the panic as a `tracing` event at the
@@ -47,7 +51,11 @@ fn should_backtrace() -> bool {
 }
 
 pub fn log_panic(panic: &PanicHookInfo, version: Arc<String>) {
-    let backtrace_str = backtrace(50);
+    let backtrace_str = if is_memory_allocation_panic(panic) {
+        Cow::Borrowed(MEMORY_BACKTRACE_SKIPPED)
+    } else {
+        Cow::Owned(backtrace(50))
+    };
 
     eprintln!("{}", panic);
     eprintln!("{}", backtrace_str);
@@ -55,15 +63,32 @@ pub fn log_panic(panic: &PanicHookInfo, version: Arc<String>) {
     if let Some(location) = panic.location() {
         error!(
             version = version,
-            backtrace = &backtrace_str,
+            backtrace = backtrace_str.as_ref(),
             "panic.file" = location.file(),
             "panic.line" = location.line(),
             "panic.column" = location.column();
             "{}", panic,
         );
     } else {
-        error!(version=version, backtrace = backtrace_str; "{}", panic);
+        error!(version=version, backtrace = backtrace_str.as_ref(); "{}", panic);
     }
+}
+
+fn is_memory_allocation_panic(panic: &PanicHookInfo) -> bool {
+    panic_message(panic).is_some_and(is_memory_allocation_message)
+}
+
+fn panic_message<'a>(panic: &'a PanicHookInfo<'a>) -> Option<&'a str> {
+    panic
+        .payload()
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.payload().downcast_ref::<String>().map(String::as_str))
+}
+
+fn is_memory_allocation_message(message: &str) -> bool {
+    (message.starts_with("memory allocation of ") && message.ends_with(" bytes failed"))
+        || (message.starts_with("memory usage ") && message.contains(" exceeds limit "))
 }
 
 pub fn captures_frames(frames: &mut Vec<BacktraceFrame>) {
@@ -86,6 +111,7 @@ mod tests {
     use backtrace::BacktraceFrame;
 
     use crate::panic_hook::captures_frames;
+    use crate::panic_hook::is_memory_allocation_message;
 
     #[test]
     fn test_captures_frames() {
@@ -105,5 +131,18 @@ mod tests {
         let frames_size = recursion_f(100, 1000).len();
         assert!(frames_size >= 100);
         assert!(frames_size < 1000);
+    }
+
+    #[test]
+    fn test_memory_allocation_message_detection() {
+        assert!(is_memory_allocation_message(
+            "memory allocation of 4096 bytes failed"
+        ));
+        assert!(is_memory_allocation_message(
+            "memory usage 2.00 GiB(2147483648) exceeds limit 1.00 GiB(1073741824)"
+        ));
+        assert!(!is_memory_allocation_message(
+            "called `Option::unwrap()` on a `None` value"
+        ));
     }
 }

--- a/src/common/tracing/src/panic_hook.rs
+++ b/src/common/tracing/src/panic_hook.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::Ordering;
 use backtrace::Backtrace;
 use backtrace::BacktraceFrame;
 use databend_common_base::runtime::LimitMemGuard;
+use databend_common_base::runtime::take_alloc_error_panic;
 use databend_common_exception::USER_SET_ENABLE_BACKTRACE;
 use log::error;
 
@@ -51,7 +52,7 @@ fn should_backtrace() -> bool {
 }
 
 pub fn log_panic(panic: &PanicHookInfo, version: Arc<String>) {
-    let backtrace_str = if is_memory_allocation_panic(panic) {
+    let backtrace_str = if take_alloc_error_panic() {
         Cow::Borrowed(MEMORY_BACKTRACE_SKIPPED)
     } else {
         Cow::Owned(backtrace(50))
@@ -74,23 +75,6 @@ pub fn log_panic(panic: &PanicHookInfo, version: Arc<String>) {
     }
 }
 
-fn is_memory_allocation_panic(panic: &PanicHookInfo) -> bool {
-    panic_message(panic).is_some_and(is_memory_allocation_message)
-}
-
-fn panic_message<'a>(panic: &'a PanicHookInfo<'a>) -> Option<&'a str> {
-    panic
-        .payload()
-        .downcast_ref::<&str>()
-        .copied()
-        .or_else(|| panic.payload().downcast_ref::<String>().map(String::as_str))
-}
-
-fn is_memory_allocation_message(message: &str) -> bool {
-    (message.starts_with("memory allocation of ") && message.ends_with(" bytes failed"))
-        || (message.starts_with("memory usage ") && message.contains(" exceeds limit "))
-}
-
 pub fn captures_frames(frames: &mut Vec<BacktraceFrame>) {
     backtrace::trace(|frame| {
         frames.push(BacktraceFrame::from(frame.clone()));
@@ -111,7 +95,6 @@ mod tests {
     use backtrace::BacktraceFrame;
 
     use crate::panic_hook::captures_frames;
-    use crate::panic_hook::is_memory_allocation_message;
 
     #[test]
     fn test_captures_frames() {
@@ -131,18 +114,5 @@ mod tests {
         let frames_size = recursion_f(100, 1000).len();
         assert!(frames_size >= 100);
         assert!(frames_size < 1000);
-    }
-
-    #[test]
-    fn test_memory_allocation_message_detection() {
-        assert!(is_memory_allocation_message(
-            "memory allocation of 4096 bytes failed"
-        ));
-        assert!(is_memory_allocation_message(
-            "memory usage 2.00 GiB(2147483648) exceeds limit 1.00 GiB(1073741824)"
-        ));
-        assert!(!is_memory_allocation_message(
-            "called `Option::unwrap()` on a `None` value"
-        ));
     }
 }

--- a/src/query/expression/src/kernels/concat.rs
+++ b/src/query/expression/src/kernels/concat.rs
@@ -147,7 +147,7 @@ impl Column {
             Column::Boolean(_) => Column::Boolean(Self::concat_boolean_types(
                 columns.map(|col| col.into_boolean().unwrap()),
                 capacity,
-            )),
+            )?),
             Column::Timestamp(_) => {
                 let buffer = Self::concat_primitive_types(
                     columns.map(|col| TimestampType::try_downcast_column(&col).unwrap()),
@@ -211,7 +211,7 @@ impl Column {
                     .map(|col| col.into_nullable().unwrap().destructure())
                     .unzip(); // break the recursion type
                 let column = Self::concat_columns_impl(inner.into_iter())?;
-                let validity = Self::concat_boolean_types(validity.into_iter(), capacity);
+                let validity = Self::concat_boolean_types(validity.into_iter(), capacity)?;
                 NullableColumn::new_column(column, validity)
             }
             Column::Tuple(fields) => {
@@ -253,7 +253,7 @@ impl Column {
             | Column::Geography(_)
             | Column::Binary(_)
             | Column::Bitmap(_) => {
-                Self::concat_use_arrow(columns, first_column.data_type(), capacity)
+                Self::concat_use_arrow(columns, first_column.data_type(), capacity)?
             }
         };
         Ok(column)
@@ -297,18 +297,26 @@ impl Column {
         cols: impl Iterator<Item = Column>,
         data_type: DataType,
         _num_rows: usize,
-    ) -> Column {
+    ) -> Result<Column> {
         let arrays: Vec<Arc<dyn Array>> = cols.map(|c| c.into_arrow_rs()).collect();
         let arrays = arrays.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
-        let result = arrow_select::concat::concat(&arrays).unwrap();
-        Column::from_arrow_rs(result, &data_type).unwrap()
+        let result = arrow_select::concat::concat(&arrays)?;
+        Column::from_arrow_rs(result, &data_type)
     }
 
-    pub fn concat_boolean_types(bitmaps: impl Iterator<Item = Bitmap>, num_rows: usize) -> Bitmap {
+    pub fn concat_boolean_types(
+        bitmaps: impl Iterator<Item = Bitmap>,
+        num_rows: usize,
+    ) -> Result<Bitmap> {
         let cols = bitmaps.map(Column::Boolean);
-        Self::concat_use_arrow(cols, DataType::Boolean, num_rows)
+        Self::concat_use_arrow(cols, DataType::Boolean, num_rows)?
             .into_boolean()
-            .unwrap()
+            .map_err(|col| {
+                ErrorCode::Internal(format!(
+                    "Arrow boolean concat returned {} column",
+                    col.data_type()
+                ))
+            })
     }
 
     fn concat_value_types<T: ValueType>(
@@ -327,7 +335,26 @@ impl Column {
 #[cfg(test)]
 mod tests {
     use crate::Column;
+    use crate::FromData;
+    use crate::types::BinaryType;
     use crate::types::string::StringColumn;
+
+    #[test]
+    fn test_concat_binary_columns_uses_arrow_path() {
+        let left = BinaryType::from_data(vec![b"left".as_slice(), b"payload".as_slice()]);
+        let right = BinaryType::from_data(vec![b"right".as_slice(), b"bytes".as_slice()]);
+
+        let result = Column::concat_columns(vec![left, right].into_iter()).unwrap();
+        let result = result.into_binary().unwrap();
+        let values = result.iter().collect::<Vec<_>>();
+
+        assert_eq!(values, vec![
+            b"left".as_slice(),
+            b"payload".as_slice(),
+            b"right".as_slice(),
+            b"bytes".as_slice(),
+        ]);
+    }
 
     #[test]
     fn test_concat_string_columns_fast_path() {

--- a/src/query/service/src/spillers/adapter.rs
+++ b/src/query/service/src/spillers/adapter.rs
@@ -202,7 +202,7 @@ impl Spiller {
         let mut partition_ids = Vec::new();
         for (partition_id, data_blocks) in partitioned_data.into_iter() {
             partition_ids.push(partition_id);
-            encoder.add_blocks(data_blocks);
+            encoder.add_blocks(data_blocks)?;
         }
 
         let write_bytes = encoder.size();

--- a/src/query/service/src/spillers/block_writer.rs
+++ b/src/query/service/src/spillers/block_writer.rs
@@ -47,7 +47,7 @@ impl BlocksWriter {
         assert!(!block.is_empty());
 
         let mut block_encoder = BlocksEncoder::new(true, Alignment::MIN, 8 * 1024 * 1024);
-        block_encoder.add_blocks(vec![block]);
+        block_encoder.add_blocks(vec![block])?;
 
         let buf = block_encoder
             .buf

--- a/src/query/service/src/spillers/inner.rs
+++ b/src/query/service/src/spillers/inner.rs
@@ -155,7 +155,7 @@ impl<A> SpillerInner<A> {
 
         // Spill data to storage.
         let mut encoder = self.block_encoder();
-        encoder.add_blocks(data_block);
+        encoder.add_blocks(data_block)?;
         let data_size = encoder.size();
         let BlocksEncoder {
             buf,

--- a/src/query/service/src/spillers/serialize.rs
+++ b/src/query/service/src/spillers/serialize.rs
@@ -67,36 +67,35 @@ impl BlocksEncoder {
         }
     }
 
-    pub(super) fn add_blocks(&mut self, mut blocks: Vec<DataBlock>) {
+    pub(super) fn add_blocks(&mut self, mut blocks: Vec<DataBlock>) -> Result<()> {
         let layout = if self.use_parquet {
             // Currently we splice multiple complete parquet files into one,
             // so that the file contains duplicate headers/footers and metadata,
             // which can lead to file bloat. A better approach would be for the entire file to be ONE parquet,
             // with each group of blocks (i.e. Chunk) corresponding to one or more row groupsx
-            bare_blocks_to_parquet(blocks, &mut self.buf).unwrap();
+            bare_blocks_to_parquet(blocks, &mut self.buf)?;
             Layout::Parquet
         } else {
             let block = if blocks.len() == 1 {
                 blocks.remove(0)
             } else {
-                DataBlock::concat(&std::mem::take(&mut blocks)).unwrap()
+                DataBlock::concat(&std::mem::take(&mut blocks))?
             };
-            let columns_layout = Some(self.size())
-                .into_iter()
-                .chain(block.take_columns().into_iter().map(|entry| {
-                    let column = entry.to_column();
-                    write_column(&column, &mut self.buf).unwrap();
-                    self.size()
-                }))
-                .map_windows(|x: &[_; 2]| x[1] - x[0])
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-
-            Layout::ArrowIpc(columns_layout)
+            let mut columns_layout = Vec::with_capacity(block.num_columns());
+            let mut last_size = self.size();
+            for entry in block.take_columns() {
+                let column = entry.to_column();
+                write_column(&column, &mut self.buf)?;
+                let current_size = self.size();
+                columns_layout.push(current_size - last_size);
+                last_size = current_size;
+            }
+            Layout::ArrowIpc(columns_layout.into_boxed_slice())
         };
 
         self.columns_layout.push(layout);
-        self.offsets.push(self.size())
+        self.offsets.push(self.size());
+        Ok(())
     }
 
     pub(super) fn size(&self) -> usize {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Large RECLUSTER or spill workloads can hit allocation failures while compacting blocks, especially when Arrow concat needs to allocate large Binary/Variant buffers. Previously, some failure paths used unwraps, so an allocation failure could panic, trigger heavy panic backtrace collection, and finally abort the databend-query process.

- fixes: #19996

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20039)
<!-- Reviewable:end -->
