### PR TITLE
fix(query): cleanup canceled Lance stage output

### DIFF
--- a/src/query/storages/stage/src/append/lance_dataset/pipeline.rs
+++ b/src/query/storages/stage/src/append/lance_dataset/pipeline.rs
@@ -18,10 +18,13 @@ use databend_common_base::runtime::GlobalIORuntime;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::TableSchemaRef;
+use databend_common_pipeline::core::ExecutionInfo;
 use databend_common_pipeline::core::Pipeline;
+use databend_common_pipeline::core::basic_callback;
 use databend_common_storage::ensure_no_stage_path_traversal;
 use databend_storages_common_stage::CopyIntoLocationInfo;
 use futures::TryStreamExt;
+use log::warn;
 use opendal::Operator;
 use opendal::services::Memory;
 
@@ -49,6 +52,8 @@ pub(crate) fn append_data_to_lance_dataset(
         op.clone(),
         target_dataset_path.as_str(),
     ))?;
+    cleanup_target_dataset_on_error(pipeline, op.clone(), target_dataset_path.clone());
+
     let staging_accessor = Operator::new(Memory::default())?.finish();
     let staging_dataset_path = "tmp".to_string();
 
@@ -79,6 +84,43 @@ pub(crate) fn append_data_to_lance_dataset(
             fragment_state.clone(),
         )
     })?;
+    Ok(())
+}
+
+fn cleanup_target_dataset_on_error(
+    pipeline: &mut Pipeline,
+    data_accessor: Operator,
+    target_dataset_path: String,
+) {
+    pipeline.lift_on_finished(basic_callback(move |info: &ExecutionInfo| {
+        if let Err(query_error) = &info.res {
+            let cleanup_result =
+                GlobalIORuntime::instance().block_on(cleanup_target_dataset_for_result(
+                    &info.res,
+                    &data_accessor,
+                    target_dataset_path.as_str(),
+                ));
+            if let Err(cleanup_error) = cleanup_result {
+                warn!(
+                    "failed to cleanup canceled LANCE stage dataset at '{}', query error: {}, cleanup error: {}",
+                    target_dataset_path, query_error, cleanup_error
+                );
+            }
+        }
+
+        Ok(())
+    }));
+}
+
+async fn cleanup_target_dataset_for_result(
+    query_result: &Result<()>,
+    data_accessor: &Operator,
+    target_dataset_path: &str,
+) -> Result<()> {
+    if query_result.is_err() {
+        cleanup_dataset_if_exists(data_accessor, target_dataset_path).await?;
+    }
+
     Ok(())
 }
 
@@ -130,7 +172,22 @@ async fn cleanup_dataset_if_exists(data_accessor: &Operator, path: &str) -> Resu
         ));
     }
 
-    if let Ok(mut lister) = data_accessor.lister_with(path).recursive(true).await {
+    if let Ok(metadata) = data_accessor.stat(path).await {
+        if metadata.is_file() {
+            data_accessor.delete(path).await?;
+        }
+    }
+
+    let prefix = if path.ends_with('/') {
+        path.to_string()
+    } else {
+        format!("{path}/")
+    };
+    if let Ok(mut lister) = data_accessor
+        .lister_with(prefix.as_str())
+        .recursive(true)
+        .await
+    {
         while let Some(entry) = lister.try_next().await? {
             if entry.metadata().is_file() {
                 data_accessor.delete(entry.path()).await?;
@@ -155,13 +212,24 @@ async fn prepare_target_dataset_path(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use databend_common_ast::ast::CopyIntoLocationOptions;
+    use databend_common_exception::ErrorCode;
+    use databend_common_exception::Result;
     use databend_common_meta_app::principal::FileFormatParams;
     use databend_common_meta_app::principal::ParquetFileFormatParams;
     use databend_common_meta_app::principal::StageInfo;
+    use databend_common_pipeline::core::ExecutionInfo;
+    use databend_common_pipeline::core::Pipeline;
+    use databend_common_pipeline::core::basic_callback;
     use databend_storages_common_stage::CopyIntoLocationInfo;
+    use opendal::Operator;
+    use opendal::services::Memory;
 
     use super::build_target_dataset_path;
+    use super::cleanup_target_dataset_for_result;
+    use super::cleanup_target_dataset_on_error;
 
     fn make_info(path: &str, use_raw_path: bool) -> CopyIntoLocationInfo {
         let mut stage = StageInfo::new_internal_stage("test");
@@ -203,5 +271,82 @@ mod tests {
         let info = make_info("/", true);
         let path = build_target_dataset_path(&info, "qid");
         assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn test_cleanup_target_dataset_for_error_removes_partial_dataset() -> Result<()> {
+        let op = Operator::new(Memory::default())?.finish();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(async {
+            op.write("dataset", vec![0]).await?;
+            op.write("dataset/data/part.lance", vec![1, 2, 3]).await?;
+            op.write("dataset-other/data/part.lance", vec![7, 8, 9])
+                .await?;
+            op.write("unrelated/data/part.lance", vec![4, 5, 6]).await
+        })?;
+
+        let query_result = Err(ErrorCode::AbortedQuery("cancelled"));
+        runtime.block_on(cleanup_target_dataset_for_result(
+            &query_result,
+            &op,
+            "dataset",
+        ))?;
+        runtime.block_on(async {
+            assert!(op.stat("dataset").await.is_err());
+            assert!(op.stat("dataset/data/part.lance").await.is_err());
+            assert!(op.stat("dataset-other/data/part.lance").await.is_ok());
+            assert!(op.stat("unrelated/data/part.lance").await.is_ok());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cleanup_target_dataset_for_success_keeps_dataset() -> Result<()> {
+        let op = Operator::new(Memory::default())?.finish();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(async { op.write("dataset/data/part.lance", vec![1, 2, 3]).await })?;
+
+        let query_result = Ok(());
+        runtime.block_on(cleanup_target_dataset_for_result(
+            &query_result,
+            &op,
+            "dataset",
+        ))?;
+
+        runtime.block_on(async {
+            assert!(op.stat("dataset/data/part.lance").await.is_ok());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cleanup_callback_keeps_dataset_when_later_callback_fails() -> Result<()> {
+        let op = Operator::new(Memory::default())?.finish();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(async { op.write("dataset/data/part.lance", vec![1, 2, 3]).await })?;
+
+        let mut pipeline = Pipeline::create();
+        cleanup_target_dataset_on_error(&mut pipeline, op.clone(), "dataset".to_string());
+        pipeline.set_on_finished(basic_callback(move |_info: &ExecutionInfo| {
+            Err(ErrorCode::Internal("later callback failed"))
+        }));
+
+        let mut on_finished = pipeline.take_on_finished();
+        assert!(
+            on_finished
+                .apply(ExecutionInfo::create(Ok(()), HashMap::new()))
+                .is_err()
+        );
+
+        runtime.block_on(async {
+            assert!(op.stat("dataset/data/part.lance").await.is_ok());
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20044

This PR cleans up partial Lance stage output when a `COPY INTO <location> FILE_FORMAT = LANCE` pipeline finishes with an error or cancellation.

The Lance stage append pipeline can make target data files visible before the corresponding Lance manifest is committed under `_versions/`. If the query is cancelled while the writer or committer is in an async step, the target path can be left with partial dataset files that do not form a complete Lance dataset.

This change registers a finished callback for the Lance stage append pipeline. If the pipeline result is an error, the callback performs best-effort cleanup of the current target dataset path. If the pipeline succeeds, the committed dataset is left untouched.

The callback is registered with `lift_on_finished` so it observes the original pipeline result before later finished callbacks can change the callback-chain result. Cleanup failures are logged and do not mask the original query error.

The existing cleanup helper now lists the normalized dataset directory prefix, so cleanup targets only the intended dataset path and does not accidentally match sibling paths with the same string prefix.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation commands:

```bash
cargo test -p databend-common-storages-stage test_cleanup
cargo fmt --all -- --check
git diff --check
cargo clippy -p databend-common-storages-stage --all-targets --all-features --no-deps -- -D warnings
```

Added unit coverage for:

- cleanup on an error/cancellation result;
- preserving successful Lance output;
- preserving successful output when a later finished callback fails;
- avoiding cleanup of sibling paths with the same string prefix.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20050)
<!-- Reviewable:end -->
