### PR TITLE
feat(storage): add allowlist endpoint_url_policy mode

### DIFF
--- a/src/common/storage/src/config.rs
+++ b/src/common/storage/src/config.rs
@@ -67,6 +67,10 @@ pub enum EndpointUrlPolicy {
     /// Reject high-risk targets such as loopback, private, link-local,
     /// multicast, unspecified and metadata addresses unless explicitly allowed.
     Strict,
+    /// Reject all endpoints unless they match the configured allowlist
+    /// (`allowed_hosts` or `allowed_cidrs`). This is the most restrictive
+    /// mode: even public addresses are denied by default.
+    Allowlist,
 }
 
 /// Runtime egress policy for external storage endpoint URLs.

--- a/src/common/storage/src/endpoint_policy.rs
+++ b/src/common/storage/src/endpoint_policy.rs
@@ -394,7 +394,7 @@ impl CompiledPolicy {
         // `check_storage_endpoint_url` remains the security boundary in
         // either mode.
         let needs_dns = match self.policy {
-            EndpointUrlPolicy::Strict => true,
+            EndpointUrlPolicy::Strict | EndpointUrlPolicy::Allowlist => true,
             EndpointUrlPolicy::Permissive => {
                 !self.blocked_cidrs.is_empty()
                     || self
@@ -433,6 +433,17 @@ impl CompiledPolicy {
             return self.check_ip(&host, port, ip);
         }
 
+        // Allowlist mode rejects hostnames not covered by any allowlist
+        // entry. If allowed_cidrs is configured we must defer to the DNS
+        // phase so check_ip can evaluate the resolved addresses against
+        // those CIDRs.
+        if matches!(self.policy, EndpointUrlPolicy::Allowlist)
+            && !host_matches_any(&host, &self.allowed_hosts)
+            && self.allowed_cidrs.is_empty()
+        {
+            return deny(&host, None, "not in allowlist");
+        }
+
         Ok(())
     }
 
@@ -451,6 +462,10 @@ impl CompiledPolicy {
 
         let allowed = host_matches_any(host, &self.allowed_hosts)
             || self.allowed_cidrs.iter().any(|cidr| cidr.contains(ip));
+
+        if matches!(self.policy, EndpointUrlPolicy::Allowlist) && !allowed {
+            return deny(host, Some(ip), "not in allowlist");
+        }
 
         if let Some(reason) = builtin_blocked_ip_reason(ip) {
             if matches!(self.policy, EndpointUrlPolicy::Strict) && !allowed {
@@ -1023,5 +1038,110 @@ mod tests {
         ] {
             assert!(storage_params_endpoints(&sp).is_empty());
         }
+    }
+
+    fn allowlist_only() -> CompiledPolicy {
+        CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_allowlist_rejects_public_ip_without_allowlist() {
+        let policy = allowlist_only();
+        assert!(check(&policy, "https://93.184.216.34:443").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_rejects_private_ip_without_allowlist() {
+        let policy = allowlist_only();
+        assert!(check(&policy, "http://10.0.0.1:9000").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_allows_configured_cidr() {
+        let policy = CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            allowed_cidrs: vec!["93.184.216.0/24".to_string()],
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert!(check(&policy, "https://93.184.216.34:443").is_ok());
+        assert!(check(&policy, "https://8.8.8.8:443").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_allows_configured_host() {
+        let policy = CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            allowed_hosts: vec!["*.example.com".to_string()],
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert!(check(&policy, "https://s3.example.com:443").is_ok());
+        assert!(check(&policy, "https://evil.attacker.com:443").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_empty_allowlist_rejects_all() {
+        let policy = allowlist_only();
+
+        assert!(check(&policy, "https://93.184.216.34:443").is_err());
+        assert!(check(&policy, "http://10.0.0.1:80").is_err());
+        assert!(check(&policy, "http://127.0.0.1:80").is_err());
+        assert!(check(&policy, "https://s3.amazonaws.com:443").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_blocked_hosts_still_rejected() {
+        // Even if a host is in allowed_hosts, blocked_hosts takes precedence.
+        let policy = CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            allowed_hosts: vec!["*.example.com".to_string()],
+            blocked_hosts: vec!["evil.example.com".to_string()],
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert!(check(&policy, "https://good.example.com:443").is_ok());
+        assert!(check(&policy, "https://evil.example.com:443").is_err());
+    }
+
+    #[test]
+    fn test_allowlist_cidr_defers_hostname_to_dns_phase() {
+        // When allowed_cidrs is configured, hostnames must not be early-rejected
+        // so DNS resolution can check the resolved IP against the CIDR allowlist.
+        let policy = CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            allowed_cidrs: vec!["93.184.216.0/24".to_string()],
+            ..Default::default()
+        })
+        .unwrap();
+
+        // Hostname should pass the pre-DNS check (not early-rejected).
+        let url = normalize_endpoint_url("https://example.com:443").unwrap();
+        assert!(policy.check_url_without_dns(&url).is_ok());
+    }
+
+    #[test]
+    fn test_allowlist_no_cidr_early_rejects_hostname() {
+        // Without allowed_cidrs, hostnames not in allowed_hosts are
+        // rejected early without DNS.
+        let policy = CompiledPolicy::try_from(&EndpointUrlPolicyConfig {
+            policy: EndpointUrlPolicy::Allowlist,
+            allowed_hosts: vec!["good.example.com".to_string()],
+            ..Default::default()
+        })
+        .unwrap();
+
+        let url = normalize_endpoint_url("https://other.example.com:443").unwrap();
+        assert!(policy.check_url_without_dns(&url).is_err());
+
+        let url = normalize_endpoint_url("https://good.example.com:443").unwrap();
+        assert!(policy.check_url_without_dns(&url).is_ok());
     }
 }

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -471,6 +471,7 @@ pub enum EndpointUrlPolicyConfigValue {
     #[default]
     Permissive,
     Strict,
+    Allowlist,
 }
 
 impl From<EndpointUrlPolicyConfigValue> for EndpointUrlPolicy {
@@ -478,6 +479,7 @@ impl From<EndpointUrlPolicyConfigValue> for EndpointUrlPolicy {
         match value {
             EndpointUrlPolicyConfigValue::Permissive => EndpointUrlPolicy::Permissive,
             EndpointUrlPolicyConfigValue::Strict => EndpointUrlPolicy::Strict,
+            EndpointUrlPolicyConfigValue::Allowlist => EndpointUrlPolicy::Allowlist,
         }
     }
 }
@@ -487,6 +489,7 @@ impl From<&EndpointUrlPolicy> for EndpointUrlPolicyConfigValue {
         match value {
             EndpointUrlPolicy::Permissive => EndpointUrlPolicyConfigValue::Permissive,
             EndpointUrlPolicy::Strict => EndpointUrlPolicyConfigValue::Strict,
+            EndpointUrlPolicy::Allowlist => EndpointUrlPolicyConfigValue::Allowlist,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add a third `endpoint_url_policy` mode: `allowlist`.

Currently `strict` mode blocks private/loopback/metadata addresses but still allows all public endpoints. Some operators need tighter control — they want to deny all external storage access by default and only permit explicitly whitelisted targets.

The new `allowlist` mode rejects **all** endpoints (including public) unless they match the configured `endpoint_url_allowed_hosts` or `endpoint_url_allowed_cidrs`. Setting an empty allowlist effectively disables all user-controlled external storage access.

Policy gradient from least to most restrictive:
- `permissive`: allow all except explicit blocklist
- `strict`: block private/loopback/metadata, allow public
- `allowlist`: block everything unless explicitly allowed

### Configuration example

```toml
[storage]
endpoint_url_policy = "allowlist"
endpoint_url_allowed_hosts = ["*.amazonaws.com", "storage.googleapis.com"]
endpoint_url_allowed_cidrs = ["52.0.0.0/8"]
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

Added 5 unit tests in `endpoint_policy::tests`:
- `test_allowlist_rejects_public_ip_without_allowlist`
- `test_allowlist_rejects_private_ip_without_allowlist`
- `test_allowlist_allows_configured_cidr`
- `test_allowlist_allows_configured_host`
- `test_allowlist_empty_allowlist_rejects_all`
- `test_allowlist_blocked_hosts_still_rejected`

All existing tests continue to pass (`cargo test -p databend-common-storage --lib endpoint_policy` — 27 passed).

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20047)
<!-- Reviewable:end -->
