### PR TITLE
fix(query): skip unsupported runtime filter probe targets

### DIFF
--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -152,16 +152,8 @@ pub async fn build_runtime_filter(
             })
         })
     {
-        // Skip if the probe expression is neither a direct column reference nor a
-        // cast from not null to nullable type (e.g. CAST(col AS Nullable(T))).
-        match &probe_key {
-            RemoteExpr::ColumnRef { .. } => {}
-            RemoteExpr::Cast {
-                expr: box RemoteExpr::ColumnRef { data_type, .. },
-                dest_type,
-                ..
-            } if &dest_type.remove_nullable() == data_type => {}
-            _ => continue,
+        if !supported_probe_key_for_runtime_filter(&probe_key) {
+            continue;
         }
 
         let probe_targets =
@@ -277,28 +269,48 @@ fn scalar_to_remote_expr(
     metadata: &MetadataRef,
     scalar: &ScalarExpr,
 ) -> Result<Option<(RemoteExpr<String>, usize, Symbol)>> {
-    if scalar.used_columns().iter().all(|idx| {
-        matches!(
-            metadata.read().column(*idx),
-            ColumnEntry::BaseTableColumn(_)
-        )
-    }) {
-        if let Some(column_idx) = scalar.used_columns().iter().next() {
-            let scan_id = metadata.read().base_column_scan_id(*column_idx);
+    let used_columns = scalar.used_columns();
+    if used_columns.len() != 1 {
+        return Ok(None);
+    }
 
-            if let Some(scan_id) = scan_id {
-                let remote_expr = scalar
-                    .as_raw_expr()
-                    .type_check(&*metadata.read())?
-                    .project_column_ref(|col| Ok(col.column_name.clone()))?
-                    .as_remote_expr();
+    let column_idx = *used_columns.iter().next().unwrap();
+    if !matches!(
+        metadata.read().column(column_idx),
+        ColumnEntry::BaseTableColumn(_)
+    ) {
+        return Ok(None);
+    }
 
-                return Ok(Some((remote_expr, scan_id, *column_idx)));
-            }
-        }
+    let Some(scan_id) = metadata.read().base_column_scan_id(column_idx) else {
+        return Ok(None);
+    };
+
+    let remote_expr = scalar
+        .as_raw_expr()
+        .type_check(&*metadata.read())?
+        .project_column_ref(|col| Ok(col.column_name.clone()))?
+        .as_remote_expr();
+
+    if supported_probe_key_for_runtime_filter(&remote_expr) {
+        return Ok(Some((remote_expr, scan_id, column_idx)));
     }
 
     Ok(None)
+}
+
+fn supported_probe_key_for_runtime_filter(probe_key: &RemoteExpr<String>) -> bool {
+    match probe_key {
+        RemoteExpr::ColumnRef { .. } => true,
+        // Support simple cast that only changes nullability, e.g. CAST(col AS Nullable(T)).
+        RemoteExpr::Cast {
+            expr, dest_type, ..
+        } => matches!(
+            expr.as_ref(),
+            RemoteExpr::ColumnRef { data_type, .. } if &dest_type.remove_nullable() == data_type
+        ),
+        _ => false,
+    }
 }
 
 struct UnionFind {

--- a/tests/sqllogictests/suites/query/join/runtime_filter.test
+++ b/tests/sqllogictests/suites/query/join/runtime_filter.test
@@ -91,3 +91,59 @@ drop table table1;
 
 statement ok
 drop table table2;
+
+statement ok
+set disable_join_reorder = 1;
+
+statement ok
+set enable_join_runtime_filter = 1;
+
+statement ok
+drop table if exists rf_expr_probe_t1;
+
+statement ok
+drop table if exists rf_expr_probe_t2;
+
+statement ok
+drop table if exists rf_expr_probe_t3;
+
+statement ok
+create table rf_expr_probe_t1(a bigint);
+
+statement ok
+create table rf_expr_probe_t2(x int, y int);
+
+statement ok
+create table rf_expr_probe_t3(a bigint);
+
+statement ok
+insert into rf_expr_probe_t1 values (3), (5);
+
+statement ok
+insert into rf_expr_probe_t2 values (1, 2), (2, 3);
+
+statement ok
+insert into rf_expr_probe_t3 values (3);
+
+query I
+select count(*)
+from rf_expr_probe_t1 t1
+join rf_expr_probe_t2 t2 on t1.a = cast(t2.x + t2.y as bigint)
+join rf_expr_probe_t3 t3 on t1.a = t3.a;
+----
+1
+
+statement ok
+drop table rf_expr_probe_t1;
+
+statement ok
+drop table rf_expr_probe_t2;
+
+statement ok
+drop table rf_expr_probe_t3;
+
+statement ok
+unset enable_join_runtime_filter;
+
+statement ok
+unset disable_join_reorder;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prevent runtime filter equivalence propagation from producing unsupported probe targets for complex/cast expressions.
- Keep runtime filter probe targets limited to direct column references and nullable-only casts, matching execution-side support.
- Add sqllogictest coverage for an outer join runtime filter reaching an inner `cast(t2.x + t2.y as bigint)` condition.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --package databend-query`
- `db-slt --suite-root tests/sqllogictests/suites/query --run-dir join --run-file runtime_filter.test --parallel 1 --no-complete`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20040)
<!-- Reviewable:end -->
