### PR TITLE
refactor: meta: decouple table create option

### DIFF
--- a/src/meta/api/src/api_impl/auto_increment_api_test_suite.rs
+++ b/src/meta/api/src/api_impl/auto_increment_api_test_suite.rs
@@ -23,7 +23,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::principal::AutoIncrementKey;
 use databend_common_meta_app::schema::AutoIncrementStorageIdent;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::GcDroppedTableReq;
@@ -120,7 +119,7 @@ impl AutoIncrementApiTestSuite {
             let tenant = orphan_util.tenant();
 
             let create_table_req = CreateTableReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: Tenant::new_or_err(tenant_name, func_name!())?,

--- a/src/meta/api/src/api_impl/table_api.rs
+++ b/src/meta/api/src/api_impl/table_api.rs
@@ -29,9 +29,7 @@ use databend_common_meta_app::app_error::DuplicatedIndexColumnId;
 use databend_common_meta_app::app_error::DuplicatedUpsertFiles;
 use databend_common_meta_app::app_error::IndexColumnIdNotFound;
 use databend_common_meta_app::app_error::MultiStmtTxnCommitFailed;
-use databend_common_meta_app::app_error::StreamAlreadyExists;
 use databend_common_meta_app::app_error::StreamVersionMismatched;
-use databend_common_meta_app::app_error::TableAlreadyExists;
 use databend_common_meta_app::app_error::TableSnapshotExpired;
 use databend_common_meta_app::app_error::TableVersionMismatched;
 use databend_common_meta_app::app_error::UndropTableHasNoHistory;
@@ -40,14 +38,12 @@ use databend_common_meta_app::app_error::UnknownDatabaseId;
 use databend_common_meta_app::app_error::UnknownStreamId;
 use databend_common_meta_app::app_error::UnknownTable;
 use databend_common_meta_app::app_error::UnknownTableId;
-use databend_common_meta_app::app_error::ViewAlreadyExists;
 use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::principal::AutoIncrementKey;
 use databend_common_meta_app::schema::AutoIncrementStorageIdent;
 use databend_common_meta_app::schema::AutoIncrementStorageValue;
 use databend_common_meta_app::schema::CommitTableMetaReply;
 use databend_common_meta_app::schema::CommitTableMetaReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DBIdTableName;
@@ -217,30 +213,6 @@ where
     #[logcall::logcall]
     #[fastrace::trace]
     async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply, KVAppError> {
-        // Make an error if table exists.
-        fn make_exists_err(req: &CreateTableReq) -> AppError {
-            let name = &req.name_ident.table_name;
-            let name_ident = &req.name_ident;
-
-            match req.table_meta.engine.as_str() {
-                "STREAM" => {
-                    let exist_err =
-                        StreamAlreadyExists::new(name, format!("create_table: {}", name_ident));
-                    AppError::from(exist_err)
-                }
-                "VIEW" => {
-                    let exist_err =
-                        ViewAlreadyExists::new(name, format!("create_table: {}", name_ident));
-                    AppError::from(exist_err)
-                }
-                _ => {
-                    let exist_err =
-                        TableAlreadyExists::new(name, format!("create_table: {}", name_ident));
-                    AppError::from(exist_err)
-                }
-            }
-        }
-
         debug!(req :? =(&req); "SchemaApi: {}", func_name!());
 
         let tenant_dbname_tbname = &req.name_ident;
@@ -337,46 +309,38 @@ where
                 assert_eq!(key_dbid_tbname, k);
 
                 if let Some(id) = v {
-                    // TODO: move if_not_exists to upper caller. It is not duty of SchemaApi.
-                    match req.create_option {
-                        CreateOption::Create => {
-                            let app_err = make_exists_err(&req);
-                            return Err(KVAppError::AppError(app_err));
-                        }
-                        CreateOption::CreateIfNotExists => {
-                            return Ok(CreateTableReply {
-                                table_id: *id.data,
-                                table_id_seq: None,
-                                db_id: *seq_db_id.data,
-                                new_table: false,
-                                prev_table_id: None,
-                                orphan_table_name: None,
-                            });
-                        }
-                        CreateOption::CreateOrReplace => {
-                            if req.as_dropped {
-                                // If the table is being created as a dropped table, we do not
-                                // need to combine with drop_table_txn operations, just return
-                                // the sequence number associated with the value part of
-                                // the key-value pair (key_dbid_tbname, table_id).
+                    if !req.override_existing {
+                        return Ok(CreateTableReply {
+                            table_id: *id.data,
+                            table_id_seq: None,
+                            db_id: *seq_db_id.data,
+                            new_table: false,
+                            created: false,
+                            prev_table_id: None,
+                            orphan_table_name: None,
+                        });
+                    }
 
-                                SeqV::new(id.seq, *id.data)
-                            } else {
-                                let (seq, id) = construct_drop_table_txn_operations(
-                                    self,
-                                    req.name_ident.table_name.clone(),
-                                    &req.name_ident.tenant,
-                                    req.catalog_name.clone(),
-                                    *id.data,
-                                    *seq_db_id.data,
-                                    true,
-                                    false,
-                                    &mut txn,
-                                )
-                                .await?;
-                                SeqV::new(seq, id)
-                            }
-                        }
+                    if req.as_dropped {
+                        // If the table is being created as a dropped table, we do not
+                        // need to combine with drop_table_txn operations, just return
+                        // the sequence number associated with the value part of
+                        // the key-value pair (key_dbid_tbname, table_id).
+                        SeqV::new(id.seq, *id.data)
+                    } else {
+                        let (seq, id) = construct_drop_table_txn_operations(
+                            self,
+                            req.name_ident.table_name.clone(),
+                            &req.name_ident.tenant,
+                            req.catalog_name.clone(),
+                            *id.data,
+                            *seq_db_id.data,
+                            true,
+                            false,
+                            &mut txn,
+                        )
+                        .await?;
+                        SeqV::new(seq, id)
                     }
                 } else {
                     SeqV::new(0, 0)
@@ -509,6 +473,7 @@ where
                         table_id_seq,
                         db_id: *seq_db_id.data,
                         new_table: dbid_tbname_seq == 0,
+                        created: true,
                         prev_table_id,
                         orphan_table_name,
                     });

--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -514,15 +514,12 @@ impl Display for TableIdList {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CreateTableReq {
-    pub create_option: CreateOption,
+    pub override_existing: bool,
     pub catalog_name: Option<String>,
     pub name_ident: TableNameIdent,
     pub table_meta: TableMeta,
 
     /// Set it to true if a dropped table needs to be created,
-    ///
-    /// since [CreateOption] is used by various scenarios, we use
-    /// this dedicated flag to mark this behavior.
     ///
     /// currently used in atomic CTAS.
     pub as_dropped: bool,
@@ -547,31 +544,24 @@ impl CreateTableReq {
 
 impl Display for CreateTableReq {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self.create_option {
-            CreateOption::Create => write!(
-                f,
-                "create_table:{}/{}-{}={}",
-                self.tenant().tenant_name(),
-                self.db_name(),
-                self.table_name(),
-                self.table_meta
-            ),
-            CreateOption::CreateIfNotExists => write!(
-                f,
-                "create_table_if_not_exists:{}/{}-{}={}",
-                self.tenant().tenant_name(),
-                self.db_name(),
-                self.table_name(),
-                self.table_meta
-            ),
-            CreateOption::CreateOrReplace => write!(
+        if self.override_existing {
+            write!(
                 f,
                 "create_or_replace_table:{}/{}-{}={}",
                 self.tenant().tenant_name(),
                 self.db_name(),
                 self.table_name(),
                 self.table_meta
-            ),
+            )
+        } else {
+            write!(
+                f,
+                "create_table:{}/{}-{}={}",
+                self.tenant().tenant_name(),
+                self.db_name(),
+                self.table_name(),
+                self.table_meta
+            )
         }
     }
 }
@@ -581,7 +571,10 @@ pub struct CreateTableReply {
     pub table_id: u64,
     pub table_id_seq: Option<u64>,
     pub db_id: u64,
+    /// Whether this request inserted a new table-name binding.
     pub new_table: bool,
+    /// Whether this request created a table object. False means an existing table was returned.
+    pub created: bool,
     pub prev_table_id: Option<u64>,
     pub orphan_table_name: Option<String>,
 }

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -35,7 +35,6 @@ use databend_common_meta_api::DatabaseApi;
 use databend_common_meta_api::TableApi;
 use databend_common_meta_api::txn_put_pb_with_ttl;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DropTableByIdReq;
 use databend_common_meta_app::schema::GetTableReq;
@@ -417,7 +416,7 @@ async fn benchmark_table(client: &MetaStore, prefix: u64, client_num: u64, i: u6
 
     let res = client
         .create_table(CreateTableReq {
-            create_option: CreateOption::CreateIfNotExists,
+            override_existing: false,
             catalog_name: None,
             name_ident: tb_name_ident(),
             table_meta: Default::default(),
@@ -471,7 +470,7 @@ async fn benchmark_table(client: &MetaStore, prefix: u64, client_num: u64, i: u6
 
     let res = client
         .create_table(CreateTableReq {
-            create_option: CreateOption::CreateIfNotExists,
+            override_existing: false,
             catalog_name: None,
             name_ident: tb_name_ident(),
             table_meta: Default::default(),

--- a/src/meta/schema-api-test-suite/src/db_table_harness.rs
+++ b/src/meta/schema-api-test-suite/src/db_table_harness.rs
@@ -24,7 +24,6 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_meta_api::DatabaseApi;
 use databend_common_meta_api::TableApi;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DatabaseId;
 use databend_common_meta_app::schema::DatabaseMeta;
@@ -182,7 +181,7 @@ where MT: kvapi::KVApi<Error = MetaError> + TableApi
         let table_meta = f(table_meta);
 
         let req = CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: self.tenant(),
@@ -208,7 +207,7 @@ where MT: kvapi::KVApi<Error = MetaError> + TableApi
     pub(crate) async fn create_table(&mut self) -> anyhow::Result<(u64, TableMeta)> {
         let table_meta = self.table_meta();
         let req = CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: self.tenant(),

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -1684,7 +1684,7 @@ impl SchemaApiTestSuite {
             let created_on = Utc::now();
 
             let req = CreateTableReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
@@ -1778,7 +1778,7 @@ impl SchemaApiTestSuite {
                         meta
                     },
                     |mut req| {
-                        req.create_option = CreateOption::CreateIfNotExists;
+                        req.override_existing = false;
                         req
                     },
                 )
@@ -1802,7 +1802,7 @@ impl SchemaApiTestSuite {
         info!("--- create table again with if_not_exists = false");
         {
             let req = CreateTableReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
@@ -1817,16 +1817,9 @@ impl SchemaApiTestSuite {
             let res = mt.create_table(req).await;
             info!("create table res: {:?}", res);
 
-            let status = res.err().unwrap();
-            let err_code = ErrorCode::from(status);
-
-            assert_eq!(
-                format!(
-                    "TableAlreadyExists. Code: 2302, Text = Table '{}' already exists.",
-                    tbl_name
-                ),
-                err_code.to_string()
-            );
+            let res = res?;
+            assert!(!res.new_table);
+            assert!(!res.created);
 
             // get_table returns the old table
 
@@ -2021,7 +2014,7 @@ impl SchemaApiTestSuite {
                         meta
                     },
                     |mut req| {
-                        req.create_option = CreateOption::CreateOrReplace;
+                        req.override_existing = true;
                         req.name_ident.table_name = table.to_string();
                         req
                     },
@@ -2053,7 +2046,7 @@ impl SchemaApiTestSuite {
             };
 
             let create_table_req = CreateTableReq {
-                create_option: CreateOption::Create,
+                override_existing: false,
                 catalog_name: None,
                 name_ident: TableNameIdent {
                     tenant: tenant.clone(),
@@ -2107,14 +2100,15 @@ impl SchemaApiTestSuite {
                 // case 1: table exists
                 let create_table_if_not_exist_req = {
                     let mut req = create_table_req.clone();
-                    req.create_option = CreateOption::CreateIfNotExists;
+                    req.override_existing = false;
                     req
                 };
 
                 let create_if_not_exist_resp =
                     mt.create_table(create_table_if_not_exist_req).await?;
-                // no new table should be created
+                // no table should be created
                 assert!(!create_if_not_exist_resp.new_table);
+                assert!(!create_if_not_exist_resp.created);
                 // the tabled id that returned should be the same
                 assert_eq!(
                     create_if_not_exist_resp.table_id,
@@ -2130,14 +2124,15 @@ impl SchemaApiTestSuite {
                 let create_table_if_not_exist_req = {
                     let mut req = create_table_req.clone();
                     req.name_ident.table_name = "not_exist".to_owned();
-                    req.create_option = CreateOption::CreateIfNotExists;
+                    req.override_existing = false;
                     req
                 };
 
                 let create_if_not_exist_resp =
                     mt.create_table(create_table_if_not_exist_req).await?;
-                // new table should be created
+                // table should be created
                 assert!(create_if_not_exist_resp.new_table);
+                assert!(create_if_not_exist_resp.created);
                 // table should not be visible
                 let req = GetTableReq::new(&tenant, db_name, "not_exist");
                 let got = mt.get_table(req).await;
@@ -2152,14 +2147,15 @@ impl SchemaApiTestSuite {
             {
                 let create_or_replace_req = {
                     let mut req = create_table_req.clone();
-                    req.create_option = CreateOption::CreateOrReplace;
+                    req.override_existing = true;
                     req
                 };
 
                 let create_or_replace_resp = mt.create_table(create_or_replace_req).await?;
-                // since table of same name has been created, "new_table" (in the sense of table name) should be false
+                // table name already existed, but a replacement table should be created
                 assert!(!create_or_replace_resp.new_table);
-                // but a table of different id should be created
+                assert!(create_or_replace_resp.created);
+                // a table of different id should be created
                 assert_ne!(
                     create_or_replace_resp.table_id,
                     create_table_as_dropped_resp.table_id
@@ -4356,7 +4352,7 @@ impl SchemaApiTestSuite {
         };
 
         let req = CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident,
             table_meta: create_table_meta.clone(),
@@ -5178,7 +5174,7 @@ impl SchemaApiTestSuite {
             for i in 0..number {
                 let table_name = format!("tb{:?}", i);
                 let req = CreateTableReq {
-                    create_option: CreateOption::Create,
+                    override_existing: false,
                     catalog_name: None,
                     name_ident: TableNameIdent {
                         tenant: Tenant::new_or_err(tenant, func_name!())?,
@@ -5466,6 +5462,7 @@ impl SchemaApiTestSuite {
                 db_id: *util.db_id(),
                 prev_table_id: None,
                 new_table: true,
+                created: true,
                 orphan_table_name: None,
             };
             let cur_db = util.get_database().await?;
@@ -5667,7 +5664,7 @@ impl SchemaApiTestSuite {
         let created_on = Utc::now();
 
         let create_table_req = CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: util.tenant(),
@@ -5756,7 +5753,7 @@ impl SchemaApiTestSuite {
             util.create_table_with(
                 |_meta| table_meta(created_on),
                 |mut req| {
-                    req.create_option = CreateOption::CreateOrReplace;
+                    req.override_existing = true;
                     req
                 },
             )
@@ -5787,7 +5784,7 @@ impl SchemaApiTestSuite {
 
             // replace with a new as_dropped = true and table_meta.as_drop is None table
             let create_table_req = CreateTableReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: util.tenant(),
@@ -5807,7 +5804,7 @@ impl SchemaApiTestSuite {
             ));
 
             let create_table_req = CreateTableReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: util.tenant(),
@@ -5843,7 +5840,7 @@ impl SchemaApiTestSuite {
             let tenant = orphan_util.tenant();
 
             let create_table_req = CreateTableReq {
-                create_option: CreateOption::CreateOrReplace,
+                override_existing: true,
                 catalog_name: Some("default".to_string()),
                 name_ident: TableNameIdent {
                     tenant: Tenant::new_or_err(tenant_name, func_name!())?,
@@ -5936,7 +5933,7 @@ impl SchemaApiTestSuite {
         let created_on = Utc::now();
 
         let create_table_req = CreateTableReq {
-            create_option: CreateOption::CreateOrReplace,
+            override_existing: true,
             catalog_name: Some("default".to_string()),
             name_ident: TableNameIdent {
                 tenant: Tenant::new_or_err(tenant_name, func_name!())?,

--- a/src/query/ee/src/attach_table/handler.rs
+++ b/src/query/ee/src/attach_table/handler.rs
@@ -109,7 +109,7 @@ impl AttachTableHandler for RealAttachTableHandler {
             ..Default::default()
         };
         let req = CreateTableReq {
-            create_option: plan.create_option,
+            override_existing: plan.create_option.is_overriding(),
             catalog_name: if plan.create_option.is_overriding() {
                 Some(plan.catalog.to_string())
             } else {

--- a/src/query/ee/src/stream/handler.rs
+++ b/src/query/ee/src/stream/handler.rs
@@ -141,7 +141,7 @@ impl StreamHandler for RealStreamHandler {
         }
 
         let req = CreateTableReq {
-            create_option: plan.create_option,
+            override_existing: plan.create_option.is_overriding(),
             catalog_name: if plan.create_option.is_overriding() {
                 Some(plan.catalog.to_string())
             } else {
@@ -163,7 +163,15 @@ impl StreamHandler for RealStreamHandler {
             table_partition: None,
         };
 
-        catalog.create_table(req).await
+        let reply = catalog.create_table(req).await?;
+        if !reply.created && plan.create_option.if_return_error() {
+            return Err(ErrorCode::StreamAlreadyExists(format!(
+                "'{}' as stream Already Exists",
+                plan.stream_name
+            )));
+        }
+
+        Ok(reply)
     }
 
     #[async_backtrace::framed]

--- a/src/query/ee/tests/it/stream/stream_create.rs
+++ b/src/query/ee/tests/it/stream/stream_create.rs
@@ -14,6 +14,7 @@
 
 use chrono::Duration;
 use chrono::Utc;
+use databend_common_exception::ErrorCode;
 use databend_enterprise_query::test_kits::context::EESetup;
 use databend_query::test_kits::TestFixture;
 use databend_query::test_kits::generate_snapshots;
@@ -68,6 +69,12 @@ async fn test_stream_create() -> anyhow::Result<()> {
         );
         let r = fixture.execute_command(&qry).await;
         assert!(r.is_ok());
+    }
+
+    {
+        let qry = format!("create stream s on table {}.{}", db, tbl);
+        let r = fixture.execute_command(&qry).await;
+        assert_eq!(r.unwrap_err().code(), ErrorCode::STREAM_ALREADY_EXISTS);
     }
 
     Ok(())

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -29,7 +29,6 @@ use databend_common_license::license_manager::LicenseManagerSwitch;
 use databend_common_management::RoleApi;
 use databend_common_meta_app::principal::OwnershipObject;
 use databend_common_meta_app::schema::CommitTableMetaReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::TableIdent;
@@ -186,6 +185,18 @@ impl Interpreter for CreateTableInterpreter {
 }
 
 impl CreateTableInterpreter {
+    fn table_exists_error(req: &CreateTableReq) -> ErrorCode {
+        let name = &req.name_ident.table_name;
+
+        match req.table_meta.engine.as_str() {
+            "STREAM" => {
+                ErrorCode::StreamAlreadyExists(format!("'{}' as stream Already Exists", name))
+            }
+            "VIEW" => ErrorCode::ViewAlreadyExists(format!("'{}' as view Already Exists", name)),
+            _ => ErrorCode::TableAlreadyExists(format!("Table '{}' already exists", name)),
+        }
+    }
+
     #[async_backtrace::framed]
     async fn create_table_as_select(&self, select_plan: Box<Plan>) -> Result<PipelineBuildResult> {
         assert!(
@@ -204,7 +215,11 @@ impl CreateTableInterpreter {
         req.table_meta.drop_on = Some(Utc::now());
         let table_meta = req.table_meta.clone();
         let reply = catalog.create_table(req.clone()).await?;
-        if !reply.new_table && self.plan.create_option != CreateOption::CreateOrReplace {
+        if !reply.created {
+            if self.plan.create_option.if_return_error() {
+                return Err(Self::table_exists_error(&req));
+            }
+
             return Ok(PipelineBuildResult::create());
         }
         if let Some(prefix) = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX).cloned() {
@@ -385,6 +400,10 @@ impl CreateTableInterpreter {
         }
 
         let reply = catalog.create_table(req.clone()).await?;
+        if !reply.created && self.plan.create_option.if_return_error() {
+            return Err(Self::table_exists_error(&req));
+        }
+
         if let Some(prefix) = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX).cloned() {
             self.register_temp_table(prefix).await?;
         }
@@ -521,7 +540,7 @@ impl CreateTableInterpreter {
         }
 
         let req = CreateTableReq {
-            create_option: self.plan.create_option,
+            override_existing: self.plan.create_option.is_overriding(),
             catalog_name: if self.plan.create_option.is_overriding() {
                 Some(self.plan.catalog.to_string())
             } else {

--- a/src/query/service/src/interpreters/interpreter_view_create.rs
+++ b/src/query/service/src/interpreters/interpreter_view_create.rs
@@ -116,7 +116,7 @@ impl Interpreter for CreateViewInterpreter {
         options.insert(QUERY.to_string(), subquery);
 
         let plan = CreateTableReq {
-            create_option: self.plan.create_option,
+            override_existing: self.plan.create_option.is_overriding(),
             catalog_name: if self.plan.create_option.is_overriding() {
                 Some(self.plan.catalog.to_string())
             } else {
@@ -136,7 +136,13 @@ impl Interpreter for CreateViewInterpreter {
             table_properties: None,
             table_partition: None,
         };
-        catalog.create_table(plan).await?;
+        let reply = catalog.create_table(plan).await?;
+        if !reply.created && self.plan.create_option.if_return_error() {
+            return Err(ErrorCode::ViewAlreadyExists(format!(
+                "'{}' as view Already Exists",
+                self.plan.view_name
+            )));
+        }
 
         Ok(PipelineBuildResult::create())
     }

--- a/src/query/service/tests/it/catalogs/database_catalog.rs
+++ b/src/query/service/tests/it/catalogs/database_catalog.rs
@@ -20,7 +20,6 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::DropDatabaseReq;
@@ -152,7 +151,7 @@ async fn test_catalogs_table() -> anyhow::Result<()> {
         let created_on = Utc::now();
 
         let req = CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: tenant.clone(),

--- a/src/query/service/tests/it/catalogs/test_error_handling.rs
+++ b/src/query/service/tests/it/catalogs/test_error_handling.rs
@@ -25,7 +25,6 @@ use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::schema::CreateDatabaseReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DatabaseMeta;
 use databend_common_meta_app::schema::TableMeta;
@@ -76,7 +75,7 @@ async fn test_get_table_error_handling() -> anyhow::Result<()> {
     )]));
 
     let table_req = CreateTableReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: TableNameIdent {
             tenant: tenant.clone(),
@@ -210,7 +209,7 @@ async fn test_get_table_by_info_error_handling() -> anyhow::Result<()> {
     )]));
 
     let table_req = CreateTableReq {
-        create_option: CreateOption::Create,
+        override_existing: false,
         catalog_name: None,
         name_ident: TableNameIdent {
             tenant: tenant.clone(),

--- a/src/query/service/tests/it/storages/system.rs
+++ b/src/query/service/tests/it/storages/system.rs
@@ -557,7 +557,7 @@ async fn test_show_tables_ignores_broken_attached_table_refresh() -> anyhow::Res
     // try to fetch the last snapshot hint and fail.
     catalog
         .create_table(CreateTableReq {
-            create_option: CreateOption::Create,
+            override_existing: false,
             catalog_name: None,
             name_ident: TableNameIdent {
                 tenant: tenant.clone(),

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -21,7 +21,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::CommitTableMetaReply;
 use databend_common_meta_app::schema::CommitTableMetaReq;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DropTableByIdReq;
@@ -99,7 +98,7 @@ impl TempTblMgr {
         prefix: String,
     ) -> Result<CreateTableReply> {
         let CreateTableReq {
-            create_option,
+            override_existing,
             name_ident,
             table_meta,
             as_dropped,
@@ -117,14 +116,9 @@ impl TempTblMgr {
         let desc = Self::temp_table_desc(&name_ident.db_name, &name_ident.table_name);
         let engine = table_meta.engine.to_string();
         let table_id = self.next_id;
-        let new_table = match (self.name_to_id.contains_key(&desc), create_option) {
-            (true, CreateOption::Create) => {
-                return Err(ErrorCode::TableAlreadyExists(format!(
-                    "Temporary table {} already exists",
-                    desc
-                )));
-            }
-            (true, CreateOption::CreateIfNotExists) => false,
+        let existed = self.name_to_id.contains_key(&desc);
+        let created = match (existed, override_existing) {
+            (true, false) => false,
             _ => {
                 let desc = orphan_table_name
                     .as_ref()
@@ -153,7 +147,8 @@ impl TempTblMgr {
             table_id,
             table_id_seq: Some(0),
             db_id,
-            new_table,
+            new_table: !existed,
+            created,
             prev_table_id: None,
             orphan_table_name,
         })

--- a/src/query/storages/iceberg/src/database.rs
+++ b/src/query/storages/iceberg/src/database.rs
@@ -31,7 +31,6 @@ use databend_common_expression::TableDataType::Timestamp;
 use databend_common_expression::TableSchema;
 use databend_common_expression::types::NumberDataType::Float32;
 use databend_common_expression::types::NumberDataType::Float64;
-use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReply;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::DatabaseId;
@@ -207,24 +206,23 @@ impl Database for IcebergDatabase {
     #[async_backtrace::framed]
     async fn create_table(&self, req: CreateTableReq) -> Result<CreateTableReply> {
         let table_name = TableIdent::new(self.ident.clone(), req.table_name().to_string());
+        let mut new_table = true;
 
-        match req.create_option {
-            CreateOption::Create => {}
-            CreateOption::CreateIfNotExists => {
-                if let Ok(exists) = self.ctl.iceberg_catalog().table_exists(&table_name).await {
-                    if exists {
-                        return Ok(CreateTableReply {
-                            table_id: 0,
-                            table_id_seq: None,
-                            db_id: 0,
-                            new_table: true,
-                            prev_table_id: None,
-                            orphan_table_name: None,
-                        });
-                    }
-                }
+        if let Ok(exists) = self.ctl.iceberg_catalog().table_exists(&table_name).await {
+            new_table = !exists;
+            if exists && !req.override_existing {
+                return Ok(CreateTableReply {
+                    table_id: 0,
+                    table_id_seq: None,
+                    db_id: 0,
+                    new_table,
+                    created: false,
+                    prev_table_id: None,
+                    orphan_table_name: None,
+                });
             }
-            CreateOption::CreateOrReplace => {
+
+            if exists {
                 self.drop_table_by_id(DropTableByIdReq {
                     if_exists: true,
                     tenant: req.tenant().clone(),
@@ -269,7 +267,8 @@ impl Database for IcebergDatabase {
             table_id: 0,
             table_id_seq: None,
             db_id: 0,
-            new_table: true,
+            new_table,
+            created: true,
             prev_table_id: None,
             orphan_table_name: None,
         })


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### refactor: meta: decouple table create option
# Summary

Table creation requests now pass only override intent into meta APIs, while SQL duplicate handling stays in the query-facing layer.

# Details

CreateTableReq no longer carries CreateOption, so the meta table API returns the existing table when override is disabled instead of deciding whether that should be an error or an IF NOT EXISTS no-op.

Query interpreters translate SQL create options into the override flag and restore the previous user-facing duplicate behavior after reading the create reply.

Temporary table and Iceberg table creation now follow the same created-versus-existing reply contract, and table create tests/bench callers use the narrower request shape.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Refactoring

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20072)
<!-- Reviewable:end -->
