### PR TITLE
fix(query): rewrite residual aggregates in having

### DIFF
--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -22,6 +22,7 @@ use super::Finder;
 use crate::BindContext;
 use crate::Binder;
 use crate::binder::ExprContext;
+use crate::binder::aggregate::AggregateRewriter;
 use crate::binder::split_conjunctions;
 use crate::optimizer::ir::SExpr;
 use crate::planner::semantic::GroupingChecker;
@@ -65,9 +66,15 @@ impl Binder {
             .set_span(having.span()));
         }
 
+        let mut having = having;
+        AggregateRewriter::rewrite_existing_expr(
+            &bind_context.aggregate_info,
+            &mut having,
+            "Invalid aggregate function in HAVING clause",
+        )?;
+
         let scalar = if bind_context.in_grouping {
             // If we are in grouping context, we will perform the grouping check
-            let mut having = having;
             let mut grouping_checker = GroupingChecker::new(bind_context, None);
             grouping_checker.visit(&mut having)?;
             having

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -142,6 +142,14 @@ async fn test_binder_clauses_and_ordering() -> Result<()> {
             sql: "SELECT number FROM t HAVING count(*) > 0",
         },
         SqlTestCase {
+            name: "having_aggregate_reuses_select_alias_name_as_input_column",
+            description: "A HAVING aggregate argument should resolve to the input column even when a SELECT aggregate has the same alias.",
+            setup_sqls: &[
+                "CREATE TABLE t(creative_name String, impressions UInt64, clicks UInt64, cost UInt64, installs UInt64)",
+            ],
+            sql: "SELECT creative_name, sum(cost) AS cost FROM t GROUP BY creative_name HAVING sum(impressions) > 0 OR sum(clicks) > 0 OR sum(cost) > 0 OR sum(installs) > 0",
+        },
+        SqlTestCase {
             name: "order_by_can_introduce_aggregate_in_aggregate_query",
             description: "ORDER BY may introduce a new aggregate expression when the query is already aggregated.",
             setup_sqls: &["CREATE TABLE t(number UInt64)"],

--- a/src/query/sql/tests/it/semantic/binder_clauses.txt
+++ b/src/query/sql/tests/it/semantic/binder_clauses.txt
@@ -37,6 +37,26 @@ status: error
 code: 1065
 message: column "number" must appear in the GROUP BY clause or be used in an aggregate function
 
+=== having_aggregate_reuses_select_alias_name_as_input_column ===
+description: A HAVING aggregate argument should resolve to the input column even when a SELECT aggregate has the same alias.
+sql: SELECT creative_name, sum(cost) AS cost FROM t GROUP BY creative_name HAVING sum(impressions) > 0 OR sum(clicks) > 0 OR sum(cost) > 0 OR sum(installs) > 0
+status: ok
+EvalScalar
+├── scalars: [t.creative_name (#0) AS (#0), sum(cost) (#5) AS (#5)]
+└── Filter
+    ├── filters: [or(or(or(gt(sum(impressions) (#6), 0), gt(sum(clicks) (#7), 0)), gt(sum(cost) (#5), 0)), gt(sum(installs) (#8), 0))]
+    └── Aggregate(Initial)
+        ├── group items: [t.creative_name (#0) AS (#0)]
+        ├── aggregate functions: [sum(t.cost (#3)) AS (#5), sum(t.impressions (#1)) AS (#6), sum(t.clicks (#2)) AS (#7), sum(t.installs (#4)) AS (#8)]
+        └── EvalScalar
+            ├── scalars: [t.creative_name (#0) AS (#0), t.impressions (#1) AS (#1), t.clicks (#2) AS (#2), t.cost (#3) AS (#3), t.installs (#4) AS (#4)]
+            └── Scan
+                ├── table: default.t (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
 === order_by_can_introduce_aggregate_in_aggregate_query ===
 description: ORDER BY may introduce a new aggregate expression when the query is already aggregated.
 sql: SELECT count(*) FROM t ORDER BY sum(number)

--- a/tests/sqllogictests/suites/query/having.test
+++ b/tests/sqllogictests/suites/query/having.test
@@ -7,3 +7,20 @@ query I
 select sum(number) from numbers(10) group by number % 2 having avg(number) = 5
 ----
 25
+
+query TI
+select creative_name, sum(cost) as cost
+from (
+    select 'creative_a' as creative_name, 1 as impressions, 0 as clicks, 3 as cost, 0 as installs
+    union all
+    select 'creative_a' as creative_name, 0 as impressions, 1 as clicks, 4 as cost, 0 as installs
+    union all
+    select 'creative_b' as creative_name, 0 as impressions, 0 as clicks, 0 as cost, 0 as installs
+)
+group by creative_name
+having sum(impressions) > 0
+    or sum(clicks) > 0
+    or sum(cost) > 0
+    or sum(installs) > 0
+----
+creative_a 7


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`HAVING` predicates can still contain aggregate expressions after the aggregate analysis pass in some query shapes. If such an aggregate reaches physical filter construction, it is lowered as the internal `DummyColumnType::AggregateFunction` symbol and later fails schema lookup with errors like:

```text
Unable to get field named "18446744073709551613". Valid fields: ["0", "32", "33", "34", "35"]
```

This PR makes `bind_having` rewrite any residual aggregate expressions against already-registered aggregate outputs before building the logical `Filter`. It also adds regression coverage for the reported shape where a SELECT aggregate alias has the same name as an input column and HAVING contains an OR chain of `sum(...)` predicates.

## Changes

- Reuse `AggregateRewriter::rewrite_existing_expr` in `bind_having` before grouping checks and filter construction.
- Add a binder golden case to assert HAVING aggregates are bound to aggregate output columns instead of dummy aggregate symbols.
- Add a sqllogictest case that exercises the user-facing SQL path with `sum(cost) AS cost` and multiple HAVING aggregate predicates.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Commands run:

```bash
cargo test -p databend-common-sql --test it semantic::binder::test_binder_clauses_and_ordering -- --nocapture
target/debug/databend-sqllogictests --run_file having.test --enable_sandbox --parallel 1
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20056)
<!-- Reviewable:end -->