### PR TITLE
fix(query): normalize nullable runtime inlist filters

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/local_builder.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/local_builder.rs
@@ -38,7 +38,7 @@ use crate::pipelines::processors::transforms::hash_join::util::hash_by_method_fo
 
 struct SingleFilterBuilder {
     id: usize,
-    data_type: DataType,
+    inlist_data_type: DataType,
     hash_method: Option<HashMethodKind>,
 
     min_max_domain: Option<Domain>,
@@ -71,13 +71,13 @@ impl SingleFilterBuilder {
             None
         } else {
             Some(DataBlock::choose_hash_method_with_types(&[
-                bloom_data_type,
+                bloom_data_type.clone(),
             ])?)
         };
 
         Ok(Self {
             id: desc.id,
-            data_type,
+            inlist_data_type: bloom_data_type,
             hash_method,
             min_max_domain: None,
             min_max_threshold: if desc.enable_min_max_runtime_filter {
@@ -134,11 +134,12 @@ impl SingleFilterBuilder {
             self.inlist_builder = None;
             return;
         }
+        let column = column.remove_nullable();
         let mut builder = match self.inlist_builder.take() {
             Some(b) => b,
-            None => ColumnBuilder::with_capacity(&self.data_type, column.len()),
+            None => ColumnBuilder::with_capacity(&self.inlist_data_type, column.len()),
         };
-        builder.append_column(column);
+        builder.append_column(&column);
         self.inlist_builder = Some(builder);
     }
 
@@ -213,7 +214,7 @@ impl SingleFilterBuilder {
                 if column.len() == 0 {
                     None
                 } else {
-                    Some(dedup_column(column, func_ctx, &self.data_type)?)
+                    Some(dedup_column(column, func_ctx, &self.inlist_data_type)?)
                 }
             } else {
                 None
@@ -383,4 +384,43 @@ fn dedup_column(
     let value = evaluator.run(&expr)?;
 
     Ok(value.into_scalar().unwrap().into_array().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::Expr;
+    use databend_common_expression::FromData;
+    use databend_common_expression::types::StringType;
+
+    use super::*;
+
+    #[test]
+    fn test_inlist_runtime_filter_removes_nullable_build_key() -> Result<()> {
+        let desc = RuntimeFilterDesc {
+            id: 0,
+            build_key: Expr::ColumnRef(ColumnRef {
+                span: None,
+                id: 0,
+                data_type: DataType::Nullable(Box::new(DataType::String)),
+                display_name: "build_key".to_string(),
+            }),
+            probe_targets: vec![],
+            build_table_rows: Some(2),
+            enable_bloom_runtime_filter: false,
+            enable_inlist_runtime_filter: true,
+            enable_min_max_runtime_filter: false,
+            spatial_mode: None,
+        };
+
+        let mut builder = SingleFilterBuilder::new(&desc, 10, 0, 0, 0)?;
+        let column = StringType::from_opt_data(vec![Some("a"), Some("b")]);
+        builder.add_column(&column, 0)?;
+
+        let packet = builder.finish(&FunctionContext::default())?;
+        let inlist = packet.inlist.unwrap();
+        assert_eq!(inlist.data_type(), DataType::String);
+        assert_eq!(inlist.len(), 2);
+        Ok(())
+    }
 }

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_inlist_bloom_prune.test
@@ -237,6 +237,67 @@ HashJoin
     └── estimated rows: 100000.00
 
 statement ok
+create or replace table test_nullable_build_token(s String) row_per_block = 1000 as
+select to_string(if(number < 10, number + 50000, number + 1000000)) as s from numbers(10000);
+
+statement ok
+create or replace table test_non_nullable_probe_token(s String not null) bloom_index_columns='s' bloom_index_type='binary_fuse32' row_per_block = 1000 as
+select to_string((number % 1000) * 100 + (number DIV 1000)) as s from numbers(100000);
+
+query I
+select count() from test_non_nullable_probe_token where s in (select s from test_nullable_build_token limit 10);
+----
+10
+
+query T
+EXPLAIN select * from test_non_nullable_probe_token where s in (select s from test_nullable_build_token limit 10);
+----
+HashJoin
+├── output columns: [test_non_nullable_probe_token.s (#0)]
+├── join type: LEFT SEMI
+├── build keys: [subquery_1 (#1)]
+├── probe keys: [CAST(test_non_nullable_probe_token.s (#0) AS String NULL)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:subquery_1 (#1), probe targets:[CAST(test_non_nullable_probe_token.s (#0) AS String NULL)@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: 100000.00
+├── Limit(Build)
+│   ├── output columns: [test_nullable_build_token.s (#1)]
+│   ├── limit: 10
+│   ├── offset: 0
+│   ├── estimated rows: 10.00
+│   └── TableScan
+│       ├── table: default.default.test_nullable_build_token
+│       ├── scan id: 1
+│       ├── output columns: [s (#1)]
+│       ├── read rows: 1000
+│       ├── read size: < 1 KiB
+│       ├── partitions total: 10
+│       ├── partitions scanned: 1
+│       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 2 to 1 cost: <slt:ignore>>]
+│       ├── push downs: [filters: [], limit: 10]
+│       └── estimated rows: 10000.00
+└── TableScan(Probe)
+    ├── table: default.default.test_non_nullable_probe_token
+    ├── scan id: 0
+    ├── output columns: [s (#0)]
+    ├── read rows: 100000
+    ├── read size: 98.68 KiB
+    ├── partitions total: 99
+    ├── partitions scanned: 99
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 99 to 99 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 100000.00
+
+statement ok
+drop table if exists test_nullable_build_token;
+
+statement ok
+drop table if exists test_non_nullable_probe_token;
+
+statement ok
 drop table if exists test_nullable_string_a;
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix false negatives in runtime inlist filters when the build key is nullable but the probe column is non-nullable.

The inlist runtime filter now normalizes the build-side column and packet type with `remove_nullable()`, matching the existing bloom/min-max runtime filter behavior. This keeps scan-time pruning value-set based instead of preserving nullable wrapper encoding from the join build key.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

Validated locally with:

- `cargo build -p databend-binaries --bin databend-query`
- `cargo fmt --all --check`
- `cargo test -p databend-query --lib test_inlist_runtime_filter_removes_nullable_build_key`
- `/home/ubuntu/work/databend-automation/db-slt --clean-meta --skip-build --suite-root tests/sqllogictests/suites/mode --run-dir standalone --run-file runtime_filter_inlist_bloom_prune.test --no-complete`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20066)
<!-- Reviewable:end -->
