### PR TITLE
feat(stage): support avro unload

### DIFF
--- a/src/query/storages/stage/src/append/avro_file/mod.rs
+++ b/src/query/storages/stage/src/append/avro_file/mod.rs
@@ -12,20 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod arrow_file;
-mod avro_file;
-mod column_based;
-mod file_size;
-mod lance_dataset;
-mod output;
-mod parquet_file;
-mod partition;
-mod path;
-mod row_based_file;
-mod stage_sink_table;
+mod pipeline;
+mod writer_processor;
 
-pub(crate) use arrow_file::append_data_to_arrow_files;
-pub(crate) use avro_file::append_data_to_avro_files;
-pub(crate) use lance_dataset::append_data_to_lance_dataset;
-pub use output::UnloadOutput;
-pub use stage_sink_table::StageSinkTable;
+pub(crate) use pipeline::append_data_to_avro_files;

--- a/src/query/storages/stage/src/append/avro_file/pipeline.rs
+++ b/src/query/storages/stage/src/append/avro_file/pipeline.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+use databend_common_expression::TableSchemaRef;
+use databend_common_pipeline::core::Pipeline;
+use databend_storages_common_stage::CopyIntoLocationInfo;
+use opendal::Operator;
+
+use super::writer_processor::AvroFileWriter;
+use crate::append::file_size::resolve_file_size_options;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_data_to_avro_files(
+    pipeline: &mut Pipeline,
+    info: CopyIntoLocationInfo,
+    schema: TableSchemaRef,
+    op: Operator,
+    query_id: String,
+    group_id: &std::sync::atomic::AtomicUsize,
+    mem_limit: usize,
+    max_threads: usize,
+) -> Result<()> {
+    let (target_file_size, max_threads) =
+        resolve_file_size_options(mem_limit, max_threads, &info.options);
+    pipeline.try_resize(max_threads)?;
+    pipeline.add_transform(|input, output| {
+        let gid = group_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        AvroFileWriter::try_create(
+            input,
+            output,
+            info.clone(),
+            schema.clone(),
+            op.clone(),
+            query_id.clone(),
+            gid,
+            target_file_size,
+        )
+    })?;
+    Ok(())
+}

--- a/src/query/storages/stage/src/append/avro_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/avro_file/writer_processor.rs
@@ -1,0 +1,746 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::mem;
+use std::sync::Arc;
+
+use apache_avro::Codec;
+use apache_avro::Days;
+use apache_avro::Decimal;
+use apache_avro::Duration;
+use apache_avro::Millis;
+use apache_avro::Months;
+use apache_avro::Schema as AvroSchema;
+use apache_avro::to_avro_datum;
+use apache_avro::types::Value as AvroValue;
+use async_trait::async_trait;
+use databend_common_column::types::months_days_micros;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_expression::ScalarRef;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableSchemaRef;
+use databend_common_expression::types::DecimalDataType;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::VectorDataType;
+use databend_common_expression::types::VectorScalarRef;
+use databend_common_meta_app::principal::FileFormatParams;
+use databend_common_meta_app::principal::StageFileCompression;
+use databend_common_pipeline::core::Event;
+use databend_common_pipeline::core::InputPort;
+use databend_common_pipeline::core::OutputPort;
+use databend_common_pipeline::core::Processor;
+use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_storage::ensure_no_stage_path_traversal;
+use databend_storages_common_stage::CopyIntoLocationInfo;
+use jsonb::RawJsonb;
+use num_bigint::BigInt;
+use opendal::Operator;
+use serde_json::json;
+
+use crate::append::UnloadOutput;
+use crate::append::output::DataSummary;
+use crate::append::partition::partition_from_block;
+use crate::append::path::unload_path;
+use crate::avro_utils::avro_tuple_field_names;
+
+const AVRO_WRITE_CHUNK_ROWS: usize = 1024;
+const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
+const DEFAULT_AVRO_BLOCK_SIZE: usize = 16 * 1024;
+
+pub struct AvroFileWriter {
+    input: Arc<InputPort>,
+    output: Arc<OutputPort>,
+
+    info: CopyIntoLocationInfo,
+    schema: TableSchemaRef,
+
+    input_data: VecDeque<DataBlock>,
+    file_data: Vec<u8>,
+    block_data: Vec<u8>,
+    block_rows: usize,
+    avro_schema: AvroSchema,
+    codec: Codec,
+    sync_marker: [u8; 16],
+    input_bytes: usize,
+    row_counts: usize,
+
+    file_to_write: Option<(Vec<u8>, DataSummary, Option<Arc<str>>)>,
+    data_accessor: Operator,
+
+    unload_output: UnloadOutput,
+    unload_output_blocks: Option<VecDeque<DataBlock>>,
+
+    query_id: String,
+    group_id: usize,
+    batch_id: usize,
+
+    target_file_size: Option<usize>,
+    current_partition: Option<Option<Arc<str>>>,
+}
+
+impl AvroFileWriter {
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_create(
+        input: Arc<InputPort>,
+        output: Arc<OutputPort>,
+        info: CopyIntoLocationInfo,
+        schema: TableSchemaRef,
+        data_accessor: Operator,
+        query_id: String,
+        group_id: usize,
+        target_file_size: Option<usize>,
+    ) -> Result<ProcessorPtr> {
+        let unload_output = UnloadOutput::create(info.options.detailed_output);
+        let avro_schema = build_avro_schema(&schema)?;
+        let codec = if let FileFormatParams::Avro(params) = &info.stage.file_format_params {
+            avro_codec(params.compression)?
+        } else {
+            unreachable!()
+        };
+        let sync_marker = avro_sync_marker();
+        Ok(ProcessorPtr::create(Box::new(AvroFileWriter {
+            input,
+            output,
+            info,
+            schema,
+            unload_output,
+            unload_output_blocks: None,
+            input_data: VecDeque::new(),
+            file_data: Vec::new(),
+            block_data: Vec::new(),
+            block_rows: 0,
+            avro_schema,
+            codec,
+            sync_marker,
+            input_bytes: 0,
+            row_counts: 0,
+            file_to_write: None,
+            data_accessor,
+            query_id,
+            group_id,
+            batch_id: 0,
+            target_file_size,
+            current_partition: None,
+        })))
+    }
+
+    fn append_block(&mut self, block: &DataBlock) -> Result<()> {
+        for row in 0..block.num_rows() {
+            let value = avro_record(block, &self.schema, row)?;
+            let row_data = to_avro_datum(&self.avro_schema, value)
+                .map_err(|e| ErrorCode::BadBytes(format!("failed to write Avro data: {e}")))?;
+            self.block_data.extend(row_data);
+            self.block_rows += 1;
+
+            if self.block_data.len() >= DEFAULT_AVRO_BLOCK_SIZE {
+                self.flush_avro_block()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_header(&mut self) -> Result<()> {
+        if !self.file_data.is_empty() {
+            return Ok(());
+        }
+
+        let schema_bytes = serde_json::to_string(&self.avro_schema)
+            .map_err(|e| ErrorCode::BadBytes(format!("failed to build Avro header: {e}")))?
+            .into_bytes();
+        let mut metadata = HashMap::with_capacity(2);
+        metadata.insert("avro.schema".to_string(), AvroValue::Bytes(schema_bytes));
+        metadata.insert("avro.codec".to_string(), self.codec.into());
+
+        self.file_data.extend_from_slice(AVRO_OBJECT_HEADER);
+        self.file_data.extend(
+            to_avro_datum(
+                &AvroSchema::map(AvroSchema::Bytes),
+                AvroValue::Map(metadata),
+            )
+            .map_err(|e| ErrorCode::BadBytes(format!("failed to build Avro header: {e}")))?,
+        );
+        self.file_data.extend_from_slice(&self.sync_marker);
+        Ok(())
+    }
+
+    fn flush_avro_block(&mut self) -> Result<()> {
+        if self.block_rows == 0 {
+            return Ok(());
+        }
+
+        self.ensure_header()?;
+        self.codec
+            .compress(&mut self.block_data)
+            .map_err(|e| ErrorCode::BadBytes(format!("failed to compress Avro data: {e}")))?;
+
+        self.file_data.extend(
+            to_avro_datum(&AvroSchema::Long, AvroValue::Long(self.block_rows as i64))
+                .map_err(|e| ErrorCode::BadBytes(format!("failed to write Avro data: {e}")))?,
+        );
+        self.file_data.extend(
+            to_avro_datum(
+                &AvroSchema::Long,
+                AvroValue::Long(self.block_data.len() as i64),
+            )
+            .map_err(|e| ErrorCode::BadBytes(format!("failed to write Avro data: {e}")))?,
+        );
+        self.file_data.extend_from_slice(&self.block_data);
+        self.file_data.extend_from_slice(&self.sync_marker);
+        self.block_data.clear();
+        self.block_rows = 0;
+        Ok(())
+    }
+
+    fn flush_file(&mut self) -> Result<()> {
+        self.flush_avro_block()?;
+        let data = mem::take(&mut self.file_data);
+        let output_bytes = data.len();
+        self.file_to_write = Some((
+            data,
+            DataSummary {
+                row_counts: self.row_counts,
+                input_bytes: self.input_bytes,
+                output_bytes,
+            },
+            self.current_partition.clone().flatten(),
+        ));
+        self.row_counts = 0;
+        self.input_bytes = 0;
+        self.current_partition = None;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Processor for AvroFileWriter {
+    fn name(&self) -> String {
+        "AvroFileWriter".to_string()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn event(&mut self) -> Result<Event> {
+        if self.output.is_finished() {
+            self.input.finish();
+            Ok(Event::Finished)
+        } else if self.file_to_write.is_some() {
+            self.input.set_not_need_data();
+            Ok(Event::Async)
+        } else if !self.input_data.is_empty() {
+            self.input.set_not_need_data();
+            Ok(Event::Sync)
+        } else if self.input.is_finished() {
+            if self.row_counts > 0 {
+                return Ok(Event::Sync);
+            }
+            if self.unload_output.is_empty() {
+                self.output.finish();
+                return Ok(Event::Finished);
+            }
+            if self.unload_output_blocks.is_none() {
+                self.unload_output_blocks = Some(self.unload_output.to_block_partial().into());
+            }
+            if self.output.can_push() {
+                if let Some(block) = self.unload_output_blocks.as_mut().unwrap().pop_front() {
+                    self.output.push_data(Ok(block));
+                    Ok(Event::NeedConsume)
+                } else {
+                    self.output.finish();
+                    Ok(Event::Finished)
+                }
+            } else {
+                Ok(Event::NeedConsume)
+            }
+        } else if self.input.has_data() {
+            let block = self.input.pull_data().unwrap()?;
+            self.input_data.push_back(block);
+            self.input.set_not_need_data();
+            Ok(Event::Sync)
+        } else {
+            self.input.set_need_data();
+            Ok(Event::NeedData)
+        }
+    }
+
+    fn process(&mut self) -> Result<()> {
+        while let Some(block) = self.input_data.pop_front() {
+            let partition = partition_from_block(&block);
+            if self.current_partition.as_ref() != Some(&partition) {
+                if self.row_counts > 0 {
+                    self.input_data.push_front(block);
+                    self.flush_file()?;
+                    return Ok(());
+                }
+                self.current_partition = Some(partition.clone());
+            }
+
+            let rows = block.num_rows();
+            let mut start = 0;
+            while start < rows {
+                let end = (start + AVRO_WRITE_CHUNK_ROWS).min(rows);
+                let chunk = block.slice(start..end);
+                self.input_bytes += chunk.memory_size();
+                self.row_counts += chunk.num_rows();
+                self.append_block(&chunk)?;
+                start = end;
+
+                if let Some(target) = self.target_file_size {
+                    self.flush_avro_block()?;
+                    if self.file_data.len() >= target {
+                        if start < rows {
+                            self.input_data.push_front(block.slice(start..rows));
+                        }
+                        self.flush_file()?;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        if self.input.is_finished() && self.row_counts > 0 {
+            self.flush_file()?;
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    #[async_backtrace::framed]
+    async fn async_process(&mut self) -> Result<()> {
+        assert!(self.file_to_write.is_some());
+        let (data, summary, partition) = mem::take(&mut self.file_to_write).unwrap();
+        let path = unload_path(
+            &self.info,
+            &self.query_id,
+            self.group_id,
+            self.batch_id,
+            None,
+            partition.as_deref(),
+        );
+        if !self.info.allow_path_traversal {
+            ensure_no_stage_path_traversal(&path)?;
+        }
+        self.unload_output.add_file(&path, summary);
+        self.data_accessor.write(&path, data).await?;
+        self.batch_id += 1;
+        self.sync_marker = avro_sync_marker();
+        Ok(())
+    }
+}
+
+fn avro_codec(compression: StageFileCompression) -> Result<Codec> {
+    match compression {
+        StageFileCompression::None | StageFileCompression::Auto => Ok(Codec::Null),
+        StageFileCompression::Deflate | StageFileCompression::RawDeflate => Ok(Codec::Deflate),
+        StageFileCompression::Snappy => Ok(Codec::Snappy),
+        StageFileCompression::Zstd => Ok(Codec::Zstandard),
+        StageFileCompression::Bz2 => Ok(Codec::Bzip2),
+        StageFileCompression::Xz => Ok(Codec::Xz),
+        _ => Err(ErrorCode::InvalidArgument(format!(
+            "Unsupported Avro compression: {compression}"
+        ))),
+    }
+}
+
+fn avro_sync_marker() -> [u8; 16] {
+    *uuid::Uuid::new_v4().as_bytes()
+}
+
+fn build_avro_schema(schema: &TableSchemaRef) -> Result<AvroSchema> {
+    let mut builder = AvroSchemaBuilder::default();
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            Ok(json!({
+                "name": field.name(),
+                "type": builder.avro_type(field.data_type())?
+            }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let schema = json!({
+        "type": "record",
+        "name": "databend_unload_record",
+        "fields": fields,
+    });
+    AvroSchema::parse(&schema)
+        .map_err(|e| ErrorCode::BadBytes(format!("failed to build Avro schema: {e}")))
+}
+
+#[derive(Default)]
+struct AvroSchemaBuilder {
+    record_id: usize,
+}
+
+impl AvroSchemaBuilder {
+    fn avro_type(&mut self, ty: &TableDataType) -> Result<serde_json::Value> {
+        let value = match ty {
+            TableDataType::Null => json!("null"),
+            TableDataType::EmptyArray => json!({"type": "array", "items": "null"}),
+            TableDataType::EmptyMap => json!({"type": "map", "values": "null"}),
+            TableDataType::Boolean => json!("boolean"),
+            TableDataType::Binary => json!("bytes"),
+            TableDataType::String | TableDataType::Variant => json!("string"),
+            TableDataType::Bitmap
+            | TableDataType::Geometry
+            | TableDataType::Geography
+            | TableDataType::Opaque(_)
+            | TableDataType::TimestampTz => {
+                // Keep Avro unload aligned with Avro load: these logical/internal
+                // Databend types are not supported by the Avro reader yet.
+                return Err(ErrorCode::InvalidArgument(format!(
+                    "Avro output does not support {}",
+                    ty.sql_name()
+                )));
+            }
+            TableDataType::Number(num_ty) => match num_ty {
+                NumberDataType::UInt8
+                | NumberDataType::UInt16
+                | NumberDataType::Int8
+                | NumberDataType::Int16
+                | NumberDataType::Int32 => json!("int"),
+                NumberDataType::UInt32 | NumberDataType::UInt64 | NumberDataType::Int64 => {
+                    json!("long")
+                }
+                NumberDataType::Float32 => json!("float"),
+                NumberDataType::Float64 => json!("double"),
+            },
+            TableDataType::Decimal(decimal_ty) => {
+                let size = match decimal_ty {
+                    DecimalDataType::Decimal64(size)
+                    | DecimalDataType::Decimal128(size)
+                    | DecimalDataType::Decimal256(size) => size,
+                };
+                json!({
+                    "type": "bytes",
+                    "logicalType": "decimal",
+                    "precision": size.precision(),
+                    "scale": size.scale(),
+                })
+            }
+            TableDataType::Timestamp => json!({"type": "long", "logicalType": "timestamp-micros"}),
+            TableDataType::Date => json!({"type": "int", "logicalType": "date"}),
+            TableDataType::Nullable(inner) => json!(["null", self.avro_type(inner)?]),
+            TableDataType::Array(inner) => {
+                json!({"type": "array", "items": self.avro_type(inner)?})
+            }
+            TableDataType::Map(inner) => match inner.as_ref() {
+                TableDataType::Tuple { fields_type, .. }
+                    if matches!(fields_type.first(), Some(TableDataType::String)) =>
+                {
+                    json!({"type": "map", "values": self.avro_type(&fields_type[1])?})
+                }
+                _ => {
+                    return Err(ErrorCode::InvalidArgument(
+                        "Avro map output only supports String keys",
+                    ));
+                }
+            },
+            TableDataType::Tuple {
+                fields_name,
+                fields_type,
+            } => self.avro_record_type(fields_name, fields_type)?,
+            TableDataType::Interval => {
+                json!({"type": {"type": "fixed", "name": "duration", "size": 12}, "logicalType": "duration"})
+            }
+            TableDataType::Vector(vector_ty) => {
+                json!({"type": "array", "items": avro_vector_item_type(vector_ty)})
+            }
+            TableDataType::StageLocation => json!("string"),
+        };
+        Ok(value)
+    }
+
+    fn avro_record_type(
+        &mut self,
+        fields_name: &[String],
+        fields_type: &[TableDataType],
+    ) -> Result<serde_json::Value> {
+        let record_name = format!("databend_tuple_record_{}", self.record_id);
+        self.record_id += 1;
+        let avro_fields_name = avro_tuple_field_names(fields_name);
+        let fields = fields_name
+            .iter()
+            .zip(avro_fields_name)
+            .zip(fields_type)
+            .map(|((_, avro_field_name), field_type)| {
+                Ok(json!({
+                    "name": avro_field_name,
+                    "type": self.avro_type(field_type)?,
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(json!({
+            "type": "record",
+            "name": record_name,
+            "fields": fields,
+        }))
+    }
+}
+
+fn avro_record(block: &DataBlock, schema: &TableSchemaRef, row: usize) -> Result<AvroValue> {
+    let mut record = Vec::with_capacity(schema.num_fields());
+    for (field, entry) in schema.fields().iter().zip(block.columns()) {
+        let value = entry
+            .index(row)
+            .ok_or_else(|| ErrorCode::Internal("invalid row index while writing Avro"))?;
+        record.push((
+            field.name().clone(),
+            scalar_to_avro(value, field.data_type())?,
+        ));
+    }
+    Ok(AvroValue::Record(record))
+}
+
+fn scalar_to_avro(value: ScalarRef, ty: &TableDataType) -> Result<AvroValue> {
+    if let TableDataType::Nullable(inner) = ty {
+        return if matches!(value, ScalarRef::Null) {
+            Ok(AvroValue::Union(0, Box::new(AvroValue::Null)))
+        } else {
+            Ok(AvroValue::Union(1, Box::new(scalar_to_avro(value, inner)?)))
+        };
+    }
+
+    let value = match (value, ty) {
+        (ScalarRef::Null, _) => AvroValue::Null,
+        (ScalarRef::EmptyArray, TableDataType::EmptyArray) => AvroValue::Array(vec![]),
+        (ScalarRef::EmptyMap, TableDataType::EmptyMap) => AvroValue::Map(HashMap::new()),
+        (ScalarRef::Boolean(v), _) => AvroValue::Boolean(v),
+        (ScalarRef::Binary(v), _) => AvroValue::Bytes(v.to_vec()),
+        (ScalarRef::String(v), _) => AvroValue::String(v.to_string()),
+        (ScalarRef::Variant(v), _) => AvroValue::String(RawJsonb::new(v).to_string()),
+        (ScalarRef::Number(v), _) => number_to_avro(v)?,
+        (ScalarRef::Decimal(v), _) => AvroValue::Decimal(Decimal::from(decimal_bytes(v))),
+        (ScalarRef::Timestamp(v), _) => AvroValue::TimestampMicros(v),
+        (ScalarRef::Date(v), _) => AvroValue::Date(v),
+        (ScalarRef::Array(col), TableDataType::Array(inner)) => {
+            let mut values = Vec::with_capacity(col.len());
+            for idx in 0..col.len() {
+                let item = col
+                    .index(idx)
+                    .ok_or_else(|| ErrorCode::Internal("invalid array index while writing Avro"))?;
+                values.push(scalar_to_avro(item, inner)?);
+            }
+            AvroValue::Array(values)
+        }
+        (ScalarRef::Map(col), TableDataType::Map(inner)) => map_to_avro(col, inner)?,
+        (
+            ScalarRef::Tuple(values),
+            TableDataType::Tuple {
+                fields_name,
+                fields_type,
+            },
+        ) => {
+            let avro_fields_name = avro_tuple_field_names(fields_name);
+            let fields = values
+                .into_iter()
+                .zip(avro_fields_name.into_iter().zip(fields_type))
+                .map(|(value, (name, ty))| Ok((name, scalar_to_avro(value, ty)?)))
+                .collect::<Result<Vec<_>>>()?;
+            AvroValue::Record(fields)
+        }
+        (ScalarRef::Interval(v), _) => interval_to_avro(v)?,
+        (ScalarRef::Vector(v), _) => vector_to_avro(v),
+        (value, ty) => {
+            return Err(ErrorCode::InvalidArgument(format!(
+                "Unsupported value {value:?} for Avro type {}",
+                ty.sql_name()
+            )));
+        }
+    };
+    Ok(value)
+}
+
+fn avro_vector_item_type(vector_ty: &VectorDataType) -> serde_json::Value {
+    match vector_ty {
+        VectorDataType::Int8(_) => json!("int"),
+        VectorDataType::Float32(_) => json!("float"),
+    }
+}
+
+fn interval_to_avro(value: months_days_micros) -> Result<AvroValue> {
+    let months = u32::try_from(value.months()).map_err(|_| {
+        ErrorCode::InvalidArgument("Avro duration output does not support negative months")
+    })?;
+    let days = u32::try_from(value.days()).map_err(|_| {
+        ErrorCode::InvalidArgument("Avro duration output does not support negative days")
+    })?;
+    let millis = u32::try_from(value.microseconds() / 1000).map_err(|_| {
+        ErrorCode::InvalidArgument(
+            "Avro duration output only supports milliseconds in the range 0..=u32::MAX",
+        )
+    })?;
+
+    Ok(AvroValue::Duration(Duration::new(
+        Months::new(months),
+        Days::new(days),
+        Millis::new(millis),
+    )))
+}
+
+fn vector_to_avro(value: VectorScalarRef) -> AvroValue {
+    match value {
+        VectorScalarRef::Int8(values) => {
+            AvroValue::Array(values.iter().map(|v| AvroValue::Int((*v).into())).collect())
+        }
+        VectorScalarRef::Float32(values) => {
+            AvroValue::Array(values.iter().map(|v| AvroValue::Float(v.0)).collect())
+        }
+    }
+}
+
+fn number_to_avro(value: NumberScalar) -> Result<AvroValue> {
+    match value {
+        NumberScalar::UInt8(v) => Ok(AvroValue::Int(v.into())),
+        NumberScalar::UInt16(v) => Ok(AvroValue::Int(v.into())),
+        NumberScalar::UInt32(v) => Ok(AvroValue::Long(v.into())),
+        NumberScalar::UInt64(v) => i64::try_from(v)
+            .map(AvroValue::Long)
+            .map_err(|_| ErrorCode::InvalidArgument("UInt64 value is too large for Avro long")),
+        NumberScalar::Int8(v) => Ok(AvroValue::Int(v.into())),
+        NumberScalar::Int16(v) => Ok(AvroValue::Int(v.into())),
+        NumberScalar::Int32(v) => Ok(AvroValue::Int(v)),
+        NumberScalar::Int64(v) => Ok(AvroValue::Long(v)),
+        NumberScalar::Float32(v) => Ok(AvroValue::Float(v.0)),
+        NumberScalar::Float64(v) => Ok(AvroValue::Double(v.0)),
+    }
+}
+
+fn decimal_bytes(value: DecimalScalar) -> Vec<u8> {
+    match value {
+        DecimalScalar::Decimal64(v, _) => BigInt::from(v).to_signed_bytes_be(),
+        DecimalScalar::Decimal128(v, _) => BigInt::from(v).to_signed_bytes_be(),
+        DecimalScalar::Decimal256(v, _) => {
+            BigInt::from_signed_bytes_le(&v.to_le_bytes()).to_signed_bytes_be()
+        }
+    }
+}
+
+fn map_to_avro(col: databend_common_expression::Column, ty: &TableDataType) -> Result<AvroValue> {
+    let TableDataType::Tuple { fields_type, .. } = ty else {
+        return Err(ErrorCode::InvalidArgument(
+            "Invalid Databend map type for Avro",
+        ));
+    };
+
+    let mut values = HashMap::with_capacity(col.len());
+    for idx in 0..col.len() {
+        let entry = col
+            .index(idx)
+            .ok_or_else(|| ErrorCode::Internal("invalid map index while writing Avro"))?;
+        let ScalarRef::Tuple(kv) = entry else {
+            return Err(ErrorCode::Internal("invalid map entry while writing Avro"));
+        };
+        let [ScalarRef::String(key), value] = &kv[..] else {
+            return Err(ErrorCode::InvalidArgument(
+                "Avro map output only supports String keys",
+            ));
+        };
+        values.insert(
+            (*key).to_string(),
+            scalar_to_avro(value.clone(), &fields_type[1])?,
+        );
+    }
+    Ok(AvroValue::Map(values))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use apache_avro::Schema;
+    use databend_common_column::types::months_days_micros;
+    use databend_common_expression::TableField;
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::types::F32;
+    use databend_common_expression::types::VectorDataType;
+    use databend_common_expression::types::VectorScalarRef;
+
+    use super::*;
+
+    #[test]
+    fn test_build_avro_schema_for_special_types() {
+        let schema = Arc::new(TableSchema::new(vec![
+            TableField::new("i", TableDataType::Interval),
+            TableField::new("i2", TableDataType::Interval),
+            TableField::new("v", TableDataType::Vector(VectorDataType::Float32(3))),
+            TableField::new("d", TableDataType::Tuple {
+                fields_name: vec!["1".to_string(), "2".to_string()],
+                fields_type: vec![
+                    TableDataType::Number(NumberDataType::Int32),
+                    TableDataType::String,
+                ],
+            }),
+        ]));
+
+        let avro_schema = build_avro_schema(&schema).unwrap();
+        let Schema::Record(record) = avro_schema else {
+            panic!("expected Avro record schema");
+        };
+        assert!(matches!(&record.fields[0].schema, Schema::Duration));
+        assert!(matches!(&record.fields[1].schema, Schema::Duration));
+        let Schema::Array(array) = &record.fields[2].schema else {
+            panic!("expected Avro array schema");
+        };
+        assert!(matches!(array.items.as_ref(), Schema::Float));
+        let Schema::Record(tuple_record) = &record.fields[3].schema else {
+            panic!("expected Avro tuple record schema");
+        };
+        assert_eq!(tuple_record.fields[0].name, "field_0");
+        assert_eq!(tuple_record.fields[1].name, "field_1");
+    }
+
+    #[test]
+    fn test_interval_to_avro_duration() {
+        let value = months_days_micros::new(1, 2, 3_000);
+        let avro_value = scalar_to_avro(ScalarRef::Interval(value), &TableDataType::Interval)
+            .expect("interval should convert to Avro duration");
+        let AvroValue::Duration(duration) = avro_value else {
+            panic!("expected Avro duration");
+        };
+        assert_eq!(u32::from(duration.months()), 1);
+        assert_eq!(u32::from(duration.days()), 2);
+        assert_eq!(u32::from(duration.millis()), 3);
+
+        let negative = months_days_micros::new(-1, 0, 0);
+        assert!(scalar_to_avro(ScalarRef::Interval(negative), &TableDataType::Interval).is_err());
+    }
+
+    #[test]
+    fn test_vector_to_avro_array() {
+        let values = [F32::from(1.5), F32::from(2.5), F32::from(3.5)];
+        let avro_value = scalar_to_avro(
+            ScalarRef::Vector(VectorScalarRef::Float32(&values)),
+            &TableDataType::Vector(VectorDataType::Float32(3)),
+        )
+        .expect("vector should convert to Avro array");
+
+        assert_eq!(
+            avro_value,
+            AvroValue::Array(vec![
+                AvroValue::Float(1.5),
+                AvroValue::Float(2.5),
+                AvroValue::Float(3.5),
+            ])
+        );
+    }
+}

--- a/src/query/storages/stage/src/append/column_based/limit_file_size_processor.rs
+++ b/src/query/storages/stage/src/append/column_based/limit_file_size_processor.rs
@@ -29,6 +29,7 @@ use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
 
 use super::block_batch::BlockBatch;
+use crate::append::file_size::resolve_file_size_options;
 use crate::append::partition::partition_from_block;
 
 struct PartitionBucket {
@@ -122,33 +123,19 @@ impl LimitFileSizeProcessor {
         max_threads: usize,
         options: &CopyIntoLocationOptions,
     ) -> Result<Option<usize>> {
-        let is_single = options.single;
-        let max_file_size = options.max_file_size;
-        // when serializing block to parquet, the memory may be doubled
-        let mem_limit = if mem_limit == 0 {
-            usize::MAX
-        } else {
-            mem_limit
-        };
-        let mem_limit = mem_limit / 2;
+        let (max_file_size, max_threads) =
+            resolve_file_size_options(mem_limit, max_threads, options);
         pipeline.try_resize(1)?;
-        let max_file_size = if is_single {
-            None
-        } else {
-            let max_file_size = if max_file_size == 0 {
-                64 * 1024 * 1024
-            } else {
-                max_file_size.min(mem_limit)
-            };
+        if let Some(max_file_size) = max_file_size {
             pipeline.add_transform(|input, output| {
                 LimitFileSizeProcessor::try_create(input, output, max_file_size)
             })?;
 
-            let max_threads = max_threads.min(mem_limit / max_file_size).max(1);
             pipeline.try_resize(max_threads)?;
-            Some(max_file_size)
-        };
-        Ok(max_file_size)
+            Ok(Some(max_file_size))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/query/storages/stage/src/append/file_size.rs
+++ b/src/query/storages/stage/src/append/file_size.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_ast::ast::CopyIntoLocationOptions;
+
+pub(crate) fn resolve_file_size_options(
+    mem_limit: usize,
+    max_threads: usize,
+    options: &CopyIntoLocationOptions,
+) -> (Option<usize>, usize) {
+    if options.single {
+        return (None, 1);
+    }
+
+    let mem_limit = if mem_limit == 0 {
+        usize::MAX
+    } else {
+        mem_limit
+    };
+    let mem_limit = (mem_limit / 2).max(1);
+    let target_file_size = if options.max_file_size == 0 {
+        64 * 1024 * 1024
+    } else {
+        options.max_file_size.min(mem_limit)
+    }
+    .max(1);
+    let max_threads = max_threads.min(mem_limit / target_file_size).max(1);
+
+    (Some(target_file_size), max_threads)
+}

--- a/src/query/storages/stage/src/append/stage_sink_table.rs
+++ b/src/query/storages/stage/src/append/stage_sink_table.rs
@@ -30,6 +30,7 @@ use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 
 use crate::StageTable;
 use crate::append::append_data_to_arrow_files;
+use crate::append::append_data_to_avro_files;
 use crate::append::append_data_to_lance_dataset;
 use crate::append::output::SumSummaryTransform;
 use crate::append::parquet_file::append_data_to_parquet_files;
@@ -122,6 +123,16 @@ impl StageSinkTable {
                     max_threads,
                 )?
             }
+            FileFormatParams::Avro(_) => append_data_to_avro_files(
+                pipeline,
+                self.info.clone(),
+                self.schema.clone(),
+                op,
+                query_id,
+                &group_id,
+                mem_limit,
+                max_threads,
+            )?,
             FileFormatParams::Lance(_) => append_data_to_lance_dataset(
                 pipeline,
                 self.info.clone(),

--- a/src/query/storages/stage/src/avro_utils.rs
+++ b/src/query/storages/stage/src/avro_utils.rs
@@ -1,0 +1,50 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+pub(crate) fn avro_tuple_field_names(fields_name: &[String]) -> Vec<String> {
+    let mut used = HashSet::with_capacity(fields_name.len());
+    fields_name
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| {
+            let candidate = if is_valid_avro_name(name) {
+                name.clone()
+            } else {
+                format!("field_{idx}")
+            };
+            if used.insert(candidate.clone()) {
+                return candidate;
+            }
+
+            let mut disambiguated = format!("field_{idx}");
+            while !used.insert(disambiguated.clone()) {
+                disambiguated = format!("field_{idx}_{}", used.len());
+            }
+            disambiguated
+        })
+        .collect()
+}
+
+fn is_valid_avro_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !matches!(first, 'A'..='Z' | 'a'..='z' | '_') {
+        return false;
+    }
+    chars.all(|c| matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
+}

--- a/src/query/storages/stage/src/lib.rs
+++ b/src/query/storages/stage/src/lib.rs
@@ -24,6 +24,7 @@
 )]
 
 mod append;
+mod avro_utils;
 mod compression;
 mod infer_schema;
 mod read;

--- a/src/query/storages/stage/src/read/avro/avro_to_jsonb.rs
+++ b/src/query/storages/stage/src/read/avro/avro_to_jsonb.rs
@@ -81,10 +81,13 @@ pub(super) fn to_jsonb<'a>(value: &'a Value, schema: &Schema) -> Result<jsonb::V
             let months: u32 = d.months().into();
             let days: u32 = d.days().into();
             let millis: u32 = d.millis().into();
+            let months =
+                i32::try_from(months).map_err(|_| "duration months out of range".to_string())?;
+            let days = i32::try_from(days).map_err(|_| "duration days out of range".to_string())?;
             jsonb::Value::Interval(jsonb::Interval {
-                months: months as i32,
-                days: days as i32,
-                micros: (millis * 1000) as i64,
+                months,
+                days,
+                micros: <i64 as From<u32>>::from(millis) * 1000,
             })
         }
 

--- a/src/query/storages/stage/src/read/avro/decoder.rs
+++ b/src/query/storages/stage/src/read/avro/decoder.rs
@@ -31,6 +31,7 @@ use databend_common_expression::types::DecimalColumnBuilder;
 use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::Number;
 use databend_common_expression::types::NumberColumnBuilder;
+use databend_common_expression::types::VectorColumnBuilder;
 use databend_common_expression::types::array::ArrayColumnBuilder;
 use databend_common_expression::types::binary::BinaryColumnBuilder;
 use databend_common_expression::types::nullable::NullableColumnBuilder;
@@ -359,6 +360,7 @@ impl AvroDecoder {
             ColumnBuilder::Array(c) => self.read_array(c, value, matched_schema),
             ColumnBuilder::Map(c) => self.read_map(c, value, matched_schema),
             ColumnBuilder::Tuple(fields) => self.read_tuple(fields, value, matched_schema),
+            ColumnBuilder::Vector(c) => self.read_vector(c, value, matched_schema),
 
             // todo: Bitmap, Geometry, Geography
             _ => Err(Error::new_reason(format!(
@@ -502,10 +504,12 @@ impl AvroDecoder {
                 let months: u32 = d.months().into();
                 let days: u32 = d.days().into();
                 let millis: u32 = d.millis().into();
+                let months = i32::try_from(months).map_err(|_| Error::default())?;
+                let days = i32::try_from(days).map_err(|_| Error::default())?;
                 column.push(months_days_micros::new(
-                    months as i32,
-                    days as i32,
-                    (millis * 1000) as i64,
+                    months,
+                    days,
+                    <i64 as From<u32>>::from(millis) * 1000,
                 ));
                 Ok(())
             }
@@ -627,6 +631,51 @@ impl AvroDecoder {
             _ => Err(Error::default()),
         }
     }
+
+    fn read_vector(
+        &self,
+        column: &mut VectorColumnBuilder,
+        value: Value,
+        matched_schema: &MatchedSchema,
+    ) -> ReadFieldResult {
+        let Value::Array(vals) = value else {
+            return Err(Error::default());
+        };
+        if !matches!(matched_schema, MatchedSchema::Array(_)) {
+            return Err(Error::value_schema_not_match(
+                matched_schema,
+                &Value::Array(vals),
+            ));
+        }
+        if vals.len() != column.dimension() {
+            return Err(Error::new_reason(format!(
+                "vector dimension mismatch: expected {}, got {}",
+                column.dimension(),
+                vals.len()
+            )));
+        }
+
+        match column {
+            VectorColumnBuilder::Int8((values, _)) => {
+                for val in vals {
+                    match val {
+                        Value::Int(v) => self.read_number(values, v)?,
+                        Value::Long(v) => self.read_number(values, v)?,
+                        _ => return Err(Error::default()),
+                    }
+                }
+            }
+            VectorColumnBuilder::Float32((values, _)) => {
+                for val in vals {
+                    match val {
+                        Value::Float(v) => self.read_number(values, OrderedFloat::<f32>(v))?,
+                        _ => return Err(Error::default()),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -635,10 +684,15 @@ mod test {
     use std::sync::Arc;
 
     use apache_avro::BigDecimal;
+    use apache_avro::Days;
     use apache_avro::Decimal;
+    use apache_avro::Duration;
+    use apache_avro::Millis;
+    use apache_avro::Months;
     use apache_avro::Schema;
     use apache_avro::Writer;
     use apache_avro::types::Value;
+    use databend_common_column::types::months_days_micros;
     use databend_common_expression::ColumnBuilder;
     use databend_common_expression::ScalarRef;
     use databend_common_expression::TableDataType;
@@ -648,8 +702,11 @@ mod test {
     use databend_common_expression::types::DecimalDataType;
     use databend_common_expression::types::DecimalScalar;
     use databend_common_expression::types::DecimalSize;
+    use databend_common_expression::types::F32;
     use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::NumberScalar;
+    use databend_common_expression::types::VectorDataType;
+    use databend_common_expression::types::VectorScalarRef;
     use num_bigint::BigInt;
     use serde_json::json;
 
@@ -811,6 +868,76 @@ mod test {
 
         let value = make_value("123456");
         assert!(test_single_field(table_field, avro_schema, value, expected).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_duration() -> Result<(), String> {
+        let avro_schema = json!({
+            "type": {"type": "fixed", "name": "duration", "size": 12},
+            "logicalType": "duration",
+        });
+        let value = Value::Duration(Duration::new(
+            Months::new(1),
+            Days::new(2),
+            Millis::new(3000),
+        ));
+        let expected = ScalarRef::Interval(months_days_micros::new(1, 2, 3_000_000));
+        test_single_field(
+            TableDataType::Interval,
+            avro_schema.clone(),
+            value,
+            expected,
+        )
+        .unwrap();
+
+        let value = Value::Duration(Duration::new(
+            Months::new(i32::MAX as u32 + 1),
+            Days::new(0),
+            Millis::new(0),
+        ));
+        assert!(
+            test_single_field(
+                TableDataType::Interval,
+                avro_schema,
+                value,
+                ScalarRef::Interval(months_days_micros::new(0, 0, 0)),
+            )
+            .is_err()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vector() -> Result<(), String> {
+        let avro_schema = json!({"type": "array", "items": "float"});
+        let value = Value::Array(vec![
+            Value::Float(1.5),
+            Value::Float(2.5),
+            Value::Float(3.5),
+        ]);
+        let expected_values = [F32::from(1.5), F32::from(2.5), F32::from(3.5)];
+        let expected = ScalarRef::Vector(VectorScalarRef::Float32(&expected_values));
+        test_single_field(
+            TableDataType::Vector(VectorDataType::Float32(3)),
+            avro_schema.clone(),
+            value,
+            expected,
+        )
+        .unwrap();
+
+        let value = Value::Array(vec![Value::Float(1.5), Value::Float(2.5)]);
+        assert!(
+            test_single_field(
+                TableDataType::Vector(VectorDataType::Float32(3)),
+                avro_schema,
+                value,
+                ScalarRef::Vector(VectorScalarRef::Float32(&expected_values)),
+            )
+            .is_err()
+        );
 
         Ok(())
     }

--- a/src/query/storages/stage/src/read/avro/schema_match.rs
+++ b/src/query/storages/stage/src/read/avro/schema_match.rs
@@ -20,6 +20,8 @@ use databend_common_expression::types::Decimal;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::i256;
 
+use crate::avro_utils::avro_tuple_field_names;
+
 type MatchResult<T> = Result<T, String>;
 
 #[derive(Debug, Clone)]
@@ -87,6 +89,9 @@ impl SchemaMatcher {
             (TableDataType::Array(dst), Schema::Array(src)) => Ok(MatchedSchema::Array(Box::new(
                 self.match_field(dst, &src.items)?,
             ))),
+            (TableDataType::Vector(vector_ty), Schema::Array(src)) => Ok(MatchedSchema::Array(
+                Box::new(self.match_field(&vector_ty.inner_data_type(), &src.items)?),
+            )),
             (
                 TableDataType::Tuple {
                     fields_name,
@@ -107,8 +112,18 @@ impl SchemaMatcher {
                 let multiplier = if diff > 0 { Some(i256::e(diff)) } else { None };
                 Ok(MatchedSchema::Decimal { multiplier })
             }
-            (TableDataType::Number(NumberDataType::Int32), Schema::Int)
-            | (TableDataType::Number(NumberDataType::UInt64), Schema::Int)
+            (
+                TableDataType::Number(
+                    NumberDataType::UInt8
+                    | NumberDataType::UInt16
+                    | NumberDataType::Int8
+                    | NumberDataType::Int16
+                    | NumberDataType::Int32,
+                ),
+                Schema::Int,
+            )
+            | (TableDataType::Number(NumberDataType::UInt32), Schema::Int | Schema::Long)
+            | (TableDataType::Number(NumberDataType::UInt64), Schema::Int | Schema::Long)
             | (TableDataType::Number(NumberDataType::Int64), Schema::Int | Schema::Long)
             | (TableDataType::Number(NumberDataType::Float32), Schema::Float)
             | (TableDataType::Number(NumberDataType::Float64), Schema::Float | Schema::Double)
@@ -144,7 +159,12 @@ impl SchemaMatcher {
     ) -> MatchResult<Vec<MatchedField>> {
         let mut matched_fields = vec![MatchedField::TypeDefault; fields_name.len()];
         let mut num_matched = 0;
-        for (c, name) in fields_name.iter().enumerate() {
+        let avro_fields_name = if level == 0 {
+            fields_name.to_vec()
+        } else {
+            avro_tuple_field_names(fields_name)
+        };
+        for (c, name) in avro_fields_name.iter().enumerate() {
             if let Some(pos) = src_schema.lookup.get(name) {
                 matched_fields[c] = MatchedField::Value(
                     self.match_field(&fields_type[c], &src_schema.fields[*pos].schema)?,

--- a/tests/nox/suites/copy/test_avro.py
+++ b/tests/nox/suites/copy/test_avro.py
@@ -1,0 +1,21 @@
+def test_avro_unload_max_file_size(copy_env):
+    conn = copy_env.conn
+    name = copy_env.uniq_name
+    location = f"@{name}/avro_size/"
+
+    num_rows = 100000
+    max_file_size = 4096000
+    sql_unload = (f"settings(max_threads=1) copy into {location} "
+            "from ("
+            "select number::int64 as id, repeat('x', 200) as payload "
+            f"from numbers({num_rows})"
+            ") "
+            "file_format=(type=avro) "
+            f"max_file_size={max_file_size} "
+            "detailed_output=true")
+    # print(sql_unload)
+    rows = [row.values() for row in conn.query_iter(sql_unload)]
+    # print(rows)
+    assert len(rows) == 5
+    assert sum(row[2] for row in rows) == num_rows
+    assert max(row[1] for row in rows) < max_file_size * 1.1

--- a/tests/sqllogictests/suites/stage/formats/avro/avro_unload.test
+++ b/tests/sqllogictests/suites/stage/formats/avro/avro_unload.test
@@ -1,0 +1,135 @@
+statement ok
+drop table if exists avro_unload_t
+
+statement ok
+drop table if exists avro_unload_types_t
+
+statement ok
+create table avro_unload_t(a int, b string, c boolean, d tuple(int, string))
+
+statement ok
+remove @data/avro/unload/output_format
+
+statement ok
+copy into @data/avro/unload/output_format/ from (
+    select 1 as a, 'x' as b, true as c, (10, 'vx') as d
+    union all
+    select 2 as a, 'y' as b, false as c, (20, 'vy') as d
+) file_format = (type = avro)
+
+statement ok
+copy into avro_unload_t from @data/avro/unload/output_format file_format = (type = avro)
+
+query ITB?
+select * from avro_unload_t order by a
+----
+1 x 1 (10,"vx")
+2 y 0 (20,"vy")
+
+statement ok
+drop table avro_unload_t
+
+statement ok
+create table avro_unload_types_t(
+    u8 uint8,
+    u16 uint16,
+    u32 uint32,
+    u64 uint64,
+    i8 int8,
+    i16 int16,
+    i32 int32,
+    i64 int64,
+    f32 float32,
+    f64 float64,
+    d date,
+    dec decimal(10, 2),
+    arr array(int32),
+    m map(string, int32),
+    iv interval,
+    vec vector(3),
+    n int32 null
+)
+
+statement ok
+remove @data/avro/unload/types
+
+statement ok
+copy into @data/avro/unload/types/ from (
+    select
+        255::uint8 as u8,
+        65535::uint16 as u16,
+        '4294967295'::uint32 as u32,
+        '9223372036854775807'::uint64 as u64,
+        '-128'::int8 as i8,
+        '-32768'::int16 as i16,
+        '-2147483648'::int32 as i32,
+        '-9223372036854775808'::int64 as i64,
+        3.5::float32 as f32,
+        -7.25::float64 as f64,
+        '2024-01-02'::date as d,
+        12345.67::decimal(10, 2) as dec,
+        [1, 2, 3]::array(int32) as arr,
+        {'a': 10, 'b': 20}::map(string, int32) as m,
+        to_interval('1 month 2 days 3 seconds') as iv,
+        [1.0, 2.0, 3.0]::vector(3) as vec,
+        null::int32 as n
+) file_format = (type = avro)
+
+statement ok
+copy into avro_unload_types_t from @data/avro/unload/types file_format = (type = avro)
+
+query ??????????????????
+select
+    u8, u16, u32, u64,
+    i8, i16, i32, i64,
+    f32, f64, d, dec, arr,
+    m['a'], m['b'],
+    iv, vec, n
+from avro_unload_types_t
+----
+255 65535 4294967295 9223372036854775807 -128 -32768 -2147483648 -9223372036854775808 3.5 -7.25 2024-01-02 12345.67 [1,2,3] 10 20 1 month 2 days 0:00:03 [1.0,2.0,3.0] NULL
+
+statement ok
+drop table avro_unload_types_t
+
+statement ok
+drop table if exists avro_unload_nested_tuple_t
+
+statement ok
+drop table if exists avro_unload_nested_tuple_t2
+
+statement ok
+create table avro_unload_nested_tuple_t(t tuple(tuple(int, string), tuple(int, string)))
+
+statement ok
+create table avro_unload_nested_tuple_t2(t tuple(tuple(int, string), tuple(field_1 string, field_0 int)))
+
+statement ok
+remove @data/avro/unload/nested_tuple
+
+statement ok
+copy into @data/avro/unload/nested_tuple/ from (
+    select ((1, 'x'), (2, 'y')) as t
+) file_format = (type = avro)
+
+statement ok
+copy into avro_unload_nested_tuple_t from @data/avro/unload/nested_tuple file_format = (type = avro)
+
+statement ok
+copy into avro_unload_nested_tuple_t2 from @data/avro/unload/nested_tuple file_format = (type = avro)
+
+query ?
+select t from avro_unload_nested_tuple_t
+----
+((1,"x"),(2,"y"))
+
+query ?
+select t from avro_unload_nested_tuple_t2
+----
+((1,"x"),("y",2))
+
+statement ok
+drop table avro_unload_nested_tuple_t
+
+statement ok
+drop table avro_unload_nested_tuple_t2


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Support `COPY INTO @stage ... FILE_FORMAT = (TYPE = AVRO)` unloads.
- Route Avro unloads through a schema-aware, row-oriented Avro object container writer.
- Split Avro files by checking the actual Avro OCF buffer size after appending row chunks.
- Keep Avro map output limited to native string-key Avro maps so unload does not produce a schema shape the load path cannot read back.
- Add type coverage for primitives, decimals, dates/timestamps, arrays, tuples, nullable values, string-key maps, `UInt32` as Avro `long`, Interval as Avro `duration` when representable without loss, and Vector as Avro arrays.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p databend-common-storages-stage`
- `cargo test -p databend-common-storages-stage avro`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20080)
<!-- Reviewable:end -->
