### PR TITLE
fix: deterministic HLL row accounting in commit metadata

### DIFF
--- a/src/query/ee/src/storages/fuse/operations/virtual_columns.rs
+++ b/src/query/ee/src/storages/fuse/operations/virtual_columns.rs
@@ -325,6 +325,7 @@ pub async fn commit_refresh_virtual_column(
                     block_idx,
                 },
                 block_meta: Arc::new(extended_block_meta),
+                insert_rows: 0,
             };
             mutation_entries.push(entry);
         }
@@ -552,6 +553,7 @@ async fn prepare_vacuum_virtual_column_mutations(
                         draft_virtual_block_meta: None,
                         column_hlls: column_hlls.map(BlockHLLState::Serialized),
                     }),
+                    insert_rows: 0,
                 });
 
                 continue;

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -524,7 +524,7 @@ impl FuseTable {
         let prev_stats_meta = summary.additional_stats_meta.as_ref();
         // Previous statistics file location (if any)
         let mut prev_stats_location = snapshot.table_statistics_location();
-        // If no new rows are inserted, or HLL is empty, just reuse previous statistics
+        // If no rows are covered by commit-local HLL, just reuse previous statistics.
         if insert_rows == 0 || insert_hll.is_empty() {
             return Ok(TableStatsGenerator::new(
                 prev_stats_meta.cloned(),
@@ -535,7 +535,7 @@ impl FuseTable {
             ));
         }
 
-        // Initialize a new HLL with inserted rows
+        // Initialize a new HLL with commit-local HLL.
         let mut new_hll = insert_hll.clone();
         // Calculate updated row_count
         let (row_count, unstats_rows) = match prev_stats_meta {
@@ -573,7 +573,7 @@ impl FuseTable {
                         .ok()
                         .flatten();
                         if let Some(prev) = prev_snapshot {
-                            // Successfully loaded the previous snapshot → use its row_count + inserted rows
+                            // Successfully loaded the previous snapshot.
                             merge_column_hll_mut(&mut new_hll, &prev_stats.hll);
                             let prev_rows = prev.summary.row_count;
                             (
@@ -583,12 +583,12 @@ impl FuseTable {
                         } else {
                             // Could not load previous snapshot → old stats are invalid
                             // Drop prev_stats_location to mark stats as "reset",
-                            // and only use inserted rows as the new base.
+                            // and only use commit-local insert rows as the new base.
                             prev_stats_location = None;
                             (insert_rows, summary.row_count)
                         }
                     } else {
-                        // Normal case: accumulate old row_count + inserted rows
+                        // Normal case: accumulate old row_count + commit-local insert rows.
                         merge_column_hll_mut(&mut new_hll, &prev_stats.hll);
                         (
                             prev_stats.row_count + insert_rows,
@@ -596,7 +596,7 @@ impl FuseTable {
                         )
                     }
                 } else {
-                    // No previous stats available → start from inserted rows only
+                    // No previous stats available.
                     (insert_rows, summary.row_count)
                 }
             }

--- a/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
+++ b/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
@@ -45,6 +45,7 @@ pub enum MutationLogEntry {
     },
     AppendBlock {
         block_meta: Arc<ExtendedBlockMeta>,
+        insert_rows: u64,
     },
     DeletedBlock {
         index: BlockMetaIndex,
@@ -55,6 +56,7 @@ pub enum MutationLogEntry {
     ReplacedBlock {
         index: BlockMetaIndex,
         block_meta: Arc<ExtendedBlockMeta>,
+        insert_rows: u64,
     },
     CompactExtras {
         extras: CompactExtraInfo,

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -300,6 +300,7 @@ where F: SnapshotGenerator + Send + Sync + 'static
             new_segment_locs,
             virtual_schema,
             virtual_schema_mode,
+            insert_rows,
             hll,
             ..
         } = meta;
@@ -315,9 +316,7 @@ where F: SnapshotGenerator + Send + Sync + 'static
         self.new_virtual_schema_mode = virtual_schema_mode;
 
         if has_hll {
-            let binding = self.ctx.mutation_state().mutation_status();
-            let status = binding.read().unwrap();
-            self.insert_rows = status.insert_rows + status.update_rows;
+            self.insert_rows = insert_rows;
             self.insert_hll = hll;
         }
 

--- a/src/query/storages/fuse/src/operations/common/processors/transform_block_writer.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_block_writer.rs
@@ -294,6 +294,7 @@ impl AsyncAccumulatingTransform for TransformBlockWriter {
                     DataBlock::empty_with_meta(Box::new(MutationLogs {
                         entries: vec![MutationLogEntry::AppendBlock {
                             block_meta: Arc::new(extended_block_meta),
+                            insert_rows: 0,
                         }],
                     }))
                 };

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -92,6 +92,7 @@ pub struct TableMutationAggregator {
     removed_segment_indexes: Vec<SegmentIndex>,
     removed_statistics: Statistics,
     hll: BlockHLL,
+    insert_rows: u64,
     write_segment_ctx: WriteSegmentCtx,
 
     start_time: Instant,
@@ -135,7 +136,6 @@ impl AsyncAccumulatingTransform for TableMutationAggregator {
 
         let mut new_segment_locs = Vec::new();
         new_segment_locs.extend(self.appended_segments.clone());
-        let insert_rows = self.appended_statistics.row_count;
 
         let conflict_resolve_context = match self.write_segment_ctx.kind {
             MutationKind::Insert => ConflictResolveContext::AppendOnly((
@@ -179,7 +179,7 @@ impl AsyncAccumulatingTransform for TableMutationAggregator {
             conflict_resolve_context,
             new_segment_locs,
             self.table_id,
-            insert_rows,
+            self.insert_rows,
             std::mem::take(&mut self.virtual_schema),
             self.virtual_schema_mode,
             std::mem::take(&mut self.hll),
@@ -252,6 +252,7 @@ impl TableMutationAggregator {
             removed_segment_indexes,
             removed_statistics,
             hll: HashMap::new(),
+            insert_rows: 0,
             write_segment_ctx,
             finished_tasks: 0,
             start_time: Instant::now(),
@@ -261,8 +262,15 @@ impl TableMutationAggregator {
 
     pub fn accumulate_log_entry(&mut self, log_entry: MutationLogEntry) {
         match log_entry {
-            MutationLogEntry::ReplacedBlock { index, block_meta } => {
-                BlockHLLState::merge_column_hll(&mut self.hll, &block_meta.column_hlls);
+            MutationLogEntry::ReplacedBlock {
+                index,
+                block_meta,
+                insert_rows,
+            } => {
+                if insert_rows > 0 {
+                    self.insert_rows += insert_rows;
+                    BlockHLLState::merge_column_hll(&mut self.hll, &block_meta.column_hlls);
+                }
                 match self.extended_mutations.entry(index.segment_idx) {
                     Entry::Occupied(mut v) => {
                         v.get_mut().push_replaced(index.block_idx, block_meta);
@@ -275,8 +283,14 @@ impl TableMutationAggregator {
                     }
                 }
             }
-            MutationLogEntry::AppendBlock { block_meta } => {
-                BlockHLLState::merge_column_hll(&mut self.hll, &block_meta.column_hlls);
+            MutationLogEntry::AppendBlock {
+                block_meta,
+                insert_rows,
+            } => {
+                if insert_rows > 0 {
+                    self.insert_rows += insert_rows;
+                    BlockHLLState::merge_column_hll(&mut self.hll, &block_meta.column_hlls);
+                }
                 self.merged_blocks.push(block_meta);
             }
             MutationLogEntry::DeletedBlock { index } => {
@@ -304,7 +318,10 @@ impl TableMutationAggregator {
                     &summary,
                     self.write_segment_ctx.default_cluster_key,
                 );
-                merge_column_hll_mut(&mut self.hll, &hll);
+                self.insert_rows += summary.row_count;
+                if !hll.is_empty() {
+                    merge_column_hll_mut(&mut self.hll, &hll);
+                }
 
                 self.appended_segments
                     .push((segment_location, format_version));

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_block.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_block.rs
@@ -77,6 +77,7 @@ pub struct TransformSerializeBlock {
     dal: Operator,
     table_id: Option<u64>, // Only used in multi table insert
     kind: MutationKind,
+    pending_insert_rows: u64,
 }
 
 impl TransformSerializeBlock {
@@ -215,6 +216,7 @@ impl TransformSerializeBlock {
             dal: table.get_operator(),
             table_id: if with_tid { Some(table.get_id()) } else { None },
             kind,
+            pending_insert_rows: 0,
         })
     }
 
@@ -306,6 +308,7 @@ impl Processor for TransformSerializeBlock {
                         Ok(Event::NeedConsume)
                     } else {
                         // replace the old block
+                        self.pending_insert_rows = serialize_block.insert_rows;
                         self.state = State::NeedSerialize {
                             block: input_data,
                             stats_type: serialize_block.stats_type,
@@ -329,7 +332,14 @@ impl Processor for TransformSerializeBlock {
             self.output.push_data(Ok(data_block));
             Ok(Event::NeedConsume)
         } else {
-            // append block
+            // UPDATE carries exact affected rows in SerializeDataMeta::SerializeBlock.
+            // A no-meta UPDATE block may still contain unchanged rows.
+            self.pending_insert_rows =
+                if matches!(self.kind, MutationKind::Replace | MutationKind::MergeInto) {
+                    input_data.num_rows() as u64
+                } else {
+                    0
+                };
             self.state = State::NeedSerialize {
                 block: input_data,
                 stats_type: ClusterStatsGenType::Generally,
@@ -371,6 +381,7 @@ impl Processor for TransformSerializeBlock {
     async fn async_process(&mut self) -> Result<()> {
         match std::mem::replace(&mut self.state, State::Consume) {
             State::Serialized { serialized, index } => {
+                let insert_rows = std::mem::take(&mut self.pending_insert_rows);
                 let extended_block_meta = BlockWriter::write_down(&self.dal, serialized).await?;
 
                 let bytes = if let Some(draft_virtual_block_meta) =
@@ -395,6 +406,7 @@ impl Processor for TransformSerializeBlock {
                     Self::mutation_logs(MutationLogEntry::ReplacedBlock {
                         index,
                         block_meta: Arc::new(extended_block_meta),
+                        insert_rows,
                     })
                 } else {
                     // appending new data block
@@ -418,6 +430,7 @@ impl Processor for TransformSerializeBlock {
                         }
                         Self::mutation_logs(MutationLogEntry::AppendBlock {
                             block_meta: Arc::new(extended_block_meta),
+                            insert_rows,
                         })
                     }
                 };

--- a/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
+++ b/src/query/storages/fuse/src/operations/merge_into/mutator/matched_mutator.rs
@@ -465,6 +465,7 @@ impl AggregationContext {
                 block_idx,
             },
             block_meta: Arc::new(extended_block_meta),
+            insert_rows: 0,
         };
 
         Ok(Some(mutation))

--- a/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
+++ b/src/query/storages/fuse/src/operations/mutation/meta/mutation_meta.rs
@@ -53,11 +53,20 @@ pub enum ClusterStatsGenType {
 pub struct SerializeBlock {
     pub index: BlockMetaIndex,
     pub stats_type: ClusterStatsGenType,
+    pub insert_rows: u64,
 }
 
 impl SerializeBlock {
-    pub fn create(index: BlockMetaIndex, stats_type: ClusterStatsGenType) -> Self {
-        SerializeBlock { index, stats_type }
+    pub fn create(
+        index: BlockMetaIndex,
+        stats_type: ClusterStatsGenType,
+        insert_rows: u64,
+    ) -> Self {
+        SerializeBlock {
+            index,
+            stats_type,
+            insert_rows,
+        }
     }
 }
 

--- a/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/compact_source.rs
@@ -187,6 +187,7 @@ impl BlockMetaTransform<CompactSourceMeta> for CompactTransform {
                 let meta = Box::new(SerializeDataMeta::SerializeBlock(SerializeBlock::create(
                     index,
                     ClusterStatsGenType::Generally,
+                    0,
                 )));
                 let new_block = block.add_meta(Some(meta))?;
                 Ok(vec![new_block])

--- a/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/processors/mutation_source.rs
@@ -89,6 +89,7 @@ pub struct MutationSource {
 
     index: BlockMetaIndex,
     stats_type: ClusterStatsGenType,
+    update_rows: u64,
 }
 
 impl MutationSource {
@@ -117,6 +118,7 @@ impl MutationSource {
             update_stream_columns,
             index: BlockMetaIndex::default(),
             stats_type: ClusterStatsGenType::Generally,
+            update_rows: 0,
         })))
     }
 }
@@ -220,6 +222,7 @@ impl Processor for MutationSource {
                                         SerializeBlock::create(
                                             self.index.clone(),
                                             self.stats_type.clone(),
+                                            0,
                                         ),
                                     ));
                                     self.state = State::Output(
@@ -311,14 +314,18 @@ impl Processor for MutationSource {
                 self.state = State::PerformOperator(data_block, path);
             }
             State::PerformOperator(data_block, path) => {
+                let update_rows = std::mem::take(&mut self.update_rows);
                 let func_ctx = self.ctx.get_function_context()?;
                 let block = self
                     .operators
                     .iter()
                     .try_fold(data_block, |input, op| op.execute(&func_ctx, input))?;
-                let inner_meta = Box::new(SerializeDataMeta::SerializeBlock(
-                    SerializeBlock::create(self.index.clone(), self.stats_type.clone()),
-                ));
+                let inner_meta =
+                    Box::new(SerializeDataMeta::SerializeBlock(SerializeBlock::create(
+                        self.index.clone(),
+                        self.stats_type.clone(),
+                        update_rows,
+                    )));
                 let meta: BlockMetaInfoPtr = if self.update_stream_columns {
                     Box::new(gen_mutation_stream_meta(Some(inner_meta), &path)?)
                 } else {
@@ -365,7 +372,11 @@ impl Processor for MutationSource {
                             // whole block deletion.
                             self.update_mutation_status(fuse_part.nums_rows);
                             let meta = Box::new(SerializeDataMeta::SerializeBlock(
-                                SerializeBlock::create(self.index.clone(), self.stats_type.clone()),
+                                SerializeBlock::create(
+                                    self.index.clone(),
+                                    self.stats_type.clone(),
+                                    0,
+                                ),
                             ));
                             self.state = State::Output(
                                 self.ctx.get_partition(),
@@ -420,8 +431,9 @@ impl Processor for MutationSource {
 }
 
 impl MutationSource {
-    fn update_mutation_status(&self, num_rows: usize) {
+    fn update_mutation_status(&mut self, num_rows: usize) {
         let (update_rows, deleted_rows) = if self.action == MutationAction::Update {
+            self.update_rows = num_rows as u64;
             (num_rows as u64, 0)
         } else {
             (0, num_rows as u64)

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -584,6 +584,7 @@ impl AggregationContext {
                 block_idx: block_index,
             },
             block_meta: Arc::new(extended_block_meta),
+            insert_rows: 0,
         };
 
         Ok(Some(mutation))

--- a/src/query/storages/fuse/src/operations/table_index.rs
+++ b/src/query/storages/fuse/src/operations/table_index.rs
@@ -821,6 +821,7 @@ impl AsyncTransform for NgramIndexTransform {
         let entry = MutationLogEntry::ReplacedBlock {
             index: index.clone(),
             block_meta: Arc::new(extended_block_meta),
+            insert_rows: 0,
         };
         let meta = MutationLogs {
             entries: vec![entry],
@@ -906,6 +907,7 @@ impl AsyncTransform for VectorIndexTransform {
         let entry = MutationLogEntry::ReplacedBlock {
             index: index.clone(),
             block_meta: Arc::new(extended_block_meta),
+            insert_rows: 0,
         };
         let meta = MutationLogs {
             entries: vec![entry],
@@ -1011,6 +1013,7 @@ impl AsyncTransform for SpatialIndexTransform {
         let entry = MutationLogEntry::ReplacedBlock {
             index: index.clone(),
             block_meta: Arc::new(extended_block_meta),
+            insert_rows: 0,
         };
         let meta = MutationLogs {
             entries: vec![entry],


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary
  - Carry commit-local inserted row counts through `CommitMeta` instead of deriving them from async `MutationStatus` in commit.
  - Propagate HLL row counts through mutation logs for appended/replaced blocks and merge them in `TableMutationAggregator`.
  - Use `CommitMeta.insert_rows` for multi-table insert result/transaction bookkeeping, while only updating table stats when commit-local HLL is present.
  - Keep delete/rewrite-only paths from contributing HLL rows.

- fixes: #19922

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20065)
<!-- Reviewable:end -->
