### PR TITLE
fix(sql): fix udaf alias handling and show function params in plans

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@ tests/data/tsv/crlf_unterminated_data_cr.tsv -text
 # Golden and testdata outputs are byte-sensitive; whitespace can be expected output.
 src/query/functions/tests/it/scalars/testdata/*.txt -whitespace
 src/query/sql/test-support/data/results/**/*.txt -whitespace
-src/query/sql/tests/it/optimizer/*.txt -whitespace
-src/query/sql/tests/it/semantic/**/*.txt -whitespace
+src/query/sql/tests/it/**/*.txt -whitespace
 tests/sqllogictests/**/*.test -whitespace
 tests/suites/**/*.result -whitespace

--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -51,7 +51,7 @@ impl Binder {
     pub fn bind_having(
         &mut self,
         bind_context: &mut BindContext,
-        having: ScalarExpr,
+        mut having: ScalarExpr,
         child: SExpr,
     ) -> Result<SExpr> {
         bind_context.expr_context = ExprContext::HavingClause;
@@ -66,7 +66,6 @@ impl Binder {
             .set_span(having.span()));
         }
 
-        let mut having = having;
         AggregateRewriter::rewrite_existing_expr(
             &bind_context.aggregate_info,
             &mut having,

--- a/src/query/sql/src/planner/format/display.rs
+++ b/src/query/sql/src/planner/format/display.rs
@@ -304,15 +304,13 @@ pub fn format_scalar(scalar: &ScalarExpr) -> String {
             )
         }
         ScalarExpr::FunctionCall(func) => {
-            format!(
-                "{}({})",
-                &func.func_name,
-                func.arguments
-                    .iter()
-                    .map(format_scalar)
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )
+            let params = func.params.iter().map(|param| param.to_string()).join(", ");
+            let arguments = func.arguments.iter().map(format_scalar).join(", ");
+            if params.is_empty() {
+                format!("{}({})", &func.func_name, arguments)
+            } else {
+                format!("{}({})({})", &func.func_name, params, arguments)
+            }
         }
         ScalarExpr::CastExpr(cast) => {
             format!(

--- a/src/query/sql/src/planner/format/display_rel_operator.rs
+++ b/src/query/sql/src/planner/format/display_rel_operator.rs
@@ -111,15 +111,17 @@ fn format_scalar<I: IdHumanizer>(id_humanizer: &I, scalar: &ScalarExpr) -> Strin
             )
         }
         ScalarExpr::FunctionCall(func) => {
-            format!(
-                "{}({})",
-                &func.func_name,
-                func.arguments
-                    .iter()
-                    .map(|arg| format_scalar(id_humanizer, arg))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )
+            let params = func.params.iter().map(|param| param.to_string()).join(", ");
+            let arguments = func
+                .arguments
+                .iter()
+                .map(|arg| format_scalar(id_humanizer, arg))
+                .join(", ");
+            if params.is_empty() {
+                format!("{}({})", &func.func_name, arguments)
+            } else {
+                format!("{}({})({})", &func.func_name, params, arguments)
+            }
         }
         ScalarExpr::CastExpr(cast) => {
             format!(

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -73,6 +73,7 @@ use crate::Metadata;
 use crate::NameResolutionContext;
 use crate::Symbol;
 use crate::Visibility;
+use crate::binder::ExprContext;
 use crate::binder::StagePathAccess;
 use crate::binder::StageResolver;
 use crate::binder::wrap_cast;
@@ -724,6 +725,13 @@ where A: super::TypeCheckAdapter
             .set_span(span));
         }
 
+        let is_udaf = matches!(&udf.definition, UDFDefinition::UDAFScript(_));
+        let original_context = self.bind_context.expr_context;
+        let disallow_alias_resolution =
+            is_udaf && self.bind_context.expr_context.prefer_resolve_alias();
+        if disallow_alias_resolution {
+            self.bind_context.expr_context = ExprContext::InAggregateFunction;
+        }
         let arguments = args
             .iter()
             .map(|(display_name, arg)| {
@@ -734,7 +742,11 @@ where A: super::TypeCheckAdapter
                     data_type,
                 })
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>>>();
+        if disallow_alias_resolution {
+            self.bind_context.expr_context = original_context;
+        }
+        let arguments = arguments?;
         let udf = {
             let mut udf_resolver = UdfCallResolver {
                 udf_adapter: self.adapter.udf_adapter()?,

--- a/src/query/sql/tests/it/optimizer/push_down_filter_project_set.txt
+++ b/src/query/sql/tests/it/optimizer/push_down_filter_project_set.txt
@@ -3,9 +3,9 @@ description: Predicates that still contain an SRF after alias rewriting must rem
 sql: SELECT name, json_path_query(details, '$.features.*') AS all_features, json_path_query_first(details, '$.features.*') AS first_feature FROM products WHERE name = 'Laptop' AND first_feature = '16GB' AND all_features = '512GB'
 raw_plan:
 EvalScalar
-├── scalars: [products.name (#0) AS (#0), get(json_path_query(products.details (#1), '$.features.*') (#2)) AS (#3), json_path_query_first(products.details (#1), '$.features.*') AS (#4)]
+├── scalars: [products.name (#0) AS (#0), get(1)(json_path_query(products.details (#1), '$.features.*') (#2)) AS (#3), json_path_query_first(products.details (#1), '$.features.*') AS (#4)]
 └── Filter
-    ├── filters: [eq(products.name (#0), 'Laptop'), eq(json_path_query_first(products.details (#1), '$.features.*'), to_variant('16GB')), eq(get(json_path_query(products.details (#1), '$.features.*') (#2)), to_variant('512GB'))]
+    ├── filters: [eq(products.name (#0), 'Laptop'), eq(json_path_query_first(products.details (#1), '$.features.*'), to_variant('16GB')), eq(get(1)(json_path_query(products.details (#1), '$.features.*') (#2)), to_variant('512GB'))]
     └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(13..53), func_name: "json_path_query", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(29..36), column: ColumnBinding { database_name: Some("default"), table_name: Some("products"), column_position: Some(2), table_index: Some(0), column_name: "details", column_name_lower: None, index: 1, data_type: Nullable(Variant), visibility: Visible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(38..52), value: String("$.features.*") })] }), index: 2 }] })
         └── Scan
             ├── table: default.products (#0)
@@ -15,9 +15,9 @@ EvalScalar
 
 optimized_plan:
 EvalScalar
-├── scalars: [products.name (#0) AS (#0), get(json_path_query(products.details (#1), '$.features.*') (#2)) AS (#3), json_path_query_first(products.details (#1), '$.features.*') AS (#4), products.details (#1) AS (#5), json_path_query(products.details (#1), '$.features.*') (#2) AS (#6)]
+├── scalars: [products.name (#0) AS (#0), get(1)(json_path_query(products.details (#1), '$.features.*') (#2)) AS (#3), json_path_query_first(products.details (#1), '$.features.*') AS (#4), products.details (#1) AS (#5), json_path_query(products.details (#1), '$.features.*') (#2) AS (#6)]
 └── Filter
-    ├── filters: [eq(get(json_path_query(products.details (#1), '$.features.*') (#2)), to_variant('512GB'))]
+    ├── filters: [eq(get(1)(json_path_query(products.details (#1), '$.features.*') (#2)), to_variant('512GB'))]
     └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(13..53), func_name: "json_path_query", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(29..36), column: ColumnBinding { database_name: Some("default"), table_name: Some("products"), column_position: Some(2), table_index: Some(0), column_name: "details", column_name_lower: None, index: 1, data_type: Nullable(Variant), visibility: Visible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(38..52), value: String("$.features.*") })] }), index: 2 }] })
         └── Scan
             ├── table: default.products (#0)

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/README.md
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/README.md
@@ -306,7 +306,7 @@ precedence or grouping-set scope.
 Local context axes:
 
 ```text
-relation x legality x setting
+relation x ambiguity x function_kind
 ```
 
 ### `predicate_alias`

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
@@ -40,7 +40,7 @@ EvalScalar
 
 === aggregate_argument_alias__aggregate_argument_prefers_input_column_over_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N0S2_1_00
+key: A0N0S2_1_000
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(c) FROM t
 status: ok
@@ -60,7 +60,7 @@ EvalScalar
 
 === aggregate_argument_alias__aggregate_argument_consumes_unique_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N0S2_1_10
+key: A0N0S2_1_100
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(c) FROM t
 status: ok
@@ -80,16 +80,38 @@ EvalScalar
 
 === aggregate_argument_alias__aggregate_argument_rejects_duplicate_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N0S2_1_11
+key: A0N0S2_1_110
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, max(number) AS c, sum(c) FROM t
 status: error
 code: 1065
 message: column c reference or alias is ambiguous, please use another alias name
 
+=== aggregate_argument_alias__udaf_argument_prefers_input_column_over_prior_aggregate_alias ===
+matrix: aggregate_argument_alias
+key: A0N0S2_2_001
+setting: enable_group_by_column_first=0
+sql: SELECT creative_name, weighted_avg(cost, weight) AS cost FROM udaf_t GROUP BY creative_name HAVING weighted_avg(cost, weight) > 0
+status: ok
+EvalScalar
+├── scalars: [udaf_t.creative_name (#0) AS (#0), weighted_avg(cost, weight) (#5) AS (#5)]
+└── Filter
+    ├── filters: [gt(weighted_avg(cost, weight) (#5), 0)]
+    └── Aggregate(Initial)
+        ├── group items: [udaf_t.creative_name (#0) AS (#0)]
+        ├── aggregate functions: [weighted_avg(cost, weight) AS (#5)]
+        └── EvalScalar
+            ├── scalars: [udaf_t.creative_name (#0) AS (#0), CAST(udaf_t.cost (#2) AS Int32 NULL) AS (#3), CAST(udaf_t.weight (#1) AS Int32 NULL) AS (#4)]
+            └── Scan
+                ├── table: default.udaf_t (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_prior_select_alias ===
 matrix: aggregate_argument_alias
-key: A0N1S0_3_
+key: A0N1S0_4_
 setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, sum(t.c1) FROM t AS t GROUP BY number % 3
 status: error
@@ -98,7 +120,7 @@ message: column c1 doesn't exist
 
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N1S2_3_
+key: A0N1S2_4_
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(t.c) FROM t AS t
 status: error

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
@@ -1,6 +1,6 @@
 === aggregate_argument_alias__aggregate_argument_prefers_input_column ===
 matrix: aggregate_argument_alias
-key: A0N0S0_0_0
+key: A0N0S0_0_00
 setting: enable_group_by_column_first=0
 sql: SELECT a AS c2, sum(c2) FROM t GROUP BY a
 status: ok
@@ -20,7 +20,7 @@ EvalScalar
 
 === aggregate_argument_alias__aggregate_argument_falls_back_to_prior_select_alias ===
 matrix: aggregate_argument_alias
-key: A0N0S0_0_1
+key: A0N0S0_0_10
 setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, sum(c1) FROM t GROUP BY number % 3
 status: ok
@@ -33,6 +33,46 @@ EvalScalar
         ├── scalars: [modulo(t.number (#0), 3) AS (#1)]
         └── Scan
             ├── table: default.t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== aggregate_argument_alias__udaf_argument_prefers_input_column ===
+matrix: aggregate_argument_alias
+key: A0N0S0_0_01
+setting: enable_group_by_column_first=0
+sql: SELECT a AS c2, weighted_avg(c2, 1) FROM udaf_prior_t GROUP BY a
+status: ok
+EvalScalar
+├── scalars: [udaf_prior_t.a (#0) AS (#0), weighted_avg(c2, 1) (#4) AS (#4)]
+└── Aggregate(Initial)
+    ├── group items: [udaf_prior_t.a (#0) AS (#0)]
+    ├── aggregate functions: [weighted_avg(c2, 1) AS (#4)]
+    └── EvalScalar
+        ├── scalars: [udaf_prior_t.a (#0) AS (#0), CAST(udaf_prior_t.c2 (#1) AS Int32 NULL) AS (#2), CAST(1 AS Int32 NULL) AS (#3)]
+        └── Scan
+            ├── table: default.udaf_prior_t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== aggregate_argument_alias__udaf_argument_falls_back_to_prior_select_alias ===
+matrix: aggregate_argument_alias
+key: A0N0S0_0_11
+setting: enable_group_by_column_first=0
+sql: SELECT number % 3 AS c1, weighted_avg(c1, 1) FROM udaf_prior_t GROUP BY number % 3
+status: ok
+EvalScalar
+├── scalars: [weighted_avg(c1, 1) (#4) AS (#4), number % 3 (#1) AS (#5)]
+└── Aggregate(Initial)
+    ├── group items: [modulo(udaf_prior_t.number (#0), 3) AS (#1)]
+    ├── aggregate functions: [weighted_avg(c1, 1) AS (#4)]
+    └── EvalScalar
+        ├── scalars: [modulo(udaf_prior_t.number (#0), 3) AS (#1), CAST(modulo(udaf_prior_t.number (#0), 3) AS Int32 NULL) AS (#2), CAST(1 AS Int32 NULL) AS (#3)]
+        └── Scan
+            ├── table: default.udaf_prior_t (#0)
             ├── filters: []
             ├── order by: []
             └── limit: NONE
@@ -89,29 +129,56 @@ message: column c reference or alias is ambiguous, please use another alias name
 
 === aggregate_argument_alias__udaf_argument_prefers_input_column_over_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N0S2_2_001
+key: A0N0S2_1_001
 setting: enable_group_by_column_first=0
-sql: SELECT creative_name, weighted_avg(cost, weight) AS cost FROM udaf_t GROUP BY creative_name HAVING weighted_avg(cost, weight) > 0
+sql: SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t
 status: ok
 EvalScalar
-├── scalars: [udaf_t.creative_name (#0) AS (#0), weighted_avg(cost, weight) (#5) AS (#5)]
-└── Filter
-    ├── filters: [gt(weighted_avg(cost, weight) (#5), 0)]
-    └── Aggregate(Initial)
-        ├── group items: [udaf_t.creative_name (#0) AS (#0)]
-        ├── aggregate functions: [weighted_avg(cost, weight) AS (#5)]
-        └── EvalScalar
-            ├── scalars: [udaf_t.creative_name (#0) AS (#0), CAST(udaf_t.cost (#2) AS Int32 NULL) AS (#3), CAST(udaf_t.weight (#1) AS Int32 NULL) AS (#4)]
-            └── Scan
-                ├── table: default.udaf_t (#0)
-                ├── filters: []
-                ├── order by: []
-                └── limit: NONE
+├── scalars: [COUNT(*) (#2) AS (#2), weighted_avg(c, 1) (#5) AS (#5)]
+└── Aggregate(Initial)
+    ├── group items: []
+    ├── aggregate functions: [count() AS (#2), weighted_avg(c, 1) AS (#5)]
+    └── EvalScalar
+        ├── scalars: [CAST(udaf_t.c (#0) AS Int32 NULL) AS (#3), CAST(1 AS Int32 NULL) AS (#4)]
+        └── Scan
+            ├── table: default.udaf_t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
 
+
+=== aggregate_argument_alias__udaf_argument_consumes_unique_prior_aggregate_alias ===
+matrix: aggregate_argument_alias
+key: A0N0S2_1_101
+setting: enable_group_by_column_first=0
+sql: SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t
+status: ok
+EvalScalar
+├── scalars: [COUNT(*) (#1) AS (#1), weighted_avg(c, 1) (#4) AS (#4)]
+└── Aggregate(Initial)
+    ├── group items: []
+    ├── aggregate functions: [count() AS (#1), weighted_avg(c, 1) AS (#4)]
+    └── EvalScalar
+        ├── scalars: [CAST(count() AS Int32 NULL) AS (#2), CAST(1 AS Int32 NULL) AS (#3)]
+        └── Scan
+            ├── table: default.udaf_t (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+
+=== aggregate_argument_alias__udaf_argument_rejects_duplicate_prior_aggregate_alias ===
+matrix: aggregate_argument_alias
+key: A0N0S2_1_111
+setting: enable_group_by_column_first=0
+sql: SELECT count(*) AS c, max(number) AS c, weighted_avg(c, 1) FROM udaf_t
+status: error
+code: 1065
+message: column c reference or alias is ambiguous, please use another alias name
 
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_prior_select_alias ===
 matrix: aggregate_argument_alias
-key: A0N1S0_4_
+key: A0N1S0_3_
 setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, sum(t.c1) FROM t AS t GROUP BY number % 3
 status: error
@@ -120,7 +187,7 @@ message: column c1 doesn't exist
 
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_aggregate_alias ===
 matrix: aggregate_argument_alias
-key: A0N1S2_4_
+key: A0N1S2_3_
 setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(t.c) FROM t AS t
 status: error

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.yaml
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.yaml
@@ -4,6 +4,8 @@ local_dimensions:
     values: [input-conflict, no-input]
   - name: ambiguity
     values: [unique-select-alias, duplicate-select-alias]
+  - name: function_kind
+    values: [builtin-aggregate, udaf]
 regions:
   - description: aggregate arguments bind bare names against input columns before falling back to prior SELECT aliases
     main:
@@ -25,7 +27,7 @@ regions:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT number % 3 AS c1, sum(c1) FROM t GROUP BY number % 3"
-  - description: aggregate arguments can consume prior aggregate SELECT aliases when the alias name is unique and no input column wins first
+  - description: builtin aggregate arguments can consume prior aggregate SELECT aliases when the alias name is unique and no input column wins first
     main:
       consumers: [A0]
       name_shapes: [N0]
@@ -33,6 +35,7 @@ regions:
     local:
       relation: [input-conflict, no-input]
       ambiguity: [unique-select-alias, duplicate-select-alias]
+      function_kind: [builtin-aggregate]
     masks:
       - when:
           local:
@@ -40,24 +43,65 @@ regions:
             ambiguity: [duplicate-select-alias]
         reason: input-column precedence decides aggregate arguments before duplicate SELECT aliases are considered
     cases:
-      - key: A0N0S2_1_00
+      - key: A0N0S2_1_000
         name: aggregate_argument_prefers_input_column_over_prior_aggregate_alias
         setup_sqls:
           - "CREATE TABLE t(c UInt64)"
         runs:
           - sql: "SELECT count(*) AS c, sum(c) FROM t"
-      - key: A0N0S2_1_10
+      - key: A0N0S2_1_100
         name: aggregate_argument_consumes_unique_prior_aggregate_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT count(*) AS c, sum(c) FROM t"
-      - key: A0N0S2_1_11
+      - key: A0N0S2_1_110
         name: aggregate_argument_rejects_duplicate_prior_aggregate_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT count(*) AS c, max(number) AS c, sum(c) FROM t"
+  - description: UDAF arguments keep input-column precedence over SELECT aggregate aliases
+    main:
+      consumers: [A0]
+      name_shapes: [N0]
+      producers: [S2]
+    local:
+      relation: [input-conflict]
+      ambiguity: [unique-select-alias]
+      function_kind: [udaf]
+    cases:
+      - key: A0N0S2_2_001
+        name: udaf_argument_prefers_input_column_over_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE udaf_t(creative_name String, weight UInt64, cost UInt64)"
+          - |
+            CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+            LANGUAGE javascript AS $$
+            export function create_state() {
+                return {sum: 0, weight: 0};
+            }
+            export function accumulate(state, value, weight) {
+                state.sum += value * weight;
+                state.weight += weight;
+                return state;
+            }
+            export function retract(state, value, weight) {
+                state.sum -= value * weight;
+                state.weight -= weight;
+                return state;
+            }
+            export function merge(state1, state2) {
+                state1.sum += state2.sum;
+                state1.weight += state2.weight;
+                return state1;
+            }
+            export function finish(state) {
+                return state.sum / state.weight;
+            }
+            $$
+        runs:
+          - sql: "SELECT creative_name, weighted_avg(cost, weight) AS cost FROM udaf_t GROUP BY creative_name HAVING weighted_avg(cost, weight) > 0"
   - description: qualified aggregate-argument names included to document why alias fallback is unavailable
     main:
       consumers: [A0]
@@ -80,13 +124,13 @@ regions:
       name_shapes: [N0, N1, N2, N3, N4, N5]
       producers: [I0, S0, S1, S2, S3, S4, G0, N0]
     cases:
-      - key: A0N1S0_3_
+      - key: A0N1S0_4_
         name: aggregate_argument_qualified_name_does_not_consume_prior_select_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT number % 3 AS c1, sum(t.c1) FROM t AS t GROUP BY number % 3"
-      - key: A0N1S2_3_
+      - key: A0N1S2_4_
         name: aggregate_argument_qualified_name_does_not_consume_aggregate_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.yaml
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.yaml
@@ -14,67 +14,24 @@ regions:
       producers: [S0]
     local:
       relation: [input-conflict, no-input]
+      function_kind: [builtin-aggregate, udaf]
     cases:
-      - key: A0N0S0_0_0
+      - key: A0N0S0_0_00
         name: aggregate_argument_prefers_input_column
         setup_sqls:
           - "CREATE TABLE t(a UInt64, c2 UInt64)"
         runs:
           - sql: "SELECT a AS c2, sum(c2) FROM t GROUP BY a"
-      - key: A0N0S0_0_1
+      - key: A0N0S0_0_10
         name: aggregate_argument_falls_back_to_prior_select_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT number % 3 AS c1, sum(c1) FROM t GROUP BY number % 3"
-  - description: builtin aggregate arguments can consume prior aggregate SELECT aliases when the alias name is unique and no input column wins first
-    main:
-      consumers: [A0]
-      name_shapes: [N0]
-      producers: [S2]
-    local:
-      relation: [input-conflict, no-input]
-      ambiguity: [unique-select-alias, duplicate-select-alias]
-      function_kind: [builtin-aggregate]
-    masks:
-      - when:
-          local:
-            relation: [input-conflict]
-            ambiguity: [duplicate-select-alias]
-        reason: input-column precedence decides aggregate arguments before duplicate SELECT aliases are considered
-    cases:
-      - key: A0N0S2_1_000
-        name: aggregate_argument_prefers_input_column_over_prior_aggregate_alias
+      - key: A0N0S0_0_01
+        name: udaf_argument_prefers_input_column
         setup_sqls:
-          - "CREATE TABLE t(c UInt64)"
-        runs:
-          - sql: "SELECT count(*) AS c, sum(c) FROM t"
-      - key: A0N0S2_1_100
-        name: aggregate_argument_consumes_unique_prior_aggregate_alias
-        setup_sqls:
-          - "CREATE TABLE t(number UInt64)"
-        runs:
-          - sql: "SELECT count(*) AS c, sum(c) FROM t"
-      - key: A0N0S2_1_110
-        name: aggregate_argument_rejects_duplicate_prior_aggregate_alias
-        setup_sqls:
-          - "CREATE TABLE t(number UInt64)"
-        runs:
-          - sql: "SELECT count(*) AS c, max(number) AS c, sum(c) FROM t"
-  - description: UDAF arguments keep input-column precedence over SELECT aggregate aliases
-    main:
-      consumers: [A0]
-      name_shapes: [N0]
-      producers: [S2]
-    local:
-      relation: [input-conflict]
-      ambiguity: [unique-select-alias]
-      function_kind: [udaf]
-    cases:
-      - key: A0N0S2_2_001
-        name: udaf_argument_prefers_input_column_over_prior_aggregate_alias
-        setup_sqls:
-          - "CREATE TABLE udaf_t(creative_name String, weight UInt64, cost UInt64)"
+          - "CREATE TABLE udaf_prior_t(a UInt64, c2 UInt64)"
           - |
             CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
             LANGUAGE javascript AS $$
@@ -101,7 +58,165 @@ regions:
             }
             $$
         runs:
-          - sql: "SELECT creative_name, weighted_avg(cost, weight) AS cost FROM udaf_t GROUP BY creative_name HAVING weighted_avg(cost, weight) > 0"
+          - sql: "SELECT a AS c2, weighted_avg(c2, 1) FROM udaf_prior_t GROUP BY a"
+      - key: A0N0S0_0_11
+        name: udaf_argument_falls_back_to_prior_select_alias
+        setup_sqls:
+          - "CREATE TABLE udaf_prior_t(number UInt64)"
+          - |
+            CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+            LANGUAGE javascript AS $$
+            export function create_state() {
+                return {sum: 0, weight: 0};
+            }
+            export function accumulate(state, value, weight) {
+                state.sum += value * weight;
+                state.weight += weight;
+                return state;
+            }
+            export function retract(state, value, weight) {
+                state.sum -= value * weight;
+                state.weight -= weight;
+                return state;
+            }
+            export function merge(state1, state2) {
+                state1.sum += state2.sum;
+                state1.weight += state2.weight;
+                return state1;
+            }
+            export function finish(state) {
+                return state.sum / state.weight;
+            }
+            $$
+        runs:
+          - sql: "SELECT number % 3 AS c1, weighted_avg(c1, 1) FROM udaf_prior_t GROUP BY number % 3"
+  - description: aggregate arguments can consume prior aggregate SELECT aliases when the alias name is unique and no input column wins first
+    main:
+      consumers: [A0]
+      name_shapes: [N0]
+      producers: [S2]
+    local:
+      relation: [input-conflict, no-input]
+      ambiguity: [unique-select-alias, duplicate-select-alias]
+      function_kind: [builtin-aggregate, udaf]
+    masks:
+      - when:
+          local:
+            relation: [input-conflict]
+            ambiguity: [duplicate-select-alias]
+        reason: input-column precedence decides aggregate arguments before duplicate SELECT aliases are considered
+    cases:
+      - key: A0N0S2_1_000
+        name: aggregate_argument_prefers_input_column_over_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE t(c UInt64)"
+        runs:
+          - sql: "SELECT count(*) AS c, sum(c) FROM t"
+      - key: A0N0S2_1_100
+        name: aggregate_argument_consumes_unique_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE t(number UInt64)"
+        runs:
+          - sql: "SELECT count(*) AS c, sum(c) FROM t"
+      - key: A0N0S2_1_110
+        name: aggregate_argument_rejects_duplicate_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE t(number UInt64)"
+        runs:
+          - sql: "SELECT count(*) AS c, max(number) AS c, sum(c) FROM t"
+      - key: A0N0S2_1_001
+        name: udaf_argument_prefers_input_column_over_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE udaf_t(c UInt64, number UInt64)"
+          - |
+            CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+            LANGUAGE javascript AS $$
+            export function create_state() {
+                return {sum: 0, weight: 0};
+            }
+            export function accumulate(state, value, weight) {
+                state.sum += value * weight;
+                state.weight += weight;
+                return state;
+            }
+            export function retract(state, value, weight) {
+                state.sum -= value * weight;
+                state.weight -= weight;
+                return state;
+            }
+            export function merge(state1, state2) {
+                state1.sum += state2.sum;
+                state1.weight += state2.weight;
+                return state1;
+            }
+            export function finish(state) {
+                return state.sum / state.weight;
+            }
+            $$
+        runs:
+          - sql: "SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t"
+      - key: A0N0S2_1_101
+        name: udaf_argument_consumes_unique_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE udaf_t(number UInt64)"
+          - |
+            CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+            LANGUAGE javascript AS $$
+            export function create_state() {
+                return {sum: 0, weight: 0};
+            }
+            export function accumulate(state, value, weight) {
+                state.sum += value * weight;
+                state.weight += weight;
+                return state;
+            }
+            export function retract(state, value, weight) {
+                state.sum -= value * weight;
+                state.weight -= weight;
+                return state;
+            }
+            export function merge(state1, state2) {
+                state1.sum += state2.sum;
+                state1.weight += state2.weight;
+                return state1;
+            }
+            export function finish(state) {
+                return state.sum / state.weight;
+            }
+            $$
+        runs:
+          - sql: "SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t"
+      - key: A0N0S2_1_111
+        name: udaf_argument_rejects_duplicate_prior_aggregate_alias
+        setup_sqls:
+          - "CREATE TABLE udaf_t(number UInt64)"
+          - |
+            CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+            LANGUAGE javascript AS $$
+            export function create_state() {
+                return {sum: 0, weight: 0};
+            }
+            export function accumulate(state, value, weight) {
+                state.sum += value * weight;
+                state.weight += weight;
+                return state;
+            }
+            export function retract(state, value, weight) {
+                state.sum -= value * weight;
+                state.weight -= weight;
+                return state;
+            }
+            export function merge(state1, state2) {
+                state1.sum += state2.sum;
+                state1.weight += state2.weight;
+                return state1;
+            }
+            export function finish(state) {
+                return state.sum / state.weight;
+            }
+            $$
+        runs:
+          - sql: "SELECT count(*) AS c, max(number) AS c, weighted_avg(c, 1) FROM udaf_t"
   - description: qualified aggregate-argument names included to document why alias fallback is unavailable
     main:
       consumers: [A0]
@@ -124,13 +239,13 @@ regions:
       name_shapes: [N0, N1, N2, N3, N4, N5]
       producers: [I0, S0, S1, S2, S3, S4, G0, N0]
     cases:
-      - key: A0N1S0_4_
+      - key: A0N1S0_3_
         name: aggregate_argument_qualified_name_does_not_consume_prior_select_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"
         runs:
           - sql: "SELECT number % 3 AS c1, sum(t.c1) FROM t AS t GROUP BY number % 3"
-      - key: A0N1S2_4_
+      - key: A0N1S2_3_
         name: aggregate_argument_qualified_name_does_not_consume_aggregate_alias
         setup_sqls:
           - "CREATE TABLE t(number UInt64)"

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
@@ -362,7 +362,7 @@ Sort
 ├── sort keys: [col2 (#3) ASC NULLS LAST]
 ├── limit: [NONE]
 └── EvalScalar
-    ├── scalars: [t_str.col1 (#0) AS (#0), get(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
+    ├── scalars: [t_str.col1 (#0) AS (#0), get(1)(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
     └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(23..49), func_name: "unnest", params: [], arguments: [FunctionCall(FunctionCall { span: Some(30..48), func_name: "split", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(36..37), column: ColumnBinding { database_name: None, table_name: Some("t"), column_position: Some(2), table_index: Some(0), column_name: "col2", column_name_lower: None, index: 1, data_type: Nullable(String), visibility: Visible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(44..47), value: String(",") })] })] }), index: 2 }] })
         └── Aggregate(Initial)
             ├── group items: [t_str.col1 (#0) AS (#0), t_str.col2 (#1) AS (#1)]
@@ -388,10 +388,10 @@ Sort
 └── EvalScalar
     ├── scalars: [t_str.col1 (#0) AS (#0), col3 (#3) AS (#4)]
     └── Aggregate(Initial)
-        ├── group items: [t_str.col1 (#0) AS (#0), get(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
+        ├── group items: [t_str.col1 (#0) AS (#0), get(1)(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
         ├── aggregate functions: []
         └── EvalScalar
-            ├── scalars: [t_str.col1 (#0) AS (#0), get(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
+            ├── scalars: [t_str.col1 (#0) AS (#0), get(1)(unnest(split(t.col2 (#1), ',')) (#2)) AS (#3)]
             └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(23..49), func_name: "unnest", params: [], arguments: [FunctionCall(FunctionCall { span: Some(30..48), func_name: "split", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(36..37), column: ColumnBinding { database_name: None, table_name: Some("t"), column_position: Some(2), table_index: Some(0), column_name: "col2", column_name_lower: None, index: 1, data_type: Nullable(String), visibility: Visible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(44..47), value: String(",") })] })] }), index: 2 }] })
                 └── Scan
                     ├── table: default.t_str (#0)

--- a/src/query/sql/tests/it/semantic/binder_grouping.txt
+++ b/src/query/sql/tests/it/semantic/binder_grouping.txt
@@ -3,7 +3,7 @@ description: A set-returning function over an aggregate should stay above the ag
 sql: SELECT unnest(max([11, 12]))
 status: ok
 EvalScalar
-├── scalars: [get(unnest(max([11, 12])) (#2)) AS (#3)]
+├── scalars: [get(1)(unnest(max([11, 12])) (#2)) AS (#3)]
 └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(7..28), func_name: "unnest", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(14..27), column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "max([11, 12])", column_name_lower: None, index: 1, data_type: Nullable(Array(Number(UInt8))), visibility: InVisible, virtual_expr: None, is_srf: false } })] }), index: 2 }] })
     └── Aggregate(Initial)
         ├── group items: []
@@ -18,7 +18,7 @@ description: Repeated identical SRF expressions should reuse the registered Proj
 sql: SELECT unnest([1, 2, 3]), unnest([1, 2, 3])
 status: ok
 EvalScalar
-├── scalars: [get(unnest([1, 2, 3]) (#0)) AS (#1), get(unnest([1, 2, 3]) (#0)) AS (#2)]
+├── scalars: [get(1)(unnest([1, 2, 3]) (#0)) AS (#1), get(1)(unnest([1, 2, 3]) (#0)) AS (#2)]
 └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(7..24), func_name: "unnest", params: [], arguments: [ConstantExpr(ConstantExpr { span: Some(14..23), value: Array(UInt8([1, 2, 3])) })] }), index: 0 }] })
     └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
 
@@ -157,7 +157,7 @@ description: CUBE should expand into grouping sets and allow grouping(...) to bi
 sql: SELECT a, b, sum(c) AS sc, grouping(a, b) FROM g GROUP BY CUBE(a, b)
 status: ok
 EvalScalar
-├── scalars: [g.a (#0) AS (#0), g.b (#1) AS (#1), sum(c) (#6) AS (#6), grouping(_grouping_id (#5)) AS (#7)]
+├── scalars: [g.a (#0) AS (#0), g.b (#1) AS (#1), sum(c) (#6) AS (#6), grouping(0, 1)(_grouping_id (#5)) AS (#7)]
 └── Aggregate(Initial)
     ├── group items: [g.a (#0) AS (#0), g.b (#1) AS (#1), _grouping_id (#5) AS (#5)]
     ├── aggregate functions: [sum(g.c (#2)) AS (#6)]
@@ -180,7 +180,7 @@ EvalScalar
     ├── group items: []
     ├── aggregate functions: [max(max_arg_0 (#2)) AS (#3)]
     └── EvalScalar
-        ├── scalars: [get(unnest(split(t.col2 (#0), ',')) (#1)) AS (#2)]
+        ├── scalars: [get(1)(unnest(split(t.col2 (#0), ',')) (#1)) AS (#2)]
         └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(11..37), func_name: "unnest", params: [], arguments: [FunctionCall(FunctionCall { span: Some(18..36), func_name: "split", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(24..25), column: ColumnBinding { database_name: None, table_name: Some("t"), column_position: Some(1), table_index: Some(0), column_name: "col2", column_name_lower: None, index: 0, data_type: Nullable(String), visibility: Visible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(32..35), value: String(",") })] })] }), index: 1 }] })
             └── Scan
                 ├── table: default.t_str (#0)
@@ -194,7 +194,7 @@ description: A sqllogictest SRF-over-aggregate pattern with an extra scalar wrap
 sql: SELECT unnest(split(max(t.col2), ',')) FROM t_str AS t
 status: ok
 EvalScalar
-├── scalars: [get(unnest(split(max(t.col2), ',')) (#2)) AS (#3)]
+├── scalars: [get(1)(unnest(split(max(t.col2), ',')) (#2)) AS (#3)]
 └── ProjectSet(ProjectSet { srfs: [ScalarItem { scalar: FunctionCall(FunctionCall { span: Some(7..38), func_name: "unnest", params: [], arguments: [FunctionCall(FunctionCall { span: Some(14..37), func_name: "split", params: [], arguments: [BoundColumnRef(BoundColumnRef { span: Some(20..31), column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "max(t.col2)", column_name_lower: None, index: 1, data_type: Nullable(String), visibility: InVisible, virtual_expr: None, is_srf: false } }), ConstantExpr(ConstantExpr { span: Some(33..36), value: String(",") })] })] }), index: 2 }] })
     └── Aggregate(Initial)
         ├── group items: []
@@ -213,11 +213,11 @@ description: A sqllogictest grouping() pattern should still rewrite correctly wh
 sql: SELECT grouping(salary), grouping(depname), sum(grouping(salary)) OVER (PARTITION BY grouping(salary) + grouping(depname) ORDER BY grouping(depname) DESC) FROM empsalary GROUP BY ROLLUP(depname, salary)
 status: ok
 EvalScalar
-├── scalars: [sum(grouping(salary)) OVER (PARTITION BY grouping(salary) + grouping(depname) ORDER BY grouping(depname) DESC) (#8) AS (#8), grouping(_grouping_id (#4)) AS (#9), grouping(_grouping_id (#4)) AS (#10)]
+├── scalars: [sum(grouping(salary)) OVER (PARTITION BY grouping(salary) + grouping(depname) ORDER BY grouping(depname) DESC) (#8) AS (#8), grouping(1)(_grouping_id (#4)) AS (#9), grouping(0)(_grouping_id (#4)) AS (#10)]
 └── Window
     ├── aggregate function: sum
-    ├── partition items: [plus(grouping(_grouping_id (#4)), grouping(_grouping_id (#4))) AS (#6)]
-    ├── order by items: [grouping(_grouping_id (#4)) AS (#7) DESC]
+    ├── partition items: [plus(grouping(1)(_grouping_id (#4)), grouping(0)(_grouping_id (#4))) AS (#6)]
+    ├── order by items: [grouping(0)(_grouping_id (#4)) AS (#7) DESC]
     ├── frame: [Range: Preceding(None) ~ CurrentRow]
     └── Sort
         ├── sort keys: [sum_part_0 (#6) ASC NULLS LAST, sum_order_0 (#7) DESC NULLS LAST]
@@ -225,7 +225,7 @@ EvalScalar
         ├── window top: NONE
         ├── window function: Aggregate(AggregateFunction { span: Some(44..154), func_name: "sum", distinct: false, params: [], args: [BoundColumnRef(BoundColumnRef { span: Some(48..64), column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "sum_arg_0", column_name_lower: None, index: 5, data_type: Number(UInt32), visibility: Visible, virtual_expr: None, is_srf: false } })], return_type: Nullable(Number(UInt64)), sort_descs: [], display_name: "sum(grouping(salary)) OVER (PARTITION BY grouping(salary) + grouping(depname) ORDER BY grouping(depname) DESC)" })
         └── EvalScalar
-            ├── scalars: [grouping(_grouping_id (#4)) AS (#5), plus(grouping(_grouping_id (#4)), grouping(_grouping_id (#4))) AS (#6), grouping(_grouping_id (#4)) AS (#7)]
+            ├── scalars: [grouping(1)(_grouping_id (#4)) AS (#5), plus(grouping(1)(_grouping_id (#4)), grouping(0)(_grouping_id (#4))) AS (#6), grouping(0)(_grouping_id (#4)) AS (#7)]
             └── Aggregate(Initial)
                 ├── group items: [empsalary.depname (#0) AS (#0), empsalary.salary (#1) AS (#1), _grouping_id (#4) AS (#4)]
                 ├── aggregate functions: []

--- a/src/query/sql/tests/it/semantic/type_check/set_returning.txt
+++ b/src/query/sql/tests/it/semantic/type_check/set_returning.txt
@@ -2,7 +2,7 @@
 description: A single-output SRF should preserve the old get(unnest(...), 1) top-level extraction.
 sql: unnest([1, 2, 3])
 status: ok
-scalar: get(unnest([1, 2, 3]))
+scalar: get(1)(unnest([1, 2, 3]))
 type: UInt8 NULL
 
 === nested_set_returning_function_errors ===

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_grouping_sets.test
@@ -68,6 +68,40 @@ EvalScalar
                     ├── push downs: [filters: [], limit: NONE]
                     └── estimated rows: 1.00
 
+query T
+explain select grouping(number % 2), grouping(number % 2, number % 3) from numbers(1) group by cube(number % 2, number % 3);
+----
+EvalScalar
+├── output columns: [grouping(number % 2) (#6), grouping(number % 2, number % 3) (#7)]
+├── expressions: [grouping(0)(_grouping_id (#5)), grouping(0, 1)(_grouping_id (#5))]
+├── estimated rows: 1.00
+└── AggregateFinal
+    ├── output columns: [number % 2 (#1), number % 3 (#2), _grouping_id (#5)]
+    ├── group by: [number % 2, number % 3, _grouping_id]
+    ├── aggregate functions: []
+    ├── estimated rows: 1.00
+    └── AggregatePartial
+        ├── group by: [number % 2, number % 3, _grouping_id]
+        ├── aggregate functions: []
+        ├── estimated rows: 1.00
+        └── AggregateExpand
+            ├── output columns: [number % 2 (#1), number % 3 (#2), _dup_group_item_0 (#3), _dup_group_item_1 (#4), _grouping_id (#5)]
+            ├── grouping sets: [(), (number % 2), (number % 3), (number % 2, number % 3)]
+            ├── estimated rows: 1.00
+            └── EvalScalar
+                ├── output columns: [number % 2 (#1), number % 3 (#2)]
+                ├── expressions: [numbers.number (#0) % 2, numbers.number (#0) % 3]
+                ├── estimated rows: 1.00
+                └── TableScan
+                    ├── table: default.system.numbers
+                    ├── scan id: 0
+                    ├── output columns: [number (#0)]
+                    ├── read rows: 1
+                    ├── read size: < 1 KiB
+                    ├── partitions total: 1
+                    ├── partitions scanned: 1
+                    ├── push downs: [filters: [], limit: NONE]
+                    └── estimated rows: 1.00
 
 statement ok
 set grouping_sets_to_union = 1;

--- a/tests/sqllogictests/suites/query/having.test
+++ b/tests/sqllogictests/suites/query/having.test
@@ -24,3 +24,47 @@ having sum(impressions) > 0
     or sum(installs) > 0
 ----
 creative_a 7
+
+statement ok
+CREATE or REPLACE FUNCTION weighted_avg (INT, INT) STATE {sum INT, weight INT} RETURNS FLOAT
+LANGUAGE javascript AS $$
+export function create_state() {
+    return {sum: 0, weight: 0};
+}
+export function accumulate(state, value, weight) {
+    state.sum += value * weight;
+    state.weight += weight;
+    return state;
+}
+export function retract(state, value, weight) {
+    state.sum -= value * weight;
+    state.weight -= weight;
+    return state;
+}
+export function merge(state1, state2) {
+    state1.sum += state2.sum;
+    state1.weight += state2.weight;
+    return state1;
+}
+export function finish(state) {
+    return state.sum / state.weight;
+}
+$$;
+
+query TR
+select creative_name, weighted_avg(cost, weight) as cost
+from (
+    select 'creative_a' as creative_name, 1 as score, 2 as weight, 3 as cost
+    union all
+    select 'creative_a' as creative_name, 0 as score, 1 as weight, 9 as cost
+    union all
+    select 'creative_b' as creative_name, 0 as score, 1 as weight, 0 as cost
+)
+group by creative_name
+having weighted_avg(score, weight) > 0
+    or weighted_avg(cost, weight) > 0
+----
+creative_a 5.0
+
+statement ok
+drop function weighted_avg


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Align UDAF argument binding with builtin aggregate behavior in alias-preferred contexts, so UDAF arguments do not incorrectly resolve through SELECT aliases.
- Preserve and print scalar function params in SQL plan formatting, making rewritten calls like grouping(0, 1)(_grouping_id) and get(1)(...) visible in binder/explain output.
- Add/update focused golden and sqllogictest coverage for UDAF aggregate-argument alias resolution, HAVING UDAF behavior, grouping(...) explain output, and the affected
    function-param formatter goldens.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20061)
<!-- Reviewable:end -->
