### PR TITLE
fix(query):  Fix `unnest` to handle nullable array and variant types correctly

### DIFF
--- a/src/query/functions/src/srfs/array.rs
+++ b/src/query/functions/src/srfs/array.rs
@@ -41,7 +41,10 @@ pub fn register(registry: &mut FunctionRegistry) {
             [
                 ty @ (DataType::Null
                 | DataType::EmptyArray
-                | DataType::Nullable(_)
+                | DataType::Nullable(box DataType::Null)
+                | DataType::Nullable(box DataType::EmptyArray)
+                | DataType::Nullable(box DataType::Array(_))
+                | DataType::Nullable(box DataType::Variant)
                 | DataType::Array(_)
                 | DataType::Variant),
             ] => Some(build_unnest(ty, Box::new(|ty| ty))),
@@ -62,20 +65,21 @@ fn build_unnest(
     wrap_type: Box<dyn Fn(DataType) -> DataType>,
 ) -> Arc<Function> {
     match arg_type {
-        DataType::Null | DataType::EmptyArray | DataType::Nullable(box DataType::EmptyArray) => {
-            Arc::new(Function {
-                signature: FunctionSignature {
-                    name: "unnest".to_string(),
-                    args_type: vec![wrap_type(arg_type.clone())],
-                    return_type: DataType::Tuple(vec![DataType::Null]),
-                },
-                eval: FunctionEval::SRF {
-                    eval: Box::new(|_, ctx, _| {
-                        vec![(Value::Scalar(Scalar::Tuple(vec![Scalar::Null])), 0); ctx.num_rows]
-                    }),
-                },
-            })
-        }
+        DataType::Null
+        | DataType::EmptyArray
+        | DataType::Nullable(box DataType::Null)
+        | DataType::Nullable(box DataType::EmptyArray) => Arc::new(Function {
+            signature: FunctionSignature {
+                name: "unnest".to_string(),
+                args_type: vec![wrap_type(arg_type.clone())],
+                return_type: DataType::Tuple(vec![DataType::Null]),
+            },
+            eval: FunctionEval::SRF {
+                eval: Box::new(|_, ctx, _| {
+                    vec![(Value::Scalar(Scalar::Tuple(vec![Scalar::Null])), 0); ctx.num_rows]
+                }),
+            },
+        }),
         DataType::Array(ty) => build_unnest(
             ty,
             Box::new(move |ty| wrap_type(DataType::Array(Box::new(ty)))),

--- a/tests/sqllogictests/suites/query/functions/02_0062_function_unnest.test
+++ b/tests/sqllogictests/suites/query/functions/02_0062_function_unnest.test
@@ -472,6 +472,12 @@ select unnest(parse_json('[1,2,"a",[3,4]]'))
 "a"
 [3,4]
 
+query T
+select unnest(try_parse_json('[1,2]'))
+----
+1
+2
+
 query ?
 select unnest(parse_json('"a"'))
 ----
@@ -505,6 +511,19 @@ SELECT distinct unnest(split(coalesce(NULL, 'a,b'), ',')) AS c1
 ----
 a
 b
+
+query I
+select unnest(if(true, [1,2,3], null))
+----
+1
+2
+3
+
+statement error 1065
+select unnest(try_cast(1 as int))
+
+statement error 1065
+select unnest(try_cast('hello' as varchar))
 
 statement error 1065
 select unnest(first_value('aa') OVER (PARTITION BY 'bb'))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Previously, expressions like `unnest(try_parse_json('[1,2]'))` or `unnest(if(true, [1,2,3], null))` failed with error 1065 because the type signature matching in `build_unnest` didn't cover `Nullable(Array(_))`, `Nullable(Variant)`, and `Nullable(Null)` patterns.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20095)
<!-- Reviewable:end -->
