### PR TITLE
fix(query): cherry-pick #20055 hash nullable runtime bloom filters

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/local_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/local_builder.rs
@@ -67,11 +67,12 @@ impl SingleFilterBuilder {
         spatial_threshold: usize,
     ) -> Result<Self> {
         let data_type = desc.build_key.data_type().clone();
+        let bloom_data_type = data_type.remove_nullable();
         let hash_method = if desc.spatial_mode.is_some() {
             None
         } else {
             Some(DataBlock::choose_hash_method_with_types(&[
-                data_type.clone()
+                bloom_data_type,
             ])?)
         };
 
@@ -152,7 +153,7 @@ impl SingleFilterBuilder {
             None => Vec::with_capacity(column.len()),
         };
         hashes.reserve(column.len());
-        let entry = BlockEntry::from(column.clone());
+        let entry = BlockEntry::from(column.remove_nullable());
         let hash_method = self
             .hash_method
             .as_ref()

--- a/src/query/storages/fuse/src/pruning/expr_bloom_filter.rs
+++ b/src/query/storages/fuse/src/pruning/expr_bloom_filter.rs
@@ -29,6 +29,7 @@ impl<'a> ExprBloomFilter<'a> {
     }
 
     pub fn apply(&self, column: Column) -> Result<MutableBitmap> {
+        let column = column.remove_nullable();
         let data_type = column.data_type();
         let num_rows = column.len();
         let method = DataBlock::choose_hash_method_with_types(&[data_type.clone()])?;

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
@@ -16,6 +16,35 @@ insert into rf_cast_build values (1), (3), (5);
 statement ok
 insert into rf_cast_probe values (1), (2), (3);
 
+statement ok
+set max_threads = 1;
+
+statement ok
+set enable_join_runtime_filter = 1;
+
+statement ok
+set enable_bloom_runtime_filter = 1;
+
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 1000;
+
+statement ok
+set join_runtime_filter_selectivity_threshold = 101;
+
+query I
+SELECT count(*)
+FROM rf_cast_probe p
+JOIN rf_cast_build b
+    ON CAST(p.a AS Nullable(Int32)) = b.id;
+----
+2
+
 query T
 EXPLAIN SELECT *
 FROM rf_cast_probe p
@@ -61,3 +90,88 @@ drop table rf_cast_probe;
 
 statement ok
 drop table rf_cast_build;
+
+statement ok
+drop table if exists rf_cast_probe_s;
+
+statement ok
+drop table if exists rf_cast_build_s;
+
+statement ok
+create table rf_cast_build_s (id Nullable(String));
+
+statement ok
+create table rf_cast_probe_s (a String not null);
+
+statement ok
+insert into rf_cast_build_s values ('a'), ('c'), ('e');
+
+statement ok
+insert into rf_cast_probe_s values ('a'), ('b'), ('c');
+
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set join_runtime_filter_selectivity_threshold = 101;
+
+query I
+SELECT count(*)
+FROM rf_cast_probe_s p
+JOIN rf_cast_build_s b
+    ON CAST(p.a AS Nullable(String)) = b.id;
+----
+2
+
+statement ok
+drop table rf_cast_probe_s;
+
+statement ok
+drop table rf_cast_build_s;
+
+statement ok
+drop table if exists rf_cast_probe_nullable;
+
+statement ok
+drop table if exists rf_cast_build_nn;
+
+statement ok
+create table rf_cast_build_nn (id Int not null);
+
+statement ok
+create table rf_cast_probe_nullable (a Int);
+
+statement ok
+insert into rf_cast_build_nn values (1), (3), (5);
+
+statement ok
+insert into rf_cast_probe_nullable values (1), (2), (3), (NULL);
+
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 1000;
+
+statement ok
+set join_runtime_filter_selectivity_threshold = 101;
+
+query I
+SELECT count(*)
+FROM rf_cast_probe_nullable p
+JOIN rf_cast_build_nn b
+    ON p.a = b.id;
+----
+2
+
+statement ok
+drop table rf_cast_probe_nullable;
+
+statement ok
+drop table rf_cast_build_nn;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Cherry-pick of #20055 to release/v1.2.911-rc7 for CI validation.

Fix hash nullable runtime bloom filters consistently.

## Tests

- [x] Covered by existing tests from #20055

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20059)
<!-- Reviewable:end -->
