### PR TITLE
ci(meta): decode file format params directly

### DIFF
--- a/src/meta/proto-conv/tests/it/v053_csv_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v053_csv_format_params.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app as mt;
 use databend_common_meta_app::principal::CsvFileFormatParams;
+use databend_common_meta_app::principal::CsvQuoteStyle;
 use databend_common_meta_app::principal::EmptyFieldAs;
 use databend_common_meta_app::principal::StageFileCompression;
 use fastrace::func_name;
@@ -31,34 +31,37 @@ use crate::common;
 //
 #[test]
 fn test_decode_v53_csv_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v32 = vec![
-        18, 29, 8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58,
-        1, 39, 160, 6, 32, 168, 6, 24,
+    let csv_file_format_params_v32 = vec![
+        8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58, 1, 39,
+        160, 6, 32, 168, 6, 24,
     ];
-    let want = || {
-        mt::principal::FileFormatParams::Csv(CsvFileFormatParams {
-            compression: StageFileCompression::Gzip,
-            headers: 1,
-            output_header: false,
-            field_delimiter: "fd".to_string(),
-            record_delimiter: "rd".to_string(),
-            null_display: "\\N".to_string(),
-            nan_display: "nan".to_string(),
-            escape: "\\".to_string(),
-            quote: "\'".to_string(),
-            quote_style: mt::principal::CsvQuoteStyle::QuoteNotNull,
-            error_on_column_count_mismatch: true,
-            trim_space: false,
-            allow_quoted_nulls: false,
-            empty_field_as: Default::default(),
-            quoted_empty_field_as: EmptyFieldAs::String,
-            binary_format: Default::default(),
-            geometry_format: Default::default(),
-            encoding: "UTF-8".to_string(),
-            encoding_error_mode: "strict".to_string(),
-        })
+    let want = || CsvFileFormatParams {
+        compression: StageFileCompression::Gzip,
+        headers: 1,
+        output_header: false,
+        field_delimiter: "fd".to_string(),
+        record_delimiter: "rd".to_string(),
+        null_display: "\\N".to_string(),
+        nan_display: "nan".to_string(),
+        escape: "\\".to_string(),
+        quote: "\'".to_string(),
+        quote_style: CsvQuoteStyle::QuoteNotNull,
+        error_on_column_count_mismatch: true,
+        trim_space: false,
+        allow_quoted_nulls: false,
+        empty_field_as: Default::default(),
+        quoted_empty_field_as: EmptyFieldAs::String,
+        binary_format: Default::default(),
+        geometry_format: Default::default(),
+        encoding: "UTF-8".to_string(),
+        encoding_error_mode: "strict".to_string(),
     };
-    common::test_load_old(func_name!(), file_format_params_v32.as_slice(), 0, want())?;
+    common::test_load_old(
+        func_name!(),
+        csv_file_format_params_v32.as_slice(),
+        32,
+        want(),
+    )?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v059_csv_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v059_csv_format_params.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app as mt;
 use databend_common_meta_app::principal::CsvFileFormatParams;
+use databend_common_meta_app::principal::CsvQuoteStyle;
 use databend_common_meta_app::principal::EmptyFieldAs;
 use databend_common_meta_app::principal::StageFileCompression;
 use fastrace::func_name;
@@ -31,34 +31,37 @@ use crate::common;
 //
 #[test]
 fn test_decode_v59_csv_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v59 = vec![
-        18, 35, 8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58,
-        1, 39, 66, 2, 92, 78, 72, 1, 160, 6, 59, 168, 6, 24,
+    let csv_file_format_params_v59 = vec![
+        8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 3, 110, 97, 110, 50, 1, 92, 58, 1, 39,
+        66, 2, 92, 78, 72, 1, 160, 6, 59, 168, 6, 24,
     ];
-    let want = || {
-        mt::principal::FileFormatParams::Csv(CsvFileFormatParams {
-            compression: StageFileCompression::Gzip,
-            headers: 1,
-            output_header: false,
-            field_delimiter: "fd".to_string(),
-            record_delimiter: "rd".to_string(),
-            null_display: "\\N".to_string(),
-            nan_display: "nan".to_string(),
-            escape: "\\".to_string(),
-            quote: "\'".to_string(),
-            quote_style: mt::principal::CsvQuoteStyle::QuoteNotNull,
-            error_on_column_count_mismatch: false,
-            trim_space: false,
-            allow_quoted_nulls: false,
-            empty_field_as: Default::default(),
-            quoted_empty_field_as: EmptyFieldAs::String,
-            binary_format: Default::default(),
-            geometry_format: Default::default(),
-            encoding: "UTF-8".to_string(),
-            encoding_error_mode: "strict".to_string(),
-        })
+    let want = || CsvFileFormatParams {
+        compression: StageFileCompression::Gzip,
+        headers: 1,
+        output_header: false,
+        field_delimiter: "fd".to_string(),
+        record_delimiter: "rd".to_string(),
+        null_display: "\\N".to_string(),
+        nan_display: "nan".to_string(),
+        escape: "\\".to_string(),
+        quote: "\'".to_string(),
+        quote_style: CsvQuoteStyle::QuoteNotNull,
+        error_on_column_count_mismatch: false,
+        trim_space: false,
+        allow_quoted_nulls: false,
+        empty_field_as: Default::default(),
+        quoted_empty_field_as: EmptyFieldAs::String,
+        binary_format: Default::default(),
+        geometry_format: Default::default(),
+        encoding: "UTF-8".to_string(),
+        encoding_error_mode: "strict".to_string(),
     };
-    common::test_load_old(func_name!(), file_format_params_v59.as_slice(), 0, want())?;
+    common::test_load_old(
+        func_name!(),
+        csv_file_format_params_v59.as_slice(),
+        59,
+        want(),
+    )?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v064_ndjson_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v064_ndjson_format_params.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app as mt;
 use databend_common_meta_app::principal::NdJsonFileFormatParams;
 use databend_common_meta_app::principal::NullAs;
 use databend_common_meta_app::principal::StageFileCompression;
@@ -31,20 +30,23 @@ use crate::common;
 //
 #[test]
 fn test_decode_v64_ndjson_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v64 = vec![
-        42, 29, 8, 1, 18, 13, 102, 105, 101, 108, 100, 95, 100, 101, 102, 97, 117, 108, 116, 26, 4,
-        110, 117, 108, 108, 160, 6, 64, 168, 6, 24,
+    let nd_json_file_format_params_v64 = vec![
+        8, 1, 18, 13, 102, 105, 101, 108, 100, 95, 100, 101, 102, 97, 117, 108, 116, 26, 4, 110,
+        117, 108, 108, 160, 6, 64, 168, 6, 24,
     ];
 
-    let want = || {
-        mt::principal::FileFormatParams::NdJson(NdJsonFileFormatParams {
-            compression: StageFileCompression::Gzip,
-            missing_field_as: NullAs::FieldDefault,
-            null_field_as: NullAs::Null,
-            null_if: vec![],
-        })
+    let want = || NdJsonFileFormatParams {
+        compression: StageFileCompression::Gzip,
+        missing_field_as: NullAs::FieldDefault,
+        null_field_as: NullAs::Null,
+        null_if: vec![],
     };
     common::test_pb_from_to(func_name!(), want())?;
-    common::test_load_old(func_name!(), file_format_params_v64.as_slice(), 0, want())?;
+    common::test_load_old(
+        func_name!(),
+        nd_json_file_format_params_v64.as_slice(),
+        64,
+        want(),
+    )?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v072_csv_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v072_csv_format_params.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app as mt;
 use databend_common_meta_app::principal::CsvFileFormatParams;
+use databend_common_meta_app::principal::CsvQuoteStyle;
 use databend_common_meta_app::principal::EmptyFieldAs;
 use databend_common_meta_app::principal::StageFileCompression;
 use fastrace::func_name;
@@ -31,35 +31,38 @@ use crate::common;
 //
 #[test]
 fn test_decode_v72_csv_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v72 = vec![
-        18, 48, 8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 6, 109, 121, 95, 110, 97, 110,
-        50, 1, 124, 58, 1, 39, 66, 4, 78, 117, 108, 108, 72, 1, 82, 6, 115, 116, 114, 105, 110,
-        103, 160, 6, 72, 168, 6, 24,
+    let csv_file_format_params_v72 = vec![
+        8, 1, 16, 1, 26, 2, 102, 100, 34, 2, 114, 100, 42, 6, 109, 121, 95, 110, 97, 110, 50, 1,
+        124, 58, 1, 39, 66, 4, 78, 117, 108, 108, 72, 1, 82, 6, 115, 116, 114, 105, 110, 103, 160,
+        6, 72, 168, 6, 24,
     ];
-    let want = || {
-        mt::principal::FileFormatParams::Csv(CsvFileFormatParams {
-            compression: StageFileCompression::Gzip,
-            headers: 1,
-            output_header: false,
-            field_delimiter: "fd".to_string(),
-            record_delimiter: "rd".to_string(),
-            null_display: "Null".to_string(),
-            nan_display: "my_nan".to_string(),
-            escape: "|".to_string(),
-            quote: "\'".to_string(),
-            quote_style: mt::principal::CsvQuoteStyle::QuoteNotNull,
-            error_on_column_count_mismatch: false,
-            trim_space: false,
-            allow_quoted_nulls: false,
-            empty_field_as: EmptyFieldAs::String,
-            quoted_empty_field_as: EmptyFieldAs::String,
-            binary_format: Default::default(),
-            geometry_format: Default::default(),
-            encoding: "UTF-8".to_string(),
-            encoding_error_mode: "strict".to_string(),
-        })
+    let want = || CsvFileFormatParams {
+        compression: StageFileCompression::Gzip,
+        headers: 1,
+        output_header: false,
+        field_delimiter: "fd".to_string(),
+        record_delimiter: "rd".to_string(),
+        null_display: "Null".to_string(),
+        nan_display: "my_nan".to_string(),
+        escape: "|".to_string(),
+        quote: "\'".to_string(),
+        quote_style: CsvQuoteStyle::QuoteNotNull,
+        error_on_column_count_mismatch: false,
+        trim_space: false,
+        allow_quoted_nulls: false,
+        empty_field_as: EmptyFieldAs::String,
+        quoted_empty_field_as: EmptyFieldAs::String,
+        binary_format: Default::default(),
+        geometry_format: Default::default(),
+        encoding: "UTF-8".to_string(),
+        encoding_error_mode: "strict".to_string(),
     };
-    common::test_load_old(func_name!(), file_format_params_v72.as_slice(), 0, want())?;
+    common::test_load_old(
+        func_name!(),
+        csv_file_format_params_v72.as_slice(),
+        72,
+        want(),
+    )?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v092_orc_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v092_orc_format_params.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::OrcFileFormatParams;
 use fastrace::func_name;
 
@@ -40,19 +39,6 @@ fn test_decode_v92_orc_file_format_params() -> anyhow::Result<()> {
         92,
         want(),
     )?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}
-
-#[test]
-fn test_decode_v92_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v92 = vec![58, 6, 160, 6, 92, 168, 6, 24];
-    let want = || {
-        FileFormatParams::Orc(OrcFileFormatParams {
-            missing_field_as: Default::default(),
-        })
-    };
-    common::test_load_old(func_name!(), file_format_params_v92.as_slice(), 0, want())?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v121_avro_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v121_avro_format_params.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use databend_common_meta_app::principal::AvroFileFormatParams;
-use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::NullAs;
 use databend_common_meta_app::principal::StageFileCompression;
 use fastrace::func_name;
@@ -49,25 +48,6 @@ fn test_decode_v121_avro_file_format_params() -> anyhow::Result<()> {
         121,
         want(),
     )?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}
-
-#[test]
-fn test_decode_v121_file_format_params() -> anyhow::Result<()> {
-    let file_format_params_v121 = vec![
-        66, 35, 8, 4, 18, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 26, 4, 110, 117,
-        108, 108, 26, 4, 78, 85, 76, 76, 160, 6, 121, 168, 6, 24,
-    ];
-    let want = || {
-        FileFormatParams::Avro(AvroFileFormatParams {
-            compression: StageFileCompression::Zstd,
-            missing_field_as: NullAs::FieldDefault,
-            null_if: vec!["null".to_string(), "NULL".to_string()],
-            use_logic_type: true,
-        })
-    };
-    common::test_load_old(func_name!(), file_format_params_v121.as_slice(), 0, want())?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }

--- a/src/meta/proto-conv/tests/it/v167_lance_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v167_lance_file_format_params.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::LanceFileFormatParams;
 use fastrace::func_name;
 
@@ -40,19 +39,6 @@ fn test_decode_v167_lance_file_format_params() -> anyhow::Result<()> {
         167,
         want(),
     )?;
-    common::test_pb_from_to(func_name!(), want())?;
-
-    Ok(())
-}
-
-#[test]
-fn test_decode_v167_file_format_params_lance() -> anyhow::Result<()> {
-    let file_format_params_v167 = vec![74, 7, 160, 6, 167, 1, 168, 6, 24];
-
-    let want = || FileFormatParams::Lance(LanceFileFormatParams::default());
-
-    // FileFormatParams itself does not carry version fields and get_pb_ver() returns 0.
-    common::test_load_old(func_name!(), file_format_params_v167.as_slice(), 0, want())?;
     common::test_pb_from_to(func_name!(), want())?;
 
     Ok(())

--- a/src/meta/proto-conv/tests/it/v177_arrow_file_format_params.rs
+++ b/src/meta/proto-conv/tests/it/v177_arrow_file_format_params.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use databend_common_meta_app::principal::ArrowFileFormatParams;
-use databend_common_meta_app::principal::FileFormatParams;
 use databend_common_meta_app::principal::NullAs;
 use fastrace::func_name;
 
@@ -43,40 +42,6 @@ fn test_decode_v177_arrow_file_format_params() -> anyhow::Result<()> {
         177,
         want(),
     )?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}
-
-#[test]
-fn test_decode_v177_file_format_params_arrow() -> anyhow::Result<()> {
-    let file_format_params_v177 = vec![
-        82, 22, 10, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 160, 6, 177, 1, 168, 6,
-        24,
-    ];
-
-    let want = || {
-        FileFormatParams::Arrow(ArrowFileFormatParams {
-            missing_field_as: NullAs::FieldDefault,
-        })
-    };
-    common::test_load_old(func_name!(), file_format_params_v177.as_slice(), 0, want())?;
-    common::test_pb_from_to(func_name!(), want())?;
-    Ok(())
-}
-
-#[test]
-fn test_decode_v177_file_format_params_arrow_stream() -> anyhow::Result<()> {
-    let file_format_params_v177 = vec![
-        90, 22, 10, 13, 70, 73, 69, 76, 68, 95, 68, 69, 70, 65, 85, 76, 84, 160, 6, 177, 1, 168, 6,
-        24,
-    ];
-
-    let want = || {
-        FileFormatParams::ArrowStream(ArrowFileFormatParams {
-            missing_field_as: NullAs::FieldDefault,
-        })
-    };
-    common::test_load_old(func_name!(), file_format_params_v177.as_slice(), 0, want())?;
     common::test_pb_from_to(func_name!(), want())?;
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes: #14332

This PR updates older file format parameter compatibility tests to decode concrete format params directly instead of decoding the outer `FileFormatParams` wrapper.

Concrete format params carry their own `ver` and `min_reader_ver`, while `FileFormatParams` does not carry an outer version and reports version `0`. Testing the concrete params messages makes the compatibility assertions cover the actual protobuf message versions.

This leaves `v032_file_format_params.rs` unchanged because it specifically covers the `FileFormatParams` wrapper introduced in v32.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Not run; test-only change and existing proto-conv tests cover this path.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20078)
<!-- Reviewable:end -->
