### PR TITLE
refactor: remove unused StorageParams::None variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12864,7 +12864,6 @@ dependencies = [
  "http-body 1.0.1",
  "log",
  "md-5",
- "moka",
  "percent-encoding",
  "prometheus-client 0.23.1",
  "prost 0.13.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,6 @@ opendal = { version = "0.54.1", features = [
     "services-azdls",
     "services-ipfs",
     "services-http",
-    "services-moka",
     "services-webhdfs",
     "services-huggingface",
 ] }

--- a/src/common/storage/src/endpoint_policy.rs
+++ b/src/common/storage/src/endpoint_policy.rs
@@ -282,7 +282,7 @@ pub async fn check_storage_params_endpoints(sp: &StorageParams) -> Result<()> {
 
 /// Enumerate every endpoint URL field of a `StorageParams` variant that the
 /// egress policy validates. Variants without user-controlled URLs (Fs,
-/// Memory, Moka, FTP, HDFS name node, Huggingface, None) return empty.
+/// Memory, FTP, HDFS name node, Huggingface) return empty.
 fn storage_params_endpoints(sp: &StorageParams) -> Vec<&str> {
     match sp {
         StorageParams::Azblob(c) => vec![c.endpoint_url.as_str()],
@@ -304,7 +304,6 @@ fn storage_params_endpoints(sp: &StorageParams) -> Vec<&str> {
         | StorageParams::Ftp(_)
         | StorageParams::Hdfs(_)
         | StorageParams::Memory
-        | StorageParams::Moka(_)
         | StorageParams::Huggingface(_) => Vec::new(),
     }
 }

--- a/src/common/storage/src/endpoint_policy.rs
+++ b/src/common/storage/src/endpoint_policy.rs
@@ -305,8 +305,7 @@ fn storage_params_endpoints(sp: &StorageParams) -> Vec<&str> {
         | StorageParams::Hdfs(_)
         | StorageParams::Memory
         | StorageParams::Moka(_)
-        | StorageParams::Huggingface(_)
-        | StorageParams::None => Vec::new(),
+        | StorageParams::Huggingface(_) => Vec::new(),
     }
 }
 
@@ -1022,7 +1021,6 @@ mod tests {
         for sp in [
             StorageParams::Fs(StorageFsConfig::default()),
             StorageParams::Memory,
-            StorageParams::None,
         ] {
             assert!(storage_params_endpoints(&sp).is_empty());
         }

--- a/src/common/storage/src/operator.rs
+++ b/src/common/storage/src/operator.rs
@@ -35,7 +35,6 @@ use databend_common_meta_app::storage::StorageHdfsConfig;
 use databend_common_meta_app::storage::StorageHttpConfig;
 use databend_common_meta_app::storage::StorageHuggingfaceConfig;
 use databend_common_meta_app::storage::StorageIpfsConfig;
-use databend_common_meta_app::storage::StorageMokaConfig;
 use databend_common_meta_app::storage::StorageNetworkParams;
 use databend_common_meta_app::storage::StorageObsConfig;
 use databend_common_meta_app::storage::StorageOssConfig;
@@ -126,9 +125,6 @@ pub(crate) fn init_operator_uncached(
         )?,
         StorageParams::Memory => {
             build_operator(init_memory_operator()?, None, endpoint_policy_scope)?
-        }
-        StorageParams::Moka(cfg) => {
-            build_operator(init_moka_operator(cfg)?, None, endpoint_policy_scope)?
         }
         StorageParams::Obs(cfg) => build_operator(
             init_obs_operator(cfg)?,
@@ -547,16 +543,6 @@ fn init_oss_operator(cfg: &StorageOssConfig) -> Result<impl Builder> {
     if cfg.role_arn.is_empty() && cfg.access_key_id.is_empty() && cfg.access_key_secret.is_empty() {
         builder = builder.allow_anonymous();
     }
-
-    Ok(builder)
-}
-
-/// init_moka_operator will init a moka operator.
-fn init_moka_operator(v: &StorageMokaConfig) -> Result<impl Builder> {
-    let builder = services::Moka::default()
-        .max_capacity(v.max_capacity)
-        .time_to_live(std::time::Duration::from_secs(v.time_to_live as u64))
-        .time_to_idle(std::time::Duration::from_secs(v.time_to_idle as u64));
 
     Ok(builder)
 }

--- a/src/meta/app-storage/src/storage_params.rs
+++ b/src/meta/app-storage/src/storage_params.rs
@@ -57,7 +57,6 @@ pub enum StorageParams {
     Http(StorageHttpConfig),
     Ipfs(StorageIpfsConfig),
     Memory,
-    Moka(StorageMokaConfig),
     Obs(StorageObsConfig),
     Oss(StorageOssConfig),
     S3(StorageS3Config),
@@ -84,7 +83,6 @@ impl StorageParams {
             StorageParams::Http(_) => "http",
             StorageParams::Ipfs(_) => "ipfs",
             StorageParams::Memory => "memory",
-            StorageParams::Moka(_) => "moka",
             StorageParams::Obs(_) => "obs",
             StorageParams::Oss(_) => "oss",
             StorageParams::S3(_) => "s3",
@@ -164,7 +162,6 @@ impl StorageParams {
             StorageParams::Http(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::Ipfs(c) => c.endpoint_url.starts_with("https://"),
             StorageParams::Memory => false,
-            StorageParams::Moka(_) => false,
             StorageParams::Obs(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::Oss(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::S3(v) => v.endpoint_url.starts_with("https://"),
@@ -185,7 +182,6 @@ impl StorageParams {
             StorageParams::Http(_) => {}
             StorageParams::Ipfs(v) => v.root = f(&v.root),
             StorageParams::Memory => {}
-            StorageParams::Moka(_) => {}
             StorageParams::Obs(v) => v.root = f(&v.root),
             StorageParams::Oss(v) => v.root = f(&v.root),
             StorageParams::S3(v) => v.root = f(&v.root),
@@ -296,7 +292,7 @@ impl StorageParams {
     /// OSS, OBS, COS, Azblob), file-like backends (FS, WebHDFS, HDFS), as well as HuggingFace
     /// and IPFS locations. HTTP locations render the expanded glob patterns (if any), so the
     /// output can differ from the original shorthand. Backends that don't carry enough context
-    /// (Memory, Moka, None) return `None`.
+    /// (Memory, None) return `None`.
     pub fn url(&self) -> Option<String> {
         match self {
             StorageParams::Azblob(cfg) => bucket_style_url("azblob", &cfg.container, &cfg.root),
@@ -343,7 +339,6 @@ impl StorageParams {
                 Some(format!("ipfs://ipfs{}", normalized_dir_path(suffix, true)))
             }
             StorageParams::Memory => None,
-            StorageParams::Moka(_) => None,
             StorageParams::Obs(cfg) => bucket_style_url("obs", &cfg.bucket, &cfg.root),
             StorageParams::Oss(cfg) => bucket_style_url("oss", &cfg.bucket, &cfg.root),
             StorageParams::S3(cfg) => bucket_style_url("s3", &cfg.bucket, &cfg.root),
@@ -426,8 +421,7 @@ impl StorageParams {
             | StorageParams::Hdfs(_)
             | StorageParams::Http(_)
             | StorageParams::Ipfs(_)
-            | StorageParams::Memory
-            | StorageParams::Moka(_) => false,
+            | StorageParams::Memory => false,
         }
     }
 
@@ -449,7 +443,6 @@ impl Display for StorageParams {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             StorageParams::Memory => write!(f, "memory"),
-            StorageParams::Moka(v) => write!(f, "moka | max_capacity={}", v.max_capacity),
             StorageParams::Azblob(v) => write!(
                 f,
                 "azblob | container={},root={},endpoint={}",
@@ -956,27 +949,6 @@ impl Debug for StorageOssConfig {
                 &mask_string(&self.server_side_encryption_key_id, 3),
             )
             .finish()
-    }
-}
-
-/// config for Moka Object Storage Service
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct StorageMokaConfig {
-    pub max_capacity: u64,
-    pub time_to_live: i64,
-    pub time_to_idle: i64,
-}
-
-impl Default for StorageMokaConfig {
-    fn default() -> Self {
-        Self {
-            // Use 1G as default.
-            max_capacity: 1024 * 1024 * 1024,
-            // Use 1 hour as default time to live
-            time_to_live: 3600,
-            // Use 10 minutes as default time to idle.
-            time_to_idle: 600,
-        }
     }
 }
 

--- a/src/meta/app-storage/src/storage_params.rs
+++ b/src/meta/app-storage/src/storage_params.rs
@@ -64,11 +64,6 @@ pub enum StorageParams {
     Webhdfs(StorageWebhdfsConfig),
     Cos(StorageCosConfig),
     Huggingface(StorageHuggingfaceConfig),
-
-    /// None means this storage type is none.
-    ///
-    /// This type is mostly for cache which mean bypass the cache logic.
-    None,
 }
 
 impl Default for StorageParams {
@@ -96,7 +91,6 @@ impl StorageParams {
             StorageParams::Webhdfs(_) => "webhdfs",
             StorageParams::Cos(_) => "cos",
             StorageParams::Huggingface(_) => "huggingface",
-            StorageParams::None => "none",
         }
     }
 
@@ -178,7 +172,6 @@ impl StorageParams {
             StorageParams::Webhdfs(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::Cos(v) => v.endpoint_url.starts_with("https://"),
             StorageParams::Huggingface(_) => true,
-            StorageParams::None => false,
         }
     }
 
@@ -200,7 +193,6 @@ impl StorageParams {
             StorageParams::Webhdfs(v) => v.root = f(&v.root),
             StorageParams::Cos(v) => v.root = f(&v.root),
             StorageParams::Huggingface(v) => v.root = f(&v.root),
-            StorageParams::None => {}
         };
 
         self
@@ -377,7 +369,6 @@ impl StorageParams {
                     normalized_dir_path(&cfg.root, true)
                 ))
             }
-            StorageParams::None => None,
         }
     }
 
@@ -436,8 +427,7 @@ impl StorageParams {
             | StorageParams::Http(_)
             | StorageParams::Ipfs(_)
             | StorageParams::Memory
-            | StorageParams::Moka(_)
-            | StorageParams::None => false,
+            | StorageParams::Moka(_) => false,
         }
     }
 
@@ -460,7 +450,6 @@ impl Display for StorageParams {
         match self {
             StorageParams::Memory => write!(f, "memory"),
             StorageParams::Moka(v) => write!(f, "moka | max_capacity={}", v.max_capacity),
-            StorageParams::None => write!(f, "none"),
             StorageParams::Azblob(v) => write!(
                 f,
                 "azblob | container={},root={},endpoint={}",

--- a/src/meta/app-storage/src/storage_params_test.rs
+++ b/src/meta/app-storage/src/storage_params_test.rs
@@ -296,11 +296,6 @@ fn test_memory_url_none() {
 }
 
 #[test]
-fn test_none_url_none() {
-    assert_eq!(StorageParams::None.url(), None);
-}
-
-#[test]
 fn test_moka_url_none() {
     assert_eq!(
         StorageParams::Moka(StorageMokaConfig::default()).url(),
@@ -387,7 +382,6 @@ fn test_has_credentials_matrix() {
             false,
             "moka",
         ),
-        (StorageParams::None, false, "none"),
     ];
 
     for (params, expected, label) in cases {

--- a/src/meta/app-storage/src/storage_params_test.rs
+++ b/src/meta/app-storage/src/storage_params_test.rs
@@ -23,7 +23,6 @@ use crate::StorageHdfsConfig;
 use crate::StorageHttpConfig;
 use crate::StorageHuggingfaceConfig;
 use crate::StorageIpfsConfig;
-use crate::StorageMokaConfig;
 use crate::StorageObsConfig;
 use crate::StorageOssConfig;
 use crate::StorageParams;
@@ -296,14 +295,6 @@ fn test_memory_url_none() {
 }
 
 #[test]
-fn test_moka_url_none() {
-    assert_eq!(
-        StorageParams::Moka(StorageMokaConfig::default()).url(),
-        None
-    );
-}
-
-#[test]
 fn test_has_credentials_matrix() {
     let s3 = StorageS3Config {
         access_key_id: "ak".to_string(),
@@ -377,11 +368,6 @@ fn test_has_credentials_matrix() {
             "hdfs",
         ),
         (StorageParams::Memory, false, "memory"),
-        (
-            StorageParams::Moka(StorageMokaConfig::default()),
-            false,
-            "moka",
-        ),
     ];
 
     for (params, expected, label) in cases {

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -35,7 +35,6 @@ use databend_common_meta_app::storage::StorageCosConfig as InnerStorageCosConfig
 use databend_common_meta_app::storage::StorageFsConfig as InnerStorageFsConfig;
 use databend_common_meta_app::storage::StorageGcsConfig as InnerStorageGcsConfig;
 use databend_common_meta_app::storage::StorageHdfsConfig as InnerStorageHdfsConfig;
-use databend_common_meta_app::storage::StorageMokaConfig as InnerStorageMokaConfig;
 use databend_common_meta_app::storage::StorageNetworkParams;
 use databend_common_meta_app::storage::StorageObsConfig as InnerStorageObsConfig;
 use databend_common_meta_app::storage::StorageOssConfig as InnerStorageOssConfig;
@@ -1368,42 +1367,6 @@ impl TryInto<InnerStorageOssConfig> for OssStorageConfig {
             server_side_encryption: self.oss_server_side_encryption,
             server_side_encryption_key_id: self.oss_server_side_encryption_key_id,
             network_config: None,
-        })
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Args)]
-#[serde(default)]
-pub struct MokaStorageConfig {
-    pub max_capacity: u64,
-    pub time_to_live: i64,
-    pub time_to_idle: i64,
-}
-
-impl Default for MokaStorageConfig {
-    fn default() -> Self {
-        InnerStorageMokaConfig::default().into()
-    }
-}
-
-impl From<InnerStorageMokaConfig> for MokaStorageConfig {
-    fn from(v: InnerStorageMokaConfig) -> Self {
-        Self {
-            max_capacity: v.max_capacity,
-            time_to_live: v.time_to_live,
-            time_to_idle: v.time_to_idle,
-        }
-    }
-}
-
-impl TryInto<InnerStorageMokaConfig> for MokaStorageConfig {
-    type Error = ErrorCode;
-
-    fn try_into(self) -> Result<InnerStorageMokaConfig> {
-        Ok(InnerStorageMokaConfig {
-            max_capacity: self.max_capacity,
-            time_to_live: self.time_to_live,
-            time_to_idle: self.time_to_idle,
         })
     }
 }

--- a/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_catalog_show_create.rs
@@ -21,7 +21,6 @@ use databend_common_expression::Scalar;
 use databend_common_expression::types::DataType;
 use databend_common_meta_app::schema::CatalogOption;
 use databend_common_meta_app::schema::IcebergCatalogOption;
-use databend_common_meta_app::storage::StorageParams;
 use databend_common_sql::plans::ShowCreateCatalogPlan;
 use log::debug;
 
@@ -66,8 +65,9 @@ impl Interpreter for ShowCreateCatalogInterpreter {
                     "METASTORE ADDRESS\n{}\nSTORAGE PARAMS\n{}",
                     op.address,
                     op.storage_params
-                        .clone()
-                        .unwrap_or(Box::new(StorageParams::None))
+                        .as_ref()
+                        .map(|sp| sp.to_string())
+                        .unwrap_or_else(|| "none".to_string())
                 ),
             ),
             CatalogOption::Iceberg(op) => (String::from("iceberg"), match op {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Remove two dead/unused `StorageParams` variants. Neither was ever serialized to protobuf nor written to meta-service, so there is no compatibility concern.

### `StorageParams::None`

A pure in-memory sentinel that was never persisted:

- proto-conv `to_pb()` errors on it (falls into the `others =>` arm) and `from_pb()` never produces it, so it could never reach the meta store.
- Its only real construction site was the SHOW CREATE CATALOG display fallback, which now formats the `Option<Box<StorageParams>>` directly and still prints `none` when a hive catalog has no storage params.

### `StorageParams::Moka`

Dead code since Feb 2023. It was introduced in Oct 2022 (commit 4f1031c) as the backing storage for `CacheOperator` (`CacheConfig.params = StorageParams::Moka(...)`). That entire `CacheOperator`/`CacheConfig` system was removed in PR #10096, leaving the variant, `StorageMokaConfig`, and `init_moka_operator()` with no remaining caller.

- Never serialized to protobuf or written to meta-service.
- Old config files aren't a concern: the config parser's match on `storage.type` has no `"moka"` branch, so a legacy `type = "moka"` config is already rejected at startup with "not supported storage type".
- Also removes the orphaned `MokaStorageConfig` in config.rs and the now-unused `services-moka` opendal feature.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

`cargo check` passes for `databend-common-meta-app-storage`, `databend-common-storage`, and `databend-common-config`; `cargo test -p databend-common-meta-app-storage` passes. SHOW CREATE CATALOG display behavior is unchanged.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20041)
<!-- Reviewable:end -->
