### PR TITLE
fix(query): avoid range join for single-row side

### DIFF
--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -27,6 +27,10 @@ use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 
+fn is_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
+    matches!(stat_info.statistics.precise_cardinality, Some(1)) || stat_info.cardinality == 1.0
+}
+
 enum PhysicalJoinType {
     Hash,
     // The first arg is range conditions, the second arg is other conditions
@@ -63,6 +67,7 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
 
     let left_rel_expr = RelExpr::with_s_expr(s_expr.left_child());
     let right_rel_expr = RelExpr::with_s_expr(s_expr.right_child());
+    let left_stat_info = left_rel_expr.derive_cardinality()?;
     let right_stat_info = right_rel_expr.derive_cardinality()?;
 
     if !join.equi_conditions.is_empty() {
@@ -75,10 +80,10 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
         return Ok(PhysicalJoinType::Hash);
     }
 
-    if matches!(right_stat_info.statistics.precise_cardinality, Some(1))
-        || right_stat_info.cardinality == 1.0
-    {
-        // If the output rows of build side is equal to 1, we use CROSS JOIN + FILTER instead of RANGE JOIN.
+    if is_single_row(&left_stat_info) || is_single_row(&right_stat_info) {
+        // If one side has a single row, use CROSS JOIN + FILTER instead of RANGE JOIN.
+        // Range join is optimized for a larger right side and can degenerate when join
+        // commutation places the large input on the left.
         return Ok(PhysicalJoinType::Hash);
     }
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -1027,6 +1027,34 @@ HashJoin
     └── estimated rows: 4.00
 
 query T
+EXPLAIN SELECT * FROM (SELECT MAX(a) AS a FROM t2) AS s, t1 WHERE s.a <= t1.a AND t1.a > 100;
+----
+HashJoin
+├── output columns: [MAX(a) (#1), t1.a (#2)]
+├── join type: INNER
+├── build keys: []
+├── probe keys: []
+├── keys is null equal: []
+├── filters: [s.a (#1) <= t1.a (#2)]
+├── estimated rows: 0.00
+├── TableScan(Build)
+│   ├── table: default.default.t1
+│   ├── scan id: 1
+│   ├── output columns: [a (#2)]
+│   ├── read rows: 0
+│   ├── read size: 0
+│   ├── partitions total: 1
+│   ├── partitions scanned: 0
+│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [is_true(t1.a (#2) > 100)], limit: NONE]
+│   └── estimated rows: 0.00
+└── EvalScalar(Probe)
+    ├── output columns: [MAX(a) (#1)]
+    ├── expressions: [1]
+    ├── estimated rows: 1.00
+    └── DummyTableScan
+
+query T
 EXPLAIN SELECT * FROM t1 JOIN t3 ON t1.a = t3.a;
 ----
 HashJoin


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Avoid selecting range join when either input side is known to produce a single row.
- Keep the existing Hash/CROSS+FILTER fallback for scalar-side range predicates independent of join commutation.
- Add an explain regression covering scalar aggregate + non-equi join with an empty/filtered table side.

## Motivation

Range join is optimized for a larger right side. If join commutation or cardinality estimation places the large input on the left and the scalar/single-row side elsewhere, the merge range join path can degenerate and allocate excessive result blocks for broad one-sided inequality predicates.

## Implementation

`physical_join` used to check only the right/build side for single-row cardinality before selecting range join. This PR checks both sides and falls back to Hash/CROSS+FILTER when either side is known to be a single row.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation run locally:

- `cargo fmt --check`
- `cargo check -p databend-query --lib`

Note: full `cargo build --bin databend-query` was attempted but timed out during final codegen/link in this environment; type checking completed successfully.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20062)
<!-- Reviewable:end -->
