### PR TITLE
refactor: meta: decouple index create option

### DIFF
--- a/src/meta/api/src/api_impl/catalog_api.rs
+++ b/src/meta/api/src/api_impl/catalog_api.rs
@@ -33,7 +33,6 @@ use log::debug;
 
 use crate::kv_app_error::KVAppError;
 use crate::kv_pb_api::KVPbApi;
-use crate::name_id_value_api::CreateIdValueMode;
 use crate::name_id_value_api::CreateIdValueResult;
 use crate::name_id_value_api::NameIdValueApi;
 use crate::serialize_struct;
@@ -65,7 +64,7 @@ where
             .create_id_value(
                 name_ident,
                 meta,
-                CreateIdValueMode::CreateOnly,
+                false,
                 |id| {
                     vec![(
                         CatalogIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),

--- a/src/meta/api/src/api_impl/dictionary_api.rs
+++ b/src/meta/api/src/api_impl/dictionary_api.rs
@@ -40,7 +40,6 @@ use log::debug;
 use crate::kv_app_error::KVAppError;
 use crate::kv_pb_api::KVPbApi;
 use crate::meta_txn_error::MetaTxnError;
-use crate::name_id_value_api::CreateIdValueMode;
 use crate::name_id_value_api::CreateIdValueResult;
 use crate::name_id_value_api::NameIdValueApi;
 use crate::txn::meta_txn;
@@ -92,7 +91,7 @@ where
             .create_id_value(
                 name_ident,
                 &req.dictionary_meta,
-                CreateIdValueMode::CreateOnly,
+                false,
                 |_| vec![],
                 |_, _| Ok(vec![]),
                 |_, _| {},

--- a/src/meta/api/src/api_impl/index_api.rs
+++ b/src/meta/api/src/api_impl/index_api.rs
@@ -63,7 +63,6 @@ use super::schema_api::mark_table_index_as_deleted;
 use crate::kv_app_error::KVAppError;
 use crate::kv_pb_api::KVPbApi;
 use crate::meta_txn_error::MetaTxnError;
-use crate::name_id_value_api::CreateIdValueMode;
 use crate::name_id_value_api::CreateIdValueResult;
 use crate::name_id_value_api::NameIdValueApi;
 use crate::serialize_struct;
@@ -96,17 +95,13 @@ where
 
         let name_ident = &req.name_ident;
         let meta = &req.meta;
-        let create_mode = match req.create_option {
-            CreateOption::Create | CreateOption::CreateIfNotExists => CreateIdValueMode::CreateOnly,
-            CreateOption::CreateOrReplace => CreateIdValueMode::CreateOrReplace,
-        };
         let name_ident_raw = serialize_struct(&IndexNameIdentRaw::from(name_ident));
 
         let create_res = self
             .create_id_value(
                 name_ident,
                 meta,
-                create_mode,
+                req.override_existing,
                 |id| {
                     vec![(
                         IndexIdToNameIdent::new_generic(name_ident.tenant(), id).to_string_key(),
@@ -122,20 +117,14 @@ where
             .await?;
 
         match create_res {
-            CreateIdValueResult::Created(id) => Ok(CreateIndexReply { index_id: *id }),
-            CreateIdValueResult::Existing(existent) => match req.create_option {
-                CreateOption::Create => {
-                    Err(AppError::from(name_ident.exist_error(func_name!())).into())
-                }
-                CreateOption::CreateIfNotExists => Ok(CreateIndexReply {
-                    index_id: *existent.data,
-                }),
-                CreateOption::CreateOrReplace => {
-                    unreachable!(
-                        "create_index: CreateOrReplace should never conflict with existent"
-                    );
-                }
-            },
+            CreateIdValueResult::Created(id) => Ok(CreateIndexReply {
+                index_id: *id,
+                created: true,
+            }),
+            CreateIdValueResult::Existing(existent) => Ok(CreateIndexReply {
+                index_id: *existent.data,
+                created: false,
+            }),
         }
     }
 

--- a/src/meta/api/src/api_impl/sequence_api_impl.rs
+++ b/src/meta/api/src/api_impl/sequence_api_impl.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app::KeyExistsBuilder;
 use databend_common_meta_app::KeyUnknownBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::SequenceError;
 use databend_common_meta_app::app_error::UnsupportedSequenceStorageVersion;
 use databend_common_meta_app::app_error::WrongSequenceCount;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateSequenceReply;
 use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::DropSequenceReply;
@@ -67,7 +65,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
         let storage_ident = SequenceStorageIdent::new_from(req.ident.clone());
         let storage_value = ValueId::<SequenceStorageValue>::new(req.start);
 
-        let conditions = if req.create_option == CreateOption::CreateOrReplace {
+        let conditions = if req.override_existing {
             vec![]
         } else {
             vec![txn_cond_eq_seq(&req.ident, 0)]
@@ -80,19 +78,7 @@ impl<KV: kvapi::KVApi<Error = MetaError> + ?Sized> SequenceApi for KV {
 
         let (succ, _response) = send_txn(self, txn).await?;
 
-        if succ {
-            return Ok(CreateSequenceReply {});
-        }
-
-        match req.create_option {
-            CreateOption::Create => Err(KVAppError::AppError(AppError::SequenceError(
-                SequenceError::SequenceAlreadyExists(req.ident.exist_error(func_name!())),
-            ))),
-            CreateOption::CreateIfNotExists => Ok(CreateSequenceReply {}),
-            CreateOption::CreateOrReplace => {
-                unreachable!("CreateOrReplace should always success")
-            }
-        }
+        Ok(CreateSequenceReply { success: succ })
     }
 
     async fn get_sequence(

--- a/src/meta/api/src/kv/name_id_value_api.rs
+++ b/src/meta/api/src/kv/name_id_value_api.rs
@@ -52,13 +52,6 @@ pub enum CreateIdValueResult<IdRsc> {
     Existing(SeqV<DataId<IdRsc>>),
 }
 
-/// Defines how to handle an existing `name -> id` mapping when creating.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CreateIdValueMode {
-    CreateOnly,
-    CreateOrReplace,
-}
-
 /// NameIdValueApi provide generic meta-service access pattern implementations for `name -> id -> value` mapping.
 ///
 /// Such a two level mapping provides a consistent id `id` for internal use,
@@ -99,7 +92,7 @@ where
         &self,
         name_ident: &K,
         value: &IdRsc::ValueType,
-        create_mode: CreateIdValueMode,
+        override_existing: bool,
         associated_records: A,
         mark_delete_records: M,
         on_override_fn: O,
@@ -125,9 +118,9 @@ where
                 let get_res = self.get_id_and_value(name_ident).await?;
 
                 if let Some((seq_id, seq_meta)) = get_res {
-                    let CreateIdValueMode::CreateOrReplace = create_mode else {
+                    if !override_existing {
                         return Ok(CreateIdValueResult::Existing(seq_id));
-                    };
+                    }
 
                     // Override take place only when the id -> value does not change.
                     // If it does not override, no such condition is required.

--- a/src/meta/app/src/schema/index.rs
+++ b/src/meta/app/src/schema/index.rs
@@ -21,7 +21,6 @@ use chrono::DateTime;
 use chrono::Utc;
 use databend_meta_client::types::MetaId;
 
-use super::CreateOption;
 use crate::KeyWithTenant;
 use crate::schema::IndexNameIdent;
 use crate::tenant::Tenant;
@@ -100,34 +99,27 @@ impl Default for IndexMeta {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateIndexReq {
-    pub create_option: CreateOption,
+    pub override_existing: bool,
     pub name_ident: IndexNameIdent,
     pub meta: IndexMeta,
 }
 
 impl Display for CreateIndexReq {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match self.create_option {
-            CreateOption::Create => {
-                write!(
-                    f,
-                    "create_index:{}={:?}",
-                    self.name_ident.tenant_name(),
-                    self.meta
-                )
-            }
-            CreateOption::CreateIfNotExists => write!(
-                f,
-                "create_index_if_not_exists:{}={:?}",
-                self.name_ident.tenant_name(),
-                self.meta
-            ),
-            CreateOption::CreateOrReplace => write!(
+        if self.override_existing {
+            write!(
                 f,
                 "create_or_replace_index:{}={:?}",
                 self.name_ident.tenant_name(),
                 self.meta
-            ),
+            )
+        } else {
+            write!(
+                f,
+                "create_index:{}={:?}",
+                self.name_ident.tenant_name(),
+                self.meta
+            )
         }
     }
 }
@@ -135,6 +127,7 @@ impl Display for CreateIndexReq {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateIndexReply {
     pub index_id: u64,
+    pub created: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/app/src/schema/sequence.rs
+++ b/src/meta/app/src/schema/sequence.rs
@@ -18,7 +18,6 @@ use chrono::DateTime;
 use chrono::Utc;
 pub use kvapi_impl::SequenceRsc;
 
-use super::CreateOption;
 use crate::tenant::Tenant;
 use crate::tenant_key::ident::TIdent;
 
@@ -65,7 +64,7 @@ impl From<CreateSequenceReq> for SequenceMeta {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateSequenceReq {
-    pub create_option: CreateOption,
+    pub override_existing: bool,
     pub ident: SequenceIdent,
     pub create_on: DateTime<Utc>,
     pub start: u64,
@@ -77,7 +76,9 @@ pub struct CreateSequenceReq {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CreateSequenceReply {}
+pub struct CreateSequenceReply {
+    pub success: bool,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GetSequenceNextValueReq {

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -4634,7 +4634,7 @@ impl SchemaApiTestSuite {
         }
 
         let agg_index_create_req = CreateIndexReq {
-            create_option: CreateOption::CreateIfNotExists,
+            override_existing: false,
             name_ident: IndexNameIdent::new(&tenant, idx1_name),
             meta: IndexMeta {
                 table_id,
@@ -7180,7 +7180,7 @@ impl SchemaApiTestSuite {
         {
             info!("--- create index");
             let req = CreateIndexReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 name_ident: name_ident_1.clone(),
                 meta: index_meta_1.clone(),
             };
@@ -7197,7 +7197,7 @@ impl SchemaApiTestSuite {
             }
 
             let req = CreateIndexReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 name_ident: name_ident_2.clone(),
                 meta: index_meta_2.clone(),
             };
@@ -7207,24 +7207,22 @@ impl SchemaApiTestSuite {
         }
 
         {
-            info!("--- create index again with if_not_exists = false");
+            info!("--- create index again without override");
             let req = CreateIndexReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 name_ident: name_ident_1.clone(),
                 meta: index_meta_1.clone(),
             };
 
-            let res = mt.create_index(req).await;
-            let status = res.err().unwrap();
-            let err_code = ErrorCode::from(status);
-
-            assert_eq!(ErrorCode::INDEX_ALREADY_EXISTS, err_code.code());
+            let res = mt.create_index(req).await?;
+            assert_eq!(index_id, res.index_id);
+            assert!(!res.created);
         }
 
         {
-            info!("--- create index again with if_not_exists = true");
+            info!("--- create index again without override");
             let req = CreateIndexReq {
-                create_option: CreateOption::CreateIfNotExists,
+                override_existing: false,
                 name_ident: name_ident_1.clone(),
                 meta: index_meta_1.clone(),
             };
@@ -7397,7 +7395,7 @@ impl SchemaApiTestSuite {
             let replace_index_name = "replace_idx";
             let replace_name_ident = IndexNameIdent::new(&tenant, replace_index_name);
             let req = CreateIndexReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 name_ident: replace_name_ident.clone(),
                 meta: index_meta_1.clone(),
             };
@@ -7414,7 +7412,7 @@ impl SchemaApiTestSuite {
             assert_eq!(resp.index_meta, index_meta_1);
 
             let req = CreateIndexReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 name_ident: replace_name_ident.clone(),
                 meta: index_meta_2.clone(),
             };

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -70,6 +70,7 @@ use databend_common_meta_app::schema::CreateDictionaryReq;
 use databend_common_meta_app::schema::CreateIndexReq;
 use databend_common_meta_app::schema::CreateLockRevReq;
 use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::schema::CreateSequenceReply;
 use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_meta_app::schema::CreateTableReply;
@@ -6258,7 +6259,7 @@ impl SchemaApiTestSuite {
         info!("--- create sequence");
         {
             let req = CreateSequenceReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 ident: SequenceIdent::new(&tenant, sequence_name),
                 create_on,
                 start: 1,
@@ -6267,7 +6268,24 @@ impl SchemaApiTestSuite {
                 storage_version,
             };
 
-            mt.create_sequence(req).await?;
+            let resp = mt.create_sequence(req).await?;
+            assert_eq!(resp, CreateSequenceReply { success: true });
+        }
+
+        info!("--- create sequence again without override");
+        {
+            let req = CreateSequenceReq {
+                override_existing: false,
+                ident: SequenceIdent::new(&tenant, sequence_name),
+                create_on,
+                start: 2,
+                increment: 2,
+                comment: Some("seq2".to_string()),
+                storage_version,
+            };
+
+            let resp = mt.create_sequence(req).await?;
+            assert_eq!(resp, CreateSequenceReply { success: false });
         }
 
         info!("--- get sequence");
@@ -6282,7 +6300,7 @@ impl SchemaApiTestSuite {
         info!("--- list sequence");
         {
             let req = CreateSequenceReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 ident: SequenceIdent::new(&tenant, "seq1"),
                 create_on,
                 start: 1,
@@ -6291,7 +6309,8 @@ impl SchemaApiTestSuite {
                 storage_version,
             };
 
-            mt.create_sequence(req).await?;
+            let resp = mt.create_sequence(req).await?;
+            assert_eq!(resp, CreateSequenceReply { success: true });
             let values = mt.list_sequences(&tenant).await?;
             assert_eq!(values.len(), 2);
             assert_eq!(values[0].0, sequence_name);
@@ -6333,7 +6352,7 @@ impl SchemaApiTestSuite {
         info!("--- replace sequence");
         {
             let req = CreateSequenceReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 ident: SequenceIdent::new(&tenant, sequence_name),
                 create_on,
                 start: 1,
@@ -6342,7 +6361,8 @@ impl SchemaApiTestSuite {
                 storage_version,
             };
 
-            mt.create_sequence(req).await?;
+            let resp = mt.create_sequence(req).await?;
+            assert_eq!(resp, CreateSequenceReply { success: true });
 
             let req = SequenceIdent::new(&tenant, sequence_name);
 

--- a/src/query/management/src/procedure/procedure_mgr.rs
+++ b/src/query/management/src/procedure/procedure_mgr.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use databend_common_meta_api::kv_pb_api::KVPbApi;
 use databend_common_meta_api::meta_txn_error::MetaTxnError;
-use databend_common_meta_api::name_id_value_api::CreateIdValueMode;
 use databend_common_meta_api::name_id_value_api::CreateIdValueResult;
 use databend_common_meta_api::name_id_value_api::NameIdValueApi;
 use databend_common_meta_api::serialize_struct;
@@ -79,11 +78,6 @@ impl ProcedureMgr {
         let name_ident = &req.name_ident;
         let meta = &req.meta;
         let name_ident_raw = serialize_struct(name_ident.procedure_name());
-        let create_mode = if overriding {
-            CreateIdValueMode::CreateOrReplace
-        } else {
-            CreateIdValueMode::CreateOnly
-        };
 
         let tenant = &self.tenant;
         let create_res = self
@@ -91,7 +85,7 @@ impl ProcedureMgr {
             .create_id_value(
                 name_ident,
                 meta,
-                create_mode,
+                overriding,
                 |id| {
                     vec![(
                         ProcedureIdToNameIdent::new_generic(name_ident.tenant(), id)

--- a/src/query/service/src/interpreters/interpreter_index_create.rs
+++ b/src/query/service/src/interpreters/interpreter_index_create.rs
@@ -63,7 +63,7 @@ impl Interpreter for CreateIndexInterpreter {
         let catalog = self.ctx.get_catalog(&catalog).await?;
 
         let create_index_req = CreateIndexReq {
-            create_option: self.plan.create_option,
+            override_existing: self.plan.create_option.is_overriding(),
             name_ident: IndexNameIdent::new(tenant, &index_name),
             meta: IndexMeta {
                 table_id: self.plan.table_id,
@@ -77,7 +77,14 @@ impl Interpreter for CreateIndexInterpreter {
             },
         };
 
-        let _ = catalog.create_index(create_index_req).await?;
+        let reply = catalog.create_index(create_index_req).await?;
+        if !reply.created && self.plan.create_option.if_return_error() {
+            return Err(ErrorCode::IndexAlreadyExists(format!(
+                "{} index exists",
+                index_name
+            )));
+        }
+
         Ok(PipelineBuildResult::create())
     }
 }

--- a/src/query/service/src/interpreters/interpreter_sequence_create.rs
+++ b/src/query/service/src/interpreters/interpreter_sequence_create.rs
@@ -17,12 +17,17 @@ use std::sync::Arc;
 use chrono::Utc;
 use databend_common_exception::Result;
 use databend_common_management::RoleApi;
+use databend_common_meta_api::kv_app_error::KVAppError;
+use databend_common_meta_app::KeyExistsBuilder;
 use databend_common_meta_app::KeyWithTenant;
+use databend_common_meta_app::app_error::AppError;
+use databend_common_meta_app::app_error::SequenceError;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_sql::plans::CreateSequencePlan;
 use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
+use fastrace::func_name;
 
 use crate::interpreters::Interpreter;
 use crate::pipelines::PipelineBuildResult;
@@ -55,7 +60,7 @@ impl Interpreter for CreateSequenceInterpreter {
     #[async_backtrace::framed]
     async fn execute2(&self) -> Result<PipelineBuildResult> {
         let req = CreateSequenceReq {
-            create_option: self.plan.create_option,
+            override_existing: self.plan.create_option.is_overriding(),
             ident: self.plan.ident.clone(),
             start: self.plan.start,
             increment: self.plan.increment,
@@ -64,7 +69,17 @@ impl Interpreter for CreateSequenceInterpreter {
             storage_version: 0,
         };
         let catalog = self.ctx.get_default_catalog()?;
-        let _reply = catalog.create_sequence(req).await?;
+        let reply = catalog.create_sequence(req).await?;
+        if !reply.success {
+            if self.plan.create_option.if_return_error() {
+                return Err(KVAppError::AppError(AppError::SequenceError(
+                    SequenceError::SequenceAlreadyExists(self.plan.ident.exist_error(func_name!())),
+                ))
+                .into());
+            }
+
+            return Ok(PipelineBuildResult::create());
+        }
 
         // Grant ownership as the current role
         if self

--- a/src/query/service/tests/it/indexes/aggregating_index/index_refresh.rs
+++ b/src/query/service/tests/it/indexes/aggregating_index/index_refresh.rs
@@ -644,7 +644,7 @@ async fn create_index(
         let tenant = ctx.get_tenant();
 
         let create_index_req = CreateIndexReq {
-            create_option: plan.create_option,
+            override_existing: plan.create_option.is_overriding(),
             name_ident: IndexNameIdent::new(tenant, index_name),
             meta: IndexMeta {
                 table_id: plan.table_id,


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: decouple index create option
# Summary

Regular index creation now passes only override intent into the meta API, leaving duplicate-error behavior at the query layer.

# Details

CreateIndexReq now carries an override flag and CreateIndexReply reports whether a new index was created. This keeps meta-service behavior focused on storage invariants instead of SQL create-option semantics.

The shared name-id-value helper now accepts the same override flag directly, so callers no longer convert booleans through a create-mode enum.


##### refactor: meta: decouple sequence create options
# Summary

Sequence creation in meta now takes only the overwrite invariant and reports whether the conditional write happened, leaving SQL-facing duplicate handling to the query layer.

# Details

The meta API no longer depends on `CreateOption` for sequence creation, so it does not choose between duplicate errors and `IF NOT EXISTS` success responses.

The query interpreter maps the existing create option methods into the meta request and preserves the previous user-facing duplicate behavior after reading the meta reply.

The sequence API test suite now checks both successful writes and the failed no-overwrite path explicitly.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20069)
<!-- Reviewable:end -->
