### PR TITLE
refactor: meta: split dictionary updates by id

### DIFF
--- a/src/meta/api/src/api_impl/dictionary_api.rs
+++ b/src/meta/api/src/api_impl/dictionary_api.rs
@@ -14,7 +14,6 @@
 
 use databend_common_exception::ErrorCode;
 use databend_common_meta_app::KeyExistsBuilder;
-use databend_common_meta_app::KeyUnknownBuilder;
 use databend_common_meta_app::app_error::AppError;
 use databend_common_meta_app::app_error::AppErrorMessage;
 use databend_common_meta_app::schema::CreateDictionaryReply;
@@ -23,15 +22,15 @@ use databend_common_meta_app::schema::DictionaryIdentity;
 use databend_common_meta_app::schema::DictionaryMeta;
 use databend_common_meta_app::schema::ListDictionaryReq;
 use databend_common_meta_app::schema::RenameDictionaryReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameRsc;
 use databend_common_meta_app::tenant_key::errors::ExistError;
 use databend_common_meta_app::tenant_key::errors::UnknownError;
 use databend_meta_client::kvapi;
 use databend_meta_client::kvapi::DirName;
+use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaError;
 use databend_meta_client::types::SeqV;
 use fastrace::func_name;
@@ -108,21 +107,26 @@ where
 
     #[logcall::logcall]
     #[fastrace::trace]
-    async fn update_dictionary(
+    async fn get_dictionary_id(
         &self,
-        req: UpdateDictionaryReq,
-    ) -> Result<UpdateDictionaryReply, KVAppError> {
-        debug!(req :? = (&req); "DictionaryApi: {}", func_name!());
+        name_ident: &DictionaryNameIdent,
+    ) -> Result<Option<SeqV<DictionaryId>>, MetaError> {
+        debug!(dict_ident :? =(name_ident); "DictionaryApi: {}", func_name!());
 
-        let res = self
-            .update_id_value(&req.dictionary_ident, req.dictionary_meta)
-            .await?;
+        self.get_pb(name_ident).await
+    }
 
-        if let Some((id, _meta)) = res {
-            Ok(UpdateDictionaryReply { dictionary_id: *id })
-        } else {
-            Err(AppError::from(req.dictionary_ident.unknown_error(func_name!())).into())
-        }
+    #[logcall::logcall]
+    #[fastrace::trace]
+    async fn update_dictionary_by_id(
+        &self,
+        id_ident: DictionaryIdIdent,
+        dictionary_meta: DictionaryMeta,
+    ) -> Result<Change<DictionaryMeta>, MetaError> {
+        debug!(id_ident :? =(&id_ident); "DictionaryApi: {}", func_name!());
+
+        NameIdValueApi::<DictionaryNameIdent, _>::update_by_id(self, id_ident, dictionary_meta)
+            .await
     }
 
     #[logcall::logcall]
@@ -154,7 +158,7 @@ where
     async fn list_dictionaries(
         &self,
         req: ListDictionaryReq,
-    ) -> Result<Vec<(String, DictionaryMeta)>, KVAppError> {
+    ) -> Result<Vec<(String, DictionaryMeta)>, MetaError> {
         debug!(req :? =(&req); "DictionaryApi: {}", func_name!());
 
         let dictionary_ident = DictionaryNameIdent::new(

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -144,13 +144,13 @@ use databend_common_meta_app::schema::TagNameIdent;
 use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
 use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdentRaw;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::index_id_ident::IndexId;
 use databend_common_meta_app::schema::index_id_ident::IndexIdIdent;
@@ -8283,12 +8283,13 @@ impl SchemaApiTestSuite {
         );
         let dict3 = DictionaryIdentity::new(db_id, dict_name3.to_string());
         let dict_ident3 = DictionaryNameIdent::new(dict_tenant.clone(), dict3.clone());
+        let dictionary_meta_mysql = dictionary_meta("mysql");
 
         {
             info!("--- create dictionary");
             let req = CreateDictionaryReq {
                 dictionary_ident: dict_ident1.clone(),
-                dictionary_meta: dictionary_meta("mysql"),
+                dictionary_meta: dictionary_meta_mysql.clone(),
             };
             let res = mt.create_dictionary(req).await;
             assert!(res.is_ok());
@@ -8342,13 +8343,21 @@ impl SchemaApiTestSuite {
         }
 
         {
-            info!("--- update dictionary");
-            let req = UpdateDictionaryReq {
-                dictionary_ident: dict_ident1.clone(),
-                dictionary_meta: dictionary_meta("postgresql"),
-            };
-            let res = mt.update_dictionary(req).await;
-            assert!(res.is_ok());
+            info!("--- get dictionary id and update dictionary by id");
+            let seq_id = mt.get_dictionary_id(&dict_ident1).await?;
+            assert!(seq_id.is_some());
+            let seq_id = seq_id.unwrap();
+            assert_eq!(*seq_id.data, dict_id);
+
+            let id_ident = seq_id.data.into_t_ident(dict_ident1.tenant());
+            let dictionary_meta_postgresql = dictionary_meta("postgresql");
+            let transition = mt
+                .update_dictionary_by_id(id_ident, dictionary_meta_postgresql.clone())
+                .await?;
+            let (prev, result) = transition.unwrap();
+            assert_eq!(prev.data, dictionary_meta_mysql);
+            assert_eq!(result.data, dictionary_meta_postgresql);
+            assert!(result.seq > prev.seq);
 
             let req = dict_ident1.clone();
             let res = mt.get_dictionary(req).await?;
@@ -8359,17 +8368,20 @@ impl SchemaApiTestSuite {
         }
 
         {
-            info!("--- update unknown dictionary");
-            let req = UpdateDictionaryReq {
-                dictionary_ident: dict_ident2.clone(),
-                dictionary_meta: dictionary_meta("postgresql"),
-            };
-            let res = mt.update_dictionary(req).await;
-            assert!(res.is_err());
-            let status = res.err().unwrap();
-            let err_code = ErrorCode::from(status);
+            info!("--- get unknown dictionary id");
+            let seq_id = mt.get_dictionary_id(&dict_ident2).await?;
+            assert!(seq_id.is_none());
+        }
 
-            assert_eq!(ErrorCode::UNKNOWN_DICTIONARY, err_code.code());
+        {
+            info!("--- update unknown dictionary id");
+            let id_ident = DictionaryId::new(u64::MAX).into_t_ident(dict_ident1.tenant());
+            let transition = mt
+                .update_dictionary_by_id(id_ident, dictionary_meta("postgresql"))
+                .await?;
+            assert!(!transition.is_changed());
+            assert!(transition.prev.is_none());
+            assert!(transition.result.is_none());
         }
 
         {

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -101,8 +101,6 @@ use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableByIdReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
@@ -114,10 +112,13 @@ use databend_common_meta_app::schema::UpdateTempTableReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::GrantObjectVisibilityChecker;
+use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaId;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_session::SessionState;
@@ -696,7 +697,20 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
     /// Dictionary
     async fn create_dictionary(&self, req: CreateDictionaryReq) -> Result<CreateDictionaryReply>;
 
-    async fn update_dictionary(&self, req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply>;
+    async fn get_dictionary_id(
+        &self,
+        _dict_ident: DictionaryNameIdent,
+    ) -> Result<Option<SeqV<DictionaryId>>> {
+        unimplemented!()
+    }
+
+    async fn update_dictionary_by_id(
+        &self,
+        _id_ident: DictionaryIdIdent,
+        _dictionary_meta: DictionaryMeta,
+    ) -> Result<Change<DictionaryMeta>> {
+        unimplemented!()
+    }
 
     async fn drop_dictionary(
         &self,

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -108,8 +108,6 @@ use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableByIdReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
@@ -117,10 +115,13 @@ use databend_common_meta_app::schema::UpdateMultiTableMetaResult;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::GrantObjectVisibilityChecker;
+use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaId;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_session::SessionState;
@@ -970,8 +971,22 @@ impl Catalog for DatabaseCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn update_dictionary(&self, req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
-        self.mutable_catalog.update_dictionary(req).await
+    async fn get_dictionary_id(
+        &self,
+        dict_ident: DictionaryNameIdent,
+    ) -> Result<Option<SeqV<DictionaryId>>> {
+        self.mutable_catalog.get_dictionary_id(dict_ident).await
+    }
+
+    #[async_backtrace::framed]
+    async fn update_dictionary_by_id(
+        &self,
+        id_ident: DictionaryIdIdent,
+        dictionary_meta: DictionaryMeta,
+    ) -> Result<Change<DictionaryMeta>> {
+        self.mutable_catalog
+            .update_dictionary_by_id(id_ident, dictionary_meta)
+            .await
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/catalogs/default/immutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/immutable_catalog.rs
@@ -94,8 +94,6 @@ use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableByIdReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
@@ -608,11 +606,6 @@ impl Catalog for ImmutableCatalog {
     /// Dictionary
     #[async_backtrace::framed]
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        unimplemented!()
-    }
-
-    #[async_backtrace::framed]
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         unimplemented!()
     }
 

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -126,8 +126,6 @@ use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableByIdReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
@@ -135,6 +133,8 @@ use databend_common_meta_app::schema::UpdateMultiTableMetaResult;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::index_id_ident::IndexId;
 use databend_common_meta_app::schema::index_id_ident::IndexIdIdent;
@@ -144,6 +144,7 @@ use databend_common_meta_app::tenant::Tenant;
 use databend_common_meta_app::tenant_key::errors::UnknownError;
 use databend_common_meta_store::MetaStoreProvider;
 use databend_common_users::GrantObjectVisibilityChecker;
+use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaId;
 use databend_meta_client::types::SeqV;
 use databend_meta_runtime::DatabendRuntime;
@@ -1036,8 +1037,30 @@ impl Catalog for MutableCatalog {
     }
 
     #[async_backtrace::framed]
-    async fn update_dictionary(&self, req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
-        Ok(self.ctx.meta.update_dictionary(req).await?)
+    async fn get_dictionary_id(
+        &self,
+        dict_ident: DictionaryNameIdent,
+    ) -> Result<Option<SeqV<DictionaryId>>> {
+        Ok(self
+            .ctx
+            .meta
+            .get_dictionary_id(&dict_ident)
+            .await
+            .map_err(meta_service_error)?)
+    }
+
+    #[async_backtrace::framed]
+    async fn update_dictionary_by_id(
+        &self,
+        id_ident: DictionaryIdIdent,
+        dictionary_meta: DictionaryMeta,
+    ) -> Result<Change<DictionaryMeta>> {
+        Ok(self
+            .ctx
+            .meta
+            .update_dictionary_by_id(id_ident, dictionary_meta)
+            .await
+            .map_err(meta_service_error)?)
     }
 
     #[async_backtrace::framed]
@@ -1070,7 +1093,12 @@ impl Catalog for MutableCatalog {
         &self,
         req: ListDictionaryReq,
     ) -> Result<Vec<(String, DictionaryMeta)>> {
-        Ok(self.ctx.meta.list_dictionaries(req).await?)
+        Ok(self
+            .ctx
+            .meta
+            .list_dictionaries(req)
+            .await
+            .map_err(meta_service_error)?)
     }
 
     async fn set_table_lvt(

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -103,8 +103,6 @@ use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableByIdReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
@@ -112,10 +110,13 @@ use databend_common_meta_app::schema::UpdateMultiTableMetaResult;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryId;
+use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_meta_app::tenant::Tenant;
 use databend_common_users::GrantObjectVisibilityChecker;
+use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaId;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_session::SessionState;
@@ -868,8 +869,21 @@ impl Catalog for SessionCatalog {
         self.inner.create_dictionary(req).await
     }
 
-    async fn update_dictionary(&self, req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
-        self.inner.update_dictionary(req).await
+    async fn get_dictionary_id(
+        &self,
+        dict_ident: DictionaryNameIdent,
+    ) -> Result<Option<SeqV<DictionaryId>>> {
+        self.inner.get_dictionary_id(dict_ident).await
+    }
+
+    async fn update_dictionary_by_id(
+        &self,
+        id_ident: DictionaryIdIdent,
+        dictionary_meta: DictionaryMeta,
+    ) -> Result<Change<DictionaryMeta>> {
+        self.inner
+            .update_dictionary_by_id(id_ident, dictionary_meta)
+            .await
     }
 
     async fn drop_dictionary(

--- a/src/query/service/src/catalogs/iceberg/iceberg_catalog.rs
+++ b/src/query/service/src/catalogs/iceberg/iceberg_catalog.rs
@@ -91,8 +91,6 @@ use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
@@ -599,11 +597,6 @@ impl Catalog for IcebergCatalog {
     /// Dictionary
     #[async_backtrace::framed]
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        unimplemented!()
-    }
-
-    #[async_backtrace::framed]
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         unimplemented!()
     }
 

--- a/src/query/service/src/interpreters/interpreter_dictionary_create.rs
+++ b/src/query/service/src/interpreters/interpreter_dictionary_create.rs
@@ -19,7 +19,6 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::CreateDictionaryReq;
 use databend_common_meta_app::schema::DictionaryIdentity;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_sql::plans::CreateDictionaryPlan;
 
@@ -78,11 +77,25 @@ impl Interpreter for CreateDictionaryInterpreter {
                         return Ok(PipelineBuildResult::create());
                     }
                     CreateOption::CreateOrReplace => {
-                        let req = UpdateDictionaryReq {
-                            dictionary_meta: dictionary_meta.clone(),
-                            dictionary_ident: dictionary_ident.clone(),
+                        let Some(seq_id) = catalog.get_dictionary_id(dictionary_ident).await?
+                        else {
+                            return Err(ErrorCode::UnknownDictionary(format!(
+                                "Dictionary {} does not exist",
+                                self.plan.dictionary,
+                            )));
                         };
-                        let _reply = catalog.update_dictionary(req).await?;
+
+                        let id_ident = seq_id.data.into_t_ident(tenant);
+                        let transition = catalog
+                            .update_dictionary_by_id(id_ident, dictionary_meta.clone())
+                            .await?;
+                        if !transition.is_changed() {
+                            return Err(ErrorCode::UnknownDictionary(format!(
+                                "Dictionary {} does not exist",
+                                self.plan.dictionary,
+                            )));
+                        }
+
                         return Ok(PipelineBuildResult::create());
                     }
                 }

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -123,8 +123,6 @@ use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
@@ -454,10 +452,6 @@ impl Catalog for FakedCatalog {
     }
 
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        todo!()
-    }
-
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -119,8 +119,6 @@ use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpdateMultiTableMetaReq;
@@ -1243,10 +1241,6 @@ impl Catalog for FakedCatalog {
     }
 
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        todo!()
-    }
-
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         todo!()
     }
 

--- a/src/query/sql/tests/it/framework/lite_context.rs
+++ b/src/query/sql/tests/it/framework/lite_context.rs
@@ -629,10 +629,6 @@ impl Catalog for DummyCatalog {
         unsupported("catalog::create_dictionary")
     }
 
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
-        unsupported("catalog::update_dictionary")
-    }
-
     async fn drop_dictionary(
         &self,
         _dict_ident: dictionary_name_ident::DictionaryNameIdent,

--- a/src/query/storages/hive/hive/src/hive_catalog.rs
+++ b/src/query/storages/hive/hive/src/hive_catalog.rs
@@ -93,8 +93,6 @@ use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
@@ -742,11 +740,6 @@ impl Catalog for HiveCatalog {
     /// Dictionary
     #[async_backtrace::framed]
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        unimplemented!()
-    }
-
-    #[async_backtrace::framed]
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         unimplemented!()
     }
 

--- a/src/query/storages/iceberg/src/catalog.rs
+++ b/src/query/storages/iceberg/src/catalog.rs
@@ -96,8 +96,6 @@ use databend_common_meta_app::schema::TruncateTableReq;
 use databend_common_meta_app::schema::UndropDatabaseReply;
 use databend_common_meta_app::schema::UndropDatabaseReq;
 use databend_common_meta_app::schema::UndropTableReq;
-use databend_common_meta_app::schema::UpdateDictionaryReply;
-use databend_common_meta_app::schema::UpdateDictionaryReq;
 use databend_common_meta_app::schema::UpdateIndexReply;
 use databend_common_meta_app::schema::UpdateIndexReq;
 use databend_common_meta_app::schema::UpsertTableOptionReply;
@@ -775,11 +773,6 @@ impl Catalog for IcebergMutableCatalog {
     /// Dictionary
     #[async_backtrace::framed]
     async fn create_dictionary(&self, _req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        unimplemented!()
-    }
-
-    #[async_backtrace::framed]
-    async fn update_dictionary(&self, _req: UpdateDictionaryReq) -> Result<UpdateDictionaryReply> {
         unimplemented!()
     }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### change(meta): split dictionary updates by id
# Summary

Dictionary updates now require callers to resolve the dictionary id from the name before updating the id-backed metadata value.

# Details

The meta dictionary API drops the name-based update method and exposes explicit name-to-id lookup plus id-based metadata update methods, making the two storage steps visible to callers.

Query catalog implementations forward the split methods, and CREATE OR REPLACE DICTIONARY now performs lookup followed by id-based update while preserving unknown-dictionary handling.

Schema API tests now cover successful id lookup and id-based update, missing-name lookup, and missing-id update behavior.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20083)
<!-- Reviewable:end -->
