### PR TITLE
fix(query): avoid empty role cache during reload race

### DIFF
--- a/src/query/service/src/sessions/session_privilege_mgr.rs
+++ b/src/query/service/src/sessions/session_privilege_mgr.rs
@@ -375,9 +375,13 @@ impl SessionPrivilegeManager for SessionPrivilegeManagerImpl<'_> {
                     .map(|r| r.name.clone())
                     .collect::<Vec<_>>()
                     .join(",");
+                let user_name = self
+                    .get_current_user()
+                    .map(|u| u.identity().display().to_string())
+                    .unwrap_or_else(|_| "unknown".to_string());
                 Err(ErrorCode::InvalidRole(format!(
-                    "Invalid role {} for current session, available: {}",
-                    role_name, available_role_names,
+                    "Invalid role {} for current session, user: {}, available: {}",
+                    role_name, user_name, available_role_names,
                 )))
             }
         }

--- a/src/query/users/src/role_cache_mgr.rs
+++ b/src/query/users/src/role_cache_mgr.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use databend_common_base::base::GlobalInstance;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::Result;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::principal::RoleInfo;
@@ -26,6 +27,7 @@ use log::warn;
 use parking_lot::RwLock;
 use tokio::task::JoinHandle;
 
+use crate::BUILTIN_ROLE_PUBLIC;
 use crate::UserApiProvider;
 use crate::role_util::find_all_related_roles;
 
@@ -131,45 +133,58 @@ impl RoleCacheManager {
         tenant: &Tenant,
         roles: &[String],
     ) -> Result<Vec<RoleInfo>> {
-        self.maybe_reload(tenant).await?;
-        let cached = self.cache.read();
-        let cached_roles = match cached.get(tenant) {
-            None => return Ok(vec![]),
-            Some(cached_roles) => cached_roles,
-        };
-        Ok(find_all_related_roles(&cached_roles.roles, roles))
+        if self.need_reload(tenant) {
+            return self.load_cache_and_find_related_roles(tenant, roles).await;
+        }
+
+        {
+            let cached = self.cache.read();
+            if let Some(cached_roles) = cached.get(tenant) {
+                return Ok(find_all_related_roles(&cached_roles.roles, roles));
+            }
+        }
+
+        // The tenant cache may be invalidated after need_reload() returns false.
+        self.load_cache_and_find_related_roles(tenant, roles).await
     }
 
     #[async_backtrace::framed]
     pub async fn force_reload(&self, tenant: &Tenant) -> Result<()> {
         let data = load_roles_data(&self.user_manager, tenant).await?;
-        let mut cached = self.cache.write();
-        cached.insert(tenant.clone(), data);
+        self.cache_roles_data(tenant, data);
         Ok(())
     }
 
-    // Load roles data if not found in cache. Watch this tenant's role data in background if
-    // once it loads successfully.
     #[async_backtrace::framed]
-    async fn maybe_reload(&self, tenant: &Tenant) -> Result<()> {
-        let need_reload = {
-            let cached = self.cache.read();
-            match cached.get(tenant) {
-                None => true,
-                Some(cached_roles) => {
-                    // force reload the data when:
-                    // - if the cache is too old (the background polling task
-                    //   may got some network errors, leaves the cache outdated)
-                    // - if the cache is empty
-                    cached_roles.cached_at.elapsed() >= self.polling_interval * 2
-                        || cached_roles.roles.is_empty()
-                }
+    async fn load_cache_and_find_related_roles(
+        &self,
+        tenant: &Tenant,
+        roles: &[String],
+    ) -> Result<Vec<RoleInfo>> {
+        let data = load_roles_data(&self.user_manager, tenant).await?;
+        let related_roles = find_all_related_roles(&data.roles, roles);
+        self.cache_roles_data(tenant, data);
+        Ok(related_roles)
+    }
+
+    fn cache_roles_data(&self, tenant: &Tenant, data: CachedRoles) {
+        let mut cached = self.cache.write();
+        cached.insert(tenant.clone(), data);
+    }
+
+    fn need_reload(&self, tenant: &Tenant) -> bool {
+        let cached = self.cache.read();
+        match cached.get(tenant) {
+            None => true,
+            Some(cached_roles) => {
+                // force reload the data when:
+                // - if the cache is too old (the background polling task
+                //   may got some network errors, leaves the cache outdated)
+                // - if the cache is empty
+                cached_roles.cached_at.elapsed() >= self.polling_interval * 2
+                    || cached_roles.roles.is_empty()
             }
-        };
-        if need_reload {
-            self.force_reload(tenant).await?;
         }
-        Ok(())
     }
 }
 
@@ -179,6 +194,14 @@ async fn load_roles_data(user_api: &Arc<UserApiProvider>, tenant: &Tenant) -> Re
         .into_iter()
         .map(|r| (r.identity().to_string(), r))
         .collect::<HashMap<_, _>>();
+    let configured_tenant = &GlobalConfig::instance().query.tenant_id;
+    if tenant == configured_tenant && !roles_map.contains_key(BUILTIN_ROLE_PUBLIC) {
+        warn!(
+            "role_cache_mgr loaded roles data without public role for configured tenant {}, roles_count={}",
+            tenant.display(),
+            roles_map.len()
+        );
+    }
     Ok(CachedRoles {
         roles: roles_map,
         cached_at: Instant::now(),

--- a/tests/suites/0_stateless/18_rbac/18_0009_set_role.result
+++ b/tests/suites/0_stateless/18_rbac/18_0009_set_role.result
@@ -4,8 +4,8 @@
 -- test 1: set role as testrole1, then SELECT current_role()
 testrole1
 -- test 2: set a nonexistent role, a existed but not granted role, will fail
-Error: APIError: QueryFailed: [2206]Invalid role nonexisting_role for current session, available: public,testrole1,testrole2,testrole3
-Error: APIError: QueryFailed: [2206]Invalid role testrole4 for current session, available: public,testrole1,testrole2,testrole3
+Error: APIError: QueryFailed: [2206]Invalid role nonexisting_role for current session, user: 'testuser1'@'%', available: public,testrole1,testrole2,testrole3
+Error: APIError: QueryFailed: [2206]Invalid role testrole4 for current session, user: 'testuser1'@'%', available: public,testrole1,testrole2,testrole3
 -- test 3: set role as testrole1, secondary roles as NONE, can access table1, can not access table2
 0
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [Insert] is required on 'default'.'default'.'t20_0015_table2' for user 'testuser1'@'%' with roles [testrole1,public]
@@ -38,7 +38,7 @@ Error: APIError: QueryFailed: [2206]object is invalid
 -- test 9: set default role as testrole1, secondary roles as NONE, current role will still be testrole1 in another session
 testrole1
 -- test 10: set default role as nonexisting_role, will fail
-Error: APIError: QueryFailed: [2206]Invalid role nonexistedrole for current session, available: public,testrole1,testrole2,testrole3
+Error: APIError: QueryFailed: [2206]Invalid role nonexistedrole for current session, user: 'testuser1'@'%', available: public,testrole1,testrole2,testrole3
 -- test 11: set secondary All | None, create object only check current role
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [CreateDatabase] is required on *.* for user 'test_c'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object
 Error: APIError: QueryFailed: [1063]Permission denied: privilege [CreateDatabase] is required on *.* for user 'test_c'@'%' with roles [public]. Note: Please ensure that your current role have the appropriate permissions to create a new Object


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix a race in `RoleCacheManager::find_related_roles` that could return an empty role list for a valid session.
- The race happened when one request finished `need_reload`/reload, then another request invalidated the tenant role cache before the first request re-read it. The first request could then fall through to `Ok(vec![])`, which surfaced as `Invalid role ..., available: `.
- Keep the normal fresh-cache path borrowed under the read lock so routine privilege checks only clone the related roles, while cache-miss/reload paths compute from the freshly loaded data and repopulate the cache.
- Add a warning if the configured tenant reloads roles without `public`, and include the current user identity in invalid-role errors to make wrong-user/session mixups easier to diagnose.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

`cargo test -p databend-common-users role_cache_mgr -- --nocapture`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20071)
<!-- Reviewable:end -->
