### PR TITLE
fix(query): clear single_to_inner for cross join fallback from range join

### DIFF
--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -224,8 +224,40 @@ impl PhysicalPlanBuilder {
         } else {
             match physical_join(join, s_expr)? {
                 PhysicalJoinType::Hash => {
+                    // When a LeftSingle/RightSingle join (scalar subquery) has no
+                    // equi-conditions, the hash join executes as a cross join + filter.
+                    // The FROM_LEFT_SINGLE runtime check ("at most 1 build row per probe
+                    // row") fires during the cross-product matching phase — before the
+                    // filter is applied — and false-positives because in a cross join
+                    // every probe row matches all build rows (match_count = build rows).
+                    //
+                    // We only clear single_to_inner when the probe (left) child has
+                    // precise_cardinality == Some(1). This indicates the scalar subquery
+                    // landed on the probe side (e.g. after RuleCommuteJoin swapped
+                    // children) and is a deterministic single-row producer (no-group-by
+                    // aggregate). In that case the build side is the main table whose
+                    // multiple rows are expected — the filter will reduce them after the
+                    // cross product. We intentionally do NOT clear when only the build
+                    // (right) side is single-row (match_count would be 1 anyway, so the
+                    // check never fires) or when only a fuzzy cardinality == 1.0 estimate
+                    // holds (could be a single-row main table like numbers(1), not the
+                    // subquery — we must preserve the runtime check for that case).
+                    let left_stat =
+                        RelExpr::with_s_expr(s_expr.left_child()).derive_cardinality()?;
+                    let probe_is_scalar =
+                        matches!(left_stat.statistics.precise_cardinality, Some(1));
+                    let join = if join.equi_conditions.is_empty()
+                        && join.single_to_inner.is_some()
+                        && probe_is_scalar
+                    {
+                        let mut j = join.clone();
+                        j.single_to_inner = None;
+                        j
+                    } else {
+                        join.clone()
+                    };
                     self.build_hash_join(
-                        join,
+                        &join,
                         s_expr,
                         required,
                         others_required,

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -27,6 +27,26 @@ use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 
+fn is_precise_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
+    matches!(stat_info.statistics.precise_cardinality, Some(1))
+}
+
+fn single_join_scalar_side_is_precise_single_row(join: &Join, s_expr: &SExpr) -> Result<bool> {
+    match join.single_to_inner {
+        Some(JoinType::LeftSingle) => {
+            let right_rel_expr = RelExpr::with_s_expr(s_expr.right_child());
+            let right_stat_info = right_rel_expr.derive_cardinality()?;
+            Ok(is_precise_single_row(&right_stat_info))
+        }
+        Some(JoinType::RightSingle) => {
+            let left_rel_expr = RelExpr::with_s_expr(s_expr.left_child());
+            let left_stat_info = left_rel_expr.derive_cardinality()?;
+            Ok(is_precise_single_row(&left_stat_info))
+        }
+        _ => Ok(false),
+    }
+}
+
 enum PhysicalJoinType {
     Hash,
     // The first arg is range conditions, the second arg is other conditions
@@ -226,29 +246,14 @@ impl PhysicalPlanBuilder {
                 PhysicalJoinType::Hash => {
                     // When a LeftSingle/RightSingle join (scalar subquery) has no
                     // equi-conditions, the hash join executes as a cross join + filter.
-                    // The FROM_LEFT_SINGLE runtime check ("at most 1 build row per probe
-                    // row") fires during the cross-product matching phase — before the
-                    // filter is applied — and false-positives because in a cross join
-                    // every probe row matches all build rows (match_count = build rows).
-                    //
-                    // We only clear single_to_inner when the probe (left) child has
-                    // precise_cardinality == Some(1). This indicates the scalar subquery
-                    // landed on the probe side (e.g. after RuleCommuteJoin swapped
-                    // children) and is a deterministic single-row producer (no-group-by
-                    // aggregate). In that case the build side is the main table whose
-                    // multiple rows are expected — the filter will reduce them after the
-                    // cross product. We intentionally do NOT clear when only the build
-                    // (right) side is single-row (match_count would be 1 anyway, so the
-                    // check never fires) or when only a fuzzy cardinality == 1.0 estimate
-                    // holds (could be a single-row main table like numbers(1), not the
-                    // subquery — we must preserve the runtime check for that case).
-                    let left_stat =
-                        RelExpr::with_s_expr(s_expr.left_child()).derive_cardinality()?;
-                    let probe_is_scalar =
-                        matches!(left_stat.statistics.precise_cardinality, Some(1));
+                    // The single-join runtime check can fire during the cross-product
+                    // matching phase before the filter is applied. It is only safe to
+                    // clear that marker when the scalar side itself is proven to produce
+                    // exactly one row; an exact one-row outer/probe side says nothing
+                    // about the scalar subquery's cardinality.
                     let join = if join.equi_conditions.is_empty()
                         && join.single_to_inner.is_some()
-                        && probe_is_scalar
+                        && single_join_scalar_side_is_precise_single_row(join, s_expr)?
                     {
                         let mut j = join.clone();
                         j.single_to_inner = None;

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -18,6 +18,89 @@ use databend_common_expression::types::number::NumberScalar;
 use databend_query::test_kits::TestFixture;
 use futures_util::TryStreamExt;
 
+async fn explain_text(fixture: &TestFixture, query: &str) -> anyhow::Result<String> {
+    let blocks = fixture
+        .execute_query(&format!("EXPLAIN {query}"))
+        .await?
+        .try_collect::<Vec<DataBlock>>()
+        .await?;
+    let block = DataBlock::concat(&blocks).expect("concat explain blocks");
+    let column = block.get_by_offset(0);
+    let mut lines = Vec::with_capacity(block.num_rows());
+    for row in 0..block.num_rows() {
+        if let Some(ScalarRef::String(line)) = column.index(row) {
+            lines.push(line.to_string());
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+/// A single-row side of an inequality join (here a scalar/no-group-by aggregate, whose
+/// `precise_cardinality` is deterministically 1) must never end up driving a merge
+/// RANGE JOIN. The merge algorithm assumes the build side is the larger one and, for
+/// every driving-side row, materializes the whole matching span of the other side; when
+/// `RuleCommuteJoin` swaps children based on a corrupted cardinality estimate, a large
+/// table can land on the driving side against a single-row build side and blow up memory
+/// into a per-row cartesian product. The planner must instead pick CROSS JOIN + FILTER
+/// (a hash join) regardless of which side the single-row relation is placed on.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let db = fixture.default_db_name();
+
+    fixture
+        .execute_command(&format!(
+            "CREATE TABLE {db}.big(ts INT) AS SELECT number FROM numbers(1000)"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "CREATE TABLE {db}.threshold(ts INT) AS SELECT number FROM numbers(1000)"
+        ))
+        .await?;
+
+    // Scalar subquery on the right side of the inequality.
+    let q_right = format!(
+        "SELECT count(*) FROM {db}.big b \
+         WHERE b.ts >= (SELECT min(ts) FROM {db}.threshold)"
+    );
+    // Scalar subquery on the left side of the inequality (operands flipped). The optimizer
+    // may commute children so the single-row aggregate becomes the driving side; the guard
+    // must still avoid a merge range join.
+    let q_left = format!(
+        "SELECT count(*) FROM {db}.big b \
+         WHERE (SELECT min(ts) FROM {db}.threshold) <= b.ts"
+    );
+
+    for query in [&q_right, &q_left] {
+        let plan = explain_text(&fixture, query).await?;
+        assert!(
+            !plan.contains("RangeJoin"),
+            "single-row inequality side must not produce a RangeJoin, plan was:\n{plan}"
+        );
+    }
+
+    // And the rewritten plan must still produce the correct result (all 1000 rows match
+    // `ts >= min(ts)`).
+    for query in [&q_right, &q_left] {
+        let blocks = fixture
+            .execute_query(query)
+            .await?
+            .try_collect::<Vec<DataBlock>>()
+            .await?;
+        let block = DataBlock::concat(&blocks).expect("concat result blocks");
+        assert_eq!(block.num_rows(), 1);
+        let count = match block.get_by_offset(0).index(0) {
+            Some(ScalarRef::Number(NumberScalar::UInt64(v))) => v,
+            other => panic!("unexpected count scalar: {other:?}"),
+        };
+        assert_eq!(count, 1000, "query: {query}");
+    }
+
+    Ok(())
+}
+
 fn extract_two_u64(blocks: Vec<DataBlock>) -> (u64, u64) {
     let block = DataBlock::concat(&blocks).expect("concat blocks");
     assert_eq!(block.num_rows(), 1, "unexpected rows: {}", block.num_rows());

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -101,6 +101,30 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scalar_subquery_guard_with_one_row_outer() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+
+    let result = fixture
+        .execute_query("SELECT 1 WHERE (SELECT number FROM numbers(2)) >= 0")
+        .await;
+    let err = match result {
+        Ok(stream) => stream
+            .try_collect::<Vec<DataBlock>>()
+            .await
+            .expect_err("multi-row scalar subquery should fail"),
+        Err(err) => err,
+    };
+    assert!(
+        err.message()
+            .contains("Scalar subquery can't return more than one row"),
+        "unexpected error: {err:?}"
+    );
+
+    Ok(())
+}
+
 fn extract_two_u64(blocks: Vec<DataBlock>) -> (u64, u64) {
     let block = DataBlock::concat(&blocks).expect("concat blocks");
     assert_eq!(block.num_rows(), 1, "unexpected rows: {}", block.num_rows());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
@@ -113,6 +113,7 @@ impl Rule for RuleCommuteJoin {
                     (condition.right.clone(), condition.left.clone());
             }
             join.join_type = join.join_type.opposite();
+            join.single_to_inner = join.single_to_inner.map(|join_type| join_type.opposite());
             let mut result = SExpr::create_binary(
                 Arc::new(join.into()),
                 Arc::new(right_child.clone()),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
@@ -94,6 +94,7 @@ impl Rule for RuleCommuteJoinBaseTable {
                         (condition.right.clone(), condition.left.clone());
                 }
                 join.join_type = join.join_type.opposite();
+                join.single_to_inner = join.single_to_inner.map(|join_type| join_type.opposite());
                 let mut result = SExpr::create_binary(
                     Arc::new(join.into()),
                     Arc::new(right_child.clone()),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
@@ -102,6 +102,10 @@ impl Rule for RuleLeftExchangeJoin {
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
 
+        if join1.single_to_inner.is_some() || join2.single_to_inner.is_some() {
+            return Ok(());
+        }
+
         // Ensure inner joins or cross joins.
         if !matches!(join1.join_type, JoinType::Inner | JoinType::Cross)
             || !matches!(join2.join_type, JoinType::Inner | JoinType::Cross)

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -890,6 +890,9 @@ insert into t1 values(1), (2), (3);
 query error 1001.*Scalar subquery can't return more than one row
 select (select sum(a) from t1 where t1.a >= t2.a group by t1.a) from t1 as t2;
 
+query error 1001.*Scalar subquery can't return more than one row
+SELECT 1 WHERE (SELECT number FROM numbers(2)) >= 0;
+
 
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Follow-up to #20062. When a scalar subquery inequality join (`LeftSingle`/`RightSingle` converted to `Inner` with `single_to_inner` marker) has no equi-conditions and falls back from RangeJoin to HashJoin, the hash join executes as a cross join + filter. The `FROM_LEFT_SINGLE` runtime check ("at most 1 build row per probe row") fires during the cross-product matching phase — before the filter is applied — causing a false-positive:

```
Scalar subquery can't return more than one row, but got 65536
```

This PR clears `single_to_inner` when the join has no equi-conditions, so the runtime doesn't enforce it in this context. The scalar guarantee is already satisfied by construction (the aggregate always produces exactly one row).

- fixes: follow-up to #20062

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20073)
<!-- Reviewable:end -->
