### PR TITLE
feat(query): show pruning IO costs in explain

### DIFF
--- a/src/query/catalog/src/plan/pruning_statistics.rs
+++ b/src/query/catalog/src/plan/pruning_statistics.rs
@@ -15,6 +15,11 @@
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug, Default)]
 #[serde(default)]
 pub struct PruningStatistics {
+    /// Segment read cost in microseconds.
+    pub segments_read_cost: u64,
+    /// Segment block metas decompress cost in microseconds.
+    pub segments_decompress_cost: u64,
+
     /// Segment range pruning stats.
     pub segments_range_pruning_before: usize,
     pub segments_range_pruning_after: usize,
@@ -32,6 +37,8 @@ pub struct PruningStatistics {
     pub blocks_bloom_pruning_after: usize,
     /// Block bloom pruning cost in microseconds.
     pub blocks_bloom_pruning_cost: u64,
+    /// Block bloom index read cost in microseconds.
+    pub blocks_bloom_index_read_cost: u64,
 
     /// Block inverted index filter pruning stats.
     pub blocks_inverted_index_pruning_before: usize,
@@ -60,6 +67,8 @@ pub struct PruningStatistics {
 
 impl PruningStatistics {
     pub fn merge(&mut self, other: &Self) {
+        self.segments_read_cost += other.segments_read_cost;
+        self.segments_decompress_cost += other.segments_decompress_cost;
         self.segments_range_pruning_before += other.segments_range_pruning_before;
         self.segments_range_pruning_after += other.segments_range_pruning_after;
         self.segments_range_pruning_cost += other.segments_range_pruning_cost;
@@ -69,6 +78,7 @@ impl PruningStatistics {
         self.blocks_bloom_pruning_before += other.blocks_bloom_pruning_before;
         self.blocks_bloom_pruning_after += other.blocks_bloom_pruning_after;
         self.blocks_bloom_pruning_cost += other.blocks_bloom_pruning_cost;
+        self.blocks_bloom_index_read_cost += other.blocks_bloom_index_read_cost;
         self.blocks_inverted_index_pruning_before += other.blocks_inverted_index_pruning_before;
         self.blocks_inverted_index_pruning_after += other.blocks_inverted_index_pruning_after;
         self.blocks_inverted_index_pruning_cost += other.blocks_inverted_index_pruning_cost;

--- a/src/query/catalog/src/table_context/partitions.rs
+++ b/src/query/catalog/src/table_context/partitions.rs
@@ -77,6 +77,8 @@ pub trait TableContextPartitionStats: Send + Sync {
         unimplemented!()
     }
 
+    fn clear_pruned_partitions_stats(&self) {}
+
     fn merge_pruned_partitions_stats(&self, _other: &HashMap<u32, PartStatistics>) {
         unimplemented!()
     }

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -17,6 +17,9 @@ use std::fmt::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use databend_common_catalog::plan::PartStatistics;
+use databend_common_catalog::plan::PruningStatistics;
+use databend_common_catalog::table_context::TableContextPartitionStats;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -69,6 +72,25 @@ fn error_fields<C>(log_type: LogType, err: Option<ErrorCode<C>>) -> (LogType, i3
             }
         }
     }
+}
+
+fn pruning_stats_query_log_extra(part_stats: &HashMap<u32, PartStatistics>) -> Result<String> {
+    if part_stats.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut pruning_stats = PruningStatistics::default();
+    for stats in part_stats.values() {
+        pruning_stats.merge(&stats.pruning_stats);
+    }
+
+    Ok(serde_json::to_string(&serde_json::json!({
+        "pruning_stats": {
+            "segments_read_cost_us": pruning_stats.segments_read_cost,
+            "segments_decompress_cost_us": pruning_stats.segments_decompress_cost,
+            "blocks_bloom_index_read_cost_us": pruning_stats.blocks_bloom_index_read_cost,
+        }
+    }))?)
 }
 
 impl InterpreterQueryLog {
@@ -362,6 +384,7 @@ impl InterpreterQueryLog {
         drop(guard);
 
         let peek_memory_usage = ctx.get_node_peek_memory_usage();
+        let extra = pruning_stats_query_log_extra(&ctx.get_pruned_partitions_stats())?;
 
         Self::write_log(QueryLogElement {
             log_type,
@@ -422,12 +445,77 @@ impl InterpreterQueryLog {
             server_version: ctx.get_version().commit_detail.to_string(),
             query_tag,
             session_settings,
-            extra: "".to_string(),
+            extra,
             has_profiles,
             txn_state,
             txn_id,
             peek_memory_usage,
             session_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn pruning_stats_query_log_extra_formats_io_costs() {
+        let mut first = PartStatistics::default();
+        first.pruning_stats.segments_read_cost = 7;
+        first.pruning_stats.segments_decompress_cost = 11;
+        first.pruning_stats.blocks_bloom_index_read_cost = 13;
+
+        let mut second = PartStatistics::default();
+        second.pruning_stats.segments_read_cost = 17;
+        second.pruning_stats.segments_decompress_cost = 19;
+        second.pruning_stats.blocks_bloom_index_read_cost = 23;
+
+        let mut part_stats = HashMap::new();
+        part_stats.insert(1, first);
+        part_stats.insert(2, second);
+
+        let extra = pruning_stats_query_log_extra(&part_stats).unwrap();
+        let value: Value = serde_json::from_str(&extra).unwrap();
+        let pruning_stats = &value["pruning_stats"];
+
+        assert_eq!(pruning_stats["segments_read_cost_us"].as_u64(), Some(24));
+        assert_eq!(
+            pruning_stats["segments_decompress_cost_us"].as_u64(),
+            Some(30)
+        );
+        assert_eq!(
+            pruning_stats["blocks_bloom_index_read_cost_us"].as_u64(),
+            Some(36)
+        );
+    }
+
+    #[test]
+    fn pruning_stats_query_log_extra_preserves_zero_costs() {
+        let mut part_stats = HashMap::new();
+        part_stats.insert(1, PartStatistics::default());
+
+        let extra = pruning_stats_query_log_extra(&part_stats).unwrap();
+        let value: Value = serde_json::from_str(&extra).unwrap();
+        let pruning_stats = &value["pruning_stats"];
+
+        assert_eq!(pruning_stats["segments_read_cost_us"].as_u64(), Some(0));
+        assert_eq!(
+            pruning_stats["segments_decompress_cost_us"].as_u64(),
+            Some(0)
+        );
+        assert_eq!(
+            pruning_stats["blocks_bloom_index_read_cost_us"].as_u64(),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn pruning_stats_query_log_extra_is_empty_without_fuse_pruning() {
+        let part_stats = HashMap::new();
+
+        assert_eq!(pruning_stats_query_log_extra(&part_stats).unwrap(), "");
     }
 }

--- a/src/query/service/src/physical_plans/format/common.rs
+++ b/src/query/service/src/physical_plans/format/common.rs
@@ -82,8 +82,49 @@ pub fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNo
         FormatTreeNode::new(format!("partitions scanned: {}", info.partitions_scanned)),
     ];
 
-    // format is like "pruning stats: [segments: <range pruning: x to y>, blocks: <range pruning: x to y>]"
+    // Example:
+    // pruning stats: [segments: <read cost: ..., decompress cost: ...>,
+    //                 blocks: <range pruning: x to y, bloom index read cost: ...>]
+    let mut segments_pruning_description = String::new();
     let mut blocks_pruning_description = String::new();
+
+    // segment read status.
+    if info.pruning_stats.segments_read_cost > 0 {
+        write!(
+            segments_pruning_description,
+            "read{}",
+            format_pruning_cost_suffix(info.pruning_stats.segments_read_cost)
+        )
+        .unwrap();
+    }
+
+    // segment decompress status.
+    if info.pruning_stats.segments_decompress_cost > 0 {
+        if !segments_pruning_description.is_empty() {
+            segments_pruning_description.push_str(", ");
+        }
+        write!(
+            segments_pruning_description,
+            "decompress{}",
+            format_pruning_cost_suffix(info.pruning_stats.segments_decompress_cost)
+        )
+        .unwrap();
+    }
+
+    // segment range pruning status.
+    if info.pruning_stats.segments_range_pruning_before > 0 {
+        if !segments_pruning_description.is_empty() {
+            segments_pruning_description.push_str(", ");
+        }
+        write!(
+            segments_pruning_description,
+            "range pruning: {} to {}{}",
+            info.pruning_stats.segments_range_pruning_before,
+            info.pruning_stats.segments_range_pruning_after,
+            format_pruning_cost_suffix(info.pruning_stats.segments_range_pruning_cost)
+        )
+        .unwrap();
+    }
 
     // range pruning status.
     if info.pruning_stats.blocks_range_pruning_before > 0 {
@@ -93,6 +134,19 @@ pub fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNo
             info.pruning_stats.blocks_range_pruning_before,
             info.pruning_stats.blocks_range_pruning_after,
             format_pruning_cost_suffix(info.pruning_stats.blocks_range_pruning_cost)
+        )
+        .unwrap();
+    }
+
+    // bloom index read status.
+    if info.pruning_stats.blocks_bloom_index_read_cost > 0 {
+        if !blocks_pruning_description.is_empty() {
+            blocks_pruning_description.push_str(", ");
+        }
+        write!(
+            blocks_pruning_description,
+            "bloom index read{}",
+            format_pruning_cost_suffix(info.pruning_stats.blocks_bloom_index_read_cost)
         )
         .unwrap();
     }
@@ -173,18 +227,14 @@ pub fn part_stats_info_to_format_tree(info: &PartStatistics) -> Vec<FormatTreeNo
     }
 
     // Combine segment pruning and blocks pruning descriptions if any
-    if info.pruning_stats.segments_range_pruning_before > 0
-        || !blocks_pruning_description.is_empty()
-    {
+    if !segments_pruning_description.is_empty() || !blocks_pruning_description.is_empty() {
         let mut pruning_description = String::new();
 
-        if info.pruning_stats.segments_range_pruning_before > 0 {
+        if !segments_pruning_description.is_empty() {
             write!(
                 pruning_description,
-                "segments: <range pruning: {} to {}{}>",
-                info.pruning_stats.segments_range_pruning_before,
-                info.pruning_stats.segments_range_pruning_after,
-                format_pruning_cost_suffix(info.pruning_stats.segments_range_pruning_cost)
+                "segments: <{}>",
+                segments_pruning_description
             )
             .unwrap();
         }
@@ -344,5 +394,65 @@ impl<'a> PhysicalFormat for SimplePhysicalFormat<'a> {
             self.meta.name.clone(),
             children,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_pruning_stats_with_io_costs() {
+        let mut stats = PartStatistics::default_exact();
+        stats.pruning_stats.segments_read_cost = 2_400;
+        stats.pruning_stats.segments_decompress_cost = 900;
+        stats.pruning_stats.segments_range_pruning_before = 10;
+        stats.pruning_stats.segments_range_pruning_after = 3;
+        stats.pruning_stats.segments_range_pruning_cost = 1_100;
+        stats.pruning_stats.blocks_range_pruning_before = 20;
+        stats.pruning_stats.blocks_range_pruning_after = 5;
+        stats.pruning_stats.blocks_range_pruning_cost = 2_200;
+        stats.pruning_stats.blocks_bloom_index_read_cost = 3_300;
+        stats.pruning_stats.blocks_bloom_pruning_before = 5;
+        stats.pruning_stats.blocks_bloom_pruning_after = 1;
+        stats.pruning_stats.blocks_bloom_pruning_cost = 4_400;
+
+        let nodes = part_stats_info_to_format_tree(&stats);
+        let pruning_stats = nodes
+            .iter()
+            .map(|node| node.payload.as_str())
+            .find(|payload| payload.starts_with("pruning stats:"))
+            .unwrap();
+
+        assert_eq!(
+            pruning_stats,
+            "pruning stats: [segments: <read cost: 2 ms, decompress cost: 1 ms, range pruning: 10 to 3 cost: 1 ms>, blocks: <range pruning: 20 to 5 cost: 2 ms, bloom index read cost: 3 ms, bloom pruning: 5 to 1 cost: 4 ms>]"
+        );
+    }
+
+    #[test]
+    fn format_pruning_stats_does_not_fabricate_missing_io_costs() {
+        let mut stats = PartStatistics::default_exact();
+        stats.pruning_stats.segments_range_pruning_before = 10;
+        stats.pruning_stats.segments_range_pruning_after = 3;
+        stats.pruning_stats.segments_range_pruning_cost = 1_100;
+        stats.pruning_stats.blocks_range_pruning_before = 20;
+        stats.pruning_stats.blocks_range_pruning_after = 5;
+        stats.pruning_stats.blocks_range_pruning_cost = 2_200;
+        stats.pruning_stats.blocks_bloom_pruning_before = 5;
+        stats.pruning_stats.blocks_bloom_pruning_after = 1;
+        stats.pruning_stats.blocks_bloom_pruning_cost = 4_400;
+
+        let nodes = part_stats_info_to_format_tree(&stats);
+        let pruning_stats = nodes
+            .iter()
+            .map(|node| node.payload.as_str())
+            .find(|payload| payload.starts_with("pruning stats:"))
+            .unwrap();
+
+        assert_eq!(
+            pruning_stats,
+            "pruning stats: [segments: <range pruning: 10 to 3 cost: 1 ms>, blocks: <range pruning: 20 to 5 cost: 2 ms, bloom pruning: 5 to 1 cost: 4 ms>]"
+        );
     }
 }

--- a/src/query/service/src/physical_plans/physical_plan_builder.rs
+++ b/src/query/service/src/physical_plans/physical_plan_builder.rs
@@ -76,8 +76,21 @@ impl PhysicalPlanBuilder {
 
         let mut plan = self.build_physical_plan(s_expr, required).await?;
         plan.adjust_plan_id(&mut 0);
+        self.publish_synchronous_pruning_stats(&plan);
 
         Ok(plan)
+    }
+
+    fn publish_synchronous_pruning_stats(&self, plan: &PhysicalPlan) {
+        let mut sources = Vec::new();
+        plan.get_all_data_source(&mut sources);
+
+        for (plan_id, source) in sources {
+            if source.statistics.pruning_stats != Default::default() {
+                self.ctx
+                    .set_pruned_partitions_stats(plan_id, source.statistics);
+            }
+        }
     }
 
     #[async_recursion::async_recursion(#[recursive::recursive])]

--- a/src/query/service/src/physical_plans/physical_plan_builder.rs
+++ b/src/query/service/src/physical_plans/physical_plan_builder.rs
@@ -43,6 +43,7 @@ pub struct PhysicalPlanBuilder {
     pub mutation_build_info: Option<MutationBuildInfo>,
     pub cte_required_columns: HashMap<String, ColumnSet>,
     pub is_cte_required_columns_collected: bool,
+    pub build_depth: usize,
 }
 
 impl PhysicalPlanBuilder {
@@ -56,6 +57,7 @@ impl PhysicalPlanBuilder {
             mutation_build_info: None,
             cte_required_columns: HashMap::new(),
             is_cte_required_columns_collected: false,
+            build_depth: 0,
         }
     }
 
@@ -69,14 +71,25 @@ impl PhysicalPlanBuilder {
     }
 
     pub async fn build(&mut self, s_expr: &SExpr, required: ColumnSet) -> Result<PhysicalPlan> {
+        let is_root_build = self.build_depth == 0;
+        if is_root_build {
+            self.ctx.clear_pruned_partitions_stats();
+        }
+
         if !self.is_cte_required_columns_collected {
             self.collect_cte_required_columns(s_expr, required.clone())?;
             self.is_cte_required_columns_collected = true;
         }
 
-        let mut plan = self.build_physical_plan(s_expr, required).await?;
-        plan.adjust_plan_id(&mut 0);
-        self.publish_synchronous_pruning_stats(&plan);
+        self.build_depth += 1;
+        let build_result = self.build_physical_plan(s_expr, required).await;
+        self.build_depth -= 1;
+
+        let mut plan = build_result?;
+        if is_root_build {
+            plan.adjust_plan_id(&mut 0);
+            self.publish_synchronous_pruning_stats(&plan);
+        }
 
         Ok(plan)
     }

--- a/src/query/service/src/sessions/query_ctx/state.rs
+++ b/src/query/service/src/sessions/query_ctx/state.rs
@@ -203,6 +203,10 @@ impl TableContextPartitionStats for QueryContext {
         self.shared.set_pruned_partitions_stats(plan_id, stats);
     }
 
+    fn clear_pruned_partitions_stats(&self) {
+        self.shared.clear_pruned_partitions_stats();
+    }
+
     fn merge_pruned_partitions_stats(&self, other: &HashMap<u32, PartStatistics>) {
         self.shared.merge_pruned_partitions_stats(other);
     }

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -800,6 +800,10 @@ impl QueryContextShared {
             .or_insert(stats);
     }
 
+    pub fn clear_pruned_partitions_stats(&self) {
+        self.pruned_partitions_stats.write().clear();
+    }
+
     pub fn merge_pruned_partitions_stats(&self, other: &HashMap<u32, PartStatistics>) {
         let mut guard = self.pruned_partitions_stats.write();
         for (plan_id, stats) in other.iter() {

--- a/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
@@ -21,6 +21,8 @@ use databend_common_base::runtime::Runtime;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_catalog::plan::PushDownInfo;
+use databend_common_catalog::plan::ReadPartitionsPruningMode;
+use databend_common_catalog::query_kind::QueryKind;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
@@ -49,6 +51,7 @@ use databend_query::pipelines::executor::ExecutorSettings;
 use databend_query::pipelines::executor::QueryPipelineExecutor;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
+use databend_query::sessions::TableContextQueryIdentity;
 use databend_query::sessions::TableContextTableAccess;
 use databend_query::storages::fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use databend_query::storages::fuse::FUSE_OPT_KEY_ROW_PER_BLOCK;
@@ -264,6 +267,10 @@ async fn test_snapshot_pruner() -> anyhow::Result<()> {
         table.clone(),
         "a > 0 and b > 6",
     )?);
+    let deterministic_filter = PushDownInfo {
+        is_deterministic: true,
+        ..e2.clone()
+    };
     let b2 = num_blocks - max_val_of_b as usize - 1;
 
     // Sort asc Limit: TopN-pruner.
@@ -357,6 +364,39 @@ async fn test_snapshot_pruner() -> anyhow::Result<()> {
         check_stats(stats, &stats_res, id)?;
         assert_eq!(expected_blocks, partitions.partitions.len());
     }
+
+    let segment_locs = create_segment_location_vector(snapshot.segments.clone(), None);
+    let normal_stats = fuse_table
+        .prune_snapshot_blocks(
+            ctx.clone(),
+            Some(deterministic_filter.clone()),
+            table.get_table_info().schema(),
+            segment_locs.clone(),
+            snapshot.summary.block_count as usize,
+            ReadPartitionsPruningMode::Normal,
+            None,
+        )
+        .await?
+        .0;
+    assert_eq!(0, normal_stats.pruning_stats.segments_read_cost);
+    assert_eq!(0, normal_stats.pruning_stats.segments_decompress_cost);
+
+    let explain_ctx = fixture.new_query_ctx().await?;
+    explain_ctx.attach_query_str(QueryKind::Explain, "explain".to_string());
+    let explain_stats = fuse_table
+        .prune_snapshot_blocks(
+            explain_ctx,
+            Some(deterministic_filter),
+            table.get_table_info().schema(),
+            segment_locs,
+            snapshot.summary.block_count as usize,
+            ReadPartitionsPruningMode::Normal,
+            None,
+        )
+        .await?
+        .0;
+    assert!(explain_stats.pruning_stats.segments_read_cost > 0);
+    assert!(explain_stats.pruning_stats.segments_decompress_cost > 0);
 
     Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
+++ b/src/query/service/tests/it/storages/fuse/pruning_pipeline.rs
@@ -51,6 +51,7 @@ use databend_query::pipelines::executor::ExecutorSettings;
 use databend_query::pipelines::executor::QueryPipelineExecutor;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
+use databend_query::sessions::TableContextPartitionStats;
 use databend_query::sessions::TableContextQueryIdentity;
 use databend_query::sessions::TableContextTableAccess;
 use databend_query::storages::fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
@@ -73,12 +74,13 @@ async fn apply_snapshot_pruning(
     bloom_index_cols: BloomIndexColumns,
     fuse_table: &FuseTable,
     cache_key: Option<String>,
-) -> Result<Vec<PartInfoPtr>> {
-    let ctx: Arc<dyn TableContext> = ctx;
+    plan_id: u32,
+) -> Result<(Vec<PartInfoPtr>, PartStatistics)> {
+    let table_ctx: Arc<dyn TableContext> = ctx.clone();
     let segment_locs = table_snapshot.segments.clone();
     let segment_locs = create_segment_location_vector(segment_locs, None);
     let fuse_pruner = Arc::new(FusePruner::create(
-        &ctx,
+        &table_ctx,
         op,
         schema,
         push_down,
@@ -100,7 +102,7 @@ async fn apply_snapshot_pruning(
         res_tx,
         cache_key,
         segment_locs.len(),
-        0,
+        plan_id,
     )?;
     prune_pipeline.set_max_threads(1);
     prune_pipeline.set_on_init(move || {
@@ -140,7 +142,13 @@ async fn apply_snapshot_pruning(
         got.push(segment);
     }
 
-    Ok(got)
+    let stats = ctx
+        .get_pruned_partitions_stats()
+        .get(&plan_id)
+        .cloned()
+        .ok_or_else(|| ErrorCode::Internal("missing pruning statistics for test"))?;
+
+    Ok((got, stats))
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -336,7 +344,7 @@ async fn test_snapshot_pruner() -> anyhow::Result<()> {
 
     for (id, (extra, expected_blocks, expected_rows)) in extras.into_iter().enumerate() {
         let cache_key = Some(format!("test_block_pruner_{}", id));
-        let parts = apply_snapshot_pruning(
+        let (parts, stats) = apply_snapshot_pruning(
             snapshot.clone(),
             table.get_table_info().schema(),
             &extra,
@@ -345,6 +353,7 @@ async fn test_snapshot_pruner() -> anyhow::Result<()> {
             fuse_table.bloom_index_cols(),
             fuse_table,
             cache_key.clone(),
+            id as u32,
         )
         .await?;
         let rows = parts
@@ -360,8 +369,9 @@ async fn test_snapshot_pruner() -> anyhow::Result<()> {
         assert_eq!(expected_rows, rows);
         assert_eq!(expected_blocks, parts.len());
 
-        let (stats, partitions) = FuseTable::check_prune_cache(&cache_key).unwrap();
         check_stats(stats, &stats_res, id)?;
+        let (stats, partitions) = FuseTable::check_prune_cache(&cache_key).unwrap();
+        assert_eq!(stats.pruning_stats, Default::default());
         assert_eq!(expected_blocks, partitions.partitions.len());
     }
 

--- a/src/query/sql/test-support/data/results/basic/01_cross_join_aggregation_physical.txt
+++ b/src/query/sql/test-support/data/results/basic/01_cross_join_aggregation_physical.txt
@@ -29,7 +29,6 @@ AggregateFinal
             │       ├── read size: 19.57 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
-            │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
             │       ├── push downs: [filters: [], limit: NONE]
             │       └── estimated rows: 5000.00
             └── TableScan(Probe)

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -36,6 +36,7 @@ use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::ReadPartitionsPruningMode;
 use databend_common_catalog::plan::TopK;
 use databend_common_catalog::plan::VirtualColumnInfo;
+use databend_common_catalog::query_kind::QueryKind;
 use databend_common_catalog::table::ReusablePrunedMetas;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
@@ -146,6 +147,11 @@ fn read_partitions_pruning_mode(push_downs: &Option<PushDownInfo>) -> ReadPartit
         .as_ref()
         .map(|push_downs| push_downs.read_partitions_pruning_mode)
         .unwrap_or_default()
+}
+
+fn enable_prune_cache_for_query(ctx: &Arc<dyn TableContext>) -> Result<bool> {
+    Ok(ctx.get_settings().get_enable_prune_cache()?
+        && !matches!(ctx.get_query_kind(), QueryKind::Explain))
 }
 
 fn same_segment_locations(left: &[SegmentLocation], right: &[SegmentLocation]) -> bool {
@@ -355,7 +361,8 @@ impl FuseTable {
                     )
                 });
 
-        if ctx.get_settings().get_enable_prune_cache()? {
+        let enable_prune_cache = enable_prune_cache_for_query(&ctx)?;
+        if enable_prune_cache {
             if let Some((stat, part)) = Self::check_prune_cache(&derterministic_cache_key) {
                 ctx.set_pruned_partitions_stats(plan_id, stat);
                 let sender = part_info_tx.clone();
@@ -478,7 +485,10 @@ impl FuseTable {
             pruning_mode,
             ctx.get_settings().get_enable_proxy_bloom_pruning()?,
         );
-        if let Some(cached_result) = Self::check_prune_cache(&derterministic_cache_key) {
+        let enable_prune_cache = enable_prune_cache_for_query(&ctx)?;
+        if enable_prune_cache
+            && let Some(cached_result) = Self::check_prune_cache(&derterministic_cache_key)
+        {
             info!("Retrieved snapshot block pruning result from cache");
             return Ok((cached_result.0, cached_result.1, None));
         }
@@ -567,9 +577,11 @@ impl FuseTable {
             (statistics, partitions, None)
         };
 
-        if let Some(cache_key) = derterministic_cache_key {
+        if enable_prune_cache && let Some(cache_key) = derterministic_cache_key {
             if let Some(cache) = CacheItem::cache() {
-                cache.insert(cache_key, (result.0.clone(), result.1.clone()));
+                let mut cache_statistics = result.0.clone();
+                cache_statistics.pruning_stats = PruningStatistics::default();
+                cache.insert(cache_key, (cache_statistics, result.1.clone()));
             }
         }
         Ok(result)
@@ -623,8 +635,10 @@ impl FuseTable {
             )
         })?;
 
-        prune_pipeline
-            .add_transform(|input, output| ExtractSegmentTransform::create(input, output, true))?;
+        let pruning_cost = pruner.pruning_ctx.pruning_cost.clone();
+        prune_pipeline.add_transform(|input, output| {
+            ExtractSegmentTransform::create(input, output, true, pruning_cost.clone())
+        })?;
         let sample_probability = table_sample(&pruner.push_down)?;
         if let Some(probability) = sample_probability {
             prune_pipeline.add_transform(|input, output| {
@@ -716,7 +730,7 @@ impl FuseTable {
             .filter(|p| p.order_by.is_empty() && p.filters.is_none() && p.secure_filters.is_none())
             .and_then(|p| p.limit);
         let enable_prune_cache =
-            ctx.get_settings().get_enable_prune_cache()? && runtime_filter_prune_context.is_none();
+            enable_prune_cache_for_query(&ctx)? && runtime_filter_prune_context.is_none();
         let send_part_state = Arc::new(SendPartState::create(
             derterministic_cache_key,
             limit,

--- a/src/query/storages/fuse/src/pruning/bloom_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/bloom_pruner.rs
@@ -44,6 +44,8 @@ use crate::FuseBlockPartInfo;
 use crate::io::BlockWriter;
 use crate::io::BloomBlockFilterReader;
 use crate::io::BloomIndexRebuilder;
+use crate::pruning::PruningCostController;
+use crate::pruning::PruningCostKind;
 
 #[async_trait::async_trait]
 pub trait BloomPruner {
@@ -155,6 +157,8 @@ pub struct BloomPrunerCreator {
 
     /// bloom index builder, if set to Some(_), missing bloom index will be built during pruning
     bloom_index_builder: Option<BloomIndexRebuilder>,
+
+    pruning_cost: PruningCostController,
 }
 
 impl BloomPrunerCreator {
@@ -167,6 +171,7 @@ impl BloomPrunerCreator {
         bloom_index_cols: BloomIndexColumns,
         ngram_args: Vec<NgramArgs>,
         bloom_index_builder: Option<BloomIndexRebuilder>,
+        pruning_cost: PruningCostController,
     ) -> Result<Option<Arc<dyn BloomPruner + Send + Sync>>> {
         let Some(expr) = filter_expr else {
             return Ok(None);
@@ -219,6 +224,7 @@ impl BloomPrunerCreator {
             settings,
             data_schema: schema.clone(),
             bloom_index_builder,
+            pruning_cost,
         })))
     }
 
@@ -253,12 +259,16 @@ impl BloomPrunerCreator {
         )?;
 
         // load the relevant index columns
-        let maybe_filter = index_location
-            .read_block_filter(
-                self.dal.clone(),
-                &self.settings,
-                &index_columns,
-                index_length,
+        let maybe_filter = self
+            .pruning_cost
+            .measure_async(
+                PruningCostKind::BlocksBloomIndexRead,
+                index_location.read_block_filter(
+                    self.dal.clone(),
+                    &self.settings,
+                    &index_columns,
+                    index_length,
+                ),
             )
             .await;
 

--- a/src/query/storages/fuse/src/pruning/fuse_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/fuse_pruner.rs
@@ -116,7 +116,8 @@ impl PruningContext {
         bloom_index_builder: Option<BloomIndexRebuilder>,
     ) -> Result<Arc<PruningContext>> {
         let func_ctx = ctx.get_function_context()?;
-        let collect_pruning_cost = matches!(ctx.get_query_kind(), QueryKind::Explain);
+        let collect_pruning_cost =
+            matches!(ctx.get_query_kind(), QueryKind::Explain | QueryKind::Query);
 
         let filter_expr = push_down.as_ref().and_then(|extra| {
             extra
@@ -160,6 +161,9 @@ impl PruningContext {
             default_stats,
         )?;
 
+        let pruning_stats = Arc::new(FusePruningStatistics::default());
+        let pruning_cost = PruningCostController::new(pruning_stats.clone(), collect_pruning_cost);
+
         // Bloom pruner.
         // None will be returned, if filter is not applicable (e.g. unsuitable filter expression, index not available, etc.)
         let lightweight_pruning = push_down.as_ref().is_some_and(|push_down| {
@@ -179,6 +183,7 @@ impl PruningContext {
                 bloom_index_cols,
                 ngram_args,
                 bloom_index_builder,
+                pruning_cost.clone(),
             )?
         };
 
@@ -232,10 +237,6 @@ impl PruningContext {
             Some("pruning-worker".to_owned()),
         )?);
         let pruning_semaphore = Arc::new(Semaphore::new(max_concurrency));
-        let pruning_stats = Arc::new(FusePruningStatistics::default());
-
-        let pruning_cost = PruningCostController::new(pruning_stats.clone(), collect_pruning_cost);
-
         let pruning_ctx = Arc::new(PruningContext {
             ctx: ctx.clone(),
             dal,
@@ -423,6 +424,7 @@ impl FusePruner {
                 let segment_pruner = segment_pruner.clone();
                 let pruning_ctx = self.pruning_ctx.clone();
                 let push_down = self.push_down.clone();
+                let pruning_cost = self.pruning_ctx.pruning_cost.clone();
 
                 async move {
                     // Build pruning tasks.
@@ -463,6 +465,7 @@ impl FusePruner {
                                 &segment_location.location.0,
                                 compact_segment_info,
                                 populate_block_meta_cache,
+                                &pruning_cost,
                             )?;
                             res.extend(
                                 block_pruner
@@ -473,8 +476,12 @@ impl FusePruner {
                     } else {
                         let sample_probability = table_sample(&push_down)?;
                         for (location, info) in pruned_segments {
-                            let mut block_metas =
-                                Self::extract_block_metas(&location.location.0, &info, true)?;
+                            let mut block_metas = Self::extract_block_metas(
+                                &location.location.0,
+                                &info,
+                                true,
+                                &pruning_cost,
+                            )?;
                             if let Some(probability) = sample_probability {
                                 if block_metas.len() <= SMALL_DATASET_SAMPLE_THRESHOLD {
                                     // Deterministic sampling for small datasets
@@ -541,18 +548,25 @@ impl FusePruner {
         segment_path: &str,
         segment: &CompactSegmentInfo,
         populate_cache: bool,
+        pruning_cost: &PruningCostController,
     ) -> Result<Arc<Vec<Arc<BlockMeta>>>> {
         if let Some(cache) = CacheManager::instance().get_segment_block_metas_cache() {
             if let Some(metas) = cache.get(segment_path) {
                 Ok(metas)
             } else {
+                let metas = pruning_cost.measure(PruningCostKind::SegmentsDecompress, || {
+                    segment.block_metas()
+                })?;
                 match populate_cache {
-                    true => Ok(cache.insert(segment_path.to_string(), segment.block_metas()?)),
-                    false => Ok(Arc::new(segment.block_metas()?)),
+                    true => Ok(cache.insert(segment_path.to_string(), metas)),
+                    false => Ok(Arc::new(metas)),
                 }
             }
         } else {
-            Ok(Arc::new(segment.block_metas()?))
+            let metas = pruning_cost.measure(PruningCostKind::SegmentsDecompress, || {
+                segment.block_metas()
+            })?;
+            Ok(Arc::new(metas))
         }
     }
 
@@ -709,6 +723,9 @@ impl FusePruner {
     pub fn pruning_stats(&self) -> databend_common_catalog::plan::PruningStatistics {
         let stats = self.pruning_ctx.pruning_stats.clone();
 
+        let segments_read_cost = stats.get_segments_read_cost();
+        let segments_decompress_cost = stats.get_segments_decompress_cost();
+
         let segments_range_pruning_before = stats.get_segments_range_pruning_before() as usize;
         let segments_range_pruning_after = stats.get_segments_range_pruning_after() as usize;
         let segments_range_pruning_cost = stats.get_segments_range_pruning_cost();
@@ -720,6 +737,7 @@ impl FusePruner {
         let blocks_bloom_pruning_before = stats.get_blocks_bloom_pruning_before() as usize;
         let blocks_bloom_pruning_after = stats.get_blocks_bloom_pruning_after() as usize;
         let blocks_bloom_pruning_cost = stats.get_blocks_bloom_pruning_cost();
+        let blocks_bloom_index_read_cost = stats.get_blocks_bloom_index_read_cost();
 
         let blocks_inverted_index_pruning_before =
             stats.get_blocks_inverted_index_pruning_before() as usize;
@@ -744,6 +762,8 @@ impl FusePruner {
         let blocks_topn_pruning_cost = stats.get_blocks_topn_pruning_cost();
 
         databend_common_catalog::plan::PruningStatistics {
+            segments_read_cost,
+            segments_decompress_cost,
             segments_range_pruning_before,
             segments_range_pruning_after,
             segments_range_pruning_cost,
@@ -753,6 +773,7 @@ impl FusePruner {
             blocks_bloom_pruning_before,
             blocks_bloom_pruning_after,
             blocks_bloom_pruning_cost,
+            blocks_bloom_index_read_cost,
             blocks_inverted_index_pruning_before,
             blocks_inverted_index_pruning_after,
             blocks_inverted_index_pruning_cost,

--- a/src/query/storages/fuse/src/pruning/pruning_statistics.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_statistics.rs
@@ -23,43 +23,75 @@ use std::time::Instant;
 
 #[derive(Default)]
 pub struct FusePruningStatistics {
+    /// Segment read cost in nanoseconds.
+    pub segments_read_cost: AtomicU64,
+    /// Segment block metas decompress cost in nanoseconds.
+    pub segments_decompress_cost: AtomicU64,
+
     /// Segment range pruning stats.
     pub segments_range_pruning_before: AtomicU64,
     pub segments_range_pruning_after: AtomicU64,
+    /// Segment range pruning cost in nanoseconds.
     pub segments_range_pruning_cost: AtomicU64,
 
     /// Block range pruning stats.
     pub blocks_range_pruning_before: AtomicU64,
     pub blocks_range_pruning_after: AtomicU64,
+    /// Block range pruning cost in nanoseconds.
     pub blocks_range_pruning_cost: AtomicU64,
 
     /// Block bloom filter pruning stats.
     pub blocks_bloom_pruning_before: AtomicU64,
     pub blocks_bloom_pruning_after: AtomicU64,
+    /// Block bloom pruning cost in nanoseconds.
     pub blocks_bloom_pruning_cost: AtomicU64,
+    /// Block bloom index read cost in nanoseconds.
+    pub blocks_bloom_index_read_cost: AtomicU64,
 
     /// Block inverted index filter pruning stats.
     pub blocks_inverted_index_pruning_before: AtomicU64,
     pub blocks_inverted_index_pruning_after: AtomicU64,
+    /// Block inverted index pruning cost in nanoseconds.
     pub blocks_inverted_index_pruning_cost: AtomicU64,
 
     /// Block vector index filter pruning stats.
     pub blocks_vector_index_pruning_before: AtomicU64,
     pub blocks_vector_index_pruning_after: AtomicU64,
+    /// Block vector index pruning cost in nanoseconds.
     pub blocks_vector_index_pruning_cost: AtomicU64,
 
     /// Block spatial index filter pruning stats.
     pub blocks_spatial_index_pruning_before: AtomicU64,
     pub blocks_spatial_index_pruning_after: AtomicU64,
+    /// Block spatial index pruning cost in nanoseconds.
     pub blocks_spatial_index_pruning_cost: AtomicU64,
 
     /// Block topn pruning stats.
     pub blocks_topn_pruning_before: AtomicU64,
     pub blocks_topn_pruning_after: AtomicU64,
+    /// Block topn pruning cost in nanoseconds.
     pub blocks_topn_pruning_cost: AtomicU64,
 }
 
 impl FusePruningStatistics {
+    pub fn add_segments_read_cost(&self, duration: Duration) {
+        self.segments_read_cost
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub fn get_segments_read_cost(&self) -> u64 {
+        nanos_to_display_micros(self.segments_read_cost.load(Ordering::Relaxed))
+    }
+
+    pub fn add_segments_decompress_cost(&self, duration: Duration) {
+        self.segments_decompress_cost
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub fn get_segments_decompress_cost(&self) -> u64 {
+        nanos_to_display_micros(self.segments_decompress_cost.load(Ordering::Relaxed))
+    }
+
     pub fn set_segments_range_pruning_before(&self, v: u64) {
         self.segments_range_pruning_before
             .fetch_add(v, Ordering::Relaxed);
@@ -80,11 +112,11 @@ impl FusePruningStatistics {
 
     pub fn add_segments_range_pruning_cost(&self, duration: Duration) {
         self.segments_range_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_segments_range_pruning_cost(&self) -> u64 {
-        self.segments_range_pruning_cost.load(Ordering::Relaxed)
+        nanos_to_display_micros(self.segments_range_pruning_cost.load(Ordering::Relaxed))
     }
 
     pub fn set_blocks_range_pruning_before(&self, v: u64) {
@@ -107,11 +139,11 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_range_pruning_cost(&self, duration: Duration) {
         self.blocks_range_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_range_pruning_cost(&self) -> u64 {
-        self.blocks_range_pruning_cost.load(Ordering::Relaxed)
+        nanos_to_display_micros(self.blocks_range_pruning_cost.load(Ordering::Relaxed))
     }
 
     pub fn set_blocks_bloom_pruning_before(&self, v: u64) {
@@ -134,11 +166,20 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_bloom_pruning_cost(&self, duration: Duration) {
         self.blocks_bloom_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_bloom_pruning_cost(&self) -> u64 {
-        self.blocks_bloom_pruning_cost.load(Ordering::Relaxed)
+        nanos_to_display_micros(self.blocks_bloom_pruning_cost.load(Ordering::Relaxed))
+    }
+
+    pub fn add_blocks_bloom_index_read_cost(&self, duration: Duration) {
+        self.blocks_bloom_index_read_cost
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub fn get_blocks_bloom_index_read_cost(&self) -> u64 {
+        nanos_to_display_micros(self.blocks_bloom_index_read_cost.load(Ordering::Relaxed))
     }
 
     pub fn set_blocks_inverted_index_pruning_before(&self, v: u64) {
@@ -163,12 +204,14 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_inverted_index_pruning_cost(&self, duration: Duration) {
         self.blocks_inverted_index_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_inverted_index_pruning_cost(&self) -> u64 {
-        self.blocks_inverted_index_pruning_cost
-            .load(Ordering::Relaxed)
+        nanos_to_display_micros(
+            self.blocks_inverted_index_pruning_cost
+                .load(Ordering::Relaxed),
+        )
     }
 
     pub fn set_blocks_vector_index_pruning_before(&self, v: u64) {
@@ -193,12 +236,14 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_vector_index_pruning_cost(&self, duration: Duration) {
         self.blocks_vector_index_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_vector_index_pruning_cost(&self) -> u64 {
-        self.blocks_vector_index_pruning_cost
-            .load(Ordering::Relaxed)
+        nanos_to_display_micros(
+            self.blocks_vector_index_pruning_cost
+                .load(Ordering::Relaxed),
+        )
     }
 
     pub fn set_blocks_spatial_index_pruning_before(&self, v: u64) {
@@ -223,12 +268,14 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_spatial_index_pruning_cost(&self, duration: Duration) {
         self.blocks_spatial_index_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_spatial_index_pruning_cost(&self) -> u64 {
-        self.blocks_spatial_index_pruning_cost
-            .load(Ordering::Relaxed)
+        nanos_to_display_micros(
+            self.blocks_spatial_index_pruning_cost
+                .load(Ordering::Relaxed),
+        )
     }
 
     pub fn set_blocks_topn_pruning_before(&self, v: u64) {
@@ -251,16 +298,17 @@ impl FusePruningStatistics {
 
     pub fn add_blocks_topn_pruning_cost(&self, duration: Duration) {
         self.blocks_topn_pruning_cost
-            .fetch_add(duration_to_micros(duration), Ordering::Relaxed);
+            .fetch_add(duration_to_nanos(duration), Ordering::Relaxed);
     }
 
     pub fn get_blocks_topn_pruning_cost(&self) -> u64 {
-        self.blocks_topn_pruning_cost.load(Ordering::Relaxed)
+        nanos_to_display_micros(self.blocks_topn_pruning_cost.load(Ordering::Relaxed))
     }
 }
 
-fn duration_to_micros(duration: Duration) -> u64 {
-    duration.as_micros().min(u64::MAX as u128) as u64
+fn nanos_to_display_micros(nanos: u64) -> u64 {
+    let micros = nanos / 1_000;
+    if micros == 0 && nanos > 0 { 1 } else { micros }
 }
 
 fn duration_to_nanos(duration: Duration) -> u64 {
@@ -315,8 +363,11 @@ impl PruningCostController {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PruningCostKind {
+    SegmentsRead,
+    SegmentsDecompress,
     SegmentsRange,
     BlocksRange,
+    BlocksBloomIndexRead,
     BlocksBloom,
     BlocksInverted,
     BlocksVector,
@@ -324,18 +375,21 @@ pub enum PruningCostKind {
     BlocksTopN,
 }
 
-const PRUNING_COST_KIND_COUNT: usize = 7;
+const PRUNING_COST_KIND_COUNT: usize = 10;
 
 impl PruningCostKind {
     const fn as_index(self) -> usize {
         match self {
-            PruningCostKind::SegmentsRange => 0,
-            PruningCostKind::BlocksRange => 1,
-            PruningCostKind::BlocksBloom => 2,
-            PruningCostKind::BlocksInverted => 3,
-            PruningCostKind::BlocksVector => 4,
-            PruningCostKind::BlocksSpatial => 5,
-            PruningCostKind::BlocksTopN => 6,
+            PruningCostKind::SegmentsRead => 0,
+            PruningCostKind::SegmentsDecompress => 1,
+            PruningCostKind::SegmentsRange => 2,
+            PruningCostKind::BlocksRange => 3,
+            PruningCostKind::BlocksBloomIndexRead => 4,
+            PruningCostKind::BlocksBloom => 5,
+            PruningCostKind::BlocksInverted => 6,
+            PruningCostKind::BlocksVector => 7,
+            PruningCostKind::BlocksSpatial => 8,
+            PruningCostKind::BlocksTopN => 9,
         }
     }
 }
@@ -365,11 +419,20 @@ impl PruningCostGuardToken {
         };
 
         match self.kind {
+            PruningCostKind::SegmentsRead => {
+                stats.add_segments_read_cost(elapsed);
+            }
+            PruningCostKind::SegmentsDecompress => {
+                stats.add_segments_decompress_cost(elapsed);
+            }
             PruningCostKind::SegmentsRange => {
                 stats.add_segments_range_pruning_cost(elapsed);
             }
             PruningCostKind::BlocksRange => {
                 stats.add_blocks_range_pruning_cost(elapsed);
+            }
+            PruningCostKind::BlocksBloomIndexRead => {
+                stats.add_blocks_bloom_index_read_cost(elapsed);
             }
             PruningCostKind::BlocksBloom => {
                 stats.add_blocks_bloom_pruning_cost(elapsed);
@@ -454,6 +517,21 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn pruning_cost_rounds_total_sub_microsecond_duration_for_display() {
+        assert_eq!(nanos_to_display_micros(0), 0);
+        assert_eq!(nanos_to_display_micros(1), 1);
+        assert_eq!(nanos_to_display_micros(1_000), 1);
+
+        let stats = FusePruningStatistics::default();
+        stats.add_blocks_range_pruning_cost(Duration::from_nanos(400));
+        stats.add_blocks_range_pruning_cost(Duration::from_nanos(400));
+        assert_eq!(stats.get_blocks_range_pruning_cost(), 1);
+
+        stats.add_blocks_range_pruning_cost(Duration::from_nanos(400));
+        assert_eq!(stats.get_blocks_range_pruning_cost(), 1);
+    }
 
     #[test]
     fn pruning_cost_controller_records_parallel_time_once() {

--- a/src/query/storages/fuse/src/pruning/segment_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/segment_pruner.rs
@@ -64,13 +64,17 @@ impl SegmentPruner {
         let pruning_cost = self.pruning_ctx.pruning_cost.clone();
 
         for segment_location in segment_locs {
-            let info = T::SegmentReader::read_compact_segment_through_cache(
-                self.pruning_ctx.dal.clone(),
-                segment_location.location.clone(),
-                &self.projection,
-                self.table_schema.clone(),
-            )
-            .await?;
+            let info = pruning_cost
+                .measure_async(
+                    PruningCostKind::SegmentsRead,
+                    T::SegmentReader::read_compact_segment_through_cache(
+                        self.pruning_ctx.dal.clone(),
+                        segment_location.location.clone(),
+                        &self.projection,
+                        self.table_schema.clone(),
+                    ),
+                )
+                .await?;
 
             let total_bytes = info.summary().uncompressed_byte_size;
             // Perf.

--- a/src/query/storages/fuse/src/pruning_pipeline/extract_segment_transform.rs
+++ b/src/query/storages/fuse/src/pruning_pipeline/extract_segment_transform.rs
@@ -25,11 +25,14 @@ use databend_storages_common_cache::CacheManager;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 
+use crate::pruning::PruningCostController;
+use crate::pruning::PruningCostKind;
 use crate::pruning_pipeline::block_metas_meta::BlockMetasMeta;
 use crate::pruning_pipeline::pruned_segment_meta::PrunedCompactSegmentMeta;
 
 pub struct ExtractSegmentTransform {
     populate_cache: bool,
+    pruning_cost: PruningCostController,
 }
 
 impl ExtractSegmentTransform {
@@ -37,10 +40,12 @@ impl ExtractSegmentTransform {
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
         populate_cache: bool,
+        pruning_cost: PruningCostController,
     ) -> databend_common_exception::Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(
             BlockMetaAccumulatingTransformer::create(input, output, ExtractSegmentTransform {
                 populate_cache,
+                pruning_cost,
             }),
         ))
     }
@@ -55,8 +60,12 @@ impl BlockMetaAccumulatingTransform<PrunedCompactSegmentMeta> for ExtractSegment
     ) -> databend_common_exception::Result<Option<DataBlock>> {
         let (segment_location, info) = data.segments;
 
-        let block_metas =
-            Self::extract_block_metas(&segment_location.location.0, &info, self.populate_cache)?;
+        let block_metas = Self::extract_block_metas(
+            &segment_location.location.0,
+            &info,
+            self.populate_cache,
+            &self.pruning_cost,
+        )?;
 
         if block_metas.is_empty() {
             return Ok(None);
@@ -74,18 +83,25 @@ impl ExtractSegmentTransform {
         segment_path: &str,
         segment: &CompactSegmentInfo,
         populate_cache: bool,
+        pruning_cost: &PruningCostController,
     ) -> databend_common_exception::Result<Arc<Vec<Arc<BlockMeta>>>> {
         if let Some(cache) = CacheManager::instance().get_segment_block_metas_cache() {
             if let Some(metas) = cache.get(segment_path) {
                 Ok(metas)
             } else {
+                let metas = pruning_cost.measure(PruningCostKind::SegmentsDecompress, || {
+                    segment.block_metas()
+                })?;
                 match populate_cache {
-                    true => Ok(cache.insert(segment_path.to_string(), segment.block_metas()?)),
-                    false => Ok(Arc::new(segment.block_metas()?)),
+                    true => Ok(cache.insert(segment_path.to_string(), metas)),
+                    false => Ok(Arc::new(metas)),
                 }
             }
         } else {
-            Ok(Arc::new(segment.block_metas()?))
+            let metas = pruning_cost.measure(PruningCostKind::SegmentsDecompress, || {
+                segment.block_metas()
+            })?;
+            Ok(Arc::new(metas))
         }
     }
 }

--- a/src/query/storages/fuse/src/pruning_pipeline/send_part_info_sink.rs
+++ b/src/query/storages/fuse/src/pruning_pipeline/send_part_info_sink.rs
@@ -94,12 +94,11 @@ impl SendPartState {
         let send_part_cache = self.cache.lock();
         if let Some(cache_key) = &send_part_cache.derterministic_cache_key {
             if let Some(cache) = CacheItem::cache() {
+                let mut cache_statistics = send_part_cache.statistics.clone();
+                cache_statistics.pruning_stats = Default::default();
                 cache.insert(
                     cache_key.clone(),
-                    (
-                        send_part_cache.statistics.clone(),
-                        send_part_cache.partitions.clone(),
-                    ),
+                    (cache_statistics, send_part_cache.partitions.clone()),
                 );
             }
         }

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0011_row_policy_result_cache.test
@@ -100,7 +100,7 @@ Sort(Single)
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], secure_filters: REDACTED, limit: NONE]
     └── estimated rows: 2.50
 

--- a/tests/sqllogictests/suites/mode/cluster/explain_analyze.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_analyze.test
@@ -117,7 +117,7 @@ Exchange
     ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 6
-    ├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 6.00
 
@@ -143,7 +143,7 @@ Exchange
     ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 6
-    ├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 6.00
 
@@ -169,7 +169,7 @@ Exchange
     ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 4
-    ├── pruning stats: [segments: <range pruning: 6 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(article.article_id (#0) < 3)], limit: NONE]
     └── estimated rows: 3.00
 
@@ -214,7 +214,7 @@ Exchange
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 5
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [is_true(author.name (#5) = 'mark4')], limit: NONE]
     │       └── estimated rows: 1.25
     └── TableScan(Probe)
@@ -234,7 +234,7 @@ Exchange
         ├── read size: < 1 KiB
         ├── partitions total: 6
         ├── partitions scanned: 6
-        ├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 6.00

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -30,7 +30,7 @@ Exchange
     ├── read size: < 1 KiB
     ├── partitions total: 3
     ├── partitions scanned: 3
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
     └── estimated rows: 99.00
 
@@ -65,7 +65,7 @@ Exchange
         │       ├── read size: < 1 KiB
         │       ├── partitions total: 3
         │       ├── partitions scanned: 3
-        │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         │       ├── push downs: [filters: [t2.a (#2) > 3 or t2.a (#2) > 1], limit: NONE]
         │       └── estimated rows: 99.92
         └── TableScan(Probe)
@@ -76,7 +76,7 @@ Exchange
             ├── read size: < 1 KiB
             ├── partitions total: 3
             ├── partitions scanned: 3
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
             ├── push downs: [filters: [t1.a (#0) > 3 or t1.a (#0) > 1], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 99.92
@@ -108,7 +108,7 @@ Exchange
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 3
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
@@ -119,7 +119,7 @@ Exchange
         ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 100.00
@@ -238,7 +238,7 @@ Limit
                     │       ├── read size: < 1 KiB
                     │       ├── partitions total: 3
                     │       ├── partitions scanned: 3
-                    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
                     │       ├── push downs: [filters: [], limit: NONE]
                     │       └── estimated rows: 100.00
                     └── TableScan(Probe)
@@ -249,7 +249,7 @@ Limit
                         ├── read size: < 1 KiB
                         ├── partitions total: 3
                         ├── partitions scanned: 3
-                        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
                         ├── push downs: [filters: [], limit: NONE]
                         ├── apply join filters: [#0]
                         └── estimated rows: 100.00
@@ -284,7 +284,7 @@ Exchange
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 3
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: NONE]
     │       └── estimated rows: 100.00
     └── TableScan(Probe)
@@ -295,7 +295,7 @@ Exchange
         ├── read size: < 1 KiB
         ├── partitions total: 3
         ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 100.00
@@ -444,7 +444,7 @@ Exchange
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
+++ b/tests/sqllogictests/suites/mode/cluster/filter_nulls.test
@@ -70,7 +70,7 @@ Exchange
     │       ├── read size: 2.31 KiB
     │       ├── partitions total: 6
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [is_not_null(table2.value (#1))], limit: NONE]
     │       └── estimated rows: 1000.00
     └── TableScan(Probe)
@@ -81,7 +81,7 @@ Exchange
         ├── read size: 3.95 KiB
         ├── partitions total: 6
         ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_not_null(table1.value (#0))], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 2000.00
@@ -113,7 +113,7 @@ Exchange
     │       ├── read size: 3.95 KiB
     │       ├── partitions total: 6
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [is_not_null(table3.value (#2))], limit: NONE]
     │       └── estimated rows: 2001.00
     └── HashJoin(Probe)
@@ -137,7 +137,7 @@ Exchange
         │       ├── read size: 2.31 KiB
         │       ├── partitions total: 6
         │       ├── partitions scanned: 3
-        │       ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         │       ├── push downs: [filters: [is_not_null(table2.value (#1))], limit: NONE]
         │       ├── apply join filters: [#1]
         │       └── estimated rows: 1000.00
@@ -152,7 +152,7 @@ Exchange
                 ├── read size: 3.95 KiB
                 ├── partitions total: 6
                 ├── partitions scanned: 3
-                ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
                 ├── push downs: [filters: [is_not_null(table1.value (#0))], limit: NONE]
                 ├── apply join filters: [#1, #0]
                 └── estimated rows: 2000.00
@@ -185,7 +185,7 @@ Exchange
     │       ├── read size: 2.31 KiB
     │       ├── partitions total: 6
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [is_not_null(table2.value (#1))], limit: NONE]
     │       └── estimated rows: 1000.00
     └── TableScan(Probe)
@@ -196,7 +196,7 @@ Exchange
         ├── read size: 3.95 KiB
         ├── partitions total: 6
         ├── partitions scanned: 3
-        ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_not_null(table1.value (#0))], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 2000.00
@@ -228,7 +228,7 @@ Exchange
     │       ├── read size: 2.31 KiB
     │       ├── partitions total: 6
     │       ├── partitions scanned: 3
-    │       ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [is_not_null(table2.value (#1))], limit: NONE]
     │       └── estimated rows: 1000.00
     └── Exchange(Probe)
@@ -242,7 +242,7 @@ Exchange
             ├── read size: 3.95 KiB
             ├── partitions total: 6
             ├── partitions scanned: 3
-            ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
             ├── push downs: [filters: [is_not_null(table1.value (#0))], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 2000.00

--- a/tests/sqllogictests/suites/mode/cluster/lazy_materialization_join.test
+++ b/tests/sqllogictests/suites/mode/cluster/lazy_materialization_join.test
@@ -111,7 +111,7 @@ RowFetch
                     │       ├── read size: < 1 KiB
                     │       ├── partitions total: 1
                     │       ├── partitions scanned: 1
-                    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     │       ├── push downs: [filters: [is_true(lazy_join_t1.create_time (#3) >= '2021-01-02 00:00:00.000000')], limit: NONE]
                     │       └── estimated rows: 2.67
                     └── TableScan(Probe)
@@ -122,7 +122,7 @@ RowFetch
                         ├── read size: < 1 KiB
                         ├── partitions total: 1
                         ├── partitions scanned: 1
-                        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                         ├── push downs: [filters: [], limit: NONE]
                         ├── apply join filters: [#0]
                         └── estimated rows: 3.00
@@ -178,7 +178,7 @@ RowFetch
             │               ├── read size: < 1 KiB
             │               ├── partitions total: 1
             │               ├── partitions scanned: 1
-            │               ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │               ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │               ├── push downs: [filters: [is_true(lazy_join_t1.create_time (#3) >= '2021-01-02 00:00:00.000000')], limit: 3]
             │               └── estimated rows: 2.67
             └── Exchange(Probe)
@@ -192,7 +192,7 @@ RowFetch
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/cluster/lazy_read.test
+++ b/tests/sqllogictests/suites/mode/cluster/lazy_read.test
@@ -52,7 +52,7 @@ RowFetch
                     ├── read size: < 1 KiB
                     ├── partitions total: 3
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 2 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 2 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: 2]
                     └── estimated rows: 300.00
 
@@ -84,7 +84,7 @@ RowFetch
                 ├── read size: < 1 KiB
                 ├── partitions total: 3
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 3 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [t_lazy.a (#0) < 100], limit: 2]
                 └── estimated rows: 0.00
 
@@ -118,7 +118,7 @@ Limit
                 ├── read size: 1.26 KiB
                 ├── partitions total: 3
                 ├── partitions scanned: 2
-                ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 2 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, topn pruning: 3 to 2 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: 2]
                 └── estimated rows: 300.00
 
@@ -146,7 +146,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 3
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 3 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [t_lazy.a (#0) < 100], limit: 2]
             └── estimated rows: 0.00
 
@@ -174,7 +174,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 3
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 2]
             └── estimated rows: 300.00
 

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -88,7 +88,7 @@ CommitSink
                             ├── read size: < 1 KiB
                             ├── partitions total: 1
                             ├── partitions scanned: 1
-                            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                             ├── push downs: [filters: [], limit: NONE]
                             └── estimated rows: 1.00
 
@@ -123,7 +123,7 @@ CommitSink
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [], limit: NONE]
             │   └── estimated rows: 1.00
             └── TableScan(Probe)
@@ -134,7 +134,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 3
                 ├── partitions scanned: 3
-                ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 15.00
 
@@ -164,7 +164,7 @@ CommitSink
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [], limit: NONE]
             │   └── estimated rows: 1.00
             └── TableScan(Probe)
@@ -175,7 +175,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 3
                 ├── partitions scanned: 3
-                ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 15.00
 
@@ -284,7 +284,7 @@ CommitSink
                             ├── read size: < 1 KiB
                             ├── partitions total: 1
                             ├── partitions scanned: 1
-                            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                             ├── push downs: [filters: [], limit: NONE]
                             └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/cluster/multi_table_insert_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/multi_table_insert_distributed.test
@@ -77,7 +77,7 @@ Commit
                             ├── read size: < 1 KiB
                             ├── partitions total: <slt:ignore>
                             ├── partitions scanned: <slt:ignore>
-                            ├── pruning stats: [segments: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
+                            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
                             ├── push downs: [filters: [], limit: NONE]
                             └── estimated rows: 100.00
 
@@ -113,7 +113,7 @@ Fragment 0:
                             ├── read size: < 1 KiB
                             ├── partitions total: <slt:ignore>
                             ├── partitions scanned: <slt:ignore>
-                            ├── pruning stats: [segments: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
+                            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
                             ├── push downs: [filters: [], limit: NONE]
                             └── estimated rows: 100.00
 (empty)

--- a/tests/sqllogictests/suites/mode/cluster/shuffle.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle.test
@@ -69,7 +69,7 @@ Sort(Final)
             │                   ├── read size: < 1 KiB
             │                   ├── partitions total: <slt:ignore>
             │                   ├── partitions scanned: <slt:ignore>
-            │                   ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
+            │                   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
             │                   ├── push downs: [filters: [], limit: NONE]
             │                   └── estimated rows: 14.00
             └── Exchange(Probe)
@@ -83,7 +83,7 @@ Sort(Final)
                     ├── read size: < 1 KiB
                     ├── partitions total: <slt:ignore>
                     ├── partitions scanned: <slt:ignore>
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: <slt:ignore> to <slt:ignore> cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 5.00

--- a/tests/sqllogictests/suites/mode/cluster/subquery.test
+++ b/tests/sqllogictests/suites/mode/cluster/subquery.test
@@ -70,7 +70,7 @@ Exchange
         │           ├── read size: < 1 KiB
         │           ├── partitions total: 1
         │           ├── partitions scanned: 1
-        │           ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        │           ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         │           ├── push downs: [filters: [is_true(t2.a (#3) = t2.a (#3))], limit: NONE]
         │           └── estimated rows: 2.00
         └── Exchange(Probe)
@@ -99,7 +99,7 @@ Exchange
                 │           ├── read size: < 1 KiB
                 │           ├── partitions total: 1
                 │           ├── partitions scanned: 1
-                │           ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │           ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │           ├── push downs: [filters: [is_true(t2.a (#1) = t2.a (#1))], limit: NONE]
                 │           └── estimated rows: 2.00
                 └── Exchange(Probe)
@@ -113,7 +113,7 @@ Exchange
                         ├── read size: < 1 KiB
                         ├── partitions total: 1
                         ├── partitions scanned: 1
-                        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 3.00
 
@@ -150,7 +150,7 @@ Exchange
         │       ├── read size: < 1 KiB
         │       ├── partitions total: 1
         │       ├── partitions scanned: 1
-        │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         │       ├── push downs: [filters: [], limit: NONE]
         │       └── estimated rows: 2.00
         └── Exchange(Probe)
@@ -175,7 +175,7 @@ Exchange
                 │       ├── read size: < 1 KiB
                 │       ├── partitions total: 1
                 │       ├── partitions scanned: 1
-                │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │       ├── push downs: [filters: [], limit: NONE]
                 │       └── estimated rows: 2.00
                 └── Exchange(Probe)
@@ -189,7 +189,7 @@ Exchange
                         ├── read size: < 1 KiB
                         ├── partitions total: 1
                         ├── partitions scanned: 1
-                        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                         ├── push downs: [filters: [], limit: NONE]
                         └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -112,7 +112,7 @@ Exchange
                 │       ├── read size: < 1 KiB
                 │       ├── partitions total: 1
                 │       ├── partitions scanned: 1
-                │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │       ├── push downs: [filters: [], limit: NONE]
                 │       └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -123,7 +123,7 @@ Exchange
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 10.00

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_hilbert_clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_hilbert_clustering.test
@@ -37,7 +37,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(test_hilbert.a (#0) = 1)], limit: NONE]
 └── estimated rows: 2.00
 
@@ -52,7 +52,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(test_hilbert.b (#1) = 1)], limit: NONE]
 └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_virtual_column.test
@@ -51,7 +51,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 1.00
 
@@ -70,7 +70,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(TRY_CAST(get_by_keypath(t1.v (#1), '{"b","c"}') AS UInt8 NULL) = 10)], limit: NONE]
     └── estimated rows: 0.20
 
@@ -94,7 +94,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 ├── virtual columns: [v['a'][0], v['b']['c']]
 └── estimated rows: 1.00
@@ -114,7 +114,7 @@ Filter
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(TRY_CAST(t2.v['b']['c'] (#3) AS UInt8 NULL) = 10)], limit: NONE]
     ├── virtual columns: [v['a'][0], v['b']['c']]
     └── estimated rows: 1.00
@@ -138,7 +138,7 @@ EvalScalar
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_true(like(CAST(t2.v['b']['c'] (#3) AS String NULL), '%10%'))], limit: NONE]
         ├── virtual columns: [v['a'][0], v['b']['c']]
         └── estimated rows: 1.00
@@ -158,7 +158,7 @@ Filter
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(TRY_CAST(t2.v['d'] (#2) AS UInt8 NULL) = 20)], limit: NONE]
     ├── virtual columns: [v['d']]
     └── estimated rows: 1.00
@@ -174,7 +174,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 ├── virtual columns: [v['a'][0], v['b']['c']]
 └── estimated rows: 1.00
@@ -194,7 +194,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── virtual columns: [v['d']]
     └── estimated rows: 1.00
@@ -223,7 +223,7 @@ EvalScalar
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_true(like(CAST(t2.v['d'] (#2) AS String NULL), '%20%'))], limit: NONE]
         ├── virtual columns: [v['d']]
         └── estimated rows: 1.00
@@ -247,7 +247,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -258,7 +258,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── virtual columns: [v['b'], v['b']['c']]
     └── estimated rows: 1.00
@@ -286,7 +286,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [is_true(TRY_CAST(t2.v['a'][0] (#6) AS UInt8 NULL) = 1)], limit: NONE]
 │       ├── virtual columns: [v['a'][0], v['b']['c']]
 │       └── estimated rows: 1.00
@@ -298,7 +298,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 1.00
 
@@ -325,7 +325,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [is_true(TRY_CAST(t2.v['b']['c'] (#4) AS Int32 NULL) = t2.a (#2))], limit: NONE]
 │       ├── virtual columns: [v['b']['c']]
 │       └── estimated rows: 1.00
@@ -337,7 +337,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 1.00
 
@@ -364,7 +364,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [is_true(TRY_CAST(t2.v['b']['c'] (#5) AS Int32 NULL) > t2.a (#2))], limit: NONE]
 │       ├── virtual columns: [v['b']['c']]
 │       └── estimated rows: 1.00
@@ -376,7 +376,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 1.00
 
@@ -408,7 +408,7 @@ AggregateFinal
         │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
-        │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         │   ├── push downs: [filters: [], limit: NONE]
         │   └── estimated rows: 1.00
         └── TableScan(Probe)
@@ -419,7 +419,7 @@ AggregateFinal
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             ├── virtual columns: [v['b']['c']]
             └── estimated rows: 1.00
@@ -441,7 +441,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── virtual columns: [v['b']['c']]
 │       └── estimated rows: 1.00
@@ -562,7 +562,7 @@ EvalScalar
                 │       ├── read size: < 1 KiB
                 │       ├── partitions total: 1
                 │       ├── partitions scanned: 1
-                │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │       ├── push downs: [filters: [is_not_null(CAST(data_source_a.content_object['category_a'] (#19) AS String NULL)) and is_not_null(CAST(data_source_a.content_object['category_b'] (#20) AS String NULL)) and is_not_null(CAST(CAST(CAST(data_source_a.content_object['event_date'] (#16) AS Int64 NULL) AS Timestamp NULL) AS Date NULL))], limit: NONE]
                 │       ├── virtual columns: [content_object['category_a'], content_object['category_b'], content_object['event_date'], metadata_object['type']]
                 │       └── estimated rows: 1.00
@@ -606,7 +606,7 @@ EvalScalar
                                     │       ├── read size: < 1 KiB
                                     │       ├── partitions total: 1
                                     │       ├── partitions scanned: 1
-                                    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                                    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                                     │       ├── push downs: [filters: [is_not_null(CAST(CAST(CAST(data_source_a.content_object['event_date'] (#13) AS Int64 NULL) AS Timestamp NULL) AS Date NULL))], limit: NONE]
                                     │       ├── apply join filters: [#2, #3]
                                     │       ├── virtual columns: [content_object['event_date']]
@@ -619,7 +619,7 @@ EvalScalar
                                         ├── read size: < 1 KiB
                                         ├── partitions total: 1
                                         ├── partitions scanned: 1
-                                        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+                                        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
                                         ├── push downs: [filters: [is_true(config_table.process_mode (#12) = 'standard_mode')], limit: NONE]
                                         ├── apply join filters: [#2, #3, #0, #1]
                                         └── estimated rows: 1.00
@@ -748,7 +748,7 @@ CommitSink
                 │       ├── read size: < 1 KiB
                 │       ├── partitions total: 1
                 │       ├── partitions scanned: 1
-                │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │       ├── push downs: [filters: [], limit: NONE]
                 │       ├── virtual columns: [data_object['metadata']['category_id'], data_object['unique_key']]
                 │       └── estimated rows: 1.00
@@ -760,7 +760,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0, #1]
                     └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/09_0041_merge_into_issue_15669.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/09_0041_merge_into_issue_15669.test
@@ -11,7 +11,7 @@ statement ok
 merge into t using (select  99  c ) s on t.c = s.c when matched then delete;
 
 
-# expects that bloom pruning prunes 1 block: "bloom pruning: 1 to 0 cost: <slt:ignore>"
+# expects that bloom pruning prunes 1 block and reports bloom index read cost.
 query T
 explain select * from t where c = 99;
 ----
@@ -23,6 +23,6 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) = 99)], limit: NONE]
 └── estimated rows: 1.04

--- a/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
@@ -417,7 +417,7 @@ AggregateFinal
         │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
-        │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         │   ├── push downs: [filters: [], limit: NONE]
         │   └── estimated rows: 10.00
         └── TableScan(Right)
@@ -428,7 +428,7 @@ AggregateFinal
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -29,7 +29,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c1 (#0) = 5)], limit: NONE]
     └── estimated rows: 1.50
 
@@ -48,7 +48,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c1 (#0) = '5')], limit: NONE]
     └── estimated rows: 1.20
 
@@ -131,7 +131,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 3
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 3 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c2 (#1) = 0)], limit: NONE]
     └── estimated rows: 0.00
 
@@ -150,7 +150,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 3
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c2 (#1) = 3)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -169,7 +169,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 3
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c3 (#2) = 12345)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -208,7 +208,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 2
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_alter_t1.c1 (#0) = 5)], limit: NONE]
     └── estimated rows: 1.50
 
@@ -239,7 +239,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 2
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_alter_t2.c1 (#0) = 5)], limit: NONE]
     └── estimated rows: 1.50
 
@@ -267,7 +267,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 3
     ├── partitions scanned: 2
-    ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom pruning: 3 to 2 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 3 to 2 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_alter_t2.c1 (#0) = 5)], limit: NONE]
     └── estimated rows: 1.80
 
@@ -290,7 +290,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 3
     ├── partitions scanned: 3
-    ├── pruning stats: [segments: <range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 3 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_alter_t2.c1 (#0) = 7)], limit: NONE]
     └── estimated rows: 1.80
 
@@ -324,7 +324,7 @@ EvalScalar
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [bloom_test_nullable_t.c1 (#0) = 5 and bloom_test_nullable_t.c2 (#1) > 1], limit: NONE]
     └── estimated rows: 1.50
 
@@ -343,7 +343,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 2
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_nullable_t.c2 (#1) = 12345)], limit: NONE]
     └── estimated rows: 1.20
 
@@ -370,7 +370,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [NOT is_not_null(bloom_test_nullable_t2.c2 (#2) = '1')], limit: NONE]
 └── estimated rows: 0.40
 
@@ -385,6 +385,6 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(bloom_test_nullable_t2.c0 (#0))], limit: NONE]
 └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
@@ -29,7 +29,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(test_linear.a (#0) = 1)], limit: NONE]
 └── estimated rows: 2.00
 
@@ -44,7 +44,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(test_linear.b (#1) = 1)], limit: NONE]
 └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/common_subexpression_optimizer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/common_subexpression_optimizer.test
@@ -22,7 +22,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 6.00
 └── HashJoin
@@ -122,7 +122,7 @@ Sequence
 │           │       ├── read size: < 1 KiB
 │           │       ├── partitions total: 1
 │           │       ├── partitions scanned: 1
-│           │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│           │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │           │       ├── push downs: [filters: [cse_right.b (#1) < 1 or cse_right.b (#1) < 2], limit: NONE]
 │           │       └── estimated rows: 3.00
 │           └── Filter(Probe)
@@ -137,7 +137,7 @@ Sequence
 │                   ├── read size: < 1 KiB
 │                   ├── partitions total: 1
 │                   ├── partitions scanned: 1
-│                   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│                   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │                   ├── push downs: [filters: [cse_left.a (#0) < 1 or cse_left.a (#0) < 2], limit: NONE]
 │                   ├── apply join filters: [#0]
 │                   └── estimated rows: 3.00
@@ -412,7 +412,7 @@ Sequence
 │       │   ├── read size: < 1 KiB
 │       │   ├── partitions total: 1
 │       │   ├── partitions scanned: 1
-│       │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
+│       │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
 │       │   ├── push downs: [filters: [is_true(store.s_store_name (#10) = 'ese')], limit: NONE]
 │       │   └── estimated rows: 1.00
 │       └── HashJoin(Probe)
@@ -437,7 +437,7 @@ Sequence
 │           │       ├── read size: < 1 KiB
 │           │       ├── partitions total: 1
 │           │       ├── partitions scanned: 1
-│           │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
+│           │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
 │           │       ├── push downs: [filters: [time_dim.t_hour (#7) = 8 and time_dim.t_minute (#8) >= 30 or time_dim.t_hour (#7) = 9 and time_dim.t_minute (#8) < 30 or time_dim.t_hour (#7) = 9 and time_dim.t_minute (#8) >= 30 or time_dim.t_hour (#7) = 10 and time_dim.t_minute (#8) < 30 or time_dim.t_hour (#7) = 10 and time_dim.t_minute (#8) >= 30 or time_dim.t_hour (#7) = 11 and time_dim.t_minute (#8) < 30 or time_dim.t_hour (#7) = 11 and time_dim.t_minute (#8) >= 30 or time_dim.t_hour (#7) = 12 and time_dim.t_minute (#8) < 30], limit: NONE]
 │           │       └── estimated rows: 9.00
 │           └── HashJoin(Probe)
@@ -458,7 +458,7 @@ Sequence
 │               │   ├── read size: < 1 KiB
 │               │   ├── partitions total: 1
 │               │   ├── partitions scanned: 1
-│               │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
+│               │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: <slt:ignore>>]
 │               │   ├── push downs: [filters: [household_demographics.hd_dep_count (#4) = 4 and household_demographics.hd_vehicle_count (#5) <= 6 or household_demographics.hd_dep_count (#4) = 2 and household_demographics.hd_vehicle_count (#5) <= 4 or household_demographics.hd_dep_count (#4) = 0 and household_demographics.hd_vehicle_count (#5) <= 2], limit: NONE]
 │               │   └── estimated rows: 2.20
 │               └── TableScan(Probe)
@@ -469,7 +469,7 @@ Sequence
 │                   ├── read size: < 1 KiB
 │                   ├── partitions total: 1
 │                   ├── partitions scanned: 1
-│                   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│                   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │                   ├── push downs: [filters: [], limit: NONE]
 │                   ├── apply join filters: [#2, #1, #0]
 │                   └── estimated rows: 36.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/cte_filter_pushdown.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/cte_filter_pushdown.test
@@ -23,7 +23,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(cte1.a (#0) = 1)], limit: NONE]
 └── estimated rows: 1.67
 
@@ -44,7 +44,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(cte1.a (#0) = 1)], limit: NONE]
 └── estimated rows: 1.00
 
@@ -65,7 +65,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(cte1.sum_b (#2) > 25)], limit: NONE]
 └── estimated rows: 3.00
 
@@ -86,7 +86,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) > 1 and cte1.sum_b (#2) > 25], limit: NONE]
 └── estimated rows: 2.00
 
@@ -113,7 +113,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(cte1.a (#0) = 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -124,7 +124,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(cte1.a (#2) = 2)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -156,7 +156,7 @@ UnionAll
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [is_true(cte1.a (#0) = 1)], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan
@@ -167,7 +167,7 @@ UnionAll
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [is_true(cte1.a (#2) = 2)], limit: NONE]
 │       └── estimated rows: 1.00
 └── TableScan
@@ -178,7 +178,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(cte1.a (#6) = 3)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -197,7 +197,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) = 1 and cte1.b (#1) < 50], limit: NONE]
 └── estimated rows: 1.67
 
@@ -219,7 +219,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(cte1.a (#0) > 1)], limit: NONE]
 └── estimated rows: 2.00
 
@@ -240,7 +240,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) = 1 and cte1.b (#1) > 15], limit: NONE]
 └── estimated rows: 1.67
 
@@ -264,7 +264,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) = 1 and cte1.sum_b (#2) > 25], limit: NONE]
 └── estimated rows: 1.00
 
@@ -285,7 +285,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) = 1 or cte1.a (#0) = 2], limit: NONE]
 └── estimated rows: 1.67
 
@@ -306,7 +306,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.b (#1) > 10 and (cte1.a (#0) = 1 or cte1.a (#0) = 2)], limit: NONE]
 └── estimated rows: 2.78
 
@@ -327,7 +327,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [cte1.a (#0) > 1 and cte1.cnt (#1) > 0], limit: NONE]
 └── estimated rows: 2.00
 
@@ -347,7 +347,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(cte1.a (#0) = 1)], limit: NONE]
 └── estimated rows: 1.67
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/cte_prune_columns.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/cte_prune_columns.test
@@ -30,7 +30,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [is_true(cte_prune_t.a (#0) > 0)], limit: NONE]
 │       └── estimated rows: 2.00
 └── HashJoin
@@ -77,7 +77,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 3.00
 └── HashJoin
@@ -121,7 +121,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 3.00
 └── Sequence
@@ -190,7 +190,7 @@ Sequence
 │           ├── read size: < 1 KiB
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
-│           ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│           ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │           ├── push downs: [filters: [], limit: NONE]
 │           └── estimated rows: 3.00
 └── EvalScalar

--- a/tests/sqllogictests/suites/mode/standalone/explain/delete.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/delete.test
@@ -55,7 +55,7 @@ CommitSink
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [], limit: NONE]
             │   └── estimated rows: 2.00
             └── TableScan(Probe)
@@ -66,7 +66,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 ├── apply join filters: [#0]
                 └── estimated rows: 4.00
@@ -111,7 +111,7 @@ CommitSink
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [], limit: NONE]
             │   └── estimated rows: 2.00
             └── TableScan(Probe)
@@ -122,7 +122,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [is_true(t1.b (#1) > 2)], limit: NONE]
                 ├── apply join filters: [#0]
                 └── estimated rows: 3.50

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -29,7 +29,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -40,7 +40,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -63,7 +63,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -74,7 +74,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -97,7 +97,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -108,7 +108,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -133,7 +133,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -144,7 +144,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_not_null(t.a (#0))], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -170,7 +170,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -181,7 +181,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_not_null(t.a (#0))], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -205,7 +205,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -216,7 +216,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_not_null(t.a (#0))], limit: NONE]
     └── estimated rows: 10.00
 
@@ -239,7 +239,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_not_null(t.a (#0))], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -250,7 +250,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
     └── estimated rows: 10.00
 
@@ -275,7 +275,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_not_null(t.a (#1))], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -286,7 +286,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_not_null(t.a (#0))], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -312,7 +312,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) = 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -323,7 +323,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) = 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00
@@ -349,7 +349,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) > 1)], limit: NONE]
 │   └── estimated rows: 8.00
 └── TableScan(Probe)
@@ -360,7 +360,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) > 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 8.00
@@ -386,7 +386,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) < 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -397,7 +397,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) < 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00
@@ -423,7 +423,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) <> 1)], limit: NONE]
 │   └── estimated rows: 9.00
 └── TableScan(Probe)
@@ -434,7 +434,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) <> 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 9.00
@@ -460,7 +460,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) >= 1)], limit: NONE]
 │   └── estimated rows: 9.00
 └── TableScan(Probe)
@@ -471,7 +471,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) >= 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 9.00
@@ -497,7 +497,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t.a (#1) <= 1)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -508,7 +508,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.a (#0) <= 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 2.00
@@ -537,7 +537,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -548,7 +548,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 10.00
 
@@ -577,7 +577,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t.a (#1) <= 1 or t.a (#1) > 1], limit: NONE]
     │   └── estimated rows: 8.40
     └── TableScan(Probe)
@@ -588,7 +588,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [t.a (#0) <= 1 or t.a (#0) > 1], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 8.40
@@ -616,7 +616,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 10.00
     └── TableScan(Probe)
@@ -627,7 +627,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 10.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_self_join.test
@@ -50,7 +50,7 @@ Filter
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 100.00
 
@@ -103,7 +103,7 @@ Filter
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 5.00
 
@@ -192,7 +192,7 @@ HashJoin
 │               ├── read size: < 1 KiB
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
-│               ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│               ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │               ├── push downs: [filters: [], limit: NONE]
 │               └── estimated rows: 5.00
 └── Filter(Probe)
@@ -216,7 +216,7 @@ HashJoin
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 ├── apply join filters: [#0]
                 └── estimated rows: 5.00
@@ -282,7 +282,7 @@ EvalScalar
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 100.00
 
@@ -366,7 +366,7 @@ Sort(Single)
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 100.00
 
@@ -448,7 +448,7 @@ HashJoin
 │               ├── read size: < 1 KiB
 │               ├── partitions total: 1
 │               ├── partitions scanned: 1
-│               ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│               ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │               ├── push downs: [filters: [], limit: NONE]
 │               └── estimated rows: 100.00
 └── AggregateFinal(Probe)
@@ -468,7 +468,7 @@ HashJoin
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 100.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -33,7 +33,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
 └── estimated rows: 0.00
 
@@ -90,7 +90,7 @@ Filter
     │   ├── read size: 0
     │   ├── partitions total: 1
     │   ├── partitions scanned: 0
-    │   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t1.a (#0) > 3 or t1.a (#0) > 1], limit: NONE]
     │   └── estimated rows: 0.00
     └── TableScan(Probe)
@@ -101,7 +101,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [t2.a (#2) > 3 or t2.a (#2) > 1], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 3.40
@@ -127,7 +127,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -138,7 +138,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 5.00
@@ -329,7 +329,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -340,7 +340,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 5.00
 
@@ -367,7 +367,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 3], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -378,7 +378,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [t2.a (#2) > 2 or t2.b (#3) < 4], limit: NONE]
         └── estimated rows: 4.40
 
@@ -405,7 +405,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 3 or t1.a (#0) = 2], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -416,7 +416,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 5.00
 
@@ -453,7 +453,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -464,7 +464,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 5.00
 └── TableScan(Probe)
@@ -475,7 +475,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -510,7 +510,7 @@ HashJoin
 │       │   ├── read size: < 1 KiB
 │       │   ├── partitions total: 1
 │       │   ├── partitions scanned: 1
-│       │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 3], limit: NONE]
 │       │   └── estimated rows: 1.00
 │       └── TableScan(Probe)
@@ -521,7 +521,7 @@ HashJoin
 │           ├── read size: < 1 KiB
 │           ├── partitions total: 1
 │           ├── partitions scanned: 1
-│           ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│           ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │           ├── push downs: [filters: [t2.a (#2) > 2 or t2.b (#3) < 4], limit: NONE]
 │           └── estimated rows: 4.40
 └── TableScan(Probe)
@@ -532,7 +532,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t3.a (#4) > 1], limit: NONE]
     └── estimated rows: 8.00
 
@@ -568,7 +568,7 @@ Limit
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 2 or t1.b (#1) < 3], limit: NONE]
             │   └── estimated rows: 1.00
             └── TableScan(Probe)
@@ -579,7 +579,7 @@ Limit
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [t2.a (#2) > 2 or t2.b (#3) < 4], limit: NONE]
                 └── estimated rows: 4.40
 
@@ -602,7 +602,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 2], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -613,7 +613,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 5.00
 
@@ -646,7 +646,7 @@ AggregateFinal
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 1.00
 
@@ -679,7 +679,7 @@ AggregateFinal
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 1.00
 
@@ -827,7 +827,7 @@ Limit
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [a.c1 (#1) >= 1683648000 and a.c1 (#1) <= 1683734400], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -838,7 +838,7 @@ Limit
         ├── read size: < 1 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
         ├── push downs: [filters: [b.c1 (#3) >= 1683648000 and b.c1 (#3) <= 1683734400], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 2.00
@@ -943,7 +943,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(b.id (#2) = b.id (#2))], limit: NONE]
 │   └── estimated rows: 0.40
 └── TableScan(Probe)
@@ -954,7 +954,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0, #1]
     └── estimated rows: 3.00
@@ -990,7 +990,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── AggregateFinal(Probe)
@@ -1029,7 +1029,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 3.00
     └── AggregateFinal(Probe)
@@ -1081,7 +1081,7 @@ Sort(Single)
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3.00
 
@@ -1126,7 +1126,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(get(t3.b (#1), 'k2') = 'm')], limit: NONE]
 └── estimated rows: 1.20
 
@@ -1141,7 +1141,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(get(t3.c (#2), 'k3') = '"v"')], limit: NONE]
 └── estimated rows: 1.20
 
@@ -1156,7 +1156,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(TRY_CAST(get(t3.c (#2), 'k2') AS UInt8 NULL) = 100)], limit: NONE]
 └── estimated rows: 1.20
 
@@ -1613,7 +1613,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.a:"1" (#2) > 0)], limit: NONE]
 └── estimated rows: 2.00
 
@@ -1628,7 +1628,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.a:"1" (#2) > 1)], limit: NONE]
 └── estimated rows: 1.33
 
@@ -1643,7 +1643,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.a:"2" (#1) > 1)], limit: NONE]
 └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -405,7 +405,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t1.a (#0) > 1 or t1.b (#1) < 3 or t1.a (#0) = 2], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
@@ -195,7 +195,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 5
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(author.name (#5) = 'mark4')], limit: NONE]
 │   └── estimated rows: 1.25
 └── TableScan(Probe)

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze.test
@@ -110,7 +110,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 6
 ├── partitions scanned: 6
-├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 6.00
 
@@ -134,7 +134,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 6
 ├── partitions scanned: 6
-├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 6.00
 
@@ -158,7 +158,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 6
 ├── partitions scanned: 4
-├── pruning stats: [segments: <range pruning: 6 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(article.article_id (#0) < 3)], limit: NONE]
 └── estimated rows: 3.00
 
@@ -195,7 +195,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 5
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 5 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(author.name (#5) = 'mark4')], limit: NONE]
 │   └── estimated rows: 1.25
 └── TableScan(Probe)
@@ -215,7 +215,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 6
     ├── partitions scanned: 6
-    ├── pruning stats: [segments: <range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 6 to 6 cost: <slt:ignore>>, blocks: <range pruning: 6 to 6 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 6.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_like.test
@@ -25,7 +25,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_not_null(t1.s (#0))], limit: NONE]
 └── estimated rows: 5.00
 
@@ -40,7 +40,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_not_null(t1.s (#0))], limit: NONE]
 └── estimated rows: 5.00
 
@@ -59,7 +59,7 @@ Sort(Single)
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.s (#0) >= 'abcd' and t1.s (#0) < 'abce'], limit: NONE]
     └── estimated rows: 0.50
 
@@ -83,7 +83,7 @@ Sort(Single)
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.s (#0) = 'abcd')], limit: NONE]
     └── estimated rows: 1.00
 
@@ -107,7 +107,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like_any(t1.s (#0), 'abc%'))], limit: NONE]
 └── estimated rows: 1.00
 
@@ -130,7 +130,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like_any(t1.s (#0), ('abc%', '%bcd')))], limit: NONE]
 └── estimated rows: 1.00
 
@@ -150,7 +150,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.s (#0), '%b$%c%', '$'))], limit: NONE]
 └── estimated rows: 2.50
 
@@ -170,7 +170,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like_any(t1.s (#0), '%b$%c%', '$'))], limit: NONE]
 └── estimated rows: 1.00
 
@@ -192,7 +192,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_substr.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_substr.test
@@ -19,7 +19,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(substr(t1.c (#0), 1, 2) = 'ab')], limit: NONE]
 └── estimated rows: 0.80
 
@@ -34,7 +34,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(substr(t1.c (#0), 2, 2) = 'ab')], limit: NONE]
 └── estimated rows: 0.80
 
@@ -50,7 +50,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(left(t1.c (#0), 2) = 'ab')], limit: NONE]
 └── estimated rows: 0.80
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/expression_scan.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── ExpressionScan(Probe)
@@ -78,7 +78,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── ExpressionScan(Probe)
@@ -120,7 +120,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── EvalScalar(Probe)
@@ -176,7 +176,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 3.00
 │   └── EvalScalar(Probe)
@@ -249,7 +249,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 3.00
 │   └── ExpressionScan(Probe)

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -72,7 +72,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 2
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 2 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 2 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t1.d (#0) < CAST(t1.a (#1) AS Timestamp NULL))], limit: NONE]
 └── estimated rows: 0.00
 
@@ -87,7 +87,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 2
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 2 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 2 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [t2.d (#0) < CAST(t2.a (#1) AS Timestamp)], limit: NONE]
 └── estimated rows: 0.00
 
@@ -138,7 +138,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t1_tz.d (#0) < CAST(t1_tz.a (#1) AS TimestampTz NULL))], limit: NONE]
 └── estimated rows: 40.00
 
@@ -153,6 +153,6 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [t2_tz.d (#0) < CAST(t2_tz.a (#1) AS TimestampTz)], limit: NONE]
 └── estimated rows: 40.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -85,7 +85,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_true(t.number (#0) > 10)], limit: NONE]
         └── estimated rows: 2983.50
 
@@ -109,7 +109,7 @@ AggregateFinal
         ├── read size: 5.90 KiB
         ├── partitions total: 2
         ├── partitions scanned: 2
-        ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 3000.00
 
@@ -162,7 +162,7 @@ EvalScalar
                     ├── read size: <slt:ignore>
                     ├── partitions total: 2
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 3000.00
 
@@ -208,7 +208,7 @@ EvalScalar
             ├── read size: <slt:ignore>
             ├── partitions total: 2
             ├── partitions scanned: 2
-            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 3000.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/index/explain_agg_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/index/explain_agg_index.test
@@ -678,7 +678,7 @@ EvalScalar
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             ├── aggregating index: [SELECT event_name, user_id, COUNT(), COUNT(id), MAX(user_id), SUM(id) FROM test_index_db.t GROUP BY event_name, user_id]
             ├── rewritten query: [selection: [index_col_0 (#0), index_col_1 (#1), index_col_4 (#4), index_col_5 (#5), index_col_3 (#3)]]
@@ -719,7 +719,7 @@ EvalScalar
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [is_true(t.user_id (#1) > 1)], limit: NONE]
             ├── aggregating index: [SELECT event_name, user_id, COUNT(), COUNT(id), MAX(user_id), SUM(id) FROM test_index_db.t GROUP BY event_name, user_id]
             ├── rewritten query: [selection: [index_col_0 (#0), index_col_1 (#1), index_col_4 (#4), index_col_5 (#5), index_col_3 (#3)], filter: is_true(index_col_0 (#0) > CAST(1 AS Int32 NULL))]
@@ -762,7 +762,7 @@ Sort(Single)
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [is_true(t.user_id (#1) > 1)], limit: NONE]
                 ├── aggregating index: [SELECT event_name, user_id, COUNT(), COUNT(id), MAX(user_id), SUM(id) FROM test_index_db.t GROUP BY event_name, user_id]
                 ├── rewritten query: [selection: [index_col_0 (#0), index_col_1 (#1), index_col_4 (#4), index_col_5 (#5), index_col_3 (#3)], filter: is_true(index_col_0 (#0) > CAST(1 AS Int32 NULL))]

--- a/tests/sqllogictests/suites/mode/standalone/explain/index/explain_inverted_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/index/explain_inverted_index.test
@@ -44,7 +44,7 @@ Filter
     ├── read size: < 1 KiB
     ├── partitions total: 5
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1._search_matched (#2)], limit: NONE]
     └── estimated rows: 10.00
 
@@ -76,7 +76,7 @@ RowFetch
                 ├── read size: < 1 KiB
                 ├── partitions total: 5
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [t1._search_matched (#2)], limit: 1]
                 └── estimated rows: 10.00
 
@@ -108,7 +108,7 @@ RowFetch
                 ├── read size: 0
                 ├── partitions total: 5
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [t1._search_matched (#2)], limit: 1]
                 └── estimated rows: 10.00
 
@@ -136,7 +136,7 @@ RowFetch
             ├── read size: 0
             ├── partitions total: 5
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 5 to 5 cost: <slt:ignore>, inverted pruning: 5 to 3 cost: <slt:ignore>, topn pruning: 3 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [t1._search_matched (#2)], limit: 1]
             └── estimated rows: 10.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/index/explain_ngram_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/index/explain_ngram_index.test
@@ -46,7 +46,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 8
 ├── partitions scanned: 8
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom pruning: 8 to 8 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 8 to 8 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.content (#1), '%yo%'))], limit: NONE]
 └── estimated rows: 8.00
 
@@ -61,7 +61,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 8
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.content (#1), '%your eggs%'))], limit: NONE]
 └── estimated rows: 0.06
 
@@ -76,7 +76,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 8
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.content (#1), '%your eggs'))], limit: NONE]
 └── estimated rows: 0.03
 
@@ -91,7 +91,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 8
 ├── partitions scanned: 8
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom pruning: 8 to 8 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 8 to 8 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.content (#1), '%风来%'))], limit: NONE]
 └── estimated rows: 8.00
 
@@ -106,7 +106,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 8
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 8 to 8 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 8 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t1.content (#1), '%月无声%'))], limit: NONE]
 └── estimated rows: 4.00
 
@@ -162,7 +162,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t3.content1 (#1), '%speak%'))], limit: NONE]
 └── estimated rows: 0.25
 
@@ -182,7 +182,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t3.content2 (#2), '%arrow%'))], limit: NONE]
 └── estimated rows: 0.25
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/index/explain_spatial_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/index/explain_spatial_index.test
@@ -32,7 +32,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 4
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_within(stores.location (#4), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 1.60
 
@@ -47,7 +47,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 4
 ├── partitions scanned: 4
-├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 4 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 4 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_intersects(stores.location (#4), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') or stores.category (#1) = 'coffee'], limit: NONE]
 └── estimated rows: 4.00
 
@@ -62,7 +62,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 4
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, bloom pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_dwithin(stores.location (#4), 'POINT(10 10)', 2) and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 1.60
 
@@ -77,7 +77,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 4
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_coveredby(stores.location (#4), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 1.60
 
@@ -92,7 +92,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 4
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_covers('POLYGON((9 9,9 12,12 12,12 9,9 9))', stores.location (#4)) and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 1.60
 
@@ -116,7 +116,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 7
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 7 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_within(stores.location (#4), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 2.80
 
@@ -131,7 +131,7 @@ TableScan
 ├── read size: 1.33 KiB
 ├── partitions total: 7
 ├── partitions scanned: 7
-├── pruning stats: [segments: <range pruning: 7 to 7 cost: <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>, spatial pruning: 7 to 7 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 cost: <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>, spatial pruning: 7 to 7 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_intersects(stores.location (#4), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') or stores.category (#1) = 'coffee'], limit: NONE]
 └── estimated rows: 7.00
 
@@ -146,7 +146,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 7
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 7 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, bloom pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 4 to 4 cost: <slt:ignore>, spatial pruning: 4 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_dwithin(stores.location (#4), 'POINT(10 10)', 2) and stores.category (#1) = 'coffee' and stores.status (#3) = 'active'], limit: NONE]
 └── estimated rows: 2.80
 
@@ -181,7 +181,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 4.00
 └── TableScan(Probe)
@@ -192,7 +192,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 7
     ├── partitions scanned: 7
-    ├── pruning stats: [segments: <range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 14.00
@@ -218,7 +218,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 4.00
 └── TableScan(Probe)
@@ -229,7 +229,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 7
     ├── partitions scanned: 7
-    ├── pruning stats: [segments: <range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 14.00
@@ -264,7 +264,7 @@ AggregateFinal
         │   ├── read size: < 1 KiB
         │   ├── partitions total: 1
         │   ├── partitions scanned: 1
-        │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
+        │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: 1 ms>, blocks: <range pruning: 1 to 1 cost: 1 ms>]
         │   ├── push downs: [filters: [], limit: NONE]
         │   └── estimated rows: 4.00
         └── TableScan(Probe)
@@ -275,7 +275,7 @@ AggregateFinal
             ├── read size: < 1 KiB
             ├── partitions total: 7
             ├── partitions scanned: 7
-            ├── pruning stats: [segments: <range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 cost: 1 ms>, blocks: <range pruning: 7 to 7 cost: 1 ms>]
             ├── push downs: [filters: [], limit: NONE]
             ├── apply join filters: [#0]
             └── estimated rows: 14.00
@@ -313,7 +313,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 4.00
 └── TableScan(Probe)
@@ -335,7 +335,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 7
     ├── partitions scanned: 7
-    ├── pruning stats: [segments: <range pruning: 7 to 7 <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 14.00
@@ -373,7 +373,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 4.00
 └── TableScan(Probe)
@@ -395,7 +395,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 7
     ├── partitions scanned: 7
-    ├── pruning stats: [segments: <range pruning: 7 to 7 <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 7 to 7 <slt:ignore>>, blocks: <range pruning: 7 to 7 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 14.00
@@ -423,7 +423,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 3
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 3 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, spatial pruning: 2 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, spatial pruning: 2 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [st_within(t_nullable.location (#2), 'POLYGON((9 9,9 12,12 12,12 9,9 9))') and t_nullable.category (#1) = 'coffee'], limit: NONE]
 └── estimated rows: 1.20
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/index/explain_vector_index.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/index/explain_vector_index.test
@@ -62,7 +62,7 @@ RowFetch
             ├── read size: 0
             ├── partitions total: 4
             ├── partitions scanned: 3
-            ├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, topn pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 3 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, topn pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 3 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 5]
             └── estimated rows: 16.00
 
@@ -90,7 +90,7 @@ RowFetch
             ├── read size: 0
             ├── partitions total: 4
             ├── partitions scanned: 2
-            ├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, topn pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 2 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, topn pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 2 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 16.00
 
@@ -122,7 +122,7 @@ RowFetch
                 ├── read size: 0
                 ├── partitions total: 4
                 ├── partitions scanned: 3
-                ├── pruning stats: [segments: <range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 3 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 4 to 4 cost: <slt:ignore>>, blocks: <range pruning: 4 to 4 cost: <slt:ignore>, vector pruning: 4 to 3 cost: <slt:ignore>>]
                 ├── push downs: [filters: [t._vector_score (#2) > 0.1], limit: 3]
                 └── estimated rows: 16.00
 
@@ -167,7 +167,7 @@ RowFetch
             ├── read size: 0
             ├── partitions total: 2
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, topn pruning: 2 to 2 cost: <slt:ignore>, vector pruning: 2 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, topn pruning: 2 to 2 cost: <slt:ignore>, vector pruning: 2 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 8.00
 
@@ -195,7 +195,7 @@ RowFetch
             ├── read size: 0
             ├── partitions total: 2
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, topn pruning: 2 to 2 cost: <slt:ignore>, vector pruning: 2 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, topn pruning: 2 to 2 cost: <slt:ignore>, vector pruning: 2 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 8.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -767,7 +767,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.id (#1) = 869550529)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -778,7 +778,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.id (#0) = 869550529], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/infer_filter.test
@@ -767,7 +767,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.id (#1) = 869550529)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -778,7 +778,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.id (#0) = 869550529], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -48,7 +48,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -74,7 +74,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -85,7 +85,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.number (#1) = t1.number (#1) + 1], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 2.00
@@ -109,7 +109,7 @@ HashJoin
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [t.number (#0) > 1], limit: NONE]
 │   └── estimated rows: 0.00
 └── TableScan(Probe)
@@ -120,7 +120,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.number (#1) > 1], limit: NONE]
     └── estimated rows: 8.00
 
@@ -147,7 +147,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -158,7 +158,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 10.00
 
@@ -192,7 +192,7 @@ HashJoin
 │   │   ├── read size: 0
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 0
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [t.number (#0) = 1], limit: NONE]
 │   │   └── estimated rows: 0.00
 │   └── TableScan(Probe)
@@ -203,7 +203,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -214,7 +214,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100.00
@@ -260,7 +260,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(onecolumn.x (#0) > 42)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -271,7 +271,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(twocolumn.x (#1) > 42)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 2.25
@@ -297,7 +297,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [onecolumn.x (#0) > 44 or onecolumn.x (#0) < 43], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -308,7 +308,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [twocolumn.x (#1) > 44 or twocolumn.x (#1) < 43], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 1.36
@@ -334,7 +334,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [twocolumn.x (#1) > 42 and twocolumn.x (#1) < 45], limit: NONE]
 │   └── estimated rows: 1.50
 └── TableScan(Probe)
@@ -345,7 +345,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [onecolumn.x (#0) > 42 and onecolumn.x (#0) < 45], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 2.00
@@ -375,7 +375,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [], limit: NONE]
     │   └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -386,7 +386,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -411,7 +411,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [twocolumn.x (#1) > 42 and twocolumn.x (#1) < 45], limit: NONE]
 │   └── estimated rows: 1.50
 └── TableScan(Probe)
@@ -422,7 +422,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [onecolumn.x (#0) > 42 and onecolumn.x (#0) < 45], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 2.00
@@ -761,7 +761,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 2
 │   ├── partitions scanned: 2
-│   ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(twocolumn.y (#2) = 53)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -772,7 +772,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 2
     ├── partitions scanned: 2
-    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 7.00
@@ -988,7 +988,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 
@@ -1011,7 +1011,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#1) > 0)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -1022,7 +1022,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 
@@ -1045,7 +1045,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -1056,7 +1056,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 
@@ -1081,7 +1081,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -1092,7 +1092,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 4.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -59,7 +59,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -70,7 +70,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -82,7 +82,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -117,7 +117,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -128,7 +128,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -139,7 +139,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 100.00
 
@@ -177,7 +177,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -188,7 +188,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -200,7 +200,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -236,7 +236,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -247,7 +247,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -259,7 +259,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -295,7 +295,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -306,7 +306,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -318,7 +318,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -354,7 +354,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -365,7 +365,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -377,7 +377,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -413,7 +413,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -424,7 +424,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -436,7 +436,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -460,7 +460,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── EvalScalar(Probe)
@@ -475,7 +475,7 @@ HashJoin
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 10.00
 
@@ -502,7 +502,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -513,7 +513,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 
@@ -538,7 +538,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -549,7 +549,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -575,7 +575,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -586,7 +586,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -612,7 +612,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -623,7 +623,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -647,7 +647,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan(Probe)
@@ -658,7 +658,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -47,7 +47,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -58,7 +58,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -70,7 +70,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -106,7 +106,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -117,7 +117,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -129,7 +129,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -165,7 +165,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -176,7 +176,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -188,7 +188,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -224,7 +224,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -235,7 +235,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -247,7 +247,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -283,7 +283,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -294,7 +294,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -306,7 +306,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -342,7 +342,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -353,7 +353,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -365,7 +365,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -128,7 +128,7 @@ EvalScalar
     │       │       ├── read size: < 1 KiB
     │       │       ├── partitions total: 1
     │       │       ├── partitions scanned: 1
-    │       │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       │       ├── push downs: [filters: [is_true(t1.a (#2) = t1.a (#2))], limit: NONE]
     │       │       └── estimated rows: 3.00
     │       └── HashJoin(Probe)
@@ -157,7 +157,7 @@ EvalScalar
     │                       ├── read size: < 1 KiB
     │                       ├── partitions total: 1
     │                       ├── partitions scanned: 1
-    │                       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │                       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │                       ├── push downs: [filters: [], limit: NONE]
     │                       └── estimated rows: 4.00
     └── TableScan(Probe)
@@ -168,7 +168,7 @@ EvalScalar
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -47,7 +47,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -58,7 +58,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -70,7 +70,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -106,7 +106,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -117,7 +117,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -129,7 +129,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -165,7 +165,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -176,7 +176,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -188,7 +188,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -224,7 +224,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -235,7 +235,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 100.00
@@ -247,7 +247,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 10.00
@@ -283,7 +283,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -294,7 +294,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -306,7 +306,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00
@@ -342,7 +342,7 @@ HashJoin
 │   │   ├── read size: < 1 KiB
 │   │   ├── partitions total: 1
 │   │   ├── partitions scanned: 1
-│   │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
@@ -353,7 +353,7 @@ HashJoin
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
 │       └── estimated rows: 10.00
@@ -365,7 +365,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
     └── estimated rows: 100.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/lazy_materialization_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/lazy_materialization_join.test
@@ -100,7 +100,7 @@ RowFetch
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [is_true(lazy_join_t1.create_time (#3) >= '2021-01-02 00:00:00.000000')], limit: NONE]
             │   └── estimated rows: 2.67
             └── TableScan(Probe)
@@ -111,7 +111,7 @@ RowFetch
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 ├── apply join filters: [#0]
                 └── estimated rows: 3.00
@@ -159,7 +159,7 @@ RowFetch
             │       ├── read size: < 1 KiB
             │       ├── partitions total: 1
             │       ├── partitions scanned: 1
-            │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │       ├── push downs: [filters: [is_true(lazy_join_t1.create_time (#3) >= '2021-01-02 00:00:00.000000')], limit: 3]
             │       └── estimated rows: 2.67
             └── TableScan(Probe)
@@ -170,7 +170,7 @@ RowFetch
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 ├── apply join filters: [#0]
                 └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/materialized_cte.test
@@ -19,7 +19,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -30,7 +30,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00
@@ -56,7 +56,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -67,7 +67,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/merge_into.test
@@ -50,7 +50,7 @@ CommitSink
             │   ├── read size: < 1 KiB
             │   ├── partitions total: 1
             │   ├── partitions scanned: 1
-            │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             │   ├── push downs: [filters: [], limit: NONE]
             │   └── estimated rows: 4.00
             └── TableScan(Probe)
@@ -61,7 +61,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 4.00
 
@@ -97,7 +97,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -108,7 +108,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 4.00
 
@@ -139,7 +139,7 @@ CommitSink
                 ├── read size: < 1 KiB
                 ├── partitions total: 1
                 ├── partitions scanned: 1
-                ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 ├── push downs: [filters: [], limit: NONE]
                 └── estimated rows: 4.00
 
@@ -177,7 +177,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -188,7 +188,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 4.00
 
@@ -226,7 +226,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -237,7 +237,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 2
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 6.00
@@ -273,7 +273,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -284,7 +284,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 2
                     ├── partitions scanned: 2
-                    ├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 6.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/multi_table_insert.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/multi_table_insert.test
@@ -44,6 +44,6 @@ Commit
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 5.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/nullable_prune.test
@@ -24,7 +24,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 2
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
 ├── push downs: [filters: [], limit: NONE]
 └── estimated rows: 6.00
 
@@ -39,7 +39,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_not_null(t_nullable_prune.a (#0))], limit: NONE]
 └── estimated rows: 3.00
 
@@ -54,7 +54,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 2
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [NOT is_not_null(t_nullable_prune.a (#0))], limit: NONE]
 └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/project_set.test
@@ -34,7 +34,7 @@ AggregateFinal
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
             └── estimated rows: 1.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/prune_column.test
@@ -266,7 +266,7 @@ AggregateFinal
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [is_true(t.b (#1) = 2)], limit: NONE]
         └── estimated rows: 1.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -37,7 +37,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -48,7 +48,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 0)], limit: NONE]
     └── estimated rows: 3.00
 
@@ -74,7 +74,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -85,7 +85,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 0)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00
@@ -110,7 +110,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -121,7 +121,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.b (#1) > 0)], limit: NONE]
     └── estimated rows: 3.00
 
@@ -147,7 +147,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.b (#3) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -158,7 +158,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 4.00
@@ -185,7 +185,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [t2.a (#2) > 0 and t2.b (#3) > 0], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -196,7 +196,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 0)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00
@@ -223,7 +223,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -234,7 +234,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.a (#0) > 0 and t1.b (#1) > 0], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00
@@ -259,7 +259,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -270,7 +270,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -39,7 +39,7 @@ HashJoin
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
 │   └── estimated rows: 0.00
 └── TableScan(Probe)
@@ -50,7 +50,7 @@ HashJoin
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 0.00
@@ -81,7 +81,7 @@ Filter
     │   ├── read size: < 1 KiB
     │   ├── partitions total: 1
     │   ├── partitions scanned: 1
-    │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t2.a (#2) <= 2 or t2.a (#2) > 1], limit: NONE]
     │   └── estimated rows: 2.33
     └── TableScan(Probe)
@@ -92,7 +92,7 @@ Filter
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [t1.a (#0) <= 2 or t1.a (#0) > 1], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_left_outer.test
@@ -40,7 +40,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -51,7 +51,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 0)], limit: NONE]
     └── estimated rows: 3.00
 
@@ -75,7 +75,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -86,7 +86,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 
@@ -110,7 +110,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -121,7 +121,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.b (#1) > 0)], limit: NONE]
     └── estimated rows: 3.00
 
@@ -147,7 +147,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -158,7 +158,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 0)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00
@@ -185,7 +185,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.b (#3) > 0)], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -196,7 +196,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 4.00
@@ -306,7 +306,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#2) > 1)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 5.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -39,7 +39,7 @@ HashJoin
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
 │   └── estimated rows: 0.00
 └── TableScan(Probe)
@@ -50,7 +50,7 @@ HashJoin
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 0.00
@@ -75,7 +75,7 @@ HashJoin
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
 │   └── estimated rows: 0.00
 └── TableScan(Probe)
@@ -86,7 +86,7 @@ HashJoin
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
     └── estimated rows: 0.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -21,7 +21,7 @@ Sequence
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       └── estimated rows: 20.00
 └── HashJoin

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_project_set.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_project_set.test
@@ -31,7 +31,7 @@ EvalScalar
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [products.name (#0) = 'Laptop' and json_path_query_first(products.details (#1), '$.features.*') = '"16GB"'], limit: NONE]
             └── estimated rows: 0.60
 
@@ -59,7 +59,7 @@ EvalScalar
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [products.name (#0) = 'Laptop' and json_path_query_first(products.details (#1), '$.features.*') = '"16GB"'], limit: NONE]
         └── estimated rows: 0.60
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_scan.test
@@ -23,7 +23,7 @@ Filter
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t.x (#0) > 1)], limit: NONE]
     └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -19,7 +19,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(range_t.c (#0) > 'efg')], limit: NONE]
     └── estimated rows: 0.00
 
@@ -44,7 +44,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(range_t.i (#1) > 20)], limit: NONE]
     └── estimated rows: 0.00
 
@@ -69,7 +69,7 @@ EvalScalar
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [range_pruner_trust_loan_daily.notify_date (#1) = '20240513' and range_pruner_trust_loan_daily.contract_no (#0) = '20240508003088208902099794704998'], limit: NONE]
     └── estimated rows: 0.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
@@ -40,7 +40,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3.00
 └── TableScan(Probe)
@@ -51,7 +51,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
@@ -64,7 +64,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -83,7 +83,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -132,7 +132,7 @@ HashJoin
 │       ├── read size: 1.06 KiB
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -152,7 +152,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -211,7 +211,7 @@ HashJoin
 │       ├── read size: <slt:ignore>
 │       ├── partitions total: 10
 │       ├── partitions scanned: 1
-│       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: 10]
 │       └── estimated rows: 10000.00
 └── TableScan(Probe)
@@ -231,7 +231,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -328,7 +328,7 @@ HashJoin
 │   ├── read size: <slt:ignore>
 │   ├── partitions total: 3
 │   ├── partitions scanned: 3
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3000.00
 └── TableScan(Probe)
@@ -347,7 +347,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00
@@ -385,7 +385,7 @@ HashJoin
 │   ├── read size: <slt:ignore>
 │   ├── partitions total: 3
 │   ├── partitions scanned: 3
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 3 to 3 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 3000.00
 └── TableScan(Probe)
@@ -405,7 +405,7 @@ HashJoin
     ├── read size: 180.86 KiB
     ├── partitions total: 99
     ├── partitions scanned: 99
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 100000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_min_max_before_static_bloom.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_min_max_before_static_bloom.test
@@ -97,7 +97,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10.00
 └── TableScan(Probe)
@@ -117,7 +117,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 10
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 10 to 10 cost: <slt:ignore>>, blocks: <range pruning: 10 to 10 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 10 to 10 cost: <slt:ignore>>, blocks: <range pruning: 10 to 10 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [rf_min_max_probe.tag (#1) = 'keep'], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10000.00
@@ -173,7 +173,7 @@ HashJoin
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -193,7 +193,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 10
     ├── partitions scanned: 2
-    ├── pruning stats: [segments: <range pruning: 10 to 10 cost: <slt:ignore>>, blocks: <range pruning: 10 to 10 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 10 to 10 cost: <slt:ignore>>, blocks: <range pruning: 10 to 10 cost: <slt:ignore>, bloom pruning: 2 to 2 cost: <slt:ignore>>]
     ├── push downs: [filters: [rf_min_max_probe.tag (#1) = 'keep'], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 10000.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select_limit_offset.test
@@ -154,7 +154,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -165,7 +165,7 @@ Limit
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 2.00
@@ -201,7 +201,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 1.00
     └── TableScan(Probe)
@@ -212,7 +212,7 @@ Limit
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         ├── apply join filters: [#0]
         └── estimated rows: 2.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/filter.test
@@ -12,7 +12,7 @@ TableScan
 ├── read size: 1.10 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.number (#0) > 731)], limit: NONE]
 └── estimated rows: 6.00
 
@@ -27,7 +27,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.number (#0) > 737)], limit: NONE]
 └── estimated rows: 0.00
 
@@ -42,7 +42,7 @@ TableScan
 ├── read size: 1.10 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.number (#0) > 700)], limit: NONE]
 └── estimated rows: 37.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/is_not_null.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/is_not_null.test
@@ -15,7 +15,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_not_null(twocolumn.x (#0))], limit: NONE]
 └── estimated rows: 3.00
 
@@ -39,7 +39,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_not_null(t_user.name (#1))], limit: NONE]
 └── estimated rows: 2.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/modulo.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/modulo.test
@@ -32,7 +32,7 @@ AggregateFinal
         ├── read size: 1.41 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [t1.number (#0) % 10 = 2], limit: NONE]
         └── estimated rows: 100.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/pr_16069.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/pr_16069.test
@@ -15,7 +15,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [10 < t.number (#0) or 20 < t.number (#0)], limit: NONE]
 └── estimated rows: 97.69
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/spatial_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/spatial_join.test
@@ -51,7 +51,7 @@ HashJoin
 │   ├── read size: <slt:ignore>
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -62,7 +62,7 @@ HashJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#0]
     └── estimated rows: 3.00
@@ -88,7 +88,7 @@ SpatialJoin
 │   ├── read size: <slt:ignore>
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 2.00
 └── TableScan(Probe)
@@ -99,7 +99,7 @@ SpatialJoin
     ├── read size: <slt:ignore>
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -635,7 +635,7 @@ EvalScalar
     │                   ├── read size: 0
     │                   ├── partitions total: 1
     │                   ├── partitions scanned: 0
-    │                   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    │                   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     │                   ├── push downs: [filters: [is_true(t.i (#1) > 10)], limit: 1]
     │                   └── estimated rows: 0.00
     └── TableScan(Probe)
@@ -646,7 +646,7 @@ EvalScalar
         ├── read size: < 1 KiB
         ├── partitions total: 1
         ├── partitions scanned: 1
-        ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
         ├── push downs: [filters: [], limit: NONE]
         └── estimated rows: 4.00
 
@@ -800,7 +800,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t.i (#0), 'data%'))], limit: NONE]
 └── estimated rows: 0.38
 
@@ -833,7 +833,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 3.00
 
@@ -853,7 +853,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t.i (#0), 'data$%%', '$'))], limit: NONE]
 └── estimated rows: 0.38
 
@@ -884,7 +884,7 @@ HashJoin
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 3.00
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -36,7 +36,7 @@ UnionAll
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > t1.b (#1))], limit: NONE]
 │   └── estimated rows: 0.00
 └── TableScan
@@ -47,7 +47,7 @@ UnionAll
     ├── read size: 0
     ├── partitions total: 1
     ├── partitions scanned: 0
-    ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.a (#2) > t2.b (#3))], limit: NONE]
     └── estimated rows: 0.00
 
@@ -65,7 +65,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -76,7 +76,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.a (#2) > 1)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -104,7 +104,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 3]
     │       └── estimated rows: 2.00
     └── Limit
@@ -120,7 +120,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 3]
             └── estimated rows: 2.00
 
@@ -148,7 +148,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 4]
     │       └── estimated rows: 2.00
     └── Limit
@@ -164,7 +164,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 4]
             └── estimated rows: 2.00
 
@@ -192,7 +192,7 @@ Limit
     │       ├── read size: < 1 KiB
     │       ├── partitions total: 1
     │       ├── partitions scanned: 1
-    │       ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     │       ├── push downs: [filters: [], limit: 1]
     │       └── estimated rows: 2.00
     └── Limit
@@ -208,7 +208,7 @@ Limit
             ├── read size: < 1 KiB
             ├── partitions total: 1
             ├── partitions scanned: 1
-            ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+            ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: 1]
             └── estimated rows: 2.00
 
@@ -227,7 +227,7 @@ UnionAll
 │   ├── read size: < 1 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > 1)], limit: NONE]
 │   └── estimated rows: 1.00
 └── TableScan
@@ -238,7 +238,7 @@ UnionAll
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.b (#3) > 2)], limit: NONE]
     └── estimated rows: 1.00
 
@@ -280,7 +280,7 @@ UnionAll
     ├── read size: 10.60 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
-    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 10000.00
 
@@ -299,7 +299,7 @@ UnionAll
 │   ├── read size: 10.60 KiB
 │   ├── partitions total: 1
 │   ├── partitions scanned: 1
-│   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [], limit: NONE]
 │   └── estimated rows: 10000.00
 └── EmptyResultScan

--- a/tests/sqllogictests/suites/mode/standalone/explain/update.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/update.test
@@ -45,7 +45,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 2.00
                 └── TableScan(Probe)
@@ -56,7 +56,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 4.00
@@ -120,7 +120,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 2.00
                 └── TableScan(Probe)
@@ -131,7 +131,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [is_true(t1.b (#1) > 2)], limit: NONE]
                     ├── apply join filters: [#0]
                     └── estimated rows: 3.50
@@ -222,7 +222,7 @@ CommitSink
                 │   ├── read size: < 1 KiB
                 │   ├── partitions total: 1
                 │   ├── partitions scanned: 1
-                │   ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                 │   ├── push downs: [filters: [], limit: NONE]
                 │   └── estimated rows: 4.00
                 └── TableScan(Probe)
@@ -233,7 +233,7 @@ CommitSink
                     ├── read size: < 1 KiB
                     ├── partitions total: 1
                     ├── partitions scanned: 1
-                    ├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                     ├── push downs: [filters: [], limit: NONE]
                     ├── apply join filters: [#0, #1, #2]
                     └── estimated rows: 4.00

--- a/tests/sqllogictests/suites/no_table_meta_cache/col_stats_of_all_null.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/col_stats_of_all_null.test
@@ -23,6 +23,6 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) > 6)], limit: NONE]
 └── estimated rows: 0.50

--- a/tests/sqllogictests/suites/no_table_meta_cache/explain/auto_rebuild_missing_bloom_index.test
+++ b/tests/sqllogictests/suites/no_table_meta_cache/explain/auto_rebuild_missing_bloom_index.test
@@ -32,7 +32,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) = 6)], limit: NONE]
 └── estimated rows: 1.00
 
@@ -56,7 +56,7 @@ TableScan
 ├── read size: < 1 KiB
 ├── partitions total: 1
 ├── partitions scanned: 1
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) = 6)], limit: NONE]
 └── estimated rows: 1.00
 
@@ -81,7 +81,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 1
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) = 6)], limit: NONE]
 └── estimated rows: 1.00
 
@@ -118,7 +118,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 2
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.s (#1) = '12')], limit: NONE]
 └── estimated rows: 1.00
 
@@ -147,7 +147,7 @@ TableScan
 ├── read size: 0
 ├── partitions total: 2
 ├── partitions scanned: 0
-├── pruning stats: [segments: <range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
+├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>, bloom index read cost: <slt:ignore>, bloom pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.c (#0) = 6)], limit: NONE]
 └── estimated rows: 1.00
 

--- a/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.result
+++ b/tests/suites/5_ee/11_security/11_0001_row_access_policy_pushdown.result
@@ -93,7 +93,7 @@ EXPLAIN PERF redacts RAP expression
 >>>> CREATE ROW ACCESS POLICY rap_pruning_policy AS (region STRING) RETURNS boolean -> region = 'APAC'
 >>>> ALTER TABLE rap_pruning_test ADD ROW ACCESS POLICY rap_pruning_policy ON (region)
 #### EXPLAIN ANALYZE should show blocks range pruning: 4 to 2 (2 EMEA blocks pruned by RAP)
-├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 4 to 2, bloom pruning: 2 to 2>]
+├── pruning stats: [segments: <read, decompress, range pruning: 1 to 1>, blocks: <range pruning: 4 to 2, bloom pruning: 2 to 2>]
 >>>> ALTER TABLE rap_pruning_test DROP ROW ACCESS POLICY rap_pruning_policy
 >>>> DROP TABLE IF EXISTS rap_pruning_test
 >>>> DROP ROW ACCESS POLICY IF EXISTS rap_pruning_policy


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Show segment read, segment block meta decompress, and bloom index read costs in EXPLAIN pruning stats.
- Collect the new timings through the existing pruning cost controller so normal query execution does not pay the measurement cost.
- Update EXPLAIN expected output to make metadata/index IO visible when total EXPLAIN time is higher than the pruning CPU time previously shown.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20058)
<!-- Reviewable:end -->