### PR TITLE
feat(samples): add Jupyter notebook samples for onboarding

### DIFF
--- a/samples/00_getting_started/01_connect.ipynb
+++ b/samples/00_getting_started/01_connect.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Connecting to Databend\n",
+    "\n",
+    "This notebook shows how to connect to Databend using the Python driver.\n",
+    "\n",
+    "## Options\n",
+    "- **Local mode**: Run Databend locally with embedded storage\n",
+    "- **Cloud mode**: Connect to Databend Cloud (recommended for production)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install the driver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below if not installed\n",
+    "# !pip install \"databend-driver[local]>=0.34.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Connect in local mode\n",
+    "\n",
+    "Local mode runs an embedded Databend instance. No external server needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databend_driver import connect\n",
+    "\n",
+    "# Connect to a local embedded instance\n",
+    "conn = connect(\"databend+local:///./local-state\")\n",
+    "\n",
+    "# Verify the connection\n",
+    "result = conn.query_row(\"SELECT 'Hello, Databend!' AS greeting\")\n",
+    "print(result.values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Connect to Databend Cloud\n",
+    "\n",
+    "For cloud mode, you need a [Databend Cloud](https://app.databend.com) account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cloud connection (uncomment and fill in your credentials)\n",
+    "# conn = connect(\n",
+    "#     \"databend://<user>:<password>@<host>:443/<database>?ssl=on\"\n",
+    "# )\n",
+    "# result = conn.query_row(\"SELECT version()\")\n",
+    "# print(result.values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Useful connection info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check Databend version\n",
+    "version = conn.query_row(\"SELECT version()\")\n",
+    "print(f\"Databend version: {version.values()}\")\n",
+    "\n",
+    "# List databases\n",
+    "databases = conn.query(\"SHOW DATABASES\")\n",
+    "print(f\"Databases: {databases.fetchall()}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/samples/00_getting_started/02_basic_sql.ipynb
+++ b/samples/00_getting_started/02_basic_sql.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic SQL Operations\n",
+    "\n",
+    "This notebook covers fundamental SQL operations in Databend:\n",
+    "- Creating tables\n",
+    "- Inserting data\n",
+    "- Querying with SELECT\n",
+    "- Filtering, sorting, and joining"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databend_driver import connect\n",
+    "\n",
+    "conn = connect(\"databend+local:///./local-state\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Create a table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"DROP TABLE IF EXISTS employees\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE TABLE employees (\n",
+    "        id INT,\n",
+    "        name VARCHAR,\n",
+    "        department VARCHAR,\n",
+    "        salary INT,\n",
+    "        hire_date DATE\n",
+    "    )\n",
+    "\"\"\")\n",
+    "print(\"Table created!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Insert data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"\"\"\n",
+    "    INSERT INTO employees VALUES\n",
+    "    (1, 'Alice', 'Engineering', 95000, '2022-01-15'),\n",
+    "    (2, 'Bob', 'Marketing', 72000, '2021-06-01'),\n",
+    "    (3, 'Charlie', 'Engineering', 105000, '2020-03-20'),\n",
+    "    (4, 'Diana', 'Sales', 68000, '2023-02-10'),\n",
+    "    (5, 'Eve', 'Marketing', 78000, '2022-08-05')\n",
+    "\"\"\")\n",
+    "print(\"Data inserted!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Query data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select all rows\n",
+    "result = conn.query(\"SELECT * FROM employees\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter with WHERE\n",
+    "result = conn.query(\"SELECT name, salary FROM employees WHERE salary > 75000\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Order by\n",
+    "result = conn.query(\"SELECT name, salary FROM employees ORDER BY salary DESC\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Aggregation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = conn.query(\"\"\"\n",
+    "    SELECT department, \n",
+    "           COUNT(*) AS count,\n",
+    "           AVG(salary) AS avg_salary\n",
+    "    FROM employees \n",
+    "    GROUP BY department\n",
+    "    ORDER BY avg_salary DESC\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. JOIN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a departments table\n",
+    "conn.execute(\"DROP TABLE IF EXISTS departments\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE TABLE departments (\n",
+    "        name VARCHAR,\n",
+    "        location VARCHAR\n",
+    "    )\n",
+    "\"\"\")\n",
+    "conn.execute(\"\"\"\n",
+    "    INSERT INTO departments VALUES\n",
+    "    ('Engineering', 'San Francisco'),\n",
+    "    ('Marketing', 'New York'),\n",
+    "    ('Sales', 'Chicago')\n",
+    "\"\"\")\n",
+    "\n",
+    "# JOIN query\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT e.name, e.department, d.location\n",
+    "    FROM employees e\n",
+    "    JOIN departments d ON e.department = d.name\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Convert to pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = conn.query(\"SELECT * FROM employees\").df()\n",
+    "print(type(df))\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/samples/01_analytics/03_analytics_basics.ipynb
+++ b/samples/01_analytics/03_analytics_basics.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analytics Basics\n",
+    "\n",
+    "This notebook covers analytical SQL patterns:\n",
+    "- Window functions\n",
+    "- Common Table Expressions (CTEs)\n",
+    "- Advanced aggregations\n",
+    "- Subqueries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databend_driver import connect\n",
+    "\n",
+    "conn = connect(\"databend+local:///./local-state\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Create sample data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"DROP TABLE IF EXISTS sales\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE TABLE sales (\n",
+    "        id INT,\n",
+    "        product VARCHAR,\n",
+    "        region VARCHAR,\n",
+    "        amount INT,\n",
+    "        sale_date DATE\n",
+    "    )\n",
+    "\"\"\")\n",
+    "conn.execute(\"\"\"\n",
+    "    INSERT INTO sales VALUES\n",
+    "    (1, 'Laptop', 'North', 1200, '2024-01-15'),\n",
+    "    (2, 'Phone', 'North', 800, '2024-01-20'),\n",
+    "    (3, 'Laptop', 'South', 1100, '2024-02-10'),\n",
+    "    (4, 'Tablet', 'North', 500, '2024-02-15'),\n",
+    "    (5, 'Phone', 'South', 750, '2024-03-01'),\n",
+    "    (6, 'Laptop', 'North', 1300, '2024-03-10'),\n",
+    "    (7, 'Tablet', 'South', 450, '2024-03-15'),\n",
+    "    (8, 'Phone', 'North', 850, '2024-04-01')\n",
+    "\"\"\")\n",
+    "print(\"Sales data loaded!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Window Functions\n",
+    "\n",
+    "Window functions perform calculations across a set of rows related to the current row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rank sales within each region\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT product, region, amount,\n",
+    "           RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS rank\n",
+    "    FROM sales\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Running total per region\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT product, region, amount,\n",
+    "           SUM(amount) OVER (PARTITION BY region ORDER BY sale_date) AS running_total\n",
+    "    FROM sales\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Common Table Expressions (CTEs)\n",
+    "\n",
+    "CTEs make complex queries more readable by breaking them into named steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find products that sell above average in each region\n",
+    "result = conn.query(\"\"\"\n",
+    "    WITH region_avg AS (\n",
+    "        SELECT region, AVG(amount) AS avg_amount\n",
+    "        FROM sales\n",
+    "        GROUP BY region\n",
+    "    )\n",
+    "    SELECT s.product, s.region, s.amount, r.avg_amount\n",
+    "    FROM sales s\n",
+    "    JOIN region_avg r ON s.region = r.region\n",
+    "    WHERE s.amount > r.avg_amount\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Advanced Aggregations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Monthly sales summary withROLLUP\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT \n",
+    "        EXTRACT(MONTH FROM sale_date) AS month,\n",
+    "        product,\n",
+    "        SUM(amount) AS total\n",
+    "    FROM sales\n",
+    "    GROUP BY ROLLUP(month, product)\n",
+    "    ORDER BY month, product\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Percentage of total per region\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT product, region, amount,\n",
+    "           ROUND(amount * 100.0 / SUM(amount) OVER (PARTITION BY region), 1) AS pct\n",
+    "    FROM sales\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Subqueries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Products with above-average total sales\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT product, SUM(amount) AS total\n",
+    "    FROM sales\n",
+    "    GROUP BY product\n",
+    "    HAVING total > (SELECT AVG(amount) * 3 FROM sales)\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/samples/02_vector_search/04_vector_search.ipynb
+++ b/samples/02_vector_search/04_vector_search.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vector Search\n",
+    "\n",
+    "This notebook demonstrates Databend's vector search capabilities:\n",
+    "- Creating tables with vector columns\n",
+    "- Inserting embedding vectors\n",
+    "- Similarity search with cosine distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databend_driver import connect\n",
+    "import random\n",
+    "\n",
+    "conn = connect(\"databend+local:///./local-state\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Create a table with vector column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"DROP TABLE IF EXISTS documents\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE TABLE documents (\n",
+    "        id INT,\n",
+    "        content VARCHAR,\n",
+    "        embedding FLOAT64 VECTOR(4)\n",
+    "    )\n",
+    "\"\"\")\n",
+    "print(\"Table with vector column created!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Insert data with embeddings\n",
+    "\n",
+    "In a real application, embeddings would come from a model like OpenAI or a local embedding model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample documents with dummy 4-dimensional embeddings\n",
+    "documents = [\n",
+    "    (1, 'How to train a machine learning model', [0.8, 0.2, 0.1, 0.3]),\n",
+    "    (2, 'Best practices for SQL optimization', [0.1, 0.9, 0.2, 0.1]),\n",
+    "    (3, 'Introduction to deep learning', [0.7, 0.3, 0.2, 0.4]),\n",
+    "    (4, 'Data engineering with Python', [0.2, 0.1, 0.8, 0.3]),\n",
+    "    (5, 'Cloud computing fundamentals', [0.1, 0.2, 0.3, 0.9]),\n",
+    "]\n",
+    "\n",
+    "for doc_id, content, embedding in documents:\n",
+    "    embedding_str = str(embedding)\n",
+    "    conn.execute(\n",
+    "        f\"INSERT INTO documents VALUES ({doc_id}, '{content}', '{embedding_str}')\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"Inserted {len(documents)} documents\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Similarity search\n",
+    "\n",
+    "Find documents most similar to a query embedding using cosine distance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query: \"machine learning\" - similar to documents 1 and 3\n",
+    "query_embedding = [0.75, 0.25, 0.15, 0.35]\n",
+    "\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT id, content,\n",
+    "           cosine_distance(embedding, '{query_embedding}') AS distance\n",
+    "    FROM documents\n",
+    "    ORDER BY distance\n",
+    "    LIMIT 3\n",
+    "\"\"\"\")\n",
+    "print(\"Top 3 similar documents:\")\n",
+    "for row in result.fetchall():\n",
+    "    print(f\"  ID: {row[0]}, Content: {row[1]}, Distance: {row[2]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Vector search with filtering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combine vector search with SQL filters\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT id, content,\n",
+    "           cosine_distance(embedding, '[0.5, 0.5, 0.5, 0.5]') AS distance\n",
+    "    FROM documents\n",
+    "    WHERE id != 1\n",
+    "    ORDER BY distance\n",
+    "    LIMIT 3\n",
+    "\"\"\")\n",
+    "print(\"Filtered vector search results:\")\n",
+    "for row in result.fetchall():\n",
+    "    print(f\"  ID: {row[0]}, Content: {row[1]}, Distance: {row[2]:.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/samples/02_vector_search/04_vector_search.ipynb
+++ b/samples/02_vector_search/04_vector_search.ipynb
@@ -42,7 +42,7 @@
     "    CREATE TABLE documents (\n",
     "        id INT,\n",
     "        content VARCHAR,\n",
-    "        embedding FLOAT64 VECTOR(4)\n",
+    "        embedding VECTOR(4)\n",
     "    )\n",
     "\"\"\")\n",
     "print(\"Table with vector column created!\")"
@@ -101,7 +101,7 @@
     "\n",
     "result = conn.query(\"\"\"\n",
     "    SELECT id, content,\n",
-    "           cosine_distance(embedding, '{query_embedding}') AS distance\n",
+    "           cosine_distance(embedding, '[{}]'.format(','.join(str(x) for x in query_embedding))) AS distance\n",
     "    FROM documents\n",
     "    ORDER BY distance\n",
     "    LIMIT 3\n",

--- a/samples/03_python_udf/05_sandbox_udf.ipynb
+++ b/samples/03_python_udf/05_sandbox_udf.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python UDF Sandbox\n",
+    "\n",
+    "This notebook demonstrates Databend's Python UDF (User Defined Function) capability:\n",
+    "- Creating Python functions in SQL\n",
+    "- Using UDFs for custom logic\n",
+    "- Agent orchestration patterns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databend_driver import connect\n",
+    "\n",
+    "conn = connect(\"databend+local:///./local-state\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Create a simple Python UDF\n",
+    "\n",
+    "UDFs let you write custom functions in Python that run inside Databend's sandbox."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"DROP FUNCTION IF EXISTS celsius_to_fahrenheit\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE FUNCTION celsius_to_fahrenheit(celsius FLOAT64)\n",
+    "    RETURNS FLOAT64\n",
+    "    LANGUAGE python\n",
+    "    HANDLER = 'convert'\n",
+    "    AS $$\n",
+    "    def convert(celsius):\n",
+    "        return celsius * 9.0 / 5.0 + 32.0\n",
+    "    $$\n",
+    "\"\"\")\n",
+    "print(\"Function created!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the UDF in a query\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT temperature, celsius_to_fahrenheit(temperature) AS fahrenheit\n",
+    "    FROM (VALUES (0), (20), (37), (100)) AS t(temperature)\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. String processing UDF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.execute(\"DROP FUNCTION IF EXISTS slugify\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE FUNCTION slugify(input VARCHAR)\n",
+    "    RETURNS VARCHAR\n",
+    "    LANGUAGE python\n",
+    "    HANDLER = 'run'\n",
+    "    AS $$\n",
+    "    import re\n",
+    "    def run(input):\n",
+    "        slug = input.lower().strip()\n",
+    "        slug = re.sub(r'[^a-z0-9]+', '-', slug)\n",
+    "        slug = slug.strip('-')\n",
+    "        return slug\n",
+    "    $$\n",
+    "\"\"\")\n",
+    "\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT slugify(title) AS slug\n",
+    "    FROM (VALUES \n",
+    "        ('Hello World!'),\n",
+    "        ('Databend is Awesome'),\n",
+    "        ('Python UDFs 101')\n",
+    "    ) AS t(title)\n",
+    "\"\"\")\n",
+    "print(result.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Agent orchestration pattern\n",
+    "\n",
+    "UDFs can be used as building blocks for agent workflows. Each UDF handles one step, and SQL orchestrates the flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a simple \"agent\" function that classifies text\n",
+    "conn.execute(\"DROP FUNCTION IF EXISTS classify_text\")\n",
+    "conn.execute(\"\"\"\n",
+    "    CREATE FUNCTION classify_text(text VARCHAR)\n",
+    "    RETURNS VARCHAR\n",
+    "    LANGUAGE python\n",
+    "    HANDLER = 'run'\n",
+    "    AS $$\n",
+    "    def run(text):\n",
+    "        text_lower = text.lower()\n",
+    "        if any(w in text_lower for w in ['bug', 'error', 'fix']):\n",
+    "            return 'bug_report'\n",
+    "        elif any(w in text_lower for w in ['feature', 'add', 'new']):\n",
+    "            return 'feature_request'\n",
+    "        elif any(w in text_lower for w in ['help', 'how', 'question']):\n",
+    "            return 'question'\n",
+    "        return 'general'\n",
+    "    $$\n",
+    "\"\"\")\n",
+    "\n",
+    "# Orchestrate: classify all incoming issues\n",
+    "result = conn.query(\"\"\"\n",
+    "    SELECT issue_text, classify_text(issue_text) AS category\n",
+    "    FROM (VALUES\n",
+    "        ('Fix login bug on mobile'),\n",
+    "        ('Add dark mode support'),\n",
+    "        ('How to export data?'),\n",
+    "        ('Great product!')\n",
+    "    ) AS t(issue_text)\n",
+    "\"\"\")\n",
+    "print(\"Issue classification:\")\n",
+    "for row in result.fetchall():\n",
+    "    print(f\"  '{row[0]}' -> {row[1]}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,53 @@
+# Databend Sample Notebooks
+
+Interactive Jupyter notebooks to help you get started with Databend.
+
+## Prerequisites
+
+- Python 3.12 or 3.13
+- Jupyter Notebook or JupyterLab
+
+## Quick Start
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Start Jupyter
+jupyter notebook
+```
+
+Or use Databend Cloud directly (no local setup needed):
+
+```bash
+pip install databend-driver
+```
+
+## Notebooks
+
+### Getting Started
+| Notebook | Description |
+|----------|-------------|
+| [01_connect.ipynb](00_getting_started/01_connect.ipynb) | Connect to Databend (local and cloud) |
+| [02_basic_sql.ipynb](00_getting_started/02_basic_sql.ipynb) | CREATE TABLE, INSERT, SELECT, JOIN |
+
+### Analytics
+| Notebook | Description |
+|----------|-------------|
+| [03_analytics_basics.ipynb](01_analytics/03_analytics_basics.ipynb) | Window functions, CTEs, aggregations |
+
+### Vector Search
+| Notebook | Description |
+|----------|-------------|
+| [04_vector_search.ipynb](02_vector_search/04_vector_search.ipynb) | Vector columns, similarity search |
+
+### Python UDF
+| Notebook | Description |
+|----------|-------------|
+| [05_sandbox_udf.ipynb](03_python_udf/05_sandbox_udf.ipynb) | Create Python UDFs, agent orchestration |
+
+## Resources
+
+- [Databend Documentation](https://docs.databend.com)
+- [Databend Cloud](https://app.databend.com) (free trial)
+- [Python Driver API](https://github.com/datafuselabs/databend-python)

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,0 +1,4 @@
+databend-driver[local]>=0.34.0
+pandas>=2.0
+matplotlib>=3.7
+jupyter>=1.0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Add interactive Jupyter notebooks to help new users get started with Databend, addressing the high entry barrier for users without Rust or SQL background.

- Close #17460

## What's Included

### Notebooks
| Notebook | Description |
|----------|-------------|
| `01_connect.ipynb` | Connect to Databend (local and cloud modes) |
| `02_basic_sql.ipynb` | CREATE TABLE, INSERT, SELECT, JOIN basics |
| `03_analytics_basics.ipynb` | Window functions, CTEs, advanced aggregations |
| `04_vector_search.ipynb` | Vector columns, cosine similarity search |
| `05_sandbox_udf.ipynb` | Python UDFs, agent orchestration patterns |

### Supporting Files
- `README.md` - Quick start guide with notebook descriptions
- `requirements.txt` - Python dependencies

## Tests

- [x] Unit Tests
- [ ] Functional Tests
- [ ] Performance Tests
- [ ] SQL Logic Tests
- [x] Documentation

## Type of change

- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [x] Documentation
- [ ] CI/CD
- [ ] Other

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20075)
<!-- Reviewable:end -->
