### PR TITLE
fix(storage): move copy_status tracking from partition planning to actual read in parquet copy

### DIFF
--- a/src/query/storages/parquet/src/copy_into_table/source.rs
+++ b/src/query/storages/parquet/src/copy_into_table/source.rs
@@ -29,6 +29,8 @@ use databend_common_pipeline::core::Event;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_storage::CopyStatus;
+use databend_common_storage::FileStatus;
 use opendal::Operator;
 
 use crate::ParquetPart;
@@ -46,6 +48,7 @@ pub struct ParquetCopySource {
     // Source processor related fields.
     output: Arc<OutputPort>,
     scan_progress: Arc<Progress>,
+    copy_status: Arc<CopyStatus>,
 
     // Used for event transforming.
     ctx: Arc<dyn TableContext>,
@@ -58,6 +61,7 @@ pub struct ParquetCopySource {
     copy_projection_evaluator: CopyProjectionEvaluator,
     state: State,
     batch_size: usize,
+    current_location: Option<String>,
 }
 
 impl ParquetCopySource {
@@ -69,6 +73,7 @@ impl ParquetCopySource {
         schema: DataSchemaRef,
     ) -> Result<ProcessorPtr> {
         let scan_progress = ctx.get_scan_progress();
+        let copy_status = ctx.copy_state().copy_status();
         let batch_size = ctx.get_settings().get_parquet_max_block_size()? as usize;
         let func_ctx = Arc::new(ctx.get_function_context()?);
         let copy_projection_evaluator = CopyProjectionEvaluator::new(schema, func_ctx);
@@ -76,6 +81,7 @@ impl ParquetCopySource {
         Ok(ProcessorPtr::create(Box::new(Self {
             output,
             scan_progress,
+            copy_status,
             ctx,
             operator,
             row_group_readers,
@@ -84,6 +90,7 @@ impl ParquetCopySource {
             is_finished: false,
             state: State::Init,
             copy_projection_evaluator,
+            current_location: None,
         })))
     }
 }
@@ -127,6 +134,12 @@ impl Processor for ParquetCopySource {
                     ProfileStatisticsName::ScanBytes,
                     data_block.memory_size(),
                 );
+                if let Some(location) = &self.current_location {
+                    self.copy_status.add_chunk(location.as_str(), FileStatus {
+                        num_rows_loaded: data_block.num_rows(),
+                        error: None,
+                    });
+                }
                 self.output.push_data(Ok(data_block));
                 Ok(Event::NeedConsume)
             }
@@ -158,6 +171,7 @@ impl Processor for ParquetCopySource {
                     match ParquetPart::from_part(&part)? {
                         ParquetPart::RowGroup(part) => {
                             let schema_index = part.schema_index;
+                            self.current_location = Some(part.location.clone());
                             let builder = self
                                 .row_group_readers
                                 .get(&schema_index)

--- a/src/query/storages/parquet/src/copy_into_table/table.rs
+++ b/src/query/storages/parquet/src/copy_into_table/table.rs
@@ -86,10 +86,15 @@ impl ParquetTableForCopy {
             };
             let num_rows = meta.meta.file_metadata().num_rows() as usize;
             stats.read_rows += num_rows;
-            copy_status.add_chunk(meta.location.as_str(), FileStatus {
-                num_rows_loaded: num_rows,
-                error: None,
-            });
+            // For files that will produce no rows, no blocks will be emitted
+            // by the source processor, so register them here to ensure they
+            // appear in the COPY result with rows_loaded = 0.
+            if meta.meta.file_metadata().num_rows() == 0 {
+                copy_status.add_chunk(meta.location.as_str(), FileStatus {
+                    num_rows_loaded: 0,
+                    error: None,
+                });
+            }
             let mut start_row = 0;
             for rg in meta.meta.row_groups() {
                 let part = ParquetRowGroupPart {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

In `COPY FROM` parquet, `copy_status` (which drives the final COPY result's `rows_loaded` column) was being updated in `do_read_partitions` — at partition planning time, using row counts from file metadata. Currently this is correct because parquet does not support `on_error=continue` or `abort_num`, so all rows from metadata are always loaded.

However, this pre-counting pattern would silently produce incorrect `rows_loaded` values if `on_error` support is added to parquet in the future (as it exists today for CSV/NDJSON/Arrow). This PR moves the `copy_status` update to the source processor where blocks are actually produced, making the accounting future-proof and consistent with the pattern used in the other `ParquetSource` paths (`source.rs`, `parquet_variant_table/source.rs`).

For parquet files with no row groups (valid but empty), a zero-row status is still registered at partition time to ensure they appear in the COPY result with `rows_loaded = 0`.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - No behavioral change under current semantics (parquet always aborts on error). The fix is a preventive refactor for future `on_error` support. Verified via `cargo check`.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20045)
<!-- Reviewable:end -->
