### PR TITLE
fix(query): handle nan in float arithmetic domains

### DIFF
--- a/src/query/functions/src/scalars/numeric_basic_arithmetic/src/numeric_basic_arithmetic.rs
+++ b/src/query/functions/src/scalars/numeric_basic_arithmetic/src/numeric_basic_arithmetic.rs
@@ -137,6 +137,22 @@ fn number_to_i128<N: Number>(value: N) -> Option<i128> {
     }
 }
 
+fn number_is_nan<N: Number>(value: N) -> bool {
+    match N::upcast_scalar(value) {
+        NumberScalar::Float32(value) => value.is_nan(),
+        NumberScalar::Float64(value) => value.is_nan(),
+        _ => false,
+    }
+}
+
+fn domain_or_full<N: Number>(min: N, max: N) -> FunctionDomain<NumberType<N>> {
+    if number_is_nan(min) || number_is_nan(max) {
+        FunctionDomain::Full
+    } else {
+        FunctionDomain::Domain(SimpleDomain { min, max })
+    }
+}
+
 fn derive_modulo_stat<L, R, M, O>(stat: StatBinaryArg) -> Result<Option<ReturnStat>, String>
 where
     L: Number,
@@ -255,10 +271,7 @@ where
                 let rm: AddMulResult<L, R> = num_traits::cast::cast(rhs.max)?;
                 let rn: AddMulResult<L, R> = num_traits::cast::cast(rhs.min)?;
 
-                FunctionDomain::Domain(SimpleDomain::<AddMulResult<L, R>> {
-                    min: ln.checked_add(rn)?,
-                    max: lm.checked_add(rm)?,
-                })
+                domain_or_full(ln.checked_add(rn)?, lm.checked_add(rm)?)
             }
             .unwrap_or(FunctionDomain::Full)
         })
@@ -349,10 +362,7 @@ where
                 let rm: MinusResult<L, R> = num_traits::cast::cast(rhs.max)?;
                 let rn: MinusResult<L, R> = num_traits::cast::cast(rhs.min)?;
 
-                Some(FunctionDomain::Domain(SimpleDomain::<MinusResult<L, R>> {
-                    min: ln.checked_sub(rm)?,
-                    max: lm.checked_sub(rn)?,
-                }))
+                Some(domain_or_full(ln.checked_sub(rm)?, lm.checked_sub(rn)?))
             })()
             .unwrap_or(FunctionDomain::Full)
         },
@@ -383,10 +393,10 @@ where
                 let m = ln.checked_mul(rm)?;
                 let n = ln.checked_mul(rn)?;
 
-                Some(FunctionDomain::Domain(SimpleDomain::<AddMulResult<L, R>> {
-                    min: x.min(y).min(m).min(n),
-                    max: x.max(y).max(m).max(n),
-                }))
+                Some(domain_or_full(
+                    x.min(y).min(m).min(n),
+                    x.max(y).max(m).max(n),
+                ))
             })()
             .unwrap_or(FunctionDomain::Full)
         },

--- a/src/query/sql/tests/it/optimizer/selectivity_smoke.rs
+++ b/src/query/sql/tests/it/optimizer/selectivity_smoke.rs
@@ -33,6 +33,7 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_expression::types::number::F32;
+use databend_common_expression::types::number::F64 as ExprF64;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_sql::ColumnBinding;
 use databend_common_sql::ColumnBindingBuilder;
@@ -144,6 +145,33 @@ fn distorted_histogram_comparison_estimate_narrows_range() {
     assert!((estimated_rows - 50.0).abs() < f64::EPSILON);
     assert_eq!(stat.min, Datum::UInt(101));
     assert_eq!(stat.max, Datum::UInt(1000));
+}
+
+#[test]
+fn float_full_domain_arithmetic_selectivity_is_not_empty() {
+    let column = column_expr("a", 0, DataType::Number(NumberDataType::Float64));
+    let expr = comparison_expr(
+        "lt",
+        function_expr("minus", vec![
+            function_expr("plus", vec![
+                column.clone(),
+                constant_expr(Scalar::Number(NumberScalar::Float64(ExprF64::from(1.0)))),
+            ]),
+            column,
+        ]),
+        constant_expr(Scalar::Number(NumberScalar::Float64(ExprF64::from(10.0)))),
+    );
+
+    let mut estimator =
+        SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::estimate(10.0));
+    let estimated_rows = estimator
+        .apply(&[expr])
+        .expect("float arithmetic comparison should estimate");
+
+    assert!(
+        estimated_rows > 0.0,
+        "full Float64 domain arithmetic is not proof of an empty result"
+    );
 }
 
 #[test]

--- a/tests/sqllogictests/suites/query/aggregate.test
+++ b/tests/sqllogictests/suites/query/aggregate.test
@@ -69,6 +69,23 @@ SELECT SUM(agg0) FROM (
 ----
 4.0
 
+query TR
+WITH user_income AS (
+  SELECT CAST(number % 2 AS STRING) AS user_id,
+         SUM(number::FLOAT64) AS total_entry_fee,
+         SUM(number::FLOAT64) + 1 AS total_actual_reward
+  FROM numbers(5)
+  GROUP BY user_id
+)
+SELECT user_id,
+       total_actual_reward - total_entry_fee AS total_user_income
+FROM user_income
+WHERE total_user_income < 10
+ORDER BY user_id
+----
+0 1.0
+1 1.0
+
 query TT
 select typeof(sum(number::Decimal(18, 1))), typeof(sum(number::Decimal(19, 1))) from numbers(1000);
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20064.

- Avoid producing numeric arithmetic domains with NaN endpoints for float full domains.
- Add optimizer and sqllogic regressions for aggregate alias filters that previously folded to false.

## Changes

Float32/Float64 full domains can use NaN as the upper endpoint to represent the complete float domain. When plus/minus/multiply propagated that endpoint as a regular SimpleDomain, later comparison selectivity could treat the predicate as impossible.

This PR returns FunctionDomain::Full whenever float arithmetic domain endpoints become NaN, preserving correctness while still allowing normal finite domains.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20067)
<!-- Reviewable:end -->