### PR TITLE
refactor: meta: decouple database create option

### DIFF
--- a/src/meta/api/src/api_impl/auto_increment_api_test_suite.rs
+++ b/src/meta/api/src/api_impl/auto_increment_api_test_suite.rs
@@ -240,7 +240,7 @@ where MT: AutoIncrementApi + kvapi::KVApi<Error = MetaError>
 
     async fn create_db(&mut self) -> anyhow::Result<()> {
         let plan = CreateDatabaseReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: DatabaseNameIdent::new(self.tenant(), self.db_name()),
             meta: DatabaseMeta {

--- a/src/meta/api/src/api_impl/database_api.rs
+++ b/src/meta/api/src/api_impl/database_api.rs
@@ -29,7 +29,6 @@ use databend_common_meta_app::app_error::UnknownDatabaseId;
 use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::schema::CreateDatabaseReply;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseIdHistoryIdent;
 use databend_common_meta_app::schema::DatabaseIdToName;
@@ -126,32 +125,22 @@ where
             let mut txn = TxnRequest::default();
 
             if let Some(ref curr_seq_db_id) = curr_seq_db_id {
-                match req.create_option {
-                    CreateOption::Create => {
-                        return Err(KVAppError::AppError(AppError::DatabaseAlreadyExists(
-                            DatabaseAlreadyExists::new(
-                                name_key.database_name(),
-                                format!("create db: tenant: {}", name_key.tenant_name()),
-                            ),
-                        )));
-                    }
-                    CreateOption::CreateIfNotExists => {
-                        return Ok(CreateDatabaseReply {
-                            db_id: curr_seq_db_id.data,
-                        });
-                    }
-                    CreateOption::CreateOrReplace => {
-                        let _ = drop_database_meta(
-                            self,
-                            name_key,
-                            req.catalog_name.clone(),
-                            false,
-                            false,
-                            &mut txn,
-                        )
-                        .await?;
-                    }
+                if !req.override_existing {
+                    return Ok(CreateDatabaseReply {
+                        db_id: curr_seq_db_id.data,
+                        created: false,
+                    });
                 }
+
+                let _ = drop_database_meta(
+                    self,
+                    name_key,
+                    req.catalog_name.clone(),
+                    false,
+                    false,
+                    &mut txn,
+                )
+                .await?;
             };
 
             // get db id list from _fd_db_id_list/db_id
@@ -203,7 +192,10 @@ where
                 );
 
                 if succ {
-                    return Ok(CreateDatabaseReply { db_id: id_key });
+                    return Ok(CreateDatabaseReply {
+                        db_id: id_key,
+                        created: true,
+                    });
                 }
             }
         }

--- a/src/meta/app/src/schema/database.rs
+++ b/src/meta/app/src/schema/database.rs
@@ -23,7 +23,6 @@ use chrono::Utc;
 use databend_meta_client::kvapi;
 use databend_meta_client::types::SeqV;
 
-use super::CreateOption;
 use crate::KeyWithTenant;
 use crate::schema::database_id::DatabaseId;
 use crate::schema::database_name_ident::DatabaseNameIdent;
@@ -183,7 +182,7 @@ impl Display for DbIdList {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateDatabaseReq {
-    pub create_option: CreateOption,
+    pub override_existing: bool,
     pub catalog_name: Option<String>,
     pub name_ident: DatabaseNameIdent,
     pub meta: DatabaseMeta,
@@ -191,29 +190,22 @@ pub struct CreateDatabaseReq {
 
 impl Display for CreateDatabaseReq {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self.create_option {
-            CreateOption::Create => write!(
-                f,
-                "create_db:{}/{}={:?}",
-                self.name_ident.tenant_name(),
-                self.name_ident.database_name(),
-                self.meta
-            ),
-            CreateOption::CreateIfNotExists => write!(
-                f,
-                "create_db_if_not_exists:{}/{}={:?}",
-                self.name_ident.tenant_name(),
-                self.name_ident.database_name(),
-                self.meta
-            ),
-
-            CreateOption::CreateOrReplace => write!(
+        if self.override_existing {
+            write!(
                 f,
                 "create_or_replace_db:{}/{}={:?}",
                 self.name_ident.tenant_name(),
                 self.name_ident.database_name(),
                 self.meta
-            ),
+            )
+        } else {
+            write!(
+                f,
+                "create_db:{}/{}={:?}",
+                self.name_ident.tenant_name(),
+                self.name_ident.database_name(),
+                self.meta
+            )
         }
     }
 }
@@ -221,6 +213,7 @@ impl Display for CreateDatabaseReq {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseReply {
     pub db_id: DatabaseId,
+    pub created: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -401,7 +401,7 @@ async fn benchmark_table(client: &MetaStore, prefix: u64, client_num: u64, i: u6
 
     let res = client
         .create_database(CreateDatabaseReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: DatabaseNameIdent::new(tenant(), db_name()),
             meta: Default::default(),

--- a/src/meta/schema-api-test-suite/src/db_table_harness.rs
+++ b/src/meta/schema-api-test-suite/src/db_table_harness.rs
@@ -133,7 +133,7 @@ where MT: kvapi::KVApi<Error = MetaError> + DatabaseApi
 {
     pub(crate) async fn create_db(&mut self) -> anyhow::Result<()> {
         let plan = CreateDatabaseReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: DatabaseNameIdent::new(self.tenant(), self.db_name()),
             meta: DatabaseMeta {

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -652,10 +652,10 @@ impl SchemaApiTestSuite {
             assert_eq!(1, *util.db_id(), "first database id is 1");
         }
 
-        info!("--- create db1 again with if_not_exists=false");
+        info!("--- create db1 again without override");
         {
             let req = CreateDatabaseReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
@@ -664,19 +664,16 @@ impl SchemaApiTestSuite {
                 },
             };
 
-            let res = mt.create_database(req).await;
+            let res = mt.create_database(req).await?;
             info!("create database res: {:?}", res);
-            let err = res.unwrap_err();
-            assert_eq!(
-                ErrorCode::DATABASE_ALREADY_EXISTS,
-                ErrorCode::from(err).code()
-            );
+            assert_eq!(1, *res.db_id, "db1 id is 1");
+            assert!(!res.created);
         }
 
         info!("--- create db1 again with if_not_exists=true");
         {
             let req = CreateDatabaseReq {
-                create_option: CreateOption::CreateIfNotExists,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
@@ -689,6 +686,7 @@ impl SchemaApiTestSuite {
             info!("create database res: {:?}", res);
             let res = res.unwrap();
             assert_eq!(1, *res.db_id, "db1 id is 1");
+            assert!(!res.created);
         }
 
         info!("--- get db1");
@@ -781,7 +779,7 @@ impl SchemaApiTestSuite {
             assert_eq!(ret_db_name_ident, DatabaseNameIdentRaw::from(&db_name));
 
             let req = CreateDatabaseReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 catalog_name: Some("default".to_string()),
                 name_ident: DatabaseNameIdent::new(&tenant, "db1"),
                 meta: DatabaseMeta {
@@ -1172,7 +1170,7 @@ impl SchemaApiTestSuite {
         {
             // first create database
             let req = CreateDatabaseReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
@@ -1264,7 +1262,7 @@ impl SchemaApiTestSuite {
 
             // then create database
             let req = CreateDatabaseReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
@@ -1294,7 +1292,7 @@ impl SchemaApiTestSuite {
         {
             // first create db2
             let req = CreateDatabaseReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: new_db_name_ident.clone(),
                 meta: DatabaseMeta {
@@ -4158,7 +4156,7 @@ impl SchemaApiTestSuite {
 
             // first create database
             let req = CreateDatabaseReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: db_name_ident.clone(),
                 meta: DatabaseMeta {
@@ -4217,7 +4215,7 @@ impl SchemaApiTestSuite {
         delete: bool,
     ) -> anyhow::Result<()> {
         let req = CreateDatabaseReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: db_name.clone(),
             meta: DatabaseMeta {

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -46,6 +46,7 @@ use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::CreateTableTagReq;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DeleteLockRevReq;
 use databend_common_meta_app::schema::DictionaryMeta;
 use databend_common_meta_app::schema::DropDatabaseReply;
@@ -236,6 +237,13 @@ impl Catalog for DatabaseCatalog {
             .exists_database(req.name_ident.tenant(), req.name_ident.database_name())
             .await?
         {
+            if !req.override_existing {
+                return Ok(CreateDatabaseReply {
+                    db_id: DatabaseId::new(0),
+                    created: false,
+                });
+            }
+
             return Err(ErrorCode::DatabaseAlreadyExists(format!(
                 "{} database exists",
                 req.name_ident.database_name()

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::table_function::TableFunction;
 use databend_common_config::InnerConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_meta_app::KeyWithTenant;
 use databend_common_meta_app::principal::UDTFServer;
 use databend_common_meta_app::schema::CatalogInfo;
 use databend_common_meta_app::schema::CommitTableMetaReply;
@@ -41,6 +42,7 @@ use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DeleteLockRevReq;
 use databend_common_meta_app::schema::DictionaryMeta;
 use databend_common_meta_app::schema::DropDatabaseReply;
@@ -197,7 +199,18 @@ impl Catalog for ImmutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn create_database(&self, _req: CreateDatabaseReq) -> Result<CreateDatabaseReply> {
+    async fn create_database(&self, req: CreateDatabaseReq) -> Result<CreateDatabaseReply> {
+        if !req.override_existing
+            && self
+                .exists_database(req.name_ident.tenant(), req.name_ident.database_name())
+                .await?
+        {
+            return Ok(CreateDatabaseReply {
+                db_id: DatabaseId::new(0),
+                created: false,
+            });
+        }
+
         Err(ErrorCode::Unimplemented("Cannot create system database"))
     }
 

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -52,7 +52,6 @@ use databend_common_meta_app::schema::CreateIndexReply;
 use databend_common_meta_app::schema::CreateIndexReq;
 use databend_common_meta_app::schema::CreateLockRevReply;
 use databend_common_meta_app::schema::CreateLockRevReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateSequenceReply;
 use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::CreateTableIndexReq;
@@ -213,7 +212,7 @@ impl MutableCatalog {
 
         // Create default database.
         let req = CreateDatabaseReq {
-            create_option: CreateOption::CreateIfNotExists,
+            override_existing: false,
             catalog_name: None,
             name_ident: DatabaseNameIdent::new(&tenant, "default"),
             meta: DatabaseMeta {
@@ -359,6 +358,10 @@ impl Catalog for MutableCatalog {
     async fn create_database(&self, req: CreateDatabaseReq) -> Result<CreateDatabaseReply> {
         // Create database.
         let res = self.ctx.meta.create_database(req.clone()).await?;
+        if !res.created {
+            return Ok(res);
+        }
+
         info!(
             "[CATALOG] Creating database: name={}, engine={}",
             req.name_ident.database_name(),
@@ -374,7 +377,7 @@ impl Catalog for MutableCatalog {
         });
         let database = self.build_db_instance(&db_info)?;
         database.init_database(req.name_ident.tenant_name()).await?;
-        Ok(CreateDatabaseReply { db_id: res.db_id })
+        Ok(res)
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/catalogs/iceberg/iceberg_catalog.rs
+++ b/src/query/service/src/catalogs/iceberg/iceberg_catalog.rs
@@ -43,6 +43,7 @@ use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::CreateTableIndexReq;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DeleteLockRevReq;
 use databend_common_meta_app::schema::DictionaryMeta;
 use databend_common_meta_app::schema::DropDatabaseReply;
@@ -193,6 +194,13 @@ impl Catalog for IcebergCatalog {
             .exists_database(req.name_ident.tenant(), req.name_ident.database_name())
             .await?
         {
+            if !req.override_existing {
+                return Ok(CreateDatabaseReply {
+                    db_id: DatabaseId::new(0),
+                    created: false,
+                });
+            }
+
             return Err(ErrorCode::DatabaseAlreadyExists(format!(
                 "{} database exists",
                 req.name_ident.database_name()

--- a/src/query/service/src/interpreters/interpreter_database_create.rs
+++ b/src/query/service/src/interpreters/interpreter_database_create.rs
@@ -74,6 +74,16 @@ impl Interpreter for CreateDatabaseInterpreter {
 
         let create_db_req: CreateDatabaseReq = self.plan.clone().into();
         let reply = catalog.create_database(create_db_req).await?;
+        if !reply.created {
+            if self.plan.create_option.if_return_error() {
+                return Err(ErrorCode::DatabaseAlreadyExists(format!(
+                    "{} database exists",
+                    self.plan.database
+                )));
+            }
+
+            return Ok(PipelineBuildResult::create());
+        }
 
         // Grant ownership as the current role. The above create_db_req.meta.owner could be removed in
         // the future.

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -70,7 +70,7 @@ async fn test_catalogs_database() -> anyhow::Result<()> {
     // Create.
     {
         let req = CreateDatabaseReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: DatabaseNameIdent::new(&tenant, "db1"),
             meta: DatabaseMeta {

--- a/src/query/service/tests/it/catalogs/immutable_catalogs.rs
+++ b/src/query/service/tests/it/catalogs/immutable_catalogs.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::DropDatabaseReq;
 use databend_common_meta_app::schema::RenameDatabaseReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
@@ -43,15 +42,15 @@ async fn test_immutable_catalogs_database() -> anyhow::Result<()> {
     let db_3 = catalog.get_database(&tenant, "test").await;
     assert!(db_3.is_err());
 
-    // create database should failed
+    // create existing database should be a no-op.
     let create_db_req = CreateDatabaseReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "system"),
         meta: Default::default(),
     };
     let create_db_req = catalog.create_database(create_db_req).await;
-    assert!(create_db_req.is_err());
+    assert!(!create_db_req?.created);
 
     let drop_db_req = DropDatabaseReq {
         if_exists: false,

--- a/src/query/service/tests/it/catalogs/test_error_handling.rs
+++ b/src/query/service/tests/it/catalogs/test_error_handling.rs
@@ -63,7 +63,7 @@ async fn test_get_table_error_handling() -> anyhow::Result<()> {
 
     // Create a test database and table
     let req = CreateDatabaseReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "test_db"),
         meta: DatabaseMeta::default(),
@@ -126,7 +126,7 @@ async fn test_get_table_history_error_handling() -> anyhow::Result<()> {
 
     // Create a test database
     let req = CreateDatabaseReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "history_test_db"),
         meta: DatabaseMeta::default(),
@@ -197,7 +197,7 @@ async fn test_get_table_by_info_error_handling() -> anyhow::Result<()> {
 
     // Create a test database and table
     let req = CreateDatabaseReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "info_test_db"),
         meta: DatabaseMeta::default(),
@@ -254,7 +254,7 @@ async fn test_delegation_between_catalogs() -> anyhow::Result<()> {
 
     // Test that user-created databases are handled by mutable catalog
     let req = CreateDatabaseReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: DatabaseNameIdent::new(&tenant, "user_db"),
         meta: DatabaseMeta::default(),

--- a/src/query/sql/src/planner/plans/ddl/database.rs
+++ b/src/query/sql/src/planner/plans/ddl/database.rs
@@ -38,7 +38,7 @@ pub struct CreateDatabasePlan {
 impl From<CreateDatabasePlan> for CreateDatabaseReq {
     fn from(p: CreateDatabasePlan) -> Self {
         CreateDatabaseReq {
-            create_option: p.create_option,
+            override_existing: p.create_option.is_overriding(),
             catalog_name: if p.create_option.is_overriding() {
                 Some(p.catalog.to_string())
             } else {
@@ -53,7 +53,7 @@ impl From<CreateDatabasePlan> for CreateDatabaseReq {
 impl From<&CreateDatabasePlan> for CreateDatabaseReq {
     fn from(p: &CreateDatabasePlan) -> Self {
         CreateDatabaseReq {
-            create_option: p.create_option,
+            override_existing: p.create_option.is_overriding(),
             catalog_name: if p.create_option.is_overriding() {
                 Some(p.catalog.to_string())
             } else {

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -42,7 +42,6 @@ use databend_common_meta_app::schema::CreateIndexReply;
 use databend_common_meta_app::schema::CreateIndexReq;
 use databend_common_meta_app::schema::CreateLockRevReply;
 use databend_common_meta_app::schema::CreateLockRevReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateSequenceReply;
 use databend_common_meta_app::schema::CreateSequenceReq;
 use databend_common_meta_app::schema::CreateTableIndexReq;
@@ -359,25 +358,22 @@ impl Catalog for IcebergMutableCatalog {
 
     #[async_backtrace::framed]
     async fn create_database(&self, req: CreateDatabaseReq) -> Result<CreateDatabaseReply> {
-        match req.create_option {
-            CreateOption::Create => {}
-            CreateOption::CreateIfNotExists => {
-                if self
-                    .exists_database(req.name_ident.tenant(), req.name_ident.name())
-                    .await?
-                {
-                    return Ok(CreateDatabaseReply {
-                        db_id: DatabaseId::new(0),
-                    });
-                }
+        if self
+            .exists_database(req.name_ident.tenant(), req.name_ident.name())
+            .await?
+        {
+            if !req.override_existing {
+                return Ok(CreateDatabaseReply {
+                    db_id: DatabaseId::new(0),
+                    created: false,
+                });
             }
-            CreateOption::CreateOrReplace => {
-                self.drop_database(DropDatabaseReq {
-                    if_exists: true,
-                    name_ident: req.name_ident.clone(),
-                })
-                .await?;
-            }
+
+            self.drop_database(DropDatabaseReq {
+                if_exists: true,
+                name_ident: req.name_ident.clone(),
+            })
+            .await?;
         }
 
         let ns = NamespaceIdent::new(req.name_ident.name().to_owned());
@@ -394,6 +390,7 @@ impl Catalog for IcebergMutableCatalog {
 
         Ok(CreateDatabaseReply {
             db_id: DatabaseId::new(0),
+            created: true,
         })
     }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: decouple database create option
# Summary

Move database creation in the meta API from SQL-oriented create options to a minimal override flag and explicit created result.

# Details

CreateDatabaseReq now carries only whether existing records may be overridden, while CreateDatabaseReply reports whether a new database was actually created.

SQL-facing create semantics stay in the query layer, which maps no-op creates back to the appropriate IF NOT EXISTS or already-exists behavior.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20070)
<!-- Reviewable:end -->
