### PR TITLE
fix(query): avoid alias expansion in aggregate args

### DIFF
--- a/src/query/sql/src/planner/binder/aggregate_prepass.rs
+++ b/src/query/sql/src/planner/binder/aggregate_prepass.rs
@@ -314,6 +314,7 @@ struct Scanner<'a> {
     ast_aliases: &'a SelectAliasCatalog,
     in_subquery: bool,
     window_depth: usize,
+    aggregate_depth: usize,
     expanding_aliases: HashSet<String>,
     expansion_stack: Vec<String>,
     facts: Vec<AggregatePrepassFact>,
@@ -334,6 +335,7 @@ impl Scanner<'_> {
             ast_aliases,
             in_subquery: false,
             window_depth: 0,
+            aggregate_depth: 0,
             expanding_aliases: HashSet::new(),
             expansion_stack: Vec::new(),
             facts: Vec::new(),
@@ -365,8 +367,30 @@ impl Scanner<'_> {
         Ok(VisitControl::Continue)
     }
 
+    fn visit_aggregate_expr_children(&mut self, expr: &Expr) -> VisitResult {
+        match expr {
+            Expr::CountAll {
+                window: None,
+                qualified,
+                ..
+            } => {
+                for item in qualified {
+                    if let databend_common_ast::ast::Indirection::Identifier(ident) = item {
+                        try_ast_walk!(ident.walk(self));
+                    }
+                }
+            }
+            Expr::FunctionCall { func, .. } => {
+                try_ast_walk!(func.walk(self));
+            }
+            _ => unreachable!("aggregate expr helper must only be called for aggregate exprs"),
+        }
+
+        Ok(VisitControl::Continue)
+    }
+
     fn handle_column_ref(&mut self, column: &ColumnRef) {
-        if self.in_subquery || self.window_depth > 0 {
+        if self.in_subquery || self.window_depth > 0 || self.aggregate_depth > 0 {
             return;
         }
 
@@ -441,6 +465,16 @@ impl Scanner<'_> {
         let ast = &ast_aliases.unique_aggregate_prepass_expr_info(&alias)?.ast;
         Some((alias, ast))
     }
+
+    fn is_aggregate_expr(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::CountAll { window: None, .. } => true,
+            Expr::FunctionCall { func, .. } => {
+                is_aggregate_target(self.name_resolution_ctx, self.udaf_names, func)
+            }
+            _ => false,
+        }
+    }
 }
 
 impl Visitor for Scanner<'_> {
@@ -454,6 +488,14 @@ impl Visitor for Scanner<'_> {
         if is_window_expr(expr) {
             let result = self.visit_window_expr_children(expr);
             self.window_depth -= 1;
+            result?;
+            return Ok(VisitControl::SkipChildren);
+        }
+
+        if self.is_aggregate_expr(expr) && !self.in_subquery {
+            self.aggregate_depth += 1;
+            let result = self.visit_aggregate_expr_children(expr);
+            self.aggregate_depth -= 1;
             result?;
             return Ok(VisitControl::SkipChildren);
         }
@@ -808,6 +850,19 @@ mod tests {
 
         assert_eq!(facts.len(), 1);
         assert!(!facts[0].contains_window);
+    }
+
+    #[test]
+    fn aggregate_prepass_does_not_expand_alias_inside_aggregate_arguments() {
+        let test_bed = AggregatePrepassTestBed::new();
+        let facts = test_bed.scan(
+            ExprContext::HavingClause,
+            &[("cost", "sum(cost)")],
+            "sum(cost) > 0",
+        );
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].source, AggregatePrepassSource::DirectClause);
     }
 
     #[test]

--- a/tests/sqllogictests/suites/query/alias/having_with_alias.test
+++ b/tests/sqllogictests/suites/query/alias/having_with_alias.test
@@ -17,3 +17,37 @@ query I
 select a+1 as a from (select number+1 as a from numbers(1)) having a = 2
 ----
 2
+
+statement error (?s)1065.*column cost_alias doesn't exist
+SELECT SUM(number) AS cost_alias FROM numbers(5) HAVING SUM(cost_alias) > 0
+
+query II
+SELECT
+    creative_name,
+    SUM(cost) AS cost
+FROM
+    (
+        SELECT
+            number % 2 AS creative_name,
+            number AS cost,
+            number AS impressions,
+            number AS clicks,
+            number AS c_bi_install,
+            TO_DATE('2026-06-17') AS install_date
+        FROM
+            numbers(5)
+    ) AS t
+WHERE
+    install_date BETWEEN '2026-06-17' AND '2026-06-24'
+GROUP BY
+    creative_name
+HAVING
+    SUM(impressions) > 0
+    OR SUM(clicks) > 0
+    OR SUM(cost) > 0
+    OR SUM(c_bi_install) > 0
+ORDER BY
+    creative_name
+----
+0 6
+1 4


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes HAVING aggregate prepass alias handling so aggregate function arguments do not expand SELECT aliases.

For example, when a query selects `SUM(cost) AS cost`, the `cost` inside `HAVING SUM(cost) > 0` should resolve to the input column, not the SELECT alias. The prepass now matches the binder behavior by suppressing alias expansion while visiting aggregate arguments.

The PR also adds coverage for the boundary:

- `HAVING SUM(cost)` works when `cost` is an input column, even if the SELECT output alias is also `cost`.
- `HAVING SUM(cost_alias)` reports a semantic error when `cost_alias` exists only as a SELECT alias.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_
## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20057)
<!-- Reviewable:end -->
