### PR TITLE
chore: add aggressive_recluster gate for recluster

### DIFF
--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -26,6 +26,7 @@ use databend_common_io::constants::DEFAULT_BLOCK_ROW_COUNT;
 use databend_common_settings::Settings;
 use databend_common_sql::ApproxDistinctColumns;
 use databend_common_sql::BloomIndexColumns;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
@@ -80,6 +81,7 @@ pub static CREATE_FUSE_OPTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(
     r.insert(FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD);
     r.insert(FUSE_OPT_KEY_FILE_SIZE);
     r.insert(FUSE_OPT_KEY_RECLUSTER_DEPTH);
+    r.insert(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP);
     r.insert(FUSE_OPT_KEY_ENABLE_AUTO_VACUUM);
@@ -159,6 +161,7 @@ pub static UNSET_TABLE_OPTIONS_WHITE_LIST: LazyLock<HashSet<&'static str>> = Laz
     // Deprecated: no longer affects recluster, but old tables can still unset it.
     r.insert(FUSE_OPT_KEY_ROW_AVG_DEPTH_THRESHOLD);
     r.insert(FUSE_OPT_KEY_RECLUSTER_DEPTH);
+    r.insert(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER);
     r.insert(FUSE_OPT_KEY_FILE_SIZE);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
     r.insert(FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP);

--- a/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
+++ b/src/query/service/src/interpreters/interpreter_cluster_key_alter.rs
@@ -18,6 +18,7 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableExt;
 use databend_common_exception::Result;
 use databend_common_sql::plans::AlterTableClusterKeyPlan;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FuseTable;
 use databend_storages_common_table_meta::table::OPT_KEY_CLUSTER_TYPE;
 
@@ -89,6 +90,9 @@ impl Interpreter for AlterTableClusterKeyInterpreter {
                     meta.cluster_key_v2 = cluster_key_meta;
                     meta.options
                         .insert(OPT_KEY_CLUSTER_TYPE.to_owned(), plan.cluster_type.clone());
+                    meta.options
+                        .entry(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER.to_owned())
+                        .or_insert_with(|| "1".to_owned());
                 }
             },
         )

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -43,6 +43,7 @@ use databend_common_pipeline::core::ExecutionInfo;
 use databend_common_pipeline::core::always_callback;
 use databend_common_sql::DefaultExprBinder;
 use databend_common_sql::plans::CreateTablePlan;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_VACUUM;
@@ -492,6 +493,7 @@ impl CreateTableInterpreter {
         is_valid_option_of_type::<u32>(&table_meta.options, FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)?;
         // check enable auto analyze.
         is_valid_option_of_type::<u32>(&table_meta.options, FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE)?;
+        is_valid_option_of_type::<u32>(&table_meta.options, FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER)?;
         is_valid_option_of_type::<u64>(
             &table_meta.options,
             FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD,

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -537,6 +537,9 @@ impl ReclusterTableInterpreter {
         linear_final_carry: &mut ReclusterFinalCarry,
     ) -> Result<Option<PhysicalPlan>> {
         let fuse_table = FuseTable::try_from_table(tbl)?;
+        // Missing `aggressive_recluster` marks a pre-option clustered table. Keep
+        // those tables on the conservative strategy until CREATE/ALTER CLUSTER BY
+        // materializes the option with value 1.
         let mode = if self.plan.is_final
             && fuse_table.get_option(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER, 0u32) != 0
         {

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -50,6 +50,7 @@ use databend_common_sql::plans::ReclusterPlan;
 use databend_common_sql::plans::plan_hilbert_sql;
 use databend_common_sql::plans::replace_with_constant;
 use databend_common_sql::plans::set_update_stream_columns;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::operations::ReclusterFinalCarry;
 use databend_common_storages_fuse::operations::ReclusterMode;
@@ -536,16 +537,19 @@ impl ReclusterTableInterpreter {
         linear_final_carry: &mut ReclusterFinalCarry,
     ) -> Result<Option<PhysicalPlan>> {
         let fuse_table = FuseTable::try_from_table(tbl)?;
+        let mode = if self.plan.is_final
+            && fuse_table.get_option(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER, 0u32) != 0
+        {
+            ReclusterMode::Aggressive
+        } else {
+            ReclusterMode::Conservative
+        };
         let Some((parts, snapshot)) = fuse_table
             .do_recluster(
                 self.ctx.clone(),
                 push_downs.clone(),
                 limit,
-                if self.plan.is_final {
-                    ReclusterMode::Final
-                } else {
-                    ReclusterMode::Normal
-                },
+                mode,
                 linear_final_carry,
             )
             .await?

--- a/src/query/service/src/interpreters/interpreter_table_set_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_set_options.rs
@@ -26,6 +26,7 @@ use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_sql::plans::SetOptionsPlan;
 use databend_common_storages_factory::Table;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ENABLE_AUTO_VACUUM;
@@ -149,6 +150,7 @@ impl Interpreter for SetOptionsInterpreter {
 
         // Same as settings of FUSE_OPT_KEY_ENABLE_AUTO_VACUUM, expect value type is unsigned integer
         is_valid_option_of_type::<u32>(&self.plan.set_options, FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)?;
+        is_valid_option_of_type::<u32>(&self.plan.set_options, FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER)?;
         is_valid_option_of_type::<u64>(
             &self.plan.set_options,
             FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD,

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -1015,7 +1015,7 @@ async fn test_select_segments_normal_conservative() -> anyhow::Result<()> {
             .iter()
             .map(|window| window.len())
             .collect::<Vec<_>>(),
-        vec![4, 3]
+        vec![4]
     );
 
     let segment_locations = gen_recluster_segments_by_ranges(

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -87,6 +87,7 @@ fn new_test_mutator(
     thresholds: BlockThresholds,
     cluster_key_id: u32,
     max_tasks: usize,
+    mode: ReclusterMode,
 ) -> ReclusterMutator {
     ReclusterMutator::new(
         ctx,
@@ -97,6 +98,7 @@ fn new_test_mutator(
         thresholds,
         cluster_key_id,
         max_tasks,
+        mode,
     )
 }
 
@@ -352,6 +354,7 @@ async fn materialize_segment_locations_with_mode(
         thresholds,
         cluster_key_id,
         max_tasks,
+        mode,
     );
 
     let segment_windows = mutator.select_segments(&compact_segments, max_segments)?;
@@ -361,7 +364,7 @@ async fn materialize_segment_locations_with_mode(
     for selected_segs in segment_windows {
         selected_segments = selected_segs.len();
         let (candidate_block_num, candidate_parts) =
-            materialize_candidate_window(&mutator, selected_segs, mode, max_tasks).await?;
+            materialize_candidate_window(&mutator, selected_segs, max_tasks).await?;
         if !candidate_parts.is_empty() {
             block_num = candidate_block_num;
             parts = candidate_parts;
@@ -374,7 +377,6 @@ async fn materialize_segment_locations_with_mode(
 async fn materialize_candidate_window(
     mutator: &ReclusterMutator,
     selected_segs: Vec<SelectedReclusterSegment>,
-    mode: ReclusterMode,
     task_budget: usize,
 ) -> anyhow::Result<(u64, ReclusterParts)> {
     let segment_indexes = selected_segs
@@ -387,13 +389,7 @@ async fn materialize_candidate_window(
     )?);
     let decode_semaphore = Arc::new(Semaphore::new(4));
     let window = mutator
-        .probe_candidate_window(
-            selected_segs,
-            mode,
-            task_budget,
-            decode_runtime,
-            decode_semaphore,
-        )
+        .probe_candidate_window(selected_segs, task_budget, decode_runtime, decode_semaphore)
         .await?;
     if window.task_count() == 0 {
         return Ok((0, ReclusterParts::default()));
@@ -483,7 +479,7 @@ async fn test_recluster_limit_skips_empty_range() -> anyhow::Result<()> {
             ctx.clone(),
             Some(push_downs),
             Some(2),
-            ReclusterMode::Normal,
+            ReclusterMode::Conservative,
             &mut carry,
         )
         .await?
@@ -537,7 +533,7 @@ async fn test_removed_segments_match_selected_blocks() -> anyhow::Result<()> {
         cluster_key_id,
         1,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -582,7 +578,7 @@ async fn test_compacts_small_overlaps() -> anyhow::Result<()> {
         cluster_key_id,
         1,
         8,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
     assert!(!parts.is_empty());
@@ -631,6 +627,7 @@ async fn test_repack_window_without_rewrite() -> anyhow::Result<()> {
         thresholds,
         cluster_key_id,
         1,
+        ReclusterMode::Conservative,
     );
     let selected_segs = mutator
         .select_segments(&compact_segments, 8)?
@@ -643,13 +640,7 @@ async fn test_repack_window_without_rewrite() -> anyhow::Result<()> {
     )?);
     let decode_semaphore = Arc::new(Semaphore::new(4));
     let window = mutator
-        .probe_candidate_window(
-            selected_segs,
-            ReclusterMode::Normal,
-            1,
-            decode_runtime,
-            decode_semaphore,
-        )
+        .probe_candidate_window(selected_segs, 1, decode_runtime, decode_semaphore)
         .await?;
     assert_eq!(window.task_count(), 1);
     let score = window.task_score(0);
@@ -666,7 +657,7 @@ async fn test_repack_window_without_rewrite() -> anyhow::Result<()> {
         cluster_key_id,
         1,
         8,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -674,6 +665,106 @@ async fn test_repack_window_without_rewrite() -> anyhow::Result<()> {
     assert!(parts.tasks.is_empty());
     assert_eq!(parts.remained_blocks.len(), 3);
     assert_eq!(parts.removed_segment_indexes.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_conservative_repack_unordered_window_without_rewrite() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_recluster_block_size(1000)?;
+
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
+    let location_generator = TableMetaLocationGenerator::new("_prefix".to_owned());
+    let cluster_key_id = 0;
+    let thresholds = BlockThresholds::new(1000, 100, 100, 2);
+    let segment_locations = gen_recluster_segments_by_ranges(
+        &data_accessor,
+        &location_generator,
+        &[vec![(3, 4), (1, 2)]],
+        1000,
+        100,
+        100,
+        thresholds,
+        cluster_key_id,
+    )
+    .await?;
+
+    let schema = test_cluster_schema();
+    let ctx: Arc<dyn TableContext> = ctx.clone();
+    let compact_segments = segment_pruning(
+        &ctx,
+        schema.clone(),
+        data_accessor.clone(),
+        create_segment_location_vector(segment_locations.clone(), None),
+    )
+    .await?;
+
+    let aggressive_mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        1,
+        ReclusterMode::Aggressive,
+    );
+    let conservative_mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        1,
+        ReclusterMode::Conservative,
+    );
+
+    let selected_segs = aggressive_mutator
+        .select_segments(&compact_segments, 2)?
+        .into_iter()
+        .next()
+        .expect("unordered single-segment window should be selected");
+    let decode_runtime = Arc::new(Runtime::with_worker_threads(
+        2,
+        Some("recluster-block-meta-test-worker".to_owned()),
+    )?);
+    let decode_semaphore = Arc::new(Semaphore::new(4));
+    let aggressive_window = aggressive_mutator
+        .probe_candidate_window(
+            selected_segs.clone(),
+            1,
+            decode_runtime.clone(),
+            decode_semaphore.clone(),
+        )
+        .await?;
+    assert_eq!(aggressive_window.task_count(), 0);
+
+    let conservative_window = conservative_mutator
+        .probe_candidate_window(selected_segs, 1, decode_runtime, decode_semaphore)
+        .await?;
+    assert_eq!(conservative_window.task_count(), 1);
+    let score = conservative_window.task_score(0);
+    assert_eq!(score.selected_total_bytes, 0);
+    assert_eq!(score.max_depth, 0);
+    assert_eq!(score.average_depth, 0.0);
+
+    let (_, block_num, parts) = materialize_segment_locations_with_mode(
+        ctx,
+        data_accessor,
+        segment_locations,
+        thresholds,
+        cluster_key_id,
+        1,
+        2,
+        ReclusterMode::Conservative,
+    )
+    .await?;
+
+    assert_eq!(block_num, 2);
+    assert!(parts.tasks.is_empty());
+    assert_eq!(parts.remained_blocks.len(), 2);
+    assert_eq!(parts.removed_segment_indexes.len(), 1);
 
     Ok(())
 }
@@ -727,6 +818,7 @@ async fn test_select_segments_covers_candidates() -> anyhow::Result<()> {
         thresholds,
         cluster_key_id,
         1,
+        ReclusterMode::Aggressive,
     );
 
     let segment_windows = mutator.select_segments(&compact_segments, 3)?;
@@ -792,6 +884,7 @@ async fn test_select_segments_covers_candidates() -> anyhow::Result<()> {
         thresholds,
         cluster_key_id,
         1,
+        ReclusterMode::Aggressive,
     );
     let segment_windows = mutator.select_segments(&compact_segments, 3)?;
     let window_sizes = segment_windows
@@ -829,10 +922,123 @@ async fn test_select_segments_covers_candidates() -> anyhow::Result<()> {
         segment_locations,
     )
     .await?;
-    let mutator = new_test_mutator(ctx, data_accessor, schema, thresholds, cluster_key_id, 1);
+    let mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        1,
+        ReclusterMode::Aggressive,
+    );
     let segment_windows = mutator.select_segments(&compact_segments, 2)?;
     assert_eq!(segment_windows.len(), 1);
     assert_eq!(segment_windows[0].len(), 4);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_select_segments_normal_conservative() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_max_threads(2)?;
+
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
+    let location_generator = TableMetaLocationGenerator::new("_prefix".to_owned());
+    let cluster_key_id = 0;
+    let thresholds = BlockThresholds::new(1000, 100, 100, 2);
+
+    let segment_locations = gen_recluster_segments_by_ranges(
+        &data_accessor,
+        &location_generator,
+        &[
+            vec![(1, 2)],
+            vec![(1, 2)],
+            vec![(1, 2)],
+            vec![(1, 2)],
+            vec![(10, 11)],
+            vec![(10, 11)],
+            vec![(10, 11)],
+            vec![(20, 21)],
+            vec![(20, 21)],
+            vec![(30, 31)],
+        ],
+        1000,
+        100,
+        100,
+        thresholds,
+        cluster_key_id,
+    )
+    .await?;
+
+    let schema = test_cluster_schema();
+    let ctx: Arc<dyn TableContext> = ctx.clone();
+    let compact_segments = segment_pruning(
+        &ctx,
+        schema.clone(),
+        data_accessor.clone(),
+        create_segment_location_vector(segment_locations, None),
+    )
+    .await?;
+
+    let aggressive_mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        1,
+        ReclusterMode::Aggressive,
+    );
+    let aggressive_windows = aggressive_mutator.select_segments(&compact_segments, 2)?;
+    assert_eq!(
+        aggressive_windows
+            .iter()
+            .map(|window| window.len())
+            .collect::<Vec<_>>(),
+        vec![4, 3, 3]
+    );
+
+    let conservative_mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        1,
+        ReclusterMode::Conservative,
+    );
+    let conservative_windows = conservative_mutator.select_segments(&compact_segments, 2)?;
+    assert_eq!(
+        conservative_windows
+            .iter()
+            .map(|window| window.len())
+            .collect::<Vec<_>>(),
+        vec![4, 3]
+    );
+
+    let segment_locations = gen_recluster_segments_by_ranges(
+        &data_accessor,
+        &TableMetaLocationGenerator::new("_prefix_disjoint".to_owned()),
+        &[vec![(1, 2)], vec![(3, 4)], vec![(5, 6)]],
+        1000,
+        100,
+        100,
+        thresholds,
+        cluster_key_id,
+    )
+    .await?;
+    let compact_segments = segment_pruning(
+        &ctx,
+        schema,
+        data_accessor,
+        create_segment_location_vector(segment_locations, None),
+    )
+    .await?;
+    let conservative_windows = conservative_mutator.select_segments(&compact_segments, 2)?;
+    assert_eq!(conservative_windows.len(), 1);
+    assert_eq!(conservative_windows[0].len(), 3);
 
     Ok(())
 }
@@ -877,6 +1083,15 @@ async fn test_accumulates_tasks_across_windows() -> anyhow::Result<()> {
     .await?;
 
     let max_tasks = 2;
+    let select_mutator = new_test_mutator(
+        ctx.clone(),
+        data_accessor.clone(),
+        schema.clone(),
+        thresholds,
+        cluster_key_id,
+        max_tasks,
+        ReclusterMode::Aggressive,
+    );
     let mutator = new_test_mutator(
         ctx.clone(),
         data_accessor.clone(),
@@ -884,9 +1099,10 @@ async fn test_accumulates_tasks_across_windows() -> anyhow::Result<()> {
         thresholds,
         cluster_key_id,
         max_tasks,
+        ReclusterMode::Conservative,
     );
 
-    let segment_windows = mutator.select_segments(&compact_segments, 2)?;
+    let segment_windows = select_mutator.select_segments(&compact_segments, 2)?;
     // The two far-apart clusters produce two disjoint windows.
     assert_eq!(segment_windows.len(), 2);
 
@@ -898,13 +1114,8 @@ async fn test_accumulates_tasks_across_windows() -> anyhow::Result<()> {
         if task_budget == 0 {
             break;
         }
-        let (_, candidate_parts) = materialize_candidate_window(
-            &mutator,
-            selected_segs,
-            ReclusterMode::Normal,
-            task_budget,
-        )
-        .await?;
+        let (_, candidate_parts) =
+            materialize_candidate_window(&mutator, selected_segs, task_budget).await?;
         parts.tasks.extend(candidate_parts.tasks);
         parts
             .removed_segment_indexes
@@ -974,17 +1185,12 @@ async fn test_builds_multiple_peaks_in_one_window() -> anyhow::Result<()> {
         thresholds,
         cluster_key_id,
         2,
+        ReclusterMode::Conservative,
     );
 
     let mut segment_windows = mutator.select_segments(&compact_segments, 1000)?;
     assert_eq!(segment_windows.len(), 1);
-    let (_, parts) = materialize_candidate_window(
-        &mutator,
-        segment_windows.remove(0),
-        ReclusterMode::Normal,
-        2,
-    )
-    .await?;
+    let (_, parts) = materialize_candidate_window(&mutator, segment_windows.remove(0), 2).await?;
 
     assert_eq!(parts.tasks.len(), 2);
 
@@ -1038,7 +1244,7 @@ async fn test_splits_hotspot_by_memory() -> anyhow::Result<()> {
         cluster_key_id,
         4,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1081,7 +1287,7 @@ async fn test_repacks_when_min_task_over_memory() -> anyhow::Result<()> {
         cluster_key_id,
         2,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1134,7 +1340,7 @@ async fn test_skips_singleton_over_memory() -> anyhow::Result<()> {
         cluster_key_id,
         2,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1208,7 +1414,7 @@ async fn test_keeps_full_hotspot_task() -> anyhow::Result<()> {
         cluster_key_id,
         2,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1265,7 +1471,7 @@ async fn test_keeps_hotspot_plateau() -> anyhow::Result<()> {
         cluster_key_id,
         2,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1339,7 +1545,7 @@ async fn test_fills_hotspot_tail_from_sides() -> anyhow::Result<()> {
         cluster_key_id,
         3,
         1000,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1365,7 +1571,7 @@ async fn test_defers_after_empty_group() -> anyhow::Result<()> {
         &[(0, 1), (1, 3), (2, 10)],
         thresholds,
         1,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1382,9 +1588,13 @@ async fn test_defers_after_empty_group() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_keeps_low_level_small_task() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    let (block_num, parts) =
-        materialize_segments_by_level_with_mode(&[(0, 3)], thresholds, 1, ReclusterMode::Normal)
-            .await?;
+    let (block_num, parts) = materialize_segments_by_level_with_mode(
+        &[(0, 3)],
+        thresholds,
+        1,
+        ReclusterMode::Conservative,
+    )
+    .await?;
 
     assert_eq!(block_num, 3);
     assert_eq!(parts.tasks.len(), 1);
@@ -1401,7 +1611,7 @@ async fn test_fills_budget_with_next_task() -> anyhow::Result<()> {
         &[(1, 3), (2, 4)],
         thresholds,
         2,
-        ReclusterMode::Normal,
+        ReclusterMode::Conservative,
     )
     .await?;
 
@@ -1429,7 +1639,7 @@ async fn test_final_groups_mature_level_bands() -> anyhow::Result<()> {
         &[(0, 1), (1, 1), (2, 1)],
         thresholds,
         1,
-        ReclusterMode::Final,
+        ReclusterMode::Aggressive,
     )
     .await?;
 
@@ -1442,9 +1652,13 @@ async fn test_final_groups_mature_level_bands() -> anyhow::Result<()> {
     // Two high-level blocks alone do not produce rewrite tasks (both are at or
     // above MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS), but they can still be repacked
     // when that reduces segment count.
-    let (block_num, parts) =
-        materialize_segments_by_level_with_mode(&[(2, 2)], thresholds, 1, ReclusterMode::Final)
-            .await?;
+    let (block_num, parts) = materialize_segments_by_level_with_mode(
+        &[(2, 2)],
+        thresholds,
+        1,
+        ReclusterMode::Aggressive,
+    )
+    .await?;
 
     assert_eq!(block_num, 2);
     assert!(parts.tasks.is_empty());
@@ -1463,7 +1677,7 @@ async fn test_final_wide_bin_merges_mature_levels() -> anyhow::Result<()> {
         &[(4, 1), (8, 1), (8, 1)],
         thresholds,
         1,
-        ReclusterMode::Final,
+        ReclusterMode::Aggressive,
     )
     .await?;
 
@@ -1485,7 +1699,7 @@ async fn test_final_high_maturity_bin_majority_level() -> anyhow::Result<()> {
         &[(9, 1), (10, 2), (12, 1)],
         thresholds,
         1,
-        ReclusterMode::Final,
+        ReclusterMode::Aggressive,
     )
     .await?;
 
@@ -1507,7 +1721,7 @@ async fn test_final_bin_boundary_is_a_hard_split() -> anyhow::Result<()> {
         &[(3, 3), (4, 3)],
         thresholds,
         2,
-        ReclusterMode::Final,
+        ReclusterMode::Aggressive,
     )
     .await?;
 
@@ -1527,9 +1741,13 @@ async fn test_final_bin_boundary_is_a_hard_split() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_repacks_max_level_without_rewrite() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    let (block_num, parts) =
-        materialize_segments_by_level_with_mode(&[(32, 3)], thresholds, 1, ReclusterMode::Final)
-            .await?;
+    let (block_num, parts) = materialize_segments_by_level_with_mode(
+        &[(32, 3)],
+        thresholds,
+        1,
+        ReclusterMode::Aggressive,
+    )
+    .await?;
 
     assert_eq!(block_num, 3);
     assert!(parts.tasks.is_empty());
@@ -1604,6 +1822,15 @@ async fn test_safety_for_recluster() -> anyhow::Result<()> {
         .await?;
 
         let mut parts = ReclusterParts::default();
+        let select_mutator = new_test_mutator(
+            ctx.clone(),
+            data_accessor.clone(),
+            schema.clone(),
+            threshold,
+            cluster_key_id,
+            max_tasks,
+            ReclusterMode::Aggressive,
+        );
         let mutator = new_test_mutator(
             ctx.clone(),
             data_accessor.clone(),
@@ -1611,8 +1838,9 @@ async fn test_safety_for_recluster() -> anyhow::Result<()> {
             threshold,
             cluster_key_id,
             max_tasks,
+            ReclusterMode::Conservative,
         );
-        let segment_windows = mutator.select_segments(&compact_segments, 8)?;
+        let segment_windows = select_mutator.select_segments(&compact_segments, 8)?;
         // `select_segments` only skips large unclustered segments (level < 0 and
         // block_count >= block_per_segment). Every other candidate segment must
         // land in exactly one window, with no duplicates across windows.
@@ -1633,13 +1861,8 @@ async fn test_safety_for_recluster() -> anyhow::Result<()> {
 
         // select the blocks with the highest depth.
         for selected_segs in segment_windows {
-            let (_, candidate_parts) = materialize_candidate_window(
-                &mutator,
-                selected_segs,
-                ReclusterMode::Normal,
-                max_tasks,
-            )
-            .await?;
+            let (_, candidate_parts) =
+                materialize_candidate_window(&mutator, selected_segs, max_tasks).await?;
             if !candidate_parts.is_empty() {
                 parts = candidate_parts;
                 break;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -1059,8 +1059,8 @@ async fn test_compact_segment_with_cluster() -> anyhow::Result<()> {
         for chunks in segments.chunks_mut(chunk_size) {
             chunks.sort_by(|a, b| {
                 sort_by_cluster_stats(
-                    &a.summary.cluster_stats,
-                    &b.summary.cluster_stats,
+                    a.summary.cluster_stats.as_ref(),
+                    b.summary.cluster_stats.as_ref(),
                     cluster_key_id,
                 )
             });

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -174,6 +174,8 @@ use crate::plans::VacuumTableOption;
 use crate::plans::VacuumTablePlan;
 use crate::plans::VacuumTemporaryFilesPlan;
 
+const FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER: &str = "aggressive_recluster";
+
 pub(in crate::planner::binder) struct AnalyzeCreateTableResult {
     pub(in crate::planner::binder) schema: TableSchemaRef,
     pub(in crate::planner::binder) field_comments: Vec<String>,
@@ -937,6 +939,9 @@ impl Binder {
                     OPT_KEY_CLUSTER_TYPE.to_owned(),
                     cluster_opt.cluster_type.to_string().to_lowercase(),
                 );
+                options
+                    .entry(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER.to_owned())
+                    .or_insert_with(|| "1".to_owned());
                 cluster_key = Some(format!("({})", keys.join(", ")));
             }
         }

--- a/src/query/storages/fuse/src/constants.rs
+++ b/src/query/storages/fuse/src/constants.rs
@@ -17,6 +17,7 @@ pub const FUSE_OPT_KEY_BLOCK_PER_SEGMENT: &str = "block_per_segment";
 pub const FUSE_OPT_KEY_ROW_PER_BLOCK: &str = "row_per_block";
 pub const FUSE_OPT_KEY_ROW_PER_PAGE: &str = "row_per_page";
 pub const FUSE_OPT_KEY_RECLUSTER_DEPTH: &str = "recluster_depth";
+pub const FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER: &str = "aggressive_recluster";
 pub const FUSE_OPT_KEY_FILE_SIZE: &str = "file_size";
 pub const FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS: &str = "data_retention_period_in_hours";
 pub const FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP: &str =

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -356,8 +356,9 @@ impl TableMutationAggregator {
 
         if let Some(id) = self.write_segment_ctx.default_cluster_key {
             // sort ascending.
-            merged_blocks
-                .sort_by(|a, b| sort_by_cluster_stats(&a.0.cluster_stats, &b.0.cluster_stats, id));
+            merged_blocks.sort_by(|a, b| {
+                sort_by_cluster_stats(a.0.cluster_stats.as_ref(), b.0.cluster_stats.as_ref(), id)
+            });
         }
 
         let mut tasks = Vec::new();

--- a/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/block_compact_mutator.rs
@@ -136,8 +136,8 @@ impl BlockCompactMutator {
                 // sort descending.
                 segment_infos.sort_by(|a, b| {
                     sort_by_cluster_stats(
-                        &b.1.summary.cluster_stats,
-                        &a.1.summary.cluster_stats,
+                        b.1.summary.cluster_stats.as_ref(),
+                        a.1.summary.cluster_stats.as_ref(),
                         default_cluster_key,
                     )
                 });
@@ -628,7 +628,11 @@ impl CompactTaskBuilder {
         if let Some(default_cluster_key) = self.cluster_key_id {
             // sort ascending.
             blocks.sort_by(|a, b| {
-                sort_by_cluster_stats(&a.0.cluster_stats, &b.0.cluster_stats, default_cluster_key)
+                sort_by_cluster_stats(
+                    a.0.cluster_stats.as_ref(),
+                    b.0.cluster_stats.as_ref(),
+                    default_cluster_key,
+                )
             });
         }
 

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -79,13 +79,14 @@ const MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS: i32 = 2;
 /// Blocks that reach this level have already been rewritten many times, so
 /// keep them out of future recluster tasks to avoid unbounded level growth.
 const MAX_RECLUSTER_LEVEL: i32 = 32;
+const NORMAL_CONSERVATIVE_WINDOW_LIMIT: usize = 2;
 const SMALL_TABLE_RECLUSTER_BLOCK_COUNT: u64 = 1000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum ReclusterGroup {
     /// A single level forms its own group.
     Level(i32),
-    /// FINAL mode: a fixed maturity bin identified by its lower bound `lo`.
+    /// Aggressive mode: a fixed maturity bin identified by its lower bound `lo`.
     Range(i32),
 }
 
@@ -93,12 +94,13 @@ impl ReclusterGroup {
     /// Assign a block's recluster group for the given mode.
     fn assign(level: i32, mode: ReclusterMode) -> ReclusterGroup {
         match mode {
-            ReclusterMode::Normal => ReclusterGroup::Level(level),
-            ReclusterMode::Final if level == 0 => ReclusterGroup::Level(level),
-            ReclusterMode::Final => {
-                // FINAL packs blocks into fixed maturity bins so each round can pick tasks
-                // across a wider level span, letting high-overlap blocks at high levels land
-                // in the same candidate group instead of being split across narrow windows:
+            ReclusterMode::Conservative => ReclusterGroup::Level(level),
+            ReclusterMode::Aggressive if level == 0 => ReclusterGroup::Level(level),
+            ReclusterMode::Aggressive => {
+                // Aggressive recluster packs blocks into fixed maturity bins so each
+                // round can pick tasks across a wider level span, letting high-overlap
+                // blocks at high levels land in the same candidate group instead of
+                // being split across narrow windows:
                 //   - {1..=3}: young-ish blocks, room for early recluster.
                 //   - {4..=8}: mature blocks.
                 //   - {9..}  : high-maturity blocks (upper-bounded by MAX_RECLUSTER_LEVEL).
@@ -304,6 +306,7 @@ pub struct SelectedReclusterSegment {
 pub struct ReclusterMutator {
     pub(crate) ctx: Arc<dyn TableContext>,
     pub(crate) operator: Operator,
+    pub(crate) mode: ReclusterMode,
     pub(crate) depth_threshold: f64,
     pub(crate) block_thresholds: BlockThresholds,
     pub(crate) cluster_key_id: u32,
@@ -319,6 +322,7 @@ impl ReclusterMutator {
         table: &FuseTable,
         ctx: Arc<dyn TableContext>,
         snapshot: &TableSnapshot,
+        mode: ReclusterMode,
     ) -> Result<Self> {
         let schema = table.schema_with_stream();
         let cluster_key_id = table.cluster_key_id().unwrap();
@@ -364,6 +368,7 @@ impl ReclusterMutator {
         Ok(Self {
             ctx,
             operator: table.get_operator(),
+            mode,
             schema,
             depth_threshold,
             block_thresholds,
@@ -386,6 +391,7 @@ impl ReclusterMutator {
         block_thresholds: BlockThresholds,
         cluster_key_id: u32,
         max_tasks: usize,
+        mode: ReclusterMode,
     ) -> Self {
         assert!(
             !cluster_key_exprs.is_empty(),
@@ -405,6 +411,7 @@ impl ReclusterMutator {
         Self {
             ctx,
             operator,
+            mode,
             schema,
             depth_threshold,
             block_thresholds,
@@ -420,7 +427,6 @@ impl ReclusterMutator {
     pub async fn probe_candidate_window(
         &self,
         compact_segments: Vec<SelectedReclusterSegment>,
-        mode: ReclusterMode,
         task_budget: usize,
         decode_runtime: Arc<Runtime>,
         decode_semaphore: Arc<Semaphore>,
@@ -456,10 +462,7 @@ impl ReclusterMutator {
         };
         let mut selected_window_positions = vec![false; window_segment_infos.len()];
 
-        // FINAL bins blocks into fixed maturity ranges ({0} {1-3} {4-8} {9+});
-        // NORMAL keeps each level as its own group. A single pass over the
-        // window builds rewrite-task candidates per group.
-        let tasks = self.build_tasks(&blocks, mode, task_budget)?;
+        let tasks = self.build_tasks(&blocks, task_budget)?;
 
         for candidate in &tasks {
             for (window_pos, _) in &candidate.selected_blocks {
@@ -472,10 +475,12 @@ impl ReclusterMutator {
             let selected_segment_count = window_segment_infos.len();
             let target_segment_count =
                 total_block_count.div_ceil(self.block_thresholds.block_per_segment);
-            if total_block_count > 0
+            let compactable_repack = total_block_count > 0
                 && selected_segment_count > 1
-                && target_segment_count < selected_segment_count
-            {
+                && target_segment_count < selected_segment_count;
+            let unordered_repack =
+                self.mode == ReclusterMode::Conservative && Self::blocks_unordered(&blocks);
+            if compactable_repack || unordered_repack {
                 // Repack-only candidate removes segments without rewrite tasks.
                 selected_window_positions.fill(true);
                 candidate_window.tasks.push(ReclusterTaskCandidate {
@@ -526,6 +531,26 @@ impl ReclusterMutator {
         Ok(candidate_window)
     }
 
+    fn blocks_unordered(blocks: &[&ReclusterBlock]) -> bool {
+        blocks.windows(2).any(|window| {
+            let left = window[0].stats();
+            let right = window[1].stats();
+            let ord_min = left
+                .min()
+                .iter()
+                .map(Scalar::as_ref)
+                .cmp(right.min().iter().map(Scalar::as_ref));
+            if ord_min != cmp::Ordering::Equal {
+                return ord_min == cmp::Ordering::Greater;
+            }
+            left.max()
+                .iter()
+                .map(Scalar::as_ref)
+                .cmp(right.max().iter().map(Scalar::as_ref))
+                == cmp::Ordering::Greater
+        })
+    }
+
     /// Bin block indices into recluster groups and build rewrite-task
     /// candidates. This reuses the already decoded block metas in this window;
     /// it only builds in-memory groups and runs candidate selection, without
@@ -533,7 +558,6 @@ impl ReclusterMutator {
     fn build_tasks(
         &self,
         blocks: &[&ReclusterBlock],
-        mode: ReclusterMode,
         task_budget: usize,
     ) -> Result<Vec<ReclusterTaskCandidate>> {
         let mut blocks_map: BTreeMap<ReclusterGroup, Vec<usize>> = BTreeMap::new();
@@ -547,7 +571,7 @@ impl ReclusterMutator {
                 continue;
             }
             blocks_map
-                .entry(ReclusterGroup::assign(level, mode))
+                .entry(ReclusterGroup::assign(level, self.mode))
                 .or_default()
                 .push(idx);
         }
@@ -990,6 +1014,10 @@ impl ReclusterMutator {
                 .then_with(|| right_indices.len().cmp(&left_indices.len()))
         });
 
+        if self.mode == ReclusterMode::Conservative {
+            windows = Self::select_normal_conservative_windows(windows);
+        }
+
         debug!(
             "recluster: segment selection windows segments={} blocks={} window_count={}",
             compact_segments.len(),
@@ -1008,6 +1036,20 @@ impl ReclusterMutator {
             })
             .filter(|window| !window.is_empty())
             .collect())
+    }
+
+    fn select_normal_conservative_windows(
+        windows: Vec<(IndexSet<usize>, usize)>,
+    ) -> Vec<(IndexSet<usize>, usize)> {
+        if windows.iter().any(|(_, depth)| *depth > 1) {
+            windows
+                .into_iter()
+                .filter(|(_, depth)| *depth > 1)
+                .take(NORMAL_CONSERVATIVE_WINDOW_LIMIT)
+                .collect()
+        } else {
+            windows
+        }
     }
 
     fn build_cluster_stats_for_recluster(

--- a/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/recluster_mutator.rs
@@ -70,6 +70,7 @@ use crate::statistics::RangeMaxTree;
 use crate::statistics::get_min_max_stats;
 use crate::statistics::prepare_cluster_key_exprs;
 use crate::statistics::reducers::merge_statistics_mut;
+use crate::statistics::sort_by_cluster_stats;
 
 /// Maximum recluster depth allowed when only two blocks remain.
 /// For two-block layouts, repeated reclustering beyond this level
@@ -79,7 +80,6 @@ const MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS: i32 = 2;
 /// Blocks that reach this level have already been rewritten many times, so
 /// keep them out of future recluster tasks to avoid unbounded level growth.
 const MAX_RECLUSTER_LEVEL: i32 = 32;
-const NORMAL_CONSERVATIVE_WINDOW_LIMIT: usize = 2;
 const SMALL_TABLE_RECLUSTER_BLOCK_COUNT: u64 = 1000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -472,14 +472,22 @@ impl ReclusterMutator {
         candidate_window.tasks = tasks;
 
         if candidate_window.tasks.is_empty() {
+            let unordered = || {
+                blocks.windows(2).any(|window| {
+                    sort_by_cluster_stats(
+                        Some(window[0].stats()),
+                        Some(window[1].stats()),
+                        self.cluster_key_id,
+                    ) == cmp::Ordering::Greater
+                })
+            };
             let selected_segment_count = window_segment_infos.len();
             let target_segment_count =
                 total_block_count.div_ceil(self.block_thresholds.block_per_segment);
             let compactable_repack = total_block_count > 0
                 && selected_segment_count > 1
                 && target_segment_count < selected_segment_count;
-            let unordered_repack =
-                self.mode == ReclusterMode::Conservative && Self::blocks_unordered(&blocks);
+            let unordered_repack = self.mode == ReclusterMode::Conservative && unordered();
             if compactable_repack || unordered_repack {
                 // Repack-only candidate removes segments without rewrite tasks.
                 selected_window_positions.fill(true);
@@ -529,26 +537,6 @@ impl ReclusterMutator {
         }
 
         Ok(candidate_window)
-    }
-
-    fn blocks_unordered(blocks: &[&ReclusterBlock]) -> bool {
-        blocks.windows(2).any(|window| {
-            let left = window[0].stats();
-            let right = window[1].stats();
-            let ord_min = left
-                .min()
-                .iter()
-                .map(Scalar::as_ref)
-                .cmp(right.min().iter().map(Scalar::as_ref));
-            if ord_min != cmp::Ordering::Equal {
-                return ord_min == cmp::Ordering::Greater;
-            }
-            left.max()
-                .iter()
-                .map(Scalar::as_ref)
-                .cmp(right.max().iter().map(Scalar::as_ref))
-                == cmp::Ordering::Greater
-        })
     }
 
     /// Bin block indices into recluster groups and build rewrite-task
@@ -1015,7 +1003,11 @@ impl ReclusterMutator {
         });
 
         if self.mode == ReclusterMode::Conservative {
-            windows = Self::select_normal_conservative_windows(windows);
+            // Conservative mode is kept for legacy tables without
+            // `aggressive_recluster`. Probe only the deepest window per round to
+            // avoid over-reclustering old tables and creating a sharp behavior
+            // gap from the pre-option strategy.
+            windows.truncate(1);
         }
 
         debug!(
@@ -1036,20 +1028,6 @@ impl ReclusterMutator {
             })
             .filter(|window| !window.is_empty())
             .collect())
-    }
-
-    fn select_normal_conservative_windows(
-        windows: Vec<(IndexSet<usize>, usize)>,
-    ) -> Vec<(IndexSet<usize>, usize)> {
-        if windows.iter().any(|(_, depth)| *depth > 1) {
-            windows
-                .into_iter()
-                .filter(|(_, depth)| *depth > 1)
-                .take(NORMAL_CONSERVATIVE_WINDOW_LIMIT)
-                .collect()
-        } else {
-            windows
-        }
     }
 
     fn build_cluster_stats_for_recluster(

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -235,8 +235,8 @@ impl<'a> SegmentCompactor<'a> {
                 // sort ascending.
                 segment_infos.sort_by(|a, b| {
                     sort_by_cluster_stats(
-                        &a.0.summary.cluster_stats,
-                        &b.0.summary.cluster_stats,
+                        a.0.summary.cluster_stats.as_ref(),
+                        b.0.summary.cluster_stats.as_ref(),
                         default_cluster_key,
                     )
                 });

--- a/src/query/storages/fuse/src/operations/recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster.rs
@@ -48,8 +48,8 @@ const DEFAULT_MIN_RECLUSTER_SEGMENT_WINDOW: usize = 32;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReclusterMode {
-    Normal,
-    Final,
+    Conservative,
+    Aggressive,
 }
 
 impl FuseTable {
@@ -84,6 +84,7 @@ impl FuseTable {
             self,
             ctx.clone(),
             snapshot.as_ref(),
+            mode,
         )?);
 
         // Carry is tied to the current cluster key because cached block metas
@@ -281,7 +282,6 @@ impl FuseTable {
                                 mutator
                                     .probe_candidate_window(
                                         selected_segs,
-                                        mode,
                                         remaining_task_budget,
                                         decode_runtime,
                                         decode_semaphore,
@@ -413,7 +413,7 @@ impl FuseTable {
             }
         };
 
-        if mode != ReclusterMode::Final {
+        if mode != ReclusterMode::Aggressive {
             *carry = ReclusterFinalCarry::default();
         }
 

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -185,11 +185,11 @@ impl ClusterStatsGenerator {
 }
 
 pub fn sort_by_cluster_stats(
-    v1: &Option<ClusterStatistics>,
-    v2: &Option<ClusterStatistics>,
+    v1: Option<&ClusterStatistics>,
+    v2: Option<&ClusterStatistics>,
     default_cluster_key: u32,
 ) -> Ordering {
-    match (v1.as_ref(), v2.as_ref()) {
+    match (v1, v2) {
         (Some(a), Some(b)) => {
             if a.cluster_key_id != default_cluster_key && b.cluster_key_id != default_cluster_key {
                 return Ordering::Equal;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

  - Added Fuse table option `aggressive_recluster`.
    - `aggressive_recluster = 0` or missing option: use the legacy-compatible Conservative strategy.
    - `aggressive_recluster != 0`: allows `RECLUSTER FINAL` to use the Aggressive strategy.
    - Missing option is intentional for upgraded pre-option tables; they stay Conservative until `CREATE/ALTER TABLE ... CLUSTER
    BY ...` materializes the option or users set it manually.
    - `CREATE TABLE ... CLUSTER BY ...` and `ALTER TABLE ... CLUSTER BY ...` insert `aggressive_recluster = 1` only when the option is
    absent, and do not overwrite an explicit value.

  - Changed recluster strategy selection:
    - Normal `RECLUSTER` always uses Conservative mode.
    - `RECLUSTER FINAL` uses Aggressive mode only when `aggressive_recluster != 0`.
    - `RECLUSTER FINAL` with `aggressive_recluster = 0` or missing option still runs as FINAL at the statement level, but uses
    Conservative candidate selection internally.

  - Conservative strategy behavior:
    - Kept as the compatibility path for old clustered tables.
    - Probes only the deepest segment-overlap window per round.
    - Groups rewrite candidates by exact recluster level, so it does not build cross-level tasks.
    - May no-op if the selected deepest window cannot materialize rewrite/repack work; this is intentional to avoid over-reclustering
    upgraded tables and creating a large behavior gap from the old strategy.
    - Keeps the unordered-block repack fallback to preserve the old conservative repack behavior when no rewrite task is built.

  - Aggressive strategy behavior:
    - Used only by `RECLUSTER FINAL` when `aggressive_recluster != 0`.
    - Does not truncate selection to one conservative window, so FINAL can probe more candidate windows and consume more task budget.
    - Allows cross-level candidate grouping inside selected windows by using fixed maturity bins:
      - level `0` remains its own group.
      - levels `1..=3` are grouped together.
      - levels `4..=8` are grouped together.
      - levels `9..MAX_RECLUSTER_LEVEL` are grouped together.
    - This lets FINAL recluster mature/high-overlap blocks that would otherwise be split by exact-level conservative grouping.


```sql
alter table t set options(aggressive_recluster = 1);
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20052)
<!-- Reviewable:end -->
