### PR TITLE
fix(query): mark async accumulating finish after completion

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating_async.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating_async.rs
@@ -133,9 +133,128 @@ impl<T: AsyncAccumulatingTransform + 'static> Processor for AsyncAccumulatingTra
         }
 
         if !self.called_on_finish {
+            let result = self.inner.on_finish(true).await;
             self.called_on_finish = true;
-            self.output_data = self.inner.on_finish(true).await?;
+            self.output_data = result?;
         }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use databend_common_exception::ErrorCode;
+    use databend_common_exception::Result;
+    use databend_common_expression::DataBlock;
+    use databend_common_pipeline::core::InputPort;
+    use databend_common_pipeline::core::OutputPort;
+    use databend_common_pipeline::core::Processor;
+    use tokio::sync::oneshot;
+
+    use super::AsyncAccumulatingTransform;
+    use super::AsyncAccumulatingTransformer;
+
+    struct BlockingFinishTransform {
+        finish_entered_tx: Option<oneshot::Sender<()>>,
+        finish_release_rx: Option<oneshot::Receiver<()>>,
+    }
+
+    #[async_trait]
+    impl AsyncAccumulatingTransform for BlockingFinishTransform {
+        const NAME: &'static str = "BlockingFinishTransform";
+
+        async fn transform(&mut self, _data: DataBlock) -> Result<Option<DataBlock>> {
+            Ok(None)
+        }
+
+        async fn on_finish(&mut self, _output: bool) -> Result<Option<DataBlock>> {
+            if let Some(tx) = self.finish_entered_tx.take() {
+                let _ = tx.send(());
+            }
+
+            if let Some(rx) = self.finish_release_rx.take() {
+                let _ = rx.await;
+            }
+
+            Ok(None)
+        }
+    }
+
+    struct ErrorFinishTransform;
+
+    #[async_trait]
+    impl AsyncAccumulatingTransform for ErrorFinishTransform {
+        const NAME: &'static str = "ErrorFinishTransform";
+
+        async fn transform(&mut self, _data: DataBlock) -> Result<Option<DataBlock>> {
+            Ok(None)
+        }
+
+        async fn on_finish(&mut self, _output: bool) -> Result<Option<DataBlock>> {
+            Err(ErrorCode::Internal("finish failed"))
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_cancel_pending_on_finish_does_not_mark_finish_called() -> Result<()> {
+        let (finish_entered_tx, finish_entered_rx) = oneshot::channel();
+        let (_finish_release_tx, finish_release_rx) = oneshot::channel();
+
+        let mut transform = AsyncAccumulatingTransformer {
+            inner: BlockingFinishTransform {
+                finish_entered_tx: Some(finish_entered_tx),
+                finish_release_rx: Some(finish_release_rx),
+            },
+            input: InputPort::create(),
+            output: OutputPort::create(),
+            called_on_start: true,
+            called_on_finish: false,
+            input_data: None,
+            output_data: None,
+        };
+
+        let mut finish_future = Box::pin(transform.async_process());
+
+        tokio::select! {
+            entered = finish_entered_rx => {
+                entered.expect("on_finish should be entered");
+            }
+            result = &mut finish_future => {
+                panic!("on_finish should remain pending, got {result:?}");
+            }
+        }
+
+        drop(finish_future);
+
+        assert!(
+            !transform.called_on_finish,
+            "pending on_finish must not be recorded as completed"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_on_finish_error_marks_finish_called() -> Result<()> {
+        let mut transform = AsyncAccumulatingTransformer {
+            inner: ErrorFinishTransform,
+            input: InputPort::create(),
+            output: OutputPort::create(),
+            called_on_start: true,
+            called_on_finish: false,
+            input_data: None,
+            output_data: None,
+        };
+
+        let result = transform.async_process().await;
+
+        assert!(result.is_err(), "on_finish should propagate its error");
+        assert!(
+            transform.called_on_finish,
+            "completed on_finish errors must be recorded as attempted"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
Related to #20042

`AsyncAccumulatingTransformer` marked `called_on_finish` before awaiting
`inner.on_finish(true)`. If the async processor future is cancelled while
`on_finish` is still pending, the transformer can record an unfinished
finalizer as completed.

This PR moves the finish marker after the `on_finish` future returns, matching
the async sink finish bookkeeping behavior. Pending finalizers that are
cancelled are no longer recorded as completed, while completed `on_finish`
errors are still recorded as attempted and propagated.

The bug is visible in the generic async accumulating processor lifecycle, and
it is especially relevant for finalizers that perform externally visible work
before returning their downstream output. This PR keeps the fix deliberately
narrow: it corrects the wrapper's lifecycle state and adds regression coverage.
It does not introduce a Fuse-specific cleanup ledger for uncommitted storage
objects.

## Changes

- Mark `AsyncAccumulatingTransformer::called_on_finish` only after
  `inner.on_finish(true).await` returns.
- Add a regression test that drops a pending `on_finish` future and verifies
  that finish is not recorded as completed.
- Add a regression test that verifies a completed `on_finish` error is still
  recorded as an attempted finish and propagated to the caller.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Passed:

```bash
cargo test -p databend-common-pipeline-transforms test_cancel_pending_on_finish_does_not_mark_finish_called
cargo test -p databend-common-pipeline-transforms test_on_finish_error_marks_finish_called
cargo fmt --all -- --check
cargo clippy -p databend-common-pipeline-transforms --all-targets --all-features --no-deps -- -D warnings
```

Attempted full workspace clippy:

```bash
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

It is currently blocked on this checkout by an unrelated existing lint in
`databend-functions-scalar-decimal`:

```text
src/query/functions/src/scalars/decimal/src/math.rs:72
target_scale: scale as i64
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20043)
<!-- Reviewable:end -->
